### PR TITLE
Migrate Interactivity Router package to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49374,6 +49374,7 @@
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"devDependencies": {
+				"@testing-library/jest-dom": "^6.9.1",
 				"vitest": "^4.1.10"
 			},
 			"engines": {
@@ -51677,6 +51678,9 @@
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/interactivity": "file:../interactivity",
 				"es-module-lexer": "^1.5.4"
+			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/interactivity-router/global.d.ts
+++ b/packages/interactivity-router/global.d.ts
@@ -1,0 +1,3 @@
+// Import the Vitest-specific Testing Library matcher augmentation explicitly
+// because the repository config restricts automatic type inclusion.
+import '@testing-library/jest-dom/vitest';

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -49,6 +49,10 @@
 		"@wordpress/interactivity": "file:../interactivity",
 		"es-module-lexer": "^1.5.4"
 	},
+	"devDependencies": {
+		"@testing-library/jest-dom": "^6.9.1",
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/interactivity-router/src/assets/test/script-modules.test.ts
+++ b/packages/interactivity-router/src/assets/test/script-modules.test.ts
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { preloadScriptModules } from '../script-modules';
 
-jest.mock( '../dynamic-importmap', () => ( {
-	...jest.requireActual( '../dynamic-importmap' ),
-	preloadWithMap: jest.fn( () => Promise.resolve( {} ) ),
+vi.mock( import( '../dynamic-importmap' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	preloadWithMap: vi.fn( async () => ( {} ) ),
 } ) );
 
 describe( 'preloadScriptModules', () => {

--- a/packages/interactivity-router/src/assets/test/scs.test.ts
+++ b/packages/interactivity-router/src/assets/test/scs.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { shortestCommonSupersequence } from '../scs';

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/interactivity-router/tsconfig.test.json
+++ b/packages/interactivity-router/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "./tsconfig.main.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": true,
+		"emitDeclarationOnly": false,
+		"types": [ "gutenberg-vitest-test-env" ]
+	},
+	"files": [
+		"global.d.ts",
+		"src/assets/test/script-modules.test.ts",
+		"src/assets/test/scs.test.ts",
+		"src/assets/test/styles.test.ts"
+	],
+	"include": [],
+	"exclude": []
+}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -40,6 +40,7 @@
 					"packages/i18n",
 					"packages/interface",
 					"packages/interactivity",
+					"packages/interactivity-router",
 					"packages/is-shallow-equal",
 					"packages/keycodes",
 					"packages/media-fields",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, type-safe partial module mocking, Vitest-specific jest-dom matcher typing, package test-TypeScript configuration, jsdom routing, and direct workspace dependency ownership.

See #80855.

This migrates all remaining tests in `@wordpress/interactivity-router`: three TypeScript test files and 50 tests.

## Why?

The router asset tests are a complete, snapshot-free package slice covering script-module preloading, stylesheet lifecycle behavior, and shortest-common-supersequence ordering. Keeping the package together preserves its DOM-focused behavior and removes another complete workspace from Jest.

## How?

- imports all Vitest APIs explicitly and declares Vitest in the owning workspace;
- routes the complete Interactivity Router test directory through jsdom;
- replaces `jest.requireActual()` module mocking with a type-checked dynamic `vi.mock(import(...))` factory and `importOriginal()`;
- adds a package test TypeScript configuration that directly checks the Vitest-specific Testing Library matcher augmentation;
- declares both Vitest and the jest-dom matcher package in the workspace that owns the tests.

No production implementation, public API, DOM behavior, stylesheet behavior, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- --run packages/interactivity-router/src/assets/test
npm run test:unit:routing
npm run test:unit:conventions
node_modules/.bin/tsc --project packages/interactivity-router/tsconfig.test.json --pretty false
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 3 files / 50 tests;
- migrated Vitest slice: 3 files / 50 tests pass;
- routing: 534 Jest / 469 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 469 Vitest tests, 485 ESM graph files, 74 workspace dependencies, and 301 TypeScript tests pass;
- remaining Jest partition: 533 suites / 28,575 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- no snapshot files changed.

All changed-file linting, strict pre-commit linting, formatting, package metadata, TypeScript configuration, lockfile, generated-documentation, and diff checks pass.

## Use of AI Tools

This PR was authored with Codex. The partial module mock, DOM matcher type ownership, test TypeScript configuration, and verification output were reviewed before publication.