### PR TITLE
Tabs: Support Home and End keys for keyboard navigation

### DIFF
--- a/packages/block-library/src/tabs/view.js
+++ b/packages/block-library/src/tabs/view.js
@@ -66,7 +66,7 @@ const { actions, state } = store(
 			 * @param {KeyboardEvent} event The keydown event.
 			 */
 			handleTabKeyDown: withSyncEvent( ( event ) => {
-				const { tabIndex } = state;
+				const { tabIndex, tabsList } = state;
 
 				if ( tabIndex === null ) {
 					return;
@@ -78,6 +78,12 @@ const { actions, state } = store(
 				} else if ( event.key === 'ArrowLeft' ) {
 					event.preventDefault();
 					actions.moveFocus( tabIndex - 1 );
+				} else if ( event.key === 'Home' ) {
+					event.preventDefault();
+					actions.moveFocus( 0 );
+				} else if ( event.key === 'End' ) {
+					event.preventDefault();
+					actions.moveFocus( tabsList.length - 1 );
 				}
 			} ),
 			/**


### PR DESCRIPTION
## What?
Closes #80877 

Adds `Home` and `End` key support to the Tabs block's frontend tab list, so pressing them moves focus to the first and last tab respectively.

## Why?
The W3C APG tabs pattern specifies that `Home` should move focus to the first tab and `End` to the last tab. 

## How?
In `packages/block-library/src/tabs/view.js`, `handleTabKeyDown` now branches on `Home` and `End` in addition to the existing arrow keys, calling the existing `moveFocus` action with index `0` (first tab) or `tabsList.length - 1` (last tab). 

## Testing Instructions
1. Create a Tabs block with five tabs (e.g. Alpha, Bravo, Charlie, Delta, Echo).
2. Publish and view the post on the frontend.
3. Click the "Charlie" tab to focus it.
4. Press `End` or `Fn + Right Arrow`, focus should move to "Echo".
5. Press `Home`  or `Fn + Left Arrow`, focus should move to "Alpha".
6. Press `ArrowRight`/`ArrowLeft` to confirm existing arrow-key navigation still works.

### Testing Instructions for Keyboard
Same as above. This change is keyboard-only:
1. Tab to the active tab label in the tab list.
2. Press `End` or `Fn + Right Arrow`, confirm focus lands on the last tab.
3. Press `Home`  or `Fn + Left Arrow`, confirm focus lands on the first tab.
4. Press `Enter`/`Space` on the focused tab to confirm activation still works after moving focus with `Home`/`End`.

## Screenshots or screencast 
https://github.com/user-attachments/assets/9b1cfc4b-ebb7-4778-b6bc-95510aeb9c33

## Use of AI Tools
This PR was developed with the assistance of Claude Code.
