### PR TITLE
Migrate Global Styles Engine to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49374,7 +49374,6 @@
 				"@wordpress/i18n": "file:../i18n"
 			},
 			"devDependencies": {
-				"@testing-library/jest-dom": "^6.9.1",
 				"vitest": "^4.1.10"
 			},
 			"engines": {
@@ -51467,8 +51466,7 @@
 				"memize": "^2.1.1"
 			},
 			"devDependencies": {
-				"@testing-library/jest-dom": "^6.9.1",
-				"@types/jest": "^30.0.0"
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -51684,6 +51682,7 @@
 				"es-module-lexer": "^1.5.4"
 			},
 			"devDependencies": {
+				"@testing-library/jest-dom": "^6.9.1",
 				"vitest": "^4.1.10"
 			},
 			"engines": {

--- a/packages/global-styles-engine/global.d.ts
+++ b/packages/global-styles-engine/global.d.ts
@@ -1,5 +1,0 @@
-// When typeRoots is set in tsconfig, TypeScript only includes
-// type definitions found in the specified directories.
-// To ensure that global types are included, we need to
-// explicitly reference them here.
-import '@testing-library/jest-dom';

--- a/packages/global-styles-engine/package.json
+++ b/packages/global-styles-engine/package.json
@@ -54,8 +54,7 @@
 		"memize": "^2.1.1"
 	},
 	"devDependencies": {
-		"@testing-library/jest-dom": "^6.9.1",
-		"@types/jest": "^30.0.0"
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
+++ b/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
@@ -1,9 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import getGlobalStylesChanges, {
-	getGlobalStylesChangelist,
-} from '../utils/get-global-styles-changes';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -13,6 +11,13 @@ import {
 	unregisterBlockType,
 	getBlockTypes,
 } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import getGlobalStylesChanges, {
+	getGlobalStylesChangelist,
+} from '../utils/get-global-styles-changes';
 
 describe( 'getGlobalStylesChanges and utils', () => {
 	const next = {
@@ -195,6 +200,7 @@ describe( 'getGlobalStylesChanges and utils', () => {
 	beforeEach( () => {
 		registerBlockType( 'core/test-fiori-di-zucca', {
 			apiVersion: 3,
+			attributes: {},
 			save: () => {},
 			category: 'text',
 			title: 'Test pumpkin flowers',

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -1,4 +1,15 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import {
@@ -16,33 +27,20 @@ import {
 } from '../utils/common';
 
 // Mock WordPress data store
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	select: vi.fn(),
 } ) );
 
 // Mock WordPress blocks store
-jest.mock( '@wordpress/blocks', () => ( {
-	__EXPERIMENTAL_STYLE_PROPERTY: {
-		filter: {
-			value: [ 'filter', 'duotone' ],
-			support: [ 'filter', 'duotone' ],
-		},
-	},
-	__EXPERIMENTAL_ELEMENTS: {
-		link: 'a:where(:not(.wp-element-button))',
-		h1: 'h1',
-		h2: 'h2',
-		h3: 'h3',
-		h4: 'h4',
-		h5: 'h5',
-		h6: 'h6',
-		button: '.wp-element-button',
-		caption: '.wp-element-caption',
-	},
-	getBlockSupport: jest.fn(),
-	getBlockTypes: jest.fn(),
-	store: 'core/blocks',
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	getBlockSupport: vi.fn(),
+	getBlockTypes: vi.fn(),
 } ) );
+
+const mockedSelect = vi.mocked( select ) as Mock;
+const mockedGetBlockSupport = vi.mocked( getBlockSupport ) as Mock;
 
 // Mock WordPress elements (minimal, no mocking of complex APIs)
 const ELEMENTS = {
@@ -1486,9 +1484,8 @@ describe( 'global styles renderer', () => {
 
 	describe( 'generateGlobalStyles', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
-			const mockSelect = require( '@wordpress/data' ).select as jest.Mock;
-			mockSelect.mockReturnValue( {
+			vi.clearAllMocks();
+			mockedSelect.mockReturnValue( {
 				getBlockStyles: () => [],
 			} );
 		} );
@@ -1598,8 +1595,7 @@ describe( 'global styles renderer', () => {
 		} );
 
 		it( 'should output duotone SVG filters with __unstableType of svgs', () => {
-			const mockSelect = require( '@wordpress/data' ).select as jest.Mock;
-			mockSelect.mockReturnValue( {
+			mockedSelect.mockReturnValue( {
 				getBlockStyles: () => [],
 			} );
 
@@ -1648,13 +1644,12 @@ describe( 'global styles renderer', () => {
 	describe( 'getBlockSelectors', () => {
 		beforeEach( () => {
 			// Reset mocks before each test
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'should return block selectors data', () => {
 			// Mock the select function to return getBlockStyles
-			const mockSelect = require( '@wordpress/data' ).select as jest.Mock;
-			mockSelect.mockReturnValue( {
+			mockedSelect.mockReturnValue( {
 				getBlockStyles: () => [ { name: 'foo', label: 'foo' } ],
 			} );
 
@@ -1670,7 +1665,13 @@ describe( 'global styles renderer', () => {
 				category: 'media',
 			};
 			const blockTypes = [ imageBlock ];
-			expect( getBlockSelectors( blockTypes ) ).toEqual( {
+			expect(
+				getBlockSelectors(
+					blockTypes as unknown as Parameters<
+						typeof getBlockSelectors
+					>[ 0 ]
+				)
+			).toEqual( {
 				'core/image': {
 					name: imageBlock.name,
 					selector: imageSelectors.root,
@@ -1691,15 +1692,12 @@ describe( 'global styles renderer', () => {
 
 		it( 'should return block selectors data with old experimental selectors', () => {
 			// Mock the select function to return getBlockStyles with empty array
-			const mockSelect = require( '@wordpress/data' ).select as jest.Mock;
-			mockSelect.mockReturnValue( {
+			mockedSelect.mockReturnValue( {
 				getBlockStyles: () => [],
 			} );
 
 			// Mock getBlockSupport to handle experimental duotone support
-			const mockGetBlockSupport = require( '@wordpress/blocks' )
-				.getBlockSupport as jest.Mock;
-			mockGetBlockSupport.mockImplementation(
+			mockedGetBlockSupport.mockImplementation(
 				( blockType, path, defaultValue ) => {
 					if ( path === 'color.__experimentalDuotone' ) {
 						return 'img';
@@ -1726,7 +1724,13 @@ describe( 'global styles renderer', () => {
 			};
 			const blockTypes = [ imageBlock ];
 
-			expect( getBlockSelectors( blockTypes ) ).toEqual( {
+			expect(
+				getBlockSelectors(
+					blockTypes as unknown as Parameters<
+						typeof getBlockSelectors
+					>[ 0 ]
+				)
+			).toEqual( {
 				'core/image': {
 					name: imageBlock.name,
 					selector: imageSupports.__experimentalSelector,

--- a/packages/global-styles-engine/src/test/resolve-style.test.ts
+++ b/packages/global-styles-engine/src/test/resolve-style.test.ts
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { resolveStyle, privateHelpers } from '../resolve-style';
+import type { GlobalStylesConfig } from '../types';
 
 const {
 	isExplicitEmpty,
@@ -41,8 +47,8 @@ describe( 'resolveStyle – merged output', () => {
 				},
 			};
 			const out = pickLayerRootContribution( layer );
-			expect( out.typography ).toEqual( { lineHeight: '1.2' } );
-			expect( out.elements ).toBe( layer.elements );
+			expect( out?.typography ).toEqual( { lineHeight: '1.2' } );
+			expect( out?.elements ).toBe( layer.elements );
 		} );
 
 		test( 'pickLayerRootContribution returns null for empty layers', () => {
@@ -138,7 +144,7 @@ describe( 'resolveStyle – merged output', () => {
 		} );
 
 		test( 'deepMergeDroppingEmpties records a single source entry for backgroundImage', () => {
-			const sources = {};
+			const sources: Record< string, { layer: string } > = {};
 			deepMergeDroppingEmpties(
 				{},
 				{ background: { backgroundImage: { id: 1, url: 'a.jpg' } } },
@@ -735,14 +741,14 @@ describe( 'resolveStyle – memoization', () => {
 				},
 			},
 		};
-		const buildWithLinks = ( href ) =>
+		const buildWithLinks = ( href: string ) =>
 			resolveStyle(
 				{
 					...gs,
 					_links: {
 						'wp:theme-file': [ { name: 'file:./img.jpg', href } ],
 					},
-				},
+				} as GlobalStylesConfig,
 				{ blockName: 'core/paragraph' }
 			).value.background.backgroundImage.url;
 
@@ -797,14 +803,14 @@ describe( 'resolveStyle – memoization', () => {
 describe( 'resolveStyle – non-cascading root drop', () => {
 	// Each call builds against a fresh `globalStyles` object so the
 	// identity-keyed memo never returns a cross-test cache hit.
-	const build = ( styles, extra = {} ) =>
-		resolveStyle(
-			{ styles },
-			{
-				blockName: 'core/paragraph',
-				...extra,
-			}
-		);
+	const build = (
+		styles: Record< string, unknown >,
+		extra: Parameters< typeof resolveStyle >[ 1 ] = {}
+	) =>
+		resolveStyle( { styles } as GlobalStylesConfig, {
+			blockName: 'core/paragraph',
+			...extra,
+		} );
 
 	test( 'drops a root-sourced background color and its source', () => {
 		const { value, sources } = build( {
@@ -891,7 +897,7 @@ describe( 'resolveStyle – non-cascading root drop', () => {
 						},
 					],
 				},
-			},
+			} as GlobalStylesConfig,
 			{ blockName: 'core/paragraph' }
 		);
 		expect( value.background.backgroundImage.url ).toBe(

--- a/packages/global-styles-engine/src/test/style-state-back-compat.test.ts
+++ b/packages/global-styles-engine/src/test/style-state-back-compat.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { normalizeStyleStateAliases } from '../style-state-back-compat';

--- a/packages/global-styles-engine/src/test/typography-utils.test.ts
+++ b/packages/global-styles-engine/src/test/typography-utils.test.ts
@@ -4,6 +4,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -254,14 +259,14 @@ describe( 'typography utils', () => {
 			},
 		];
 
-		testCases.forEach( ( { message, preset, settings, expected } ) => {
-			// eslint-disable-next-line jest/valid-title
-			it( message, () => {
+		it.each( testCases )(
+			'$message',
+			( { preset, settings, expected } ) => {
 				expect(
 					getTypographyFontSizeValue( preset, settings || {} )
 				).toEqual( expected );
-			} );
-		} );
+			}
+		);
 	} );
 
 	describe( 'getFluidTypographyOptionsFromSettings', () => {
@@ -342,13 +347,10 @@ describe( 'typography utils', () => {
 			},
 		];
 
-		testCases.forEach( ( { message, settings, expected } ) => {
-			// eslint-disable-next-line jest/valid-title
-			it( message, () => {
-				expect(
-					getFluidTypographyOptionsFromSettings( settings || {} )
-				).toEqual( expected );
-			} );
+		it.each( testCases )( '$message', ( { settings, expected } ) => {
+			expect(
+				getFluidTypographyOptionsFromSettings( settings || {} )
+			).toEqual( expected );
 		} );
 	} );
 } );

--- a/packages/global-styles-engine/src/test/utils.test.ts
+++ b/packages/global-styles-engine/src/test/utils.test.ts
@@ -4,6 +4,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import type { GlobalStylesConfig } from '../types';

--- a/packages/global-styles-engine/src/test/variation.test.ts
+++ b/packages/global-styles-engine/src/test/variation.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getVariationStyle } from '../variation';

--- a/packages/global-styles-engine/src/test/viewport-utils.test.ts
+++ b/packages/global-styles-engine/src/test/viewport-utils.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/global-styles-engine/tsconfig.json
+++ b/packages/global-styles-engine/tsconfig.json
@@ -3,7 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"checkJs": false,
-		"types": [ "gutenberg-env", "gutenberg-test-env", "jest" ]
+		"types": [ "gutenberg-env" ]
 	},
 	"references": [
 		{ "path": "../blocks" },
@@ -12,5 +12,5 @@
 		{ "path": "../private-apis" },
 		{ "path": "../style-engine" }
 	],
-	"files": [ "global.d.ts" ]
+	"files": []
 }

--- a/packages/global-styles-engine/tsconfig.test.json
+++ b/packages/global-styles-engine/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"composite": false,
+		"emitDeclarationOnly": false,
+		"noEmit": true,
+		"rootDir": ".",
+		"types": [ "gutenberg-env", "gutenberg-vitest-test-env" ]
+	},
+	"references": [ { "path": "./tsconfig.json" } ],
+	"files": [],
+	"include": [ "src/test/**/*.ts" ],
+	"exclude": []
+}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -79,6 +79,7 @@
 					"packages/design-system-mcp",
 					"packages/docgen",
 					"packages/eslint-plugin",
+					"packages/global-styles-engine",
 					"packages/npm-package-json-lint-config",
 					"packages/postcss-themes",
 					"packages/preferences",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -266,6 +266,10 @@ export default defineConfig( {
 					name: 'node',
 					environment: 'node',
 					include: vitestTests.node,
+					setupFiles: path.join(
+						ROOT_DIR,
+						'test/unit/config/gutenberg-env.js'
+					),
 				},
 			},
 		],


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, type-checked partial WordPress module mocks, imported mock handles, isolated Vitest test types, Node-project routing, direct dependency cleanup, and Node setup parity for Gutenberg feature flags.

See #80855.

This migrates the complete `@wordpress/global-styles-engine` test suite: eight TypeScript files and 184 tests.

## Why?

The package is a complete, snapshot-free typed slice covering CSS rendering, responsive and legacy style states, style resolution, variations, typography, and selector utilities. Migrating it together preserves renderer behavior while removing its Jest globals, CommonJS mock access, Jest ambient types, and unused Testing Library matcher dependency.

The migration also exposed that the Vitest Node project did not load the repository's Gutenberg/Core feature-flag setup. Loading that shared setup restores the same build-mode contract used by Jest and prevents Node tests from silently exercising Core-only branches.

## How?

- imports every Vitest API explicitly in all eight test files;
- replaces Jest whole-module mocks and runtime `require()` lookups with type-checked dynamic partial `vi.mock(import(...))` factories and `vi.mocked()` handles;
- replaces Jest-specific dynamic-title lint suppressions with Vitest `it.each()` cases;
- adds a dedicated package test TypeScript configuration and removes Jest and Testing Library test types from the production configuration;
- removes the package's direct `@types/jest` and `@testing-library/jest-dom` development dependencies and declares Vitest directly;
- routes the complete package test directory through the Node project;
- loads the existing `gutenberg-env.js` feature-flag setup in the Node project, matching the established jsdom and Jest environments.

No production implementation, public API, generated CSS, responsive behavior, feature-flag value, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/global-styles-engine/src/test
npm run test:unit:vitest -- --project node
node_modules/.bin/tsc --project packages/global-styles-engine/tsconfig.test.json --pretty false
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 8 files / 184 tests;
- migrated Vitest slice: 8 files / 184 tests pass;
- complete Node Vitest project after setup parity change: 98 files / 1,277 tests pass;
- routing: 524 Jest / 479 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 479 Vitest tests, 495 ESM graph files, 77 workspace dependencies, and 309 TypeScript tests pass;
- remaining Jest partition: 523 suites / 28,315 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- all 228 remaining Jest snapshots pass and no snapshot files changed.

All package test TypeScript checking, focused and strict linting, formatting, package metadata, TypeScript configuration, lockfile, generated-documentation, routing, conventions, Node-project Vitest, remaining Jest, and diff checks pass subject to the documented offline `wp-env` cases.

## Use of AI Tools

This PR was authored with Codex. The Node feature-flag parity, partial WordPress module mocks, fixture type boundaries, dependency cleanup, and verification output were reviewed before publication.