### PR TITLE
Test: Add Vitest Browser Mode pilot

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -107,6 +107,9 @@ jobs:
                     --shard="$SHARD" \
                     --cacheDirectory="$HOME/.jest-cache"
 
+            - name: Install Chromium for Vitest Browser Mode
+              run: npx playwright install chromium --with-deps
+
             - name: Run the migrated Vitest partition
               env:
                   SHARD: ${{ matrix.shard }}

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ phpunit.xml
 phpunit-watcher.yml
 .tool-versions
 test/storybook-playwright/test-results
+test-results/vitest-browser-*
 test/storybook-playwright/specs/__snapshots__
 test/storybook-playwright/specs/*-snapshots/**
 test/gutenberg-test-themes/twentytwentyone

--- a/package-lock.json
+++ b/package-lock.json
@@ -2232,6 +2232,13 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"license": "MIT"
 		},
+		"node_modules/@blazediff/core": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+			"integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@bufbuild/protobuf": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
@@ -12260,9 +12267,10 @@
 			}
 		},
 		"node_modules/@polka/url": {
-			"version": "1.0.0-next.23",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
-			"integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg=="
+			"version": "1.0.0-next.29",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+			"license": "MIT"
 		},
 		"node_modules/@preact/signals": {
 			"version": "1.3.0",
@@ -16380,6 +16388,155 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@vitest/browser": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+			"integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@blazediff/core": "1.9.1",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pngjs": "^7.0.0",
+				"sirv": "^3.0.2",
+				"tinyrainbow": "^3.1.0",
+				"ws": "^8.19.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"vitest": "4.1.10"
+			}
+		},
+		"node_modules/@vitest/browser-playwright": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+			"integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/browser": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"playwright": "*",
+				"vitest": "4.1.10"
+			},
+			"peerDependenciesMeta": {
+				"playwright": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@vitest/browser-playwright/node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/browser/node_modules/mrmime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/sirv": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@polka/url": "^1.0.0-next.24",
+				"mrmime": "^2.0.0",
+				"totalist": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/ws": {
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -40130,6 +40287,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/pngjs": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+			"integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.19.0"
+			}
+		},
 		"node_modules/posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -47403,6 +47570,31 @@
 				}
 			}
 		},
+		"node_modules/vitest-browser-react": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/vitest-browser-react/-/vitest-browser-react-2.2.0.tgz",
+			"integrity": "sha512-oY3KM6305kwJMa6nHo92vVtkOsih7mjEf12dLKuphaF+9ywWPEc+qanIBd394SZ6m5LadVEaG6dicvvizOzmjA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0",
+				"vitest": "^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/vitest/node_modules/@vitest/expect": {
 			"version": "4.1.10",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -54256,6 +54448,7 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
+				"@vitest/browser-playwright": "^4.1.10",
 				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
@@ -54278,6 +54471,7 @@
 				"timezone-mock": "^1.3.6",
 				"vite-plugin-commonjs": "^0.10.4",
 				"vitest": "^4.1.10",
+				"vitest-browser-react": "^2.2.0",
 				"yargs": "^17.7.2"
 			}
 		},

--- a/test/unit/browser/components.vitest.test.tsx
+++ b/test/unit/browser/components.vitest.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+
+/**
+ * Internal dependencies
+ */
+import { Composite } from '../../../packages/components/src/composite';
+import Tooltip from '../../../packages/components/src/tooltip';
+
+test( 'moves focus through a composite with real keyboard input', async () => {
+	const user = userEvent.setup();
+	await render(
+		<>
+			<button>Before</button>
+			<Composite>
+				<Composite.Item>Item 1</Composite.Item>
+				<Composite.Item>Item 2</Composite.Item>
+				<Composite.Item>Item 3</Composite.Item>
+			</Composite>
+			<button>After</button>
+		</>
+	);
+	const before = page.getByRole( 'button', { name: 'Before' } );
+	const firstItem = page.getByRole( 'button', { name: 'Item 1' } );
+	const secondItem = page.getByRole( 'button', { name: 'Item 2' } );
+	const after = page.getByRole( 'button', { name: 'After' } );
+
+	await user.tab();
+	await expect.element( before ).toHaveFocus();
+
+	await user.tab();
+	await expect.element( firstItem ).toHaveFocus();
+
+	await user.keyboard( '{ArrowDown}' );
+	await expect.element( secondItem ).toHaveFocus();
+
+	await user.tab();
+	await expect.element( after ).toHaveFocus();
+} );
+
+test( 'shows a portal tooltip through real pointer input', async () => {
+	const user = userEvent.setup();
+	const view = await render(
+		<Tooltip delay={ 0 } text="Browser mode tooltip">
+			<button>Tooltip anchor</button>
+		</Tooltip>
+	);
+	const anchor = page.getByRole( 'button', {
+		name: 'Tooltip anchor',
+	} );
+	const tooltip = page.getByRole( 'tooltip', {
+		name: 'Browser mode tooltip',
+	} );
+
+	await expect.element( tooltip ).not.toBeInTheDocument();
+	await user.hover( anchor );
+	await expect.element( tooltip ).toBeVisible();
+	await expect
+		.element( anchor )
+		.toHaveAttribute( 'aria-describedby', tooltip.element().id );
+
+	expect( view.container.contains( tooltip.element() ) ).toBe( false );
+} );

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -29,6 +29,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
+		"@vitest/browser-playwright": "^4.1.10",
 		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
 		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
