### PR TITLE
Test: Add Vitest environment routing

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -21,13 +21,17 @@ const testMigration = require( './test-migration.json' );
 
 const escapeRegExp = ( value ) =>
 	value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+const vitestProjects = Object.values( testMigration.vitest.projects );
 const vitestTestPathIgnorePatterns = [
-	...[ ...testMigration.vitest.files, ...testMigration.added.vitest ].map(
-		( testPath ) => `<rootDir>/${ escapeRegExp( testPath ) }$`
-	),
-	...testMigration.vitest.directories.map(
-		( directoryPath ) => `<rootDir>/${ escapeRegExp( directoryPath ) }/`
-	),
+	...[
+		...vitestProjects.flatMap( ( project ) => project.files ),
+		...Object.values( testMigration.added.vitest ).flat(),
+	].map( ( testPath ) => `<rootDir>/${ escapeRegExp( testPath ) }$` ),
+	...vitestProjects
+		.flatMap( ( project ) => project.directories )
+		.map(
+			( directoryPath ) => `<rootDir>/${ escapeRegExp( directoryPath ) }/`
+		),
 ];
 
 // Ensure Babel config resolution works from the repo root,

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -29,6 +29,48 @@ export const TEST_IGNORES = [
 	'vendor/**',
 ];
 
+export const VITEST_PROJECT_NAMES = [ 'browser', 'jsdom', 'node' ];
+
+export function assertVitestProjectNames( label, projects ) {
+	const actualProjectNames = Object.keys( projects ).sort();
+	const expectedProjectNames = [ ...VITEST_PROJECT_NAMES ].sort();
+
+	if (
+		actualProjectNames.length !== expectedProjectNames.length ||
+		actualProjectNames.some(
+			( projectName, index ) =>
+				projectName !== expectedProjectNames[ index ]
+		)
+	) {
+		throw new Error(
+			`${ label } must define exactly these projects: ${ VITEST_PROJECT_NAMES.join(
+				', '
+			) }.`
+		);
+	}
+}
+
+export function findOverlappingVitestProjectTests( testsByProject ) {
+	const projectOwners = new Map();
+
+	for ( const [ projectName, projectTests ] of Object.entries(
+		testsByProject
+	) ) {
+		for ( const testPath of projectTests ) {
+			const owners = projectOwners.get( testPath ) ?? [];
+			owners.push( projectName );
+			projectOwners.set( testPath, owners );
+		}
+	}
+
+	return [ ...projectOwners ]
+		.filter( ( [ , owners ] ) => owners.length > 1 )
+		.map(
+			( [ testPath, owners ] ) =>
+				`${ testPath }: ${ owners.join( ', ' ) }`
+		);
+}
+
 function normalizeTestPath( testPath ) {
 	return testPath.split( path.sep ).join( '/' );
 }
@@ -48,10 +90,11 @@ export function discoverTestFiles( rootDir ) {
 	].sort();
 }
 
