### PR TITLE
Migrate Compose tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49978,7 +49978,8 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"mock-match-media": "^0.4.2",
-				"react-dom": "^18.3.1"
+				"react-dom": "^18.3.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Make the `basePipe` TypeScript signature reflect its existing support for arrays of functions, and use an explicitly browser-scoped timer in `useFocusOutside`.
+
 ## 8.4.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -63,7 +63,8 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"mock-match-media": "^0.4.2",
-		"react-dom": "^18.3.1"
+		"react-dom": "^18.3.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/compose/src/higher-order/pipe.ts
+++ b/packages/compose/src/higher-order/pipe.ts
@@ -49,7 +49,7 @@
  */
 const basePipe =
 	( reverse: boolean = false ) =>
-	( ...funcs: Function[] ) =>
+	( ...funcs: ( Function | Function[] )[] ) =>
 	( ...args: unknown[] ) => {
 		const functions = funcs.flat();
 		if ( reverse ) {

--- a/packages/compose/src/higher-order/pure/test/index.js
+++ b/packages/compose/src/higher-order/pure/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/higher-order/test/compose.ts
+++ b/packages/compose/src/higher-order/test/compose.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import compose from '../compose';
@@ -9,27 +14,27 @@ describe( 'compose', () => {
 	} );
 
 	it( 'executes functions right-to-left when passed as separate arguments', () => {
-		const a = ( value ) => ( value += 'a' );
-		const b = ( value ) => ( value += 'b' );
-		const c = ( value ) => ( value += 'c' );
+		const a = ( value: string ) => ( value += 'a' );
+		const b = ( value: string ) => ( value += 'b' );
+		const c = ( value: string ) => ( value += 'c' );
 
 		expect( compose( a, b, c )( 'test' ) ).toBe( 'testcba' );
 	} );
 
 	it( 'executes functions right-to-left when passed as a single array', () => {
-		const a = ( value ) => ( value += 'a' );
-		const b = ( value ) => ( value += 'b' );
-		const c = ( value ) => ( value += 'c' );
+		const a = ( value: string ) => ( value += 'a' );
+		const b = ( value: string ) => ( value += 'b' );
+		const c = ( value: string ) => ( value += 'c' );
 
 		expect( compose( [ a, b, c ] )( 'test' ) ).toBe( 'testcba' );
 	} );
 
 	it( 'executes functions right-to-left when passed as a mix of separate arguments and arrays', () => {
-		const a = ( value ) => ( value += 'a' );
-		const b = ( value ) => ( value += 'b' );
-		const c = ( value ) => ( value += 'c' );
-		const d = ( value ) => ( value += 'd' );
-		const e = ( value ) => ( value += 'e' );
+		const a = ( value: string ) => ( value += 'a' );
+		const b = ( value: string ) => ( value += 'b' );
+		const c = ( value: string ) => ( value += 'c' );
+		const d = ( value: string ) => ( value += 'd' );
+		const e = ( value: string ) => ( value += 'e' );
 
 		expect( compose( [ a, b ], c, [ d ], e )( 'test' ) ).toBe(
 			'testedcba'

--- a/packages/compose/src/higher-order/test/pipe.ts
+++ b/packages/compose/src/higher-order/test/pipe.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import pipe from '../pipe';
@@ -9,27 +14,27 @@ describe( 'pipe', () => {
 	} );
 
 	it( 'executes functions left-to-right when passed as separate arguments', () => {
-		const a = ( value ) => ( value += 'a' );
-		const b = ( value ) => ( value += 'b' );
-		const c = ( value ) => ( value += 'c' );
+		const a = ( value: string ) => ( value += 'a' );
+		const b = ( value: string ) => ( value += 'b' );
+		const c = ( value: string ) => ( value += 'c' );
 
 		expect( pipe( a, b, c )( 'test' ) ).toBe( 'testabc' );
 	} );
 
 	it( 'executes functions left-to-right when passed as a single array', () => {
-		const a = ( value ) => ( value += 'a' );
-		const b = ( value ) => ( value += 'b' );
-		const c = ( value ) => ( value += 'c' );
+		const a = ( value: string ) => ( value += 'a' );
+		const b = ( value: string ) => ( value += 'b' );
+		const c = ( value: string ) => ( value += 'c' );
 
 		expect( pipe( [ a, b, c ] )( 'test' ) ).toBe( 'testabc' );
 	} );
 
 	it( 'executes functions left-to-right when passed as a mix of separate arguments and arrays', () => {
-		const a = ( value ) => ( value += 'a' );
-		const b = ( value ) => ( value += 'b' );
-		const c = ( value ) => ( value += 'c' );
-		const d = ( value ) => ( value += 'd' );
-		const e = ( value ) => ( value += 'e' );
+		const a = ( value: string ) => ( value += 'a' );
+		const b = ( value: string ) => ( value += 'b' );
+		const c = ( value: string ) => ( value += 'c' );
+		const d = ( value: string ) => ( value += 'd' );
+		const e = ( value: string ) => ( value += 'e' );
 
 		expect( pipe( [ a, b ], c, [ d ], e )( 'test' ) ).toBe( 'testabcde' );
 	} );

--- a/packages/compose/src/higher-order/with-global-events/test/index.js
+++ b/packages/compose/src/higher-order/with-global-events/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -14,18 +15,20 @@ import { Component } from '@wordpress/element';
 import withGlobalEvents from '../';
 import Listener from '../listener';
 
-jest.mock( '../listener', () => {
-	const ActualListener = jest.requireActual( '../listener' ).default;
+vi.mock( import( '../listener' ), async ( importOriginal ) => {
+	const { default: ActualListener } = await importOriginal();
 
-	return class extends ActualListener {
-		constructor() {
-			super( ...arguments );
+	return {
+		default: class extends ActualListener {
+			constructor() {
+				super( ...arguments );
 
-			this.constructor._instance = this;
+				this.constructor._instance = this;
 
-			jest.spyOn( this, 'add' );
-			jest.spyOn( this, 'remove' );
-		}
+				vi.spyOn( this, 'add' );
+				vi.spyOn( this, 'remove' );
+			}
+		},
 	};
 } );
 
@@ -42,11 +45,11 @@ describe( 'withGlobalEvents', () => {
 	}
 
 	beforeAll( () => {
-		jest.spyOn( OriginalComponent.prototype, 'handleResize' );
+		vi.spyOn( OriginalComponent.prototype, 'handleResize' );
 	} );
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'renders with original component', () => {
@@ -78,7 +81,7 @@ describe( 'withGlobalEvents', () => {
 		const EnhancedComponent = withGlobalEvents( {
 			resize: 'handleResize',
 		} )( OriginalComponent );
-		const onResize = jest.fn();
+		const onResize = vi.fn();
 
 		render(
 			<EnhancedComponent ref={ () => {} } onResize={ onResize }>

--- a/packages/compose/src/higher-order/with-global-events/test/listener.js
+++ b/packages/compose/src/higher-order/with-global-events/test/listener.js
@@ -1,22 +1,35 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+/**
  * Internal dependencies
  */
 import Listener from '../listener';
 
 describe( 'Listener', () => {
-	const createHandler = () => ( { handleEvent: jest.fn() } );
+	const createHandler = () => ( { handleEvent: vi.fn() } );
 
 	let listener, _addEventListener, _removeEventListener;
 	beforeAll( () => {
 		_addEventListener = global.window.addEventListener;
 		_removeEventListener = global.window.removeEventListener;
-		global.window.addEventListener = jest.fn();
-		global.window.removeEventListener = jest.fn();
+		global.window.addEventListener = vi.fn();
+		global.window.removeEventListener = vi.fn();
 	} );
 
 	beforeEach( () => {
 		listener = new Listener();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	afterAll( () => {

--- a/packages/compose/src/higher-order/with-instance-id/test/index.js
+++ b/packages/compose/src/higher-order/with-instance-id/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/higher-order/with-state/test/index.js
+++ b/packages/compose/src/higher-order/with-state/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/compose/src/hooks/use-copy-on-click/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-on-click/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -15,7 +16,7 @@ import { useRef } from '@wordpress/element';
  */
 import useCopyOnClick from '../';
 
-jest.mock( '@wordpress/deprecated' );
+vi.mock( import( '@wordpress/deprecated' ) );
 
 interface TestComponentProps {
 	text: string | ( () => string );
@@ -23,6 +24,10 @@ interface TestComponentProps {
 }
 
 describe( 'useCopyOnClick', () => {
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
 	const TestComponent = ( { text, timeout = 4000 }: TestComponentProps ) => {
 		const ref = useRef< HTMLButtonElement >( null );
 		const hasCopied = useCopyOnClick( ref, text, timeout );
@@ -34,7 +39,7 @@ describe( 'useCopyOnClick', () => {
 	};
 
 	it( 'should call deprecated when the hook is used', () => {
-		jest.mocked( deprecated ).mockClear();
+		vi.mocked( deprecated ).mockClear();
 		render( <TestComponent text="test text" /> );
 
 		expect( deprecated ).toHaveBeenCalledWith(
@@ -50,7 +55,7 @@ describe( 'useCopyOnClick', () => {
 		const user = userEvent.setup();
 		render( <TestComponent text="test text" /> );
 
-		const writeTextMock = jest
+		const writeTextMock = vi
 			.spyOn( navigator.clipboard, 'writeText' )
 			.mockResolvedValue();
 
@@ -64,7 +69,7 @@ describe( 'useCopyOnClick', () => {
 		const user = userEvent.setup();
 		render( <TestComponent text="test text" /> );
 
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockResolvedValue();
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockResolvedValue();
 
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Copy' );
 
@@ -78,36 +83,32 @@ describe( 'useCopyOnClick', () => {
 	} );
 
 	it( 'should reset hasCopied after timeout', async () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers( { shouldAdvanceTime: true } );
 		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
+			advanceTimers: ( delay ) => vi.advanceTimersByTime( delay ),
 		} );
 		render( <TestComponent text="test text" timeout={ 1000 } /> );
 
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockResolvedValue();
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockResolvedValue();
 
 		await user.click( screen.getByRole( 'button' ) );
 
 		await act( async () => {
-			const p = new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
-			jest.advanceTimersByTime( 0 );
-			await p;
+			await vi.advanceTimersByTimeAsync( 0 );
 		} );
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Copied!' );
 
-		act( () => {
-			jest.advanceTimersByTime( 1000 );
+		await act( async () => {
+			await vi.advanceTimersByTimeAsync( 1000 );
 		} );
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Copy' );
-
-		jest.useRealTimers();
 	} );
 
 	it( 'should not set hasCopied when copy fails', async () => {
 		const user = userEvent.setup();
 		render( <TestComponent text="test text" /> );
 
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockRejectedValue(
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockRejectedValue(
 			new Error()
 		);
 
@@ -121,7 +122,7 @@ describe( 'useCopyOnClick', () => {
 	} );
 
 	it( 'should not update hasCopied after unmount', async () => {
-		const renderSpy = jest.fn();
+		const renderSpy = vi.fn();
 
 		const SpyComponent = ( { text }: { text: string } ) => {
 			const ref = useRef< HTMLButtonElement >( null );
@@ -138,7 +139,7 @@ describe( 'useCopyOnClick', () => {
 		const delayedPromise = new Promise< void >( ( resolve ) => {
 			resolvePromise = resolve;
 		} );
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
 			delayedPromise as Promise< void >
 		);
 

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -24,7 +25,7 @@ describe( 'useCopyToClipboard', () => {
 		const user = userEvent.setup();
 		render( <TestComponent text="test text" /> );
 
-		const writeTextMock = jest
+		const writeTextMock = vi
 			.spyOn( navigator.clipboard, 'writeText' )
 			.mockResolvedValue();
 
@@ -36,7 +37,7 @@ describe( 'useCopyToClipboard', () => {
 
 	it( 'should call onSuccess when copy succeeds', async () => {
 		const user = userEvent.setup();
-		const onSuccess = jest.fn();
+		const onSuccess = vi.fn();
 		render( <TestComponent text="test text" onSuccess={ onSuccess } /> );
 
 		await user.click( screen.getByRole( 'button' ) );
@@ -46,7 +47,7 @@ describe( 'useCopyToClipboard', () => {
 
 	it( 'should call onSuccess when copy empty text', async () => {
 		const user = userEvent.setup();
-		const onSuccess = jest.fn();
+		const onSuccess = vi.fn();
 		render( <TestComponent text="" onSuccess={ onSuccess } /> );
 
 		await user.click( screen.getByRole( 'button' ) );
@@ -56,10 +57,10 @@ describe( 'useCopyToClipboard', () => {
 
 	it( 'should not call onSuccess when copy fails', async () => {
 		const user = userEvent.setup();
-		const onSuccess = jest.fn();
+		const onSuccess = vi.fn();
 		render( <TestComponent text="test text" onSuccess={ onSuccess } /> );
 
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockRejectedValue(
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockRejectedValue(
 			new Error()
 		);
 
@@ -73,12 +74,12 @@ describe( 'useCopyToClipboard', () => {
 		const delayedPromise = new Promise< void >( ( resolve ) => {
 			resolvePromise = resolve;
 		} );
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
 			delayedPromise
 		);
 
 		const user = userEvent.setup();
-		const onSuccess = jest.fn();
+		const onSuccess = vi.fn();
 		const { unmount } = render(
 			<TestComponent text="test" onSuccess={ onSuccess } />
 		);
@@ -99,7 +100,7 @@ describe( 'useCopyToClipboard', () => {
 		const delayedPromise = new Promise< void >( ( resolve ) => {
 			resolvePromise = resolve;
 		} );
-		jest.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
+		vi.spyOn( navigator.clipboard, 'writeText' ).mockReturnValue(
 			delayedPromise
 		);
 
@@ -107,7 +108,7 @@ describe( 'useCopyToClipboard', () => {
 		const { unmount } = render( <TestComponent text="test" /> );
 
 		const button = screen.getByRole( 'button' );
-		const focusSpy = jest.spyOn( button, 'focus' );
+		const focusSpy = vi.spyOn( button, 'focus' );
 
 		await user.click( button );
 		unmount();
@@ -136,7 +137,7 @@ describe( 'copyToClipboard', () => {
 
 		// JSDOM does not implement execCommand; add a mock for the fallback path.
 		// See: https://github.com/jsdom/jsdom/issues/1742
-		const execCommandMock = jest.fn().mockReturnValue( true );
+		const execCommandMock = vi.fn().mockReturnValue( true );
 		Object.defineProperty( document, 'execCommand', {
 			value: execCommandMock,
 			configurable: true,
@@ -161,7 +162,7 @@ describe( 'restoreFocus', () => {
 	it( 'should focus the trigger element', () => {
 		const trigger = document.createElement( 'button' );
 		document.body.appendChild( trigger );
-		const focusMock = jest.spyOn( trigger, 'focus' );
+		const focusMock = vi.spyOn( trigger, 'focus' );
 
 		restoreFocus( trigger );
 

--- a/packages/compose/src/hooks/use-dialog/test/index.tsx
+++ b/packages/compose/src/hooks/use-dialog/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createPortal } from 'react-dom';
@@ -27,7 +28,7 @@ function Dialog( { onClose }: { onClose?: () => void } ) {
 describe( 'useDialog', () => {
 	it( 'should call onClose when Escape is pressed', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
+		const onClose = vi.fn();
 
 		render( <Dialog onClose={ onClose } /> );
 
@@ -39,7 +40,7 @@ describe( 'useDialog', () => {
 
 	it( 'should not call onClose when Escape is pressed if defaultPrevented', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
+		const onClose = vi.fn();
 
 		function DialogWithChild() {
 			const [ ref, props ] = useDialog( {
@@ -76,8 +77,8 @@ describe( 'useDialog', () => {
 
 	it( 'should stop Escape event from propagating to parent elements', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
-		const parentKeyDownHandler = jest.fn();
+		const onClose = vi.fn();
+		const parentKeyDownHandler = vi.fn();
 
 		render(
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -95,7 +96,7 @@ describe( 'useDialog', () => {
 
 	it( 'should let Escape propagate when there is no onClose handler', async () => {
 		const user = userEvent.setup();
-		const parentKeyDownHandler = jest.fn();
+		const parentKeyDownHandler = vi.fn();
 
 		render(
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -112,8 +113,8 @@ describe( 'useDialog', () => {
 
 	it( 'should not close when a portaled descendant handles Escape and stops propagation', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
-		const descendantHandled = jest.fn();
+		const onClose = vi.fn();
+		const descendantHandled = vi.fn();
 
 		const portalTarget = document.createElement( 'div' );
 		document.body.appendChild( portalTarget );
@@ -160,8 +161,8 @@ describe( 'useDialog', () => {
 
 	it( 'should close only the innermost dialog when nested', async () => {
 		const user = userEvent.setup();
-		const outerOnClose = jest.fn();
-		const innerOnClose = jest.fn();
+		const outerOnClose = vi.fn();
+		const innerOnClose = vi.fn();
 
 		function NestedDialogs() {
 			const [ outerRef, outerProps ] = useDialog( {
@@ -203,8 +204,8 @@ describe( 'useDialog', () => {
 
 	it( 'should call the consumer-provided onKeyDown alongside close-on-Escape', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
-		const consumerOnKeyDown = jest.fn();
+		const onClose = vi.fn();
+		const consumerOnKeyDown = vi.fn();
 
 		function DialogWithConsumerOnKeyDown() {
 			const [ ref, props ] = useDialog( {
@@ -234,7 +235,7 @@ describe( 'useDialog', () => {
 
 	it( 'should let the consumer-provided onKeyDown opt out of close-on-Escape via preventDefault', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
+		const onClose = vi.fn();
 
 		function DialogOptingOut() {
 			const [ ref, props ] = useDialog( {
@@ -262,7 +263,7 @@ describe( 'useDialog', () => {
 
 	it( 'should not call onClose for non-Escape keys', async () => {
 		const user = userEvent.setup();
-		const onClose = jest.fn();
+		const onClose = vi.fn();
 
 		render( <Dialog onClose={ onClose } /> );
 

--- a/packages/compose/src/hooks/use-disabled/test/index.js
+++ b/packages/compose/src/hooks/use-disabled/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/hooks/use-drop-zone/test/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -151,7 +151,7 @@ export default function useFocusOutside(
 			return;
 		}
 
-		blurCheckTimeoutIdRef.current = setTimeout( () => {
+		blurCheckTimeoutIdRef.current = window.setTimeout( () => {
 			// If document is not focused then focus should remain
 			// inside the wrapped component and therefore we cancel
 			// this blur event thereby leaving focus in place.

--- a/packages/compose/src/hooks/use-focus-outside/test/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -26,7 +27,7 @@ const FocusOutsideComponent = ( { onFocusOutside: callback } ) => (
 
 describe( 'useFocusOutside', () => {
 	it( 'should not call handler if focus shifts to element within component', async () => {
-		const mockOnFocusOutside = jest.fn();
+		const mockOnFocusOutside = vi.fn();
 		const user = userEvent.setup();
 
 		render(
@@ -47,7 +48,7 @@ describe( 'useFocusOutside', () => {
 	} );
 
 	it( 'should not call handler if focus transitions via click to button', async () => {
-		const mockOnFocusOutside = jest.fn();
+		const mockOnFocusOutside = vi.fn();
 		const user = userEvent.setup();
 
 		render(
@@ -64,7 +65,7 @@ describe( 'useFocusOutside', () => {
 	} );
 
 	it( 'should call handler if focus shifts to element outside component', async () => {
-		const mockOnFocusOutside = jest.fn();
+		const mockOnFocusOutside = vi.fn();
 		const user = userEvent.setup();
 
 		render(
@@ -89,10 +90,10 @@ describe( 'useFocusOutside', () => {
 	it( 'should not call handler if focus shifts outside the component when the document does not have focus', async () => {
 		// Force document.hasFocus() to return false to simulate the window/document losing focus
 		// See https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus.
-		const mockedDocumentHasFocus = jest
+		const mockedDocumentHasFocus = vi
 			.spyOn( document, 'hasFocus' )
 			.mockImplementation( () => false );
-		const mockOnFocusOutside = jest.fn();
+		const mockOnFocusOutside = vi.fn();
 		const user = userEvent.setup();
 
 		render(
@@ -121,9 +122,7 @@ describe( 'useFocusOutside', () => {
 		const promise = new Promise( ( resolve ) => {
 			resolvePromise = resolve;
 		} );
-		const mockOnFocusOutside = jest
-			.fn()
-			.mockImplementation( resolvePromise );
+		const mockOnFocusOutside = vi.fn().mockImplementation( resolvePromise );
 		const user = userEvent.setup();
 
 		const { unmount } = render(

--- a/packages/compose/src/hooks/use-instance-id/test/index.js
+++ b/packages/compose/src/hooks/use-instance-id/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/hooks/use-media-query/test/index.js
+++ b/packages/compose/src/hooks/use-media-query/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { act, render } from '@testing-library/react';
 import { matchMedia, setMedia } from 'mock-match-media';
 

--- a/packages/compose/src/hooks/use-media-query/test/ssr.js
+++ b/packages/compose/src/hooks/use-media-query/test/ssr.js
@@ -1,10 +1,9 @@
-/**
- * @jest-environment node
- */
+// @vitest-environment node
 
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { renderToString } from 'react-dom/server';
 
 /**

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/hooks/use-observable-value/test/index.js
+++ b/packages/compose/src/hooks/use-observable-value/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 
 /**
@@ -14,7 +15,7 @@ describe( 'useObservableValue', () => {
 		const map = observableMap();
 		map.set( 'a', 1 );
 
-		const MapUI = jest.fn( () => {
+		const MapUI = vi.fn( () => {
 			const value = useObservableValue( map, 'a' );
 			return <div>value is { value }</div>;
 		} );

--- a/packages/compose/src/hooks/use-state-with-history/test/index.js
+++ b/packages/compose/src/hooks/use-state-with-history/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { screen, render, fireEvent } from '@testing-library/react';
 
 /**

--- a/packages/compose/src/hooks/use-viewport-match/test/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/test/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -8,9 +9,7 @@ import { render } from '@testing-library/react';
  */
 import useViewportMatch from '../';
 
-jest.mock( '../../use-media-query', () => {
-	return jest.fn();
-} );
+vi.mock( import( '../../use-media-query' ), () => ( { default: vi.fn() } ) );
 
 import useMediaQueryMock from '../../use-media-query';
 

--- a/packages/compose/src/utils/create-higher-order-component/test/index.js
+++ b/packages/compose/src/utils/create-higher-order-component/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';

--- a/packages/compose/src/utils/debounce/test/index.ts
+++ b/packages/compose/src/utils/debounce/test/index.ts
@@ -1,9 +1,14 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { debounce } from '../index';
 
-const identity = ( value ) => value;
+const identity = < T >( value: T ) => value;
 
 describe( 'debounce', () => {
 	it( 'should debounce a function', () => {
@@ -329,12 +334,12 @@ describe( 'debounce', () => {
 
 	it( 'should invoke the trailing call with the correct arguments and `this` binding', () => {
 		return new Promise( ( done ) => {
-			let actual;
+			let actual: unknown[] | undefined;
 			let callCount = 0;
 			const object = {};
 
 			const debounced = debounce(
-				function ( ...args ) {
+				function ( this: object, ...args: unknown[] ) {
 					actual = [ this ];
 					Array.prototype.push.apply( actual, args );
 					return ++callCount !== 2;

--- a/packages/compose/src/utils/observable-map/test/index.js
+++ b/packages/compose/src/utils/observable-map/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { observableMap } from '..';
@@ -7,8 +12,8 @@ describe( 'ObservableMap', () => {
 	test( 'should observe individual values', () => {
 		const map = observableMap();
 
-		const listenerA = jest.fn();
-		const listenerB = jest.fn();
+		const listenerA = vi.fn();
+		const listenerB = vi.fn();
 
 		const unsubA = map.subscribe( 'a', listenerA );
 		const unsubB = map.subscribe( 'b', listenerB );

--- a/packages/compose/src/utils/subscribe-delegated-listener/test/index.js
+++ b/packages/compose/src/utils/subscribe-delegated-listener/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import subscribeDelegatedListener from '..';
@@ -30,14 +35,14 @@ describe( 'subscribeDelegatedListener', () => {
 	}
 
 	test( 'invokes element subscriber when event fires on that element', () => {
-		const cb = jest.fn();
+		const cb = vi.fn();
 		subscribeDelegatedListener( target, 'click', cb );
 		fire( target );
 		expect( cb ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'invokes element subscriber when event fires on a descendant', () => {
-		const cb = jest.fn();
+		const cb = vi.fn();
 		const child = document.createElement( 'b' );
 		target.appendChild( child );
 		subscribeDelegatedListener( target, 'click', cb );
@@ -46,7 +51,7 @@ describe( 'subscribeDelegatedListener', () => {
 	} );
 
 	test( 'does not invoke element subscriber when event fires outside its subtree', () => {
-		const cb = jest.fn();
+		const cb = vi.fn();
 		const sibling = document.createElement( 'div' );
 		document.body.appendChild( sibling );
 		subscribeDelegatedListener( target, 'click', cb );
@@ -86,8 +91,8 @@ describe( 'subscribeDelegatedListener', () => {
 	} );
 
 	test( 'capture and bubble registries are independent', () => {
-		const captureCb = jest.fn();
-		const bubbleCb = jest.fn();
+		const captureCb = vi.fn();
+		const bubbleCb = vi.fn();
 		subscribeDelegatedListener( target, 'click', captureCb, true );
 		subscribeDelegatedListener( target, 'click', bubbleCb, false );
 		fire( target );
@@ -96,15 +101,15 @@ describe( 'subscribeDelegatedListener', () => {
 	} );
 
 	test( 'document subscriber always fires for events in the document', () => {
-		const cb = jest.fn();
+		const cb = vi.fn();
 		subscribeDelegatedListener( document, 'click', cb );
 		fire( target );
 		expect( cb ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'window subscriber fans out independently of element subscribers', () => {
-		const winCb = jest.fn();
-		const elCb = jest.fn();
+		const winCb = vi.fn();
+		const elCb = vi.fn();
 		subscribeDelegatedListener( window, 'resize', winCb );
 		subscribeDelegatedListener( target, 'resize', elCb );
 		window.dispatchEvent( new Event( 'resize' ) );
@@ -114,8 +119,8 @@ describe( 'subscribeDelegatedListener', () => {
 	} );
 
 	test( 'multiple callbacks for the same element all fire', () => {
-		const a = jest.fn();
-		const b = jest.fn();
+		const a = vi.fn();
+		const b = vi.fn();
 		subscribeDelegatedListener( target, 'click', a );
 		subscribeDelegatedListener( target, 'click', b );
 		fire( target );
@@ -124,7 +129,7 @@ describe( 'subscribeDelegatedListener', () => {
 	} );
 
 	test( 'unsubscribe stops further dispatch', () => {
-		const cb = jest.fn();
+		const cb = vi.fn();
 		const unsub = subscribeDelegatedListener( target, 'click', cb );
 		fire( target );
 		expect( cb ).toHaveBeenCalledTimes( 1 );
@@ -134,12 +139,12 @@ describe( 'subscribeDelegatedListener', () => {
 	} );
 
 	test( 'attaches one native listener per (root, eventType, phase) regardless of subscriber count', () => {
-		const spy = jest.spyOn( document, 'addEventListener' );
+		const spy = vi.spyOn( document, 'addEventListener' );
 		// First subscribe attaches the native listener; subsequent ones
 		// for the same key share it.
-		subscribeDelegatedListener( target, 'mousemove', jest.fn() );
-		subscribeDelegatedListener( root, 'mousemove', jest.fn() );
-		subscribeDelegatedListener( document, 'mousemove', jest.fn() );
+		subscribeDelegatedListener( target, 'mousemove', vi.fn() );
+		subscribeDelegatedListener( root, 'mousemove', vi.fn() );
+		subscribeDelegatedListener( document, 'mousemove', vi.fn() );
 		const nativeMousemoves = spy.mock.calls.filter(
 			( [ type, , opts ] ) => type === 'mousemove' && ! opts // bubble-phase only
 		).length;
@@ -157,7 +162,7 @@ describe( 'subscribeDelegatedListener', () => {
 		const iframeTarget = iframeDoc.createElement( 'span' );
 		iframeDoc.body.appendChild( iframeTarget );
 
-		const cb = jest.fn();
+		const cb = vi.fn();
 		expect( () =>
 			subscribeDelegatedListener( iframeTarget, 'click', cb )
 		).not.toThrow();

--- a/packages/compose/src/utils/throttle/test/index.ts
+++ b/packages/compose/src/utils/throttle/test/index.ts
@@ -1,17 +1,22 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { throttle } from '../index';
 
-const identity = ( value ) => value;
+const identity = < T >( value: T ) => value;
 
 describe( 'throttle', () => {
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	it( 'should throttle a function', () => {
@@ -27,7 +32,7 @@ describe( 'throttle', () => {
 		const lastCount = callCount;
 		expect( callCount ).toBeGreaterThan( 0 );
 
-		jest.advanceTimersByTime( 64 );
+		vi.advanceTimersByTime( 64 );
 
 		expect( callCount ).toBeGreaterThan( lastCount );
 	} );
@@ -38,7 +43,7 @@ describe( 'throttle', () => {
 
 		expect( results ).toStrictEqual( [ 'a', 'a' ] );
 
-		jest.advanceTimersByTime( 64 );
+		vi.advanceTimersByTime( 64 );
 
 		results = [ throttled( 'c' ), throttled( 'd' ) ];
 		expect( results[ 0 ] ).not.toBe( 'a' );
@@ -64,7 +69,7 @@ describe( 'throttle', () => {
 		throttled();
 		throttled();
 
-		jest.advanceTimersByTime( 64 );
+		vi.advanceTimersByTime( 64 );
 
 		expect( callCount ).toBe( 2 );
 		global.Date.now = globalDateNow;
@@ -79,7 +84,7 @@ describe( 'throttle', () => {
 		throttled();
 		expect( callCount ).toBe( 1 );
 
-		jest.advanceTimersByTime( 64 );
+		vi.advanceTimersByTime( 64 );
 
 		expect( callCount ).toBe( 1 );
 	} );
@@ -103,11 +108,11 @@ describe( 'throttle', () => {
 				const start = Date.now();
 				while ( Date.now() - start < limit ) {
 					throttled();
-					jest.advanceTimersByTime( 1 );
+					vi.advanceTimersByTime( 1 );
 				}
 				const actual = callCount;
 
-				jest.advanceTimersByTime( 1 );
+				vi.advanceTimersByTime( 1 );
 
 				expect( actual ).toBeGreaterThan( 1 );
 			}
@@ -127,16 +132,16 @@ describe( 'throttle', () => {
 
 		throttled();
 
-		jest.advanceTimersByTime( 192 );
+		vi.advanceTimersByTime( 192 );
 
 		expect( callCount ).toBe( 1 );
 		throttled();
 
-		jest.advanceTimersByTime( 64 );
+		vi.advanceTimersByTime( 64 );
 
 		expect( callCount ).toBe( 1 );
 
-		jest.advanceTimersByTime( 130 );
+		vi.advanceTimersByTime( 130 );
 
 		expect( callCount ).toBe( 2 );
 	} );
@@ -155,7 +160,7 @@ describe( 'throttle', () => {
 		throttled();
 		expect( callCount ).toBe( 1 );
 
-		jest.advanceTimersByTime( 128 );
+		vi.advanceTimersByTime( 128 );
 
 		expect( callCount ).toBe( 2 );
 	} );
@@ -196,7 +201,7 @@ describe( 'throttle', () => {
 		expect( withoutTrailing( 'a' ) ).toBe( 'a' );
 		expect( withoutTrailing( 'b' ) ).toBe( 'a' );
 
-		jest.advanceTimersByTime( 256 );
+		vi.advanceTimersByTime( 256 );
 
 		expect( withCount ).toBe( 2 );
 		expect( withoutCount ).toBe( 1 );
@@ -216,12 +221,12 @@ describe( 'throttle', () => {
 		throttled();
 		throttled();
 
-		jest.advanceTimersByTime( 96 );
+		vi.advanceTimersByTime( 96 );
 
 		throttled();
 		throttled();
 
-		jest.advanceTimersByTime( 96 );
+		vi.advanceTimersByTime( 96 );
 
 		expect( callCount ).toBeGreaterThan( 1 );
 	} );
@@ -248,7 +253,7 @@ describe( 'throttle', () => {
 		expect( results ).toStrictEqual( [ 'a', 'a', 'a' ] );
 		expect( callCount ).toBe( 1 );
 
-		jest.advanceTimersByTime( 64 );
+		vi.advanceTimersByTime( 64 );
 
 		expect( callCount ).toBe( 2 );
 		global.Date.now = globalDateNow;

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -12,6 +12,7 @@
 			"packages/block-directory",
 			"packages/connectors",
 			"packages/components",
+			"packages/compose",
 			"packages/core-commands",
 			"packages/date",
 			"packages/dom-ready",


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the complete `@wordpress/compose` test package, including Testing Library interactions, fake-timer behavior, SSR environment selection, and partial ESM module mocks.

See #80855.

This stacked PR routes all 25 active `packages/compose` test files to Vitest while preserving the executable Jest baseline: 25 passing suites and 123 passing tests, with no snapshots.

No product runtime behavior changes are intended.

## Why?

`@wordpress/compose` is a bounded package that validates the migration path for reusable hooks and higher-order utilities before larger editor packages move. Its tests cover Testing Library and user-event, clipboard APIs, fake timers, server rendering without `window`, global event listeners, and partial module mocks.

## How?

- Uses explicit local imports from `vitest`; globals and `vitest/globals` types remain disabled.
- Keeps Testing Library and user-event as the DOM and user-interaction layer.
- Replaces Jest mock functions and timer APIs with `vi` equivalents.
- Converts the listener partial mock and other module mocks to Vitest's dynamic-import ESM form.
- Uses `@vitest-environment node` for the SSR-only test.
- Enables Vitest's `shouldAdvanceTime` behavior for the user-event fake-timer test because React Testing Library's timer wrapper only auto-detects Jest timers; the asserted clipboard timeout behavior is unchanged.
- Makes the Compose workspace own Vitest directly and tightens the migrated TypeScript tests so the repository's strict Vitest test-graph type-check passes.
- Updates `basePipe`'s type signature to describe its existing array input behavior and scopes `useFocusOutside` to `window.setTimeout`, avoiding the Node/browser timer-handle conflict introduced by Vitest's Node types.

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/compose`.
   - Expected: 25 passing files and 123 passing tests.
2. Run `npm run test:unit:conventions`.
   - Expected: 287 Vitest tests, 303 ESM graph files, 28 workspace dependencies, and 225 TypeScript tests validated.
3. Run `npm run test:unit:routing`.
   - Expected: all 996 baseline files have exactly one owner: 713 Jest, 287 Vitest, 0 retired, and 4 added.
4. Run the complete Vitest partition.
   - Verified: 285 passing files, 2 skipped files; 3,519 passing tests, 8 skipped tests.
5. Run the remaining Jest partition in four CI shards.
   - Verified: 713 suites, 31,221 tests, and 259 snapshots pass across the shards.
6. Run `npm run lint:lockfile`, `npm run lint:pkg-json`, `npm run lint:tsconfig`, and JavaScript lint for `packages/compose/src`.
7. Run `./node_modules/.bin/dependency-audit --collapse-root-cause packages/compose`.
   - Expected: no undeclared imports.

The commit hook also passed formatting, strict JavaScript lint, package JSON, lockfile, and generated-doc checks for the complete change.

### Testing Instructions for Keyboard

Not applicable; this is test-tooling-only and does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement the migration, run verification, investigate runner-semantics differences, and draft this description. The resulting changes and evidence were reviewed before publication.