### PR TITLE
Migrate worker threads tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53801,6 +53801,9 @@
 			"dependencies": {
 				"comctx": "^1.4.3"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/worker-threads/package.json
+++ b/packages/worker-threads/package.json
@@ -51,6 +51,9 @@
 	"dependencies": {
 		"comctx": "^1.4.3"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/worker-threads/src/test/error-propagation.test.ts
+++ b/packages/worker-threads/src/test/error-propagation.test.ts
@@ -8,15 +8,28 @@
  * a rejection. See https://github.com/WordPress/gutenberg/issues/80259.
  */
 
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from 'vitest';
+
 // Store the original self.
 const originalSelf = globalThis.self;
 
 // Mock self for worker context.
-let mockPostMessage: jest.Mock;
+let mockPostMessage: Mock;
 let messageListeners: Array< ( event: MessageEvent ) => void > = [];
 
 function setupMockSelf() {
-	mockPostMessage = jest.fn();
+	mockPostMessage = vi.fn();
 	messageListeners = [];
 
 	// Override self with addEventListener pattern (matching comctx usage).
@@ -104,7 +117,7 @@ async function callExposedMethod(
 describe( 'worker-thread error propagation', () => {
 	beforeEach( () => {
 		setupMockSelf();
-		jest.resetModules();
+		vi.resetModules();
 	} );
 
 	afterEach( () => {

--- a/packages/worker-threads/src/test/main-thread.test.ts
+++ b/packages/worker-threads/src/test/main-thread.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { wrap, terminate } from '../main-thread';
@@ -10,8 +15,8 @@ import { WORKER_SYMBOL } from '../types';
  * error/messageerror events used for worker failure detection.
  */
 class MockWorker {
-	postMessage = jest.fn();
-	terminate = jest.fn();
+	postMessage = vi.fn();
+	terminate = vi.fn();
 
 	private listeners: Map< string, Array< ( event: Event ) => void > > =
 		new Map();
@@ -47,7 +52,7 @@ class MockWorker {
 	 * @param type  Event type.
 	 * @param event Event object.
 	 */
-	simulateEvent( type: string, event: Partial< Event > = {} ) {
+	simulateEvent( type: string, event: Partial< ErrorEvent > = {} ) {
 		for ( const handler of this.listeners.get( type ) || [] ) {
 			handler( event as Event );
 		}

--- a/packages/worker-threads/src/test/worker-thread.test.ts
+++ b/packages/worker-threads/src/test/worker-thread.test.ts
@@ -1,12 +1,25 @@
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from 'vitest';
+
 // Store the original self.
 const originalSelf = globalThis.self;
 
 // Mock self for worker context.
-let mockPostMessage: jest.Mock;
+let mockPostMessage: Mock;
 let messageListeners: Array< ( event: MessageEvent ) => void > = [];
 
 function setupMockSelf() {
-	mockPostMessage = jest.fn();
+	mockPostMessage = vi.fn();
 	messageListeners = [];
 
 	// Override self with addEventListener pattern (matching comctx usage).
@@ -51,7 +64,7 @@ function restoreSelf() {
 describe( 'worker-thread', () => {
 	beforeEach( () => {
 		setupMockSelf();
-		jest.resetModules();
+		vi.resetModules();
 	} );
 
 	afterEach( () => {
@@ -61,7 +74,7 @@ describe( 'worker-thread', () => {
 	describe( 'expose', () => {
 		it( 'should set up message handler', async () => {
 			const { expose } = await import( '../worker-thread' );
-			const api = { method: jest.fn() };
+			const api = { method: vi.fn() };
 
 			expose( api );
 
@@ -70,8 +83,8 @@ describe( 'worker-thread', () => {
 
 		it( 'should register handlers for all methods on target', async () => {
 			const { expose } = await import( '../worker-thread' );
-			const method1 = jest.fn();
-			const method2 = jest.fn();
+			const method1 = vi.fn();
+			const method2 = vi.fn();
 			const api = {
 				method1,
 				method2,
@@ -85,7 +98,7 @@ describe( 'worker-thread', () => {
 		it( 'should only expose functions, not other properties', async () => {
 			const { expose } = await import( '../worker-thread' );
 			const api = {
-				validMethod: jest.fn(),
+				validMethod: vi.fn(),
 				stringProp: 'not a function',
 				numberProp: 42,
 				objectProp: { nested: true },

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -62,6 +62,7 @@
 					"packages/prettier-config",
 					"packages/redux-routine",
 					"packages/views",
+					"packages/worker-threads",
 					"packages/wp-build"
 				]
 			}


### PR DESCRIPTION
## What?

TL;DR: Advanced reset-module and typed worker-mock migration, explicit Vitest imports, Node routing, and workspace dependency ownership.

See #80855.

This migrates all three `@wordpress/worker-threads` test files (26 tests) from Jest to the Vitest Node project.

## Why?

The worker RPC tests are a bounded advanced-mocking slice of the Jest-to-Vitest migration. Moving the complete package together preserves coverage of both sides of the worker boundary while avoiding split runner ownership.

## How?

- replaces Jest globals and mock types with explicit Vitest imports, `vi.fn()`, `vi.resetModules()`, and Vitest's `Mock` type;
- keeps dynamic module reloading, mocked `self`, async RPC reply polling, worker error events, and termination behavior intact;
- makes the error-event fixture accurately use `Partial< ErrorEvent >`, exposed by the migrated TypeScript test-graph check;
- routes the complete package to the Node project and declares Vitest in the package workspace.

No production implementation, snapshots, package exports, or supported engines change.

## Testing Instructions

```sh
npm run test:unit:vitest -- --project=node packages/worker-threads/src/test
npm run test:unit:routing
npm run test:unit:conventions
npm run lint:js -- packages/worker-threads/src/test/error-propagation.test.ts packages/worker-threads/src/test/main-thread.test.ts packages/worker-threads/src/test/worker-thread.test.ts
```

Expected focused result: 3 test files and 26 tests pass. The routing gate reports 637 Jest and 366 Vitest baseline tests with exactly one runner and environment each.

## Use of AI Tools

This PR was authored with Codex. The resulting diff and verification output were reviewed before publication.