### PR TITLE
Test: Preserve baseline identity across test file renames

### DIFF
--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -71,6 +71,18 @@ export function findOverlappingVitestProjectTests( testsByProject ) {
 		);
 }
 
+export function canonicalizeRenamedTestFiles( testFiles, renamedTests ) {
+	const currentToBaseline = new Map(
+		Object.entries( renamedTests ).map(
+			( [ baselinePath, currentPath ] ) => [ currentPath, baselinePath ]
+		)
+	);
+
+	return testFiles
+		.map( ( testPath ) => currentToBaseline.get( testPath ) ?? testPath )
+		.sort();
+}
+
 function normalizeTestPath( testPath ) {
 	return testPath.split( path.sep ).join( '/' );
 }

--- a/test/unit/scripts/test/discover-test-files.js
+++ b/test/unit/scripts/test/discover-test-files.js
@@ -8,6 +8,7 @@ import { describe, expect, test } from 'vitest';
  */
 import {
 	assertVitestProjectNames,
+	canonicalizeRenamedTestFiles,
 	findOverlappingVitestProjectTests,
 } from '../discover-test-files.mjs';
 
@@ -55,6 +56,24 @@ describe( 'Vitest project routing', () => {
 			} )
 		).toEqual( [
 			'packages/components/src/test/index.js: browser, jsdom',
+		] );
+	} );
+
+	test( 'preserves baseline identities for renamed tests', () => {
+		expect(
+			canonicalizeRenamedTestFiles(
+				[
+					'packages/example/src/test/unchanged.js',
+					'packages/example/src/test/renamed.jsx',
+				],
+				{
+					'packages/example/src/test/renamed.js':
+						'packages/example/src/test/renamed.jsx',
+				}
+			)
+		).toEqual( [
+			'packages/example/src/test/renamed.js',
+			'packages/example/src/test/unchanged.js',
 		] );
 	} );
 } );

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -18,6 +18,7 @@ import globPackage from 'glob';
  */
 import {
 	assertVitestProjectNames,
+	canonicalizeRenamedTestFiles,
 	discoverTestFiles,
 	findOverlappingVitestProjectTests,
 	getVitestTests,
@@ -146,6 +147,9 @@ const addedJestTests = manifest.added.jest;
 const addedVitestTests = Object.values( manifest.added.vitest ).flat();
 const addedTests = [ ...addedJestTests, ...addedVitestTests ];
 const retiredTests = manifest.retired;
+const renamedTests = manifest.renamed;
+const renamedBaselineTests = Object.keys( renamedTests );
+const renamedCurrentTests = Object.values( renamedTests );
 const migratedTestFiles = Object.values( manifest.vitest.projects ).flatMap(
 	( project ) => project.files
 );
@@ -155,6 +159,8 @@ const migratedDirectories = Object.values( manifest.vitest.projects ).flatMap(
 
 assertUniquePaths( 'added.jest', addedJestTests );
 assertUniquePaths( 'retired', retiredTests );
+assertUniquePaths( 'renamed baseline paths', renamedBaselineTests );
+assertUniquePaths( 'renamed current paths', renamedCurrentTests );
 for ( const projectName of VITEST_PROJECT_NAMES ) {
 	assertUniquePaths(
 		`added.vitest.${ projectName }`,
@@ -179,6 +185,27 @@ assert.deepEqual(
 	duplicateManifestEntries,
 	[],
 	`Migration manifest entries must be disjoint:\n${ duplicateManifestEntries.join(
+		'\n'
+	) }`
+);
+
+const conflictingRenamedEntries = Object.entries( renamedTests )
+	.filter(
+		( [ baselinePath, currentPath ] ) =>
+			baselinePath === currentPath ||
+			addedTests.includes( baselinePath ) ||
+			addedTests.includes( currentPath ) ||
+			retiredTests.includes( baselinePath ) ||
+			retiredTests.includes( currentPath )
+	)
+	.map(
+		( [ baselinePath, currentPath ] ) =>
+			`${ baselinePath } -> ${ currentPath }`
+	);
+assert.deepEqual(
+	conflictingRenamedEntries,
+	[],
+	`Renamed tests must be distinct from added and retired tests:\n${ conflictingRenamedEntries.join(
 		'\n'
 	) }`
 );
@@ -218,6 +245,28 @@ assert.deepEqual(
 	invalidAddedTests,
 	[],
 	`Added tests do not exist:\n${ invalidAddedTests.join( '\n' ) }`
+);
+
+const invalidRenamedTests = Object.entries( renamedTests )
+	.filter(
+		( [ baselinePath, currentPath ] ) =>
+			existsSync( path.join( ROOT_DIR, baselinePath ) ) ||
+			! existsSync( path.join( ROOT_DIR, currentPath ) ) ||
+			jestTests.has( baselinePath ) ||
+			vitestTests.has( baselinePath ) ||
+			( ! jestTests.has( currentPath ) &&
+				! vitestTests.has( currentPath ) )
+	)
+	.map(
+		( [ baselinePath, currentPath ] ) =>
+			`${ baselinePath } -> ${ currentPath }`
+	);
+assert.deepEqual(
+	invalidRenamedTests,
+	[],
+	`Renamed tests must replace an absent baseline path with one discoverable current path:\n${ invalidRenamedTests.join(
+		'\n'
+	) }`
 );
 
 const activeRetiredTests = retiredTests.filter(
@@ -294,14 +343,18 @@ const accountedBaseline = [
 		...retiredTests,
 	] ),
 ].sort();
+const canonicalBaseline = canonicalizeRenamedTestFiles(
+	accountedBaseline,
+	renamedTests
+);
 
 assert.equal(
-	accountedBaseline.length,
+	canonicalBaseline.length,
 	manifest.baseline.count,
 	'The number of accounted baseline tests changed.'
 );
 assert.equal(
-	hashTestFiles( accountedBaseline ),
+	hashTestFiles( canonicalBaseline ),
 	manifest.baseline.sha256,
 	'The accounted baseline test file list changed.'
 );
@@ -344,7 +397,7 @@ console.log(
 	} Vitest (${ VITEST_PROJECT_NAMES.map(
 		( projectName ) =>
 			`${ projectName }: ${ vitestTestsByProject[ projectName ].size }`
-	).join( ', ' ) }), ${ retiredTests.length } retired, and ${
-		addedTests.length
-	} added.`
+	).join( ', ' ) }), ${ retiredTests.length } retired, ${
+		renamedBaselineTests.length
+	} renamed, and ${ addedTests.length } added.`
 );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -55,6 +55,7 @@
 		}
 	},
 	"retired": [],
