### PR TITLE
Migrate Docgen tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50722,7 +50722,8 @@
 				"docgen": "bin/cli.js"
 			},
 			"devDependencies": {
-				"@types/babel__core": "^7.20.5"
+				"@types/babel__core": "^7.20.5",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -43,7 +43,8 @@
 		"unified": "^7.1.0"
 	},
 	"devDependencies": {
-		"@types/babel__core": "^7.20.5"
+		"@types/babel__core": "^7.20.5",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/docgen/test/engine.js
+++ b/packages/docgen/test/engine.js
@@ -1,7 +1,15 @@
 /**
  * Internal dependencies
  */
-const engine = require( '../lib/engine' );
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import engine from '../lib/engine';
 
 describe( 'Engine', () => {
 	it( 'should return a void IR for undefined code', () => {

--- a/packages/docgen/test/formatter-markdown.js
+++ b/packages/docgen/test/formatter-markdown.js
@@ -1,7 +1,15 @@
 /**
  * Internal dependencies
  */
-const formatter = require( '../lib/markdown/formatter' );
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import formatter from '../lib/markdown/formatter';
 
 describe( 'Formatter', () => {
 	it( 'returns markdown', () => {

--- a/packages/docgen/test/get-export-entries.js
+++ b/packages/docgen/test/get-export-entries.js
@@ -1,8 +1,16 @@
 /**
  * Internal dependencies
  */
-const engine = require( '../lib/engine' );
-const getExportEntries = require( '../lib/get-export-entries' );
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import engine from '../lib/engine';
+import getExportEntries from '../lib/get-export-entries';
 
 /**
  * Parses sample code into testable structure.

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -1,8 +1,16 @@
 /**
  * Internal dependencies
  */
-const engine = require( '../lib/engine' );
-const getIntermediateRepresentation = require( '../lib/get-intermediate-representation' );
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import engine from '../lib/engine';
+import getIntermediateRepresentation from '../lib/get-intermediate-representation';
 
 /**
  * Parses sample code into testable structure.

--- a/packages/docgen/test/get-jsdoc-from-token.js
+++ b/packages/docgen/test/get-jsdoc-from-token.js
@@ -1,8 +1,16 @@
 /**
  * Internal dependencies
  */
-const getJSDocFromToken = require( '../lib/get-jsdoc-from-token' );
-const engine = require( '../lib/engine' );
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import getJSDocFromToken from '../lib/get-jsdoc-from-token';
+import engine from '../lib/engine';
 
 /**
  * Generate the AST necessary to assert inferred types.

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -1,8 +1,16 @@
 /**
  * Internal dependencies
  */
-const engine = require( '../lib/engine' );
-const getTypeAnnotation = require( '../lib/get-type-annotation' );
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import engine from '../lib/engine';
+import getTypeAnnotation from '../lib/get-type-annotation';
 
 /**
  * Generate the AST necessary to assert inferred types.

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -57,6 +57,7 @@
 					"packages/babel-plugin-makepot",
 					"packages/browserslist-config",
 					"packages/data-controls",
+					"packages/docgen",
 					"packages/eslint-plugin",
 					"packages/npm-package-json-lint-config",
 					"packages/preferences",


### PR DESCRIPTION
## What?

TL;DR: Complete Node package migration, ESM-authored tests over the published CommonJS implementation, explicit Vitest imports, and workspace dependency ownership.

See #80855.

This migrates all six `@wordpress/docgen` test files (121 tests) from Jest to the Vitest Node project.

## Why?

Docgen is a published CommonJS package whose test files also used CommonJS. Migrating the tests separately removes avoidable test-side CommonJS while preserving the package's current consumer contract for its eventual explicit compatibility/major-release decision.

## How?

- replaces test-side `require()` calls with ESM imports;
- imports `describe`, `expect`, and `it` explicitly from Vitest;
- verifies Vitest can consume the existing CommonJS implementation without adding Docgen to the repository's `vite-plugin-commonjs` filter;
- routes the complete package to Node and declares Vitest in the package workspace.

No production implementation, snapshots, Babel parsing behavior, package exports, module format, or supported engines change.

## Testing Instructions

```sh
npm run test:unit:vitest -- --project=node packages/docgen/test
npm run test:unit:routing
npm run test:unit:conventions
npm run lint:js -- packages/docgen/test
```

Expected focused result: 6 files and 121 tests pass. The routing gate reports 620 Jest and 383 Vitest baseline tests with exactly one runner and environment each.

## Use of AI Tools

This PR was authored with Codex. The CommonJS interoperability boundary, resulting diff, and verification output were reviewed before publication.