### PR TITLE
Docs: show media upload metadata example

### DIFF
--- a/packages/media-utils/README.md
+++ b/packages/media-utils/README.md
@@ -116,7 +116,22 @@ wp.mediaUtils.utils.uploadMedia( {
 } );
 ```
 
-Beware that first onFileChange is called with temporary blob URLs and then with the final URL's this allows to show the result in an optimistic UI as if the upload was already completed. E.g.: when uploading an image, one can show the image right away in the UI even before the upload is complete.
+The `additionalData` parameter can be used to pass attachment fields supported by the WordPress REST API. For example, the following code uploads an image and stores editor-facing metadata on the media item:
+
+```js
+wp.mediaUtils.utils.uploadMedia( {
+	filesList: [ imageFile ],
+	additionalData: {
+		alt_text: 'Close-up of a mountain trail marker',
+		caption: 'Trail marker on the Lycian Way.',
+		title: 'Lycian Way trail marker',
+	},
+	onFileChange: handleFileChange,
+	onError: console.error,
+} );
+```
+
+Beware that first onFileChange is called with temporary blob URLs and then with the final URLs. This allows showing the result in an optimistic UI as if the upload was already completed. E.g.: when uploading an image, one can show the image right away in the UI even before the upload is complete.
 
 ### MediaUpload
 


### PR DESCRIPTION
## What?
Adds a `@wordpress/media-utils` `uploadMedia` usage example showing how to pass media-library metadata through `additionalData`, including `alt_text`, `caption`, and `title`.

Also fixes the nearby `URL's` wording while touching the paragraph.

## Why?
The API reference lists `additionalData`, but the usage section only shows uploading a file and reading the URL. A short metadata example makes the attachment-field path clearer for block/editor integrations that need to preserve image context during upload.

## Testing Instructions
- Reviewed the rendered Markdown diff locally.
- Ran `git diff --check`.

I also tried `npm run lint:md:docs -- packages/media-utils/README.md`, but this checkout does not have the monorepo dependencies installed, so `wp-scripts` was not available.