+	"renamed": {},
 	"added": {
 		"jest": [ "packages/wp-build/lib/test/source-files.js" ],
 		"vitest": {


### PR DESCRIPTION
## What?

**TL;DR — migration change class: routing infrastructure.** Add an explicit old-to-current test filename map so JSX extension normalization can rename test files without rewriting the immutable executable Jest baseline.

This PR does not move or reroute any tests. It teaches the exactly-one-runner validator to:

- canonicalize renamed current paths back to their original baseline identities for baseline count and hash checks;
- keep static inventory and runner ownership checks on current paths;
- reject duplicate, no-op, missing, still-discoverable, added, or retired rename entries;
- report the number of tracked renames.

It is stacked on #80894 and is independently revertible.

## Why?

The migration baseline must remain stable while JSX-bearing `*.js` test files are renamed to `*.jsx`. Recomputing the baseline after every filename-only change would weaken the proof that every originally discovered test still belongs to exactly one runner.

## How?

A new `renamed` manifest object maps each original baseline path to its current path. The discovery helper converts only current paths back to their baseline identities before the immutable baseline count and hash are checked. All other validation continues to use the real current paths.

## Testing Instructions

```sh
npm run test:unit:routing
node --test test/unit/scripts/test/discover-test-files.js
npm run test:unit:vitest-conventions
npm run lint:js -- test/unit/scripts/discover-test-files.mjs test/unit/scripts/test/discover-test-files.js test/unit/scripts/validate-test-routing.mjs
```

Verified result:

- routing: 996 baseline tests; 692 Jest, 311 Vitest, 7 additive tests, 0 renamed;
- discovery helper: 5 tests passed;
- Vitest conventions: 311 tests, 327 ESM graph files, 36 workspaces, 243 TypeScript files.

## Screenshots or screencast

Not applicable; test infrastructure only.