### PR TITLE
Migrate URL tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53368,6 +53368,9 @@
 			"dependencies": {
 				"remove-accents": "^0.5.0"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -45,6 +45,9 @@
 	"dependencies": {
 		"remove-accents": "^0.5.0"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -491,22 +496,26 @@ describe( 'isValidQueryString', () => {
 } );
 
 describe( 'getPathAndQueryString', () => {
-	beforeAll( jest.resetModules );
-	afterAll( jest.resetModules );
-	it( 'combines the results of `getPath` and `getQueryString`', () => {
-		jest.doMock( '../get-path', () => ( {
+	beforeAll( () => vi.resetModules() );
+	afterAll( () => {
+		vi.doUnmock( import( '../get-path' ) );
+		vi.doUnmock( import( '../get-query-string' ) );
+		vi.resetModules();
+	} );
+	it( 'combines the results of `getPath` and `getQueryString`', async () => {
+		vi.doMock( import( '../get-path' ), () => ( {
 			getPath( { path } = {} ) {
 				return path;
 			},
 		} ) );
-		jest.doMock( '../get-query-string', () => ( {
+		vi.doMock( import( '../get-query-string' ), () => ( {
 			getQueryString( { queryString } = {} ) {
 				return queryString;
 			},
 		} ) );
-		const {
-			getPathAndQueryString,
-		} = require( '../get-path-and-query-string' );
+		const { getPathAndQueryString } = await import(
+			'../get-path-and-query-string'
+		);
 		expect(
 			getPathAndQueryString( {
 				path: 'path',

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -36,6 +36,7 @@
 			"packages/token-list",
 			"packages/ui",
 			"packages/undo-manager",
+			"packages/url",
 			"packages/warning",
 			"packages/widget-dashboard",
 			"packages/wordcount"


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the complete `@wordpress/url` test package, replacing Jest's module-cache, non-hoisted string mocks, and runtime `require` with typed dynamic-import Vitest mocks and ESM loading.

See #80855.

This stacked PR routes the active `packages/url` suite to Vitest while preserving the executable Jest baseline: 1 passing suite and 495 passing tests, with no snapshots.

No product runtime behavior changes are intended.

## Why?

The URL suite is a bounded advanced-mocking case. Most of its 495 tests are runner-agnostic, while one isolated block deliberately replaces `getPath` and `getQueryString` after resetting the module cache. Migrating it separately makes the Jest-to-ESM lifecycle change explicit and reviewable.

## How?

- Uses explicit local imports from `vitest`; globals and `vitest/globals` types remain disabled.
- Replaces `jest.resetModules()` with explicit `vi.resetModules()` setup and teardown.
- Replaces string-based `jest.doMock()` calls with non-hoisted `vi.doMock(import(...))` calls so the module paths and mock exports use Vitest's ESM-aware form.
- Replaces runtime CommonJS `require()` with an awaited dynamic import of the subject after the mocks are registered.
- Explicitly removes both non-hoisted mocks during teardown to prevent registry leakage beyond the test block.
- Makes the URL workspace own Vitest directly and routes the complete package through the migration manifest.

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/url`.
   - Expected: 1 passing file and 495 passing tests.
2. Run `npm run test:unit:conventions`.
   - Expected: 309 Vitest tests, 325 ESM graph files, 36 workspace dependencies, and 242 TypeScript tests validated.
3. Run `npm run test:unit:routing`.
   - Expected: all 996 baseline files have exactly one owner: 691 Jest, 309 Vitest, 0 retired, and 4 added.
4. Run the complete Vitest partition.
   - Verified: 307 passing files, 2 skipped files; 4,429 passing tests, 8 skipped tests.
5. Run the remaining Jest partition in four CI shards.
   - Verified: 691 suites, 30,311 tests, and 251 snapshots pass across the shards.
6. Run `npm run lint:lockfile`, `npm run lint:pkg-json`, `npm run lint:tsconfig`, and JavaScript lint for `packages/url/src/test/index.js`.
7. Run `./node_modules/.bin/dependency-audit --collapse-root-cause packages/url`.
   - Expected: no undeclared imports.

The commit hook also passed formatting, strict JavaScript lint, package JSON, lockfile, and generated-doc checks for the complete change.

### Testing Instructions for Keyboard

Not applicable; this is test-tooling-only and does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to implement the migration, run verification, investigate the module lifecycle, and draft this description. The resulting changes and evidence were reviewed before publication.