### PR TITLE
Migrate video conversion tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53594,6 +53594,9 @@
 				"@wordpress/worker-threads": "file:../worker-threads",
 				"mediabunny": "^1.45.2"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/video-conversion/package.json
+++ b/packages/video-conversion/package.json
@@ -57,6 +57,9 @@
 		"@wordpress/worker-threads": "file:../worker-threads",
 		"mediabunny": "^1.45.2"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/video-conversion/src/test/index.ts
+++ b/packages/video-conversion/src/test/index.ts
@@ -1,13 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import {
-	convertGifToVideo,
-	cancelOperations,
-	UNSUPPORTED_ERROR_PREFIX,
-	SIZE_LIMIT_ERROR_PREFIX,
-	DEFAULT_MAX_TOTAL_PIXELS,
-} from '../index';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Configurable decoded-frame dimensions; the default (10x10) is even so the
 // canvas/resize path is skipped. Tests set odd values to exercise it.
@@ -90,10 +84,12 @@ class FakeReplacementVideoFrame {
 const mockAddedSamples: Array< {
 	init: { timestamp: number; duration: number };
 } > = [];
-const mockCanEncodeVideo = jest.fn().mockResolvedValue( true );
+const mockCanEncodeVideo = vi
+	.fn< ( ...args: unknown[] ) => Promise< boolean > >()
+	.mockResolvedValue( true );
 // Default VideoSampleSource.add implementation; tests can override it,
 // e.g. to make it reject and exercise frame-cleanup error paths.
-const mockSourceAdd = jest.fn(
+const mockSourceAdd = vi.fn(
 	async ( sample: { init: { timestamp: number; duration: number } } ) => {
 		mockAddedSamples.push( sample );
 	}
@@ -111,50 +107,68 @@ let mockVideoSamples: Array< { closed: boolean } > = [];
 // encoding configuration.
 let mockVideoSampleSourceOpts: Array< Record< string, unknown > > = [];
 
-jest.mock( 'mediabunny', () => ( {
-	Output: class {
-		opts: { target: { buffer: ArrayBuffer | null } };
-		constructor( opts: { target: { buffer: ArrayBuffer | null } } ) {
-			this.opts = opts;
-		}
-		addVideoTrack() {}
-		async start() {}
-		async finalize() {
-			this.opts.target.buffer = new Uint8Array( [ 1, 2, 3 ] ).buffer;
-		}
-	},
-	BufferTarget: class {
-		buffer: ArrayBuffer | null = null;
-	},
-	Mp4OutputFormat: class {},
-	WebMOutputFormat: class {},
-	VideoSampleSource: class {
-		constructor( opts: Record< string, unknown > ) {
-			mockVideoSampleSourceOpts.push( opts );
-		}
-		add( sample: { init: { timestamp: number; duration: number } } ) {
-			return mockSourceAdd( sample );
-		}
-	},
-	VideoSample: class {
-		frame: unknown;
-		init: { timestamp: number; duration: number };
-		closed = false;
-		constructor(
-			frame: unknown,
-			init: { timestamp: number; duration: number }
-		) {
-			this.frame = frame;
-			this.init = init;
-			mockVideoSamples.push( this );
-		}
-		close() {
-			this.closed = true;
-		}
-	},
-	QUALITY_HIGH: 'quality-high',
-	canEncodeVideo: ( ...args: unknown[] ) => mockCanEncodeVideo( ...args ),
-} ) );
+vi.doMock( import( 'mediabunny' ), async ( importOriginal ) => {
+	const original = await importOriginal();
+
+	return {
+		...original,
+		Output: class {
+			opts: { target: { buffer: ArrayBuffer | null } };
+			constructor( opts: { target: { buffer: ArrayBuffer | null } } ) {
+				this.opts = opts;
+			}
+			addVideoTrack() {}
+			async start() {}
+			async finalize() {
+				this.opts.target.buffer = new Uint8Array( [ 1, 2, 3 ] ).buffer;
+			}
+		} as unknown as typeof original.Output,
+		BufferTarget: class {
+			buffer: ArrayBuffer | null = null;
+		} as unknown as typeof original.BufferTarget,
+		Mp4OutputFormat: class {} as unknown as typeof original.Mp4OutputFormat,
+		WebMOutputFormat:
+			class {} as unknown as typeof original.WebMOutputFormat,
+		VideoSampleSource: class {
+			constructor( opts: Record< string, unknown > ) {
+				mockVideoSampleSourceOpts.push( opts );
+			}
+			add( sample: { init: { timestamp: number; duration: number } } ) {
+				return mockSourceAdd( sample );
+			}
+		} as unknown as typeof original.VideoSampleSource,
+		VideoSample: class {
+			frame: unknown;
+			init: { timestamp: number; duration: number };
+			closed = false;
+			constructor(
+				frame: unknown,
+				init: { timestamp: number; duration: number }
+			) {
+				this.frame = frame;
+				this.init = init;
+				mockVideoSamples.push( this );
+			}
+			close() {
+				this.closed = true;
+			}
+		} as unknown as typeof original.VideoSample,
+		QUALITY_HIGH: 'quality-high' as unknown as typeof original.QUALITY_HIGH,
+		canEncodeVideo:
+			mockCanEncodeVideo as unknown as typeof original.canEncodeVideo,
+	};
+} );
+
+/**
+ * Internal dependencies
+ */
+const {
+	convertGifToVideo,
+	cancelOperations,
+	UNSUPPORTED_ERROR_PREFIX,
+	SIZE_LIMIT_ERROR_PREFIX,
+	DEFAULT_MAX_TOTAL_PIXELS,
+} = await import( '../index' );
 
 beforeEach( () => {
 	mockAddedSamples.length = 0;

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -61,6 +61,7 @@
 					"packages/preferences",
 					"packages/prettier-config",
 					"packages/redux-routine",
+					"packages/video-conversion",
 					"packages/views",
 					"packages/worker-threads",
 					"packages/wp-build"


### PR DESCRIPTION
## What?

TL;DR: Deferred typed ESM module mock, explicit Vitest imports, Node routing, and workspace dependency ownership.

See #80855.

This migrates the complete `@wordpress/video-conversion` Jest suite (1 file, 18 tests) to the Vitest Node project.

## Why?

The suite has a stateful `mediabunny` module factory plus mocked WebCodecs and worker-adjacent behavior. Migrating it as one package-bounded slice preserves the resource-cleanup, cancellation, codec, and pixel-budget contracts while exercising Vitest's native ESM mock model.

## How?

- replaces the hoisted Jest factory with `vi.doMock(import('mediabunny'))`, registered before a dynamic import of the module under test;
- partially preserves the real module shape while explicitly typing each test-double boundary against the installed `mediabunny` exports;
- replaces Jest globals with explicit Vitest imports and typed `vi.fn()` mocks;
- keeps the mutable decoder, canvas, frame, sample, cancellation, and codec fixtures local to the test;
- routes the complete package to the Node project and declares Vitest in the package workspace.

No production implementation, snapshots, package exports, or supported engines change.

## Testing Instructions

```sh
npm run test:unit -- packages/video-conversion/src/test/index.ts --runInBand
npm run test:unit:vitest -- --project=node packages/video-conversion/src/test/index.ts
npm run test:unit:routing
npm run test:unit:conventions
npm run lint:js -- packages/video-conversion/src/test/index.ts
```

The pre-migration Jest baseline and migrated Vitest run both pass all 18 tests. The routing gate reports 636 Jest and 367 Vitest baseline tests with exactly one runner and environment each.

## Use of AI Tools

This PR was authored with Codex. The ESM mock design, resulting diff, and verification output were reviewed before publication.