### PR TITLE
Migrate Components tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49869,13 +49869,11 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/jest": "^30.0.0",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/jest-console": "file:../jest-console",
 				"@wordpress/stylelint-tools": "file:../../tools/stylelint",
-				"snapshot-diff": "^0.10.0",
 				"storybook": "^10.4.3",
-				"timezone-mock": "^1.3.6"
+				"timezone-mock": "^1.3.6",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/components/global.d.ts
+++ b/packages/components/global.d.ts
@@ -2,6 +2,4 @@
 // type definitions found in the specified directories.
 // To ensure that global types are included, we need to
 // explicitly reference them here.
-import '@testing-library/jest-dom';
-import '@wordpress/jest-console';
-import 'snapshot-diff';
+import '@testing-library/jest-dom/vitest';

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -109,13 +109,11 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/jest": "^30.0.0",
 		"@types/react-dom": "^18.3.1",
-		"@wordpress/jest-console": "file:../jest-console",
 		"@wordpress/stylelint-tools": "file:../../tools/stylelint",
-		"snapshot-diff": "^0.10.0",
 		"storybook": "^10.4.3",
-		"timezone-mock": "^1.3.6"
+		"timezone-mock": "^1.3.6",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/components/src/alignment-matrix-control/test/index.tsx
+++ b/packages/components/src/alignment-matrix-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { press, click } from '@ariakit/test';
 
