### PR TITLE
Migrate low-risk utility packages to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50535,6 +50535,9 @@
 				"@wordpress/data": "file:../data",
 				"@wordpress/deprecated": "file:../deprecated"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -52302,6 +52305,9 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"clsx": "^2.1.1"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -52480,7 +52486,8 @@
 				"rungen": "^0.3.2"
 			},
 			"devDependencies": {
-				"redux": "^5.0.1"
+				"redux": "^5.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -53279,6 +53286,9 @@
 			"name": "@wordpress/style-runtime",
 			"version": "0.7.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
@@ -53621,6 +53631,9 @@
 				"@wordpress/preferences": "file:../preferences",
 				"@wordpress/private-apis": "file:../private-apis",
 				"dequal": "^2.0.3"
+			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -47,6 +47,9 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"react": "^18 || ^19"
 	},

--- a/packages/data-controls/src/test/index.js
+++ b/packages/data-controls/src/test/index.js
@@ -1,9 +1,16 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import triggerFetch from '@wordpress/api-fetch';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( import( '@wordpress/api-fetch' ) );
+
+const mockedTriggerFetch = vi.mocked( triggerFetch );
 
 /**
  * Internal dependencies
@@ -13,15 +20,15 @@ import { controls } from '../index';
 describe( 'controls', () => {
 	describe( 'API_FETCH', () => {
 		afterEach( () => {
-			triggerFetch.mockClear();
+			mockedTriggerFetch.mockClear();
 		} );
 		it( 'invokes the triggerFetch function', () => {
 			controls.API_FETCH( { request: '' } );
-			expect( triggerFetch ).toHaveBeenCalledTimes( 1 );
+			expect( mockedTriggerFetch ).toHaveBeenCalledTimes( 1 );
 		} );
 		it( 'invokes the triggerFetch function with the passed in request', () => {
 			controls.API_FETCH( { request: 'foo' } );
-			expect( triggerFetch ).toHaveBeenCalledWith( 'foo' );
+			expect( mockedTriggerFetch ).toHaveBeenCalledWith( 'foo' );
 		} );
 	} );
 } );

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -62,6 +62,9 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"clsx": "^2.1.1"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",
 		"react": "^18 || ^19",

--- a/packages/preferences/src/store/test/actions.ts
+++ b/packages/preferences/src/store/test/actions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { setPersistenceLayer } from '../actions';

--- a/packages/preferences/src/store/test/reducer.ts
+++ b/packages/preferences/src/store/test/reducer.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { preferences } from '../reducer';
@@ -12,15 +17,20 @@ describe( 'withPersistenceLayer( preferences )', () => {
 
 		const action = {
 			type: 'SET_PERSISTENCE_LAYER',
+			persistenceLayer: {
+				get: async () => persistedData,
+				set() {},
+			},
 			persistedData,
-		};
+		} as const;
 
 		expect( preferences( {}, action ) ).toEqual( persistedData );
 	} );
 
 	it( 'calls the persistence layer `set` function with the updated store state whenever the `SET_PREFERENCE_VALUE` action is dispatched', () => {
-		const set = jest.fn();
+		const set = vi.fn();
 		const persistenceLayer = {
+			get: async () => ( {} ),
 			set,
 		};
 
@@ -28,7 +38,7 @@ describe( 'withPersistenceLayer( preferences )', () => {
 			type: 'SET_PERSISTENCE_LAYER',
 			persistenceLayer,
 			persistedData: {},
-		};
+		} as const;
 
 		// Set the persistence layer.
 		preferences( {}, setPersistenceLayerAction );
@@ -36,9 +46,10 @@ describe( 'withPersistenceLayer( preferences )', () => {
 		// Update a value.
 		const setPreferenceValueAction = {
 			type: 'SET_PREFERENCE_VALUE',
+			scope: 'test-scope',
 			name: 'myPreference',
 			value: 'myValue',
-		};
+		} as const;
 
 		const state = preferences( {}, setPreferenceValueAction );
 

--- a/packages/preferences/src/store/test/selectors.ts
+++ b/packages/preferences/src/store/test/selectors.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { get } from '../selectors';

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -51,7 +51,8 @@
 		"rungen": "^0.3.2"
 	},
 	"devDependencies": {
-		"redux": "^5.0.1"
+		"redux": "^5.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"redux": ">=4"

--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createStore, applyMiddleware } from 'redux';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies
@@ -50,7 +51,7 @@ describe( 'createMiddleware', () => {
 	} );
 
 	it( 'should throw if promise rejects', async () => {
-		expect.hasAssertions();
+		let caughtError;
 		const middleware = createMiddleware( {
 			WAIT_FAIL: () =>
 				new Promise( ( resolve, reject ) => reject( 'Message' ) ),
@@ -60,16 +61,16 @@ describe( 'createMiddleware', () => {
 			try {
 				yield { type: 'WAIT_FAIL' };
 			} catch ( error ) {
-				// eslint-disable-next-line jest/no-conditional-expect
-				expect( error ).toBe( 'Message' );
+				caughtError = error;
 			}
 		}
 
 		await store.dispatch( createAction() );
+		expect( caughtError ).toBe( 'Message' );
 	} );
 
-	it( 'should throw if promise throws', () => {
-		expect.hasAssertions();
+	it( 'should throw if promise throws', async () => {
+		let caughtError;
 		const middleware = createMiddleware( {
 			WAIT_FAIL: () =>
 				new Promise( () => {
@@ -81,22 +82,16 @@ describe( 'createMiddleware', () => {
 			try {
 				yield { type: 'WAIT_FAIL' };
 			} catch ( error ) {
-				// eslint-disable-next-line jest/no-conditional-expect
-				expect( error.message ).toBe( 'Message' );
+				caughtError = error;
 			}
 		}
 
-		return store.dispatch( createAction() );
+		await store.dispatch( createAction() );
+		expect( caughtError ).toHaveProperty( 'message', 'Message' );
 	} );
 
-	// Currently this test will not error even under conditions producing it but
-	// instead will have an uncaught error/warning printed in the cli console:
-	// - (node:37109) UnhandledPromiseRejectionWarning: TypeError: Cannot read
-	// property 'type' of null (and others)
-	// See this github thread for context:
-	// https://github.com/facebook/jest/issues/3251
-	it( 'should handle a null returned from a caught promise error', () => {
-		expect.hasAssertions();
+	it( 'should handle a null returned from a caught promise error', async () => {
+		let caughtError;
 		const middleware = createMiddleware( {
 			WAIT_FAIL: () =>
 				new Promise( () => {
@@ -108,12 +103,12 @@ describe( 'createMiddleware', () => {
 			try {
 				yield { type: 'WAIT_FAIL' };
 			} catch ( error ) {
-				// eslint-disable-next-line jest/no-conditional-expect
-				expect( error.message ).toBe( 'Message' );
+				caughtError = error;
 				return null;
 			}
 		}
-		store.dispatch( createAction() );
+		await store.dispatch( createAction() );
+		expect( caughtError ).toHaveProperty( 'message', 'Message' );
 	} );
 
 	it( 'assigns sync controlled return value into yield assignment', () => {

--- a/packages/redux-routine/src/test/is-action.js
+++ b/packages/redux-routine/src/test/is-action.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { isAction, isActionOfType } from '../is-action';

--- a/packages/redux-routine/src/test/is-generator.js
+++ b/packages/redux-routine/src/test/is-generator.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import isGenerator from '../is-generator';

--- a/packages/style-runtime/package.json
+++ b/packages/style-runtime/package.json
@@ -41,6 +41,9 @@
 	},
 	"types": "build-types",
 	"sideEffects": false,
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/style-runtime/test/index.ts
+++ b/packages/style-runtime/test/index.ts
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
 import { registerDocument, registerStyle } from '../src';
 
 type GlobalScopeWithStyleRuntime = typeof globalThis & {

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -49,6 +49,9 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"dequal": "^2.0.3"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/views/src/test/filter-utils.ts
+++ b/packages/views/src/test/filter-utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import type { View } from '@wordpress/dataviews';

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -37,6 +37,7 @@
 					"packages/server-side-render",
 					"packages/shortcode",
 					"packages/style-engine",
+					"packages/style-runtime",
 					"packages/sync",
 					"packages/theme",
 					"packages/token-list",
@@ -50,7 +51,12 @@
 			},
 			"node": {
 				"files": [],
-				"directories": []
+				"directories": [
+					"packages/data-controls",
+					"packages/preferences",
+					"packages/redux-routine",
+					"packages/views"
+				]
 			}
 		}
 	},


### PR DESCRIPTION
## What?

Follow-up to #80855.

**TL;DR — Migration change class:** runner imports, Node/jsdom routing, Jest mock replacement, workspace dependency ownership, and type-safe test cleanup.

Migrates all nine test files in `data-controls`, `preferences`, `redux-routine`, `style-runtime`, and `views` from Jest to Vitest. These files contain 80 assertions in total.

## Why?

This is the next bounded partition in the repository-wide Jest-to-Vitest migration. Keeping pure utility tests in Node avoids unnecessary web-platform setup, while `style-runtime` remains in jsdom because its contract is DOM style injection.

## How?

- Uses explicit imports from `vitest`; no runner globals are enabled.
- Routes four pure packages to the Node project and `style-runtime` to jsdom through the exactly-one-runner manifest.
- Replaces the `api-fetch` auto-mock with `vi.mock( import( ... ) )` and `vi.mocked`.
- Replaces `jest.fn()` with `vi.fn()`.
- Moves Redux Routine rejection assertions after the awaited dispatch, removing Jest-specific conditional-expect suppressions.
- Completes typed Preferences actions exposed by the Vitest TypeScript convention gate instead of weakening that gate.
- Declares `vitest` in each owning workspace and updates the lockfile.

No production code, snapshots, or npm engine requirements change.

## Testing Instructions

1. `npm run test:unit:routing`
2. `npm run test:unit:conventions`
3. `npm run test:unit:vitest`
4. `npm run test:unit -- --runInBand`
5. `npm run lint:js -- packages/redux-routine/src/test packages/style-runtime/test/index.ts packages/views/src/test/filter-utils.ts packages/data-controls/src/test/index.js packages/preferences/src/store/test`

Expected routing at this stack head: 683 Jest files and 320 Vitest files (`browser: 1`, `jsdom: 310`, `node: 9`).

### Testing Instructions for Keyboard

Not applicable; this PR changes test tooling only.

## Use of AI Tools

Codex was used to inspect the existing migration conventions, implement the bounded test migration, and run the verification commands. The resulting diff and test failures were reviewed before publishing this draft.