### PR TITLE
Migrate Vips package to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53683,6 +53683,9 @@
 				"@wordpress/worker-threads": "file:../worker-threads",
 				"wasm-vips": "^0.0.18"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/vips/package.json
+++ b/packages/vips/package.json
@@ -58,6 +58,9 @@
 		"@wordpress/worker-threads": "file:../worker-threads",
 		"wasm-vips": "^0.0.18"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/vips/src/test/convert-image-format.ts
+++ b/packages/vips/src/test/convert-image-format.ts
@@ -1,37 +1,51 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type VipsFactory from 'wasm-vips';
+
+/**
  * Internal dependencies
  */
 import { convertImageFormat, compressImage } from '../';
 
-const mockNewFromBuffer = jest.fn( () => new MockImage() );
-const mockWriteToBuffer = jest.fn( () => ( {
-	buffer: '',
-} ) );
+const { MockVipsImage, mockNewFromBuffer } = vi.hoisted( () => {
+	const writeToBufferMock = vi.fn( () => ( {
+		buffer: '',
+	} ) );
 
-class MockImage {
-	width = 100;
-	height = 100;
-	pageHeight = 100;
-	writeToBuffer = mockWriteToBuffer;
-	getInt = jest.fn( () => 0 );
-}
+	class ImageMock {
+		width = 100;
+		height = 100;
+		pageHeight = 100;
+		writeToBuffer = writeToBufferMock;
+		getInt = vi.fn( () => 0 );
+	}
 
-class MockVipsImage {
-	static newFromBuffer = mockNewFromBuffer;
-}
+	const newFromBufferMock = vi.fn( () => new ImageMock() );
 
-jest.mock( 'wasm-vips', () =>
-	jest.fn( () => ( {
+	class VipsImageMock {
+		static newFromBuffer = newFromBufferMock;
+	}
+
+	return {
+		MockVipsImage: VipsImageMock,
+		mockNewFromBuffer: newFromBufferMock,
+	};
+} );
+
+vi.mock( import( 'wasm-vips' ), () => ( {
+	default: vi.fn( () => ( {
 		Image: MockVipsImage,
 		Cache: {
-			max: jest.fn(),
+			max: vi.fn(),
 		},
-	} ) )
-);
+	} ) ) as unknown as typeof VipsFactory,
+} ) );
 
 describe( 'convertImageFormat', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'loads only the first frame when converting a GIF to JPEG', async () => {

--- a/packages/vips/src/test/has-transparency.ts
+++ b/packages/vips/src/test/has-transparency.ts
@@ -1,35 +1,59 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type VipsFactory from 'wasm-vips';
+
+/**
  * Internal dependencies
  */
 import { hasTransparency } from '../';
 
-const mockHasAlpha = jest.fn();
-const mockExtractBand = jest.fn();
-const mockMin = jest.fn();
+const {
+	MockAlphaBand,
+	MockImage,
+	mockExtractBand,
+	mockHasAlpha,
+	mockMin,
+	mockNewFromBuffer,
+} = vi.hoisted( () => {
+	const hasAlphaMock = vi.fn();
+	const extractBandMock = vi.fn();
+	const minMock = vi.fn();
 
-class MockAlphaBand {
-	min = mockMin;
-}
+	class AlphaBandMock {
+		min = minMock;
+	}
 
-class MockImage {
-	hasAlpha = mockHasAlpha;
-	extractBand = mockExtractBand;
-	bands = 4;
-	format = 'uchar';
-}
+	class ImageMock {
+		hasAlpha = hasAlphaMock;
+		extractBand = extractBandMock;
+		bands = 4;
+		format = 'uchar';
+	}
 
-const mockNewFromBuffer = jest.fn( () => new MockImage() );
+	const newFromBufferMock = vi.fn( () => new ImageMock() );
 
-jest.mock( 'wasm-vips', () =>
-	jest.fn( () => ( {
+	return {
+		MockAlphaBand: AlphaBandMock,
+		MockImage: ImageMock,
+		mockExtractBand: extractBandMock,
+		mockHasAlpha: hasAlphaMock,
+		mockMin: minMock,
+		mockNewFromBuffer: newFromBufferMock,
+	};
+} );
+
+vi.mock( import( 'wasm-vips' ), () => ( {
+	default: vi.fn( () => ( {
 		Image: {
 			newFromBuffer: mockNewFromBuffer,
 		},
 		Cache: {
-			max: jest.fn(),
+			max: vi.fn(),
 		},
-	} ) )
-);
+	} ) ) as unknown as typeof VipsFactory,
+} ) );
 
 describe( 'hasTransparency', () => {
 	beforeEach( () => {
@@ -37,7 +61,7 @@ describe( 'hasTransparency', () => {
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'returns false when the image has no alpha channel', async () => {

--- a/packages/vips/src/test/highbitdepth-avif.ts
+++ b/packages/vips/src/test/highbitdepth-avif.ts
@@ -1,14 +1,11 @@
 /**
- * @jest-environment node
- */
-
-/**
  * External dependencies
  */
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import Vips from 'wasm-vips';
 
-/**
+/*
  * Loads the real `wasm-vips` build to exercise the actual AVIF decoder.
  *
  * Unlike the other tests in this package, this is an integration test: it does
@@ -21,9 +18,16 @@ import { join } from 'node:path';
  * AVIF images (kleisauke/wasm-vips#118). Earlier builds threw "error in tile"
  * decode failures on the same files.
  */
-const Vips = require( 'wasm-vips' );
 
-const FIXTURES = join( __dirname, 'fixtures' );
+/**
+ * Returns a fixture URL relative to this ESM test module.
+ *
+ * @param file Fixture filename.
+ *
+ * @return Fixture URL.
+ */
+const getFixtureUrl = ( file: string ) =>
+	new URL( `./fixtures/${ file }`, import.meta.url );
 
 describe( 'wasm-vips high-bit-depth AVIF decoding', () => {
 	let vips: Awaited< ReturnType< typeof Vips > >;
@@ -40,7 +44,7 @@ describe( 'wasm-vips high-bit-depth AVIF decoding', () => {
 		[ '10-bit', 'highbitdepth-10bit.avif' ],
 		[ '12-bit', 'highbitdepth-12bit.avif' ],
 	] )( 'decodes a %s AVIF image into a 16-bit image', ( _label, file ) => {
-		const buffer = readFileSync( join( FIXTURES, file ) );
+		const buffer = readFileSync( getFixtureUrl( file ) );
 
 		const image = vips.Image.newFromBuffer( buffer );
 
@@ -55,7 +59,7 @@ describe( 'wasm-vips high-bit-depth AVIF decoding', () => {
 	} );
 
 	it( 'decodes a standard 8-bit AVIF image into an 8-bit image', () => {
-		const buffer = readFileSync( join( FIXTURES, 'standard-8bit.avif' ) );
+		const buffer = readFileSync( getFixtureUrl( 'standard-8bit.avif' ) );
 
 		const image = vips.Image.newFromBuffer( buffer );
 
@@ -85,7 +89,7 @@ describe( 'wasm-vips high-bit-depth AVIF decoding', () => {
 		] )(
 			'keeps a %s AVIF high-bit-depth through resize and re-encode',
 			( _label, file, depth ) => {
-				const buffer = readFileSync( join( FIXTURES, file ) );
+				const buffer = readFileSync( getFixtureUrl( file ) );
 
 				// `thumbnail` flattens samples to 8-bit sRGB...
 				const flattened = vips.Image.thumbnailBuffer( buffer, 32, {
@@ -126,7 +130,7 @@ describe( 'wasm-vips high-bit-depth AVIF decoding', () => {
 			// would be inflated to 12-bit (larger, not "similar") unless the
 			// original depth is written explicitly.
 			const buffer = readFileSync(
-				join( FIXTURES, 'highbitdepth-10bit.avif' )
+				getFixtureUrl( 'highbitdepth-10bit.avif' )
 			);
 			const resized = vips.Image.newFromBuffer( buffer ).resize( 0.5 );
 

--- a/packages/vips/src/test/resize-image.ts
+++ b/packages/vips/src/test/resize-image.ts
@@ -1,51 +1,73 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type VipsFactory from 'wasm-vips';
+
+/**
  * Internal dependencies
  */
 import { resizeImage } from '../';
 import type { ImageSizeCrop } from '../types';
 
-const mockThumbnailBuffer = jest.fn( () => new MockImage() );
-const mockCrop = jest.fn( () => new MockImage() );
-const mockResize = jest.fn( () => new MockImage() );
-const mockNewFromBuffer = jest.fn( () => new MockImage() );
-const mockWriteToBuffer = jest.fn( () => ( {
-	buffer: '',
-} ) );
+const {
+	MockVipsImage,
+	mockCrop,
+	mockResize,
+	mockState,
+	mockThumbnailBuffer,
+	mockWriteToBuffer,
+} = vi.hoisted( () => {
+	const state = { bitdepth: 8 };
+	const writeToBufferMock = vi.fn( () => ( {
+		buffer: '',
+	} ) );
 
-// Controls the `heif-bitdepth` value reported by the mocked source image so
-// tests can exercise both the standard (8-bit) and high-bit-depth code paths.
-let mockBitdepth = 8;
+	class ImageMock {
+		width = 100;
+		height = 100;
+		pageHeight = 100;
+		crop = cropMock;
+		resize = resizeMock;
+		writeToBuffer = writeToBufferMock;
+		getInt = vi.fn( ( name: string ) =>
+			'heif-bitdepth' === name ? state.bitdepth : 0
+		);
+	}
 
-class MockImage {
-	width = 100;
-	height = 100;
-	pageHeight = 100;
-	crop = mockCrop;
-	resize = mockResize;
-	writeToBuffer = mockWriteToBuffer;
-	getInt = jest.fn( ( name: string ) =>
-		'heif-bitdepth' === name ? mockBitdepth : 0
-	);
-}
+	const thumbnailBufferMock = vi.fn( () => new ImageMock() );
+	const cropMock = vi.fn( () => new ImageMock() );
+	const resizeMock = vi.fn( () => new ImageMock() );
+	const newFromBufferMock = vi.fn( () => new ImageMock() );
 
-class MockVipsImage {
-	static thumbnailBuffer = mockThumbnailBuffer;
-	static newFromBuffer = mockNewFromBuffer;
-}
+	class VipsImageMock {
+		static thumbnailBuffer = thumbnailBufferMock;
+		static newFromBuffer = newFromBufferMock;
+	}
 
-jest.mock( 'wasm-vips', () =>
-	jest.fn( () => ( {
+	return {
+		MockVipsImage: VipsImageMock,
+		mockCrop: cropMock,
+		mockResize: resizeMock,
+		mockState: state,
+		mockThumbnailBuffer: thumbnailBufferMock,
+		mockWriteToBuffer: writeToBufferMock,
+	};
+} );
+
+vi.mock( import( 'wasm-vips' ), () => ( {
+	default: vi.fn( () => ( {
 		Image: MockVipsImage,
 		Cache: {
-			max: jest.fn(),
+			max: vi.fn(),
 		},
-	} ) )
-);
+	} ) ) as unknown as typeof VipsFactory,
+} ) );
 
 describe( 'resizeImage', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
-		mockBitdepth = 8;
+		vi.clearAllMocks();
+		mockState.bitdepth = 8;
 	} );
 
 	it( 'resizes without crop', async () => {
@@ -262,7 +284,7 @@ describe( 'resizeImage', () => {
 
 	describe( 'high-bit-depth AVIF', () => {
 		it( 'preserves bit depth when resizing a 10-bit AVIF without crop', async () => {
-			mockBitdepth = 10;
+			mockState.bitdepth = 10;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -285,7 +307,7 @@ describe( 'resizeImage', () => {
 		} );
 
 		it( 'centre-crops a 12-bit AVIF while preserving bit depth', async () => {
-			mockBitdepth = 12;
+			mockState.bitdepth = 12;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -307,7 +329,7 @@ describe( 'resizeImage', () => {
 		} );
 
 		it( 'crops a 10-bit AVIF to a position while preserving bit depth', async () => {
-			mockBitdepth = 10;
+			mockState.bitdepth = 10;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -331,7 +353,7 @@ describe( 'resizeImage', () => {
 		} );
 
 		it( 'uses the standard thumbnail path for an 8-bit AVIF', async () => {
-			mockBitdepth = 8;
+			mockState.bitdepth = 8;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -395,7 +417,7 @@ describe( 'resizeImage', () => {
 
 	describe( 'image_max_bit_depth', () => {
 		it( 'caps a 12-bit AVIF at 10-bit', async () => {
-			mockBitdepth = 12;
+			mockState.bitdepth = 12;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -422,7 +444,7 @@ describe( 'resizeImage', () => {
 		} );
 
 		it( 'snaps an unsupported cap down to the nearest valid depth', async () => {
-			mockBitdepth = 12;
+			mockState.bitdepth = 12;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -446,7 +468,7 @@ describe( 'resizeImage', () => {
 		} );
 
 		it( 'flattens a 10-bit AVIF via the thumbnail path when capped at 8-bit', async () => {
-			mockBitdepth = 10;
+			mockState.bitdepth = 10;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );
@@ -474,7 +496,7 @@ describe( 'resizeImage', () => {
 		} );
 
 		it( 'ignores the cap for sources at or below it', async () => {
-			mockBitdepth = 10;
+			mockState.bitdepth = 10;
 			const avifFile = new File( [ '<BLOB>' ], 'example.avif', {
 				type: 'image/avif',
 			} );

--- a/packages/vips/src/test/rotate-image-integration.ts
+++ b/packages/vips/src/test/rotate-image-integration.ts
@@ -1,12 +1,9 @@
 /**
- * @jest-environment node
- */
-
-/**
  * External dependencies
  */
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type VipsFactory from 'wasm-vips';
 
 /**
  * Internal dependencies
@@ -39,17 +36,31 @@ import { rotateImage } from '../';
  * See https://github.com/WordPress/gutenberg/issues/79383.
  */
 
-jest.mock( 'wasm-vips', () => {
-	const RealVips = jest.requireActual( 'wasm-vips' );
-	return jest.fn( ( options: Record< string, unknown > = {} ) =>
-		RealVips( { dynamicLibraries: options.dynamicLibraries } )
-	);
+vi.mock( import( 'wasm-vips' ), async ( importOriginal ) => {
+	const original = await importOriginal();
+
+	return {
+		...original,
+		default: vi.fn( ( options: { dynamicLibraries?: string[] } = {} ) =>
+			original.default( {
+				dynamicLibraries: options.dynamicLibraries,
+			} )
+		) as unknown as typeof original.default,
+	};
 } );
 
-const FIXTURES = join( __dirname, 'fixtures' );
+/**
+ * Returns a fixture URL relative to this ESM test module.
+ *
+ * @param file Fixture filename.
+ *
+ * @return Fixture URL.
+ */
+const getFixtureUrl = ( file: string ) =>
+	new URL( `./fixtures/${ file }`, import.meta.url );
 
 const loadFixture = ( file: string ): ArrayBuffer => {
-	const contents = readFileSync( join( FIXTURES, file ) );
+	const contents = readFileSync( getFixtureUrl( file ) );
 	return contents.buffer.slice(
 		contents.byteOffset,
 		contents.byteOffset + contents.byteLength
@@ -61,10 +72,12 @@ const isRed = ( [ r, , b ]: number[] ) => r > 128 && r > b;
 const isBlue = ( [ r, , b ]: number[] ) => b > 128 && b > r;
 
 describe( 'rotateImage EXIF orientation fixtures', () => {
-	let vips: any;
+	let vips: Awaited< ReturnType< typeof VipsFactory > >;
 
 	beforeAll( async () => {
-		const Vips = jest.requireActual( 'wasm-vips' );
+		const { default: Vips } = await vi.importActual< {
+			default: typeof VipsFactory;
+		} >( 'wasm-vips' );
 		vips = await Vips( { dynamicLibraries: [ 'vips-heif.wasm' ] } );
 	} );
 
@@ -127,7 +140,9 @@ describe( 'rotateImage EXIF orientation fixtures', () => {
 			expect( result.width ).toBe( width );
 			expect( result.height ).toBe( height );
 
-			const rotated = vips.Image.newFromBuffer( result.buffer );
+			const rotated = vips.Image.newFromBuffer(
+				result.buffer as ArrayBuffer
+			);
 			expect( rotated.width ).toBe( width );
 			expect( rotated.height ).toBe( height );
 
@@ -187,7 +202,9 @@ describe( 'rotateImage EXIF orientation fixtures', () => {
 				6
 			);
 
-			const rotated = vips.Image.newFromBuffer( result.buffer );
+			const rotated = vips.Image.newFromBuffer(
+				result.buffer as ArrayBuffer
+			);
 			expect( reportedOrientation( rotated ) ).toBe( 1 );
 			rotated.delete();
 		}

--- a/packages/vips/src/test/rotate-image.ts
+++ b/packages/vips/src/test/rotate-image.ts
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type VipsFactory from 'wasm-vips';
+
+/**
  * Internal dependencies
  */
 import { rotateImage } from '../';
@@ -10,66 +16,72 @@ import { rotateImage } from '../';
  * returns the same image instance so chained calls (e.g. `flipHor().rot90()`)
  * are captured in order.
  */
-let calls: string[];
-let removed: string[];
+const { MockVipsImage, mockState } = vi.hoisted( () => {
+	const state = {
+		calls: [] as string[],
+		removed: [] as string[],
+	};
 
-class MockImage {
-	width = 100;
-	height = 100;
-	pageHeight = 100;
-	onProgress = () => {};
-	kill = false;
+	class ImageMock {
+		width = 100;
+		height = 100;
+		pageHeight = 100;
+		onProgress = () => {};
+		kill = false;
 
-	flipHor = jest.fn( () => {
-		calls.push( 'flipHor' );
-		return this;
-	} );
-	flipVer = jest.fn( () => {
-		calls.push( 'flipVer' );
-		return this;
-	} );
-	rot90 = jest.fn( () => {
-		calls.push( 'rot90' );
-		return this;
-	} );
-	rot180 = jest.fn( () => {
-		calls.push( 'rot180' );
-		return this;
-	} );
-	rot270 = jest.fn( () => {
-		calls.push( 'rot270' );
-		return this;
-	} );
-	remove = jest.fn( ( field: string ) => {
-		removed.push( field );
-		return true;
-	} );
-	writeToBuffer = jest.fn( () => ( {
-		buffer: new ArrayBuffer( 0 ),
-	} ) );
-}
+		flipHor = vi.fn( () => {
+			state.calls.push( 'flipHor' );
+			return this;
+		} );
+		flipVer = vi.fn( () => {
+			state.calls.push( 'flipVer' );
+			return this;
+		} );
+		rot90 = vi.fn( () => {
+			state.calls.push( 'rot90' );
+			return this;
+		} );
+		rot180 = vi.fn( () => {
+			state.calls.push( 'rot180' );
+			return this;
+		} );
+		rot270 = vi.fn( () => {
+			state.calls.push( 'rot270' );
+			return this;
+		} );
+		remove = vi.fn( ( field: string ) => {
+			state.removed.push( field );
+			return true;
+		} );
+		writeToBuffer = vi.fn( () => ( {
+			buffer: new ArrayBuffer( 0 ),
+		} ) );
+	}
 
-class MockVipsImage {
-	static newFromBuffer = jest.fn( () => new MockImage() );
-}
+	class VipsImageMock {
+		static newFromBuffer = vi.fn( () => new ImageMock() );
+	}
 
-jest.mock( 'wasm-vips', () =>
-	jest.fn( () => ( {
+	return { MockVipsImage: VipsImageMock, mockState: state };
+} );
+
+vi.mock( import( 'wasm-vips' ), () => ( {
+	default: vi.fn( () => ( {
 		Image: MockVipsImage,
 		Cache: {
-			max: jest.fn(),
+			max: vi.fn(),
 		},
-	} ) )
-);
+	} ) ) as unknown as typeof VipsFactory,
+} ) );
 
 describe( 'rotateImage', () => {
 	beforeEach( () => {
-		calls = [];
-		removed = [];
+		mockState.calls = [];
+		mockState.removed = [];
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	async function rotate( orientation: number ) {
@@ -98,13 +110,13 @@ describe( 'rotateImage', () => {
 		async ( orientation, expected ) => {
 			await rotate( orientation );
 
-			expect( calls ).toEqual( expected );
+			expect( mockState.calls ).toEqual( expected );
 		}
 	);
 
 	it( 'strips the EXIF orientation tag after rotating', async () => {
 		await rotate( 6 );
 
-		expect( removed ).toContain( 'orientation' );
+		expect( mockState.removed ).toContain( 'orientation' );
 	} );
 } );

--- a/packages/vips/src/test/ultrahdr.ts
+++ b/packages/vips/src/test/ultrahdr.ts
@@ -1,51 +1,81 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type VipsFactory from 'wasm-vips';
+
+/**
  * Internal dependencies
  */
 import { getUltraHdrInfo, resizeImage } from '../';
 
-const mockThumbnailImage = jest.fn();
-const mockThumbnailBuffer = jest.fn();
-const mockNewFromBuffer = jest.fn();
-const mockUhdrLoadBuffer = jest.fn();
-const mockWriteToBuffer = jest.fn( () => ( { buffer: new ArrayBuffer( 0 ) } ) );
-const mockGetDouble = jest.fn();
-const mockSetImage = jest.fn();
-const mockCrop = jest.fn();
+const {
+	MockImage,
+	MockVipsImage,
+	mockGetDouble,
+	mockNewFromBuffer,
+	mockSetImage,
+	mockThumbnailBuffer,
+	mockUhdrLoadBuffer,
+	mockWriteToBuffer,
+} = vi.hoisted( () => {
+	const thumbnailImageMock = vi.fn();
+	const thumbnailBufferMock = vi.fn();
+	const newFromBufferMock = vi.fn();
+	const uhdrLoadBufferMock = vi.fn();
+	const writeToBufferMock = vi.fn( () => ( {
+		buffer: new ArrayBuffer( 0 ),
+	} ) );
+	const getDoubleMock = vi.fn();
+	const setImageMock = vi.fn();
+	const cropMock = vi.fn();
 
-class MockImage {
-	width = 100;
-	height = 100;
-	pageHeight = 100;
-	gainmap: MockImage | undefined;
-	thumbnailImage = mockThumbnailImage.mockImplementation( () => this );
-	writeToBuffer = mockWriteToBuffer;
-	getDouble = mockGetDouble;
-	crop = mockCrop.mockImplementation( () => this );
-	copy = jest.fn( () => this );
-	setImage = mockSetImage;
-}
+	class ImageMock {
+		width = 100;
+		height = 100;
+		pageHeight = 100;
+		gainmap: ImageMock | undefined;
+		thumbnailImage = thumbnailImageMock.mockImplementation( () => this );
+		writeToBuffer = writeToBufferMock;
+		getDouble = getDoubleMock;
+		crop = cropMock.mockImplementation( () => this );
+		copy = vi.fn( () => this );
+		setImage = setImageMock;
+	}
 
-class MockVipsImage {
-	static thumbnailBuffer = mockThumbnailBuffer.mockImplementation(
-		() => new MockImage()
-	);
-	static newFromBuffer = mockNewFromBuffer.mockImplementation(
-		() => new MockImage()
-	);
-	static uhdrloadBuffer = mockUhdrLoadBuffer;
-}
+	class VipsImageMock {
+		static thumbnailBuffer = thumbnailBufferMock.mockImplementation(
+			() => new ImageMock()
+		);
+		static newFromBuffer = newFromBufferMock.mockImplementation(
+			() => new ImageMock()
+		);
+		static uhdrloadBuffer = uhdrLoadBufferMock;
+	}
 
-jest.mock( 'wasm-vips', () =>
-	jest.fn( () => ( {
+	return {
+		MockImage: ImageMock,
+		MockVipsImage: VipsImageMock,
+		mockGetDouble: getDoubleMock,
+		mockNewFromBuffer: newFromBufferMock,
+		mockSetImage: setImageMock,
+		mockThumbnailBuffer: thumbnailBufferMock,
+		mockUhdrLoadBuffer: uhdrLoadBufferMock,
+		mockWriteToBuffer: writeToBufferMock,
+	};
+} );
+
+vi.mock( import( 'wasm-vips' ), () => ( {
+	default: vi.fn( () => ( {
 		Image: MockVipsImage,
 		// getVips() calls Cache.max(0) to disable libvips's operation cache.
-		Cache: { max: jest.fn() },
-	} ) )
-);
+		Cache: { max: vi.fn() },
+	} ) ) as unknown as typeof VipsFactory,
+} ) );
 
 describe( 'UltraHDR helpers', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'getUltraHdrInfo', () => {

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -81,6 +81,7 @@
 					"packages/redux-routine",
 					"packages/stylelint-config",
 					"packages/video-conversion",
+					"packages/vips",
 					"packages/views",
 					"packages/worker-threads",
 					"packages/wp-build"


### PR DESCRIPTION
## What?

TL;DR: Typed hoisted WASM mocks, partial real-module mocking, native-ESM fixture URLs, Node-project routing, and direct workspace dependency ownership.

See #80855.

This migrates all seven remaining `@wordpress/vips` test files and all 71 tests from Jest to the Vitest Node project.

## Why?

Vips is a complete, bounded package slice that exercises both deterministic `wasm-vips` unit factories and real WebAssembly integration tests. Migrating it separately makes the mock-hoisting and CommonJS-to-ESM changes reviewable without mixing image-processing behavior with unrelated packages.

## How?

- imports all Vitest APIs explicitly and declares Vitest in the Vips workspace;
- routes the complete package test directory through the Node Vitest project;
- replaces Jest globals with `vi` and uses `vi.hoisted()` for typed mock classes, mutable bit-depth state, and operation-call recording;
- replaces `jest.requireActual()` with a typed `importOriginal()` partial mock and `vi.importActual()` for the real integration decoder;
- replaces `require()`, `__dirname`, and Node path joining with the package's ESM import condition and `import.meta.url`-relative fixture URLs;
- keeps the real AVIF/HEIC/JPEG decoding, EXIF rotation, image-buffer, cache, crop, resize, gain-map, and bit-depth assertions unchanged.

No production implementation, public API, image fixture, or snapshot changes.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/vips --run
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 7 files / 71 tests;
- migrated Vitest Node slice: 7 files / 71 tests pass, including both real-WASM integration files;
- routing: 552 Jest / 451 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 451 Vitest tests, 467 ESM graph files, 70 workspace dependencies, and 283 TypeScript tests pass;
- remaining Jest partition: 551 suites / 28,874 tests pass in the network-restricted run; the only blocked `wp-env` integration suite passes 9/9 when rerun with network access;
- no snapshot files changed.

All changed-file linting, strict pre-commit linting, formatting, package metadata, lockfile, generated-documentation, and diff checks pass.

## Use of AI Tools

This PR was authored with Codex. The hoisted WASM factories, real-module boundary, ESM fixture resolution, image-buffer typing, and verification output were reviewed before publication.