### PR TITLE
Migrate ESLint plugin tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51194,7 +51194,8 @@
 				"@types/estree": "^1.0.8",
 				"@typescript-eslint/parser": "^8.57.1",
 				"eslint": "^10.0.0",
-				"typescript": "npm:@typescript/typescript6@^6.0.2"
+				"typescript": "npm:@typescript/typescript6@^6.0.2",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -67,7 +67,8 @@
 		"@types/estree": "^1.0.8",
 		"@typescript-eslint/parser": "^8.57.1",
 		"eslint": "^10.0.0",
-		"typescript": "npm:@typescript/typescript6@^6.0.2"
+		"typescript": "npm:@typescript/typescript6@^6.0.2",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@babel/core": ">=7",

--- a/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-missing-40px-size-prop.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../components-no-missing-40px-size-prop';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/components-no-unsafe-button-disabled.js
+++ b/packages/eslint-plugin/rules/__tests__/components-no-unsafe-button-disabled.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../components-no-unsafe-button-disabled';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../data-no-store-string-literals';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../dependency-group';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-ellipsis.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-ellipsis.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-ellipsis';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-hyphenated-range.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-hyphenated-range.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-hyphenated-range';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-no-collapsible-whitespace.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-no-collapsible-whitespace.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-no-collapsible-whitespace';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-no-flanking-whitespace.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-no-flanking-whitespace.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-no-flanking-whitespace';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-no-placeholders-only.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-no-placeholders-only.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-no-placeholders-only';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-no-variables.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-no-variables.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-no-variables';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-text-domain.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-text-domain.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-text-domain';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../i18n-translator-comments';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-base-control-with-label-without-id.js
+++ b/packages/eslint-plugin/rules/__tests__/no-base-control-with-label-without-id.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-base-control-with-label-without-id';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-constructor.js
+++ b/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-constructor.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-dom-globals-in-constructor';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {
@@ -60,7 +64,7 @@ ruleTester.run( 'no-dom-globals-in-constructor', rule, {
 // TypeScript-specific tests for shouldSkipReference.
 const tsRuleTester = new RuleTester( {
 	languageOptions: {
-		parser: require( '@typescript-eslint/parser' ),
+		parser: typescriptParser,
 		ecmaVersion: 2020,
 		sourceType: 'module',
 		parserOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-module-scope.js
+++ b/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-module-scope.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-dom-globals-in-module-scope';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {
@@ -94,7 +98,7 @@ ruleTester.run( 'no-dom-globals-in-module-scope', rule, {
 // TypeScript-specific tests for shouldSkipReference.
 const tsRuleTester = new RuleTester( {
 	languageOptions: {
-		parser: require( '@typescript-eslint/parser' ),
+		parser: typescriptParser,
 		ecmaVersion: 2020,
 		sourceType: 'module',
 		parserOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-react-cc-render.js
+++ b/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-react-cc-render.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-dom-globals-in-react-cc-render';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {
@@ -55,7 +59,7 @@ ruleTester.run( 'no-dom-globals-in-react-cc-render', rule, {
 // TypeScript-specific tests for shouldSkipReference.
 const tsRuleTester = new RuleTester( {
 	languageOptions: {
-		parser: require( '@typescript-eslint/parser' ),
+		parser: typescriptParser,
 		ecmaVersion: 2020,
 		sourceType: 'module',
 		parserOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-react-fc.js
+++ b/packages/eslint-plugin/rules/__tests__/no-dom-globals-in-react-fc.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-dom-globals-in-react-fc';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {
@@ -81,7 +85,7 @@ ruleTester.run( 'no-dom-globals-in-react-fc', rule, {
 // TypeScript-specific tests for shouldSkipReference.
 const tsRuleTester = new RuleTester( {
 	languageOptions: {
-		parser: require( '@typescript-eslint/parser' ),
+		parser: typescriptParser,
 		ecmaVersion: 2020,
 		sourceType: 'module',
 		parserOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
+++ b/packages/eslint-plugin/rules/__tests__/no-ds-tokens.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-ds-tokens';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-global-active-element.js
+++ b/packages/eslint-plugin/rules/__tests__/no-global-active-element.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-global-active-element';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-global-get-selection.js
+++ b/packages/eslint-plugin/rules/__tests__/no-global-get-selection.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-global-get-selection';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-i18n-in-save.js
+++ b/packages/eslint-plugin/rules/__tests__/no-i18n-in-save.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-i18n-in-save';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-non-module-stylesheet-imports.js
+++ b/packages/eslint-plugin/rules/__tests__/no-non-module-stylesheet-imports.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-non-module-stylesheet-imports';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-setting-ds-tokens.js
+++ b/packages/eslint-plugin/rules/__tests__/no-setting-ds-tokens.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-setting-ds-tokens';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-unguarded-get-range-at.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unguarded-get-range-at.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-unguarded-get-range-at';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-unknown-ds-tokens.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unknown-ds-tokens.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-unknown-ds-tokens';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-unmerged-classname.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unmerged-classname.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-unmerged-classname';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-render-order.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-render-order.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-unsafe-render-order';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-unsafe-wp-apis';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-unused-vars-before-return';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/no-wp-process-env.js
+++ b/packages/eslint-plugin/rules/__tests__/no-wp-process-env.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../no-wp-process-env';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/react-no-unsafe-timeout.js
+++ b/packages/eslint-plugin/rules/__tests__/react-no-unsafe-timeout.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../react-no-unsafe-timeout';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/use-import-as.js
+++ b/packages/eslint-plugin/rules/__tests__/use-import-as.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../use-import-as';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -1,5 +1,9 @@
-import { RuleTester } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule, { ALLOWLIST, DENYLIST } from '../use-recommended-components';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/valid-sprintf.js
+++ b/packages/eslint-plugin/rules/__tests__/valid-sprintf.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../valid-sprintf';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/rules/__tests__/wp-global-usage.js
+++ b/packages/eslint-plugin/rules/__tests__/wp-global-usage.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import configureRuleTester from '../../test-utils/configure-rule-tester';
 import rule from '../wp-global-usage';
+
+const RuleTester = configureRuleTester( { describe, it } );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {

--- a/packages/eslint-plugin/test-utils/configure-rule-tester.js
+++ b/packages/eslint-plugin/test-utils/configure-rule-tester.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+export default function configureRuleTester( { describe, it } ) {
+	RuleTester.describe = describe;
+	RuleTester.it = it;
+	RuleTester.itOnly = it.only;
+
+	return RuleTester;
+}

--- a/packages/eslint-plugin/utils/test/is-package-installed.js
+++ b/packages/eslint-plugin/utils/test/is-package-installed.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import isPackageInstalled from '../is-package-installed';

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -56,6 +56,7 @@
 					"packages/babel-plugin-makepot",
 					"packages/browserslist-config",
 					"packages/data-controls",
+					"packages/eslint-plugin",
 					"packages/npm-package-json-lint-config",
 					"packages/preferences",
 					"packages/prettier-config",


### PR DESCRIPTION
## What?

Follow-up to #80855.

**TL;DR — Migration change class:** ESLint RuleTester adapter, explicit Vitest imports, ESM parser imports, Node routing, and workspace dependency ownership.

Migrates the complete `@wordpress/eslint-plugin` suite: 36 test files and 555 cases move from Jest to Vitest's Node project.

## Why?

Rule tests are pure Node tests, but ESLint's RuleTester normally discovers runner globals. The repository deliberately keeps Vitest globals disabled, so the package needs an explicit, test-only bridge to register its cases with Vitest.

## How?

- Adds a package-local `configure-rule-tester` helper that assigns Vitest's imported `describe`, `it`, and `it.only` functions to ESLint RuleTester.
- Keeps explicit `vitest` imports in every active test file; no globals or `vitest/globals` types are introduced.
- Replaces four CommonJS `require( '@typescript-eslint/parser' )` calls with static ESM imports.
- Routes the complete package to the Node project and declares its direct `vitest` development dependency.

No ESLint rule implementation, fixture, expected diagnostic, snapshot, package export, or engine requirement changes.

## Testing Instructions

1. `npm run test:unit:routing`
2. `npm run test:unit:conventions`
3. `npm run test:unit:vitest -- packages/eslint-plugin`
4. `npm run lint:js -- packages/eslint-plugin/rules/__tests__ packages/eslint-plugin/utils/test/is-package-installed.js packages/eslint-plugin/test-utils/configure-rule-tester.js`

Expected routing at this stack head: 640 Jest files and 363 Vitest files (`browser: 1`, `jsdom: 310`, `node: 52`).

### Testing Instructions for Keyboard

Not applicable; this PR changes test tooling only.

## Use of AI Tools

Codex was used to inventory RuleTester behavior, implement the explicit Vitest adapter and ESM cleanup, and run routing, convention, focused Vitest, formatting, and lint verification. The resulting diff was reviewed before publishing this draft.