### PR TITLE
Migrate block serialization parsers to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49853,7 +49853,8 @@
 			"version": "5.51.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser"
+				"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -49867,6 +49868,9 @@
 			"dependencies": {
 				"pegjs": "^0.10.0",
 				"phpegjs": "^1.0.0-beta7"
+			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -44,7 +44,8 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"devDependencies": {
-		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser"
+		"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -1,7 +1,12 @@
 /**
+ * Node dependencies
+ */
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-import path from 'path';
+import { describe, expect, test } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -16,9 +21,15 @@ import {
  */
 import { parse } from '../src';
 
-describe( 'block-serialization-default-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe-callback
+const testRunner = { describe, expect, test };
+
+describe(
+	'block-serialization-default-parser-js',
+	jsTester( parse, testRunner )
+);
 
 phpTester(
 	'block-serialization-default-parser-php',
-	path.join( __dirname, 'test-parser.php' )
+	fileURLToPath( new URL( './test-parser.php', import.meta.url ) ),
+	testRunner
 );

--- a/packages/block-serialization-spec-parser/CHANGELOG.md
+++ b/packages/block-serialization-spec-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Allow the shared parser-test helpers to receive explicit runner APIs and use Node ESM imports.
+
 ## 5.51.0 (2026-07-14)
 
 ## 5.50.0 (2026-07-01)

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -36,6 +36,9 @@
 		"pegjs": "^0.10.0",
 		"phpegjs": "^1.0.0-beta7"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -1,4 +1,11 @@
-export const jsTester = ( parse ) => () => {
+/**
+ * Node dependencies
+ */
+import { spawnSync } from 'node:child_process';
+
+export const jsTester = ( parse, runner ) => () => {
+	runner ??= globalThis;
+	const { describe, expect, test } = runner;
 	describe( 'output structure', () => {
 		test( 'output is an array', () => {
 			expect( parse( '' ) ).toEqual( expect.any( Array ) );
@@ -196,7 +203,9 @@ export const jsTester = ( parse ) => () => {
 				'<p>Break me</p><!-- wp:block --><!-- /wp:block -->',
 			].forEach( ( input ) =>
 				expect( parse( input ) ).toEqual( [
-					expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
+					expect.objectContaining( {
+						innerHTML: '<p>Break me</p>',
+					} ),
 					expect.objectContaining( {
 						blockName: 'core/block',
 						innerHTML: '',
@@ -233,7 +242,9 @@ export const jsTester = ( parse ) => () => {
 						blockName: 'core/block',
 						innerHTML: '',
 					} ),
-					expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
+					expect.objectContaining( {
+						innerHTML: '<p>Break me</p>',
+					} ),
 				] )
 			) );
 	} );
@@ -319,44 +330,39 @@ export const jsTester = ( parse ) => () => {
 const hasPHP =
 	'test' === process.env.NODE_ENV
 		? ( () => {
-				const process = require( 'child_process' ).spawnSync(
-					'php',
-					[ '-r', 'echo 1;' ],
-					{
-						encoding: 'utf8',
-					}
-				);
+				const phpProcess = spawnSync( 'php', [ '-r', 'echo 1;' ], {
+					encoding: 'utf8',
+				} );
 
-				return process.status === 0 && process.stdout === '1';
+				return phpProcess.status === 0 && phpProcess.stdout === '1';
 		  } )()
 		: false;
 
 // Skipping if `php` isn't available to us, such as in local dev without it
 // skipping preserves snapshots while commenting out or simply
-// not injecting the tests prompts `jest` to remove "obsolete snapshots"
-const makeTest = hasPHP
-	? // eslint-disable-next-line jest/valid-describe-callback, jest/valid-title
-	  ( ...args ) => describe( ...args )
-	: // eslint-disable-next-line jest/no-disabled-tests, jest/valid-describe-callback, jest/valid-title
-	  ( ...args ) => describe.skip( ...args );
+// not injecting the tests can prompt snapshot-aware runners to remove
+// "obsolete snapshots"
+const makeTest = ( describe ) =>
+	hasPHP
+		? ( ...args ) => describe( ...args )
+		: ( ...args ) => describe.skip( ...args );
 
-export const phpTester = ( name, filename ) =>
-	makeTest(
+export const phpTester = ( name, filename, testRunner = globalThis ) => {
+	const { describe } = testRunner;
+	return makeTest( describe )(
 		name,
 		'test' === process.env.NODE_ENV
 			? jsTester( ( doc ) => {
-					const process = require( 'child_process' ).spawnSync(
-						'php',
-						[ '-f', filename ],
-						{
-							input: doc,
-							encoding: 'utf8',
-							timeout: 30 * 1000, // Abort after 30 seconds, that's too long anyway.
-						}
-					);
+					const phpProcess = spawnSync( 'php', [ '-f', filename ], {
+						input: doc,
+						encoding: 'utf8',
+						timeout: 30 * 1000, // Abort after 30 seconds, that's too long anyway.
+					} );
 
-					if ( process.status !== 0 ) {
-						throw new Error( process.stderr || process.stdout );
+					if ( phpProcess.status !== 0 ) {
+						throw new Error(
+							phpProcess.stderr || phpProcess.stdout
+						);
 					}
 
 					try {
@@ -367,16 +373,17 @@ export const phpTester = ( name, filename ) =>
 						 * This is an issue with the test runner, not with the parser.
 						 */
 						return JSON.parse(
-							process.stdout.replace(
+							phpProcess.stdout.replace(
 								/"attrs":\s*\[\]/g,
 								'"attrs":{}'
 							)
 						);
 					} catch {
 						throw new Error(
-							'failed to parse JSON:\n' + process.stdout
+							'failed to parse JSON:\n' + phpProcess.stdout
 						);
 					}
-			  } )
+			  }, testRunner )
 			: () => {}
 	);
+};

--- a/packages/block-serialization-spec-parser/test/index.js
+++ b/packages/block-serialization-spec-parser/test/index.js
@@ -1,17 +1,27 @@
 /**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-import path from 'path';
+import { describe, expect, test } from 'vitest';
 
 /**
  * Internal dependencies
  */
-import { parse } from '../';
 import { jsTester, phpTester } from '../shared-tests';
 
-describe( 'block-serialization-spec-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe-callback
+const require = createRequire( import.meta.url );
+const { parse } = require( '../parser.js' );
+const testRunner = { describe, expect, test };
+
+describe( 'block-serialization-spec-parser-js', jsTester( parse, testRunner ) );
 
 phpTester(
 	'block-serialization-spec-parser-php',
-	path.join( __dirname, 'test-parser.php' )
+	fileURLToPath( new URL( './test-parser.php', import.meta.url ) ),
+	testRunner
 );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -72,6 +72,8 @@
 					"packages/babel-plugin-import-jsx-pragma",
 					"packages/babel-plugin-makepot",
 					"packages/babel-preset-default",
+					"packages/block-serialization-default-parser",
+					"packages/block-serialization-spec-parser",
 					"packages/browserslist-config",
 					"packages/data-controls",
 					"packages/design-system-mcp",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -109,7 +109,6 @@ export default defineConfig( {
 		commonjs( {
 			filter: ( id ) =>
 				[
-					`${ ROOT_DIR }/packages/block-serialization-spec-parser/parser.js`,
 					`${ ROOT_DIR }/packages/env/lib/`,
 					`${ ROOT_DIR }/packages/project-management-automation/lib/`,
 					`${ ROOT_DIR }/packages/scripts/utils/`,


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest runner injection, native Node ESM paths, deliberate PEG CommonJS isolation, reduced Vitest CommonJS-plugin scope, Node routing, and direct workspace dependency ownership.

See #80855.

This migrates the complete JavaScript and PHP parity-test entry points for `@wordpress/block-serialization-default-parser` and `@wordpress/block-serialization-spec-parser`: two files and 76 tests.

## Why?

These sibling packages share one parser-behavior harness, so migrating them together preserves the same JavaScript/PHP parity coverage while removing another complete package boundary from Jest. The slice also narrows the remaining CommonJS compatibility surface without changing the published PEG parser format.

## How?

- imports Vitest APIs explicitly and passes them into the shared parser-test helpers;
- keeps the published helpers backward compatible by falling back to the active runner globals when no runner is supplied;
- replaces `__dirname`, `path`, and unbound `require()` usage with native Node ESM APIs;
- deliberately loads the generated CommonJS PEG parser through a local `createRequire(import.meta.url)` boundary;
- removes that parser from the Vitest CommonJS-plugin filter because the compatibility boundary is now explicit;
- routes both complete package test directories through the Node project and declares Vitest in the owning workspaces.

No parser implementation, serialized output, public parser API, PHP parity behavior, or snapshots change. The shared test-helper signature change is additive and retains its legacy call form.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/block-serialization-default-parser/test/index.js packages/block-serialization-spec-parser/test/index.js
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 2 files / 76 tests;
- migrated Vitest slice: 2 files / 76 tests pass, including all available PHP parity cases;
- routing: 532 Jest / 471 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 471 Vitest tests, 487 ESM graph files, 76 workspace dependencies, and 301 TypeScript tests pass;
- remaining Jest partition: 531 suites / 28,499 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- all 228 remaining Jest snapshots pass and no snapshot files changed.

All changed-file linting, strict pre-commit linting, formatting, package metadata, lockfile, generated-documentation, routing, conventions, focused Vitest, and diff checks pass.

## Use of AI Tools

This PR was authored with Codex. The published helper compatibility, generated-parser CommonJS boundary, and verification output were reviewed before publication.