@@ -51,6 +52,7 @@
 		"timezone-mock": "^1.3.6",
 		"vite-plugin-commonjs": "^0.10.4",
 		"vitest": "^4.1.10",
+		"vitest-browser-react": "^2.2.0",
 		"yargs": "^17.7.2"
 	},
 	"publishConfig": {

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -23,7 +23,11 @@ import { fileURLToPath } from 'node:url';
 /**
  * Internal dependencies
  */
-import { getVitestTests } from './discover-test-files.mjs';
+import {
+	getVitestTests,
+	getVitestTestsByProject,
+	VITEST_PROJECT_NAMES,
+} from './discover-test-files.mjs';
 
 const traverse = traverseModule.default ?? traverseModule;
 const { sync: glob } = globPackage;
@@ -37,6 +41,7 @@ const migration = JSON.parse(
 		'utf8'
 	)
 );
+const vitestTestsByProject = getVitestTestsByProject( ROOT_DIR, migration );
 const vitestTests = getVitestTests( ROOT_DIR, migration );
 const vitestInfrastructure = [
 	'test/unit/vitest.config.mjs',
@@ -242,12 +247,30 @@ if ( violations.length ) {
 	);
 }
 
-const typescriptTests = vitestTests.filter( ( file ) =>
-	/\.tsx?$/.test( file )
+const typescriptTestsByProject = Object.fromEntries(
+	VITEST_PROJECT_NAMES.map( ( projectName ) => [
+		projectName,
+		vitestTestsByProject[ projectName ].filter( ( file ) =>
+			/\.tsx?$/.test( file )
+		),
+	] )
 );
-if ( typescriptTests.length ) {
+const typescriptTests = Object.values( typescriptTestsByProject ).flat();
+const commonTypes = [
+	'gutenberg-env',
+	'node',
+	'react-css-custom-properties',
+	'style-imports',
+];
+
+for ( const projectName of VITEST_PROJECT_NAMES ) {
+	const projectTypescriptTests = typescriptTestsByProject[ projectName ];
+	if ( ! projectTypescriptTests.length ) {
+		continue;
+	}
+
 	const temporaryDirectory = mkdtempSync(
-		path.join( os.tmpdir(), 'gutenberg-vitest-typecheck-' )
+		path.join( os.tmpdir(), `gutenberg-vitest-${ projectName }-typecheck-` )
 	);
 	const configPath = path.join( temporaryDirectory, 'tsconfig.json' );
 	const compatibilityTypesPath = path.join(
@@ -269,18 +292,24 @@ if ( typescriptTests.length ) {
 				path.join( ROOT_DIR, 'typings' ),
 				path.join( ROOT_DIR, 'node_modules/@types' ),
 			],
-			types: [
-				'gutenberg-env',
-				'gutenberg-vitest-test-env',
-				'node',
-				'react-css-custom-properties',
-				'style-imports',
-			],
+			types:
+				projectName === 'jsdom'
+					? [ ...commonTypes, 'gutenberg-vitest-test-env' ]
+					: commonTypes,
 		},
 		files: [
 			compatibilityTypesPath,
-			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
-			...typescriptTests.map( ( file ) => path.join( ROOT_DIR, file ) ),
+			...( projectName === 'jsdom'
+				? [
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/testing-library.vitest.js'
+						),
+				  ]
+				: [] ),
+			...projectTypescriptTests.map( ( file ) =>
+				path.join( ROOT_DIR, file )
+			),
 		],
 	};
 

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -58,7 +58,7 @@
 	"added": {
 		"jest": [],
 		"vitest": {
-			"browser": [],
+			"browser": [ "test/unit/browser/components.vitest.test.tsx" ],
 			"jsdom": [
 				"test/unit/config/console.vitest.test.js",
 				"test/unit/config/emotion-serializer.vitest.test.jsx",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
  * External dependencies
  */
 import { transformAsync } from '@babel/core';
+import { playwright } from '@vitest/browser-playwright';
 import globPackage from 'glob';
 import commonjs from 'vite-plugin-commonjs';
 import { defineConfig } from 'vitest/config';
@@ -190,6 +191,41 @@ export default defineConfig( {
 		includeTaskLocation: true,
 		passWithNoTests: false,
 		projects: [
+			{
+				extends: true,
+				optimizeDeps: {
+					entries: vitestTests.browser,
+					// Babel injects the automatic JSX runtime after Vite's
+					// dependency scan, so declare it directly.
+					include: [ 'react/jsx-runtime' ],
+					esbuildOptions: {
+						// Gutenberg still has JSX in .js package sources.
+						// Keep this browser dependency-scan exception explicit
+						// until that legacy contract is removed.
+						loader: {
+							'.js': 'jsx',
+						},
+					},
+				},
+				test: {
+					name: 'browser',
+					attachmentsDir: 'test-results/vitest-browser-attachments',
+					include: vitestTests.browser,
+					browser: {
+						enabled: true,
+						headless: true,
+						instances: [ { browser: 'chromium' } ],
+						provider: playwright(),
+						screenshotDirectory:
+							'test-results/vitest-browser-screenshots',
+						screenshotFailures: true,
+						trace: {
+							mode: 'retain-on-failure',
+							tracesDir: 'test-results/vitest-browser-traces',
+						},
+					},
+				},
+			},
 			{
 				extends: true,
 				test: {

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -454,6 +454,7 @@ export default dedupePlugins( [
 			'test/e2e/**/*.[tj]s?(x)',
 			'test/performance/**/*.[tj]s?(x)',
 			'test/storybook-playwright/**/*.[tj]s?(x)',
+			'test/unit/browser/**/*.[tj]s?(x)',
 		],
 	},
 	{
@@ -463,6 +464,7 @@ export default dedupePlugins( [
 			'test/e2e/**/*.[tj]s?(x)',
 			'test/performance/**/*.[tj]s?(x)',
 			'test/storybook-playwright/**/*.[tj]s?(x)',
+			'test/unit/browser/**/*.[tj]s?(x)',
 		],
 	},
 	{
@@ -472,6 +474,7 @@ export default dedupePlugins( [
 			'test/e2e/**/*.[tj]s?(x)',
 			'test/performance/**/*.[tj]s?(x)',
 			'test/storybook-playwright/**/*.[tj]s?(x)',
+			'test/unit/browser/**/*.[tj]s?(x)',
 		],
 		rules: {
 			...jestPlugin.configs[ 'flat/recommended' ].rules,


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80887; review commit `150446d1be5`.

**TL;DR — Browser Mode runtime and representative pilot:** adds a Chromium-backed Vitest project and two real-browser component tests; it does not reroute existing baseline tests or change production behavior.

The pilot covers:

- real keyboard focus movement through `Composite`;
- real pointer hover, accessible-description wiring, and portal placement for `Tooltip`.

It also adds environment-specific TypeScript convention checks and keeps Browser Mode files out of Jest and Testing Library ESLint overrides.

## Why?

Some Gutenberg tests recreate browser behavior in jsdom. A bounded Browser Mode pilot establishes how real Chromium can replace suitable DOM, layout, focus, pointer, and observer mocks without moving the entire suite at once.

The pilot is additive. Existing Jest and jsdom-routed Vitest tests continue unchanged.

## How?

- Adds `@vitest/browser-playwright` and `vitest-browser-react` to the private unit-test workspace, using the repository's existing Vitest, React, Playwright, Node, and npm support.
- Adds a `browser` Vitest project using headless Chromium, Browser Mode locators, retrying assertions, and real `userEvent` input.
- Installs the matching Playwright Chromium build in every sharded unit-test job because Browser Mode files may be assigned to any shard as the browser partition grows.
- Captures failure screenshots and Playwright traces under ignored `test-results/vitest-browser-*` paths.
- Extends the exactly-one-runner manifest with the additive browser pilot.
- Type-checks browser, jsdom, and Node partitions independently.
- Keeps the Vite dependency scanner's temporary JSX-in-`.js` handling explicit; #80889 removes that exception from the pilot graph.

No snapshots were regenerated.

## Testing Instructions

1. `npx playwright install chromium --with-deps`
2. `npm run test:unit:vitest -- --project browser`
3. `npm run test:unit:vitest`
4. `npm run test:unit:conventions`
5. `npm run test:unit:routing`
6. Run focused JS and package-JSON lint.

Verified locally:

- Browser Mode: 1 file and 2 tests passed.
- Complete mixed Vitest suite: 309 passed and 2 skipped files; 4,435 passed and 8 skipped tests.
- Routing: 996 baseline tests assigned exactly once — 691 Jest and 311 Vitest (`browser: 1`, `jsdom: 309`, `node: 1`) — plus 6 additive tests.
- Complete Jest partition: 690 suites and 30,302 tests passed locally; the one failing 9-test environment integration suite passed when rerun with network access.
- Failure-artifact smoke testing produced both a screenshot and retained trace; the intentional failure and artifacts were removed.
- `npm audit --workspace @wordpress/unit-tests` reports only existing advisories; neither added package appears in an advisory path.

### Testing Instructions for Keyboard

The pilot uses real keyboard input: Tab moves into and out of the composite, and Arrow Down moves focus between composite items.

## Screenshots or screencast

Not applicable; this changes test infrastructure only.

## Use of AI Tools

AI tools helped inspect the existing infrastructure, implement the pilot, reproduce and repair clean-CI browser provisioning, and run the verification matrix.