### PR TITLE
Migrate API Fetch tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49480,6 +49480,9 @@
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -48,6 +48,9 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/api-fetch/src/middlewares/test/fetch-all-middleware.ts
+++ b/packages/api-fetch/src/middlewares/test/fetch-all-middleware.ts
@@ -1,52 +1,71 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import type { ApiFetch } from '../../index';
+import type { APIFetchOptions, FetchHandler } from '../../types';
+
 describe( 'Fetch All Middleware', () => {
-	beforeEach( jest.resetModules );
+	beforeEach( vi.resetModules );
 
 	it( 'should defer with the same options to the next middleware', async () => {
 		expect.hasAssertions();
 		const originalOptions = { path: '/posts' };
-		const next = ( options ) => {
+		const next: FetchHandler = async ( options ) => {
 			expect( options ).toBe( originalOptions );
-			return Promise.resolve( 'ok' );
+			return 'ok';
 		};
 
-		await require( '../fetch-all-middleware' ).default(
-			originalOptions,
-			next
+		const { default: fetchAllMiddleware } = await import(
+			'../fetch-all-middleware'
 		);
+
+		await fetchAllMiddleware( originalOptions, next );
 	} );
 
 	it( 'should paginate the request', async () => {
 		expect.hasAssertions();
 		const originalOptions = { url: '/posts?per_page=-1' };
 		let counter = 1;
-		jest.doMock( '../../index.ts', () => ( options ) => {
-			const expectedUrl =
-				counter === 1
-					? '/posts?per_page=100'
-					: '/posts?per_page=100&page=2';
-			expect( options.url ).toBe( expectedUrl );
+		vi.doMock( import( '../../index' ), () => {
+			const mockApiFetch = ( ( options: APIFetchOptions ) => {
+				const expectedUrl =
+					counter === 1
+						? '/posts?per_page=100'
+						: '/posts?per_page=100&page=2';
+				expect( options.url ).toBe( expectedUrl );
 
-			const response = Promise.resolve( {
-				status: 200,
-				headers: {
-					get() {
-						return options.url === '/posts?per_page=100'
-							? '</posts?per_page=100&page=2>; rel="next"'
-							: '';
+				const response = Promise.resolve( {
+					status: 200,
+					headers: {
+						get() {
+							return options.url === '/posts?per_page=100'
+								? '</posts?per_page=100&page=2>; rel="next"'
+								: '';
+						},
 					},
-				},
-				json() {
-					return Promise.resolve( [ 'item' ] );
-				},
-			} );
+					json() {
+						return Promise.resolve( [ 'item' ] );
+					},
+				} );
 
-			counter++;
+				counter++;
 
-			return response;
+				return response;
+			} ) as ApiFetch;
+
+			return { default: mockApiFetch };
 		} );
-		const result = await require( '../fetch-all-middleware' ).default(
+		const { default: fetchAllMiddleware } = await import(
+			'../fetch-all-middleware'
+		);
+		const result = await fetchAllMiddleware(
 			originalOptions,
-			() => {}
+			async () => {}
 		);
 
 		expect( result ).toEqual( [ 'item', 'item' ] );

--- a/packages/api-fetch/src/middlewares/test/http-v1.ts
+++ b/packages/api-fetch/src/middlewares/test/http-v1.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';

--- a/packages/api-fetch/src/middlewares/test/media-upload.ts
+++ b/packages/api-fetch/src/middlewares/test/media-upload.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';
@@ -20,15 +25,15 @@ describe( 'Media Upload Middleware', () => {
 		expect.hasAssertions();
 
 		const requestOptions = { method: 'POST', path: '/wp/v2/media' };
-		const next = ( options ) => {
+		const next: FetchHandler = async ( options ) => {
 			expect( options.parse ).toBe( false );
 
-			return Promise.resolve( {
+			return {
 				status: 200,
 				json() {
 					return Promise.resolve( [ 'item' ] );
 				},
-			} );
+			};
 		};
 
 		mediaUploadMiddleware( requestOptions, next );

--- a/packages/api-fetch/src/middlewares/test/namespace-endpoint.ts
+++ b/packages/api-fetch/src/middlewares/test/namespace-endpoint.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';

--- a/packages/api-fetch/src/middlewares/test/nonce.ts
+++ b/packages/api-fetch/src/middlewares/test/nonce.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';

--- a/packages/api-fetch/src/middlewares/test/preloading.ts
+++ b/packages/api-fetch/src/middlewares/test/preloading.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';
@@ -53,7 +58,7 @@ describe( 'Preloading Middleware', () => {
 						method: 'GET',
 						path: 'wp/v2/posts',
 					};
-					const nextSpy = jest.fn();
+					const nextSpy = vi.fn();
 
 					preloadingMiddleware( requestOptions, nextSpy );
 					expect( nextSpy ).not.toHaveBeenCalled();
@@ -76,7 +81,7 @@ describe( 'Preloading Middleware', () => {
 						method: 'GET',
 						path: 'wp/v2/posts',
 					};
-					const nextSpy = jest.fn();
+					const nextSpy = vi.fn();
 
 					await expect(
 						preloadingMiddleware( requestOptions, nextSpy )
@@ -97,21 +102,7 @@ describe( 'Preloading Middleware', () => {
 			} );
 
 			describe( 'and the OPTIONS request has a parse flag', () => {
-				it( 'should return the full response if parse: false', () => {
-					const noResponseMock =
-						'undefined' === typeof window.Response;
-					if ( noResponseMock ) {
-						// @ts-expect-error
-						window.Response = class {
-							constructor( body, options ) {
-								// @ts-expect-error
-								this.body = JSON.parse( body );
-								// @ts-expect-error
-								this.headers = options.headers;
-							}
-						};
-					}
-
+				it( 'should return the full response if parse: false', async () => {
 					const data = {
 						body: {
 							status: 'this is the preloaded response',
@@ -136,17 +127,18 @@ describe( 'Preloading Middleware', () => {
 						parse: false,
 					};
 
-					const response = preloadingMiddleware(
+					const response = await preloadingMiddleware(
 						requestOptions,
 						async () => {}
 					);
-					if ( noResponseMock ) {
-						// @ts-expect-error
-						delete window.Response;
-					}
-					return response.then( ( value ) => {
-						expect( value ).toEqual( data );
-					} );
+
+					expect( response ).toBeInstanceOf( window.Response );
+					expect( response.headers.get( 'Allow' ) ).toBe(
+						'GET, POST'
+					);
+					await expect( response.json() ).resolves.toEqual(
+						data.body
+					);
 				} );
 
 				it( 'should return only the response body if parse: true', () => {
@@ -201,7 +193,7 @@ describe( 'Preloading Middleware', () => {
 					method: 'GET',
 					path: 'wp/v2/fake_resource',
 				};
-				const nextSpy = jest.fn();
+				const nextSpy = vi.fn();
 
 				preloadingMiddleware( requestOptions, nextSpy );
 				expect( nextSpy ).toHaveBeenCalled();
@@ -308,39 +300,18 @@ describe( 'Preloading Middleware', () => {
 			path: 'wp/v2/demo',
 		};
 
-		const firstMiddleware = jest.fn();
+		const firstMiddleware = vi.fn();
 		preloadingMiddleware( requestOptions, firstMiddleware );
 		expect( firstMiddleware ).not.toHaveBeenCalled();
 
 		await preloadingMiddleware( requestOptions, firstMiddleware );
 
-		const secondMiddleware = jest.fn();
+		const secondMiddleware = vi.fn();
 		await preloadingMiddleware( requestOptions, secondMiddleware );
 		expect( secondMiddleware ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should not throw an error when non-ASCII headers are present', async () => {
-		const noResponseMock = 'undefined' === typeof window.Response;
-		if ( noResponseMock ) {
-			window.Response = class {
-				constructor( body, options ) {
-					this.body = JSON.parse( body );
-					this.headers = options.headers;
-
-					// Check for non-ASCII characters in headers
-					for ( const [ key, value ] of Object.entries(
-						this.headers || {}
-					) ) {
-						if ( /[^\x00-\x7F]/.test( value ) ) {
-							throw new Error(
-								`Invalid non-ASCII character found in header: ${ key }`
-							);
-						}
-					}
-				}
-			};
-		}
-
 		const data = {
 			body: 'Hello',
 			headers: {
@@ -362,12 +333,8 @@ describe( 'Preloading Middleware', () => {
 		};
 
 		await expect(
-			preloadingMiddleware( requestOptions, () => {} )
+			preloadingMiddleware( requestOptions, async () => {} )
 		).resolves.not.toThrow();
-
-		if ( noResponseMock ) {
-			delete window.Response;
-		}
 	} );
 
 	describe.each( [ [ 'GET' ], [ 'OPTIONS' ] ] )( '%s', ( method ) => {

--- a/packages/api-fetch/src/middlewares/test/root-url.ts
+++ b/packages/api-fetch/src/middlewares/test/root-url.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';

--- a/packages/api-fetch/src/middlewares/test/user-locale.ts
+++ b/packages/api-fetch/src/middlewares/test/user-locale.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { FetchHandler } from '../../types';

--- a/packages/api-fetch/src/test/exports.test.ts
+++ b/packages/api-fetch/src/test/exports.test.ts
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
 import apiFetch from '..';
 
 describe( 'apiFetch exports', () => {

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Mock response value for a successful fetch.
  *
  * @return {Response} Mock return value.
@@ -16,10 +21,10 @@ describe( 'apiFetch', () => {
 	beforeEach( async () => {
 		// Reset the `apiFetch` module before each test to clear
 		// internal variables (middlewares, fetch handler, etc.).
-		jest.resetModules();
+		vi.resetModules();
 		apiFetch = ( await import( '../' ) ).default;
 
-		globalThis.fetch = jest.fn();
+		globalThis.fetch = vi.fn();
 	} );
 
 	afterAll( () => {
@@ -329,7 +334,7 @@ describe( 'apiFetch', () => {
 	} );
 
 	it( 'should not use the default fetch handler when using a custom fetch handler', async () => {
-		const customFetchHandler = jest.fn();
+		const customFetchHandler = vi.fn();
 
 		apiFetch.setFetchHandler( customFetchHandler );
 
@@ -355,7 +360,7 @@ describe( 'apiFetch', () => {
 		} );
 
 		// Set a custom fetch handler to avoid using the default fetch handler.
-		apiFetch.setFetchHandler( jest.fn() );
+		apiFetch.setFetchHandler( vi.fn() );
 
 		await apiFetch( expectedOptions );
 	} );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -14,6 +14,7 @@
 				"directories": [
 					"packages/abilities",
 					"packages/annotations",
+					"packages/api-fetch",
 					"packages/autop",
 					"packages/blob",
 					"packages/block-directory",


### PR DESCRIPTION
## What?

TL;DR: Complete jsdom package migration, typed deferred module mock, real `Response` coverage, explicit Vitest imports, and workspace dependency ownership.

See #80855.

This migrates all 10 `@wordpress/api-fetch` test files (63 tests) from Jest to the jsdom-backed Vitest project.

## Why?

API Fetch mixes middleware unit tests with `window`, `navigator`, Fetch API, module-reset, and module-mocking behavior. Moving the complete package preserves one environment and runner owner while removing its active Jest surface.

## How?

- replaces injected Jest globals with explicit Vitest imports and `vi.fn()`/`vi.resetModules()`;
- replaces CommonJS `require()` and `jest.doMock()` with dynamic ESM imports and `vi.doMock(import(...))`;
- types the mocked API Fetch function and middleware callbacks against package contracts;
- uses the available `Response` implementation to verify status headers and parsed body, removing the legacy fallback `Response` class;
- routes the complete package to jsdom and declares Vitest in the package workspace.

No production implementation, snapshots, package exports, or supported engines change.

## Testing Instructions

```sh
npm run test:unit:vitest -- --project=vitest packages/api-fetch
npm run test:unit:routing
npm run test:unit:conventions
npm run lint:js -- packages/api-fetch/src/middlewares/test packages/api-fetch/src/test
```

Expected focused result: 10 files and 63 tests pass. The routing gate reports 626 Jest and 377 Vitest baseline tests with exactly one runner and environment each.

## Use of AI Tools

This PR was authored with Codex. The ESM module mock, platform-fixture change, resulting diff, and verification output were reviewed before publication.