### PR TITLE
Block editor: make the Group action wrap blocks with a group transform

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -2,17 +2,14 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	hasBlockSupport,
-	switchToBlockType,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import usePasteStyles from '../use-paste-styles';
 import { store as blockEditorStore } from '../../store';
+import { groupBlocks } from '../../utils/group-blocks';
 
 export default function BlockActions( {
 	clientIds,
@@ -106,8 +103,7 @@ export default function BlockActions( {
 
 			const groupingBlockName = getGroupingBlockName();
 
-			// Activate the `transform` on `core/group` which does the conversion.
-			const newBlocks = switchToBlockType(
+			const newBlocks = groupBlocks(
 				getBlocksByClientId( clientIds ),
 				groupingBlockName
 			);

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -11,11 +11,7 @@ import { isTextField } from '@wordpress/dom';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { useRef, useState } from '@wordpress/element';
-import {
-	switchToBlockType,
-	hasBlockSupport,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import { speak } from '@wordpress/a11y';
 import { __, sprintf, _n } from '@wordpress/i18n';
 
@@ -29,6 +25,7 @@ import {
 } from './insertion-point';
 import BlockToolbarPopover from './block-toolbar-popover';
 import { store as blockEditorStore } from '../../store';
+import { groupBlocks } from '../../utils/group-blocks';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
 import { useShowBlockTools } from './use-show-block-tools';
@@ -227,10 +224,7 @@ export default function BlockTools( {
 				event.preventDefault();
 				const blocks = getBlocksByClientId( clientIds );
 				const groupingBlockName = getGroupingBlockName();
-				const newBlocks = switchToBlockType(
-					blocks,
-					groupingBlockName
-				);
+				const newBlocks = groupBlocks( blocks, groupingBlockName );
 				replaceBlocks( clientIds, newBlocks );
 				speak( __( 'Selected blocks are grouped.' ) );
 			}

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -3,7 +3,6 @@
  */
 import { MenuItem } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
-import { switchToBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
 
@@ -11,6 +10,7 @@ import { displayShortcut } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { groupBlocks } from '../../utils/group-blocks';
 import useConvertToGroupButtonProps from './use-convert-to-group-button-props';
 import BlockGroupToolbar from './toolbar';
 
@@ -26,11 +26,7 @@ function ConvertToGroupButton( {
 	const { getSelectedBlockClientIds } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const onConvertToGroup = () => {
-		// Activate the `transform` on the Grouping Block which does the conversion.
-		const newBlocks = switchToBlockType(
-			blocksSelection,
-			groupingBlockName
-		);
+		const newBlocks = groupBlocks( blocksSelection, groupingBlockName );
 		if ( newBlocks ) {
 			replaceBlocks( clientIds, newBlocks );
 		}

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { group, row, stack, grid } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
@@ -12,6 +12,7 @@ import { _x } from '@wordpress/i18n';
  */
 import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 import { store as blockEditorStore } from '../../store';
+import { groupBlocks } from '../../utils/group-blocks';
 
 const layouts = {
 	group: { type: 'constrained' },
@@ -42,10 +43,7 @@ function BlockGroupToolbar() {
 	);
 
 	const onConvertToGroup = ( layout ) => {
-		const newBlocks = switchToBlockType(
-			blocksSelection,
-			groupingBlockName
-		);
+		const newBlocks = groupBlocks( blocksSelection, groupingBlockName );
 
 		if ( typeof layout !== 'string' ) {
 			layout = 'group';

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import {
 	hasBlockSupport,
-	switchToBlockType,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -48,6 +47,7 @@ import {
 	focusListItem,
 } from './utils';
 import { store as blockEditorStore } from '../../store';
+import { groupBlocks } from '../../utils/group-blocks';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 import { useBlockRename, BlockRenameModal } from '../block-rename';
@@ -385,10 +385,7 @@ function ListViewBlock( {
 				event.preventDefault();
 				const blocks = getBlocksByClientId( blocksToUpdate );
 				const groupingBlockName = getGroupingBlockName();
-				const newBlocks = switchToBlockType(
-					blocks,
-					groupingBlockName
-				);
+				const newBlocks = groupBlocks( blocks, groupingBlockName );
 				replaceBlocks( blocksToUpdate, newBlocks );
 				speak( __( 'Selected blocks are grouped.' ) );
 				const newlySelectedBlocks = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -6,10 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	hasBlockSupport,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -25,6 +25,7 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { groupBlocks } from '../../utils/group-blocks';
 import { unlock } from '../../lock-unlock';
 
 const getTransformCommands = () =>
@@ -202,8 +203,7 @@ const getQuickActionsCommands = () =>
 
 			const groupingBlockName = getGroupingBlockName();
 
-			// Activate the `transform` on `core/group` which does the conversion.
-			const newBlocks = switchToBlockType( blocks, groupingBlockName );
+			const newBlocks = groupBlocks( blocks, groupingBlockName );
 
 			if ( ! newBlocks ) {
 				return;

--- a/packages/block-editor/src/utils/group-blocks.js
+++ b/packages/block-editor/src/utils/group-blocks.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	findTransform,
+	getBlockTransforms,
+	switchToBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Wraps the given blocks in the grouping block. Unlike a plain
+ * `switchToBlockType` call, the blocks' own transforms to the grouping block
+ * type are never used: the Group action is a structural wrap, while a
+ * block's own transform changes what the block is (a quote's transform to
+ * group dissolves the quote into its inner blocks).
+ *
+ * @param {WPBlock[]} blocks            Blocks to group.
+ * @param {string}    groupingBlockName Name of the grouping block.
+ *
+ * @return {?WPBlock[]} The grouped blocks, or null.
+ */
+export function groupBlocks( blocks, groupingBlockName ) {
+	const groupingBlockTransform = findTransform(
+		getBlockTransforms( 'from', groupingBlockName ),
+		( transform ) =>
+			transform.type === 'block' &&
+			transform.isMultiBlock &&
+			transform.blocks.includes( '*' )
+	);
+
+	if ( groupingBlockTransform?.__experimentalConvert ) {
+		return [ groupingBlockTransform.__experimentalConvert( blocks ) ];
+	}
+
+	// A grouping block without a wildcard transform. Fall back to regular
+	// block conversion.
+	return switchToBlockType( blocks, groupingBlockName );
+}

--- a/packages/block-editor/src/utils/group-blocks.js
+++ b/packages/block-editor/src/utils/group-blocks.js
@@ -29,7 +29,8 @@ export function groupBlocks( blocks, groupingBlockName ) {
 	);
 
 	if ( groupingBlockTransform?.__experimentalConvert ) {
-		return [ groupingBlockTransform.__experimentalConvert( blocks ) ];
+		const result = groupingBlockTransform.__experimentalConvert( blocks );
+		return Array.isArray( result ) ? result : [ result ];
 	}
 
 	// A grouping block without a wildcard transform. Fall back to regular

--- a/test/e2e/specs/editor/various/block-grouping.spec.js
+++ b/test/e2e/specs/editor/various/block-grouping.spec.js
@@ -97,6 +97,52 @@ test.describe( 'Block Grouping', () => {
 			] );
 		} );
 
+		test( 'wraps a block with its own transform to the group block, instead of transforming it', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/quote',
+				attributes: { citation: 'someone' },
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'quoted words' },
+					},
+				],
+			} );
+
+			// The quote is also ungroupable, so an exact name is needed:
+			// the block options menu contains both Group and Ungroup.
+			await editor.clickBlockToolbarButton( 'Options' );
+			await page
+				.getByRole( 'menu', { name: 'Options' } )
+				.getByRole( 'menuitem', { name: 'Group', exact: true } )
+				.click();
+
+			// The quote survives whole inside the group; its transform to
+			// the group block (which dissolves it) must not be used.
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/group',
+					innerBlocks: [
+						{
+							name: 'core/quote',
+							attributes: { citation: 'someone' },
+							innerBlocks: [
+								{
+									name: 'core/paragraph',
+									attributes: {
+										content: 'quoted words',
+									},
+								},
+							],
+						},
+					],
+				},
+			] );
+		} );
+
 		test( 'creates a group from multiple blocks of the same type via options toolbar', async ( {
 			editor,
 			pageUtils,


### PR DESCRIPTION
## What?
Fixes #58042. The Group action (block options menu, toolbar group buttons, Cmd+G) wraps the selected blocks in a group. Previously, a block declaring its own transform to the group block, like Quote, was transformed instead: the quote dissolved into its inner blocks and its citation was demoted to a paragraph.

## Why?
The Group action is a structural wrap, sitting next to Ungroup and applying to multi-selections. A block's own transform changes what the block is. Both went through `switchToBlockType`, where the selected block's transform takes priority over the group block's wildcard wrap, so a single Quote (or Cover) was converted rather than grouped. The "Transform to" menu is unchanged: transforming a quote to a group still converts.

Previously attempted in #70174 with a different approach (changing the quote's transform itself).

## How?
A `groupBlocks` helper applies the grouping block's wildcard `from` transform directly, never the selected blocks' own `to` transforms, falling back to `switchToBlockType` for grouping blocks without a wildcard transform. All five Group action call sites use it; multi-block grouping resolves to the same wildcard transform as before and is unchanged.

## Testing Instructions
1. Add a Quote block with some text.
2. Select it and choose Group from the block options menu.
3. The quote is wrapped in a group, intact; previously it was dissolved into a paragraph inside the group.

Covered by a regression test; it fails on trunk.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.
