### PR TITLE
Migrate Interactivity package to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51662,7 +51662,7 @@
 				"preact": "^10.29.1"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0"
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -38,7 +38,7 @@
 		"preact": "^10.29.1"
 	},
 	"devDependencies": {
-		"@types/jest": "^30.0.0"
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/interactivity/src/proxies/test/context-proxy.ts
+++ b/packages/interactivity/src/proxies/test/context-proxy.ts
@@ -2,11 +2,17 @@
  * External dependencies
  */
 import { effect } from '@preact/signals';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
 import { proxifyContext, proxifyState, deepMerge } from '../';
+
+const trackEffect = ( callback: () => unknown ) =>
+	effect( () => {
+		callback();
+	} );
 
 describe( 'Interactivity API', () => {
 	describe( 'context proxy', () => {
@@ -168,8 +174,8 @@ describe( 'Interactivity API', () => {
 					fallback
 				);
 
-				const spy = jest.fn( () => context.fromContext );
-				effect( spy );
+				const spy = vi.fn( () => context.fromContext );
+				trackEffect( spy );
 
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( context.fromContext ).toBe( 'context' );
@@ -190,8 +196,8 @@ describe( 'Interactivity API', () => {
 					fallback
 				);
 
-				const spy = jest.fn( () => context.fromFallback );
-				effect( spy );
+				const spy = vi.fn( () => context.fromFallback );
+				trackEffect( spy );
 
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( context.fromFallback ).toBe( 'fallback' );
@@ -212,8 +218,8 @@ describe( 'Interactivity API', () => {
 					fallback
 				);
 
-				const spy = jest.fn( () => context.fromContext );
-				effect( spy );
+				const spy = vi.fn( () => context.fromContext );
+				trackEffect( spy );
 
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( context.fromContext ).toBeUndefined();
@@ -234,8 +240,8 @@ describe( 'Interactivity API', () => {
 					fallback
 				);
 
-				const spy = jest.fn( () => context.fromFallback );
-				effect( spy );
+				const spy = vi.fn( () => context.fromFallback );
+				trackEffect( spy );
 
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( context.fromFallback ).toBeUndefined();
@@ -253,8 +259,8 @@ describe( 'Interactivity API', () => {
 				const contextState: any = proxifyState( 'test', {} );
 				const context: any = proxifyContext( contextState, fallback );
 
-				const spy = jest.fn( () => context.prop );
-				effect( spy );
+				const spy = vi.fn( () => context.prop );
+				trackEffect( spy );
 
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( context.prop ).toBeUndefined();
@@ -280,8 +286,8 @@ describe( 'Interactivity API', () => {
 					fallback
 				);
 
-				const spy = jest.fn( () => Object.keys( context ) );
-				effect( spy );
+				const spy = vi.fn( () => Object.keys( context ) );
+				trackEffect( spy );
 
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( Object.keys( context ) ).toEqual( [] );
@@ -307,10 +313,10 @@ describe( 'Interactivity API', () => {
 				);
 
 				let deepValue: any;
-				const spy = jest.fn( () => {
+				const spy = vi.fn( () => {
 					deepValue = context.a?.b?.c?.d;
 				} );
-				effect( spy );
+				trackEffect( spy );
 
 				// Initial call, the deep value is undefined
 				expect( spy ).toHaveBeenCalledTimes( 1 );
@@ -334,10 +340,10 @@ describe( 'Interactivity API', () => {
 				const context: any = proxifyContext( contextState, fallback );
 
 				let deepValue: any;
-				const spy = jest.fn( () => {
+				const spy = vi.fn( () => {
 					deepValue = context.a?.b?.c?.d;
 				} );
-				effect( spy );
+				trackEffect( spy );
 
 				// Initial call, the deep value is undefined
 				expect( spy ).toHaveBeenCalledTimes( 1 );

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -2,12 +2,19 @@
  * External dependencies
  */
 import { effect } from '@preact/signals';
+import { describe, expect, it, vi } from 'vitest';
+
 /**
  * Internal dependencies
  */
 import { proxifyState, peek, deepMerge } from '../';
 import { hasPropSignal } from '../state';
 import { getProxyFromObject } from '../registry';
+
+const trackEffect = ( callback: () => unknown ) =>
+	effect( () => {
+		callback();
+	} );
 
 describe( 'Interactivity API', () => {
 	describe( 'deepMerge', () => {
@@ -308,15 +315,15 @@ describe( 'Interactivity API', () => {
 			const source = { a: 2, b: { x: 20, y: 30 }, c: 3 };
 			const result = proxifyState< any >( 'test', {} );
 
-			const spyA = jest.fn( () => result.a );
-			effect( spyA );
+			const spyA = vi.fn( () => result.a );
+			trackEffect( spyA );
 
 			expect( spyA ).toHaveBeenCalledTimes( 1 );
 
 			deepMerge( result, target );
 
-			const spyBx = jest.fn( () => result.b.x );
-			effect( spyBx );
+			const spyBx = vi.fn( () => result.b.x );
+			trackEffect( spyBx );
 			expect( spyA ).toHaveBeenCalledTimes( 2 );
 			expect( spyBx ).toHaveBeenCalledTimes( 1 );
 
@@ -339,8 +346,8 @@ describe( 'Interactivity API', () => {
 			const source = { a: 3, b: 4 };
 			const result = proxifyState< any >( 'test', {} );
 
-			const spy = jest.fn( () => ( result.a, result.b ) );
-			effect( spy );
+			const spy = vi.fn( () => ( result.a, result.b ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 
@@ -358,10 +365,10 @@ describe( 'Interactivity API', () => {
 			const source = { a: 1, b: 2, c: 3 };
 
 			let keys: any;
-			const spy = jest.fn( () => {
+			const spy = vi.fn( () => {
 				keys = Object.keys( target );
 			} );
-			effect( spy );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 
@@ -375,10 +382,10 @@ describe( 'Interactivity API', () => {
 			const target: any = proxifyState( 'test', {} );
 
 			let deepValue: any;
-			const spy = jest.fn( () => {
+			const spy = vi.fn( () => {
 				deepValue = target.a?.b?.c?.d;
 			} );
-			effect( spy );
+			trackEffect( spy );
 
 			// Initial call, the deep value is undefined
 			expect( spy ).toHaveBeenCalledTimes( 1 );
@@ -406,8 +413,8 @@ describe( 'Interactivity API', () => {
 			const target: any = proxifyState( 'test', { message: 'hello' } );
 
 			let message: any;
-			const spy = jest.fn( () => ( message = target.message ) );
-			effect( spy );
+			const spy = vi.fn( () => ( message = target.message ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 			expect( message ).toBe( 'hello' );
@@ -432,8 +439,8 @@ describe( 'Interactivity API', () => {
 			const target: any = proxifyState( 'test', { message: 'hello' } );
 
 			let message: any;
-			const spy = jest.fn( () => ( message = target.message ) );
-			effect( spy );
+			const spy = vi.fn( () => ( message = target.message ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 			expect( message ).toBe( 'hello' );
@@ -458,11 +465,11 @@ describe( 'Interactivity API', () => {
 				},
 			} );
 
-			const getterSpy = jest.spyOn( target, 'message', 'get' );
+			const getterSpy = vi.spyOn( target, 'message', 'get' );
 
 			let message: any;
-			const spy = jest.fn( () => ( message = target.message ) );
-			effect( spy );
+			const spy = vi.fn( () => ( message = target.message ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 			expect( message ).toBe( 'hello' );
@@ -487,10 +494,10 @@ describe( 'Interactivity API', () => {
 			const target: any = proxifyState( 'test', {} );
 
 			let deepValue: any;
-			const spy = jest.fn( () => {
+			const spy = vi.fn( () => {
 				deepValue = target.array?.[ 0 ];
 			} );
-			effect( spy );
+			trackEffect( spy );
 
 			// Initial call, the deep value is undefined
 			expect( spy ).toHaveBeenCalledTimes( 1 );
@@ -518,8 +525,8 @@ describe( 'Interactivity API', () => {
 			} );
 
 			let double: any;
-			const spy = jest.fn( () => ( double = target.double ) );
-			effect( spy );
+			const spy = vi.fn( () => ( double = target.double ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 			expect( double ).toBe( 4 );
@@ -552,8 +559,8 @@ describe( 'Interactivity API', () => {
 			} );
 
 			let double: any;
-			const spy = jest.fn( () => ( double = target.double ) );
-			effect( spy );
+			const spy = vi.fn( () => ( double = target.double ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 			expect( double ).toBe( 4 );
@@ -585,8 +592,8 @@ describe( 'Interactivity API', () => {
 			} );
 
 			let double: any;
-			const spy = jest.fn( () => ( double = target.double ) );
-			effect( spy );
+			const spy = vi.fn( () => ( double = target.double ) );
+			trackEffect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 			expect( double ).toBe( 4 );

--- a/packages/interactivity/src/proxies/test/state-proxy.ts
+++ b/packages/interactivity/src/proxies/test/state-proxy.ts
@@ -6,12 +6,19 @@
  * External dependencies
  */
 import { effect } from '@preact/signals';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 /**
  * Internal dependencies
  */
 import { proxifyState, peek } from '../';
 import { setScope, resetScope, getContext, getElement } from '../../scopes';
 import { setNamespace, resetNamespace } from '../../namespaces';
+
+const trackEffect = ( callback: () => unknown ) =>
+	effect( () => {
+		callback();
+	} );
 
 type State = {
 	a?: number;
@@ -604,7 +611,9 @@ describe( 'Interactivity API', () => {
 						return state.counter * 2;
 					},
 				} );
-				effect( () => ( x = state.double ) );
+				effect( () => {
+					x = state.double;
+				} );
 				expect( x ).toBe( 2 );
 				state.counter = 2;
 				expect( x ).toBe( 4 );
@@ -620,28 +629,30 @@ describe( 'Interactivity API', () => {
 						return state.switch === 'a' ? state.a : state.b;
 					},
 				} );
-				effect( () => ( data = state.aOrB.data ) );
+				effect( () => {
+					data = state.aOrB.data;
+				} );
 				expect( data ).toBe( 'a' );
 				state.switch = 'b';
 				expect( data ).toBe( 'b' );
 			} );
 
 			it( 'should subscribe to changes', () => {
-				const spy1 = jest.fn( () => state.a );
-				const spy2 = jest.fn( () => state.nested );
-				const spy3 = jest.fn( () => state.nested.b );
-				const spy4 = jest.fn( () => state.array[ 0 ] );
-				const spy5 = jest.fn(
+				const spy1 = vi.fn( () => state.a );
+				const spy2 = vi.fn( () => state.nested );
+				const spy3 = vi.fn( () => state.nested.b );
+				const spy4 = vi.fn( () => state.array[ 0 ] );
+				const spy5 = vi.fn(
 					() =>
 						typeof state.array[ 1 ] === 'object' &&
 						state.array[ 1 ].b
 				);
 
-				effect( spy1 );
-				effect( spy2 );
-				effect( spy3 );
-				effect( spy4 );
-				effect( spy5 );
+				trackEffect( spy1 );
+				trackEffect( spy2 );
+				trackEffect( spy3 );
+				trackEffect( spy4 );
+				trackEffect( spy5 );
 
 				expect( spy1 ).toHaveBeenCalledTimes( 1 );
 				expect( spy2 ).toHaveBeenCalledTimes( 1 );
@@ -727,13 +738,13 @@ describe( 'Interactivity API', () => {
 			it( 'should subscribe to array length', () => {
 				const array = [ 1 ];
 				const state = proxifyState( 'test', { array } );
-				const spy1 = jest.fn( () => state.array.length );
-				const spy2 = jest.fn( () =>
+				const spy1 = vi.fn( () => state.array.length );
+				const spy2 = vi.fn( () =>
 					state.array.map( ( i: number ) => i )
 				);
 
-				effect( spy1 );
-				effect( spy2 );
+				trackEffect( spy1 );
+				trackEffect( spy2 );
 				expect( spy1 ).toHaveBeenCalledTimes( 1 );
 				expect( spy2 ).toHaveBeenCalledTimes( 1 );
 
@@ -970,7 +981,9 @@ describe( 'Interactivity API', () => {
 					get sumValueFromElement() {
 						const element = getElement();
 						return element
-							? this.number + element.attributes.value
+							? this.number +
+									( element.attributes as { value: number } )
+										.value
 							: this.number;
 					},
 				} );
@@ -1013,22 +1026,22 @@ describe( 'Interactivity API', () => {
 			} );
 
 			it( 'should not subscribe to changes when peeking', () => {
-				const spy1 = jest.fn( () => peek( state, 'a' ) );
-				const spy2 = jest.fn( () => peek( state, 'nested' ) );
-				const spy3 = jest.fn( () => peek( state, 'nested' ).b );
-				const spy4 = jest.fn( () => peek( state, 'array' )[ 0 ] );
-				const spy5 = jest.fn( () => {
+				const spy1 = vi.fn( () => peek( state, 'a' ) );
+				const spy2 = vi.fn( () => peek( state, 'nested' ) );
+				const spy3 = vi.fn( () => peek( state, 'nested' ).b );
+				const spy4 = vi.fn( () => peek( state, 'array' )[ 0 ] );
+				const spy5 = vi.fn( () => {
 					const nested = peek( state, 'array' )[ 1 ];
 					return typeof nested === 'object' && nested.b;
 				} );
-				const spy6 = jest.fn( () => peek( state, 'array' ).length );
+				const spy6 = vi.fn( () => peek( state, 'array' ).length );
 
-				effect( spy1 );
-				effect( spy2 );
-				effect( spy3 );
-				effect( spy4 );
-				effect( spy5 );
-				effect( spy6 );
+				trackEffect( spy1 );
+				trackEffect( spy2 );
+				trackEffect( spy3 );
+				trackEffect( spy4 );
+				trackEffect( spy5 );
+				trackEffect( spy6 );
 
 				expect( spy1 ).toHaveBeenCalledTimes( 1 );
 				expect( spy2 ).toHaveBeenCalledTimes( 1 );
@@ -1055,8 +1068,8 @@ describe( 'Interactivity API', () => {
 			} );
 
 			it( 'should subscribe to some changes but not other when peeking inside an object', () => {
-				const spy1 = jest.fn( () => peek( state.nested, 'b' ) );
-				effect( spy1 );
+				const spy1 = vi.fn( () => peek( state.nested, 'b' ) );
+				trackEffect( spy1 );
 				expect( spy1 ).toHaveBeenCalledTimes( 1 );
 				state.nested.b = 22;
 				expect( spy1 ).toHaveBeenCalledTimes( 1 );
@@ -1092,8 +1105,8 @@ describe( 'Interactivity API', () => {
 					peek( state, 'double' )
 				);
 
-				const spy = jest.fn( peekStateDouble );
-				effect( spy );
+				const spy = vi.fn( peekStateDouble );
+				trackEffect( spy );
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( peekStateDouble() ).toBe( 2 );
 
@@ -1124,8 +1137,8 @@ describe( 'Interactivity API', () => {
 					() => peek( state1, 'double' )
 				);
 
-				const spy = jest.fn( peekStateDouble );
-				effect( spy );
+				const spy = vi.fn( peekStateDouble );
+				trackEffect( spy );
 				expect( spy ).toHaveBeenCalledTimes( 1 );
 				expect( peekStateDouble() ).toBe( 2 );
 

--- a/packages/interactivity/src/proxies/test/store-proxy.ts
+++ b/packages/interactivity/src/proxies/test/store-proxy.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { proxifyStore, proxifyState } from '../';

--- a/packages/interactivity/src/test/types.ts
+++ b/packages/interactivity/src/test/types.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getServerContext } from '../scopes';
@@ -9,13 +14,18 @@ import {
 	type TypeYield,
 } from '../store';
 
+function checkTypes( description: string, checks: () => void ) {
+	void description;
+	checks();
+}
+
 describe( 'Interactivity API types', () => {
 	it( 'dummy test', () => {
 		expect( true ).toBe( true );
 	} );
 
-	describe( 'store', () => {
-		describe( 'the whole store can be inferred', () => {
+	checkTypes( 'store', () => {
+		checkTypes( 'the whole store can be inferred', () => {
 			// eslint-disable-next-line no-unused-expressions
 			async () => {
 				const myStore = store( 'test', {
@@ -50,7 +60,7 @@ describe( 'Interactivity API types', () => {
 			};
 		} );
 
-		describe( 'the whole store can be manually typed', () => {
+		checkTypes( 'the whole store can be manually typed', () => {
 			// eslint-disable-next-line no-unused-expressions
 			async () => {
 				interface Store {
@@ -98,58 +108,61 @@ describe( 'Interactivity API types', () => {
 			};
 		} );
 
-		describe( 'the server state can be typed and the rest inferred', () => {
-			// eslint-disable-next-line no-unused-expressions
-			async () => {
-				type ServerStore = {
-					state: {
-						serverValue: number;
+		checkTypes(
+			'the server state can be typed and the rest inferred',
+			() => {
+				// eslint-disable-next-line no-unused-expressions
+				async () => {
+					type ServerStore = {
+						state: {
+							serverValue: number;
+						};
 					};
+
+					const clientStore = {
+						state: {
+							clientValue: 1,
+							get derived(): number {
+								return myStore.state.serverValue;
+							},
+						},
+						actions: {
+							sync( n: number ) {
+								return n;
+							},
+							*async( n: number ): AsyncAction< number > {
+								const n1 = ( yield myStore.actions.async2(
+									n
+								) ) as TypeYield<
+									typeof myStore.actions.async2
+								> satisfies number;
+								return myStore.state.derived + n1 + n;
+							},
+							*async2( n: number ) {
+								return n;
+							},
+						},
+					};
+
+					type Store = ServerStore & typeof clientStore;
+
+					const myStore = store< Store >( 'test', clientStore );
+
+					myStore.state.clientValue satisfies number;
+					myStore.state.serverValue satisfies number;
+					myStore.state.derived satisfies number;
+					// @ts-expect-error
+					myStore.state.nonExistent satisfies number;
+					myStore.actions.sync( 1 ) satisfies number;
+					myStore.actions.async( 1 ) satisfies Promise< number >;
+					( await myStore.actions.async( 1 ) ) satisfies number;
+					// @ts-expect-error
+					myStore.actions.nonExistent();
 				};
+			}
+		);
 
-				const clientStore = {
-					state: {
-						clientValue: 1,
-						get derived(): number {
-							return myStore.state.serverValue;
-						},
-					},
-					actions: {
-						sync( n: number ) {
-							return n;
-						},
-						*async( n: number ): AsyncAction< number > {
-							const n1 = ( yield myStore.actions.async2(
-								n
-							) ) as TypeYield<
-								typeof myStore.actions.async2
-							> satisfies number;
-							return myStore.state.derived + n1 + n;
-						},
-						*async2( n: number ) {
-							return n;
-						},
-					},
-				};
-
-				type Store = ServerStore & typeof clientStore;
-
-				const myStore = store< Store >( 'test', clientStore );
-
-				myStore.state.clientValue satisfies number;
-				myStore.state.serverValue satisfies number;
-				myStore.state.derived satisfies number;
-				// @ts-expect-error
-				myStore.state.nonExistent satisfies number;
-				myStore.actions.sync( 1 ) satisfies number;
-				myStore.actions.async( 1 ) satisfies Promise< number >;
-				( await myStore.actions.async( 1 ) ) satisfies number;
-				// @ts-expect-error
-				myStore.actions.nonExistent();
-			};
-		} );
-
-		describe( 'the state can be casted and the rest inferred', () => {
+		checkTypes( 'the state can be casted and the rest inferred', () => {
 			// eslint-disable-next-line no-unused-expressions
 			async () => {
 				type State = {
@@ -196,58 +209,61 @@ describe( 'Interactivity API types', () => {
 			};
 		} );
 
-		describe( 'the whole store can be manually typed even if doesnt contain state', () => {
-			// eslint-disable-next-line no-unused-expressions
-			async () => {
-				interface Store {
-					actions: {
-						sync: ( n: number ) => number;
-						async: ( n: number ) => Promise< number >;
-						async2: ( n: number ) => AsyncAction< number >;
-					};
-					callbacks: {
-						existent: number;
-					};
-				}
+		checkTypes(
+			'the whole store can be manually typed even if doesnt contain state',
+			() => {
+				// eslint-disable-next-line no-unused-expressions
+				async () => {
+					interface Store {
+						actions: {
+							sync: ( n: number ) => number;
+							async: ( n: number ) => Promise< number >;
+							async2: ( n: number ) => AsyncAction< number >;
+						};
+						callbacks: {
+							existent: number;
+						};
+					}
 
-				const myStore = store< Store >( 'test', {
-					actions: {
-						sync( n ) {
-							return n;
+					const myStore = store< Store >( 'test', {
+						actions: {
+							sync( n ) {
+								return n;
+							},
+							*async( n ): AsyncAction< number > {
+								const n1 = ( yield myStore.actions.async2(
+									n
+								) ) as TypeYield<
+									typeof myStore.actions.async2
+								> satisfies number;
+								return n1 + n;
+							},
+							*async2( n: number ) {
+								return n;
+							},
 						},
-						*async( n ): AsyncAction< number > {
-							const n1 = ( yield myStore.actions.async2(
-								n
-							) ) as TypeYield<
-								typeof myStore.actions.async2
-							> satisfies number;
-							return n1 + n;
+						callbacks: {
+							existent: 1,
+							// @ts-expect-error
+							nonExistent: 1,
 						},
-						*async2( n: number ) {
-							return n;
-						},
-					},
-					callbacks: {
-						existent: 1,
-						// @ts-expect-error
-						nonExistent: 1,
-					},
-				} );
+					} );
 
-				// @ts-expect-error
-				myStore.state.nonExistent satisfies number;
-				myStore.actions.sync( 1 ) satisfies number;
-				myStore.actions.async( 1 ) satisfies Promise< number >;
-				( await myStore.actions.async( 1 ) ) satisfies number;
-				myStore.callbacks.existent satisfies number;
-				// @ts-expect-error
-				myStore.callbacks.nonExistent satisfies number;
-				// @ts-expect-error
-				myStore.actions.nonExistent() satisfies {};
-			};
-		} );
+					// @ts-expect-error
+					myStore.state.nonExistent satisfies number;
+					myStore.actions.sync( 1 ) satisfies number;
+					myStore.actions.async( 1 ) satisfies Promise< number >;
+					( await myStore.actions.async( 1 ) ) satisfies number;
+					myStore.callbacks.existent satisfies number;
+					// @ts-expect-error
+					myStore.callbacks.nonExistent satisfies number;
+					// @ts-expect-error
+					myStore.actions.nonExistent() satisfies {};
+				};
+			}
+		);
 
-		describe( 'the store can be divided into multiple parts', () => {
+		checkTypes( 'the store can be divided into multiple parts', () => {
 			// eslint-disable-next-line no-unused-expressions
 			async () => {
 				type ServerState = {
@@ -301,130 +317,148 @@ describe( 'Interactivity API types', () => {
 			};
 		} );
 
-		describe( 'a typed store can be returned without adding a new store part', () => {
-			type State = {
-				someValue: number;
-			};
-			type Actions = {
-				incrementValue: ( n: number ) => void;
-			};
+		checkTypes(
+			'a typed store can be returned without adding a new store part',
+			() => {
+				type State = {
+					someValue: number;
+				};
+				type Actions = {
+					incrementValue: ( n: number ) => void;
+				};
 
-			const { state, actions } = store< {
-				state: State;
-				actions: Actions;
-			} >( 'storeWithState', {
-				actions: {
-					incrementValue( n ) {
-						state.someValue += n;
-					},
-				},
-			} );
-
-			state.someValue satisfies number;
-			actions.incrementValue( 1 ) satisfies void;
-
-			const { actions: actions2 } = store< { actions: Actions } >(
-				'storeWithoutState',
-				{
+				const { state, actions } = store< {
+					state: State;
+					actions: Actions;
+				} >( 'storeWithState', {
 					actions: {
 						incrementValue( n ) {
 							state.someValue += n;
 						},
 					},
-				}
-			);
-
-			actions2.incrementValue( 1 ) satisfies void;
-		} );
-
-		describe( 'async actions can pass state to yields and type the yield returns', () => {
-			// eslint-disable-next-line no-unused-expressions
-			async () => {
-				type Store = {
-					state: {
-						someValue: string;
-					};
-					actions: {
-						asyncAction: () => Promise< number >;
-					};
-				};
-
-				const asyncFunction = async (
-					someValue: string
-				): Promise< string > => {
-					return someValue;
-				};
-
-				const { state, actions } = store< Store >( 'test', {
-					actions: {
-						*asyncAction(): AsyncAction< number > {
-							( yield asyncFunction(
-								state.someValue
-							) ) as TypeYield<
-								typeof asyncFunction
-							> satisfies string;
-
-							return 1;
-						},
-					},
 				} );
 
-				( await actions.asyncAction() ) satisfies number;
-			};
-		} );
+				state.someValue satisfies number;
+				actions.incrementValue( 1 ) satisfies void;
+
+				const { actions: actions2 } = store< { actions: Actions } >(
+					'storeWithoutState',
+					{
+						actions: {
+							incrementValue( n ) {
+								state.someValue += n;
+							},
+						},
+					}
+				);
+
+				actions2.incrementValue( 1 ) satisfies void;
+			}
+		);
+
+		checkTypes(
+			'async actions can pass state to yields and type the yield returns',
+			() => {
+				// eslint-disable-next-line no-unused-expressions
+				async () => {
+					type Store = {
+						state: {
+							someValue: string;
+						};
+						actions: {
+							asyncAction: () => Promise< number >;
+						};
+					};
+
+					const asyncFunction = async (
+						someValue: string
+					): Promise< string > => {
+						return someValue;
+					};
+
+					const { state, actions } = store< Store >( 'test', {
+						actions: {
+							*asyncAction(): AsyncAction< number > {
+								( yield asyncFunction(
+									state.someValue
+								) ) as TypeYield<
+									typeof asyncFunction
+								> satisfies string;
+
+								return 1;
+							},
+						},
+					} );
+
+					( await actions.asyncAction() ) satisfies number;
+				};
+			}
+		);
 	} );
 
-	describe( 'getServerState', () => {
-		describe( 'should return a generic object when no type is passed', () => {
-			// eslint-disable-next-line no-unused-expressions
+	checkTypes( 'getServerState', () => {
+		checkTypes(
+			'should return a generic object when no type is passed',
 			() => {
-				const state = getServerState();
-				state.nonExistent satisfies any;
-			};
-		} );
+				// eslint-disable-next-line no-unused-expressions
+				() => {
+					const state = getServerState();
+					state.nonExistent satisfies any;
+				};
+			}
+		);
 
-		describe( 'should accept a type parameter to define the returned object type', () => {
-			// eslint-disable-next-line no-unused-expressions
+		checkTypes(
+			'should accept a type parameter to define the returned object type',
 			() => {
-				interface State {
-					foo: string;
-					bar: {
-						baz: number;
-					};
-				}
-				const state = getServerState< State >();
-				// @ts-expect-error
-				state.nonExistent = 'error';
-				state.foo satisfies string;
-				state.bar.baz satisfies number;
-			};
-		} );
+				// eslint-disable-next-line no-unused-expressions
+				() => {
+					interface State {
+						foo: string;
+						bar: {
+							baz: number;
+						};
+					}
+					const state = getServerState< State >();
+					// @ts-expect-error
+					state.nonExistent = 'error';
+					state.foo satisfies string;
+					state.bar.baz satisfies number;
+				};
+			}
+		);
 	} );
 
-	describe( 'getServerContext', () => {
-		describe( 'should return a generic object when no type is passed', () => {
-			// eslint-disable-next-line no-unused-expressions
+	checkTypes( 'getServerContext', () => {
+		checkTypes(
+			'should return a generic object when no type is passed',
 			() => {
-				const context = getServerContext();
-				context.nonExistent satisfies any;
-			};
-		} );
+				// eslint-disable-next-line no-unused-expressions
+				() => {
+					const context = getServerContext();
+					context.nonExistent satisfies any;
+				};
+			}
+		);
 
-		describe( 'should accept a type parameter to define the returned object type', () => {
-			// eslint-disable-next-line no-unused-expressions
+		checkTypes(
+			'should accept a type parameter to define the returned object type',
 			() => {
-				interface Context {
-					foo: string;
-					bar: {
-						baz: number;
-					};
-				}
-				const context = getServerContext< Context >();
-				// @ts-expect-error
-				context.nonExistent = 'error';
-				context.foo satisfies string;
-				context.bar.baz satisfies number;
-			};
-		} );
+				// eslint-disable-next-line no-unused-expressions
+				() => {
+					interface Context {
+						foo: string;
+						bar: {
+							baz: number;
+						};
+					}
+					const context = getServerContext< Context >();
+					// @ts-expect-error
+					context.nonExistent = 'error';
+					context.foo satisfies string;
+					context.bar.baz satisfies number;
+				};
+			}
+		);
 	} );
 } );

--- a/packages/interactivity/src/test/utils.ts
+++ b/packages/interactivity/src/test/utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { kebabToCamelCase, withScope } from '../utils';

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -2,12 +2,21 @@
  * External dependencies
  */
 import { h } from 'preact';
-import type { VNode } from 'preact';
+import type { ComponentChild } from 'preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
 import { toVdom, hydratedIslands } from '../vdom';
+
+declare module 'vitest' {
+	// Must match Vitest's generic declaration for module augmentation.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	interface Assertion< T = any > {
+		toMatchVNode: ( expected: ComponentChild ) => void;
+	}
+}
 
 function createElementFromHTML( html: string ): HTMLElement {
 	const div = document.createElement( 'div' );
@@ -15,11 +24,11 @@ function createElementFromHTML( html: string ): HTMLElement {
 	return div.firstChild as HTMLElement;
 }
 
-const normalizeVNode = ( obj: object ) =>
+const normalizeVNode = ( obj: ComponentChild ) =>
 	JSON.stringify( obj ).replace( /"__v":\d+/g, '"__v":null' );
 
 expect.extend( {
-	toMatchVNode( received: VNode, expected: VNode ) {
+	toMatchVNode( received: ComponentChild, expected: ComponentChild ) {
 		const pass = normalizeVNode( received ) === normalizeVNode( expected );
 		return {
 			pass,
@@ -206,7 +215,7 @@ describe( 'toVdom', () => {
 		it( 'should warn about malformed directive names', () => {
 			const console = global.console;
 			const originalWarn = console.warn;
-			console.warn = jest.fn();
+			console.warn = vi.fn();
 
 			toVdom(
 				createElementFromHTML( `<div data-wp-invalid[name]></div>` )

--- a/packages/interactivity/tsconfig.test.json
+++ b/packages/interactivity/tsconfig.test.json
@@ -1,10 +1,10 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
+	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"noEmit": true,
 		"emitDeclarationOnly": false,
-		"types": [ "jest" ]
+		"types": [ "gutenberg-vitest-test-env" ]
 	},
 	"references": [ { "path": "./tsconfig.json" } ],
 	"files": [ "src/test/types.ts" ],

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -39,6 +39,7 @@
 					"packages/hooks",
 					"packages/i18n",
 					"packages/interface",
+					"packages/interactivity",
 					"packages/is-shallow-equal",
 					"packages/keycodes",
 					"packages/media-fields",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, reactive-spy adaptation, package-local matcher typing, compile-only suite preservation, Jest ambient-type removal, jsdom routing, and direct workspace dependency ownership.

See #80855.

This migrates all remaining tests in `@wordpress/interactivity`: seven TypeScript test files and 188 tests.

## Why?

Interactivity is a complete, snapshot-free package slice that exercises reactive proxies, generators, scopes, VDOM conversion, and compile-time API contracts. Migrating the package as one unit removes its Jest type dependency while keeping those related behaviors under one runner and one jsdom environment.

## How?

- imports all Vitest APIs explicitly and declares Vitest in the owning workspace;
- routes the complete Interactivity test directory through jsdom;
- replaces Jest spies with `vi.fn()` / `vi.spyOn()` and adapts reactive spy callbacks to Preact Signals' `void` effect contract without changing what they observe;
- types the package-local `toMatchVNode` extension through Vitest module augmentation;
- keeps the existing compile-only API checks grouped without creating fake runtime tests, because Vitest rejects empty `describe` suites;
- replaces the test TypeScript configuration's Jest ambient types with the shared Vitest matcher environment and inherits the package's intentional compiler settings;
- removes the completed package's direct `@types/jest` dependency.

No production implementation, public API, runtime DOM behavior, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- --run packages/interactivity/src/proxies/test packages/interactivity/src/test
npm run test:unit:routing
npm run test:unit:conventions
node_modules/.bin/tsc --project packages/interactivity/tsconfig.test.json --pretty false
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 7 files / 188 tests;
- migrated Vitest slice: 7 files / 188 tests pass;
- routing: 537 Jest / 466 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 466 Vitest tests, 482 ESM graph files, 73 workspace dependencies, and 298 TypeScript tests pass;
- remaining Jest partition: 536 suites / 28,625 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases, reproduced by an exact isolated rerun;
- no snapshot files changed.

All changed-file linting, strict pre-commit linting, formatting, package metadata, TypeScript configuration, lockfile, generated-documentation, and diff checks pass.

## Use of AI Tools

This PR was authored with Codex. The reactive-effect return contract, custom matcher types, compile-only suite behavior, Jest-type removal, and verification output were reviewed before publication.