-export function getVitestTests( rootDir, manifest ) {
+export function getVitestTestsForProject( rootDir, manifest, projectName ) {
 	const discoveredTests = discoverTestFiles( rootDir );
+	const project = manifest.vitest.projects[ projectName ];
 	const directoryTests = discoveredTests.filter( ( testPath ) =>
-		manifest.vitest.directories.some(
+		project.directories.some(
 			( directoryPath ) =>
 				testPath === directoryPath ||
 				testPath.startsWith( `${ directoryPath }/` )
@@ -60,10 +103,30 @@ export function getVitestTests( rootDir, manifest ) {
 
 	return [
 		...new Set( [
-			...manifest.vitest.files,
+			...project.files,
 			...directoryTests,
-			...manifest.added.vitest,
+			...manifest.added.vitest[ projectName ],
 		] ),
+	].sort();
+}
+
+export function getVitestTestsByProject( rootDir, manifest ) {
+	assertVitestProjectNames( 'vitest.projects', manifest.vitest.projects );
+	assertVitestProjectNames( 'added.vitest', manifest.added.vitest );
+
+	return Object.fromEntries(
+		VITEST_PROJECT_NAMES.map( ( projectName ) => [
+			projectName,
+			getVitestTestsForProject( rootDir, manifest, projectName ),
+		] )
+	);
+}
+
+export function getVitestTests( rootDir, manifest ) {
+	return [
+		...new Set(
+			Object.values( getVitestTestsByProject( rootDir, manifest ) ).flat()
+		),
 	].sort();
 }
 

--- a/test/unit/scripts/test/discover-test-files.js
+++ b/test/unit/scripts/test/discover-test-files.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import {
+	assertVitestProjectNames,
+	findOverlappingVitestProjectTests,
+} from '../discover-test-files.mjs';
+
+describe( 'Vitest project routing', () => {
+	test( 'accepts the browser, jsdom, and node projects', () => {
+		expect( () =>
+			assertVitestProjectNames( 'vitest.projects', {
+				browser: {},
+				jsdom: {},
+				node: {},
+			} )
+		).not.toThrow();
+	} );
+
+	test( 'rejects a missing Vitest project', () => {
+		expect( () =>
+			assertVitestProjectNames( 'vitest.projects', {
+				jsdom: {},
+				node: {},
+			} )
+		).toThrow(
+			'vitest.projects must define exactly these projects: browser, jsdom, node.'
+		);
+	} );
+
+	test( 'rejects an unknown Vitest project', () => {
+		expect( () =>
+			assertVitestProjectNames( 'vitest.projects', {
+				browser: {},
+				jsdom: {},
+				node: {},
+				worker: {},
+			} )
+		).toThrow(
+			'vitest.projects must define exactly these projects: browser, jsdom, node.'
+		);
+	} );
+
+	test( 'reports tests owned by multiple projects', () => {
+		expect(
+			findOverlappingVitestProjectTests( {
+				browser: [ 'packages/components/src/test/index.js' ],
+				jsdom: [ 'packages/components/src/test/index.js' ],
+				node: [ 'tools/example/test/index.js' ],
+			} )
+		).toEqual( [
+			'packages/components/src/test/index.js: browser, jsdom',
+		] );
+	} );
+} );

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -17,9 +17,13 @@ import globPackage from 'glob';
  * Internal dependencies
  */
 import {
+	assertVitestProjectNames,
 	discoverTestFiles,
+	findOverlappingVitestProjectTests,
 	getVitestTests,
+	getVitestTestsByProject,
 	hashTestFiles,
+	VITEST_PROJECT_NAMES,
 } from './discover-test-files.mjs';
 
 const require = createRequire( import.meta.url );
@@ -29,6 +33,12 @@ const ROOT_DIR = path.resolve(
 );
 const JEST_CONFIG = 'test/unit/jest.config.js';
 const VITEST_CONFIG = 'test/unit/vitest.config.mjs';
+const VITEST_CONFIG_PROJECT_NAMES = {
+	browser: 'browser',
+	// Preserve the Flakiness.io identity used before project routing.
+	jsdom: 'vitest',
+	node: 'node',
+};
 const manifest = JSON.parse(
 	readFileSync(
 		path.join( ROOT_DIR, 'test/unit/test-migration.json' ),
@@ -77,6 +87,7 @@ function listTests( packageName, args ) {
 			.trim()
 			.split( /\r?\n/ )
 			.filter( Boolean )
+			.map( ( testPath ) => testPath.replace( /^\[[^\]]+\]\s+/, '' ) )
 			.map( normalizeTestPath )
 	);
 }
@@ -97,32 +108,67 @@ function assertUniquePaths( label, testPaths ) {
 	}
 }
 
+assertVitestProjectNames( 'vitest.projects', manifest.vitest.projects );
+assertVitestProjectNames( 'added.vitest', manifest.added.vitest );
+
+const expectedVitestTestsByProject = getVitestTestsByProject(
+	ROOT_DIR,
+	manifest
+);
 const jestTests = listTests( 'jest', [
 	'--config',
 	JEST_CONFIG,
 	'--listTests',
 ] );
-const vitestTests = existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) )
-	? listTests( 'vitest', [
-			'list',
-			'--config',
-			VITEST_CONFIG,
-			'--filesOnly',
-	  ] )
-	: new Set();
+const vitestTestsByProject = Object.fromEntries(
+	VITEST_PROJECT_NAMES.map( ( projectName ) => [
+		projectName,
+		existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) ) &&
+		expectedVitestTestsByProject[ projectName ].length > 0
+			? listTests( 'vitest', [
+					'list',
+					'--config',
+					VITEST_CONFIG,
+					'--project',
+					VITEST_CONFIG_PROJECT_NAMES[ projectName ],
+					'--filesOnly',
+			  ] )
+			: new Set(),
+	] )
+);
+const vitestTests = new Set(
+	Object.values( vitestTestsByProject ).flatMap( ( projectTests ) => [
+		...projectTests,
+	] )
+);
 
 const addedJestTests = manifest.added.jest;
