### PR TITLE
Migrate Theme tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53194,14 +53194,14 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/jest": "^30.0.0",
 				"@types/node": "^20.19.39",
 				"@wordpress/validation-tools": "file:../../tools/validation",
 				"esbuild": "^0.27.2",
 				"esbuild-esm-loader": "^0.3.3",
 				"prettier": "npm:wp-prettier@^3.0.3",
 				"storybook": "^10.4.3",
-				"stylelint": "^16.26.1"
+				"stylelint": "^16.26.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.13.0",

--- a/packages/theme/bin/terrazzo-plugin-ds-token-fallbacks/test/index.test.ts
+++ b/packages/theme/bin/terrazzo-plugin-ds-token-fallbacks/test/index.test.ts
@@ -1,6 +1,5 @@
+import { describe, expect, it } from 'vitest';
 import { computeBrandFallback, formatDesignTokenFallbacksScss } from '../index';
-
-jest.mock( '@terrazzo/plugin-css', () => ( { FORMAT_ID: 'css/value' } ) );
 
 describe( 'computeBrandFallback', () => {
 	it( 'throws on colors with alpha (8-digit hex)', () => {

--- a/packages/theme/global.d.ts
+++ b/packages/theme/global.d.ts
@@ -2,4 +2,4 @@
 // type definitions found in the specified directories.
 // To ensure that global types are included, we need to
 // explicitly reference them here.
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -95,14 +95,14 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/jest": "^30.0.0",
 		"@types/node": "^20.19.39",
 		"@wordpress/validation-tools": "file:../../tools/validation",
 		"esbuild": "^0.27.2",
 		"esbuild-esm-loader": "^0.3.3",
 		"prettier": "npm:wp-prettier@^3.0.3",
 		"storybook": "^10.4.3",
-		"stylelint": "^16.26.1"
+		"stylelint": "^16.26.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/theme/src/color-ramps/test/__snapshots__/index.test.ts.snap
+++ b/packages/theme/src/color-ramps/test/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`buildRamps accent ramp snapshots 1`] = `
+exports[`buildRamps > accent ramp snapshots 1`] = `
 [
   [
     {
@@ -4213,7 +4213,7 @@ exports[`buildRamps accent ramp snapshots 1`] = `
 ]
 `;
 
-exports[`buildRamps background ramp snapshots 1`] = `
+exports[`buildRamps > background ramp snapshots 1`] = `
 [
   {
     "input": {

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { serialize, to, HSL, sRGB } from 'colorjs.io/fn';
 import { buildRamp } from '../lib';
 import { getColorString } from '../lib/color-utils';

--- a/packages/theme/src/color-ramps/test/seed-input.test.ts
+++ b/packages/theme/src/color-ramps/test/seed-input.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { ColorSpace, OKLCH } from 'colorjs.io/fn';
 import { buildBgRamp, buildAccentRamp } from '../index';
 import { buildRamp } from '../lib';

--- a/packages/theme/src/postcss-plugins/test/add-fallback-to-var.test.ts
+++ b/packages/theme/src/postcss-plugins/test/add-fallback-to-var.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { addFallbackToVar } from '../../../postcss-plugins/add-fallback-to-var.mjs';
 
 const mockFallbacks: Record< string, string > = {

--- a/packages/theme/src/postcss-plugins/test/ds-token-fallbacks.test.ts
+++ b/packages/theme/src/postcss-plugins/test/ds-token-fallbacks.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { addFallbackToVar } from '../../../postcss-plugins/ds-token-fallbacks.mjs';
 
 describe( 'addFallbackToVar', () => {

--- a/packages/theme/src/stylelint-plugins/test/__snapshots__/no-setting-wpds-custom-properties.test.ts.snap
+++ b/packages/theme/src/stylelint-plugins/test/__snapshots__/no-setting-wpds-custom-properties.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`flags warnings with invalid wpds custom properties css snapshot matches warnings 1`] = `
+exports[`flags warnings with invalid wpds custom properties css > snapshot matches warnings 1`] = `
 [
   {
     "column": 2,

--- a/packages/theme/src/stylelint-plugins/test/__snapshots__/no-token-fallback-values.test.ts.snap
+++ b/packages/theme/src/stylelint-plugins/test/__snapshots__/no-token-fallback-values.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`flags warnings with invalid css (wpds fallbacks) snapshot matches warnings 1`] = `
+exports[`flags warnings with invalid css (wpds fallbacks) > snapshot matches warnings 1`] = `
 [
   {
     "column": 9,

--- a/packages/theme/src/stylelint-plugins/test/__snapshots__/no-unknown-ds-tokens.test.ts.snap
+++ b/packages/theme/src/stylelint-plugins/test/__snapshots__/no-unknown-ds-tokens.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`flags warnings with invalid wpds tokens css snapshot matches warnings 1`] = `
+exports[`flags warnings with invalid wpds tokens css > snapshot matches warnings 1`] = `
 [
   {
     "column": 2,

--- a/packages/theme/src/stylelint-plugins/test/no-setting-wpds-custom-properties.test.ts
+++ b/packages/theme/src/stylelint-plugins/test/no-setting-wpds-custom-properties.test.ts
@@ -1,6 +1,6 @@
-/**
- * @jest-environment node
- */
+// @vitest-environment node
+
+import { beforeAll, describe, expect, it } from 'vitest';
 import plugin from '../../../stylelint-plugins/no-setting-wpds-custom-properties.mjs';
 import { getStylelintResult } from './utils';
 

--- a/packages/theme/src/stylelint-plugins/test/no-token-fallback-values.test.ts
+++ b/packages/theme/src/stylelint-plugins/test/no-token-fallback-values.test.ts
@@ -1,6 +1,6 @@
-/**
- * @jest-environment node
- */
+// @vitest-environment node
+
+import { beforeAll, describe, expect, it } from 'vitest';
 import plugin from '../../../stylelint-plugins/no-token-fallback-values.mjs';
 import { getStylelintResult } from './utils';
 

--- a/packages/theme/src/stylelint-plugins/test/no-unknown-ds-tokens.test.ts
+++ b/packages/theme/src/stylelint-plugins/test/no-unknown-ds-tokens.test.ts
@@ -1,6 +1,6 @@
-/**
- * @jest-environment node
- */
+// @vitest-environment node
+
+import { beforeAll, describe, expect, it } from 'vitest';
 import plugin from '../../../stylelint-plugins/no-unknown-ds-tokens.mjs';
 import { getStylelintResult } from './utils';
 

--- a/packages/theme/src/test/__snapshots__/build-plugin-parity.test.ts.snap
+++ b/packages/theme/src/test/__snapshots__/build-plugin-parity.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`design token fallback build plugin parity keeps esbuild and Vite source-text transforms aligned 1`] = `
+exports[`design token fallback build plugin parity > keeps esbuild and Vite source-text transforms aligned 1`] = `
 "// Source text is transformed consistently: var(--wpds-border-radius-sm, 2px).
 export const templateStyles = \`color: var(--wpds-color-foreground-content-neutral, #1e1e1e);\`;
 export const doubleQuotedStyles =
@@ -10,7 +10,7 @@ export const manualFallback = 'radius: var(--wpds-border-radius-sm, 99px);';
 "
 `;
 
-exports[`design token fallback build plugin parity transforms supported CSS in styles.css 1`] = `
+exports[`design token fallback build plugin parity > transforms supported CSS in styles.css 1`] = `
 "/* Token references in CSS comments are not transformed: var(--wpds-border-radius-sm). */
 .fixture {
 	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
@@ -19,7 +19,7 @@ exports[`design token fallback build plugin parity transforms supported CSS in s
 "
 `;
 
-exports[`design token fallback build plugin parity transforms supported CSS in styles.module.css 1`] = `
+exports[`design token fallback build plugin parity > transforms supported CSS in styles.module.css 1`] = `
 ".fixture {
 	gap: var(--wpds-dimension-gap-sm, 8px);
 }

--- a/packages/theme/src/test/build-plugin-parity.test.ts
+++ b/packages/theme/src/test/build-plugin-parity.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { describe, expect, it } from 'vitest';
 import type {
 	OnLoadArgs,
 	OnLoadOptions,

--- a/packages/theme/src/test/private-apis.test.ts
+++ b/packages/theme/src/test/private-apis.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { unlock } from '../lock-unlock';
 import { privateApis } from '../private-apis';
 import { ThemeProvider } from '../theme-provider';
@@ -5,9 +6,7 @@ import { useThemeProviderStyles } from '../use-theme-provider-styles';
 
 describe( 'privateApis', () => {
 	it( 'warns when accessing useThemeProviderStyles through private APIs', () => {
-		const warn = jest
-			.spyOn( console, 'warn' )
-			.mockImplementation( () => {} );
+		const warn = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
 
 		const unlockedPrivateApis = unlock< {
 			useThemeProviderStyles: typeof useThemeProviderStyles;
@@ -25,9 +24,7 @@ describe( 'privateApis', () => {
 	} );
 
 	it( 'warns when accessing ThemeProvider through private APIs', () => {
-		const warn = jest
-			.spyOn( console, 'warn' )
-			.mockImplementation( () => {} );
+		const warn = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
 
 		const unlockedPrivateApis = unlock< {
 			ThemeProvider: typeof ThemeProvider;

--- a/packages/theme/src/test/semantic-color-contrast.test.ts
+++ b/packages/theme/src/test/semantic-color-contrast.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { getContrast } from '../color-ramps/lib/color-utils';
 import { useThemeProviderStyles } from '../use-theme-provider-styles';

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -5,14 +5,17 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '../theme-provider';
 
 // Give the wrapper a stable class so tests can locate it and read its
 // computed custom properties.
-jest.mock( '../style.module.css', () => ( {
-	root: 'theme-provider-root',
+vi.mock( import( '../style.module.css' ), () => ( {
+	default: {
+		root: 'theme-provider-root',
+	},
 } ) );
 
 // The "strong" brand background resolves to the `color.primary` seed itself, and
@@ -229,7 +232,7 @@ describe( 'ThemeProvider', () => {
 		} );
 
 		it( 'warns when multiple root providers share a document', () => {
-			const warn = jest
+			const warn = vi
 				.spyOn( console, 'warn' )
 				.mockImplementation( () => {} );
 
@@ -252,7 +255,7 @@ describe( 'ThemeProvider', () => {
 		} );
 
 		it( 'does not warn for a single root provider', () => {
-			const warn = jest
+			const warn = vi
 				.spyOn( console, 'warn' )
 				.mockImplementation( () => {} );
 

--- a/packages/theme/src/test/use-theme-provider-styles.test.tsx
+++ b/packages/theme/src/test/use-theme-provider-styles.test.tsx
@@ -10,6 +10,7 @@
 // The resolved values of the semantic `--wpds-*` tokens are covered by the
 // `ThemeProvider` tests (which read them as computed CSS custom properties).
 
+import { describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { ThemeProvider } from '../theme-provider';

--- a/packages/theme/tsconfig.src.json
+++ b/packages/theme/tsconfig.src.json
@@ -3,12 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"moduleResolution": "bundler",
-		"types": [
-			"jest",
-			"node",
-			"style-imports",
-			"react-css-custom-properties"
-		]
+		"types": [ "node", "style-imports", "react-css-custom-properties" ]
 	},
 	"exclude": [ "**/stories/**", "**/test/**", "**/*.story.*" ],
 	"references": [

--- a/packages/theme/tsconfig.test.json
+++ b/packages/theme/tsconfig.test.json
@@ -6,7 +6,7 @@
 		"noEmit": true,
 		"rootDir": ".",
 		"types": [
-			"jest",
+			"gutenberg-vitest-test-env",
 			"node",
 			"style-imports",
 			"react-css-custom-properties"

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -27,6 +27,7 @@
 			"packages/shortcode",
 			"packages/style-engine",
 			"packages/sync",
+			"packages/theme",
 			"packages/token-list",
 			"packages/ui",
 			"packages/undo-manager",


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the complete `@wordpress/theme` test package, including build, PostCSS, and Stylelint plugins; Testing Library providers; Node-environment tests; an ESM CSS-module mock; and eight individually reviewed snapshots.

See #80855.

This stacked PR routes all 13 active `packages/theme` test files to Vitest while preserving the executable Jest baseline: 13 passing suites, 136 passing tests, and 8 passing snapshots.

No product runtime behavior changes are intended.

## Why?

`@wordpress/theme` is a bounded package that validates Vitest across build-tool integrations, DOM provider tests, generated CSS, Stylelint plugins, Node-only execution, CSS-module mocking, and snapshot compatibility before larger snapshot-heavy packages move.

## How?

- Uses explicit local imports from `vitest`; globals and `vitest/globals` types remain disabled.
- Keeps Testing Library as the DOM and provider-testing layer.
- Replaces Jest spies with `vi` equivalents.
- Converts the CSS-module mock to Vitest's typed dynamic-import ESM form.
- Uses `@vitest-environment node` for the three Stylelint plugin tests.
- Removes a stale Terrazzo module mock whose `FORMAT_ID` value no longer matched the installed upstream literal type; the affected tests cover exported local helpers and pass against the real module.
- Makes the Theme workspace own Vitest directly and replaces Jest DOM/types with the Vitest-specific entry points.
- Reviews the five snapshot files individually. Only the runner header and eight Jest-to-Vitest test-name separators changed; a normalized comparison verified all eight serialized snapshot values are byte-for-byte unchanged.

## Testing Instructions

1. Run `CI=true npm run test:unit:vitest -- packages/theme`.
   - Expected: 13 passing files, 136 passing tests, and 8 passing snapshots, with no snapshot writes.
2. Run `npm run test:unit:conventions`.
   - Expected: 300 Vitest tests, 316 ESM graph files, 29 workspace dependencies, and 238 TypeScript tests validated.
3. Run `npm run test:unit:routing`.
   - Expected: all 996 baseline files have exactly one owner: 700 Jest, 300 Vitest, 0 retired, and 4 added.
4. Run the complete Vitest partition.
   - Verified: 298 passing files, 2 skipped files; 3,655 passing tests, 8 skipped tests.
5. Run the remaining Jest partition in four CI shards.
   - Verified: 700 suites, 31,085 tests, and 251 snapshots pass across the shards.
6. Run `npm run lint:lockfile`, `npm run lint:pkg-json`, `npm run lint:tsconfig`, and JavaScript lint for `packages/theme`.
7. Run `./node_modules/.bin/dependency-audit --collapse-root-cause packages/theme`.
   - Expected: no undeclared imports.
8. Compare the parent-branch Jest snapshots with the committed Vitest snapshots after normalizing only the runner header and test-name separator.
   - Verified: all 8 snapshot values are unchanged across 5 files.

The commit hook also passed formatting, strict JavaScript lint, package JSON, lockfile, and generated-doc checks for the complete change.

### Testing Instructions for Keyboard

Not applicable; this is test-tooling-only and does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement the migration, run verification, investigate runner and snapshot-format differences, and draft this description. The resulting changes and evidence were reviewed before publication.