### PR TITLE
Migrate Node configuration and build tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49511,7 +49511,8 @@
 			"version": "5.51.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@babel/plugin-syntax-jsx": "^7.25.7"
+				"@babel/plugin-syntax-jsx": "^7.25.7",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -49531,7 +49532,8 @@
 				"is-plain-object": "^5.0.0"
 			},
 			"devDependencies": {
-				"@babel/traverse": "^7.25.7"
+				"@babel/traverse": "^7.25.7",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -49966,7 +49968,8 @@
 			"version": "6.51.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"browserslist": "^4.28.4"
+				"browserslist": "^4.28.4",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -52156,6 +52159,9 @@
 			"name": "@wordpress/npm-package-json-lint-config",
 			"version": "5.51.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -52341,7 +52347,8 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/node": "^20.19.39",
-				"@types/prettier": "^2.4.4"
+				"@types/prettier": "^2.4.4",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -53851,7 +53858,8 @@
 				"wp-build": "lib/build.mjs"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39"
+				"@types/node": "^20.19.39",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -36,7 +36,8 @@
 		"./package.json": "./package.json"
 	},
 	"devDependencies": {
-		"@babel/plugin-syntax-jsx": "^7.25.7"
+		"@babel/plugin-syntax-jsx": "^7.25.7",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.25.7"

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { transformSync } from '@babel/core';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -38,7 +38,8 @@
 		"is-plain-object": "^5.0.0"
 	},
 	"devDependencies": {
-		"@babel/traverse": "^7.25.7"
+		"@babel/traverse": "^7.25.7",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.25.7"

--- a/packages/babel-plugin-makepot/test/index.js
+++ b/packages/babel-plugin-makepot/test/index.js
@@ -3,6 +3,7 @@
  */
 import { transformSync } from '@babel/core';
 import traverse from '@babel/traverse';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -32,7 +32,8 @@
 		"./package.json": "./package.json"
 	},
 	"devDependencies": {
-		"browserslist": "^4.28.4"
+		"browserslist": "^4.28.4",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/browserslist-config/test/index.test.js
+++ b/packages/browserslist-config/test/index.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import browserslist from 'browserslist';
+import { expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -31,6 +31,9 @@
 		".": "./index.js",
 		"./package.json": "./package.json"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"npm-package-json-lint": ">=6.0.0"
 	},

--- a/packages/npm-package-json-lint-config/test/index.test.js
+++ b/packages/npm-package-json-lint-config/test/index.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import config from '../';

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -34,7 +34,8 @@
 	"types": "build-types",
 	"devDependencies": {
 		"@types/node": "^20.19.39",
-		"@types/prettier": "^2.4.4"
+		"@types/prettier": "^2.4.4",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"prettier": ">=3"

--- a/packages/prettier-config/test/index.js
+++ b/packages/prettier-config/test/index.js
@@ -3,7 +3,9 @@
  */
 import { execFile } from 'child_process';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies
@@ -11,6 +13,7 @@ import { promisify } from 'util';
 import config from '../lib/';
 
 const execFileAsync = promisify( execFile );
+const testDirectory = path.dirname( fileURLToPath( import.meta.url ) );
 
 describe( 'prettier config tests', () => {
 	it( 'should be an object', () => {
@@ -19,7 +22,7 @@ describe( 'prettier config tests', () => {
 	} );
 
 	it( 'should resolve file-specific options from the root config', async () => {
-		const repositoryRoot = path.resolve( __dirname, '../../..' );
+		const repositoryRoot = path.resolve( testDirectory, '../../..' );
 		// Resolve prettier from this file
 		const prettierPath = require.resolve( 'prettier' );
 		const resolveConfigScript = `

--- a/packages/wp-build/lib/test/package-utils.js
+++ b/packages/wp-build/lib/test/package-utils.js
@@ -1,29 +1,42 @@
 /**
+ * Node dependencies
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getPackageInfo } from '../package-utils.mjs';
 
+const testDirectory = path.dirname( fileURLToPath( import.meta.url ) );
+
 describe( 'getPackageInfo() resolve-miss contract', () => {
 	it( 'returns null (does not throw) for an unresolvable scoped package', () => {
 		expect( () =>
-			getPackageInfo( '@does-not-exist/nope', __dirname )
+			getPackageInfo( '@does-not-exist/nope', testDirectory )
 		).not.toThrow();
 
 		expect(
-			getPackageInfo( '@does-not-exist/nope', __dirname )
+			getPackageInfo( '@does-not-exist/nope', testDirectory )
 		).toBeNull();
 	} );
 
 	it( 'returns the cached null on a repeated miss', () => {
-		const first = getPackageInfo( '@still-missing/pkg', __dirname );
-		const second = getPackageInfo( '@still-missing/pkg', __dirname );
+		const first = getPackageInfo( '@still-missing/pkg', testDirectory );
+		const second = getPackageInfo( '@still-missing/pkg', testDirectory );
 
 		expect( first ).toBeNull();
 		expect( second ).toBeNull();
 	} );
 
 	it( 'still resolves an installed package that exposes its package.json', () => {
-		const info = getPackageInfo( '@wordpress/build', __dirname );
+		const info = getPackageInfo( '@wordpress/build', testDirectory );
 
 		expect( info ).toMatchObject( { name: '@wordpress/build' } );
 	} );

--- a/packages/wp-build/lib/test/source-files.js
+++ b/packages/wp-build/lib/test/source-files.js
@@ -9,6 +9,7 @@ import path from 'node:path';
  * External dependencies
  */
 import glob from 'fast-glob';
+import { afterEach, describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -53,7 +53,8 @@
 		"sass-embedded": "^1.97.2"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39"
+		"@types/node": "^20.19.39",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@wordpress/boot": ">=0.3.0 <1.0.0",

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -52,10 +52,16 @@
 			"node": {
 				"files": [],
 				"directories": [
+					"packages/babel-plugin-import-jsx-pragma",
+					"packages/babel-plugin-makepot",
+					"packages/browserslist-config",
 					"packages/data-controls",
+					"packages/npm-package-json-lint-config",
 					"packages/preferences",
+					"packages/prettier-config",
 					"packages/redux-routine",
-					"packages/views"
+					"packages/views",
+					"packages/wp-build"
 				]
 			}
 		}
@@ -107,7 +113,7 @@
 		"packages/private-apis/src/test/index.js": "packages/private-apis/src/test/index.jsx"
 	},
 	"added": {
-		"jest": [ "packages/wp-build/lib/test/source-files.js" ],
+		"jest": [],
 		"vitest": {
 			"browser": [ "test/unit/browser/components.vitest.test.tsx" ],
 			"jsdom": [
@@ -116,7 +122,10 @@
 				"test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js",
 				"test/unit/config/setup.vitest.test.jsx"
 			],
-			"node": [ "test/unit/scripts/test/discover-test-files.js" ]
+			"node": [
+				"packages/wp-build/lib/test/source-files.js",
+				"test/unit/scripts/test/discover-test-files.js"
+			]
 		}
 	}
 }


### PR DESCRIPTION
## What?

Follow-up to #80855.

**TL;DR — Migration change class:** pure Node runner imports, ESM path handling, workspace dependency ownership, and added-test manifest transfer.

Migrates seven test files (40 assertions) across the two Babel plugins, Browserslist config, npm-package-json-lint config, Prettier config, and `@wordpress/build` from Jest to Vitest's Node project.

## Why?

These tests exercise parsers, configuration objects, child processes, and filesystem/package discovery. They do not need jsdom or Browser Mode, making them a bounded native-Node migration slice.

## How?

- Adds explicit local imports from `vitest`; globals remain disabled.
- Replaces the two active `__dirname` test assumptions with `fileURLToPath( import.meta.url )`, so the migrated tests run as ESM without a CommonJS wrapper.
- Transfers the post-baseline `wp-build/source-files.js` addition from the Jest manifest to Vitest's Node additions while preserving exactly-one-runner ownership.
- Declares `vitest` in each owning workspace and updates the lockfile.

No production code, snapshots, package exports, or engine requirements change.

## Testing Instructions

1. `npm run test:unit:routing`
2. `npm run test:unit:conventions`
3. `npm run test:unit:vitest -- packages/babel-plugin-import-jsx-pragma/test/index.js packages/babel-plugin-makepot/test/index.js packages/browserslist-config/test/index.test.js packages/npm-package-json-lint-config/test/index.test.js packages/prettier-config/test/index.js packages/wp-build/lib/test`
4. `npm run lint:js -- packages/babel-plugin-import-jsx-pragma/test/index.js packages/babel-plugin-makepot/test/index.js packages/browserslist-config/test/index.test.js packages/npm-package-json-lint-config/test/index.test.js packages/prettier-config/test/index.js packages/wp-build/lib/test`

Expected routing at this stack head: 676 Jest files and 327 Vitest files (`browser: 1`, `jsdom: 310`, `node: 16`).

### Testing Instructions for Keyboard

Not applicable; this PR changes test tooling only.

## Use of AI Tools

Codex was used to inspect the remaining Node-test inventory, implement the migration, and run routing, convention, focused Vitest, formatting, and lint verification. The resulting diff was reviewed before publishing this draft.