### PR TITLE
Build: Support JSX source file extensions

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Transpile `.jsx` package, route, and widget source files alongside the existing JavaScript and TypeScript extensions.
 -   Widgets: carry a widget's declarative `actions` from `widget.json` into
     the generated PHP registry ([#80363](https://github.com/WordPress/gutenberg/pull/80363)).
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -56,6 +56,7 @@ import {
 	renderTemplateToString,
 } from './php-generator.mjs';
 import { getPackageInfo, getPackageInfoFromFile } from './package-utils.mjs';
+import { getSourceFileGlob, isTestSourceFile } from './source-files.mjs';
 import { createWordpressExternalsPlugin } from './wordpress-externals-plugin.mjs';
 import {
 	getAllRoutes,
@@ -78,17 +79,12 @@ const ROOT_DIR = process.cwd();
 const PACKAGES_DIR = path.join( ROOT_DIR, 'packages' );
 const BUILD_DIR = path.join( ROOT_DIR, 'build' );
 
-const SOURCE_EXTENSIONS = '{js,mjs,ts,tsx}';
 const ASSET_EXTENSIONS = 'json';
 const IGNORE_PATTERNS = [
 	'**/benchmark/**',
 	'**/{__mocks__,__tests__,test}/**',
 	'**/{storybook,stories}/**',
 	'**/*.{spec,test}.*',
-];
-const TEST_FILE_PATTERNS = [
-	/\/(benchmark|__mocks__|__tests__|test|storybook|stories)\/.+/,
-	/\.(spec|test)\.(js|ts|tsx)$/,
 ];
 
 /**
@@ -1346,7 +1342,7 @@ async function transpilePackage( packageName ) {
 		);
 	}
 
-	const srcFiles = await glob( `src/**/*.${ SOURCE_EXTENSIONS }`, {
+	const srcFiles = await glob( getSourceFileGlob( 'src/**/*' ), {
 		cwd: packageDir,
 		ignore: IGNORE_PATTERNS,
 		absolute: true,
@@ -1667,7 +1663,7 @@ function isPackageSourceFile( filename ) {
 		return false;
 	}
 
-	if ( TEST_FILE_PATTERNS.some( ( regex ) => regex.test( relativePath ) ) ) {
+	if ( isTestSourceFile( relativePath ) ) {
 		return false;
 	}
 
@@ -1724,7 +1720,7 @@ async function buildRoute( routeName ) {
 
 	// Build route.js if it exists
 	if ( files.hasRoute ) {
-		const routeEntryPoints = await glob( `route.${ SOURCE_EXTENSIONS }`, {
+		const routeEntryPoints = await glob( getSourceFileGlob( 'route' ), {
 			cwd: routeDir,
 			absolute: true,
 		} );
@@ -1887,7 +1883,7 @@ async function buildWidget( widgetName ) {
 
 	// Build render.js if it exists
 	if ( files.hasRender ) {
-		const renderEntryPoints = await glob( `render.${ SOURCE_EXTENSIONS }`, {
+		const renderEntryPoints = await glob( getSourceFileGlob( 'render' ), {
 			cwd: widgetDir,
 			absolute: true,
 		} );
@@ -1937,7 +1933,7 @@ async function buildWidget( widgetName ) {
 
 	// Build widget.js if it exists
 	if ( files.hasWidget ) {
-		const widgetEntryPoints = await glob( `widget.${ SOURCE_EXTENSIONS }`, {
+		const widgetEntryPoints = await glob( getSourceFileGlob( 'widget' ), {
 			cwd: widgetDir,
 			absolute: true,
 		} );

--- a/packages/wp-build/lib/source-files.mjs
+++ b/packages/wp-build/lib/source-files.mjs
@@ -1,0 +1,25 @@
+const SOURCE_EXTENSIONS = [ 'js', 'jsx', 'mjs', 'ts', 'tsx' ];
+const TEST_FILE_PATTERNS = [
+	/\/(benchmark|__mocks__|__tests__|test|storybook|stories)\/.+/,
+	new RegExp( `\\.(spec|test)\\.(${ SOURCE_EXTENSIONS.join( '|' ) })$` ),
+];
+
+/**
+ * Add every supported source extension to a file glob.
+ *
+ * @param {string} basePattern File glob without an extension.
+ * @return {string} File glob with all supported source extensions.
+ */
+export function getSourceFileGlob( basePattern ) {
+	return `${ basePattern }.{${ SOURCE_EXTENSIONS.join( ',' ) }}`;
+}
+
+/**
+ * Determine whether a source path belongs to tests or development fixtures.
+ *
+ * @param {string} relativePath Repository-relative source path.
+ * @return {boolean} True when the path should be excluded from production source.
+ */
+export function isTestSourceFile( relativePath ) {
+	return TEST_FILE_PATTERNS.some( ( regex ) => regex.test( relativePath ) );
+}

--- a/packages/wp-build/lib/test/source-files.js
+++ b/packages/wp-build/lib/test/source-files.js
@@ -1,0 +1,68 @@
+/**
+ * Node dependencies
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * External dependencies
+ */
+import glob from 'fast-glob';
+
+/**
+ * Internal dependencies
+ */
+import { getSourceFileGlob, isTestSourceFile } from '../source-files.mjs';
+
+describe( 'source file discovery', () => {
+	let temporaryDirectory;
+
+	afterEach( () => {
+		if ( temporaryDirectory ) {
+			rmSync( temporaryDirectory, { force: true, recursive: true } );
+			temporaryDirectory = undefined;
+		}
+	} );
+
+	it( 'discovers every supported source extension', async () => {
+		temporaryDirectory = mkdtempSync(
+			path.join( os.tmpdir(), 'wordpress-build-source-files-' )
+		);
+		const sourceDirectory = path.join( temporaryDirectory, 'src' );
+		mkdirSync( sourceDirectory );
+
+		for ( const extension of [ 'js', 'jsx', 'mjs', 'ts', 'tsx', 'css' ] ) {
+			writeFileSync(
+				path.join( sourceDirectory, `index.${ extension }` ),
+				''
+			);
+		}
+
+		const sourceFiles = await glob( getSourceFileGlob( 'src/**/*' ), {
+			cwd: temporaryDirectory,
+		} );
+
+		expect( sourceFiles.sort() ).toEqual( [
+			'src/index.js',
+			'src/index.jsx',
+			'src/index.mjs',
+			'src/index.ts',
+			'src/index.tsx',
+		] );
+	} );
+
+	it.each( [
+		'packages/example/src/test/component.jsx',
+		'packages/example/src/component.test.jsx',
+		'packages/example/src/component.spec.mjs',
+	] )( 'identifies development-only source: %s', ( filename ) => {
+		expect( isTestSourceFile( filename ) ).toBe( true );
+	} );
+
+	it( 'keeps production JSX source', () => {
+		expect( isTestSourceFile( 'packages/example/src/component.jsx' ) ).toBe(
+			false
+		);
+	} );
+} );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -56,7 +56,7 @@
 	},
 	"retired": [],
 	"added": {
-		"jest": [],
+		"jest": [ "packages/wp-build/lib/test/source-files.js" ],
 		"vitest": {
 			"browser": [ "test/unit/browser/components.vitest.test.tsx" ],
 			"jsdom": [


### PR DESCRIPTION
## What?

Part of #80855. Stacked on #80888 and intended to precede #80889.

**TL;DR — migration class:** extends `@wordpress/build` source discovery from `js/mjs/ts/tsx` to `js/jsx/mjs/ts/tsx`, with focused discovery tests and a real CJS/ESM production-build smoke test. It is an additive build-tool capability with no runtime behavior change for existing inputs.

## Why?

The JSX extension-normalization work cannot safely rename production `.js` files until package transpilation emits matching `build/*.cjs` and `build-module/*.mjs` files for `.jsx` sources.

The Browser Mode pilot proved that Vite resolves the renamed source files, but the complete production build exposed the missing build-tool contract: `.jsx` was not in the package, route, or widget source glob, so downstream bundles could not resolve the expected emitted modules.

## How?

- Centralizes supported source extensions and development/test-file detection in a small internal source-file helper.
- Adds `.jsx` to package, route, render, and widget discovery.
- Keeps `.jsx` test, story, mock, and benchmark files excluded from production source processing.
- Adds focused tests that create real files for every supported extension and verify `.jsx` discovery and test-file classification.
- Registers the new regression test as an additive Jest test in the exactly-one-runner manifest.
- Records the additive capability in the `@wordpress/build` changelog.

The existing `.js` JSX loader remains temporarily unchanged; this PR enables explicit `.jsx` sources without changing current `.js` behavior.

No tests changed runner or environment, and no snapshots changed.

## Testing Instructions

1. Run `npm run test:unit -- --runInBand packages/wp-build/lib/test/source-files.js packages/wp-build/lib/test/package-utils.js`.
2. Run `npm run test:unit:routing`.
3. Run `npm run lint:js -- packages/wp-build/lib/build.mjs packages/wp-build/lib/source-files.mjs packages/wp-build/lib/test/source-files.js`.
4. Add a temporary `packages/compose/src/jsx-source-build-smoke.jsx` that exports a component containing JSX.
5. Run `npm run build -- --skip-types`.
6. Confirm both `packages/compose/build/jsx-source-build-smoke.cjs` and `packages/compose/build-module/jsx-source-build-smoke.mjs` exist, then remove the temporary source file.

Verified locally:

- Focused build-tool partition: 2 suites and 8 tests passed.
- Exactly-one-runner routing passed for 996 baseline tests plus 7 additive tests, including the new build regression test.
- The complete production build passed with a temporary `.jsx` package source.
- Both CJS and ESM outputs were emitted; the ESM output used the automatic `react/jsx-runtime` transform.
- Focused JavaScript lint and the strict pre-commit checks passed.
- The pre-fix production build failed because `.jsx` inputs were not emitted, confirming the regression test targets the actual blocker.

### Testing Instructions for Keyboard

Not applicable; this is build infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to reproduce the complete-build failure, identify the source-discovery contract, implement and test the additive build support, and draft this description. The generated CJS/ESM outputs and reported results were inspected against the repository state.