### PR TITLE
Migrate A11y and Design System MCP tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49373,6 +49373,9 @@
 				"@wordpress/dom-ready": "file:../dom-ready",
 				"@wordpress/i18n": "file:../i18n"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -50691,8 +50694,8 @@
 				"design-system-mcp": "bin/design-system-mcp.mjs"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39"
+				"@types/node": "^20.19.39",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -48,6 +48,9 @@
 		"@wordpress/dom-ready": "file:../dom-ready",
 		"@wordpress/i18n": "file:../i18n"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/a11y/src/script/test/add-container.test.ts
+++ b/packages/a11y/src/script/test/add-container.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import addContainer from '../add-container';

--- a/packages/a11y/src/shared/test/clear.test.ts
+++ b/packages/a11y/src/shared/test/clear.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import clear from '../clear';

--- a/packages/a11y/src/shared/test/filter-message.test.ts
+++ b/packages/a11y/src/shared/test/filter-message.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import filterMessage from '../filter-message';

--- a/packages/a11y/src/test/index.test.ts
+++ b/packages/a11y/src/test/index.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
@@ -10,19 +15,18 @@ import { setup, speak } from '../';
 import clear from '../shared/clear';
 import filterMessage from '../shared/filter-message';
 
-jest.mock( '../shared/clear', () => {
-	return jest.fn();
-} );
-jest.mock( '@wordpress/dom-ready', () => {
-	return jest.fn( ( callback: () => void ) => {
+vi.mock( import( '../shared/clear' ), () => ( {
+	default: vi.fn(),
+} ) );
+vi.mock( import( '@wordpress/dom-ready' ), () => ( {
+	default: vi.fn( ( callback: VoidFunction ) => {
 		callback();
-	} );
-} );
-jest.mock( '../shared/filter-message', () => {
-	return jest.fn( ( message: string ) => {
-		return message;
-	} );
-} );
+		return undefined;
+	} ),
+} ) );
+vi.mock( import( '../shared/filter-message' ), () => ( {
+	default: vi.fn( ( message: string ) => message ),
+} ) );
 
 describe( 'speak', () => {
 	let containerPolite = document.getElementById( 'a11y-speak-polite' );

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -46,8 +46,8 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39"
+		"@types/node": "^20.19.39",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/design-system-mcp/src/test/data.ts
+++ b/packages/design-system-mcp/src/test/data.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import {
 	getComponents,
 	getComponentDetail,
@@ -16,7 +18,7 @@ const originalFetch = globalThis.fetch;
 function mockFetchResponses(
 	handlers: Record< string, { ok: boolean; body: unknown } >
 ) {
-	globalThis.fetch = jest.fn( ( url: RequestInfo | URL ) => {
+	globalThis.fetch = vi.fn( ( url: RequestInfo | URL ) => {
 		const urlStr = url.toString();
 		const handler = handlers[ urlStr ];
 		if ( ! handler ) {
@@ -37,7 +39,7 @@ function mockFetchResponses(
 describe( 'data', () => {
 	beforeEach( () => {
 		resetCache();
-		globalThis.fetch = jest.fn();
+		globalThis.fetch = vi.fn();
 	} );
 
 	afterEach( () => {

--- a/packages/design-system-mcp/src/test/format.ts
+++ b/packages/design-system-mcp/src/test/format.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { formatComponents, formatComponentDetail } from '../format';
 
 describe( 'formatComponents', () => {

--- a/packages/design-system-mcp/src/test/parse-components.ts
+++ b/packages/design-system-mcp/src/test/parse-components.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import {
 	packageNameFromPath,
 	parseProps,

--- a/packages/design-system-mcp/src/tools/test/get-component-details.ts
+++ b/packages/design-system-mcp/src/tools/test/get-component-details.ts
@@ -1,13 +1,16 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { handler } from '../get-component-details';
 import { getComponentDetail } from '../../data';
 import { formatComponentDetail } from '../../format';
 import type { ComponentDetail } from '../../types';
 
-jest.mock( '../../data' );
+vi.mock( import( '../../data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	getComponentDetail: vi.fn(),
+} ) );
 
-const mockGetComponentDetail = getComponentDetail as jest.MockedFunction<
-	typeof getComponentDetail
->;
+const mockGetComponentDetail = vi.mocked( getComponentDetail );
 
 function fakeDetail( name: string ): ComponentDetail {
 	return {

--- a/packages/design-system-mcp/tsconfig.json
+++ b/packages/design-system-mcp/tsconfig.json
@@ -3,7 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"types": [ "jest", "node" ]
+		"types": [ "node" ]
 	},
 	"include": [ "src" ],
 	"exclude": []

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -12,6 +12,7 @@
 			"jsdom": {
 				"files": [ "packages/html-entities/src/test/entities.ts" ],
 				"directories": [
+					"packages/a11y",
 					"packages/abilities",
 					"packages/admin-ui",
 					"packages/annotations",
@@ -71,6 +72,7 @@
 					"packages/babel-preset-default",
 					"packages/browserslist-config",
 					"packages/data-controls",
+					"packages/design-system-mcp",
 					"packages/docgen",
 					"packages/eslint-plugin",
 					"packages/npm-package-json-lint-config",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, typed DOM lifecycle mocks, typed partial data-module mocking, Node/jsdom routing, Jest-type removal, and direct workspace dependency ownership.

See #80855.

This migrates all remaining tests in `@wordpress/a11y` and `@wordpress/design-system-mcp`: eight test files and 61 tests.

## Why?

These two complete, snapshot-free packages form a small bounded slice across both environment classes. A11y verifies DOM and aria-live behavior in jsdom; Design System MCP verifies native-ESM parsing, formatting, fetching, and handler behavior in Node.

## How?

- imports all Vitest APIs explicitly and declares Vitest in both owning workspaces;
- routes the complete A11y test directory through jsdom and the complete Design System MCP test directory through Node;
- replaces A11y's Jest module factories with type-checked dynamic `vi.mock()` calls while preserving import-time DOM-ready execution and the package's declared `undefined` return contract;
- replaces MCP fetch mocks with `vi.fn()` and its data-module cast with a typed `importOriginal()` partial mock plus `vi.mocked()`;
- removes the completed MCP package's direct `@types/jest` dependency and Jest ambient type configuration.

No production implementation, public API, DOM behavior, network behavior, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/a11y packages/design-system-mcp --run
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 8 files / 61 tests;
- migrated Vitest slice: 8 files / 61 tests pass (14 jsdom, 47 Node);
- routing: 544 Jest / 459 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 459 Vitest tests, 475 ESM graph files, 72 workspace dependencies, and 291 TypeScript tests pass;
- remaining Jest partition: 543 suites / 28,813 tests pass in the network-restricted run; the only blocked `wp-env` integration suite passes 9/9 when rerun with network access;
- no snapshot files changed.

All changed-file linting, strict pre-commit linting, formatting, package metadata, TypeScript configuration, lockfile, generated-documentation, and diff checks pass.

## Use of AI Tools

This PR was authored with Codex. The environment split, DOM-ready return contract, partial module mock, Jest-type removal, and verification output were reviewed before publication.