### PR TITLE
Migrate UI tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53281,10 +53281,10 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/jest": "^30.0.0",
 				"@types/node": "^20.19.39",
 				"fast-glob": "^3.2.7",
-				"storybook": "^10.4.3"
+				"storybook": "^10.4.3",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.13.0",

--- a/packages/ui/global.d.ts
+++ b/packages/ui/global.d.ts
@@ -2,4 +2,4 @@
 // type definitions found in the specified directories.
 // To ensure that global types are included, we need to
 // explicitly reference them here.
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,10 +64,10 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/jest": "^30.0.0",
 		"@types/node": "^20.19.39",
 		"fast-glob": "^3.2.7",
-		"storybook": "^10.4.3"
+		"storybook": "^10.4.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/ui/src/alert-dialog/test/index.test.tsx
+++ b/packages/ui/src/alert-dialog/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { speak } from '@wordpress/a11y';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -6,8 +7,9 @@ import { createRef } from '@wordpress/element';
 import * as AlertDialog from '..';
 import type { ConfirmResult } from '../types';
 
-jest.mock( '@wordpress/a11y', () => ( {
-	speak: jest.fn(),
+vi.mock( import( '@wordpress/a11y' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	speak: vi.fn(),
 } ) );
 
 function createDeferred() {
@@ -42,7 +44,7 @@ describe( 'AlertDialog', () => {
 
 	it( 'renders with title, children, and default buttons', async () => {
 		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
+			<AlertDialog.Root open onOpenChange={ vi.fn() }>
 				<AlertDialog.Popup title="Test Title">
 					Test message content
 				</AlertDialog.Popup>
@@ -65,7 +67,7 @@ describe( 'AlertDialog', () => {
 
 	it( 'renders description when provided', async () => {
 		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
+			<AlertDialog.Root open onOpenChange={ vi.fn() }>
 				<AlertDialog.Popup
 					title="Test Title"
 					description="This is a description"
@@ -82,7 +84,7 @@ describe( 'AlertDialog', () => {
 
 	it( 'renders with role="alertdialog" for default intent', async () => {
 		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
+			<AlertDialog.Root open onOpenChange={ vi.fn() }>
 				<AlertDialog.Popup title="Default Dialog">
 					Content
 				</AlertDialog.Popup>
@@ -96,7 +98,7 @@ describe( 'AlertDialog', () => {
 
 	it( 'renders with role="alertdialog" for irreversible intent', async () => {
 		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
+			<AlertDialog.Root open onOpenChange={ vi.fn() }>
 				<AlertDialog.Popup
 					intent="irreversible"
 					title="Irreversible Dialog"
@@ -113,7 +115,7 @@ describe( 'AlertDialog', () => {
 
 	it( 'uses custom button labels', async () => {
 		render(
-			<AlertDialog.Root open onOpenChange={ jest.fn() }>
+			<AlertDialog.Root open onOpenChange={ vi.fn() }>
 				<AlertDialog.Popup
 					title="Custom Labels"
 					confirmButtonText="Yes, do it"
@@ -160,8 +162,8 @@ describe( 'AlertDialog', () => {
 
 	describe( 'sync confirm flow', () => {
 		it( 'calls onConfirm and closes on confirm click', async () => {
-			const onConfirm = jest.fn();
-			const onOpenChange = jest.fn();
+			const onConfirm = vi.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -197,13 +199,13 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'provides well-formed event details on confirm close', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
 					open
 					onOpenChange={ onOpenChange }
-					onConfirm={ jest.fn() }
+					onConfirm={ vi.fn() }
 				>
 					<AlertDialog.Popup title="Details Test">
 						Content
@@ -231,7 +233,7 @@ describe( 'AlertDialog', () => {
 			} );
 
 			const details = onOpenChange.mock.calls.find(
-				( [ open ]: [ boolean ] ) => ! open
+				( [ open ] ) => ! open
 			)?.[ 1 ];
 
 			expect( details ).toBeDefined();
@@ -242,7 +244,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'closes without onConfirm when no handler is provided', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root open onOpenChange={ onOpenChange }>
@@ -275,8 +277,8 @@ describe( 'AlertDialog', () => {
 
 	describe( 'cancel and dismiss', () => {
 		it( 'closes on cancel click without calling onConfirm', async () => {
-			const onConfirm = jest.fn();
-			const onOpenChange = jest.fn();
+			const onConfirm = vi.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -308,7 +310,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'closes on escape key', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root open onOpenChange={ onOpenChange }>
@@ -331,7 +333,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'does not close on backdrop click', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root open onOpenChange={ onOpenChange }>
@@ -354,7 +356,7 @@ describe( 'AlertDialog', () => {
 	describe( 'irreversible intent', () => {
 		it( 'renders title and buttons', async () => {
 			render(
-				<AlertDialog.Root open onOpenChange={ jest.fn() }>
+				<AlertDialog.Root open onOpenChange={ vi.fn() }>
 					<AlertDialog.Popup
 						intent="irreversible"
 						title="Irreversible Dialog"
@@ -382,7 +384,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'closes on escape key', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root open onOpenChange={ onOpenChange }>
@@ -410,7 +412,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'does not close on backdrop click', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root open onOpenChange={ onOpenChange }>
@@ -442,7 +444,7 @@ describe( 'AlertDialog', () => {
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => deferred.promise }
 				>
 					<AlertDialog.Popup title="Async Test">
@@ -478,7 +480,7 @@ describe( 'AlertDialog', () => {
 
 		it( 'closes dialog when async confirm resolves', async () => {
 			const deferred = createDeferred();
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -518,14 +520,14 @@ describe( 'AlertDialog', () => {
 
 		it( 're-enables buttons when async confirm rejects (task failure)', async () => {
 			const deferred = createDeferred();
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => deferred.promise }
 				>
 					<AlertDialog.Popup title="Async Reject">
@@ -582,7 +584,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'keeps dialog open when confirm returns { close: false }', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -621,7 +623,7 @@ describe( 'AlertDialog', () => {
 
 		it( 'keeps dialog open when async confirm returns { close: false }', async () => {
 			const deferred = createDeferred();
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -669,7 +671,7 @@ describe( 'AlertDialog', () => {
 
 		it( 'blocks dismiss while pending by default', async () => {
 			const deferred = createDeferred();
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -712,7 +714,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'ignores duplicate confirm clicks while pending', async () => {
-			const onConfirm = jest.fn(
+			const onConfirm = vi.fn(
 				() =>
 					new Promise< void >( () => {
 						// Never resolves
@@ -722,7 +724,7 @@ describe( 'AlertDialog', () => {
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ onConfirm }
 				>
 					<AlertDialog.Popup title="Double Click">
@@ -800,7 +802,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'opens and closes via cancel', async () => {
-			const onConfirm = jest.fn();
+			const onConfirm = vi.fn();
 
 			render(
 				<AlertDialog.Root onConfirm={ onConfirm }>
@@ -833,7 +835,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'closes and unmounts dialog via confirm click', async () => {
-			const onConfirm = jest.fn();
+			const onConfirm = vi.fn();
 
 			render(
 				<AlertDialog.Root onConfirm={ onConfirm }>
@@ -875,7 +877,7 @@ describe( 'AlertDialog', () => {
 			const { unmount } = render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => deferred.promise }
 				>
 					<AlertDialog.Popup title="Unmount Test">
@@ -910,12 +912,12 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'controlled mode: recovers to idle when consumer keeps dialog open after confirm', async () => {
-			const onConfirm = jest.fn();
+			const onConfirm = vi.fn();
 
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ onConfirm }
 				>
 					<AlertDialog.Popup title="Deadlock Test">
@@ -951,11 +953,11 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'recovers when onConfirm throws synchronously', async () => {
-			const onConfirm = jest.fn( () => {
+			const onConfirm = vi.fn( () => {
 				throw new Error( 'Sync error' );
 			} );
-			const onOpenChange = jest.fn();
-			const consoleSpy = jest
+			const onOpenChange = vi.fn();
+			const consoleSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
@@ -1011,7 +1013,7 @@ describe( 'AlertDialog', () => {
 
 		it( 'sets aria-describedby when description is provided', async () => {
 			render(
-				<AlertDialog.Root open onOpenChange={ jest.fn() }>
+				<AlertDialog.Root open onOpenChange={ vi.fn() }>
 					<AlertDialog.Popup
 						title="Describedby Test"
 						description="A helpful description"
@@ -1033,7 +1035,7 @@ describe( 'AlertDialog', () => {
 
 		it( 'allows re-confirm after { close: false, error }', async () => {
 			const deferred = createDeferred();
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -1077,14 +1079,14 @@ describe( 'AlertDialog', () => {
 
 		it( 'allows re-confirm after { close: false }', async () => {
 			let callCount = 0;
-			const onConfirm = jest.fn( (): { close: boolean } | undefined => {
+			const onConfirm = vi.fn( (): { close: boolean } | undefined => {
 				callCount++;
 				if ( callCount === 1 ) {
 					return { close: false };
 				}
 				return undefined;
 			} );
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -1140,14 +1142,14 @@ describe( 'AlertDialog', () => {
 
 	describe( 'error handling', () => {
 		beforeEach( () => {
-			( speak as jest.Mock ).mockClear();
+			vi.mocked( speak ).mockClear();
 		} );
 
 		it( 'displays error message when onConfirm returns { close: false, error }', async () => {
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => ( {
 						close: false,
 						error: 'Something went wrong.',
@@ -1182,7 +1184,7 @@ describe( 'AlertDialog', () => {
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => deferred.promise }
 				>
 					<AlertDialog.Popup title="Async Error">
@@ -1221,7 +1223,7 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'stays open when error is returned without explicit close: false', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<AlertDialog.Root
@@ -1260,7 +1262,7 @@ describe( 'AlertDialog', () => {
 
 		it( 'clears error message on next confirm attempt', async () => {
 			let callCount = 0;
-			const onConfirm = jest.fn( (): ConfirmResult => {
+			const onConfirm = vi.fn( (): ConfirmResult => {
 				callCount++;
 				if ( callCount === 1 ) {
 					return {
@@ -1274,7 +1276,7 @@ describe( 'AlertDialog', () => {
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ onConfirm }
 				>
 					<AlertDialog.Popup title="Clear Error">
@@ -1378,7 +1380,7 @@ describe( 'AlertDialog', () => {
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => ( {
 						close: false,
 						error: 'Announced error.',
@@ -1409,14 +1411,14 @@ describe( 'AlertDialog', () => {
 		} );
 
 		it( 'does not show error message when onConfirm throws', async () => {
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
 			render(
 				<AlertDialog.Root
 					open
-					onOpenChange={ jest.fn() }
+					onOpenChange={ vi.fn() }
 					onConfirm={ () => {
 						throw new Error( 'Unhandled throw' );
 					} }

--- a/packages/ui/src/button/test/button.test.tsx
+++ b/packages/ui/src/button/test/button.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { createRef } from '@wordpress/element';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -23,7 +24,7 @@ describe( 'Button', () => {
 	it( 'is accessible when disabled by default', async () => {
 		const user = userEvent.setup();
 
-		const onClickMock = jest.fn();
+		const onClickMock = vi.fn();
 		render(
 			<Button disabled onClick={ onClickMock }>
 				Click me

--- a/packages/ui/src/button/test/icon.test.tsx
+++ b/packages/ui/src/button/test/icon.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { createRef } from '@wordpress/element';
 import { render } from '@testing-library/react';
 import { ButtonIcon } from '../icon';

--- a/packages/ui/src/card/test/index.test.tsx
+++ b/packages/ui/src/card/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import * as Card from '../index';

--- a/packages/ui/src/collapsible-card/test/index.test.tsx
+++ b/packages/ui/src/collapsible-card/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
@@ -107,7 +108,7 @@ describe( 'CollapsibleCard', () => {
 		} );
 
 		it( 'calls onOpenChange when toggled', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 			const user = userEvent.setup();
 
 			render(

--- a/packages/ui/src/collapsible/test/index.test.tsx
+++ b/packages/ui/src/collapsible/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
@@ -113,7 +114,7 @@ describe( 'Collapsible', () => {
 
 	describe( 'controlled', () => {
 		it( 'calls onOpenChange when toggled', async () => {
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 			const user = userEvent.setup();
 
 			render( <ControlledCollapsible onOpenChange={ onOpenChange } /> );

--- a/packages/ui/src/dialog/test/index.test.tsx
+++ b/packages/ui/src/dialog/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
@@ -5,14 +6,19 @@ import * as Dialog from '../index';
 
 function collectUncaughtErrors() {
 	const errors: Error[] = [];
-	const handler = ( event: ErrorEvent ) => {
+	const windowHandler = ( event: ErrorEvent ) => {
 		event.preventDefault();
 		errors.push( event.error );
 	};
-	window.addEventListener( 'error', handler );
+	const processHandler = ( error: Error ) => errors.push( error );
+	window.addEventListener( 'error', windowHandler );
+	process.on( 'uncaughtException', processHandler );
 	return {
 		errors,
-		cleanup: () => window.removeEventListener( 'error', handler ),
+		cleanup: () => {
+			window.removeEventListener( 'error', windowHandler );
+			process.off( 'uncaughtException', processHandler );
+		},
 	};
 }
 
@@ -277,14 +283,14 @@ describe( 'Dialog', () => {
 	describe( 'Development mode validation', () => {
 		// Suppress console.error from React act() warnings and jsdom
 		// unhandled-error logging. Validation errors are caught via
-		// collectUncaughtErrors (window 'error' event) instead.
+		// collectUncaughtErrors (browser or process error event) instead.
 		let originalConsoleError: typeof console.error;
 
 		beforeEach( () => {
 			// eslint-disable-next-line no-console
 			originalConsoleError = console.error;
 			// eslint-disable-next-line no-console
-			console.error = jest.fn();
+			console.error = vi.fn();
 		} );
 
 		afterEach( () => {
@@ -694,7 +700,7 @@ describe( 'Dialog', () => {
 
 		it( 'should use a custom initialFocus callback as-is', async () => {
 			const user = userEvent.setup();
-			const customFocus = jest.fn( () => false as const );
+			const customFocus = vi.fn( () => false as const );
 
 			render(
 				<Dialog.Root>
@@ -940,7 +946,7 @@ describe( 'Dialog', () => {
 
 		it( 'invokes a consumer-supplied onScroll on Dialog.Content', async () => {
 			const user = userEvent.setup();
-			const onScroll = jest.fn();
+			const onScroll = vi.fn();
 			const contentRef = createRef< HTMLDivElement >();
 
 			render(

--- a/packages/ui/src/drawer/test/index.test.tsx
+++ b/packages/ui/src/drawer/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
@@ -5,14 +6,19 @@ import * as Drawer from '../index';
 
 function collectUncaughtErrors() {
 	const errors: Error[] = [];
-	const handler = ( event: ErrorEvent ) => {
+	const windowHandler = ( event: ErrorEvent ) => {
 		event.preventDefault();
 		errors.push( event.error );
 	};
-	window.addEventListener( 'error', handler );
+	const processHandler = ( error: Error ) => errors.push( error );
+	window.addEventListener( 'error', windowHandler );
+	process.on( 'uncaughtException', processHandler );
 	return {
 		errors,
-		cleanup: () => window.removeEventListener( 'error', handler ),
+		cleanup: () => {
+			window.removeEventListener( 'error', windowHandler );
+			process.off( 'uncaughtException', processHandler );
+		},
 	};
 }
 
@@ -298,7 +304,7 @@ describe( 'Drawer', () => {
 
 	it( 'uses a custom initialFocus callback as-is', async () => {
 		const user = userEvent.setup();
-		const customFocus = jest.fn( () => false as const );
+		const customFocus = vi.fn( () => false as const );
 
 		render(
 			<Drawer.Root>
@@ -483,7 +489,7 @@ describe( 'Drawer', () => {
 			// eslint-disable-next-line no-console
 			originalConsoleError = console.error;
 			// eslint-disable-next-line no-console
-			console.error = jest.fn();
+			console.error = vi.fn();
 		} );
 
 		afterEach( () => {
@@ -990,7 +996,7 @@ describe( 'Drawer', () => {
 
 		it( 'invokes a consumer-supplied onScroll on Drawer.Content', async () => {
 			const user = userEvent.setup();
-			const onScroll = jest.fn();
+			const onScroll = vi.fn();
 			const contentRef = createRef< HTMLDivElement >();
 
 			render(

--- a/packages/ui/src/empty-state/test/actions.test.tsx
+++ b/packages/ui/src/empty-state/test/actions.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Actions } from '../index';

--- a/packages/ui/src/empty-state/test/description.test.tsx
+++ b/packages/ui/src/empty-state/test/description.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Description } from '../index';

--- a/packages/ui/src/empty-state/test/icon.test.tsx
+++ b/packages/ui/src/empty-state/test/icon.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Icon } from '../index';

--- a/packages/ui/src/empty-state/test/root.test.tsx
+++ b/packages/ui/src/empty-state/test/root.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Root } from '../index';

--- a/packages/ui/src/empty-state/test/title.test.tsx
+++ b/packages/ui/src/empty-state/test/title.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Title } from '../index';

--- a/packages/ui/src/empty-state/test/visual.test.tsx
+++ b/packages/ui/src/empty-state/test/visual.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Visual } from '../index';

--- a/packages/ui/src/form/input-control/test/index.test.tsx
+++ b/packages/ui/src/form/input-control/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { InputControl } from '../index';

--- a/packages/ui/src/form/primitives/autocomplete/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';

--- a/packages/ui/src/form/primitives/checkbox/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/checkbox/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Checkbox } from '../index';

--- a/packages/ui/src/form/primitives/combobox/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/combobox/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
@@ -233,7 +234,7 @@ describe( 'Combobox', () => {
 	// verifies the behavioral contract, not the CSS fix itself.
 	it( 'allows selecting items when Empty is rendered after List', async () => {
 		const user = userEvent.setup();
-		const onValueChange = jest.fn();
+		const onValueChange = vi.fn();
 
 		render(
 			<Combobox.Root

--- a/packages/ui/src/form/primitives/field/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/field/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import * as Field from '../index';

--- a/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/fieldset/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import * as Fieldset from '../';

--- a/packages/ui/src/form/primitives/input-layout/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/input-layout/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { InputLayout } from '../index';

--- a/packages/ui/src/form/primitives/input/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/input/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Input } from '../index';

--- a/packages/ui/src/form/primitives/select/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/select/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
@@ -8,7 +9,7 @@ import { useEnableWpCompatOverlaySlot } from '../../../../utils/use-enable-wp-co
 describe( 'Select', () => {
 	it( 'supports object item values', async () => {
 		const user = userEvent.setup();
-		const onValueChange = jest.fn();
+		const onValueChange = vi.fn();
 		const users = [
 			{ value: '1', label: 'User 1' },
 			{ value: '2', label: 'User 2' },

--- a/packages/ui/src/form/primitives/textarea/test/index.test.tsx
+++ b/packages/ui/src/form/primitives/textarea/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
@@ -47,7 +48,7 @@ describe( 'Textarea', () => {
 	describe( 'onValueChange prop', () => {
 		it( 'calls onValueChange when user types', async () => {
 			const user = userEvent.setup();
-			const handleValueChange = jest.fn();
+			const handleValueChange = vi.fn();
 
 			render(
 				<Textarea defaultValue="" onValueChange={ handleValueChange } />
@@ -72,7 +73,7 @@ describe( 'Textarea', () => {
 
 		it( 'works with controlled component pattern', async () => {
 			const user = userEvent.setup();
-			const handleValueChange = jest.fn();
+			const handleValueChange = vi.fn();
 
 			const ControlledTextarea = () => {
 				const [ value, setValue ] = useState( 'Initial' );

--- a/packages/ui/src/form/select-control/test/index.test.tsx
+++ b/packages/ui/src/form/select-control/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
@@ -125,7 +126,7 @@ describe( 'SelectControl', () => {
 	describe( 'Form data behavior', () => {
 		it( 'submits correct form data when option is selected with custom name', async () => {
 			const user = userEvent.setup();
-			const handleSubmit = jest.fn(
+			const handleSubmit = vi.fn(
 				( event: React.FormEvent< HTMLFormElement > ) => {
 					event.preventDefault();
 					return new FormData( event.currentTarget );
@@ -166,7 +167,7 @@ describe( 'SelectControl', () => {
 
 		it( 'submits form data with default value when no selection is made', async () => {
 			const user = userEvent.setup();
-			const handleSubmit = jest.fn(
+			const handleSubmit = vi.fn(
 				( event: React.FormEvent< HTMLFormElement > ) => {
 					event.preventDefault();
 					return new FormData( event.currentTarget );

--- a/packages/ui/src/icon-button/test/index.test.tsx
+++ b/packages/ui/src/icon-button/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';

--- a/packages/ui/src/icon/test/icon.test.tsx
+++ b/packages/ui/src/icon/test/icon.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Icon } from '../index';

--- a/packages/ui/src/link-button/test/link-button.test.tsx
+++ b/packages/ui/src/link-button/test/link-button.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { createRef } from '@wordpress/element';
 import { screen, render } from '@testing-library/react';
 import { LinkButton } from '../index';

--- a/packages/ui/src/link/test/index.test.tsx
+++ b/packages/ui/src/link/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
@@ -18,7 +19,7 @@ describe( 'Link', () => {
 
 	it( 'calls onClick when clicked (often used for analytics tracking)', async () => {
 		const user = userEvent.setup();
-		const onClick = jest.fn(
+		const onClick = vi.fn(
 			( event: React.MouseEvent< HTMLAnchorElement > ) =>
 				event.preventDefault()
 		);

--- a/packages/ui/src/notice/test/index.test.tsx
+++ b/packages/ui/src/notice/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';
@@ -65,7 +66,7 @@ describe( 'Notice', () => {
 	describe( 'dismissing via CloseIcon', () => {
 		it( 'renders dismiss button when CloseIcon included', async () => {
 			const user = userEvent.setup();
-			const handleDismiss = jest.fn();
+			const handleDismiss = vi.fn();
 
 			render(
 				<Notice.Root>
@@ -98,7 +99,7 @@ describe( 'Notice', () => {
 					<Notice.Description>Test</Notice.Description>
 					<Notice.CloseIcon
 						label="Close notification"
-						onClick={ jest.fn() }
+						onClick={ vi.fn() }
 					/>
 				</Notice.Root>
 			);
@@ -151,7 +152,7 @@ describe( 'Notice', () => {
 	describe( 'actions', () => {
 		it( 'renders ActionButton and ActionLink', async () => {
 			const user = userEvent.setup();
-			const handleClick = jest.fn();
+			const handleClick = vi.fn();
 
 			render(
 				<Notice.Root>

--- a/packages/ui/src/popover/test/index.test.tsx
+++ b/packages/ui/src/popover/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from '@wordpress/element';
@@ -7,14 +8,19 @@ import { useEnableWpCompatOverlaySlot } from '../../utils/use-enable-wp-compat-o
 
 function collectUncaughtErrors() {
 	const errors: Error[] = [];
-	const handler = ( event: ErrorEvent ) => {
+	const windowHandler = ( event: ErrorEvent ) => {
 		event.preventDefault();
 		errors.push( event.error );
 	};
-	window.addEventListener( 'error', handler );
+	const processHandler = ( error: Error ) => errors.push( error );
+	window.addEventListener( 'error', windowHandler );
+	process.on( 'uncaughtException', processHandler );
 	return {
 		errors,
-		cleanup: () => window.removeEventListener( 'error', handler ),
+		cleanup: () => {
+			window.removeEventListener( 'error', windowHandler );
+			process.off( 'uncaughtException', processHandler );
+		},
 	};
 }
 
@@ -311,7 +317,7 @@ describe( 'Popover', () => {
 	describe( 'onOpenChange callback', () => {
 		it( 'should call onOpenChange when the popover opens and closes', async () => {
 			const user = userEvent.setup();
-			const onOpenChange = jest.fn();
+			const onOpenChange = vi.fn();
 
 			render(
 				<Popover.Root onOpenChange={ onOpenChange }>
@@ -773,7 +779,7 @@ describe( 'Popover', () => {
 
 		it( 'should use a custom initialFocus callback as-is', async () => {
 			const user = userEvent.setup();
-			const customFocus = jest.fn( () => false as const );
+			const customFocus = vi.fn( () => false as const );
 
 			render(
 				<Popover.Root>
@@ -801,14 +807,14 @@ describe( 'Popover', () => {
 	describe( 'title validation', () => {
 		// Suppress console.error from React act() warnings and jsdom
 		// unhandled-error logging. Validation errors are caught via
-		// collectUncaughtErrors (window 'error' event) instead.
+		// collectUncaughtErrors (browser or process error event) instead.
 		let originalConsoleError: typeof console.error;
 
 		beforeEach( () => {
 			// eslint-disable-next-line no-console
 			originalConsoleError = console.error;
 			// eslint-disable-next-line no-console
-			console.error = jest.fn();
+			console.error = vi.fn();
 		} );
 
 		afterEach( () => {

--- a/packages/ui/src/stack/test/stack.test.tsx
+++ b/packages/ui/src/stack/test/stack.test.tsx
@@ -1,9 +1,12 @@
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Stack } from '../stack';
 
-jest.mock( './style.module.css', () => ( {
-	stack: 'stack-class',
+vi.mock( import( './style.module.css' ), () => ( {
+	default: {
+		stack: 'stack-class',
+	},
 } ) );
 
 describe( 'Stack', () => {

--- a/packages/ui/src/tabs/test/index.test.tsx
+++ b/packages/ui/src/tabs/test/index.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-conditional-expect */
+import { describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
@@ -368,7 +368,7 @@ describe( 'Tabs', () => {
 
 	describe( 'pointer interactions', () => {
 		it( 'should select a tab when clicked', async () => {
-			const mockOnValueChange = jest.fn();
+			const mockOnValueChange = vi.fn();
 
 			const user = userEvent.setup();
 
@@ -426,7 +426,7 @@ describe( 'Tabs', () => {
 		} );
 
 		it( 'should not select a disabled tab when clicked', async () => {
-			const mockOnValueChange = jest.fn();
+			const mockOnValueChange = vi.fn();
 
 			const user = userEvent.setup();
 
@@ -465,7 +465,7 @@ describe( 'Tabs', () => {
 		describe( 'when a selected tab id is not specified', () => {
 			describe( 'when left `undefined` [Uncontrolled]', () => {
 				it( 'should choose the first tab as selected', async () => {
-					const mockOnValueChange = jest.fn();
+					const mockOnValueChange = vi.fn();
 
 					const user = userEvent.setup();
 
@@ -500,7 +500,7 @@ describe( 'Tabs', () => {
 				} );
 
 				it( 'should choose the first non-disabled tab if the first tab is disabled', async () => {
-					const mockOnValueChange = jest.fn();
+					const mockOnValueChange = vi.fn();
 
 					const user = userEvent.setup();
 
@@ -684,8 +684,8 @@ describe( 'Tabs', () => {
 				} );
 
 				it( 'should ignore any changes to the `defaultValue` prop after the first render', async () => {
-					const mockOnValueChange = jest.fn();
-					const consoleErrorSpy = jest
+					const mockOnValueChange = vi.fn();
+					const consoleErrorSpy = vi
 						.spyOn( console, 'error' )
 						.mockImplementation( () => {} );
 
@@ -987,7 +987,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should select tabs in the tablist when using the left and right arrow keys when automatic tab activation is enabled', async () => {
-				const mockOnValueChange = jest.fn();
+				const mockOnValueChange = vi.fn();
 				const user = userEvent.setup();
 
 				const valueProps =
@@ -1087,7 +1087,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys by default (manual tab activation)', async () => {
-				const mockOnValueChange = jest.fn();
+				const mockOnValueChange = vi.fn();
 
 				const user = userEvent.setup();
 
@@ -1173,7 +1173,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
-				const mockOnValueChange = jest.fn();
+				const mockOnValueChange = vi.fn();
 
 				const user = userEvent.setup();
 
@@ -1298,7 +1298,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
-				const mockOnValueChange = jest.fn();
+				const mockOnValueChange = vi.fn();
 
 				const user = userEvent.setup();
 
@@ -1379,7 +1379,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
-				const mockOnValueChange = jest.fn();
+				const mockOnValueChange = vi.fn();
 
 				const user = userEvent.setup();
 
@@ -1484,7 +1484,7 @@ describe( 'Tabs', () => {
 			} );
 
 			it( 'should focus tabs in the tablist even if disabled', async () => {
-				const mockOnValueChange = jest.fn();
+				const mockOnValueChange = vi.fn();
 
 				const user = userEvent.setup();
 
@@ -1710,7 +1710,7 @@ describe( 'Tabs', () => {
 		describe( 'removing a tab', () => {
 			describe( 'with no explicitly set initial tab', () => {
 				it( 'should not select a new tab when the selected tab is removed', async () => {
-					const mockOnValueChange = jest.fn();
+					const mockOnValueChange = vi.fn();
 
 					const user = userEvent.setup();
 
@@ -1794,7 +1794,7 @@ describe( 'Tabs', () => {
 				'when using the `%s` prop [%s]',
 				( propName, mode, Component ) => {
 					it( 'should handle the selected tab being removed', async () => {
-						const mockOnValueChange = jest.fn();
+						const mockOnValueChange = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -1898,7 +1898,7 @@ describe( 'Tabs', () => {
 					} );
 
 					it( `should not fall back to the tab matching the \`${ propName }\` prop when a different selected tab is removed`, async () => {
-						const mockOnValueChange = jest.fn();
+						const mockOnValueChange = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -2042,7 +2042,7 @@ describe( 'Tabs', () => {
 				'when using the `%s` prop [%s]',
 				( propName, mode, Component ) => {
 					it( `should select a newly added tab if it matches the \`${ propName }\` prop`, async () => {
-						const mockOnValueChange = jest.fn();
+						const mockOnValueChange = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -2140,7 +2140,7 @@ describe( 'Tabs', () => {
 				'when using the `%s` prop [%s]',
 				( propName, mode, Component ) => {
 					it( `should handle the initial tab matching the \`${ propName }\` prop becoming disabled`, async () => {
-						const mockOnValueChange = jest.fn();
+						const mockOnValueChange = vi.fn();
 
 						const initialComponentProps = {
 							tabs: TABS,
@@ -2245,7 +2245,7 @@ describe( 'Tabs', () => {
 					} );
 
 					it( 'should handle the user-selected tab becoming disabled', async () => {
-						const mockOnValueChange = jest.fn();
+						const mockOnValueChange = vi.fn();
 
 						const user = userEvent.setup();
 
@@ -2385,14 +2385,19 @@ describe( 'Tabs', () => {
 	describe( 'Development mode validation', () => {
 		function collectUncaughtErrors() {
 			const errors: Error[] = [];
-			const handler = ( event: ErrorEvent ) => {
+			const windowHandler = ( event: ErrorEvent ) => {
 				event.preventDefault();
 				errors.push( event.error );
 			};
-			window.addEventListener( 'error', handler );
+			const processHandler = ( error: Error ) => errors.push( error );
+			window.addEventListener( 'error', windowHandler );
+			process.on( 'uncaughtException', processHandler );
 			return {
 				errors,
-				cleanup: () => window.removeEventListener( 'error', handler ),
+				cleanup: () => {
+					window.removeEventListener( 'error', windowHandler );
+					process.off( 'uncaughtException', processHandler );
+				},
 			};
 		}
 
@@ -2548,4 +2553,3 @@ describe( 'Tabs', () => {
 		} );
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */

--- a/packages/ui/src/tabs/test/overflow.test.tsx
+++ b/packages/ui/src/tabs/test/overflow.test.tsx
@@ -6,13 +6,13 @@
  * firing only the observers that watch a tab reproduces the exact case the old
  * list-only observer missed. Passes with the fix; fails without it.
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 import { Tabs } from '../..';
 
-// The jest preset mocks CSS Modules to `{}`; expose the keys so we can assert
+// The Vitest preset mocks CSS Modules; expose the keys so we can assert
 // on `is-overflowing-last`, the class that drives the fade.
-jest.mock( '../style.module.css', () => ( {
-	__esModule: true,
+vi.mock( import( '../style.module.css' ), () => ( {
 	default: new Proxy( {}, { get: ( _target, key ) => key } ),
 } ) );
 

--- a/packages/ui/src/test/index.test.ts
+++ b/packages/ui/src/test/index.test.ts
@@ -1,5 +1,6 @@
 import { join, dirname, basename } from 'node:path';
 import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
 import glob from 'fast-glob';
 
 describe( 'index', () => {

--- a/packages/ui/src/text/test/index.test.tsx
+++ b/packages/ui/src/text/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { Text } from '../index';

--- a/packages/ui/src/tooltip/test/index.test.tsx
+++ b/packages/ui/src/tooltip/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from '@wordpress/element';

--- a/packages/ui/src/utils/test/theme-provider.test.ts
+++ b/packages/ui/src/utils/test/theme-provider.test.ts
@@ -1,41 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 const consent =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
-function loadThemeProvider( themeModule: object, privateApis = {} ) {
-	const unlock = jest.fn( () => privateApis );
-	jest.doMock( '@wordpress/theme', () => themeModule );
-	jest.doMock( '@wordpress/private-apis', () => ( {
-		__dangerousOptInToUnstableAPIsOnlyForCoreModules: jest.fn(
-			( optInConsent, moduleName ) => {
-				expect( optInConsent ).toBe( consent );
-				expect( moduleName ).toBe( '@wordpress/ui' );
+async function loadThemeProvider(
+	themeModule: Partial< typeof import('@wordpress/theme') >,
+	privateApis: object = {}
+) {
+	const unlockSpy = vi.fn();
+	const unlock = < T = unknown >( object: unknown ): T => {
+		unlockSpy( object );
+		return privateApis as T;
+	};
+	vi.doMock(
+		import( '@wordpress/theme' ),
+		() => themeModule as typeof import('@wordpress/theme')
+	);
+	vi.doMock(
+		import( '@wordpress/private-apis' ),
+		async ( importOriginal ) => ( {
+			...( await importOriginal() ),
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules: vi.fn(
+				( optInConsent, moduleName ) => {
+					expect( optInConsent ).toBe( consent );
+					expect( moduleName ).toBe( '@wordpress/ui' );
 
-				return { unlock };
-			}
-		),
-	} ) );
+					return { lock: vi.fn(), unlock };
+				}
+			),
+		} )
+	);
 
-	let ThemeProvider: unknown;
-	jest.isolateModules( () => {
-		( { ThemeProvider } = require( '../theme-provider' ) );
-	} );
+	const { ThemeProvider } = await import( '../theme-provider' );
 
-	return { ThemeProvider, unlock };
+	return { ThemeProvider, unlock: unlockSpy };
 }
 
 describe( 'ThemeProvider compatibility', () => {
 	afterEach( () => {
-		jest.resetModules();
-		jest.dontMock( '@wordpress/theme' );
-		jest.dontMock( '@wordpress/private-apis' );
+		vi.resetModules();
+		vi.doUnmock( import( '@wordpress/theme' ) );
+		vi.doUnmock( import( '@wordpress/private-apis' ) );
 	} );
 
-	it( 'uses the public ThemeProvider when it is available', () => {
-		const PublicThemeProvider = jest.fn();
-		const PrivateThemeProvider = jest.fn();
+	it( 'uses the public ThemeProvider when it is available', async () => {
+		const PublicThemeProvider = vi.fn();
+		const PrivateThemeProvider = vi.fn();
 		const themePrivateApis = {};
 
-		const { ThemeProvider, unlock } = loadThemeProvider( {
+		const { ThemeProvider, unlock } = await loadThemeProvider( {
 			ThemeProvider: PublicThemeProvider,
 			privateApis: themePrivateApis,
 		} );
@@ -45,12 +58,13 @@ describe( 'ThemeProvider compatibility', () => {
 		expect( PrivateThemeProvider ).not.toHaveBeenCalled();
 	} );
 
-	it( 'falls back to privateApis.ThemeProvider for older @wordpress/theme runtimes', () => {
-		const PrivateThemeProvider = jest.fn();
+	it( 'falls back to privateApis.ThemeProvider for older @wordpress/theme runtimes', async () => {
+		const PrivateThemeProvider = vi.fn();
 		const themePrivateApis = {};
 
-		const { ThemeProvider, unlock } = loadThemeProvider(
+		const { ThemeProvider, unlock } = await loadThemeProvider(
 			{
+				ThemeProvider: undefined,
 				privateApis: themePrivateApis,
 			},
 			{

--- a/packages/ui/src/utils/test/use-deprioritized-initial-focus.test.tsx
+++ b/packages/ui/src/utils/test/use-deprioritized-initial-focus.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef, useEffect } from '@wordpress/element';
 import { useDeprioritizedInitialFocus } from '../use-deprioritized-initial-focus';

--- a/packages/ui/src/utils/test/use-enable-wp-compat-overlay-slot.test.tsx
+++ b/packages/ui/src/utils/test/use-enable-wp-compat-overlay-slot.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import {
 	WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE,

--- a/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
+++ b/packages/ui/src/utils/test/wp-compat-overlay-slot.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
 	getWpCompatOverlaySlot,
 	WP_COMPAT_OVERLAY_SLOT_ATTRIBUTE,

--- a/packages/ui/src/visually-hidden/test/visually-hidden.test.tsx
+++ b/packages/ui/src/visually-hidden/test/visually-hidden.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 import { VisuallyHidden } from '../index';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,8 +3,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"types": [
+			"gutenberg-vitest-test-env",
 			"node",
-			"jest",
 			"style-imports",
 			"react-css-custom-properties"
 		]

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -27,6 +27,7 @@
 			"packages/style-engine",
 			"packages/sync",
 			"packages/token-list",
+			"packages/ui",
 			"packages/undo-manager",
 			"packages/widget-dashboard",
 			"packages/wordcount"


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the complete `@wordpress/ui` test package, including Testing Library interactions, typed module mocks, CSS-module mocks, and intentionally uncaught accessibility-validation errors.

See #80855.

This stacked PR routes all 42 active `packages/ui` test files to Vitest while preserving the executable Jest baseline: 42 passing suites and 434 passing tests, with no snapshots.

No product runtime behavior changes are intended.

## Why?

`@wordpress/ui` is a bounded but interaction-heavy package that exercises the canonical Vitest path against Design System components before the larger editor packages move. It covers Testing Library, Base UI overlays, dynamic compatibility mocks, CSS modules, and delayed accessibility validation.

## How?

- Uses explicit local imports from `vitest`; globals and `vitest/globals` types remain disabled.
- Keeps Testing Library and user-event as the DOM and user-interaction layer.
- Replaces Jest mock functions with `vi`, and converts TypeScript module mocks to typed dynamic-import mocks.
- Replaces `jest.isolateModules`/CommonJS loading in the ThemeProvider compatibility test with `vi.resetModules`, non-hoisted typed mocks, and dynamic ESM imports.
- Makes the UI workspace own Vitest directly, removes its Jest types, and switches its DOM matcher integration to `@testing-library/jest-dom/vitest`.
- Keeps CSS-module test behavior explicit with typed dynamic mocks.
- Observes both browser `error` and Node `uncaughtException` events in tests that intentionally schedule accessibility-validation errors. Jest surfaced these through the former; Vitest surfaces them through the latter. The asserted error messages and product behavior are unchanged.
- Removes the obsolete Jest-specific conditional-expect lint directive.

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/ui`.
   - Expected: 42 passing files and 434 passing tests.
2. Run `npm run test:unit:conventions`.
   - Expected: 262 Vitest tests, 278 ESM graph files, 27 workspace dependencies, and 218 TypeScript tests validated.
3. Run `npm run test:unit:routing`.
   - Expected: all 996 baseline files have exactly one owner: 738 Jest, 262 Vitest, 0 retired, and 4 added.
4. Run the complete Vitest partition.
   - Verified: 260 passing files, 2 skipped files; 3,396 passing tests, 8 skipped tests.
5. Run the remaining Jest partition in four CI shards.
   - Verified: 738 suites, 31,344 tests, and 259 snapshots pass across the shards.
6. Run `npm run lint:lockfile`, `npm run lint:pkg-json`, `npm run lint:tsconfig`, and JavaScript lint for `packages/ui/src`.
7. Run `./node_modules/.bin/dependency-audit --collapse-root-cause packages/ui`.
   - Expected: no undeclared imports.

The commit hook also passed formatting, strict JavaScript lint, package JSON, lockfile, tsconfig, and generated-doc checks for the complete change.

### Testing Instructions for Keyboard

Not applicable; this is test-tooling-only and does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement the migration, run verification, investigate runner-semantics differences, and draft this description. The resulting changes and evidence were reviewed before publication.