-const addedVitestTests = manifest.added.vitest;
+const addedVitestTests = Object.values( manifest.added.vitest ).flat();
 const addedTests = [ ...addedJestTests, ...addedVitestTests ];
 const retiredTests = manifest.retired;
-const migratedTestFiles = manifest.vitest.files;
-const migratedDirectories = manifest.vitest.directories;
+const migratedTestFiles = Object.values( manifest.vitest.projects ).flatMap(
+	( project ) => project.files
+);
+const migratedDirectories = Object.values( manifest.vitest.projects ).flatMap(
+	( project ) => project.directories
+);
 
 assertUniquePaths( 'added.jest', addedJestTests );
-assertUniquePaths( 'added.vitest', addedVitestTests );
 assertUniquePaths( 'retired', retiredTests );
-assertUniquePaths( 'vitest.files', migratedTestFiles );
-assertUniquePaths( 'vitest.directories', migratedDirectories );
+for ( const projectName of VITEST_PROJECT_NAMES ) {
+	assertUniquePaths(
+		`added.vitest.${ projectName }`,
+		manifest.added.vitest[ projectName ]
+	);
+	assertUniquePaths(
+		`vitest.projects.${ projectName }.files`,
+		manifest.vitest.projects[ projectName ].files
+	);
+	assertUniquePaths(
+		`vitest.projects.${ projectName }.directories`,
+		manifest.vitest.projects[ projectName ].directories
+	);
+}
 
 const duplicateManifestEntries = addedTests.filter(
 	( testPath, index ) =>
@@ -133,6 +179,17 @@ assert.deepEqual(
 	duplicateManifestEntries,
 	[],
 	`Migration manifest entries must be disjoint:\n${ duplicateManifestEntries.join(
+		'\n'
+	) }`
+);
+
+const overlappingProjectTests = findOverlappingVitestProjectTests(
+	expectedVitestTestsByProject
+);
+assert.deepEqual(
+	overlappingProjectTests,
+	[],
+	`Vitest tests are owned by multiple projects:\n${ overlappingProjectTests.join(
 		'\n'
 	) }`
 );
@@ -181,7 +238,10 @@ const missingAddedJestTests = addedJestTests.filter(
 	( testPath ) => ! jestTests.has( testPath )
 );
 const missingAddedVitestTests = addedVitestTests.filter(
-	( testPath ) => ! vitestTests.has( testPath )
+	( testPath ) =>
+		! Object.values( vitestTestsByProject ).some( ( projectTests ) =>
+			projectTests.has( testPath )
+		)
 );
 assert.deepEqual(
 	missingAddedJestTests,
@@ -210,6 +270,13 @@ assert.deepEqual(
 );
 
 const expectedVitestTests = getVitestTests( ROOT_DIR, manifest );
+for ( const projectName of VITEST_PROJECT_NAMES ) {
+	assert.deepEqual(
+		[ ...vitestTestsByProject[ projectName ] ].sort(),
+		expectedVitestTestsByProject[ projectName ],
+		`Vitest ${ projectName } discovery does not match the migration manifest.`
+	);
+}
 assert.deepEqual(
 	[ ...vitestTests ].sort(),
 	expectedVitestTests,
@@ -270,5 +337,14 @@ assert.deepEqual(
 );
 
 console.log(
-	`Validated exactly one runner for ${ manifest.baseline.count } baseline tests: ${ jestTests.size } Jest, ${ vitestTests.size } Vitest, ${ retiredTests.length } retired, and ${ addedTests.length } added.`
+	`Validated exactly one runner and environment for ${
+		manifest.baseline.count
+	} baseline tests: ${ jestTests.size } Jest, ${
+		vitestTests.size
+	} Vitest (${ VITEST_PROJECT_NAMES.map(
+		( projectName ) =>
+			`${ projectName }: ${ vitestTestsByProject[ projectName ].size }`
+	).join( ', ' ) }), ${ retiredTests.length } retired, and ${
+		addedTests.length
+	} added.`
 );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -4,52 +4,68 @@
 		"sha256": "72316673c4f35ec4d55ec15ba4dbf3435dd2f57b3b54dc5258d9c75b340ad243"
 	},
 	"vitest": {
-		"files": [ "packages/html-entities/src/test/entities.ts" ],
-		"directories": [
-			"packages/abilities",
-			"packages/annotations",
-			"packages/autop",
-			"packages/blob",
-			"packages/block-directory",
-			"packages/connectors",
-			"packages/components",
-			"packages/compose",
-			"packages/core-commands",
-			"packages/date",
-			"packages/deprecated",
-			"packages/dom-ready",
-			"packages/edit-post",
-			"packages/edit-site",
-			"packages/escape-html",
-			"packages/fields",
-			"packages/hooks",
-			"packages/i18n",
-			"packages/is-shallow-equal",
-			"packages/keycodes",
-			"packages/priority-queue",
-			"packages/private-apis",
-			"packages/server-side-render",
-			"packages/shortcode",
-			"packages/style-engine",
-			"packages/sync",
-			"packages/theme",
-			"packages/token-list",
-			"packages/ui",
-			"packages/undo-manager",
-			"packages/url",
-			"packages/warning",
-			"packages/widget-dashboard",
-			"packages/wordcount"
-		]
+		"projects": {
+			"browser": {
+				"files": [],
+				"directories": []
+			},
+			"jsdom": {
+				"files": [ "packages/html-entities/src/test/entities.ts" ],
+				"directories": [
+					"packages/abilities",
+					"packages/annotations",
+					"packages/autop",
+					"packages/blob",
+					"packages/block-directory",
+					"packages/connectors",
+					"packages/components",
+					"packages/compose",
+					"packages/core-commands",
+					"packages/date",
+					"packages/deprecated",
+					"packages/dom-ready",
+					"packages/edit-post",
+					"packages/edit-site",
+					"packages/escape-html",
+					"packages/fields",
+					"packages/hooks",
+					"packages/i18n",
+					"packages/is-shallow-equal",
+					"packages/keycodes",
+					"packages/priority-queue",
+					"packages/private-apis",
+					"packages/server-side-render",
+					"packages/shortcode",
+					"packages/style-engine",
+					"packages/sync",
+					"packages/theme",
+					"packages/token-list",
+					"packages/ui",
+					"packages/undo-manager",
+					"packages/url",
+					"packages/warning",
+					"packages/widget-dashboard",
+					"packages/wordcount"
+				]
+			},
+			"node": {
+				"files": [],
+				"directories": []
+			}
+		}
 	},
 	"retired": [],
 	"added": {
 		"jest": [],
-		"vitest": [
-			"test/unit/config/console.vitest.test.js",
-			"test/unit/config/emotion-serializer.vitest.test.jsx",
-			"test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js",
-			"test/unit/config/setup.vitest.test.jsx"
-		]
+		"vitest": {
+			"browser": [],
+			"jsdom": [
+				"test/unit/config/console.vitest.test.js",
+				"test/unit/config/emotion-serializer.vitest.test.jsx",
+				"test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js",
+				"test/unit/config/setup.vitest.test.jsx"
+			],
+			"node": [ "test/unit/scripts/test/discover-test-files.js" ]
+		}
 	}
 }

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -16,7 +16,7 @@ import { defineConfig } from 'vitest/config';
 /**
  * Internal dependencies
  */
-import { getVitestTests } from './scripts/discover-test-files.mjs';
+import { getVitestTestsByProject } from './scripts/discover-test-files.mjs';
 
 const ROOT_DIR = path.resolve(
 	path.dirname( fileURLToPath( import.meta.url ) ),
@@ -28,7 +28,7 @@ const testMigration = JSON.parse(
 		'utf8'
 	)
 );
-const vitestTests = getVitestTests( ROOT_DIR, testMigration );
+const vitestTests = getVitestTestsByProject( ROOT_DIR, testMigration );
 const { sync: glob } = globPackage;
 const reporters = [ 'default' ];
 
@@ -186,29 +186,67 @@ export default defineConfig( {
 		},
 	},
 	test: {
-		environment: 'jsdom',
-		environmentOptions: {
-			jsdom: {
-				url: 'http://localhost/',
-			},
-		},
 		globals: false,
-		include: vitestTests,
 		includeTaskLocation: true,
 		passWithNoTests: false,
+		projects: [
+			{
+				extends: true,
+				test: {
+					// The Flakiness.io reporter uses the project name as part
+					// of its environment identity. Preserve the historical
+					// default while the manifest records explicit jsdom
+					// ownership.
+					name: 'vitest',
+					environment: 'jsdom',
+					environmentOptions: {
+						jsdom: {
+							url: 'http://localhost/',
+						},
+					},
+					include: vitestTests.jsdom,
+					setupFiles: [
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/setup-globals.vitest.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/global-mocks.vitest.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/gutenberg-env.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/console.vitest.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/testing-library.vitest.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/mocks/match-media.vitest.js'
+						),
+					],
+				},
+			},
+			{
+				extends: true,
+				test: {
+					name: 'node',
+					environment: 'node',
+					include: vitestTests.node,
+				},
+			},
+		],
 		reporters,
 		sequence: {
 			hooks: 'list',
 			setupFiles: 'list',
 		},
-		setupFiles: [
-			path.join( ROOT_DIR, 'test/unit/config/setup-globals.vitest.js' ),
-			path.join( ROOT_DIR, 'test/unit/config/global-mocks.vitest.js' ),
-			path.join( ROOT_DIR, 'test/unit/config/gutenberg-env.js' ),
-			path.join( ROOT_DIR, 'test/unit/config/console.vitest.js' ),
-			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
-			path.join( ROOT_DIR, 'test/unit/mocks/match-media.vitest.js' ),
-		],
 		snapshotFormat: {
 			escapeString: false,
 			printBasicPrototype: false,


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** This is an infrastructure/routing PR. It assigns every migrated Vitest test to an explicit browser, jsdom, or Node partition and teaches the exactly-one-runner validator to reject missing, overlapping, or invalid environment ownership.

This PR:

- changes the migration manifest from one Vitest bucket to explicit `browser`, `jsdom`, and `node` projects;
- keeps the currently migrated DOM tests in jsdom and moves the routing helper's own tests to Node;
- configures separate jsdom and Node Vitest projects;
- verifies actual Vitest discovery independently for each non-empty project;
- adds focused tests for the manifest's required project set and overlap detection.

The browser partition is intentionally empty in this PR. The Browser Mode provider and first browser pilot remain a separate, revertible follow-up.

## Why?

The migration needs to distinguish tests that require a real browser from DOM emulation and tests that need no web platform at all. Without explicit environment ownership, a test can silently run in the wrong environment or be selected by more than one project.

This also establishes the invariant needed for later Browser Mode and `@ariakit/test` migration PRs while keeping the existing Jest and Vitest partitions independently runnable.

## How?

The migration manifest now records per-project files, directories, and migration-only tests. The routing validator compares that expected ownership with `vitest list --project ...`, rejects overlap, and continues to reconcile the combined Jest/Vitest result against the 996-test executable baseline.

The jsdom project's Vitest name remains `vitest` because the installed Flakiness.io reporter includes the project name in its environment identity. This preserves the existing suite's historical identity while the manifest records its semantic jsdom ownership. The new Node partition uses the `node` project name.

No test behavior, snapshots, production code, dependencies, or browser shims change here.

## Testing Instructions

1. Run `npm run test:unit:routing`.
2. Run `npm run test:unit:conventions`.
3. Run `npm run test:unit:vitest -- --project=node test/unit/scripts/test/discover-test-files.js`.
4. Run `npm run test:unit:vitest -- --project=vitest test/unit/config/console.vitest.test.js`.
5. Run the complete Vitest partition with `npm run test:unit:vitest -- --passWithNoTests`.
6. Run the remaining Jest partition with `npm run test:unit -- --runInBand`.

Verified locally:

- routing validator: 996 baseline tests, 691 Jest, 310 Vitest (`browser: 0`, `jsdom: 309`, `node: 1`), 0 retired, 5 migration-only tests;
- conventions validator: 310 Vitest tests, 326 ESM graph files, 36 workspace dependencies, 242 TypeScript tests;
- Vitest: 308 passed / 2 skipped files, 4,433 passed / 8 skipped tests;
- Jest: 690 of 691 suites and 30,302 tests passed in the sandbox; the only failures were the nine network-dependent current-WordPress-version cases in `packages/env/lib/config/test/config-integration.js`, which all passed when that suite was rerun with approved network access;
- Flakiness.io disabled-upload report: existing jsdom tests still report under environment `vitest`.

### Testing Instructions for Keyboard

Not applicable; this PR changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inspect the existing migration stack, implement the routing changes, run verification, and draft this pull request description. The author reviewed the resulting diff and verification evidence.