@@ -58,7 +59,7 @@ describe( 'AlignmentMatrixControl', () => {
 					'bottom center',
 					'bottom right',
 				] )( '%s', async ( alignment ) => {
-					const spy = jest.fn();
+					const spy = vi.fn();
 
 					await renderAndInitCompositeStore(
 						<AlignmentMatrixControl
@@ -76,7 +77,7 @@ describe( 'AlignmentMatrixControl', () => {
 				} );
 
 				it( 'unless already focused', async () => {
-					const spy = jest.fn();
+					const spy = vi.fn();
 
 					await renderAndInitCompositeStore(
 						<AlignmentMatrixControl
@@ -103,7 +104,7 @@ describe( 'AlignmentMatrixControl', () => {
 					[ 'ArrowDown', 'bottom center' ],
 					[ 'ArrowRight', 'center right' ],
 				] as const )( '%s', async ( keyRef, cellRef ) => {
-					const spy = jest.fn();
+					const spy = vi.fn();
 
 					await renderAndInitCompositeStore(
 						<AlignmentMatrixControl onChange={ spy } />
@@ -124,7 +125,7 @@ describe( 'AlignmentMatrixControl', () => {
 					[ 'ArrowDown', 'bottom right' ],
 					[ 'ArrowRight', 'bottom right' ],
 				] as const )( '%s', async ( keyRef, cellRef ) => {
-					const spy = jest.fn();
+					const spy = vi.fn();
 
 					await renderAndInitCompositeStore(
 						<AlignmentMatrixControl onChange={ spy } />

--- a/packages/components/src/autocomplete/test/get-autocomplete-match.ts
+++ b/packages/components/src/autocomplete/test/get-autocomplete-match.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getAutocompleteMatch } from '../get-autocomplete-match';
@@ -177,7 +182,7 @@ describe( 'getAutocompleteMatch', () => {
 	} );
 
 	it( 'should pass correct before/after text to allowContext', () => {
-		const allowContext = jest.fn().mockReturnValue( true );
+		const allowContext = vi.fn().mockReturnValue( true );
 		const completers = [
 			createCompleter( {
 				triggerPrefix: '@',

--- a/packages/components/src/autocomplete/test/index.tsx
+++ b/packages/components/src/autocomplete/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -130,7 +131,7 @@ describe( 'AutocompleterUI', () => {
 		it( 'should call reset function when a click on another element occurs', async () => {
 			const user = userEvent.setup();
 
-			const resetSpy = jest.fn();
+			const resetSpy = vi.fn();
 
 			const autocompleter = {
 				name: 'fruit',

--- a/packages/components/src/badge/test/index.tsx
+++ b/packages/components/src/badge/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/base-control/test/index.tsx
+++ b/packages/components/src/base-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/border-box-control/test/index.tsx
+++ b/packages/components/src/border-box-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ComponentProps } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -41,7 +42,7 @@ const mixedBorders = {
 const props = {
 	colors,
 	label: 'Border Box',
-	onChange: jest.fn().mockImplementation( ( newValue ) => {
+	onChange: vi.fn().mockImplementation( ( newValue ) => {
 		props.value = newValue;
 	} ),
 	value: undefined,
@@ -325,7 +326,7 @@ describe( 'BorderBoxControl', () => {
 
 	describe( 'onChange handling', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 			props.value = undefined;
 		} );
 

--- a/packages/components/src/border-box-control/test/utils.ts
+++ b/packages/components/src/border-box-control/test/utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import {
 	fireEvent,
 	render,
@@ -35,7 +36,7 @@ function createProps( customProps ) {
 	const props = {
 		colors,
 		label: 'Border',
-		onChange: jest.fn().mockImplementation( ( newValue ) => {
+		onChange: vi.fn().mockImplementation( ( newValue ) => {
 			props.value = newValue;
 		} ),
 		value: defaultBorder,

--- a/packages/components/src/box-control/test/index.tsx
+++ b/packages/components/src/box-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -177,7 +178,7 @@ describe( 'BoxControl', () => {
 
 		it( 'should persist cleared value when focus changes', async () => {
 			const user = userEvent.setup();
-			const spyChange = jest.fn();
+			const spyChange = vi.fn();
 
 			render(
 				<UncontrolledBoxControl onChange={ ( v ) => spyChange( v ) } />
@@ -425,7 +426,7 @@ describe( 'BoxControl', () => {
 	describe( 'onChange updates', () => {
 		it( 'should call onChange when values contain more than just CSS units', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <UncontrolledBoxControl onChange={ onChangeSpy } /> );
 
@@ -454,7 +455,7 @@ describe( 'BoxControl', () => {
 
 		it( 'should not pass invalid CSS unit only values to onChange', async () => {
 			const user = userEvent.setup();
-			const setState = jest.fn();
+			const setState = vi.fn();
 
 			render( <UncontrolledBoxControl onChange={ setState } /> );
 

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -12,12 +13,15 @@ import { plusCircle } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { press } from '@ariakit/test';
 import _Button from '..';
 import Tooltip from '../../tooltip';
 import cleanupTooltip from '../../tooltip/test/utils';
-import { press } from '@ariakit/test';
 
-jest.mock( '../../icon', () => () => <div data-testid="test-icon" /> );
+vi.mock( import( '../../icon' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	default: () => <div data-testid="test-icon" />,
+} ) );
 
 const Button = forwardRef(
 	(
@@ -623,23 +627,23 @@ describe( 'Button', () => {
 			expect( button ).toHaveAttribute( 'aria-disabled' );
 		} );
 	} );
-
-	describe( 'static typing', () => {
-		<>
-			<Button href="foo" />
-			{ /* @ts-expect-error - `target` requires `href` */ }
-			<Button target="foo" />
-
-			{ /* @ts-expect-error - `disabled` is only for buttons */ }
-			<Button href="foo" disabled />
-
-			<Button href="foo" type="image/png" />
-			{ /* @ts-expect-error - if button, type must be submit/reset/button */ }
-			<Button type="image/png" />
-			{ /* @ts-expect-error */ }
-			<Button type="invalidtype" />
-			{ /* @ts-expect-error */ }
-			<Button disabled accessibleWhenDisabled href="foo" />
-		</>;
-	} );
 } );
+
+// These expressions are checked by TypeScript without registering an empty
+// runtime suite, which Vitest treats as an error.
+<>
+	<Button href="foo" />
+	{ /* @ts-expect-error - `target` requires `href` */ }
+	<Button target="foo" />
+
+	{ /* @ts-expect-error - `disabled` is only for buttons */ }
+	<Button href="foo" disabled />
+
+	<Button href="foo" type="image/png" />
+	{ /* @ts-expect-error - if button, type must be submit/reset/button */ }
+	<Button type="image/png" />
+	{ /* @ts-expect-error */ }
+	<Button type="invalidtype" />
+	{ /* @ts-expect-error */ }
+	<Button disabled accessibleWhenDisabled href="foo" />
+</>;

--- a/packages/components/src/calendar/test/date-calendar.tsx
+++ b/packages/components/src/calendar/test/date-calendar.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -78,10 +79,7 @@ const ControlledDateCalendar = (
 };
 
 function setupUserEvent() {
-	// The `advanceTimersByTime` is needed since we're using jest
-	// fake timers to simulate a fixed date for tests.
-	const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
-	return user;
+	return userEvent.setup();
 }
 
 describe( 'DateCalendar', () => {
@@ -95,10 +93,10 @@ describe( 'DateCalendar', () => {
 	let prevPrevMonth: Date;
 
 	beforeAll( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers( { toFake: [ 'Date' ] } );
 		// For consistent tests, set the system time to a fixed date:
 		// Thursday, May 15, 2025, 20:00 UTC
-		jest.setSystemTime( 1747339200000 );
+		vi.setSystemTime( 1747339200000 );
 		today = startOfDay( new Date() );
 		tomorrow = startOfDay( addDays( today, 1 ) );
 		yesterday = startOfDay( subDays( today, 1 ) );
@@ -110,7 +108,7 @@ describe( 'DateCalendar', () => {
 	} );
 
 	afterAll( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	describe( 'Semantics and basic behavior', () => {
@@ -233,7 +231,7 @@ describe( 'DateCalendar', () => {
 		] )( '[`%s`]', ( _mode, Component ) => {
 			it( 'should select a date when a date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -258,7 +256,7 @@ describe( 'DateCalendar', () => {
 
 			it( 'should not select a disabled date when a date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component onSelect={ onSelect } disabled={ tomorrow } />
@@ -274,7 +272,7 @@ describe( 'DateCalendar', () => {
 
 			it( 'should select a new date when a different date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component
@@ -304,7 +302,7 @@ describe( 'DateCalendar', () => {
 
 			it( 'should de-select the selected date when the selected date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component
@@ -334,7 +332,7 @@ describe( 'DateCalendar', () => {
 
 			it( 'should not de-select the selected date when the selected date button is clicked if the `required` prop is set to `true`', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component
@@ -395,7 +393,7 @@ describe( 'DateCalendar', () => {
 		] )( '[`%s`]', ( _mode, Component ) => {
 			it( 'should navigate to the previous and next months when the previous and next month buttons are clicked', async () => {
 				const user = setupUserEvent();
-				const onMonthChange = jest.fn();
+				const onMonthChange = vi.fn();
 
 				render( <Component onMonthChange={ onMonthChange } /> );
 
@@ -449,7 +447,7 @@ describe( 'DateCalendar', () => {
 
 			it( 'should not navigate to a month that is before the `startMonth` prop', async () => {
 				const user = setupUserEvent();
-				const onMonthChange = jest.fn();
+				const onMonthChange = vi.fn();
 
 				render(
 					<Component
@@ -499,7 +497,7 @@ describe( 'DateCalendar', () => {
 
 			it( 'should not navigate to a month that is after the `endMonth` prop', async () => {
 				const user = setupUserEvent();
-				const onMonthChange = jest.fn();
+				const onMonthChange = vi.fn();
 
 				render(
 					<Component
@@ -920,7 +918,7 @@ describe( 'DateCalendar', () => {
 
 		it( 'should support timezones according to the `timeZone` prop', async () => {
 			const user = setupUserEvent();
-			const onSelect = jest.fn();
+			const onSelect = vi.fn();
 
 			render(
 				<DateCalendar timeZone="Asia/Tokyo" onSelect={ onSelect } />

--- a/packages/components/src/calendar/test/date-range-calendar.tsx
+++ b/packages/components/src/calendar/test/date-range-calendar.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { render, screen, within, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -74,10 +75,7 @@ const ControlledDateRangeCalendar = (
 };
 
 function setupUserEvent() {
-	// The `advanceTimersByTime` is needed since we're using jest
-	// fake timers to simulate a fixed date for tests.
-	const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
-	return user;
+	return userEvent.setup();
 }
 
 describe( 'DateRangeCalendar', () => {
@@ -91,10 +89,10 @@ describe( 'DateRangeCalendar', () => {
 	let prevPrevMonth: Date;
 
 	beforeAll( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers( { toFake: [ 'Date' ] } );
 		// For consistent tests, set the system time to a fixed date:
 		// Thursday, May 15, 2025, 20:00 UTC
-		jest.setSystemTime( 1747339200000 );
+		vi.setSystemTime( 1747339200000 );
 
 		today = startOfDay( new Date() );
 		tomorrow = addDays( today, 1 );
@@ -107,7 +105,7 @@ describe( 'DateRangeCalendar', () => {
 	} );
 
 	afterAll( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	describe( 'Semantics and basic behavior', () => {
@@ -269,7 +267,7 @@ describe( 'DateRangeCalendar', () => {
 		] )( '[`%s`]', ( _mode, Component ) => {
 			it( 'should start selecting a range when a date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -294,7 +292,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should complete a range selection when a second date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -339,7 +337,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should handle selecting dates in reverse order (end date first)', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -384,7 +382,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should expand the current range when clicking a third date after the existing range end', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -440,7 +438,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should update the current range when clicking a third date in between the existing range start and end', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -496,7 +494,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should expand the current range when clicking a third date before the existing range start', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } /> );
 
@@ -550,7 +548,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not select a disabled date when a date button is clicked', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component onSelect={ onSelect } disabled={ tomorrow } />
@@ -567,7 +565,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should clear the range when defining a one-day range and clicking on the same date again', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				const dayAfterTomorrow = addDays( today, 2 );
 
@@ -616,7 +614,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not clear the range when clicking a selected date if the `required` prop is set to `true`', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				const dayAfterTomorrow = addDays( today, 2 );
 
@@ -666,7 +664,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should complete a range selection even if there are disabled dates in the range', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component onSelect={ onSelect } disabled={ tomorrow } />
@@ -709,7 +707,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not complete a range selection if the `excludeDisabled` prop is set to `true` and there is at least one disabled date in the range', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render(
 					<Component
@@ -756,7 +754,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not complete a range selection if the range has a duration of less than the value of the `min` prop', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } min={ 3 } /> );
 
@@ -813,7 +811,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not complete a range selection if the range has a duration of more than the value of the `max` prop', async () => {
 				const user = setupUserEvent();
-				const onSelect = jest.fn();
+				const onSelect = vi.fn();
 
 				render( <Component onSelect={ onSelect } max={ 2 } /> );
 
@@ -900,7 +898,7 @@ describe( 'DateRangeCalendar', () => {
 		] )( '[`%s`]', ( _mode, Component ) => {
 			it( 'should navigate to the previous and next months when the previous and next month buttons are clicked', async () => {
 				const user = setupUserEvent();
-				const onMonthChange = jest.fn();
+				const onMonthChange = vi.fn();
 
 				render( <Component onMonthChange={ onMonthChange } /> );
 
@@ -954,7 +952,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not navigate to a month that is before the `startMonth` prop', async () => {
 				const user = setupUserEvent();
-				const onMonthChange = jest.fn();
+				const onMonthChange = vi.fn();
 
 				render(
 					<Component
@@ -1004,7 +1002,7 @@ describe( 'DateRangeCalendar', () => {
 
 			it( 'should not navigate to a month that is after the `endMonth` prop', async () => {
 				const user = setupUserEvent();
-				const onMonthChange = jest.fn();
+				const onMonthChange = vi.fn();
 
 				render(
 					<Component
@@ -1436,7 +1434,7 @@ describe( 'DateRangeCalendar', () => {
 
 		it( 'should support timezones according to the `timeZone` prop', async () => {
 			const user = setupUserEvent();
-			const onSelect = jest.fn();
+			const onSelect = vi.fn();
 
 			render(
 				<DateRangeCalendar

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Card Card component CardBody should allow scrolling content with the scrollable prop is true 1`] = `
+exports[`Card > Card component > CardBody > should allow scrolling content with the scrollable prop is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -17,7 +17,7 @@ Snapshot Diff:
     </div>
 `;
 
-exports[`Card Card component CardBody should render with a darker background color when isShady is true 1`] = `
+exports[`Card > Card component > CardBody > should render with a darker background color when isShady is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -34,7 +34,7 @@ Snapshot Diff:
     </div>
 `;
 
-exports[`Card Card component CardFooter should render with a darker background color when isShady is true 1`] = `
+exports[`Card > Card component > CardFooter > should render with a darker background color when isShady is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -51,7 +51,7 @@ Snapshot Diff:
       Footer
 `;
 
-exports[`Card Card component CardFooter should use the justify prop to align its content, like a Flex container 1`] = `
+exports[`Card > Card component > CardFooter > should use the justify prop to align its content, like a Flex container 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -69,7 +69,7 @@ Snapshot Diff:
   </div>
 `;
 
-exports[`Card Card component CardHeader should render with a darker background color when isShady is true 1`] = `
+exports[`Card > Card component > CardHeader > should render with a darker background color when isShady is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -86,7 +86,7 @@ Snapshot Diff:
       Header
 `;
 
-exports[`Card Card component should add different amounts of white space when using the size prop 1`] = `
+exports[`Card > Card component > should add different amounts of white space when using the size prop 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -115,7 +115,7 @@ Snapshot Diff:
         </div>
 `;
 
-exports[`Card Card component should add rounded border when the isRounded prop is true 1`] = `
+exports[`Card > Card component > should add rounded border when the isRounded prop is true 1`] = `
 Snapshot Diff:
 - Received styles
 + Base styles
@@ -129,7 +129,7 @@ Snapshot Diff:
   ]
 `;
 
-exports[`Card Card component should get the isBorderless and isSize props (passed from its context) overriddenwhen the same props is specified directly on the component 1`] = `
+exports[`Card > Card component > should get the isBorderless and isSize props (passed from its context) overriddenwhen the same props is specified directly on the component 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -166,7 +166,7 @@ Snapshot Diff:
           Footer
 `;
 
-exports[`Card Card component should pass the isBorderless and isSize props from its context to its sub-components 1`] = `
+exports[`Card > Card component > should pass the isBorderless and isSize props from its context to its sub-components 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -209,7 +209,7 @@ Snapshot Diff:
           Footer
 `;
 
-exports[`Card Card component should render correctly 1`] = `
+exports[`Card > Card component > should render correctly 1`] = `
 .emotion-0 {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;
@@ -412,7 +412,7 @@ exports[`Card Card component should render correctly 1`] = `
 </div>
 `;
 
-exports[`Card Card component should show a box shadow when the elevation prop is greater than 0 1`] = `
+exports[`Card > Card component > should show a box shadow when the elevation prop is greater than 0 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -439,12 +439,12 @@ Snapshot Diff:
   </div>
 `;
 
-exports[`Card Card component should support the legacy extraSmall value for the size prop as an alias for the xSmall value 1`] = `
+exports[`Card > Card component > should support the legacy extraSmall value for the size prop as an alias for the xSmall value 1`] = `
 Snapshot Diff:
 Compared values have no visual difference.
 `;
 
-exports[`Card Card component should warn when the isElevated prop is passed 1`] = `
+exports[`Card > Card component > should warn when the isElevated prop is passed 1`] = `
 .emotion-0 {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   outline: none;

--- a/packages/components/src/card/test/index.tsx
+++ b/packages/components/src/card/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/checkbox-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/checkbox-control/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CheckboxControl Basic rendering should render the indeterminate icon when in the indeterminate state 1`] = `
+exports[`CheckboxControl > Basic rendering > should render the indeterminate icon when in the indeterminate state 1`] = `
 Snapshot Diff:
 - First value
 + Second value

--- a/packages/components/src/checkbox-control/test/index.tsx
+++ b/packages/components/src/checkbox-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -98,7 +99,7 @@ describe( 'CheckboxControl', () => {
 			const user = userEvent.setup();
 
 			let state = false;
-			const setState = jest.fn(
+			const setState = vi.fn(
 				( nextState: boolean ) => ( state = nextState )
 			);
 

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { press } from '@ariakit/test';
 

--- a/packages/components/src/color-indicator/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/color-indicator/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ColorIndicator matches the snapshot 1`] = `
+exports[`ColorIndicator > matches the snapshot 1`] = `
 <div>
   <span
     aria-label="sample label"

--- a/packages/components/src/color-indicator/test/index.tsx
+++ b/packages/components/src/color-indicator/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 /**
@@ -40,7 +41,7 @@ const ControlledColorPalette = ( {
 
 describe( 'ColorPalette', () => {
 	it( 'should render three color button options', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -55,7 +56,7 @@ describe( 'ColorPalette', () => {
 
 	it( 'should call onClick on an active button with undefined', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -73,7 +74,7 @@ describe( 'ColorPalette', () => {
 
 	it( 'should call onClick on an inactive button', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -102,7 +103,7 @@ describe( 'ColorPalette', () => {
 
 	it( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -119,7 +120,7 @@ describe( 'ColorPalette', () => {
 	} );
 
 	it( 'should render custom color picker', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -135,7 +136,7 @@ describe( 'ColorPalette', () => {
 	} );
 
 	it( 'should allow disabling custom color picker', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -152,7 +153,7 @@ describe( 'ColorPalette', () => {
 	} );
 
 	it( 'should render nothing when custom colors are disabled, there are no colors, and it is not clearable', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const { container } = render(
 			<ColorPalette
 				colors={ [] }
@@ -167,7 +168,7 @@ describe( 'ColorPalette', () => {
 
 	it( 'should render dropdown and its content', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -206,7 +207,7 @@ describe( 'ColorPalette', () => {
 	} );
 
 	it( 'should show the clear button by default', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -222,7 +223,7 @@ describe( 'ColorPalette', () => {
 	} );
 
 	it( 'should show the clear button even when `colors` is an empty array', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <ColorPalette colors={ [] } onChange={ onChange } /> );
 
@@ -232,7 +233,7 @@ describe( 'ColorPalette', () => {
 	} );
 
 	it( 'should still show the clear button when colors is empty and custom colors are disabled', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ColorPalette
@@ -308,7 +309,7 @@ describe( 'ColorPalette', () => {
 				<ColorPalette
 					colors={ DUPLICATE_COLOR_PALETTE }
 					value={ undefined }
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 				/>
 			);
 
@@ -321,7 +322,7 @@ describe( 'ColorPalette', () => {
 					colors={ DUPLICATE_COLOR_PALETTE }
 					value="#000"
 					selectedSlug="dark-text"
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 				/>
 			);
 
@@ -337,7 +338,7 @@ describe( 'ColorPalette', () => {
 				<ColorPalette
 					colors={ DUPLICATE_COLOR_PALETTE }
 					value="#000"
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 				/>
 			);
 
@@ -354,7 +355,7 @@ describe( 'ColorPalette', () => {
 					colors={ DUPLICATE_COLOR_PALETTE }
 					value="#000"
 					selectedSlug=""
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 				/>
 			);
 
@@ -369,7 +370,7 @@ describe( 'ColorPalette', () => {
 					colors={ DUPLICATE_COLOR_PALETTE }
 					value="#000"
 					selectedSlug="dark-text"
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 				/>
 			);
 
@@ -382,7 +383,7 @@ describe( 'ColorPalette', () => {
 
 		it( 'should pass slug as third argument to onChange when a swatch is clicked', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ColorPalette
@@ -400,7 +401,7 @@ describe( 'ColorPalette', () => {
 
 		it( 'should clear the selection when the selected swatch is clicked', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ColorPalette
@@ -430,7 +431,7 @@ describe( 'ColorPalette', () => {
 					colors={ MIXED_PALETTE }
 					value="#fff"
 					selectedSlug="brand-white"
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 				/>
 			);
 

--- a/packages/components/src/color-palette/test/utils.ts
+++ b/packages/components/src/color-palette/test/utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { click } from '@ariakit/test';
@@ -73,7 +74,7 @@ describe( 'ColorPicker', () => {
 	describe( 'legacy props', () => {
 		it( 'should fire onChangeComplete with the legacy color format', async () => {
 			const user = userEvent.setup();
-			const onChangeComplete = jest.fn();
+			const onChangeComplete = vi.fn();
 			const color = '#000';
 
 			render(
@@ -104,7 +105,7 @@ describe( 'ColorPicker', () => {
 	describe( 'Hex input', () => {
 		it( 'should fire onChange with the correct value from the hex input', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const color = '#000';
 
 			render(
@@ -132,7 +133,7 @@ describe( 'ColorPicker', () => {
 
 		it( 'should reset color to black when the hex input is completely cleared', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const color = '#11aabb';
 
 			render(
@@ -160,7 +161,7 @@ describe( 'ColorPicker', () => {
 	] )( 'RGB inputs', ( colorInput, inputLabel, expected ) => {
 		it( `should fire onChange with the correct value when the ${ colorInput } value is updated`, async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const color = '#fff';
 
 			render(
@@ -192,7 +193,7 @@ describe( 'ColorPicker', () => {
 	describe( 'HSL inputs', () => {
 		it( 'sliders should use accurate H and S values based on user interaction when possible', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker
@@ -333,7 +334,7 @@ describe( 'ColorPicker', () => {
 		} );
 
 		it( 'should preserve hue and saturation when lightness is set to 0 (black)', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker
@@ -384,7 +385,7 @@ describe( 'ColorPicker', () => {
 		] )(
 			'should allow saturation 50→0 at %s without firing onChange',
 			async ( _label, lightness ) => {
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 
 				render(
 					<ControlledColorPicker
@@ -433,7 +434,7 @@ describe( 'ColorPicker', () => {
 		);
 
 		it( 'should fire onChange once per real color change in controlled mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker
@@ -512,7 +513,7 @@ describe( 'ColorPicker', () => {
 		} );
 
 		it( 'should preserve hue when saturation is set to 0', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker
@@ -567,7 +568,7 @@ describe( 'ColorPicker', () => {
 		] )( 'HSL inputs', ( colorInput, inputLabel, expected ) => {
 			it( `should fire onChange with the correct value when the ${ colorInput } value is updated`, async () => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				const color = '#2ad5d5';
 
 				render(
@@ -614,7 +615,7 @@ describe( 'ColorPicker', () => {
 		};
 
 		it( 'preserves saturation when keyboard-navigating to black in controlled mode', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			// Saturated red with mid brightness — HSVA s stays high at black.
 			const { container } = render(
@@ -652,7 +653,7 @@ describe( 'ColorPicker', () => {
 		} );
 
 		it( 'preserves saturation when pointer selects black in controlled mode', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const { container } = render(
 				<ControlledColorPicker
@@ -690,7 +691,7 @@ describe( 'ColorPicker', () => {
 
 		it( 'preserves saturation after a full pointer drag to black then HSL hue edit', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const { container } = render(
 				<ControlledColorPicker
@@ -772,7 +773,7 @@ describe( 'ColorPicker', () => {
 
 		it( 'places the pointer at s:0 when HSL lightness is set to white', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const { container } = render(
 				<ControlledColorPicker
@@ -891,7 +892,7 @@ describe( 'ColorPicker', () => {
 
 		it( 'uses the HSL hue when leaving white through the visual surface', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker
@@ -929,7 +930,7 @@ describe( 'ColorPicker', () => {
 
 		it( 'uses the HSL hue when leaving a mid-gray through the visual surface', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker
@@ -1009,7 +1010,7 @@ describe( 'ColorPicker', () => {
 	] )( 'Alpha-enabled %s format', ( format, formatLabel ) => {
 		it( `should update alpha correctly when ${ formatLabel } format is selected`, async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<ControlledColorPicker

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -131,7 +132,7 @@ describe.each( [
 	it( 'should select the correct option via click events', async () => {
 		const user = await userEvent.setup();
 		const targetOption = timezones[ 2 ];
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }
@@ -156,7 +157,7 @@ describe.each( [
 		const user = await userEvent.setup();
 		const targetIndex = 4;
 		const targetOption = timezones[ targetIndex ];
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }
@@ -184,7 +185,7 @@ describe.each( [
 
 	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
 		const user = userEvent.setup();
-		const onFilterValueChangeSpy = jest.fn();
+		const onFilterValueChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }
@@ -201,7 +202,7 @@ describe.each( [
 
 	it( 'clears the textbox value if there is no selected value on blur', async () => {
 		const user = userEvent.setup();
-		const onFilterValueChangeSpy = jest.fn();
+		const onFilterValueChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }
@@ -225,7 +226,7 @@ describe.each( [
 	it( 'should select the correct option from a search', async () => {
 		const user = await userEvent.setup();
 		const targetOption = timezones[ 13 ];
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }
@@ -252,7 +253,7 @@ describe.each( [
 	it( 'should render aria-live announcement upon selection', async () => {
 		const user = await userEvent.setup();
 		const targetOption = timezones[ 9 ];
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }
@@ -281,7 +282,7 @@ describe.each( [
 		const user = await userEvent.setup();
 		const unmatchedString = 'Mordor';
 		const targetOption = timezones[ 6 ];
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 		render(
 			<Component
 				options={ timezones }

--- a/packages/components/src/composite/legacy/test/index.tsx
+++ b/packages/components/src/composite/legacy/test/index.tsx
@@ -2,6 +2,16 @@
  * External dependencies
  */
 import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	test,
+	vi,
+	type MockInstance,
+} from 'vitest';
+import {
 	queryByAttribute,
 	render,
 	screen,
@@ -23,12 +33,12 @@ import {
 // page down. Without this, nothing has a height, and so paging up
 // and down doesn't behave as expected in tests.
 
-let clientHeightSpy: jest.SpiedGetter<
-	typeof HTMLElement.prototype.clientHeight
+let clientHeightSpy: MockInstance<
+	() => typeof HTMLElement.prototype.clientHeight
 >;
 
 beforeAll( () => {
-	clientHeightSpy = jest
+	clientHeightSpy = vi
 		.spyOn( HTMLElement.prototype, 'clientHeight', 'get' )
 		.mockImplementation( function getClientHeight( this: HTMLElement ) {
 			if ( this.tagName === 'BODY' ) {

--- a/packages/components/src/composite/test/index.tsx
+++ b/packages/components/src/composite/test/index.tsx
@@ -1,6 +1,16 @@
 /**
  * External dependencies
  */
+import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	test,
+	vi,
+	type MockInstance,
+} from 'vitest';
 import { queryByAttribute, render, screen } from '@testing-library/react';
 import { click, press, waitFor } from '@ariakit/test';
 import type { ComponentProps } from 'react';
@@ -29,15 +39,15 @@ async function renderAndValidate( ...args: Parameters< typeof render > ) {
 }
 
 describe( 'Composite', () => {
-	let clientHeightSpy: jest.SpiedGetter<
-		typeof HTMLElement.prototype.clientHeight
+	let clientHeightSpy: MockInstance<
+		() => typeof HTMLElement.prototype.clientHeight
 	>;
 
 	beforeAll( () => {
 		// This is necessary because of how Ariakit calculates page up and
 		// page down. Without this, nothing has a height, and so paging up
 		// and down doesn't behave as expected in tests.
-		clientHeightSpy = jest
+		clientHeightSpy = vi
 			.spyOn( HTMLElement.prototype, 'clientHeight', 'get' )
 			.mockImplementation( function getClientHeight( this: HTMLElement ) {
 				if ( this.tagName === 'BODY' ) {

--- a/packages/components/src/confirm-dialog/test/index.tsx
+++ b/packages/components/src/confirm-dialog/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -81,7 +82,7 @@ describe( 'Confirm', () => {
 			it( 'should not render if closed by clicking `OK`, and the `onConfirm` callback should be called', async () => {
 				const user = userEvent.setup();
 
-				const onConfirm = jest.fn().mockName( 'onConfirm()' );
+				const onConfirm = vi.fn().mockName( 'onConfirm()' );
 
 				render(
 					<ConfirmDialog onConfirm={ onConfirm }>
@@ -101,7 +102,7 @@ describe( 'Confirm', () => {
 			it( 'should not render if closed by clicking `Cancel`, and the `onCancel` callback should be called', async () => {
 				const user = userEvent.setup();
 
-				const onCancel = jest.fn().mockName( 'onCancel()' );
+				const onCancel = vi.fn().mockName( 'onCancel()' );
 
 				render(
 					<ConfirmDialog onConfirm={ noop } onCancel={ onCancel }>
@@ -137,7 +138,7 @@ describe( 'Confirm', () => {
 
 			it( 'should not render if dialog is closed by clicking the overlay, and the `onCancel` callback should be called', async () => {
 				const user = userEvent.setup();
-				const onCancel = jest.fn().mockName( 'onCancel()' );
+				const onCancel = vi.fn().mockName( 'onCancel()' );
 
 				render(
 					<ConfirmDialog onConfirm={ noop } onCancel={ onCancel }>
@@ -158,7 +159,7 @@ describe( 'Confirm', () => {
 			it( 'should not render if dialog is closed by pressing `Escape`, and the `onCancel` callback should be called', async () => {
 				const user = userEvent.setup();
 
-				const onCancel = jest.fn().mockName( 'onCancel()' );
+				const onCancel = vi.fn().mockName( 'onCancel()' );
 
 				render(
 					<ConfirmDialog onConfirm={ noop } onCancel={ onCancel }>
@@ -177,7 +178,7 @@ describe( 'Confirm', () => {
 			it( 'should not render if dialog is closed by pressing `Enter`, and the `onConfirm` callback should be called', async () => {
 				const user = userEvent.setup();
 
-				const onConfirm = jest.fn().mockName( 'onConfirm()' );
+				const onConfirm = vi.fn().mockName( 'onConfirm()' );
 
 				render(
 					<ConfirmDialog onConfirm={ onConfirm }>
@@ -196,8 +197,8 @@ describe( 'Confirm', () => {
 			it( 'calls only the `onCancel` callback and not the `onConfirm` callback when the cancel button is submitted using the keyboard', async () => {
 				const user = userEvent.setup();
 
-				const onConfirm = jest.fn().mockName( 'onConfirm()' );
-				const onCancel = jest.fn().mockName( 'onCancel()' );
+				const onConfirm = vi.fn().mockName( 'onConfirm()' );
+				const onCancel = vi.fn().mockName( 'onCancel()' );
 
 				render(
 					<ConfirmDialog
@@ -217,8 +218,8 @@ describe( 'Confirm', () => {
 			it( 'calls only the `onConfirm` callback when the confirm button is submitted using the keyboard', async () => {
 				const user = userEvent.setup();
 
-				const onConfirm = jest.fn().mockName( 'onConfirm()' );
-				const onCancel = jest.fn().mockName( 'onCancel()' );
+				const onConfirm = vi.fn().mockName( 'onConfirm()' );
+				const onCancel = vi.fn().mockName( 'onCancel()' );
 
 				render(
 					<ConfirmDialog
@@ -271,7 +272,7 @@ describe( 'Confirm', () => {
 		it( 'should call the `onConfirm` callback if `OK`', async () => {
 			const user = userEvent.setup();
 
-			const onConfirm = jest.fn().mockName( 'onConfirm()' );
+			const onConfirm = vi.fn().mockName( 'onConfirm()' );
 
 			render(
 				<ConfirmDialog isOpen onConfirm={ onConfirm }>
@@ -289,7 +290,7 @@ describe( 'Confirm', () => {
 		it( 'should call the `onCancel` callback if `Cancel` is clicked', async () => {
 			const user = userEvent.setup();
 
-			const onCancel = jest.fn().mockName( 'onCancel()' );
+			const onCancel = vi.fn().mockName( 'onCancel()' );
 
 			render(
 				<ConfirmDialog isOpen onConfirm={ noop } onCancel={ onCancel }>
@@ -306,7 +307,7 @@ describe( 'Confirm', () => {
 
 		it( 'should call the `onCancel` callback if the overlay is clicked', async () => {
 			const user = userEvent.setup();
-			const onCancel = jest.fn().mockName( 'onCancel()' );
+			const onCancel = vi.fn().mockName( 'onCancel()' );
 
 			render(
 				<ConfirmDialog isOpen onConfirm={ noop } onCancel={ onCancel }>
@@ -326,7 +327,7 @@ describe( 'Confirm', () => {
 		it( 'should call the `onCancel` callback if the `Escape` key is pressed', async () => {
 			const user = userEvent.setup();
 
-			const onCancel = jest.fn().mockName( 'onCancel()' );
+			const onCancel = vi.fn().mockName( 'onCancel()' );
 
 			render(
 				<ConfirmDialog onConfirm={ noop } onCancel={ onCancel }>
@@ -342,7 +343,7 @@ describe( 'Confirm', () => {
 		it( 'should call the `onConfirm` callback if the `Enter` key is pressed', async () => {
 			const user = userEvent.setup();
 
-			const onConfirm = jest.fn().mockName( 'onConfirm()' );
+			const onConfirm = vi.fn().mockName( 'onConfirm()' );
 
 			render(
 				<ConfirmDialog isOpen onConfirm={ onConfirm } onCancel={ noop }>

--- a/packages/components/src/content-editable-control/test/index.tsx
+++ b/packages/components/src/content-editable-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
@@ -149,15 +150,15 @@ describe( 'ContentEditableControl', () => {
 	it( 'forwards its ref to the contenteditable element', () => {
 		// The rich-text wiring (the `useRichText` ref, event-listener refs,
 		// an anchor ref, …) is injected through this forwarded ref.
-		const ref = jest.fn();
+		const ref = vi.fn();
 		render( <ContentEditableControl label="Note" ref={ ref } /> );
 
 		expect( ref ).toHaveBeenCalledWith( screen.getByRole( 'textbox' ) );
 	} );
 
 	it( 'calls consumer-supplied focus and blur handlers', () => {
-		const onFocus = jest.fn();
-		const onBlur = jest.fn();
+		const onFocus = vi.fn();
+		const onBlur = vi.fn();
 		render(
 			<ContentEditableControl
 				label="Field"

--- a/packages/components/src/context/test/__snapshots__/context-system-provider.js.snap
+++ b/packages/components/src/context/test/__snapshots__/context-system-provider.js.snap
@@ -1,9 +1,9 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render _override props 1`] = `
+exports[`props > should render _override props 1`] = `
 <div>
   <div
-    class="components-component test-component css-yi1hlk-View emotion-0"
+    class="components-component test-component emotion-empty-View emotion-0"
     data-wp-c16t="true"
     data-wp-component="Component"
   >
@@ -12,10 +12,10 @@ exports[`props should render _override props 1`] = `
 </div>
 `;
 
-exports[`props should render context props 1`] = `
+exports[`props > should render context props 1`] = `
 <div>
   <div
-    class="components-component css-yi1hlk-View emotion-0"
+    class="components-component emotion-empty-View emotion-0"
     data-wp-c16t="true"
     data-wp-component="Component"
   >
@@ -24,10 +24,10 @@ exports[`props should render context props 1`] = `
 </div>
 `;
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 <div>
   <div
-    class="components-component css-yi1hlk-View emotion-0"
+    class="components-component emotion-empty-View emotion-0"
     data-wp-c16t="true"
     data-wp-component="Component"
   />

--- a/packages/components/src/context/test/context-connect.tsx
+++ b/packages/components/src/context/test/context-connect.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, it } from 'vitest';
 import type { ForwardedRef } from 'react';
 
 /**
@@ -10,7 +11,6 @@ import { contextConnect, contextConnectWithoutRef } from '../context-connect';
 import type { WordPressComponentProps } from '../wordpress-component';
 
 // Static TypeScript tests
-/* eslint-disable jest/expect-expect */
 describe( 'ref forwarding', () => {
 	const ComponentWithRef = (
 		props: WordPressComponentProps< {}, 'div' >,
@@ -54,4 +54,3 @@ describe( 'ref forwarding', () => {
 		<NoRef foo={ null } />;
 	} );
 } );
-/* eslint-enable jest/expect-expect */

--- a/packages/components/src/context/test/context-system-provider.js
+++ b/packages/components/src/context/test/context-system-provider.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import styled from '@emotion/styled';
 

--- a/packages/components/src/context/test/wordpress-component.tsx
+++ b/packages/components/src/context/test/wordpress-component.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, it } from 'vitest';
 import type { ForwardedRef } from 'react';
 
 /**
@@ -14,7 +15,6 @@ import { forwardRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../wordpress-component';
 
 // Static TypeScript checks
-/* eslint-disable jest/expect-expect */
 describe( 'WordPressComponentProps', () => {
 	it( 'should not accept a ref', () => {
 		const Foo = ( props: WordPressComponentProps< {}, 'div' > ) => (
@@ -35,4 +35,3 @@ describe( 'WordPressComponentProps', () => {
 		<ForwardedFoo ref={ null } />;
 	} );
 } );
-/* eslint-enable jest/expect-expect */

--- a/packages/components/src/custom-gradient-picker/gradient-bar/test/utils.ts
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/test/utils.ts
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getHorizontalRelativeGradientPosition } from '../utils';
 
 describe( 'getHorizontalRelativeGradientPosition', () => {
 	it( 'should return relative percentage position', () => {
-		jest.spyOn(
+		vi.spyOn(
 			window.HTMLElement.prototype,
 			'getBoundingClientRect'
 		).mockImplementationOnce(
@@ -23,7 +28,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 	} );
 
 	it( 'should subtract the x position of the container from the mouse position', () => {
-		jest.spyOn(
+		vi.spyOn(
 			window.HTMLElement.prototype,
 			'getBoundingClientRect'
 		).mockImplementationOnce(
@@ -41,7 +46,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 	} );
 
 	it( 'should clamp to a whole percentage number', () => {
-		jest.spyOn(
+		vi.spyOn(
 			window.HTMLElement.prototype,
 			'getBoundingClientRect'
 		).mockImplementationOnce(
@@ -60,7 +65,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 	} );
 
 	it( 'should clamp to zero when mouse position is less the x position', () => {
-		jest.spyOn(
+		vi.spyOn(
 			window.HTMLElement.prototype,
 			'getBoundingClientRect'
 		).mockImplementationOnce(
@@ -78,7 +83,7 @@ describe( 'getHorizontalRelativeGradientPosition', () => {
 	} );
 
 	it( 'should clamp to 100 when mouse position is greater than width', () => {
-		jest.spyOn(
+		vi.spyOn(
 			window.HTMLElement.prototype,
 			'getBoundingClientRect'
 		).mockImplementationOnce(

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -123,7 +124,7 @@ describe( 'CustomGradientPicker', () => {
 	describe( 'GradientTypePicker angle persistence', () => {
 		it( 'should restore the previous linear angle when switching from radial back to linear', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<CustomGradientPicker
@@ -146,7 +147,7 @@ describe( 'CustomGradientPicker', () => {
 
 		it( 'should use HORIZONTAL_GRADIENT_ORIENTATION when no prior linear angle exists', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			// Start with a radial gradient so there is no previous linear angle in the ref
 			render(
@@ -168,7 +169,7 @@ describe( 'CustomGradientPicker', () => {
 
 		it( 'should not restore angle when switching to radial', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<CustomGradientPicker

--- a/packages/components/src/custom-gradient-picker/test/serializer.ts
+++ b/packages/components/src/custom-gradient-picker/test/serializer.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/components/src/custom-select-control-v2/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import { click, press, type } from '@ariakit/test';
 import { render } from '@ariakit/test/react';
@@ -233,7 +234,7 @@ describe.each( [
 
 	describe( 'Multiple selection', () => {
 		it( 'Should be able to select multiple items when provided an array', async () => {
-			const onChangeMock = jest.fn();
+			const onChangeMock = vi.fn();
 
 			// initial selection as defaultValue
 			const defaultValues = [

--- a/packages/components/src/custom-select-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/custom-select-control/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Legacy size support treats __unstable-large the same as default 1`] = `
+exports[`Legacy size support > treats __unstable-large the same as default 1`] = `
 Snapshot Diff:
 Compared values have no visual difference.
 `;

--- a/packages/components/src/custom-select-control/test/index.tsx
+++ b/packages/components/src/custom-select-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import { click, press, sleep, type, waitFor } from '@ariakit/test';
 import { render } from '@ariakit/test/react';
@@ -89,7 +90,7 @@ const ControlledCustomSelectControl = ( {
 };
 
 it( 'Should apply external controlled updates', async () => {
-	const mockOnChange = jest.fn();
+	const mockOnChange = vi.fn();
 	const { rerender } = await render(
 		<UncontrolledCustomSelectControl
 			{ ...props }
@@ -128,7 +129,7 @@ describe.each( [
 	const [ , Component ] = modeAndComponent;
 
 	it( 'Should select the first option when no explicit initial value is passed without firing onChange', async () => {
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 		await render( <Component { ...props } onChange={ mockOnChange } /> );
 
 		expect(
@@ -144,7 +145,7 @@ describe.each( [
 	} );
 
 	it( 'Should pick the initially selected option if the value prop is passed without firing onChange', async () => {
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 		await render(
 			<Component
 				{ ...props }
@@ -357,7 +358,7 @@ describe.each( [
 	} );
 
 	it( 'Should return object onChange', async () => {
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		await render( <Component { ...props } onChange={ mockOnChange } /> );
 
@@ -387,7 +388,7 @@ describe.each( [
 	} );
 
 	it( 'Should return selectedItem object when specified onChange', async () => {
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		await render( <Component { ...props } onChange={ mockOnChange } /> );
 
@@ -413,7 +414,7 @@ describe.each( [
 	} );
 
 	it( "Should pass arbitrary props to onChange's selectedItem, but apply only style and className to DOM elements", async () => {
-		const onChangeMock = jest.fn();
+		const onChangeMock = vi.fn();
 
 		await render( <Component { ...props } onChange={ onChangeMock } /> );
 
@@ -464,7 +465,7 @@ describe.each( [
 
 	describe( 'Keyboard behavior and accessibility', () => {
 		it( 'Captures the keypress event and does not let it propagate', async () => {
-			const onKeyDown = jest.fn();
+			const onKeyDown = vi.fn();
 
 			await render(
 				<div
@@ -642,8 +643,8 @@ describe.each( [
 		} );
 
 		it( 'Should call custom event handlers', async () => {
-			const onFocusMock = jest.fn();
-			const onBlurMock = jest.fn();
+			const onFocusMock = vi.fn();
+			const onBlurMock = vi.fn();
 
 			await render(
 				<>
@@ -718,7 +719,6 @@ describe( 'Legacy size support', () => {
 } );
 
 describe( 'Type checking', () => {
-	// eslint-disable-next-line jest/expect-expect
 	it( 'should infer the value type from available `options`, but not the `value` or `onChange` prop', () => {
 		const options = [
 			{

--- a/packages/components/src/date-time/date-picker/test/index.tsx
+++ b/packages/components/src/date-time/date-picker/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { format } from 'date-fns';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -33,7 +34,7 @@ describe( 'DatePicker', () => {
 	it( 'should call onChange when a day is selected', async () => {
 		const user = userEvent.setup();
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<DatePicker
@@ -52,8 +53,8 @@ describe( 'DatePicker', () => {
 	it( 'should call onMonthPreviewed and onChange when a day in a different month is selected', async () => {
 		const user = userEvent.setup();
 
-		const onMonthPreviewed = jest.fn();
-		const onChange = jest.fn();
+		const onMonthPreviewed = vi.fn();
+		const onChange = vi.fn();
 
 		render(
 			<DatePicker

--- a/packages/components/src/date-time/date-picker/test/use-lilius.ts
+++ b/packages/components/src/date-time/date-picker/test/use-lilius.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { addYears, getYear, set, startOfToday, subYears } from 'date-fns';
 

--- a/packages/components/src/date-time/date-time/test/index.tsx
+++ b/packages/components/src/date-time/date-time/test/index.tsx
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import timezoneMock from 'timezone-mock';
@@ -31,7 +40,7 @@ describe( 'DateTimePicker', () => {
 	} );
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 		timezoneMock.unregister();
 	} );
 
@@ -41,7 +50,7 @@ describe( 'DateTimePicker', () => {
 
 	it( 'should display and select dates correctly when timezones match', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		timezoneMock.register( 'US/Eastern' );
 
@@ -131,7 +140,7 @@ describe( 'DateTimePicker', () => {
 				} ) => {
 					it( 'should display and select dates correctly', async () => {
 						const user = userEvent.setup();
-						const onChange = jest.fn();
+						const onChange = vi.fn();
 
 						timezoneMock.register( timezone );
 
@@ -207,7 +216,7 @@ describe( 'DateTimePicker', () => {
 
 	describe( 'input types with timezone variations', () => {
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 			timezoneMock.unregister();
 		} );
 
@@ -279,16 +288,14 @@ describe( 'DateTimePicker', () => {
 					// set initial dates.
 					let user: ReturnType< typeof userEvent.setup >;
 					if ( initialDate === undefined ) {
-						jest.useFakeTimers();
-						jest.setSystemTime( Date.UTC( 2025, 10, 16, 1, 0, 0 ) );
-						user = userEvent.setup( {
-							advanceTimers: jest.advanceTimersByTime,
-						} );
+						vi.useFakeTimers( { toFake: [ 'Date' ] } );
+						vi.setSystemTime( Date.UTC( 2025, 10, 16, 1, 0, 0 ) );
+						user = userEvent.setup();
 					} else {
 						user = userEvent.setup();
 					}
 
-					const onChange = jest.fn();
+					const onChange = vi.fn();
 					const { rerender } = render(
 						<DateTimePicker
 							currentDate={ initialDate }
@@ -403,7 +410,7 @@ describe( 'DateTimePicker', () => {
 
 	it( 'should preserve time when changing date', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		timezoneMock.register( 'UTC' );
 

--- a/packages/components/src/date-time/test/utils.test.ts
+++ b/packages/components/src/date-time/test/utils.test.ts
@@ -1,3 +1,16 @@
+/**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from 'vitest';
+
 import timezoneMock from 'timezone-mock';
 import { getSettings, setSettings, type DateSettings } from '@wordpress/date';
 import { inputToDate, getDaysInMonth } from '../utils';

--- a/packages/components/src/date-time/time-picker/test/index.tsx
+++ b/packages/components/src/date-time/time-picker/test/index.tsx
@@ -1,6 +1,16 @@
 /**
  * External dependencies
  */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import timezoneMock from 'timezone-mock';
@@ -19,7 +29,7 @@ describe( 'TimePicker', () => {
 	it( 'should call onChange with updated date values', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -73,7 +83,7 @@ describe( 'TimePicker', () => {
 	it( 'should call onChange with an updated hour (12-hour clock)', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -95,7 +105,7 @@ describe( 'TimePicker', () => {
 	it( 'should call onChange with a bounded hour (12-hour clock) if the hour is out of bounds', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -117,7 +127,7 @@ describe( 'TimePicker', () => {
 	it( 'should call onChange with an updated hour (24-hour clock)', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -139,7 +149,7 @@ describe( 'TimePicker', () => {
 	it( 'should call onChange with a bounded minute if out of bounds', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -161,7 +171,7 @@ describe( 'TimePicker', () => {
 	it( 'should call onChange with a bounded day if out of bounds', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -184,7 +194,7 @@ describe( 'TimePicker', () => {
 	it( 'should clamp day when switching months', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -206,7 +216,7 @@ describe( 'TimePicker', () => {
 	it( 'should clamp day when switching year from leap to non-leap', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -230,7 +240,7 @@ describe( 'TimePicker', () => {
 	it( 'should switch to PM correctly', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -250,7 +260,7 @@ describe( 'TimePicker', () => {
 	it( 'should switch to AM correctly', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -270,7 +280,7 @@ describe( 'TimePicker', () => {
 	it( 'should allow to set the time correctly when the PM period is selected', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -303,7 +313,7 @@ describe( 'TimePicker', () => {
 	it( 'should truncate at the minutes on change', async () => {
 		const user = userEvent.setup();
 
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -323,7 +333,7 @@ describe( 'TimePicker', () => {
 	} );
 
 	it( 'should reset the date when currentTime changed', () => {
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		const { rerender } = render(
 			<TimePicker
@@ -362,7 +372,7 @@ describe( 'TimePicker', () => {
 	} );
 
 	it( 'should have different layouts/orders for 12/24 hour formats', () => {
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		const { rerender } = render(
 			<form aria-label="form">
@@ -406,7 +416,7 @@ describe( 'TimePicker', () => {
 	} );
 
 	it( 'Should change layouts/orders when `dateOrder` prop is passed', () => {
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<form aria-label="form">
@@ -436,7 +446,7 @@ describe( 'TimePicker', () => {
 	} );
 
 	it( 'Should ignore `is12Hour` prop setting when `dateOrder` prop is explicitly passed', () => {
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<form aria-label="form">
@@ -467,7 +477,7 @@ describe( 'TimePicker', () => {
 	} );
 
 	it( 'Should set a time when passed a null currentTime', () => {
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimePicker
@@ -516,7 +526,7 @@ describe( 'TimePicker', () => {
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 			timezoneMock.unregister();
 		} );
 
@@ -587,19 +597,15 @@ describe( 'TimePicker', () => {
 					// For undefined, set fake system time to get a known current time
 					let user: ReturnType< typeof userEvent.setup >;
 					if ( initialTime === undefined ) {
-						jest.useFakeTimers();
+						vi.useFakeTimers( { toFake: [ 'Date' ] } );
 						// Set system time to 12:00 UTC
-						jest.setSystemTime(
-							Date.UTC( 2025, 11, 18, 12, 0, 0 )
-						);
-						user = userEvent.setup( {
-							advanceTimers: jest.advanceTimersByTime,
-						} );
+						vi.setSystemTime( Date.UTC( 2025, 11, 18, 12, 0, 0 ) );
+						user = userEvent.setup();
 					} else {
 						user = userEvent.setup();
 					}
 
-					const onChange = jest.fn();
+					const onChange = vi.fn();
 
 					const { rerender } = render(
 						<TimePicker
@@ -664,7 +670,7 @@ describe( 'TimePicker', () => {
 	describe( 'ISO 8601 compliance', () => {
 		it( 'should handle years below 1000 with zero-padded output', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<TimePicker

--- a/packages/components/src/date-time/time-picker/time-input/test/index.tsx
+++ b/packages/components/src/date-time/time-picker/time-input/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,7 +15,7 @@ describe( 'TimeInput', () => {
 		const user = userEvent.setup();
 
 		const timeInputValue = { hours: 0, minutes: 0 };
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimeInput
@@ -66,7 +67,7 @@ describe( 'TimeInput', () => {
 		const user = userEvent.setup();
 
 		const timeInputValue = { hours: 0, minutes: 0 };
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimeInput
@@ -113,7 +114,7 @@ describe( 'TimeInput', () => {
 		const user = userEvent.setup();
 
 		const timeInputValue = { hours: 0, minutes: 0 };
-		const onChangeSpy = jest.fn();
+		const onChangeSpy = vi.fn();
 
 		render(
 			<TimeInput

--- a/packages/components/src/disabled/test/index.tsx
+++ b/packages/components/src/disabled/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/components/src/divider/test/index.tsx
+++ b/packages/components/src/divider/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -17,7 +17,7 @@ import type { DraggableProps } from './types';
 import styles from './style.module.scss';
 
 // Legacy class names preserved alongside the CSS-module hashed ones for
-// backwards compatibility. `filter(Boolean)` strips `undefined` from Jest's
+// backwards compatibility. `filter(Boolean)` strips `undefined` from the
 // CSS-module mock.
 const dragImageClasses = [
 	styles[ 'invisible-drag-image' ],

--- a/packages/components/src/dropdown-menu/test/index.tsx
+++ b/packages/components/src/dropdown-menu/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -37,22 +38,22 @@ describe( 'DropdownMenu', () => {
 			{
 				title: 'Up',
 				icon: arrowUp,
-				onClick: jest.fn(),
+				onClick: vi.fn(),
 			},
 			{
 				title: 'Right',
 				icon: arrowRight,
-				onClick: jest.fn(),
+				onClick: vi.fn(),
 			},
 			{
 				title: 'Down',
 				icon: arrowDown,
-				onClick: jest.fn(),
+				onClick: vi.fn(),
 			},
 			{
 				title: 'Left',
 				icon: arrowLeft,
-				onClick: jest.fn(),
+				onClick: vi.fn(),
 			},
 		];
 

--- a/packages/components/src/dropdown/test/index.tsx
+++ b/packages/components/src/dropdown/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/components/src/elevation/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/elevation/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render active 1`] = `
+exports[`props > should render active 1`] = `
 .emotion-0 {
   background: transparent;
   display: block;
@@ -41,7 +41,7 @@ exports[`props should render active 1`] = `
 />
 `;
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 .emotion-0 {
   background: transparent;
   display: block;
@@ -74,7 +74,7 @@ exports[`props should render correctly 1`] = `
 />
 `;
 
-exports[`props should render hover 1`] = `
+exports[`props > should render hover 1`] = `
 .emotion-0 {
   background: transparent;
   display: block;
@@ -111,7 +111,7 @@ exports[`props should render hover 1`] = `
 />
 `;
 
-exports[`props should render isInteractive 1`] = `
+exports[`props > should render isInteractive 1`] = `
 .emotion-0 {
   background: transparent;
   display: block;
@@ -152,7 +152,7 @@ exports[`props should render isInteractive 1`] = `
 />
 `;
 
-exports[`props should render offset 1`] = `
+exports[`props > should render offset 1`] = `
 .emotion-0 {
   background: transparent;
   display: block;
@@ -193,7 +193,7 @@ exports[`props should render offset 1`] = `
 />
 `;
 
-exports[`props should render value 1`] = `
+exports[`props > should render value 1`] = `
 .emotion-0 {
   background: transparent;
   display: block;

--- a/packages/components/src/elevation/test/index.tsx
+++ b/packages/components/src/elevation/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/external-link/test/index.tsx
+++ b/packages/components/src/external-link/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -12,7 +13,7 @@ import { ExternalLink } from '..';
 describe( 'ExternalLink', () => {
 	test( 'should call function passed in onClick handler when clicking the link', async () => {
 		const user = await userEvent.setup();
-		const onClickMock = jest.fn();
+		const onClickMock = vi.fn();
 
 		render(
 			<ExternalLink href="https://wordpress.org" onClick={ onClickMock }>
@@ -42,7 +43,7 @@ describe( 'ExternalLink', () => {
 
 		// We are using this approach so we can test the defaultPrevented
 		// without passing an onClick prop to the component.
-		const onClickMock = jest.fn();
+		const onClickMock = vi.fn();
 		link.onclick = onClickMock;
 
 		await user.click( link );
@@ -54,7 +55,7 @@ describe( 'ExternalLink', () => {
 
 	test( 'should call function passed in onClick handler and prevent default action when clicking an internal anchor link', async () => {
 		const user = await userEvent.setup();
-		const onClickMock = jest.fn();
+		const onClickMock = vi.fn();
 
 		render(
 			<ExternalLink href="#test" onClick={ onClickMock }>
@@ -88,7 +89,7 @@ describe( 'ExternalLink', () => {
 
 		// We are using this approach so we can test the defaultPrevented
 		// without passing an onClick prop to the component.
-		const onClickMock = jest.fn();
+		const onClickMock = vi.fn();
 		link.onclick = onClickMock;
 
 		await user.click( link );

--- a/packages/components/src/flex/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/flex/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 <div
   class="style-flex style-items-row style-expanded-row components-flex"
   data-testid="base-flex"

--- a/packages/components/src/flex/test/index.tsx
+++ b/packages/components/src/flex/test/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
 import type { CSSProperties } from 'react';
 import { render, screen } from '@testing-library/react';
 

--- a/packages/components/src/focal-point-picker/test/index.tsx
+++ b/packages/components/src/focal-point-picker/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -18,7 +19,7 @@ const Picker = ( props: React.ComponentProps< typeof _Picker > ) => {
 };
 
 const props: FocalPointPickerProps = {
-	onChange: jest.fn(),
+	onChange: vi.fn(),
 	url: 'test-url',
 	value: {
 		x: 0,
@@ -31,7 +32,7 @@ describe( 'FocalPointPicker', () => {
 		it( 'clicking the draggable area should focus it', async () => {
 			const user = userEvent.setup();
 
-			const mockOnChange = jest.fn();
+			const mockOnChange = vi.fn();
 
 			render( <Picker { ...props } onChange={ mockOnChange } /> );
 
@@ -43,9 +44,9 @@ describe( 'FocalPointPicker', () => {
 		} );
 
 		it( 'should stop a drag operation when focus is lost', () => {
-			const mockOnDrag = jest.fn();
-			const mockOnDragEnd = jest.fn();
-			const mockOnChange = jest.fn();
+			const mockOnDrag = vi.fn();
+			const mockOnDragEnd = vi.fn();
+			const mockOnChange = vi.fn();
 
 			render(
 				<Picker
@@ -106,8 +107,8 @@ describe( 'FocalPointPicker', () => {
 		it( 'should allow value altering', async () => {
 			const user = userEvent.setup();
 
-			const spyChange = jest.fn();
-			const spy = jest.fn();
+			const spyChange = vi.fn();
+			const spy = vi.fn();
 
 			render(
 				<Picker
@@ -149,7 +150,7 @@ describe( 'FocalPointPicker', () => {
 		it( 'call onChange with the expected values', async () => {
 			const user = userEvent.setup();
 
-			const spyChange = jest.fn();
+			const spyChange = vi.fn();
 			render(
 				<Picker
 					{ ...props }
@@ -172,7 +173,7 @@ describe( 'FocalPointPicker', () => {
 
 	describe( 'value handling', () => {
 		it( 'should handle legacy string values', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Picker
 					{ ...props }

--- a/packages/components/src/focal-point-picker/test/media.tsx
+++ b/packages/components/src/focal-point-picker/test/media.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/font-size-picker/test/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/test/font-size-picker-select.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@ariakit/test/react';
@@ -32,14 +33,14 @@ describe( 'FontSizePickerSelect', () => {
 
 	describe( 'valueMode prop', () => {
 		it( 'should find font size by size value when valueMode is literal', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizes }
 					value="16px"
 					valueMode="literal"
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -50,14 +51,14 @@ describe( 'FontSizePickerSelect', () => {
 		} );
 
 		it( 'should find font size by slug when valueMode is slug', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizes }
 					value="medium"
 					valueMode="slug"
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -68,14 +69,14 @@ describe( 'FontSizePickerSelect', () => {
 		} );
 
 		it( 'should handle undefined value', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizes }
 					value={ undefined }
 					valueMode="literal"
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -86,14 +87,14 @@ describe( 'FontSizePickerSelect', () => {
 		} );
 
 		it( 'should handle empty string value', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizes }
 					value=""
 					valueMode="literal"
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -107,12 +108,12 @@ describe( 'FontSizePickerSelect', () => {
 	describe( 'onChange callback', () => {
 		it( 'should call onChange with FontSize object as second parameter', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizes }
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -127,13 +128,13 @@ describe( 'FontSizePickerSelect', () => {
 
 		it( 'should call onChange with undefined as second parameter for default option', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizes }
 					value="16px" // Start with a selected value
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -167,14 +168,14 @@ describe( 'FontSizePickerSelect', () => {
 		];
 
 		it( 'should handle multiple font sizes with same value in literal mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizesWithDuplicates }
 					value="12px"
 					valueMode="literal"
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);
@@ -185,14 +186,14 @@ describe( 'FontSizePickerSelect', () => {
 		} );
 
 		it( 'should handle multiple font sizes with same value in slug mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerSelect
 					fontSizes={ fontSizesWithDuplicates }
 					value="small-1"
 					valueMode="slug"
 					onChange={ onChange }
-					onSelectCustom={ jest.fn() }
+					onSelectCustom={ vi.fn() }
 					disableCustomFontSizes={ false }
 				/>
 			);

--- a/packages/components/src/font-size-picker/test/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/test/font-size-picker-toggle-group.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@ariakit/test/react';
@@ -32,7 +33,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 
 	describe( 'valueMode prop', () => {
 		it( 'should find font size by size value when valueMode is literal', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizes }
@@ -48,7 +49,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		} );
 
 		it( 'should find font size by slug when valueMode is slug', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizes }
@@ -64,7 +65,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		} );
 
 		it( 'should handle undefined value', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizes }
@@ -80,7 +81,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		} );
 
 		it( 'should handle empty string value', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizes }
@@ -99,7 +100,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 	describe( 'onChange callback', () => {
 		it( 'should call onChange with FontSize object as second parameter', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizes }
@@ -112,7 +113,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 
 		it( 'should call onChange with FontSize object when selecting a different option', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizes }
@@ -146,7 +147,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		];
 
 		it( 'should handle multiple font sizes with same value in literal mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizesWithDuplicates }
@@ -162,7 +163,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		} );
 
 		it( 'should handle multiple font sizes with same value in slug mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ fontSizesWithDuplicates }
@@ -203,7 +204,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		];
 
 		it( 'should handle different units in literal mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ heterogeneousFontSizes }
@@ -219,7 +220,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		} );
 
 		it( 'should handle complex font size values in literal mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ heterogeneousFontSizes }
@@ -235,7 +236,7 @@ describe( 'FontSizePickerToggleGroup', () => {
 		} );
 
 		it( 'should handle different units in slug mode', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePickerToggleGroup
 					fontSizes={ heterogeneousFontSizes }

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, test, vi } from 'vitest';
+
 import { screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@ariakit/test/react';
@@ -34,7 +39,7 @@ describe( 'FontSizePicker', () => {
 		'should call onChange( $expectedValue ) after user types 80 when value is $value',
 		async ( { value, expectedValue } ) => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker value={ value } onChange={ onChange } />
 			);
@@ -57,7 +62,7 @@ describe( 'FontSizePicker', () => {
 		'should call onChange( $expectedValue ) after user types 80 when first font size is $firstFontSize',
 		async ( { firstFontSize, expectedValue } ) => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker
 					fontSizes={ [ { slug: 'slug', size: firstFontSize } ] }
@@ -142,7 +147,7 @@ describe( 'FontSizePicker', () => {
 			'calls onChange( $expectedArguments ) when $option is selected',
 			async ( { option, value, expectedArguments } ) => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				await render(
 					<FontSizePicker
 						fontSizes={ fontSizes }
@@ -264,7 +269,7 @@ describe( 'FontSizePicker', () => {
 			'calls onChange( $expectedValue ) when $option is selected',
 			async ( { option, value, expectedArguments } ) => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				await render(
 					<FontSizePicker
 						fontSizes={ fontSizes }
@@ -333,7 +338,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'calls onChange when a font size is selected', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker fontSizes={ fontSizes } onChange={ onChange } />
 			);
@@ -491,7 +496,7 @@ describe( 'FontSizePicker', () => {
 			'calls onChange( $expectedArguments ) when $radio is selected',
 			async ( { radio, expectedArguments } ) => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				await render(
 					<FontSizePicker
 						fontSizes={ fontSizes }
@@ -646,7 +651,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'allows custom values by default', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker fontSizes={ fontSizes } onChange={ onChange } />
 			);
@@ -711,7 +716,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'allows a slider to be used when withSlider is set', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker
 					fontSizes={ fontSizes }
@@ -734,7 +739,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'allows reset by default', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker
 					fontSizes={ fontSizes }
@@ -842,7 +847,7 @@ describe( 'FontSizePicker', () => {
 
 			it( 'should call onChange with size value and FontSize object when valueMode is literal', async () => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				await render(
 					<FontSizePicker
 						fontSizes={ fontSizes }
@@ -880,7 +885,7 @@ describe( 'FontSizePicker', () => {
 
 			it( 'should call onChange with size value and FontSize object when valueMode is slug', async () => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				await render(
 					<FontSizePicker
 						fontSizes={ fontSizes }
@@ -1031,7 +1036,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'should call onChange with FontSize object as second parameter for select control', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker fontSizes={ fontSizes } onChange={ onChange } />
 			);
@@ -1046,7 +1051,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'should call onChange with undefined as second parameter for default option', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			await render(
 				<FontSizePicker
 					fontSizes={ fontSizes }
@@ -1065,7 +1070,7 @@ describe( 'FontSizePicker', () => {
 
 		it( 'should call onChange with FontSize object as second parameter for toggle group control', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			// Use fewer font sizes to trigger toggle group (≤ 5)
 			const toggleGroupFontSizes = [
 				{

--- a/packages/components/src/font-size-picker/test/utils.ts
+++ b/packages/components/src/font-size-picker/test/utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { isSimpleCssValue } from '../utils';

--- a/packages/components/src/form-file-upload/test/index.tsx
+++ b/packages/components/src/form-file-upload/test/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FormFileUpload from '..';
@@ -27,7 +32,7 @@ describe( 'FormFileUpload', () => {
 	it( 'should not fire a change event after selecting the same file', async () => {
 		const user = userEvent.setup();
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<FormFileUpload onChange={ onChange }>
@@ -52,11 +57,11 @@ describe( 'FormFileUpload', () => {
 	it( 'should fire a change event after selecting the same file if the value was reset in between', async () => {
 		const user = userEvent.setup();
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<FormFileUpload
-				onClick={ jest.fn( ( e ) => ( e.currentTarget.value = '' ) ) }
+				onClick={ vi.fn( ( e ) => ( e.currentTarget.value = '' ) ) }
 				onChange={ onChange }
 			>
 				My Upload Button

--- a/packages/components/src/form-toggle/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/form-toggle/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`FormToggle basic rendering should render a span element with an unchecked checkbox 1`] = `
+exports[`FormToggle > basic rendering > should render a span element with an unchecked checkbox 1`] = `
 <div>
   <span
     class="components-form-toggle"
@@ -19,7 +19,7 @@ exports[`FormToggle basic rendering should render a span element with an uncheck
 </div>
 `;
 
-exports[`FormToggle basic rendering should render an id prop for the input checkbox 1`] = `
+exports[`FormToggle > basic rendering > should render an id prop for the input checkbox 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -38,7 +38,7 @@ Snapshot Diff:
       />
 `;
 
-exports[`FormToggle basic rendering should render with an additional className 1`] = `
+exports[`FormToggle > basic rendering > should render with an additional className 1`] = `
 Snapshot Diff:
 - First value
 + Second value

--- a/packages/components/src/form-toggle/test/index.tsx
+++ b/packages/components/src/form-toggle/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -81,7 +82,7 @@ describe( 'FormToggle', () => {
 		it( 'should flip the checked property when clicked', async () => {
 			const user = userEvent.setup();
 
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			render( <ControlledFormToggle onChange={ onChange } /> );
 
 			const input = getInput();

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -1,8 +1,7 @@
-/* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "expectTokensToBeInTheDocument", "expectTokensNotToBeInTheDocument", "expectVisibleSuggestionsToBe", "expectEscapedProperly"] }] */
-
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	render,
 	screen,
@@ -131,7 +130,7 @@ describe( 'FormTokenField', () => {
 		it( "should add tokens with the input's value when pressing the enter key", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <FormTokenFieldWithState onChange={ onChangeSpy } /> );
 
@@ -156,7 +155,7 @@ describe( 'FormTokenField', () => {
 		it( "should add a token with the input's value when pressing the comma key", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <FormTokenFieldWithState onChange={ onChangeSpy } /> );
 
@@ -172,7 +171,7 @@ describe( 'FormTokenField', () => {
 		it( 'should add a token with the input value when pressing the space key and the `tokenizeOnSpace` prop is `true`', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState onChange={ onChangeSpy } />
@@ -216,7 +215,7 @@ describe( 'FormTokenField', () => {
 		it( 'should add a token with the input value with onBlur when `tokenizeOnBlur` prop is `true`', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState onChange={ onChangeSpy } />
@@ -251,7 +250,7 @@ describe( 'FormTokenField', () => {
 		it( "should not add a token with the input's value when tokenizeOnBlur is not set and pressing the tab key", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <FormTokenFieldWithState onChange={ onChangeSpy } /> );
 
@@ -267,7 +266,7 @@ describe( 'FormTokenField', () => {
 		it( 'should remove the last token when pressing the backspace key', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -295,7 +294,7 @@ describe( 'FormTokenField', () => {
 		it( 'should remove a token when clicking the token\'s "remove" button', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -337,7 +336,7 @@ describe( 'FormTokenField', () => {
 		it( 'should remove a token when by focusing on the token\'s "remove" button and pressing space bar', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -372,7 +371,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not add a new token if a token with the same value already exists', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -399,7 +398,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not add a new token if the text input is blank', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -419,7 +418,7 @@ describe( 'FormTokenField', () => {
 		it( 'should allow moving the cursor through the tokens when pressing the arrow keys, and should remove the token in front of the cursor when pressing the delete key', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -546,7 +545,7 @@ describe( 'FormTokenField', () => {
 		it( 'should fire the `onFocus` callback when the input is focused', async () => {
 			const user = userEvent.setup();
 
-			const onFocusSpy = jest.fn();
+			const onFocusSpy = vi.fn();
 
 			render( <FormTokenFieldWithState onFocus={ onFocusSpy } /> );
 
@@ -568,7 +567,7 @@ describe( 'FormTokenField', () => {
 		it( "should fire the `onInputChange` callback when the input's value changes", async () => {
 			const user = userEvent.setup();
 
-			const onInputChangeSpy = jest.fn();
+			const onInputChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState onInputChange={ onInputChangeSpy } />
@@ -686,7 +685,7 @@ describe( 'FormTokenField', () => {
 		it( "should use the value of the `placeholder` prop as the input's placeholder only when there are no tokens", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -715,7 +714,7 @@ describe( 'FormTokenField', () => {
 		it( 'should handle accents and special characters in tokens and input value', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -760,7 +759,7 @@ describe( 'FormTokenField', () => {
 		it( 'should render suggestions when receiving focus if the `__experimentalExpandOnFocus` prop is set to `true`', async () => {
 			const user = userEvent.setup();
 
-			const onFocusSpy = jest.fn();
+			const onFocusSpy = vi.fn();
 
 			const suggestions = [ 'Cobalt', 'Blue', 'Octane' ];
 
@@ -803,7 +802,7 @@ describe( 'FormTokenField', () => {
 		it( 'should render suggestions after a selection is made when the `__experimentalExpandOnFocus` prop is set to `true`', async () => {
 			const user = userEvent.setup();
 
-			const onFocusSpy = jest.fn();
+			const onFocusSpy = vi.fn();
 
 			const suggestions = [ 'Green', 'Emerald', 'Seaweed' ];
 
@@ -835,7 +834,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not render suggestions after a selection is made when the `__experimentalExpandOnFocus` prop is set to `false` or not defined', async () => {
 			const user = userEvent.setup();
 
-			const onFocusSpy = jest.fn();
+			const onFocusSpy = vi.fn();
 
 			const suggestions = [ 'Green', 'Emerald', 'Seaweed' ];
 
@@ -866,7 +865,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not render suggestions after the input is blurred', async () => {
 			const user = userEvent.setup();
 
-			const onFocusSpy = jest.fn();
+			const onFocusSpy = vi.fn();
 
 			const suggestions = [ 'Green', 'Emerald', 'Seaweed' ];
 
@@ -963,7 +962,7 @@ describe( 'FormTokenField', () => {
 		it( 'should allow the user to use the keyboard to navigate and select suggestions (which are marked with the `aria-selected` attribute)', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const suggestions = [
 				'Pink',
@@ -1042,7 +1041,7 @@ describe( 'FormTokenField', () => {
 		it( 'should allow the user to use the mouse to navigate and select suggestions (which are marked with the `aria-selected` attribute)', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const suggestions = [ 'Tiger', 'Tangerine', 'Orange' ];
 
@@ -1112,7 +1111,7 @@ describe( 'FormTokenField', () => {
 		it( 'should hide the suggestion list when the Escape key is pressed', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const suggestions = [ 'Black', 'Ash', 'Onyx', 'Ebony' ];
 
@@ -1465,7 +1464,7 @@ describe( 'FormTokenField', () => {
 		it( 'should accept tokens in their object format', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState
@@ -1505,8 +1504,8 @@ describe( 'FormTokenField', () => {
 		it( 'should trigger mouse callbacks if the `onMouseEnter` and/or the `onMouseLeave` properties are set on a token data object', async () => {
 			const user = userEvent.setup();
 
-			const onMouseEnterSpy = jest.fn();
-			const onMouseLeaveSpy = jest.fn();
+			const onMouseEnterSpy = vi.fn();
+			const onMouseLeaveSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -1587,7 +1586,7 @@ describe( 'FormTokenField', () => {
 		it( "by default, it should trim the input's value from extra white spaces before attempting to add it as a token", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState
@@ -1651,7 +1650,7 @@ describe( 'FormTokenField', () => {
 		it( "should allow to modify the input's value when saving it as a token", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState
@@ -1714,7 +1713,7 @@ describe( 'FormTokenField', () => {
 		it( 'is applied to the search value when matching it against the list of suggestions', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const suggestions = [ 'Expensive food', 'Free food' ];
 
@@ -1752,7 +1751,7 @@ describe( 'FormTokenField', () => {
 		it( 'should allow to modify the text rendered in the browser for each token', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState
@@ -1808,7 +1807,7 @@ describe( 'FormTokenField', () => {
 		it( "is applied to each suggestions, but doesn't influence the matching against the search value", async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const suggestions = [ 'Hot coffee', 'Hot tea' ];
 
@@ -1886,7 +1885,7 @@ describe( 'FormTokenField', () => {
 		it( 'should add a token only if it passes the validation set via `__experimentalValidateInput`', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			const startsWithCapitalLetter = ( tokenText: string ) =>
 				/^[A-Z]/.test( tokenText );
 
@@ -1929,8 +1928,8 @@ describe( 'FormTokenField', () => {
 		it( 'should still preventDefault on Enter when validation rejects the value', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
-			const onSubmitSpy = jest.fn( ( e: React.FormEvent ) =>
+			const onChangeSpy = vi.fn();
+			const onSubmitSpy = vi.fn( ( e: React.FormEvent ) =>
 				e.preventDefault()
 			);
 			const startsWithCapitalLetter = ( tokenText: string ) =>
@@ -1958,7 +1957,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not preventDefault on space when validation fails and `tokenizeOnSpace` is true', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			const startsWithCapitalLetter = ( tokenText: string ) =>
 				/^[A-Z]/.test( tokenText );
 
@@ -1996,7 +1995,7 @@ describe( 'FormTokenField', () => {
 		it( 'should filter out invalid tokens when pasting with separators', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			const startsWithCapitalLetter = ( tokenText: string ) =>
 				/^[A-Z]/.test( tokenText );
 
@@ -2024,7 +2023,7 @@ describe( 'FormTokenField', () => {
 		it( 'should leave all segments in the input when none pass validation on paste', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			const startsWithCapitalLetter = ( tokenText: string ) =>
 				/^[A-Z]/.test( tokenText );
 
@@ -2047,7 +2046,7 @@ describe( 'FormTokenField', () => {
 		it( 'should commit a trailing valid segment and leave only failed segments in the input when pasting without a trailing separator', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			const startsWithCapitalLetter = ( tokenText: string ) =>
 				/^[A-Z]/.test( tokenText );
 
@@ -2071,7 +2070,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not leave a duplicate of an existing token in the input when pasting comma-separated values', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -2093,7 +2092,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not leave a duplicate of an existing token in the input when pasting comma-separated values with `__experimentalValidateInput`', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			const startsWithCapitalLetter = ( tokenText: string ) =>
 				/^[A-Z]/.test( tokenText );
 
@@ -2120,7 +2119,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not allow adding new tokens beyond the value defined by the `maxLength` prop', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState
@@ -2188,7 +2187,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not affect tokens that were added before the limit was imposed', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState onChange={ onChangeSpy } />
@@ -2231,7 +2230,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not allow adding tokens when the `disabled` prop is `true`', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const { rerender } = render(
 				<FormTokenFieldWithState onChange={ onChangeSpy } />
@@ -2259,7 +2258,7 @@ describe( 'FormTokenField', () => {
 		it( 'should not allow removing tokens when the `disable` prop is `true`', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<FormTokenFieldWithState

--- a/packages/components/src/gradient-picker/test/index.tsx
+++ b/packages/components/src/gradient-picker/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -27,7 +28,7 @@ describe( 'GradientPicker', () => {
 					aria-label="Gradient"
 					gradients={ DUPLICATE_GRADIENTS }
 					value={ undefined }
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 					disableCustomGradients
 				/>
 			);
@@ -42,7 +43,7 @@ describe( 'GradientPicker', () => {
 					gradients={ DUPLICATE_GRADIENTS }
 					value={ GRADIENT_A }
 					selectedSlug="dark-text"
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 					disableCustomGradients
 				/>
 			);
@@ -59,7 +60,7 @@ describe( 'GradientPicker', () => {
 					aria-label="Gradient"
 					gradients={ DUPLICATE_GRADIENTS }
 					value={ GRADIENT_A }
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 					disableCustomGradients
 				/>
 			);
@@ -76,7 +77,7 @@ describe( 'GradientPicker', () => {
 					gradients={ DUPLICATE_GRADIENTS }
 					value={ GRADIENT_A }
 					selectedSlug=""
-					onChange={ jest.fn() }
+					onChange={ vi.fn() }
 					disableCustomGradients
 				/>
 			);
@@ -88,7 +89,7 @@ describe( 'GradientPicker', () => {
 
 		it( 'should pass slug as third argument to onChange when a swatch is clicked', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<GradientPicker
@@ -113,7 +114,7 @@ describe( 'GradientPicker', () => {
 
 		it( 'should pass slug as third argument to onChange for multiple-origin gradients', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<GradientPicker

--- a/packages/components/src/grid/test/grid.tsx
+++ b/packages/components/src/grid/test/grid.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/guide/test/index.tsx
+++ b/packages/components/src/guide/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -99,7 +100,7 @@ describe( 'Guide', () => {
 
 	it( 'calls onFinish when the finish button is clicked', async () => {
 		const user = userEvent.setup();
-		const onFinish = jest.fn();
+		const onFinish = vi.fn();
 		render(
 			<Guide
 				{ ...defaultProps }
@@ -114,7 +115,7 @@ describe( 'Guide', () => {
 
 	it( 'calls onFinish when the modal is closed', async () => {
 		const user = userEvent.setup();
-		const onFinish = jest.fn();
+		const onFinish = vi.fn();
 		render(
 			<Guide
 				{ ...defaultProps }

--- a/packages/components/src/h-stack/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/h-stack/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render alignment 1`] = `
+exports[`props > should render alignment 1`] = `
 <div>
   <div
     class="style-flex style-items-row style-expanded-row components-flex components-h-stack"
@@ -14,7 +14,7 @@ exports[`props should render alignment 1`] = `
 </div>
 `;
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 <div>
   <div
     class="style-flex style-items-row style-expanded-row components-flex components-h-stack"
@@ -28,7 +28,7 @@ exports[`props should render correctly 1`] = `
 </div>
 `;
 
-exports[`props should render spacing 1`] = `
+exports[`props > should render spacing 1`] = `
 <div>
   <div
     class="style-flex style-items-row style-expanded-row components-flex components-h-stack"

--- a/packages/components/src/h-stack/test/index.tsx
+++ b/packages/components/src/h-stack/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 .emotion-0 {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
   line-height: 1.4;
@@ -21,7 +21,7 @@ exports[`props should render correctly 1`] = `
 </h2>
 `;
 
-exports[`props should render level as a number 1`] = `
+exports[`props > should render level as a number 1`] = `
 Snapshot Diff:
 - Received styles
 + Base styles
@@ -40,7 +40,7 @@ Snapshot Diff:
     },
 `;
 
-exports[`props should render level as a string 1`] = `
+exports[`props > should render level as a string 1`] = `
 Snapshot Diff:
 - Received styles
 + Base styles

--- a/packages/components/src/heading/test/index.tsx
+++ b/packages/components/src/heading/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/higher-order/with-fallback-styles/test/index.tsx
+++ b/packages/components/src/higher-order/with-fallback-styles/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -16,7 +17,7 @@ describe( 'withFallbackStyles', () => {
 	it( 'derives the fallback styles from the provided node prop', () => {
 		const node = document.createElement( 'span' );
 		node.dataset.color = 'rgb(1, 2, 3)';
-		const mapNodeToProps = jest.fn( ( el: HTMLElement ) => ( {
+		const mapNodeToProps = vi.fn( ( el: HTMLElement ) => ( {
 			fallbackColor: el.dataset.color,
 		} ) );
 		const Component = withFallbackStyles( mapNodeToProps )( Wrapped );
@@ -32,7 +33,7 @@ describe( 'withFallbackStyles', () => {
 	} );
 
 	it( 'derives the fallback styles from the internal wrapper node when no node prop is given', () => {
-		const mapNodeToProps = jest.fn( ( el: HTMLElement ) => ( {
+		const mapNodeToProps = vi.fn( ( el: HTMLElement ) => ( {
 			fallbackColor: el.tagName.toLowerCase(),
 		} ) );
 		const Component = withFallbackStyles( mapNodeToProps )( Wrapped );

--- a/packages/components/src/higher-order/with-filters/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/higher-order/with-filters/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`withFilters should display a component overridden by the filter 1`] = `
+exports[`withFilters > should display a component overridden by the filter 1`] = `
 <div>
   <div>
     Overridden component
@@ -8,7 +8,7 @@ exports[`withFilters should display a component overridden by the filter 1`] = `
 </div>
 `;
 
-exports[`withFilters should display original component when no filters applied 1`] = `
+exports[`withFilters > should display original component when no filters applied 1`] = `
 <div>
   <div>
     My component
@@ -16,7 +16,7 @@ exports[`withFilters should display original component when no filters applied 1
 </div>
 `;
 
-exports[`withFilters should display two components composed by the filter 1`] = `
+exports[`withFilters > should display two components composed by the filter 1`] = `
 <div>
   <div>
     <div>
@@ -29,7 +29,7 @@ exports[`withFilters should display two components composed by the filter 1`] = 
 </div>
 `;
 
-exports[`withFilters should not re-render component when new filter added before component was mounted 1`] = `
+exports[`withFilters > should not re-render component when new filter added before component was mounted 1`] = `
 <div>
   <blockquote>
     <div>
@@ -39,7 +39,7 @@ exports[`withFilters should not re-render component when new filter added before
 </div>
 `;
 
-exports[`withFilters should re-render both components once each when one filter added 1`] = `
+exports[`withFilters > should re-render both components once each when one filter added 1`] = `
 <div>
   <section>
     <blockquote>
@@ -56,7 +56,7 @@ exports[`withFilters should re-render both components once each when one filter 
 </div>
 `;
 
-exports[`withFilters should re-render component once when new filter added after component was mounted 1`] = `
+exports[`withFilters > should re-render component once when new filter added after component was mounted 1`] = `
 <div>
   <blockquote>
     <div>
@@ -66,7 +66,7 @@ exports[`withFilters should re-render component once when new filter added after
 </div>
 `;
 
-exports[`withFilters should re-render component once when two filters added in the same animation frame 1`] = `
+exports[`withFilters > should re-render component once when two filters added in the same animation frame 1`] = `
 <div>
   <section>
     <blockquote>
@@ -78,7 +78,7 @@ exports[`withFilters should re-render component once when two filters added in t
 </div>
 `;
 
-exports[`withFilters should re-render component twice when new filter added and removed in two different animation frames 1`] = `
+exports[`withFilters > should re-render component twice when new filter added and removed in two different animation frames 1`] = `
 <div>
   <div>
     Spied component

--- a/packages/components/src/higher-order/with-filters/test/index.tsx
+++ b/packages/components/src/higher-order/with-filters/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 
 /**
@@ -67,7 +68,7 @@ describe( 'withFilters', () => {
 	} );
 
 	it( 'should not re-render component when new filter added before component was mounted', async () => {
-		const SpiedComponent = jest.fn( () => <div>Spied component</div> );
+		const SpiedComponent = vi.fn( () => <div>Spied component</div> );
 		addFilter(
 			hookName,
 			'test/enhanced-component-spy-1',
@@ -88,7 +89,7 @@ describe( 'withFilters', () => {
 	} );
 
 	it( 'should re-render component once when new filter added after component was mounted', async () => {
-		const SpiedComponent = jest.fn( () => <div>Spied component</div> );
+		const SpiedComponent = vi.fn( () => <div>Spied component</div> );
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 
 		const { container } = render( <EnhancedComponent /> );
@@ -112,7 +113,7 @@ describe( 'withFilters', () => {
 	} );
 
 	it( 'should re-render component once when two filters added in the same animation frame', async () => {
-		const SpiedComponent = jest.fn( () => <div>Spied component</div> );
+		const SpiedComponent = vi.fn( () => <div>Spied component</div> );
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 
 		const { container } = render( <EnhancedComponent /> );
@@ -145,7 +146,7 @@ describe( 'withFilters', () => {
 	} );
 
 	it( 'should re-render component twice when new filter added and removed in two different animation frames', async () => {
-		const SpiedComponent = jest.fn( () => <div>Spied component</div> );
+		const SpiedComponent = vi.fn( () => <div>Spied component</div> );
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 		const { container } = render( <EnhancedComponent /> );
 
@@ -174,7 +175,7 @@ describe( 'withFilters', () => {
 	} );
 
 	it( 'should re-render both components once each when one filter added', async () => {
-		const SpiedComponent = jest.fn( () => <div>Spied component</div> );
+		const SpiedComponent = vi.fn( () => <div>Spied component</div> );
 		const EnhancedComponent = withFilters( hookName )( SpiedComponent );
 
 		const CombinedComponents = () => (

--- a/packages/components/src/higher-order/with-focus-outside/test/index.tsx
+++ b/packages/components/src/higher-order/with-focus-outside/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -50,7 +51,7 @@ describe( 'withFocusOutside', () => {
 		origHasFocus = document.hasFocus;
 		document.hasFocus = () => true;
 
-		onFocusOutside = jest.fn();
+		onFocusOutside = vi.fn();
 	} );
 
 	afterEach( () => {

--- a/packages/components/src/higher-order/with-focus-return/test/index.tsx
+++ b/packages/components/src/higher-order/with-focus-return/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/components/src/higher-order/with-notices/test/index.tsx
+++ b/packages/components/src/higher-order/with-notices/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import {
 	act,
 	render,

--- a/packages/components/src/higher-order/with-spoken-messages/test/index.tsx
+++ b/packages/components/src/higher-order/with-spoken-messages/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -10,8 +11,8 @@ import withSpokenMessages from '../';
 
 describe( 'withSpokenMessages', () => {
 	it( 'should generate speak and debouncedSpeak props', () => {
-		const testSpeak = jest.fn();
-		const testDebouncedSpeak = jest.fn();
+		const testSpeak = vi.fn();
+		const testDebouncedSpeak = vi.fn();
 		const isFunction = ( maybeFunc: any ) =>
 			typeof maybeFunc === 'function';
 		const DumpComponent = withSpokenMessages(

--- a/packages/components/src/icon/test/index.tsx
+++ b/packages/components/src/icon/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/input-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/input-control/test/__snapshots__/index.js.snap
@@ -1,11 +1,11 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`InputControl Legacy size support treats __unstable-large the same as default 1`] = `
+exports[`InputControl > Legacy size support > treats __unstable-large the same as default 1`] = `
 Snapshot Diff:
 Compared values have no visual difference.
 `;
 
-exports[`InputControl Legacy size support treats __unstable-large the same as default 2`] = `
+exports[`InputControl > Legacy size support > treats __unstable-large the same as default 2`] = `
 Snapshot Diff:
 Compared values have no visual difference.
 `;

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -70,7 +71,7 @@ describe( 'InputControl', () => {
 	describe( 'Value', () => {
 		it( 'should update value onChange', async () => {
 			const user = await userEvent.setup();
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render(
 				<InputControl value="Hello" onChange={ ( v ) => spy( v ) } />
 			);
@@ -85,7 +86,7 @@ describe( 'InputControl', () => {
 
 		it( 'should work as a controlled component given normal, falsy or nullish values', async () => {
 			const user = await userEvent.setup();
-			const spy = jest.fn();
+			const spy = vi.fn();
 			const heldKeySet = new Set();
 			const Example = () => {
 				const [ state, setState ] = useState( 'one' );
@@ -139,7 +140,7 @@ describe( 'InputControl', () => {
 		} );
 
 		it( 'should change back to initial value prop, if controlled', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			const { rerender } = render(
 				<InputControl value="Original" onChange={ spy } />
 			);
@@ -159,7 +160,7 @@ describe( 'InputControl', () => {
 
 		it( 'should not commit value until blurred when isPressEnterToChange is true', async () => {
 			const user = await userEvent.setup();
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render(
 				<InputControl
 					value=""
@@ -179,7 +180,7 @@ describe( 'InputControl', () => {
 
 		it( 'should commit value when blurred if value is invalid', async () => {
 			const user = await userEvent.setup();
-			const spyChange = jest.fn();
+			const spyChange = vi.fn();
 			render(
 				<InputControl
 					value="this is"

--- a/packages/components/src/isolated-event-container/test/index.tsx
+++ b/packages/components/src/isolated-event-container/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -12,7 +13,7 @@ import IsolatedEventContainer from '..';
 describe( 'IsolatedEventContainer', () => {
 	it( 'should pass props to container', async () => {
 		const user = userEvent.setup();
-		const clickHandler = jest.fn();
+		const clickHandler = vi.fn();
 		render(
 			<IsolatedEventContainer
 				title="Container"
@@ -45,8 +46,8 @@ describe( 'IsolatedEventContainer', () => {
 	it( 'should stop event propagation only for mousedown, but not for keydown', async () => {
 		const user = userEvent.setup();
 
-		const mousedownHandler = jest.fn();
-		const keydownHandler = jest.fn();
+		const mousedownHandler = vi.fn();
+		const keydownHandler = vi.fn();
 		render(
 			<button
 				onMouseDown={ mousedownHandler }

--- a/packages/components/src/item-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/item-group/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ItemGroup Item should read the value of the size prop from context when the prop is not defined 1`] = `
+exports[`ItemGroup > Item > should read the value of the size prop from context when the prop is not defined 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -33,7 +33,7 @@ Snapshot Diff:
         </div>
 `;
 
-exports[`ItemGroup Item should use different amounts of padding depending on the value of the size prop 1`] = `
+exports[`ItemGroup > Item > should use different amounts of padding depending on the value of the size prop 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -53,7 +53,7 @@ Snapshot Diff:
       </div>
 `;
 
-exports[`ItemGroup ItemGroup component should render correctly 1`] = `
+exports[`ItemGroup > ItemGroup component > should render correctly 1`] = `
 .emotion-0 {
   border-radius: 2px;
 }
@@ -112,7 +112,7 @@ exports[`ItemGroup ItemGroup component should render correctly 1`] = `
 </div>
 `;
 
-exports[`ItemGroup ItemGroup component should render items individually when the isSeparated prop is true 1`] = `
+exports[`ItemGroup > ItemGroup component > should render items individually when the isSeparated prop is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -140,7 +140,7 @@ Snapshot Diff:
         </div>
 `;
 
-exports[`ItemGroup ItemGroup component should show borders when the isBordered prop is true 1`] = `
+exports[`ItemGroup > ItemGroup component > should show borders when the isBordered prop is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value
@@ -168,7 +168,7 @@ Snapshot Diff:
         </div>
 `;
 
-exports[`ItemGroup ItemGroup component should show rounded corners when the isRounded prop is true 1`] = `
+exports[`ItemGroup > ItemGroup component > should show rounded corners when the isRounded prop is true 1`] = `
 Snapshot Diff:
 - First value
 + Second value

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -75,7 +76,7 @@ describe( 'ItemGroup', () => {
 	describe( 'Item', () => {
 		it( 'should render as a `button` if the `onClick` handler is specified', async () => {
 			const user = userEvent.setup();
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render( <Item onClick={ spy }>Code is poetry</Item> );
 
 			const button = screen.getByRole( 'button' );
@@ -88,7 +89,7 @@ describe( 'ItemGroup', () => {
 		} );
 
 		it( 'should give priority to the `as` prop even if the `onClick` handler is specified', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			const { rerender } = render(
 				<Item onClick={ spy }>Code is poetry</Item>
 			);

--- a/packages/components/src/keyboard-shortcuts/test/index.tsx
+++ b/packages/components/src/keyboard-shortcuts/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 
 /**
@@ -29,7 +30,7 @@ describe( 'KeyboardShortcuts', () => {
 	}
 
 	it( 'should capture key events', async () => {
-		const spy = jest.fn();
+		const spy = vi.fn();
 
 		render(
 			<KeyboardShortcuts
@@ -45,7 +46,7 @@ describe( 'KeyboardShortcuts', () => {
 	} );
 
 	it( 'should capture key events globally', () => {
-		const spy = jest.fn();
+		const spy = vi.fn();
 
 		render(
 			<div>
@@ -65,7 +66,7 @@ describe( 'KeyboardShortcuts', () => {
 	} );
 
 	it( 'should capture key events on specific event', () => {
-		const spy = jest.fn();
+		const spy = vi.fn();
 
 		render(
 			<div>
@@ -85,7 +86,7 @@ describe( 'KeyboardShortcuts', () => {
 	} );
 
 	it( 'should capture key events on children', () => {
-		const spy = jest.fn();
+		const spy = vi.fn();
 
 		render(
 			<div>

--- a/packages/components/src/menu-group/test/index.tsx
+++ b/packages/components/src/menu-group/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MenuItem should match snapshot when all props provided 1`] = `
+exports[`MenuItem > should match snapshot when all props provided 1`] = `
 <button
   aria-checked="true"
   class="components-button components-menu-item__button my-class is-compact"
@@ -34,7 +34,7 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
 </button>
 `;
 
-exports[`MenuItem should match snapshot when info is provided 1`] = `
+exports[`MenuItem > should match snapshot when info is provided 1`] = `
 <button
   class="components-button components-menu-item__button is-compact"
   role="menuitem"
@@ -61,7 +61,7 @@ exports[`MenuItem should match snapshot when info is provided 1`] = `
 </button>
 `;
 
-exports[`MenuItem should match snapshot when isSelected and role are optionally provided 1`] = `
+exports[`MenuItem > should match snapshot when isSelected and role are optionally provided 1`] = `
 <button
   class="components-button components-menu-item__button my-class is-compact"
   role="menuitem"
@@ -94,7 +94,7 @@ exports[`MenuItem should match snapshot when isSelected and role are optionally 
 </button>
 `;
 
-exports[`MenuItem should match snapshot when only label provided 1`] = `
+exports[`MenuItem > should match snapshot when only label provided 1`] = `
 <button
   class="components-button components-menu-item__button is-compact"
   role="menuitem"

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -23,7 +30,7 @@ const waitForFocusedMenuItem = ( name: string ) =>
 	);
 
 const resetTypeahead = () => {
-	act( () => jest.advanceTimersByTime( 500 ) );
+	act( () => vi.advanceTimersByTime( 500 ) );
 };
 
 // Open dropdown => open menu
@@ -446,7 +453,7 @@ describe( 'Menu', () => {
 		} );
 
 		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
-			const onRadioValueChangeSpy = jest.fn();
+			const onRadioValueChangeSpy = vi.fn();
 
 			const ControlledRadioGroup = () => {
 				const [ radioValue, setRadioValue ] = useState( 'two' );
@@ -535,7 +542,7 @@ describe( 'Menu', () => {
 		} );
 
 		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
-			const onRadioValueChangeSpy = jest.fn();
+			const onRadioValueChangeSpy = vi.fn();
 			render(
 				<Menu>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
@@ -615,7 +622,7 @@ describe( 'Menu', () => {
 		} );
 
 		it( 'should check checkbox items and keep the menu open when clicking (controlled)', async () => {
-			const onCheckboxValueChangeSpy = jest.fn();
+			const onCheckboxValueChangeSpy = vi.fn();
 
 			const ControlledRadioGroup = () => {
 				const [ itemOneChecked, setItemOneChecked ] =
@@ -747,7 +754,7 @@ describe( 'Menu', () => {
 		} );
 
 		it( 'should check checkbox items and keep the menu open when clicking (uncontrolled)', async () => {
-			const onCheckboxValueChangeSpy = jest.fn();
+			const onCheckboxValueChangeSpy = vi.fn();
 
 			render(
 				<Menu>
@@ -1057,15 +1064,8 @@ describe( 'Menu', () => {
 	} );
 
 	describe( 'typeahead', () => {
-		beforeEach( () => {
-			jest.useFakeTimers();
-			user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
-		} );
-
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'should highlight matching item', async () => {
@@ -1086,9 +1086,17 @@ describe( 'Menu', () => {
 				} )
 			);
 			await waitForFocusedMenu();
+			vi.useFakeTimers();
 
 			// Type "tw", it should match and focus the item with content "Two"
-			await user.keyboard( 'tw' );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), {
+				code: 'KeyT',
+				key: 't',
+			} );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), {
+				code: 'KeyW',
+				key: 'w',
+			} );
 			expect(
 				screen.getByRole( 'menuitem', { name: 'Two' } )
 			).toHaveFocus();
@@ -1097,7 +1105,18 @@ describe( 'Menu', () => {
 			resetTypeahead();
 
 			// Type "on", it should match and focus the item with content "One"
-			await user.keyboard( 'on' );
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'Two' } ),
+				{
+					key: 'o',
+				}
+			);
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'Two' } ),
+				{
+					key: 'n',
+				}
+			);
 			expect(
 				screen.getByRole( 'menuitem', { name: 'One' } )
 			).toHaveFocus();
@@ -1121,16 +1140,20 @@ describe( 'Menu', () => {
 				} )
 			);
 			await waitForFocusedMenu();
+			vi.useFakeTimers();
 
 			// Type a string that doesn't match any items. Focus shouldn't move.
-			await user.keyboard( 'abc' );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'a' } );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'b' } );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'c' } );
 			expect( screen.getByRole( 'menu' ) ).toHaveFocus();
 
 			// Reset the typeahead search so the next keystrokes start a new query.
 			resetTypeahead();
 
 			// Type "on", it should match and focus the item with content "One"
-			await user.keyboard( 'on' );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'o' } );
+			fireEvent.keyDown( screen.getByRole( 'menu' ), { key: 'n' } );
 			expect(
 				screen.getByRole( 'menuitem', { name: 'One' } )
 			).toHaveFocus();
@@ -1139,7 +1162,18 @@ describe( 'Menu', () => {
 			resetTypeahead();
 
 			// Type a string that doesn't match any items. Focus shouldn't move.
-			await user.keyboard( 'abc' );
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'One' } ),
+				{ key: 'a' }
+			);
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'One' } ),
+				{ key: 'b' }
+			);
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'One' } ),
+				{ key: 'c' }
+			);
 			expect(
 				screen.getByRole( 'menuitem', { name: 'One' } )
 			).toHaveFocus();
@@ -1148,7 +1182,14 @@ describe( 'Menu', () => {
 			resetTypeahead();
 
 			// Type "tw", it should match and focus the item with content "Two"
-			await user.keyboard( 'tw' );
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'One' } ),
+				{ key: 't' }
+			);
+			fireEvent.keyDown(
+				screen.getByRole( 'menuitem', { name: 'One' } ),
+				{ key: 'w' }
+			);
 			expect(
 				screen.getByRole( 'menuitem', { name: 'Two' } )
 			).toHaveFocus();

--- a/packages/components/src/modal/test/aria-helper.ts
+++ b/packages/components/src/modal/test/aria-helper.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { elementShouldBeHidden } from '../aria-helper';

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -83,7 +84,7 @@ describe( 'Modal', () => {
 
 	it( 'should call onRequestClose when the escape key is pressed', async () => {
 		const user = userEvent.setup();
-		const onRequestClose = jest.fn();
+		const onRequestClose = vi.fn();
 		render(
 			<Modal onRequestClose={ onRequestClose }>
 				<p>Modal content</p>
@@ -123,7 +124,7 @@ describe( 'Modal', () => {
 
 	it( 'should request closing of any non nested modal when opened', async () => {
 		const user = userEvent.setup();
-		const onRequestClose = jest.fn();
+		const onRequestClose = vi.fn();
 
 		const DismissAdjacent = () => {
 			const [ isShown, setIsShown ] = useState( false );
@@ -148,7 +149,7 @@ describe( 'Modal', () => {
 
 	it( 'should support nested modals', async () => {
 		const user = userEvent.setup();
-		const onRequestClose = jest.fn();
+		const onRequestClose = vi.fn();
 
 		const NestSupport = () => {
 			const [ isShown, setIsShown ] = useState( false );
@@ -173,7 +174,7 @@ describe( 'Modal', () => {
 
 	it( 'should request closing of nested modal when outer modal unmounts', async () => {
 		const user = userEvent.setup();
-		const onRequestClose = jest.fn();
+		const onRequestClose = vi.fn();
 
 		const RequestCloseOfNested = () => {
 			const [ isShown, setIsShown ] = useState( true );

--- a/packages/components/src/navigable-container/test/navigable-menu.tsx
+++ b/packages/components/src/navigable-container/test/navigable-menu.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -32,7 +33,7 @@ describe( 'NavigableMenu', () => {
 	it( 'moves focus on its focusable children by using the up/down arrow keys', async () => {
 		const user = userEvent.setup();
 
-		const onNavigateSpy = jest.fn();
+		const onNavigateSpy = vi.fn();
 
 		render( <NavigableMenuTestCase onNavigate={ onNavigateSpy } /> );
 
@@ -71,7 +72,7 @@ describe( 'NavigableMenu', () => {
 	it( 'moves focus on its focusable children by using the left/right arrow keys when the `orientation`prop is set to `horizontal', async () => {
 		const user = userEvent.setup();
 
-		const onNavigateSpy = jest.fn();
+		const onNavigateSpy = vi.fn();
 
 		render(
 			<NavigableMenuTestCase
@@ -115,7 +116,7 @@ describe( 'NavigableMenu', () => {
 	it( 'should stop at the edges when the `cycle` prop is set to `false`', async () => {
 		const user = userEvent.setup();
 
-		const onNavigateSpy = jest.fn();
+		const onNavigateSpy = vi.fn();
 
 		const { rerender } = render(
 			<NavigableMenuTestCase onNavigate={ onNavigateSpy } />
@@ -173,7 +174,7 @@ describe( 'NavigableMenu', () => {
 	it( 'stops keydown event propagation when arrow keys are pressed, regardless of the `orientation` prop', async () => {
 		const user = userEvent.setup();
 
-		const externalWrapperOnKeyDownSpy = jest.fn();
+		const externalWrapperOnKeyDownSpy = vi.fn();
 
 		render(
 			// Disable reason: this is only for test purposes.
@@ -200,7 +201,7 @@ describe( 'NavigableMenu', () => {
 	} );
 
 	it( 'should keep forwarded callback refs stable across rerenders', () => {
-		const refSpy = jest.fn();
+		const refSpy = vi.fn();
 
 		const { rerender } = render(
 			<NavigableMenu ref={ refSpy }>

--- a/packages/components/src/navigable-container/test/tababble-container.tsx
+++ b/packages/components/src/navigable-container/test/tababble-container.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -39,7 +40,7 @@ describe( 'TabbableContainer', () => {
 	it( 'moves focus on its tabbable children by using the tab key', async () => {
 		const user = userEvent.setup();
 
-		const onNavigateSpy = jest.fn();
+		const onNavigateSpy = vi.fn();
 
 		render( <TabbableContainerTestCase onNavigate={ onNavigateSpy } /> );
 
@@ -72,7 +73,7 @@ describe( 'TabbableContainer', () => {
 	it( 'should stop at the edges when the `cycle` prop is set to `false`', async () => {
 		const user = userEvent.setup();
 
-		const onNavigateSpy = jest.fn();
+		const onNavigateSpy = vi.fn();
 
 		const { rerender } = render(
 			<TabbableContainerTestCase onNavigate={ onNavigateSpy } />
@@ -144,7 +145,7 @@ describe( 'TabbableContainer', () => {
 	it( 'stops keydown event propagation when the tab key is pressed', async () => {
 		const user = userEvent.setup();
 
-		const externalWrapperOnKeyDownSpy = jest.fn();
+		const externalWrapperOnKeyDownSpy = vi.fn();
 
 		render(
 			// Disable reason: this is only for test purposes.

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import type { ComponentPropsWithoutRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -508,7 +509,7 @@ describe( 'Navigator', () => {
 	} );
 
 	it( 'should navigate across screens', async () => {
-		const spy = jest.fn();
+		const spy = vi.fn();
 
 		const user = userEvent.setup();
 
@@ -578,7 +579,7 @@ describe( 'Navigator', () => {
 	} );
 
 	it( 'should not render anything if the path does not match any available screen', async () => {
-		const spy = jest.fn();
+		const spy = vi.fn();
 
 		const user = userEvent.setup();
 

--- a/packages/components/src/navigator/test/router.ts
+++ b/packages/components/src/navigator/test/router.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { patternMatch, findParent } from '../utils/router';

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Notice should match snapshot 1`] = `
+exports[`Notice > should match snapshot 1`] = `
 <div>
   <div
     class="components-notice is-success"

--- a/packages/components/src/notice/test/index.tsx
+++ b/packages/components/src/notice/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,8 +15,11 @@ import { speak } from '@wordpress/a11y';
  */
 import Notice from '../index';
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
-const mockedSpeak = jest.mocked( speak );
+vi.mock( import( '@wordpress/a11y' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	speak: vi.fn(),
+} ) );
+const mockedSpeak = vi.mocked( speak );
 
 function getNoticeWrapper( container: HTMLElement ) {
 	return container.firstChild;
@@ -129,7 +133,7 @@ describe( 'Notice', () => {
 					actions={ [
 						{
 							label: 'Disabled action',
-							onClick: jest.fn(),
+							onClick: vi.fn(),
 							disabled: true,
 						},
 					] }
@@ -147,7 +151,7 @@ describe( 'Notice', () => {
 
 		it( 'should call onClick when action with url is clicked', async () => {
 			const user = userEvent.setup();
-			const onClick = jest.fn( ( e ) => e.preventDefault() );
+			const onClick = vi.fn( ( e ) => e.preventDefault() );
 
 			render(
 				<Notice

--- a/packages/components/src/notice/test/list.tsx
+++ b/packages/components/src/notice/test/list.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/number-control/test/index.tsx
+++ b/packages/components/src/number-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -61,7 +62,7 @@ describe( 'NumberControl', () => {
 	describe( 'onChange handling', () => {
 		it( 'should provide onChange callback with number value', async () => {
 			const user = userEvent.setup();
-			const spy = jest.fn();
+			const spy = vi.fn();
 
 			render(
 				<NumberControl value={ 5 } onChange={ ( v ) => spy( v ) } />
@@ -76,7 +77,7 @@ describe( 'NumberControl', () => {
 
 		it( 'should call onChange callback when value is clamped on blur', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<NumberControl
@@ -119,7 +120,7 @@ describe( 'NumberControl', () => {
 
 		it( 'should call onChange callback when value is not valid', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<NumberControl
@@ -262,7 +263,7 @@ describe( 'NumberControl', () => {
 		it( 'should fire onKeyDown callback', async () => {
 			const user = userEvent.setup();
 
-			const spy = jest.fn();
+			const spy = vi.fn();
 
 			render( <StatefulNumberControl value={ 5 } onKeyDown={ spy } /> );
 
@@ -415,7 +416,7 @@ describe( 'NumberControl', () => {
 	describe( 'Key DOWN interactions', () => {
 		it( 'should fire onKeyDown callback', async () => {
 			const user = userEvent.setup();
-			const spy = jest.fn();
+			const spy = vi.fn();
 
 			render( <StatefulNumberControl value={ 5 } onKeyDown={ spy } /> );
 
@@ -598,7 +599,7 @@ describe( 'NumberControl', () => {
 			'should spin %s to %s when props = %o',
 			async ( direction, expectedValue, props ) => {
 				const user = userEvent.setup();
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				render(
 					<NumberControl
 						{ ...props }

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, test, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { click, type, press } from '@ariakit/test';
 
@@ -264,7 +265,7 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'calls the `onChange` with the new color appended', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<PaletteEdit
@@ -293,7 +294,7 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'calls the `onChange` with the new gradient appended', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<PaletteEdit
@@ -333,7 +334,7 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'can remove a color', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<PaletteEdit
@@ -366,7 +367,7 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'can update palette name', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<PaletteEdit
@@ -406,7 +407,7 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'can update color palette value', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<PaletteEdit
@@ -437,7 +438,7 @@ describe( 'PaletteEdit', () => {
 	} );
 
 	it( 'can update gradient palette value', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<PaletteEdit

--- a/packages/components/src/panel/test/__snapshots__/body.tsx.snap
+++ b/packages/components/src/panel/test/__snapshots__/body.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PanelBody basic rendering should render an empty div with the matching className 1`] = `
+exports[`PanelBody > basic rendering > should render an empty div with the matching className 1`] = `
 <div>
   <div
     class="components-panel__body is-opened"

--- a/packages/components/src/panel/test/__snapshots__/header.tsx.snap
+++ b/packages/components/src/panel/test/__snapshots__/header.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PanelHeader basic rendering should render PanelHeader with empty div inside 1`] = `
+exports[`PanelHeader > basic rendering > should render PanelHeader with empty div inside 1`] = `
 <div>
   <div
     class="components-panel__header"

--- a/packages/components/src/panel/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/panel/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Panel basic rendering should render an additional className 1`] = `
+exports[`Panel > basic rendering > should render an additional className 1`] = `
 <div>
   <div
     class="the-panel components-panel"
@@ -8,7 +8,7 @@ exports[`Panel basic rendering should render an additional className 1`] = `
 </div>
 `;
 
-exports[`Panel basic rendering should render an empty div without any provided props 1`] = `
+exports[`Panel > basic rendering > should render an empty div without any provided props 1`] = `
 <div>
   <div
     class="components-panel"

--- a/packages/components/src/panel/test/__snapshots__/row.tsx.snap
+++ b/packages/components/src/panel/test/__snapshots__/row.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PanelRow should render with the custom class name 1`] = `
+exports[`PanelRow > should render with the custom class name 1`] = `
 <div>
   <div
     class="components-panel__row custom"
@@ -8,7 +8,7 @@ exports[`PanelRow should render with the custom class name 1`] = `
 </div>
 `;
 
-exports[`PanelRow should render with the default class name 1`] = `
+exports[`PanelRow > should render with the default class name 1`] = `
 <div>
   <div
     class="components-panel__row"

--- a/packages/components/src/panel/test/body.tsx
+++ b/packages/components/src/panel/test/body.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -138,7 +139,7 @@ describe( 'PanelBody', () => {
 
 		it( 'should pass button props to panel title', async () => {
 			const user = userEvent.setup();
-			const mock = jest.fn();
+			const mock = vi.fn();
 
 			render(
 				<PanelBody title="Panel" buttonProps={ { onClick: mock } }>

--- a/packages/components/src/panel/test/header.tsx
+++ b/packages/components/src/panel/test/header.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/panel/test/index.tsx
+++ b/packages/components/src/panel/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/panel/test/row.tsx
+++ b/packages/components/src/panel/test/row.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/placeholder/test/index.tsx
+++ b/packages/components/src/placeholder/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 
 /**
@@ -17,10 +18,13 @@ import BasePlaceholder from '../';
 import type { WordPressComponentProps } from '../../context';
 import type { PlaceholderProps } from '../types';
 
-jest.mock( '@wordpress/compose', () => {
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => {
+	const original = await importOriginal();
 	return {
-		...jest.requireActual( '@wordpress/compose' ),
-		useResizeObserver: jest.fn( () => [] ),
+		...original,
+		useResizeObserver: vi.fn(
+			() => []
+		) as unknown as typeof original.useResizeObserver,
 	};
 } );
 
@@ -42,15 +46,18 @@ const Placeholder = (
 
 const getPlaceholder = () => screen.getByTestId( 'placeholder' );
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
-const mockedSpeak = jest.mocked( speak );
+vi.mock( import( '@wordpress/a11y' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	speak: vi.fn(),
+} ) );
+const mockedUseResizeObserver = vi.mocked( useResizeObserver );
+const mockedSpeak = vi.mocked( speak );
 
 describe( 'Placeholder', () => {
 	beforeEach( () => {
-		// @ts-ignore
-		useResizeObserver.mockReturnValue( [
+		mockedUseResizeObserver.mockReturnValue( [
 			<div key="1" />,
-			{ width: 320 },
+			{ width: 320, height: null },
 		] );
 		mockedSpeak.mockReset();
 	} );

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -2,6 +2,16 @@
  * External dependencies
  */
 import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	test,
+	vi,
+	type Mock,
+} from 'vitest';
+import {
 	act,
 	render,
 	screen,
@@ -50,19 +60,17 @@ beforeAll( () => {
 	// which will always fail in JSDom.
 	//
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/dom/src/focusable.js#L55-L61
-	jest.spyOn(
-		HTMLElement.prototype,
-		'offsetHeight',
-		'get'
-	).mockImplementation( function getOffsetHeight( this: HTMLElement ) {
-		// The `1` returned here is somewhat arbitrary – it just needs to be a
-		// non-zero integer.
-		return 1;
-	} );
+	vi.spyOn( HTMLElement.prototype, 'offsetHeight', 'get' ).mockImplementation(
+		function getOffsetHeight( this: HTMLElement ) {
+			// The `1` returned here is somewhat arbitrary – it just needs to be a
+			// non-zero integer.
+			return 1;
+		}
+	);
 } );
 
 afterAll( () => {
-	jest.restoreAllMocks();
+	vi.restoreAllMocks();
 } );
 
 // There's no matching `placement` for 'middle center' positions,
@@ -286,7 +294,6 @@ describe( 'Popover', () => {
 			// tests for constrained tabbing fail.
 			// [1]: https://github.com/testing-library/user-event/issues/1188
 			//
-			// eslint-disable-next-line jest/no-disabled-tests
 			describe.skip( 'constrains tabbing', () => {
 				test( 'by default', async () => {
 					// The default value for `focusOnMount` is 'firstElement',
@@ -593,8 +600,8 @@ describe( 'Popover', () => {
 			onParentFocusOutside,
 			onNestedFocusOutside,
 		}: {
-			onParentFocusOutside: jest.Mock;
-			onNestedFocusOutside: jest.Mock;
+			onParentFocusOutside: Mock;
+			onNestedFocusOutside: Mock;
 		} ) {
 			const [ isNestedOpen, setIsNestedOpen ] = useState( false );
 
@@ -632,8 +639,8 @@ describe( 'Popover', () => {
 
 		it( 'should call parent onFocusOutside when focus moves from nested popover to external element', async () => {
 			const user = userEvent.setup();
-			const onParentFocusOutside = jest.fn();
-			const onNestedFocusOutside = jest.fn();
+			const onParentFocusOutside = vi.fn();
+			const onNestedFocusOutside = vi.fn();
 
 			render(
 				<NestedPopoverTestComponent
@@ -683,7 +690,7 @@ describe( 'Popover', () => {
 
 		it( 'should not call onFocusOutside when focus moves into the wp compat overlay slot', async () => {
 			const user = userEvent.setup();
-			const onFocusOutside = jest.fn();
+			const onFocusOutside = vi.fn();
 			const { slot, slotButton } = createOverlaySlot();
 
 			render(
@@ -703,7 +710,7 @@ describe( 'Popover', () => {
 
 		it( 'should not call onFocusOutside when focus returns from the slot to a popover descendant', async () => {
 			const user = userEvent.setup();
-			const onFocusOutside = jest.fn();
+			const onFocusOutside = vi.fn();
 			const { slot, slotButton } = createOverlaySlot();
 
 			render(
@@ -728,7 +735,7 @@ describe( 'Popover', () => {
 			// to `body` (so the captured `relatedTarget` is `null`), then
 			// is synchronously restored to the popover before the blur
 			// check runs.
-			const onFocusOutside = jest.fn();
+			const onFocusOutside = vi.fn();
 			const { slot, slotButton } = createOverlaySlot();
 
 			render(
@@ -762,7 +769,7 @@ describe( 'Popover', () => {
 
 		it( 'should still call onFocusOutside when focus moves to a sibling outside the slot', async () => {
 			const user = userEvent.setup();
-			const onFocusOutside = jest.fn();
+			const onFocusOutside = vi.fn();
 
 			render(
 				<>
@@ -784,8 +791,8 @@ describe( 'Popover', () => {
 
 	it( 'should call a consumer-provided onKeyDown alongside close-on-Escape', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
-		const onKeyDown = jest.fn();
+		const onClose = vi.fn();
+		const onKeyDown = vi.fn();
 
 		render(
 			<Popover onClose={ onClose } onKeyDown={ onKeyDown }>

--- a/packages/components/src/progress-bar/test/index.tsx
+++ b/packages/components/src/progress-bar/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/query-controls/test/terms.ts
+++ b/packages/components/src/query-controls/test/terms.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { buildTermsTree } from '../terms';

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -57,7 +58,7 @@ describe.each( [
 
 	describe( 'semantics and labelling', () => {
 		it( 'should render a radiogroup with an accessible label (legend)', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);
@@ -68,7 +69,7 @@ describe.each( [
 		} );
 
 		it( 'should render a radiogroup with an accessible label even when the label is visually hidden', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component
 					{ ...defaultProps }
@@ -93,7 +94,7 @@ describe.each( [
 		} );
 
 		it( 'should describe the radio group with the help text', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component
 					{ ...defaultProps }
@@ -108,7 +109,7 @@ describe.each( [
 		} );
 
 		it( 'should render radio inputs with accessible labels', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);
@@ -123,7 +124,7 @@ describe.each( [
 		} );
 
 		it( 'should not select have a selected value when the `selected` prop does not match any available options', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);
@@ -136,7 +137,7 @@ describe.each( [
 		} );
 
 		it( 'should render mutually exclusive radio inputs', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component
 					{ ...defaultProps }
@@ -153,7 +154,7 @@ describe.each( [
 		} );
 
 		it( 'should use the option description text to describe individual options', () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component
 					{ ...defaultPropsWithDescriptions }
@@ -179,7 +180,7 @@ describe.each( [
 	describe( 'interaction', () => {
 		it( 'should select a new value when clicking on the radio input', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);
@@ -204,7 +205,7 @@ describe.each( [
 
 		it( 'should select a new value when clicking on the radio label', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);
@@ -227,7 +228,7 @@ describe.each( [
 
 		it( 'should select a new value when using the arrow keys', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<Component { ...defaultProps } onChange={ onChangeSpy } />
 			);

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import RangeControl from '../';
 
@@ -11,7 +16,7 @@ const fireChangeEvent = ( input: HTMLInputElement, value?: number | string ) =>
 describe( 'RangeControl', () => {
 	describe( '#render()', () => {
 		it( 'should trigger change callback with numeric value', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render( <RangeControl onChange={ onChange } /> );
 
@@ -76,7 +81,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should not call onChange if new value is invalid', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			render(
 				<RangeControl onChange={ onChange } min={ 10 } max={ 20 } />
 			);
@@ -90,7 +95,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should keep invalid values in number input until loss of focus', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			render(
 				<RangeControl onChange={ onChange } min={ -1 } max={ 1 } />
 			);
@@ -141,7 +146,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should take into account the step starting from min', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			render(
 				<RangeControl
 					onChange={ onChange }
@@ -286,7 +291,7 @@ describe( 'RangeControl', () => {
 
 	describe( 'reset', () => {
 		it( 'should clear the input value when clicking the reset button', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render( <RangeControl allowReset onChange={ spy } /> );
 
 			const resetButton = getResetButton();
@@ -310,7 +315,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should reset to the `initialPosition` value when clicking the reset button', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render(
 				<RangeControl
 					allowReset
@@ -339,7 +344,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should reset to the `resetFallbackValue` value when clicking the reset button', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render(
 				<RangeControl
 					initialPosition={ 10 }

--- a/packages/components/src/sandbox/test/index.tsx
+++ b/packages/components/src/sandbox/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/scroll-lock/test/index.tsx
+++ b/packages/components/src/scroll-lock/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/scrollable/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/scrollable/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 .emotion-0 {
   height: 100%;
 }
@@ -48,7 +48,7 @@ exports[`props should render correctly 1`] = `
 </div>
 `;
 
-exports[`props should render smoothScroll 1`] = `
+exports[`props > should render smoothScroll 1`] = `
 Snapshot Diff:
 - Received styles
 + Base styles

--- a/packages/components/src/scrollable/test/index.tsx
+++ b/packages/components/src/scrollable/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/search-control/test/index.tsx
+++ b/packages/components/src/search-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { click, type } from '@ariakit/test';
 
@@ -41,7 +42,7 @@ describe( 'SearchControl', () => {
 		const [ , Component ] = modeAndComponent;
 
 		it( 'should call onChange with input value when value is changed', async () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render( <Component onChange={ onChangeSpy } /> );
 
 			const searchInput = screen.getByRole( 'searchbox' );
@@ -51,7 +52,7 @@ describe( 'SearchControl', () => {
 		} );
 
 		it( 'should render a Reset search button if no onClose function is provided', async () => {
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render( <Component onChange={ onChangeSpy } /> );
 
 			const searchInput = screen.getByRole( 'searchbox' );
@@ -80,8 +81,8 @@ describe( 'SearchControl', () => {
 		} );
 
 		it( 'should render a Close button (instead of Reset) when onClose function is provided', async () => {
-			const onChangeSpy = jest.fn();
-			const onCloseSpy = jest.fn();
+			const onChangeSpy = vi.fn();
+			const onCloseSpy = vi.fn();
 			render(
 				<Component onChange={ onChangeSpy } onClose={ onCloseSpy } />
 			);

--- a/packages/components/src/select-control/test/__snapshots__/select-control.tsx.snap
+++ b/packages/components/src/select-control/test/__snapshots__/select-control.tsx.snap
@@ -1,11 +1,11 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SelectControl Legacy size support treats __unstable-large the same as default 1`] = `
+exports[`SelectControl > Legacy size support > treats __unstable-large the same as default 1`] = `
 Snapshot Diff:
 Compared values have no visual difference.
 `;
 
-exports[`SelectControl Legacy size support treats __unstable-large the same as default 2`] = `
+exports[`SelectControl > Legacy size support > treats __unstable-large the same as default 2`] = `
 Snapshot Diff:
 Compared values have no visual difference.
 `;

--- a/packages/components/src/select-control/test/select-control.tsx
+++ b/packages/components/src/select-control/test/select-control.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -20,7 +21,7 @@ describe( 'SelectControl', () => {
 
 	it( 'should render its children', async () => {
 		const user = userEvent.setup();
-		const handleChangeMock = jest.fn();
+		const handleChangeMock = vi.fn();
 
 		render(
 			<SelectControl onChange={ handleChangeMock } label="Select">
@@ -49,7 +50,7 @@ describe( 'SelectControl', () => {
 
 	it( 'should render its options', async () => {
 		const user = userEvent.setup();
-		const handleChangeMock = jest.fn();
+		const handleChangeMock = vi.fn();
 
 		render(
 			<SelectControl
@@ -102,7 +103,6 @@ describe( 'SelectControl', () => {
 		).toBeInTheDocument();
 	} );
 
-	/* eslint-disable jest/expect-expect */
 	describe( 'static typing', () => {
 		describe( 'single', () => {
 			it( 'should infer the value type from available `options`, but not the `value` or `onChange` prop', () => {
@@ -225,7 +225,6 @@ describe( 'SelectControl', () => {
 			} );
 		} );
 	} );
-	/* eslint-enable jest/expect-expect */
 
 	describe( 'Legacy size support', () => {
 		it( 'treats __unstable-large the same as default', () => {

--- a/packages/components/src/shortcut/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/shortcut/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Shortcut renders passed className 1`] = `
+exports[`Shortcut > renders passed className 1`] = `
 <span
   class="my-class"
 >
@@ -8,7 +8,7 @@ exports[`Shortcut renders passed className 1`] = `
 </span>
 `;
 
-exports[`Shortcut renders the shortcut display text when a string is passed as the shortcut 1`] = `
+exports[`Shortcut > renders the shortcut display text when a string is passed as the shortcut 1`] = `
 <span>
   shortcut text
 </span>

--- a/packages/components/src/shortcut/test/index.tsx
+++ b/packages/components/src/shortcut/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Slot bubblesVirtually false should subsume another slot by the same name 1`] = `
+exports[`Slot > bubblesVirtually %p > should subsume another slot by the same name 1`] = `
 <div>
   <div
     data-position="first"
@@ -13,7 +13,7 @@ exports[`Slot bubblesVirtually false should subsume another slot by the same nam
 </div>
 `;
 
-exports[`Slot bubblesVirtually false should subsume another slot by the same name 2`] = `
+exports[`Slot > bubblesVirtually %p > should subsume another slot by the same name 2`] = `
 <div>
   <div
     data-position="first"
@@ -26,18 +26,7 @@ exports[`Slot bubblesVirtually false should subsume another slot by the same nam
 </div>
 `;
 
-exports[`Slot bubblesVirtually false should unmount two slots with the same name 1`] = `
-<div>
-  <div
-    data-position="first"
-  />
-  <div
-    data-position="second"
-  />
-</div>
-`;
-
-exports[`Slot bubblesVirtually true should subsume another slot by the same name 1`] = `
+exports[`Slot > bubblesVirtually %p > should subsume another slot by the same name 3`] = `
 <div>
   <div
     data-position="first"
@@ -54,7 +43,7 @@ exports[`Slot bubblesVirtually true should subsume another slot by the same name
 </div>
 `;
 
-exports[`Slot bubblesVirtually true should subsume another slot by the same name 2`] = `
+exports[`Slot > bubblesVirtually %p > should subsume another slot by the same name 4`] = `
 <div>
   <div
     data-position="first"
@@ -69,7 +58,7 @@ exports[`Slot bubblesVirtually true should subsume another slot by the same name
 </div>
 `;
 
-exports[`Slot bubblesVirtually true should unmount two slots with the same name 1`] = `
+exports[`Slot > bubblesVirtually %p > should unmount two slots with the same name 1`] = `
 <div>
   <div
     data-position="first"
@@ -80,7 +69,18 @@ exports[`Slot bubblesVirtually true should unmount two slots with the same name 
 </div>
 `;
 
-exports[`Slot should not infinite loop with useSlotFills 1`] = `
+exports[`Slot > bubblesVirtually %p > should unmount two slots with the same name 2`] = `
+<div>
+  <div
+    data-position="first"
+  />
+  <div
+    data-position="second"
+  />
+</div>
+`;
+
+exports[`Slot > should not infinite loop with useSlotFills 1`] = `
 <div>
   <div>
     <div>
@@ -94,7 +94,7 @@ exports[`Slot should not infinite loop with useSlotFills 1`] = `
 </div>
 `;
 
-exports[`Slot should re-render Slot when not bubbling virtually 1`] = `
+exports[`Slot > should re-render Slot when not bubbling virtually 1`] = `
 <div>
   <div>
     1
@@ -105,7 +105,7 @@ exports[`Slot should re-render Slot when not bubbling virtually 1`] = `
 </div>
 `;
 
-exports[`Slot should re-render Slot when not bubbling virtually 2`] = `
+exports[`Slot > should re-render Slot when not bubbling virtually 2`] = `
 <div>
   <div>
     2
@@ -116,7 +116,7 @@ exports[`Slot should re-render Slot when not bubbling virtually 2`] = `
 </div>
 `;
 
-exports[`Slot should render a Fill containing an array 1`] = `
+exports[`Slot > should render a Fill containing an array 1`] = `
 <div>
   <div>
     <span />
@@ -126,7 +126,7 @@ exports[`Slot should render a Fill containing an array 1`] = `
 </div>
 `;
 
-exports[`Slot should render a Fill containing an element 1`] = `
+exports[`Slot > should render a Fill containing an element 1`] = `
 <div>
   <div>
     <span />
@@ -134,7 +134,7 @@ exports[`Slot should render a Fill containing an element 1`] = `
 </div>
 `;
 
-exports[`Slot should render a string Fill 1`] = `
+exports[`Slot > should render a string Fill 1`] = `
 <div>
   <div>
     content
@@ -142,7 +142,7 @@ exports[`Slot should render a string Fill 1`] = `
 </div>
 `;
 
-exports[`Slot should render a string Fill with HTML wrapper when render props used 1`] = `
+exports[`Slot > should render a string Fill with HTML wrapper when render props used 1`] = `
 <div>
   <div>
     <blockquote>
@@ -152,19 +152,19 @@ exports[`Slot should render a string Fill with HTML wrapper when render props us
 </div>
 `;
 
-exports[`Slot should render empty Fills 1`] = `
+exports[`Slot > should render empty Fills 1`] = `
 <div>
   <div />
 </div>
 `;
 
-exports[`Slot should render empty Fills without HTML wrapper when render props used 1`] = `
+exports[`Slot > should render empty Fills without HTML wrapper when render props used 1`] = `
 <div>
   <div />
 </div>
 `;
 
-exports[`Slot should render in expected order when fills always mounted 1`] = `
+exports[`Slot > should render in expected order when fills always mounted 1`] = `
 <div>
   <div>
     first (rerendered)
@@ -175,7 +175,7 @@ exports[`Slot should render in expected order when fills always mounted 1`] = `
 </div>
 `;
 
-exports[`Slot should render in expected order when fills unmounted 1`] = `
+exports[`Slot > should render in expected order when fills unmounted 1`] = `
 <div>
   <div>
     second
@@ -198,7 +198,7 @@ exports[`Slot should render in expected order when fills unmounted 1`] = `
 </div>
 `;
 
-exports[`Slot should warn without a Provider 1`] = `
+exports[`Slot > should warn without a Provider 1`] = `
 <div>
   <div>
     <div />

--- a/packages/components/src/slot-fill/test/index.js
+++ b/packages/components/src/slot-fill/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 
 /**

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -97,7 +102,7 @@ describe( 'Slot', () => {
 	} );
 
 	it( 'calls the functions passed as the Slot’s fillProps in the Fill', async () => {
-		const onClose = jest.fn();
+		const onClose = vi.fn();
 		const user = userEvent.setup();
 		render(
 			<Provider>
@@ -300,7 +305,7 @@ describe( 'Slot', () => {
 			const styleHash = 'slot-fill-cross-document-style';
 			const css = '.slot-fill-cross-document{padding:32px;}';
 
-			// CSS module registration is skipped by the Jest transform, so mirror the
+			// CSS module registration is skipped by the test transform, so mirror the
 			// generated production call explicitly.
 			registerStyle( styleHash, css );
 

--- a/packages/components/src/snackbar/test/index.tsx
+++ b/packages/components/src/snackbar/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { click } from '@ariakit/test';
 
@@ -15,8 +16,11 @@ import { SVG, Path } from '@wordpress/primitives';
  */
 import Snackbar from '../index';
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
-const mockedSpeak = jest.mocked( speak );
+vi.mock( import( '@wordpress/a11y' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	speak: vi.fn(),
+} ) );
+const mockedSpeak = vi.mocked( speak );
 
 describe( 'Snackbar', () => {
 	const testId = 'snackbar';
@@ -56,8 +60,8 @@ describe( 'Snackbar', () => {
 	} );
 
 	it( 'should be dismissible by clicking the snackbar', async () => {
-		const onRemove = jest.fn();
-		const onDismiss = jest.fn();
+		const onRemove = vi.fn();
+		const onDismiss = vi.fn();
 
 		render(
 			<Snackbar onRemove={ onRemove } onDismiss={ onDismiss }>
@@ -80,8 +84,8 @@ describe( 'Snackbar', () => {
 	} );
 
 	it( 'should not be dismissible by clicking the snackbar when the `explicitDismiss` prop is set to `true`', async () => {
-		const onRemove = jest.fn();
-		const onDismiss = jest.fn();
+		const onRemove = vi.fn();
+		const onDismiss = vi.fn();
 
 		render(
 			<Snackbar
@@ -111,8 +115,8 @@ describe( 'Snackbar', () => {
 	} );
 
 	it( 'should be dismissible by clicking the close button when the `explicitDismiss` prop is set to `true`', async () => {
-		const onRemove = jest.fn();
-		const onDismiss = jest.fn();
+		const onRemove = vi.fn();
+		const onDismiss = vi.fn();
 
 		render(
 			<Snackbar
@@ -180,7 +184,7 @@ describe( 'Snackbar', () => {
 		} );
 
 		it( 'should be rendered as a button and call `onClick` when the `onClick` prop is set', async () => {
-			const onClick = jest.fn();
+			const onClick = vi.fn();
 
 			render(
 				<Snackbar actions={ [ { label: 'View post', onClick } ] }>

--- a/packages/components/src/snackbar/test/list.tsx
+++ b/packages/components/src/snackbar/test/list.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { click } from '@ariakit/test';
 
@@ -9,11 +10,11 @@ import { click } from '@ariakit/test';
  */
 import SnackbarList from '../list';
 
-window.scrollTo = jest.fn();
+window.scrollTo = vi.fn();
 
 describe( 'SnackbarList', () => {
 	afterEach( () => {
-		jest.resetAllMocks();
+		vi.resetAllMocks();
 	} );
 
 	it( 'should get focus after a snackbar is dismissed', async () => {

--- a/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/spacer/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 <div
   class="style-spacer components-spacer"
   data-testid="spacer"

--- a/packages/components/src/spacer/test/index.tsx
+++ b/packages/components/src/spacer/test/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
 import { render, screen } from '@testing-library/react';
 
 import { Spacer } from '../index';

--- a/packages/components/src/style-provider/test/index.tsx
+++ b/packages/components/src/style-provider/test/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
 import { render } from '@testing-library/react';
 import { registerStyle } from '@wordpress/style-runtime';
 import StyleProvider from '..';

--- a/packages/components/src/surface/test/index.tsx
+++ b/packages/components/src/surface/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/tab-panel/test/index.tsx
+++ b/packages/components/src/tab-panel/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { press, hover, click } from '@ariakit/test';
 
@@ -45,7 +46,7 @@ describe.each( [
 
 	describe( 'Accessibility and semantics', () => {
 		it( 'should use the correct aria attributes', async () => {
-			const panelRenderFunction = jest.fn();
+			const panelRenderFunction = vi.fn();
 
 			render(
 				<Component tabs={ TABS } children={ panelRenderFunction } />
@@ -77,7 +78,7 @@ describe.each( [
 		} );
 
 		it( 'should display a tooltip when hovering tabs provided with an icon', async () => {
-			const panelRenderFunction = jest.fn();
+			const panelRenderFunction = vi.fn();
 
 			const TABS_WITH_ICON = [
 				{ ...TABS[ 0 ], icon: wordpress },
@@ -113,8 +114,8 @@ describe.each( [
 		} );
 
 		it( 'should display a tooltip when moving the selection via the keyboard on tabs provided with an icon', async () => {
-			const mockOnSelect = jest.fn();
-			const panelRenderFunction = jest.fn();
+			const mockOnSelect = vi.fn();
+			const panelRenderFunction = vi.fn();
 
 			const TABS_WITH_ICON = [
 				{ ...TABS[ 0 ], icon: wordpress },
@@ -174,7 +175,7 @@ describe.each( [
 
 	describe( 'Without `initialTabName`', () => {
 		it( 'should render first tab', async () => {
-			const panelRenderFunction = jest.fn();
+			const panelRenderFunction = vi.fn();
 
 			render(
 				<Component tabs={ TABS } children={ panelRenderFunction } />
@@ -187,7 +188,7 @@ describe.each( [
 		} );
 
 		it( 'should fall back to first enabled tab if the active tab is removed', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 			const { rerender } = render(
 				<Component
 					tabs={ TABS }
@@ -258,7 +259,7 @@ describe.each( [
 		} );
 
 		it( 'should fall back to the tab associated to `initialTabName` if the currently active tab is removed', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			const { rerender } = render(
 				<Component
@@ -290,7 +291,7 @@ describe.each( [
 		} );
 
 		it( 'should have no active tabs when the tab associated to `initialTabName` is removed while being the active tab', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			const { rerender } = render(
 				<Component
@@ -322,7 +323,7 @@ describe.each( [
 		} );
 
 		it( 'waits for the tab with the `initialTabName` to be present in the `tabs` array before selecting it', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 			const { rerender } = render(
 				<Component
 					initialTabName="delta"
@@ -360,7 +361,7 @@ describe.each( [
 
 	describe( 'Disabled Tab', () => {
 		it( 'should disable the tab when `disabled` is `true`', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			render(
 				<Component
@@ -392,7 +393,7 @@ describe.each( [
 		} );
 
 		it( 'should select first enabled tab when the initial tab is disabled', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			const { rerender } = render(
 				<Component
@@ -427,7 +428,7 @@ describe.each( [
 		} );
 
 		it( 'should select first enabled tab when the tab associated to `initialTabName` is disabled', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			const { rerender } = render(
 				<Component
@@ -463,7 +464,7 @@ describe.each( [
 		} );
 
 		it( 'should select the first enabled tab when the selected tab becomes disabled', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 			const { rerender } = render(
 				<Component
 					tabs={ TABS }
@@ -507,7 +508,7 @@ describe.each( [
 		} );
 
 		it( 'should select the first enabled tab when the tab associated to `initialTabName` becomes disabled while being the active tab', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			const { rerender } = render(
 				<Component
@@ -555,8 +556,8 @@ describe.each( [
 
 	describe( 'Tab Activation', () => {
 		it( 'defaults to automatic tab activation (pointer clicks)', async () => {
-			const panelRenderFunction = jest.fn();
-			const mockOnSelect = jest.fn();
+			const panelRenderFunction = vi.fn();
+			const mockOnSelect = vi.fn();
 
 			render(
 				<Component
@@ -593,7 +594,7 @@ describe.each( [
 		} );
 
 		it( 'defaults to automatic tab activation (arrow keys)', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			render(
 				<Component
@@ -630,7 +631,7 @@ describe.each( [
 		} );
 
 		it( 'wraps around the last/first tab when using arrow keys', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			render(
 				<Component
@@ -667,7 +668,7 @@ describe.each( [
 		} );
 
 		it( 'should not move tab selection when pressing the up/down arrow keys, unless the orientation is changed to `vertical`', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			const { rerender } = render(
 				<Component
@@ -754,7 +755,7 @@ describe.each( [
 		} );
 
 		it( 'should move focus on a tab even if disabled with arrow key, but not with pointer clicks', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			render(
 				<Component
@@ -833,7 +834,7 @@ describe.each( [
 		} );
 
 		it( 'switches to manual tab activation when the `selectOnMove` prop is set to `false`', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			render(
 				<Component

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { press, click } from '@ariakit/test';
 import { render } from '@ariakit/test/react';
@@ -18,14 +19,14 @@ import { Tabs } from '..';
 import type { TabsProps } from '../types';
 
 // Setup mocking the `isRTL` function to test arrow key navigation behavior.
-jest.mock( '@wordpress/i18n', () => {
-	const original = jest.requireActual( '@wordpress/i18n' );
+vi.mock( import( '@wordpress/i18n' ), async ( importOriginal ) => {
+	const original = await importOriginal();
 	return {
 		...original,
-		isRTL: jest.fn( () => false ),
+		isRTL: vi.fn( () => false ),
 	};
 } );
-const mockedIsRTL = isRTL as jest.Mock;
+const mockedIsRTL = vi.mocked( isRTL );
 
 type Tab = {
 	tabId: string;
@@ -346,7 +347,7 @@ describe( 'Tabs', () => {
 
 	describe( 'pointer interactions', () => {
 		it( 'should select a tab when clicked', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			await render(
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
@@ -396,7 +397,7 @@ describe( 'Tabs', () => {
 		} );
 
 		it( 'should not select a disabled tab when clicked', async () => {
-			const mockOnSelect = jest.fn();
+			const mockOnSelect = vi.fn();
 
 			await render(
 				<UncontrolledTabs
@@ -652,7 +653,7 @@ describe( 'Tabs', () => {
 				} );
 
 				it( 'should ignore any changes to the `defaultTabId` prop after the first render', async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnSelect = vi.fn();
 
 					const { rerender } = await render(
 						<UncontrolledTabs
@@ -940,7 +941,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation)', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnSelect = vi.fn();
 
 				await render(
 					<Component tabs={ TABS } onSelect={ mockOnSelect } />
@@ -1019,7 +1020,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation)', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnSelect = vi.fn();
 
 				await render(
 					<Component
@@ -1092,7 +1093,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnSelect = vi.fn();
 
 				const { rerender } = await render(
 					<Component tabs={ TABS } onSelect={ mockOnSelect } />
@@ -1196,7 +1197,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnSelect = vi.fn();
 
 				await render(
 					<Component tabs={ TABS } onSelect={ mockOnSelect } />
@@ -1261,7 +1262,7 @@ describe( 'Tabs', () => {
 				// For this test only, mock the writing direction to RTL.
 				mockedIsRTL.mockImplementation( () => true );
 
-				const mockOnSelect = jest.fn();
+				const mockOnSelect = vi.fn();
 
 				await render(
 					<Component tabs={ TABS } onSelect={ mockOnSelect } />
@@ -1343,7 +1344,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should focus tabs in the tablist even if disabled', async () => {
-				const mockOnSelect = jest.fn();
+				const mockOnSelect = vi.fn();
 
 				await render(
 					<Component
@@ -1545,7 +1546,7 @@ describe( 'Tabs', () => {
 		describe( 'removing a tab', () => {
 			describe( 'with no explicitly set initial tab', () => {
 				it( 'should not select a new tab when the selected tab is removed', async () => {
-					const mockOnSelect = jest.fn();
+					const mockOnSelect = vi.fn();
 
 					const { rerender } = await render(
 						<UncontrolledTabs
@@ -1611,7 +1612,7 @@ describe( 'Tabs', () => {
 				'when using the `%s` prop [%s]',
 				( propName, _mode, Component ) => {
 					it( 'should not select a new tab when the selected tab is removed', async () => {
-						const mockOnSelect = jest.fn();
+						const mockOnSelect = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -1673,7 +1674,7 @@ describe( 'Tabs', () => {
 					} );
 
 					it( `should not select the tab matching the \`${ propName }\` prop as a fallback when the selected tab is removed`, async () => {
-						const mockOnSelect = jest.fn();
+						const mockOnSelect = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -1769,7 +1770,7 @@ describe( 'Tabs', () => {
 				'when using the `%s` prop [%s]',
 				( propName, _mode, Component ) => {
 					it( `should select a newly added tab if it matches the \`${ propName }\` prop`, async () => {
-						const mockOnSelect = jest.fn();
+						const mockOnSelect = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -1823,7 +1824,7 @@ describe( 'Tabs', () => {
 				'when using the `%s` prop [%s]',
 				( propName, _mode, Component ) => {
 					it( `should keep the initial tab matching the \`${ propName }\` prop as selected even if it becomes disabled`, async () => {
-						const mockOnSelect = jest.fn();
+						const mockOnSelect = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -1885,7 +1886,7 @@ describe( 'Tabs', () => {
 					} );
 
 					it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
-						const mockOnSelect = jest.fn();
+						const mockOnSelect = vi.fn();
 
 						const { rerender } = await render(
 							<Component

--- a/packages/components/src/text-control/test/text-control.tsx
+++ b/packages/components/src/text-control/test/text-control.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/text-highlight/test/index.tsx
+++ b/packages/components/src/text-highlight/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Text should render align 1`] = `
+exports[`Text > should render align 1`] = `
 Snapshot Diff:
 - Received styles
 + Base styles
@@ -17,7 +17,7 @@ Snapshot Diff:
   ]
 `;
 
-exports[`Text should render highlighted words with highlightCaseSensitive 1`] = `
+exports[`Text > should render highlighted words with highlightCaseSensitive 1`] = `
 .emotion-0 {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
   line-height: 1.4;
@@ -49,7 +49,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
 </div>
 `;
 
-exports[`Text snapshot tests should render correctly 1`] = `
+exports[`Text > snapshot tests > should render correctly 1`] = `
 .emotion-0 {
   color: var(--wp-components-color-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
   line-height: 1.4;

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/toggle-control/test/index.tsx
+++ b/packages/components/src/toggle-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -18,7 +19,7 @@ describe( 'ToggleControl', () => {
 	} );
 
 	it( 'triggers change callback with boolean', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <ToggleControl label="My toggle" onChange={ onChange } /> );
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ToggleGroupControl controlled should render correctly with icons 1`] = `
+exports[`ToggleGroupControl controlled > should render correctly > with icons 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -131,7 +131,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 </div>
 `;
 
-exports[`ToggleGroupControl controlled should render correctly with text options 1`] = `
+exports[`ToggleGroupControl controlled > should render correctly > with text options 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -237,7 +237,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 </div>
 `;
 
-exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] = `
+exports[`ToggleGroupControl uncontrolled > should render correctly > with icons 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -362,7 +362,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 </div>
 `;
 
-exports[`ToggleGroupControl uncontrolled should render correctly with text options 1`] = `
+exports[`ToggleGroupControl uncontrolled > should render correctly > with text options 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, test, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { press, click, hover, sleep } from '@ariakit/test';
 
@@ -154,7 +155,7 @@ describe.each( [
 		expect( screen.getByRole( 'radio', { name: 'J' } ) ).not.toBeChecked();
 	} );
 	it( 'should call onChange with proper value', async () => {
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		render(
 			<Component
@@ -413,7 +414,7 @@ describe.each( [
 	describe( 'isDeselectable', () => {
 		describe( 'isDeselectable = false', () => {
 			it( 'should not be deselectable', async () => {
-				const mockOnChange = jest.fn();
+				const mockOnChange = vi.fn();
 
 				render(
 					<Component
@@ -464,7 +465,7 @@ describe.each( [
 			} );
 
 			it( 'should ignore disabled radio options', async () => {
-				const mockOnChange = jest.fn();
+				const mockOnChange = vi.fn();
 
 				render(
 					<Component
@@ -512,7 +513,7 @@ describe.each( [
 
 		describe( 'isDeselectable = true', () => {
 			it( 'should be deselectable', async () => {
-				const mockOnChange = jest.fn();
+				const mockOnChange = vi.fn();
 
 				render(
 					<Component
@@ -578,7 +579,7 @@ describe.each( [
 			} );
 
 			it( 'should ignore disabled options', async () => {
-				const mockOnChange = jest.fn();
+				const mockOnChange = vi.fn();
 
 				render(
 					<Component

--- a/packages/components/src/toolbar/test/index.tsx
+++ b/packages/components/src/toolbar/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/toolbar/test/toolbar-group.tsx
+++ b/packages/components/src/toolbar/test/toolbar-group.tsx
@@ -1,17 +1,18 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
+import { wordpress } from '@wordpress/icons';
 import { ToolbarGroup } from '..';
 
 /**
  * WordPress dependencies
  */
-import { wordpress } from '@wordpress/icons';
 
 describe( 'ToolbarGroup', () => {
 	describe( 'basic rendering', () => {
@@ -98,7 +99,7 @@ describe( 'ToolbarGroup', () => {
 		} );
 
 		it( 'should call the clickHandler on click.', () => {
-			const clickHandler = jest.fn();
+			const clickHandler = vi.fn();
 			const controls = [
 				{
 					icon: wordpress,

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -17,7 +18,7 @@ import type {
 } from '../types';
 
 const { Fill: ToolsPanelItems, Slot } = createSlotFill( 'ToolsPanelSlot' );
-const resetAll = jest.fn();
+const resetAll = vi.fn();
 const noop = () => undefined;
 const gridContextValue = {
 	Grid: {
@@ -37,51 +38,51 @@ const defaultProps = {
 // Default props for an enabled control to be rendered within panel.
 let controlValue: ControlValue = true;
 const controlProps = {
-	hasValue: jest.fn().mockImplementation( () => {
+	hasValue: vi.fn().mockImplementation( () => {
 		return !! controlValue;
 	} ),
 	label: 'Example',
-	onDeselect: jest.fn().mockImplementation( () => {
+	onDeselect: vi.fn().mockImplementation( () => {
 		controlValue = undefined;
 	} ),
-	onSelect: jest.fn(),
+	onSelect: vi.fn(),
 };
 
 // Default props without a value for an alternate control to be rendered within
 // the panel.
 let altControlValue: ControlValue = false;
 const altControlProps = {
-	hasValue: jest.fn().mockImplementation( () => {
+	hasValue: vi.fn().mockImplementation( () => {
 		return !! altControlValue;
 	} ),
 	label: 'Alt',
-	onDeselect: jest.fn(),
-	onSelect: jest.fn(),
+	onDeselect: vi.fn(),
+	onSelect: vi.fn(),
 };
 
 // Default props for wrapped or grouped panel items.
 let nestedControlValue: ControlValue = true;
 const nestedControlProps = {
-	hasValue: jest.fn().mockImplementation( () => {
+	hasValue: vi.fn().mockImplementation( () => {
 		return !! nestedControlValue;
 	} ),
 	label: 'Nested Control 1',
-	onDeselect: jest.fn().mockImplementation( () => {
+	onDeselect: vi.fn().mockImplementation( () => {
 		nestedControlValue = undefined;
 	} ),
-	onSelect: jest.fn(),
+	onSelect: vi.fn(),
 	isShownByDefault: true,
 };
 
 // Alternative props for wrapped or grouped panel items.
 const altNestedControlValue: ControlValue = false;
 const altNestedControlProps = {
-	hasValue: jest.fn().mockImplementation( () => {
+	hasValue: vi.fn().mockImplementation( () => {
 		return !! altNestedControlValue;
 	} ),
 	label: 'Nested Control 2',
-	onDeselect: jest.fn(),
-	onSelect: jest.fn(),
+	onDeselect: vi.fn(),
+	onSelect: vi.fn(),
 };
 
 // Simple custom component grouping panel items. Used to test panel item
@@ -113,10 +114,10 @@ const panelContext: ToolsPanelContextType = {
 	hasMenuItems: false,
 	isResetting: false,
 	shouldRenderPlaceholderItems: false,
-	registerPanelItem: jest.fn(),
-	deregisterPanelItem: jest.fn(),
-	registerResetAllFilter: jest.fn(),
-	deregisterResetAllFilter: jest.fn(),
+	registerPanelItem: vi.fn(),
+	deregisterPanelItem: vi.fn(),
+	registerResetAllFilter: vi.fn(),
+	deregisterResetAllFilter: vi.fn(),
 	flagItemCustomization: noop,
 	areAllOptionalControlsHidden: true,
 };
@@ -432,8 +433,8 @@ describe( 'ToolsPanel', () => {
 					attributes: { value: toolsPanelItemValue },
 					hasValue: () => !! toolsPanelItemValue,
 					label: 'Alt',
-					onDeselect: jest.fn(),
-					onSelect: jest.fn(),
+					onDeselect: vi.fn(),
+					onSelect: vi.fn(),
 				};
 
 				return (
@@ -468,8 +469,8 @@ describe( 'ToolsPanel', () => {
 					attributes: { value: toolsPanelItemValue },
 					hasValue: () => !! toolsPanelItemValue,
 					label: 'Alt',
-					onDeselect: jest.fn(),
-					onSelect: jest.fn(),
+					onDeselect: vi.fn(),
+					onSelect: vi.fn(),
 				};
 
 				// The null panelId below simulates the panel prop when there
@@ -559,12 +560,12 @@ describe( 'ToolsPanel', () => {
 		it( 'should render default controls with conditional isShownByDefault', async () => {
 			const linkedControlValue = false;
 			const linkedControlProps = {
-				hasValue: jest.fn().mockImplementation( () => {
+				hasValue: vi.fn().mockImplementation( () => {
 					return !! linkedControlValue;
 				} ),
 				label: 'Linked',
-				onDeselect: jest.fn(),
-				onSelect: jest.fn(),
+				onDeselect: vi.fn(),
+				onSelect: vi.fn(),
 			};
 
 			const TestPanel = () => (
@@ -631,12 +632,12 @@ describe( 'ToolsPanel', () => {
 		it( 'should handle conditionally rendered default control', async () => {
 			const conditionalControlValue = false;
 			const conditionalControlProps = {
-				hasValue: jest.fn().mockImplementation( () => {
+				hasValue: vi.fn().mockImplementation( () => {
 					return !! conditionalControlValue;
 				} ),
 				label: 'Conditional',
-				onDeselect: jest.fn(),
-				onSelect: jest.fn(),
+				onDeselect: vi.fn(),
+				onSelect: vi.fn(),
 			};
 
 			const TestPanel = () => (
@@ -694,7 +695,7 @@ describe( 'ToolsPanel', () => {
 
 	describe( 'registration of panel items', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'should register and deregister items when panelId changes', () => {
@@ -831,7 +832,7 @@ describe( 'ToolsPanel', () => {
 
 	describe( 'callbacks on menu item selection', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'should call onDeselect callback when menu item is toggled off', async () => {
@@ -959,7 +960,7 @@ describe( 'ToolsPanel', () => {
 
 	describe( 'rendering via SlotFills', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'should maintain visual order of controls when toggled on and off', async () => {
@@ -1223,23 +1224,23 @@ describe( 'ToolsPanel', () => {
 	describe( 'panel header icon toggle', () => {
 		const defaultControlsValue = false;
 		const defaultControls = {
-			hasValue: jest.fn().mockImplementation( () => {
+			hasValue: vi.fn().mockImplementation( () => {
 				return !! defaultControlsValue;
 			} ),
 			label: 'Default',
-			onDeselect: jest.fn(),
-			onSelect: jest.fn(),
+			onDeselect: vi.fn(),
+			onSelect: vi.fn(),
 			isShownByDefault: true,
 		};
 
 		const optionalControlsValue = false;
 		const optionalControls = {
-			hasValue: jest.fn().mockImplementation( () => {
+			hasValue: vi.fn().mockImplementation( () => {
 				return !! optionalControlsValue;
 			} ),
 			label: 'Optional',
-			onDeselect: jest.fn(),
-			onSelect: jest.fn(),
+			onDeselect: vi.fn(),
+			onSelect: vi.fn(),
 			isShownByDefault: false,
 		};
 
@@ -1299,8 +1300,8 @@ describe( 'ToolsPanel', () => {
 		} );
 
 		it( 'should not call reset all for different panelIds', async () => {
-			const resetItem = jest.fn();
-			const resetItemB = jest.fn();
+			const resetItem = vi.fn();
+			const resetItemB = vi.fn();
 
 			const children = (
 				<>

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { press, hover, click, sleep } from '@ariakit/test';
 
@@ -326,8 +327,8 @@ describe( 'Tooltip', () => {
 		}, 10_000 );
 
 		it( 'should not show tooltip if the mouse leaves the tooltip anchor before set delay', async () => {
-			const onMouseEnterMock = jest.fn();
-			const onMouseLeaveMock = jest.fn();
+			const onMouseEnterMock = vi.fn();
+			const onMouseLeaveMock = vi.fn();
 			const HOVER_OUTSIDE_ANTICIPATION = 200;
 
 			render(
@@ -428,7 +429,7 @@ describe( 'Tooltip', () => {
 
 	describe( 'event propagation', () => {
 		it( 'should close the parent dialog component when pressing the Escape key while the tooltip is visible', async () => {
-			const onRequestClose = jest.fn();
+			const onRequestClose = vi.fn();
 			render(
 				<Modal onRequestClose={ onRequestClose }>
 					<p>Modal content</p>

--- a/packages/components/src/tree-grid/test/__snapshots__/cell.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/cell.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TreeGridCell uses a child render function to render children 1`] = `
+exports[`TreeGridCell > uses a child render function to render children 1`] = `
 <div>
   <div
     role="application"

--- a/packages/components/src/tree-grid/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/index.tsx.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TreeGrid simple rendering renders a table, tbody and any child elements 1`] = `"<div role="application"><table role="treegrid"><tbody><tr role="row" aria-level="1" aria-posinset="1" aria-setsize="1"><td role="gridcell">Test</td></tr></tbody></table></div>"`;
+exports[`TreeGrid > simple rendering > renders a table, tbody and any child elements 1`] = `"<div role="application"><table role="treegrid"><tbody><tr role="row" aria-level="1" aria-posinset="1" aria-setsize="1"><td role="gridcell">Test</td></tr></tbody></table></div>"`;

--- a/packages/components/src/tree-grid/test/__snapshots__/roving-tab-index-item.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/roving-tab-index-item.tsx.snap
@@ -1,12 +1,12 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`RovingTabIndexItem allows another component to be specified as the rendered component using the \`as\` prop 1`] = `
+exports[`RovingTabIndexItem > allows another component to be specified as the rendered component using the \`as\` prop 1`] = `
 <div>
   <button />
 </div>
 `;
 
-exports[`RovingTabIndexItem allows children to be declared using a child render function as an alternative to \`as\` 1`] = `
+exports[`RovingTabIndexItem > allows children to be declared using a child render function as an alternative to \`as\` 1`] = `
 <div>
   <button
     class="my-button"
@@ -16,7 +16,7 @@ exports[`RovingTabIndexItem allows children to be declared using a child render 
 </div>
 `;
 
-exports[`RovingTabIndexItem forwards props to the \`as\` component 1`] = `
+exports[`RovingTabIndexItem > forwards props to the \`as\` component 1`] = `
 <div>
   <button
     class="my-button"

--- a/packages/components/src/tree-grid/test/__snapshots__/roving-tab-index.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/roving-tab-index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`RovingTabIndex does not render any elements other than its children 1`] = `
+exports[`RovingTabIndex > does not render any elements other than its children 1`] = `
 <div>
   <div>
     child element

--- a/packages/components/src/tree-grid/test/__snapshots__/row.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/row.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TreeGridRow forwards other props to the rendered tr element 1`] = `
+exports[`TreeGridRow > forwards other props to the rendered tr element 1`] = `
 <div>
   <table>
     <tbody>
@@ -20,7 +20,7 @@ exports[`TreeGridRow forwards other props to the rendered tr element 1`] = `
 </div>
 `;
 
-exports[`TreeGridRow renders a tr with support for level, positionInSet and setSize props 1`] = `
+exports[`TreeGridRow > renders a tr with support for level, positionInSet and setSize props 1`] = `
 <div>
   <table>
     <tbody>

--- a/packages/components/src/tree-grid/test/cell.tsx
+++ b/packages/components/src/tree-grid/test/cell.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/tree-grid/test/index.tsx
+++ b/packages/components/src/tree-grid/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
@@ -40,7 +41,7 @@ describe( 'TreeGrid', () => {
 
 	describe( 'onExpandRow', () => {
 		it( 'should call onExpandRow when pressing Right Arrow on a collapsed row', () => {
-			const onExpandRow = jest.fn();
+			const onExpandRow = vi.fn();
 
 			render(
 				<TreeGrid onExpandRow={ onExpandRow }>
@@ -92,7 +93,7 @@ describe( 'TreeGrid', () => {
 
 	describe( 'onCollapseRow', () => {
 		it( 'should call onCollapseRow when pressing Left Arrow on an expanded row', () => {
-			const onCollapseRow = jest.fn();
+			const onCollapseRow = vi.fn();
 
 			render(
 				<TreeGrid onCollapseRow={ onCollapseRow }>
@@ -168,7 +169,7 @@ describe( 'TreeGrid', () => {
 		);
 
 		it( 'should call onFocusRow with event, start and end nodes when pressing Down Arrow', () => {
-			const onFocusRow = jest.fn();
+			const onFocusRow = vi.fn();
 			render( <TestTree onFocusRow={ onFocusRow } /> );
 
 			screen.getByText( 'Row 2' ).focus();
@@ -190,7 +191,7 @@ describe( 'TreeGrid', () => {
 		} );
 
 		it( 'should call onFocusRow with event, start and end nodes when pressing End', () => {
-			const onFocusRow = jest.fn();
+			const onFocusRow = vi.fn();
 			render( <TestTree onFocusRow={ onFocusRow } /> );
 
 			screen.getByText( 'Row 1' ).focus();
@@ -212,7 +213,7 @@ describe( 'TreeGrid', () => {
 		} );
 
 		it( 'should call onFocusRow with event, start and end nodes when pressing Up Arrow', () => {
-			const onFocusRow = jest.fn();
+			const onFocusRow = vi.fn();
 			render( <TestTree onFocusRow={ onFocusRow } /> );
 
 			screen.getByText( 'Row 2' ).focus();
@@ -234,7 +235,7 @@ describe( 'TreeGrid', () => {
 		} );
 
 		it( 'should call onFocusRow with event, start and end nodes when pressing Home', () => {
-			const onFocusRow = jest.fn();
+			const onFocusRow = vi.fn();
 			render( <TestTree onFocusRow={ onFocusRow } /> );
 
 			screen.getByText( 'Row 3' ).focus();
@@ -256,7 +257,7 @@ describe( 'TreeGrid', () => {
 		} );
 
 		it( 'should call onFocusRow when shift key is held', () => {
-			const onFocusRow = jest.fn();
+			const onFocusRow = vi.fn();
 			render( <TestTree onFocusRow={ onFocusRow } /> );
 
 			screen.getByText( 'Row 2' ).focus();

--- a/packages/components/src/tree-grid/test/roving-tab-index-item.tsx
+++ b/packages/components/src/tree-grid/test/roving-tab-index-item.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/tree-grid/test/roving-tab-index.tsx
+++ b/packages/components/src/tree-grid/test/roving-tab-index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/tree-grid/test/row.tsx
+++ b/packages/components/src/tree-grid/test/row.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/components/src/unit-control/test/index.tsx
+++ b/packages/components/src/unit-control/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -136,7 +137,7 @@ describe( 'UnitControl', () => {
 	describe( 'Value', () => {
 		it( 'should update value on change', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <UnitControl value="50px" onChange={ onChangeSpy } /> );
 
@@ -157,7 +158,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should increment value on UP press', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <UnitControl value="50px" onChange={ onChangeSpy } /> );
 
@@ -173,7 +174,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should increment value on UP + SHIFT press, with step', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <UnitControl value="50px" onChange={ onChangeSpy } /> );
 
@@ -189,7 +190,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should decrement value on DOWN press', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <UnitControl value={ 50 } onChange={ onChangeSpy } /> );
 
@@ -205,7 +206,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should decrement value on DOWN + SHIFT press, with step', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render( <UnitControl value={ 50 } onChange={ onChangeSpy } /> );
 
@@ -221,7 +222,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should cancel change when ESCAPE key is pressed', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<UnitControl
@@ -248,8 +249,8 @@ describe( 'UnitControl', () => {
 		it( 'should run onBlur callback when quantity input is blurred', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
-			const onBlurSpy = jest.fn();
+			const onChangeSpy = vi.fn();
+			const onBlurSpy = vi.fn();
 
 			render(
 				<UnitControl
@@ -278,7 +279,7 @@ describe( 'UnitControl', () => {
 		it( 'should invoke onChange when isPressEnterToChange is true and the input is blurred with an uncommitted value', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<UnitControl
@@ -310,7 +311,7 @@ describe( 'UnitControl', () => {
 		it( 'should update value correctly when typed and blurred when a single unit is passed', async () => {
 			const user = userEvent.setup();
 
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 			render(
 				<>
 					<button>Click me</button>
@@ -343,8 +344,8 @@ describe( 'UnitControl', () => {
 	describe( 'Unit', () => {
 		it( 'should update unit value on change', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
-			const onUnitChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
+			const onUnitChangeSpy = vi.fn();
 
 			render(
 				<UnitControl
@@ -392,7 +393,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should reset value on unit change, if unit has default value', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const units = [
 				{ value: 'pt', label: 'pt', default: 25 },
@@ -428,7 +429,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should not reset value on unit change, if disabled', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			const units = [
 				{ value: 'pt', label: 'pt', default: 25 },
@@ -464,7 +465,7 @@ describe( 'UnitControl', () => {
 
 		it( 'should set correct unit if single units', async () => {
 			const user = userEvent.setup();
-			const onChangeSpy = jest.fn();
+			const onChangeSpy = vi.fn();
 
 			render(
 				<UnitControl
@@ -541,8 +542,8 @@ describe( 'UnitControl', () => {
 		it( 'should run onBlur callback when the unit select is blurred', async () => {
 			const user = userEvent.setup();
 
-			const onUnitChangeSpy = jest.fn();
-			const onBlurSpy = jest.fn();
+			const onUnitChangeSpy = vi.fn();
+			const onBlurSpy = vi.fn();
 
 			render(
 				<UnitControl
@@ -611,8 +612,8 @@ describe( 'UnitControl', () => {
 			'should move focus from the input to the unit select when typing the first character of %p',
 			async ( testUnit ) => {
 				const user = userEvent.setup();
-				const onChangeSpy = jest.fn();
-				const onUnitChangeSpy = jest.fn();
+				const onChangeSpy = vi.fn();
+				const onUnitChangeSpy = vi.fn();
 
 				render(
 					<UnitControl

--- a/packages/components/src/unit-control/test/utils.ts
+++ b/packages/components/src/unit-control/test/utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/components/src/utils/hooks/test/use-controlled-state.js
+++ b/packages/components/src/utils/hooks/test/use-controlled-state.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
@@ -36,7 +37,7 @@ describe( 'hooks', () => {
 		};
 
 		it( 'should use incoming prop as state on initial render', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render( <Example value="Hello" onChange={ spy } /> );
 
 			const input = getInput();
@@ -46,7 +47,7 @@ describe( 'hooks', () => {
 		} );
 
 		it( 'should update rendered value onChange', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			render( <Example onChange={ spy } /> );
 
 			const input = getInput();
@@ -74,7 +75,7 @@ describe( 'hooks', () => {
 		 * be updated if a new incoming prop value is changed.
 		 */
 		it( 'should update changed value with new incoming prop value', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 
 			/**
 			 * The <input /> value starts with "Hello", since it is passed down
@@ -104,7 +105,7 @@ describe( 'hooks', () => {
 		} );
 
 		it( 'should render with initial value and be controllable', () => {
-			const spy = jest.fn();
+			const spy = vi.fn();
 			// Input starts off as being uncontrolled / self-managed.
 			const { rerender } = render(
 				<Example onChange={ spy } initial="Hello" />

--- a/packages/components/src/utils/hooks/test/use-controlled-value.js
+++ b/packages/components/src/utils/hooks/test/use-controlled-value.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
@@ -39,7 +40,7 @@ describe( 'useControlledValue', () => {
 	} );
 
 	it( 'should call onChange only when there is no value being passed in', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render( <Input defaultValue="WordPress.org" onChange={ onChange } /> );
 
 		expect( getInput() ).toHaveValue( 'WordPress.org' );
@@ -51,7 +52,7 @@ describe( 'useControlledValue', () => {
 	} );
 
 	it( 'should call onChange when there is a value passed in', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const { rerender } = render(
 			<Input
 				defaultValue="WordPress.org"

--- a/packages/components/src/utils/hooks/test/use-cx.js
+++ b/packages/components/src/utils/hooks/test/use-cx.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 // eslint-disable-next-line no-restricted-imports
 import { cx as innerCx } from '@emotion/css';
 import { insertStyles } from '@emotion/utils';
@@ -13,12 +14,12 @@ import createCache from '@emotion/cache';
  */
 import { useCx } from '..';
 
-jest.mock( '@emotion/css', () => ( {
-	cx: jest.fn(),
+vi.mock( import( '@emotion/css' ), () => ( {
+	cx: vi.fn(),
 } ) );
 
-jest.mock( '@emotion/utils', () => ( {
-	insertStyles: jest.fn(),
+vi.mock( import( '@emotion/utils' ), () => ( {
+	insertStyles: vi.fn(),
 } ) );
 
 function Example( { args } ) {

--- a/packages/components/src/utils/test/colors.js
+++ b/packages/components/src/utils/test/colors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getOptimalTextColor, getOptimalTextShade, rgba } from '../colors';

--- a/packages/components/src/utils/test/get-node-text.js
+++ b/packages/components/src/utils/test/get-node-text.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import getNodeText from '../get-node-text';

--- a/packages/components/src/utils/test/math.js
+++ b/packages/components/src/utils/test/math.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/packages/components/src/utils/test/polymorphic-element.tsx
+++ b/packages/components/src/utils/test/polymorphic-element.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import styled from '@emotion/styled';
 import { render, screen } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';

--- a/packages/components/src/utils/test/rtl.js
+++ b/packages/components/src/utils/test/rtl.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { convertLTRToRTL } from '../rtl';

--- a/packages/components/src/utils/test/space.js
+++ b/packages/components/src/utils/test/space.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { space } from '../space';

--- a/packages/components/src/utils/test/strings.js
+++ b/packages/components/src/utils/test/strings.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { kebabCase, normalizeTextString } from '../strings';

--- a/packages/components/src/utils/test/unit-values.js
+++ b/packages/components/src/utils/test/unit-values.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createCSSUnitValue, parseCSSUnitValue } from '../unit-values';

--- a/packages/components/src/v-stack/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/v-stack/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should render alignment 1`] = `
+exports[`props > should render alignment 1`] = `
 <div>
   <div
     class="style-flex style-items-column components-flex components-h-stack components-v-stack"
@@ -14,7 +14,7 @@ exports[`props should render alignment 1`] = `
 </div>
 `;
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 <div>
   <div
     class="style-flex style-items-column components-flex components-h-stack components-v-stack"
@@ -28,7 +28,7 @@ exports[`props should render correctly 1`] = `
 </div>
 `;
 
-exports[`props should render spacing 1`] = `
+exports[`props > should render spacing 1`] = `
 <div>
   <div
     class="style-flex style-items-column components-flex components-h-stack components-v-stack"

--- a/packages/components/src/v-stack/test/index.tsx
+++ b/packages/components/src/v-stack/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/components/src/validated-form-controls/test/checkbox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/checkbox-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedCheckboxControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/combobox-control.tsx
+++ b/packages/components/src/validated-form-controls/test/combobox-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedComboboxControl } from '../components';
@@ -11,7 +16,6 @@ describe( 'ValidatedComboboxControl', () => {
 		{ label: 'Banana', value: 'banana' },
 	];
 
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'should preserve the help description', () => {
 		render(
 			<ValidatedComboboxControl
@@ -27,7 +31,6 @@ describe( 'ValidatedComboboxControl', () => {
 		).toHaveAccessibleDescription( 'Pick a fruit.' );
 	} );
 
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'should append the validation error alongside the help description', async () => {
 		const user = userEvent.setup();
 		render(

--- a/packages/components/src/validated-form-controls/test/content-editable-control.tsx
+++ b/packages/components/src/validated-form-controls/test/content-editable-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedContentEditableControl } from '../components';
@@ -21,7 +26,6 @@ describe( 'ValidatedContentEditableControl', () => {
 	// not the editable that assistive technology interacts with. This is the
 	// same pre-existing limitation as the other delegate-based controls,
 	// tracked in #76741.
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'should append the validation error alongside the help description', async () => {
 		const user = userEvent.setup();
 		render(

--- a/packages/components/src/validated-form-controls/test/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/test/control-with-error.tsx
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	render,
+	screen,
+	waitFor,
+	act,
+	fireEvent,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -17,11 +24,13 @@ import { ValidatedInputControl, ValidatedRangeControl } from '../components';
 describe( 'ControlWithError', () => {
 	describe( 'Async Validation', () => {
 		beforeEach( () => {
-			jest.useFakeTimers();
+			vi.useFakeTimers( {
+				toFake: [ 'clearTimeout', 'setTimeout' ],
+			} );
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		const AsyncValidatedInputControl = ( {
@@ -76,49 +85,35 @@ describe( 'ControlWithError', () => {
 			);
 		};
 
-		it( 'should not show "validating" state if it takes less than 1000ms', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+		it( 'should not show "validating" state if it takes less than 1000ms', () => {
 			render( <AsyncValidatedInputControl serverDelayMs={ 500 } /> );
 
 			const input = screen.getByRole( 'textbox' );
 
-			await user.type( input, 'valid text' );
-
-			// Blur to trigger validation
-			await user.tab();
+			fireEvent.change( input, { target: { value: 'valid text' } } );
+			fireEvent.blur( input );
 
 			// Fast-forward to right before the server response
-			act( () => jest.advanceTimersByTime( 499 ) );
+			act( () => vi.advanceTimersByTime( 499 ) );
 
 			// The validating state should not be shown
-			await waitFor( () => {
-				expect(
-					screen.queryByText( 'Validating...' )
-				).not.toBeInTheDocument();
-			} );
+			expect(
+				screen.queryByText( 'Validating...' )
+			).not.toBeInTheDocument();
 
 			// Fast-forward past the server delay to show validation result
-			act( () => jest.advanceTimersByTime( 1 ) );
+			act( () => vi.advanceTimersByTime( 1 ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validated' ) ).toBeVisible();
-			} );
+			expect( screen.getByText( 'Validated' ) ).toBeVisible();
 		} );
 
-		it( 'should show "validating" state if it takes more than 1000ms', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+		it( 'should show "validating" state if it takes more than 1000ms', () => {
 			render( <AsyncValidatedInputControl serverDelayMs={ 1200 } /> );
 
 			const input = screen.getByRole( 'textbox' );
 
-			await user.type( input, 'valid text' );
-
-			// Blur to trigger validation
-			await user.tab();
+			fireEvent.change( input, { target: { value: 'valid text' } } );
+			fireEvent.blur( input );
 
 			// Initially, no validating message should be shown (before 1s delay)
 			expect(
@@ -126,98 +121,77 @@ describe( 'ControlWithError', () => {
 			).not.toBeInTheDocument();
 
 			// Fast-forward past the 1s delay to show validating state
-			act( () => jest.advanceTimersByTime( 1000 ) );
+			act( () => vi.advanceTimersByTime( 1000 ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validating...' ) ).toBeVisible();
-			} );
+			expect( screen.getByText( 'Validating...' ) ).toBeVisible();
 
 			// Fast-forward past the server delay to show validation result
-			act( () => jest.advanceTimersByTime( 200 ) );
+			act( () => vi.advanceTimersByTime( 200 ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validated' ) ).toBeVisible();
-			} );
+			expect( screen.getByText( 'Validated' ) ).toBeVisible();
 
 			// Test error case
-			await user.clear( input );
-			await user.type( input, 'error' );
+			fireEvent.change( input, { target: { value: 'error' } } );
+			fireEvent.blur( input );
 
-			// Blur to trigger validation
-			await user.tab();
+			act( () => vi.advanceTimersByTime( 1000 ) );
 
-			act( () => jest.advanceTimersByTime( 1000 ) );
+			expect( screen.getByText( 'Validating...' ) ).toBeVisible();
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validating...' ) ).toBeVisible();
-			} );
+			act( () => vi.advanceTimersByTime( 200 ) );
 
-			act( () => jest.advanceTimersByTime( 200 ) );
-
-			await waitFor( () => {
-				expect(
-					screen.getByText( 'The word "error" is not allowed.' )
-				).toBeVisible();
-			} );
+			expect(
+				screen.getByText( 'The word "error" is not allowed.' )
+			).toBeVisible();
 
 			// Test editing after error
-			await user.type( input, '{backspace}' );
+			fireEvent.change( input, { target: { value: 'erro' } } );
 
-			act( () => jest.advanceTimersByTime( 1000 ) );
+			act( () => vi.advanceTimersByTime( 1000 ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validating...' ) ).toBeVisible();
-			} );
+			expect( screen.getByText( 'Validating...' ) ).toBeVisible();
 
-			act( () => jest.advanceTimersByTime( 200 ) );
+			act( () => vi.advanceTimersByTime( 200 ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validated' ) ).toBeVisible();
-			} );
+			expect( screen.getByText( 'Validated' ) ).toBeVisible();
 		} );
 
-		it( 'should not show a "valid" state until the server response is received, even if locally valid', async () => {
-			const user = userEvent.setup( {
-				advanceTimers: jest.advanceTimersByTime,
-			} );
+		it( 'should not show a "valid" state until the server response is received, even if locally valid', () => {
 			render(
 				<AsyncValidatedInputControl serverDelayMs={ 1200 } required />
 			);
 
 			const input = screen.getByRole( 'textbox' );
 
-			await user.type( input, 'valid text' );
+			fireEvent.change( input, { target: { value: 'valid text' } } );
+			fireEvent.blur( input );
+			act( () => vi.advanceTimersByTime( 1200 ) );
 
-			await user.tab();
-			act( () => jest.advanceTimersByTime( 1200 ) );
+			expect( screen.getByText( 'Validated' ) ).toBeVisible();
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Validated' ) ).toBeVisible();
-			} );
+			fireEvent.change( input, { target: { value: '' } } );
 
-			await user.clear( input );
+			act( () => vi.advanceTimersByTime( 1000 ) );
 
-			act( () => jest.advanceTimersByTime( 1000 ) );
-
-			await waitFor( () => {
-				expect(
-					screen.getByText( 'Constraints not satisfied' )
-				).toBeVisible();
-			} );
-
-			await user.type( input, 'error' );
-
-			act( () => jest.advanceTimersByTime( 200 ) );
-
+			expect( screen.getByText( 'Validating...' ) ).toBeVisible();
 			expect( screen.queryByText( 'Validated' ) ).not.toBeInTheDocument();
 
-			act( () => jest.advanceTimersByTime( 1000 ) );
+			act( () => vi.advanceTimersByTime( 200 ) );
 
-			await waitFor( () => {
-				expect(
-					screen.getByText( 'The word "error" is not allowed.' )
-				).toBeVisible();
-			} );
+			expect(
+				screen.getByText( 'Constraints not satisfied' )
+			).toBeVisible();
+
+			fireEvent.change( input, { target: { value: 'error' } } );
+
+			act( () => vi.advanceTimersByTime( 1000 ) );
+			expect( screen.queryByText( 'Validated' ) ).not.toBeInTheDocument();
+
+			act( () => vi.advanceTimersByTime( 200 ) );
+
+			expect(
+				screen.getByText( 'The word "error" is not allowed.' )
+			).toBeVisible();
 		} );
 	} );
 
@@ -249,7 +223,7 @@ describe( 'ControlWithError', () => {
 
 		it( 'should show custom validity messages regardless of "touched" state if parent form is submitted', async () => {
 			const user = userEvent.setup();
-			const onSubmit = jest.fn();
+			const onSubmit = vi.fn();
 			render(
 				<form onSubmit={ onSubmit }>
 					<CustomValidatedInputControl label="Text" />

--- a/packages/components/src/validated-form-controls/test/custom-select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/custom-select-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedCustomSelectControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/test/form-token-field.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedFormTokenField } from '../components';

--- a/packages/components/src/validated-form-controls/test/input-control.tsx
+++ b/packages/components/src/validated-form-controls/test/input-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedInputControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/number-control.tsx
+++ b/packages/components/src/validated-form-controls/test/number-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedNumberControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/radio-control.tsx
+++ b/packages/components/src/validated-form-controls/test/radio-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedRadioControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/range-control.tsx
+++ b/packages/components/src/validated-form-controls/test/range-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState, useRef } from '@wordpress/element';

--- a/packages/components/src/validated-form-controls/test/select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/select-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedSelectControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/text-control.tsx
+++ b/packages/components/src/validated-form-controls/test/text-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedTextControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/textarea-control.tsx
+++ b/packages/components/src/validated-form-controls/test/textarea-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedTextareaControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/toggle-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ValidatedToggleControl } from '../components';

--- a/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { render, screen } from '@testing-library/react';
 import { ValidatedToggleGroupControl } from '../components';
 import { ToggleGroupControlOption } from '../../toggle-group-control';
@@ -7,7 +12,6 @@ import { ToggleGroupControlOption } from '../../toggle-group-control';
 // Additionally, the validity target is a hidden delegate radio input, not the
 // toggle group itself. These are pre-existing bugs, not caused by ControlWithError.
 describe( 'ValidatedToggleGroupControl', () => {
-	// eslint-disable-next-line jest/no-disabled-tests
 	it.skip( 'should preserve the help description', () => {
 		render(
 			<ValidatedToggleGroupControl

--- a/packages/components/src/view/test/__snapshots__/index.js.snap
+++ b/packages/components/src/view/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`props should ignore legacy css prop styles (array) 1`] = `
+exports[`props > should ignore legacy css prop styles (array) 1`] = `
 <div>
   <p
     data-testid="custom-css-array-view"
@@ -10,7 +10,7 @@ exports[`props should ignore legacy css prop styles (array) 1`] = `
 </div>
 `;
 
-exports[`props should ignore legacy css prop styles (object) 1`] = `
+exports[`props > should ignore legacy css prop styles (object) 1`] = `
 <div>
   <p
     data-testid="custom-css-object-view"
@@ -20,7 +20,7 @@ exports[`props should ignore legacy css prop styles (object) 1`] = `
 </div>
 `;
 
-exports[`props should ignore legacy css prop styles (string) 1`] = `
+exports[`props > should ignore legacy css prop styles (string) 1`] = `
 <div>
   <p
     data-testid="custom-css-string-view"
@@ -30,7 +30,7 @@ exports[`props should ignore legacy css prop styles (string) 1`] = `
 </div>
 `;
 
-exports[`props should render as a custom component 1`] = `
+exports[`props > should render as a custom component 1`] = `
 <div>
   <section
     class="custom-class"
@@ -42,7 +42,7 @@ exports[`props should render as a custom component 1`] = `
 </div>
 `;
 
-exports[`props should render as another element 1`] = `
+exports[`props > should render as another element 1`] = `
 <div>
   <p>
     <span />
@@ -50,7 +50,7 @@ exports[`props should render as another element 1`] = `
 </div>
 `;
 
-exports[`props should render correctly 1`] = `
+exports[`props > should render correctly 1`] = `
 <div>
   <div>
     <span />

--- a/packages/components/src/view/test/index.js
+++ b/packages/components/src/view/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -37,7 +38,7 @@ describe( 'props', () => {
 			<section ref={ ref } data-custom-component { ...props } />
 		) );
 
-		const ref = jest.fn();
+		const ref = vi.fn();
 		const { container } = render(
 			<View
 				as={ CustomComponent }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -4,8 +4,7 @@
 	"compilerOptions": {
 		"types": [
 			"gutenberg-env",
-			"gutenberg-test-env",
-			"jest",
+			"gutenberg-vitest-test-env",
 			"react-css-custom-properties",
 			"style-imports"
 		]

--- a/test/unit/config/__snapshots__/emotion-serializer.vitest.test.jsx.snap
+++ b/test/unit/config/__snapshots__/emotion-serializer.vitest.test.jsx.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Emotion snapshot serializer > preserves stable labels for empty styled components 1`] = `
+exports[`Emotion snapshot serializer > normalizes generated hashes while preserving labels for empty styled components 1`] = `
 <div
-  class="css-19mgf5f-EmptyBox emotion-0"
+  class="emotion-empty-EmptyBox emotion-0"
 >
   Content
 </div>

--- a/test/unit/config/emotion-serializer.vitest.js
+++ b/test/unit/config/emotion-serializer.vitest.js
@@ -34,7 +34,10 @@ export function createClassNameReplacer() {
 
 		if ( isEmptyEmotionClass( className ) ) {
 			preservedClassNames++;
-			return className;
+			const label = className.match( /^css-[^-]+-(.+)$/ )?.[ 1 ];
+			return label
+				? `emotion-empty-${ label }`
+				: `emotion-empty-${ preservedClassNames - 1 }`;
 		}
 
 		return `emotion-${ index - preservedClassNames }`;

--- a/test/unit/config/emotion-serializer.vitest.test.jsx
+++ b/test/unit/config/emotion-serializer.vitest.test.jsx
@@ -26,7 +26,7 @@ describe( 'Emotion snapshot serializer', () => {
 		` );
 	} );
 
-	it( 'preserves stable labels for empty styled components', () => {
+	it( 'normalizes generated hashes while preserving labels for empty styled components', () => {
 		const EmptyBox = styled.div``;
 		const { container } = render( <EmptyBox>Content</EmptyBox> );
 

--- a/test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js
+++ b/test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js
@@ -25,7 +25,8 @@ describe( 'snapshotDiff', () => {
 
 	it( 'captures matching stylesheet declarations', () => {
 		const style = document.createElement( 'style' );
-		style.textContent = '.received { color: red; } .base { color: blue; }';
+		style.textContent =
+			'.received, .base {} .received { color: red; } .base { color: blue; }';
 		const received = document.createElement( 'div' );
 		const base = document.createElement( 'div' );
 		received.className = 'received';

--- a/test/unit/config/matchers/to-match-style-diff-snapshot.vitest.js
+++ b/test/unit/config/matchers/to-match-style-diff-snapshot.vitest.js
@@ -37,12 +37,12 @@ const cleanStyleRule = ( rule ) => {
 
 function toMatchStyleDiffSnapshot( received, expected, testName = '' ) {
 	const styleSheets = getStyleSheets();
-	const receivedStyles = getStyleRulesForElement( received, styleSheets ).map(
-		cleanStyleRule
-	);
-	const expectedStyles = getStyleRulesForElement( expected, styleSheets ).map(
-		cleanStyleRule
-	);
+	const getMeaningfulStyles = ( element ) =>
+		getStyleRulesForElement( element, styleSheets )
+			.map( cleanStyleRule )
+			.filter( ( rule ) => Object.keys( rule ).length > 0 );
+	const receivedStyles = getMeaningfulStyles( received );
+	const expectedStyles = getMeaningfulStyles( expected );
 	const difference = snapshotDiff(
 		receivedStyles,
 		expectedStyles,

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -269,7 +269,13 @@ if ( typescriptTests.length ) {
 				path.join( ROOT_DIR, 'typings' ),
 				path.join( ROOT_DIR, 'node_modules/@types' ),
 			],
-			types: [ 'gutenberg-env', 'node', 'style-imports' ],
+			types: [
+				'gutenberg-env',
+				'gutenberg-vitest-test-env',
+				'node',
+				'react-css-custom-properties',
+				'style-imports',
+			],
 		},
 		files: [
 			compatibilityTypesPath,

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -11,6 +11,7 @@
 			"packages/blob",
 			"packages/block-directory",
 			"packages/connectors",
+			"packages/components",
 			"packages/core-commands",
 			"packages/date",
 			"packages/dom-ready",

--- a/typings/gutenberg-vitest-test-env/index.d.ts
+++ b/typings/gutenberg-vitest-test-env/index.d.ts
@@ -1,0 +1,21 @@
+// eslint-disable-next-line import/no-extraneous-dependencies -- The owning test workspaces declare Vitest.
+import 'vitest';
+
+interface GutenbergVitestMatchers< R = unknown > {
+	toBePositionedPopover: () => R;
+	toHaveErrored: () => R;
+	toHaveErroredWith: ( ...args: unknown[] ) => R;
+	toHaveInformed: () => R;
+	toHaveInformedWith: ( ...args: unknown[] ) => R;
+	toHaveLogged: () => R;
+	toHaveLoggedWith: ( ...args: unknown[] ) => R;
+	toHaveWarned: () => R;
+	toHaveWarnedWith: ( ...args: unknown[] ) => R;
+	toMatchDiffSnapshot: ( expected: unknown ) => R;
+	toMatchStyleDiffSnapshot: ( expected: Element | null ) => R;
+}
+
+declare module 'vitest' {
+	interface Assertion< T = any > extends GutenbergVitestMatchers< T > {}
+	interface AsymmetricMatchersContaining extends GutenbergVitestMatchers {}
+}


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the large, snapshot-heavy Components UI test package, including timers, typed partial mocks, custom matchers, Testing Library, Emotion serialization, and 111 snapshots.

See #80855.

This stacked PR routes all 153 active `packages/components` test files to Vitest while preserving the executable Jest baseline: 151 passing suites, 2 skipped suites, 2,060 passing tests, 8 skipped tests, and 111 passing snapshots.

No product runtime behavior changes are intended.

## Why?

Components is the largest remaining package-level migration and exercises the compatibility work established earlier in the series: DOM behavior, user-event, timers, CSS modules, custom matchers, partial module mocks, TypeScript test checking, and Emotion snapshots. Migrating it now validates those foundations against a representative UI-heavy suite before broader repository cutover.

## How?

- Uses explicit local Vitest imports with globals disabled.
- Converts module mocks to typed dynamic-import mocks and uses `vi.mocked` for typed access.
- Keeps Testing Library, user-event, and explicit shared cleanup behavior.
- Keeps fake timers scoped to the APIs each test needs; date-only tests use `toFake: [ 'Date' ]`.
- Makes Components own its Vitest dependency and Vitest-aware test types, removing its direct Jest-only test dependencies.
- Extends the migration convention validator's TypeScript graph to include the repository Vitest matcher environment.
- Stabilizes otherwise empty Emotion class names as `emotion-empty-<label>` and ignores semantically empty CSS rules in style-diff snapshots.
- Preserves the Button compile-time type fixture without an empty runtime suite and tightens the resize-observer mock fixture types.

### Snapshot review

All 111 Components snapshot entries were reviewed individually against the Jest baseline. 108 serialized bodies are byte-for-byte identical; only snapshot metadata changed. The three `context-system-provider` entries replace unstable empty Emotion hashes with the stable `emotion-empty-View` label. The shared Emotion serializer compatibility snapshot was updated to cover that intentional normalization.

<details>
<summary>Reviewed Components snapshot files (33)</summary>

Body-identical:

- `card/test/__snapshots__/index.tsx.snap`
- `checkbox-control/test/__snapshots__/index.tsx.snap`
- `color-indicator/test/__snapshots__/index.tsx.snap`
- `custom-select-control/test/__snapshots__/index.tsx.snap`
- `elevation/test/__snapshots__/index.tsx.snap`
- `flex/test/__snapshots__/index.tsx.snap`
- `form-toggle/test/__snapshots__/index.tsx.snap`
- `h-stack/test/__snapshots__/index.tsx.snap`
- `heading/test/__snapshots__/index.tsx.snap`
- `higher-order/with-filters/test/__snapshots__/index.tsx.snap`
- `input-control/test/__snapshots__/index.js.snap`
- `item-group/test/__snapshots__/index.js.snap`
- `menu-item/test/__snapshots__/index.js.snap`
- `notice/test/__snapshots__/index.tsx.snap`
- `panel/test/__snapshots__/body.tsx.snap`
- `panel/test/__snapshots__/header.tsx.snap`
- `panel/test/__snapshots__/index.tsx.snap`
- `panel/test/__snapshots__/row.tsx.snap`
- `scrollable/test/__snapshots__/index.tsx.snap`
- `select-control/test/__snapshots__/select-control.tsx.snap`
- `shortcut/test/__snapshots__/index.tsx.snap`
- `slot-fill/test/__snapshots__/slot.js.snap`
- `spacer/test/__snapshots__/index.tsx.snap`
- `text/test/__snapshots__/index.tsx.snap`
- `toggle-group-control/test/__snapshots__/index.tsx.snap`
- `tree-grid/test/__snapshots__/cell.tsx.snap`
- `tree-grid/test/__snapshots__/index.tsx.snap`
- `tree-grid/test/__snapshots__/roving-tab-index-item.tsx.snap`
- `tree-grid/test/__snapshots__/roving-tab-index.tsx.snap`
- `tree-grid/test/__snapshots__/row.tsx.snap`
- `v-stack/test/__snapshots__/index.tsx.snap`
- `view/test/__snapshots__/index.js.snap`

Intentionally normalized:

- `context/test/__snapshots__/context-system-provider.js.snap` — three empty Emotion class hashes become `emotion-empty-View`.

</details>

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/components`.
   - Expected: 151 passing files, 2 skipped files; 2,060 passing tests, 8 skipped tests; 111 passing snapshots.
2. Run `npm run test:unit:conventions`.
   - Expected: 220 Vitest tests, 236 ESM graph files, 26 workspace dependencies, and 176 TypeScript tests validated.
3. Run `npm run test:unit:routing`.
   - Expected: all 996 baseline tests have exactly one owner: 780 Jest, 220 Vitest, 0 retired, and 4 added.
4. Run the full Vitest suite and its four CI shards.
   - Verified: 218 passing files, 2 skipped files; 2,962 passing tests, 8 skipped tests. All four shards pass.
5. Run the remaining Jest partition in its four CI shards.
   - Verified: 780 suites, 31,778 tests, and 259 snapshots pass across the shards.
6. Run `npm run lint:lockfile`, `npm run lint:pkg-json`, `npm run lint:tsconfig`, and JavaScript lint for the changed files.

The commit hook also passed formatting, strict JavaScript lint, package JSON, lockfile, tsconfig, and generated-doc checks for the complete change.

`npm run lint:published-deps` verifies `@wordpress/components` has no undeclared imports, but the repository-wide command still exits on unrelated missing local build output for the unchanged `@wordpress/jest-preset-default` → `@wordpress/jest-console` dependency.

### Testing Instructions for Keyboard

Not applicable; this is test-tooling-only and does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement the migration, run verification, audit snapshot diffs, and draft this description. The resulting changes and evidence were reviewed before publication.