### PR TITLE
Migrate Project Management Automation to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52454,7 +52454,8 @@
 				"@octokit/webhooks-types": "^5.8.0"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39"
+				"@types/node": "^20.19.39",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/project-management-automation/lib/tasks/add-milestone/test/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/test/index.js
@@ -1,7 +1,15 @@
 /**
- * Internal dependencies
+ * Node dependencies
  */
-import addMilestone from '../';
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire( import.meta.url );
+const addMilestone = require( '../' );
 
 describe( 'addMilestone', () => {
 	it( 'does nothing if base is not trunk', async () => {
@@ -10,21 +18,21 @@ describe( 'addMilestone', () => {
 		};
 		const octokit = {
 			paginate: {
-				iterator: jest.fn(),
+				iterator: vi.fn(),
 			},
 			rest: {
 				issues: {
-					get: jest.fn(),
-					createMilestone: jest.fn(),
+					get: vi.fn(),
+					createMilestone: vi.fn(),
 					listMilestones: {
 						endpoint: {
-							merge: jest.fn(),
+							merge: vi.fn(),
 						},
 					},
-					update: jest.fn(),
+					update: vi.fn(),
 				},
 				repos: {
-					getContent: jest.fn(),
+					getContent: vi.fn(),
 				},
 			},
 		};
@@ -53,23 +61,23 @@ describe( 'addMilestone', () => {
 		};
 		const octokit = {
 			paginate: {
-				iterator: jest.fn(),
+				iterator: vi.fn(),
 			},
 			rest: {
 				issues: {
-					get: jest.fn( () =>
+					get: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								milestone: 'Gutenberg 6.4',
 							},
 						} )
 					),
-					createMilestone: jest.fn(),
-					listMilestones: jest.fn(),
-					update: jest.fn(),
+					createMilestone: vi.fn(),
+					listMilestones: vi.fn(),
+					update: vi.fn(),
 				},
 				repos: {
-					getContent: jest.fn(),
+					getContent: vi.fn(),
 				},
 			},
 		};
@@ -100,7 +108,7 @@ describe( 'addMilestone', () => {
 		};
 		const octokit = {
 			paginate: {
-				iterator: jest.fn().mockReturnValue( [
+				iterator: vi.fn().mockReturnValue( [
 					Promise.resolve( {
 						data: [
 							{
@@ -124,23 +132,23 @@ describe( 'addMilestone', () => {
 			},
 			rest: {
 				issues: {
-					get: jest.fn( () =>
+					get: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								milestone: null,
 							},
 						} )
 					),
-					createMilestone: jest.fn(),
+					createMilestone: vi.fn(),
 					listMilestones: {
 						endpoint: {
-							merge: jest.fn(),
+							merge: vi.fn(),
 						},
 					},
-					update: jest.fn(),
+					update: vi.fn(),
 				},
 				repos: {
-					getContent: jest.fn( () =>
+					getContent: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								content: Buffer.from(
@@ -195,7 +203,7 @@ describe( 'addMilestone', () => {
 		};
 		const octokit = {
 			paginate: {
-				iterator: jest.fn().mockReturnValue( [
+				iterator: vi.fn().mockReturnValue( [
 					Promise.resolve( {
 						data: [
 							{
@@ -219,23 +227,23 @@ describe( 'addMilestone', () => {
 			},
 			rest: {
 				issues: {
-					get: jest.fn( () =>
+					get: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								milestone: null,
 							},
 						} )
 					),
-					createMilestone: jest.fn(),
+					createMilestone: vi.fn(),
 					listMilestones: {
 						endpoint: {
-							merge: jest.fn(),
+							merge: vi.fn(),
 						},
 					},
-					update: jest.fn(),
+					update: vi.fn(),
 				},
 				repos: {
-					getContent: jest.fn( () =>
+					getContent: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								content: Buffer.from(

--- a/packages/project-management-automation/lib/tasks/assign-fixed-issues/test/index.js
+++ b/packages/project-management-automation/lib/tasks/assign-fixed-issues/test/index.js
@@ -1,7 +1,15 @@
 /**
- * Internal dependencies
+ * Node dependencies
  */
-import assignFixedIssues from '../';
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire( import.meta.url );
+const assignFixedIssues = require( '../' );
 
 describe( 'assignFixedIssues', () => {
 	it( 'does nothing if there are no fixed issues', async () => {
@@ -13,8 +21,8 @@ describe( 'assignFixedIssues', () => {
 		const octokit = {
 			rest: {
 				issues: {
-					addAssignees: jest.fn(),
-					addLabels: jest.fn(),
+					addAssignees: vi.fn(),
+					addLabels: vi.fn(),
 				},
 			},
 		};
@@ -43,8 +51,8 @@ describe( 'assignFixedIssues', () => {
 		const octokit = {
 			rest: {
 				issues: {
-					addAssignees: jest.fn( () => Promise.resolve( {} ) ),
-					addLabels: jest.fn( () => Promise.resolve( {} ) ),
+					addAssignees: vi.fn( () => Promise.resolve( {} ) ),
+					addLabels: vi.fn( () => Promise.resolve( {} ) ),
 				},
 			},
 		};

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
@@ -1,10 +1,24 @@
 /**
- * Internal dependencies
+ * Node dependencies
  */
-import firstTimeContributorAccountLink from '../';
-import hasWordPressProfile from '../../../has-wordpress-profile';
+import { createRequire } from 'node:module';
 
-jest.mock( '../../../has-wordpress-profile', () => jest.fn() );
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire( import.meta.url );
+const hasWordPressProfile = vi.fn();
+const hasWordPressProfilePath = require.resolve(
+	'../../../has-wordpress-profile'
+);
+
+require.cache[ hasWordPressProfilePath ] = {
+	exports: hasWordPressProfile,
+};
+
+const firstTimeContributorAccountLink = require( '../' );
 
 const botUser = {
 	data: {
@@ -58,10 +72,10 @@ describe( 'firstTimeContributorAccountLink', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn(),
+					listCommits: vi.fn(),
 				},
 				users: {
-					getByUsername: jest.fn( () => humanUser ),
+					getByUsername: vi.fn( () => humanUser ),
 				},
 			},
 		};
@@ -90,10 +104,10 @@ describe( 'firstTimeContributorAccountLink', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn(),
+					listCommits: vi.fn(),
 				},
 				users: {
-					getByUsername: jest.fn( () => humanUser ),
+					getByUsername: vi.fn( () => humanUser ),
 				},
 			},
 		};
@@ -108,11 +122,11 @@ describe( 'firstTimeContributorAccountLink', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn(),
+					listCommits: vi.fn(),
 				},
 				users: {
 					// Return a bot when `getByUsername` is called.
-					getByUsername: jest.fn( () => botUser ),
+					getByUsername: vi.fn( () => botUser ),
 				},
 			},
 		};
@@ -129,7 +143,7 @@ describe( 'firstTimeContributorAccountLink', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn( () =>
+					listCommits: vi.fn( () =>
 						Promise.resolve( {
 							data: [
 								{
@@ -143,10 +157,10 @@ describe( 'firstTimeContributorAccountLink', () => {
 					),
 				},
 				users: {
-					getByUsername: jest.fn( () => humanUser ),
+					getByUsername: vi.fn( () => humanUser ),
 				},
 				issues: {
-					createComment: jest.fn(),
+					createComment: vi.fn(),
 				},
 			},
 		};
@@ -168,7 +182,7 @@ describe( 'firstTimeContributorAccountLink', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn( () =>
+					listCommits: vi.fn( () =>
 						Promise.resolve( {
 							data: [
 								{
@@ -179,10 +193,10 @@ describe( 'firstTimeContributorAccountLink', () => {
 					),
 				},
 				users: {
-					getByUsername: jest.fn( () => humanUser ),
+					getByUsername: vi.fn( () => humanUser ),
 				},
 				issues: {
-					createComment: jest.fn(),
+					createComment: vi.fn(),
 				},
 			},
 		};
@@ -208,7 +222,7 @@ describe( 'firstTimeContributorAccountLink', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn( () =>
+					listCommits: vi.fn( () =>
 						Promise.resolve( {
 							data: [
 								{
@@ -219,10 +233,10 @@ describe( 'firstTimeContributorAccountLink', () => {
 					),
 				},
 				users: {
-					getByUsername: jest.fn( () => humanUser ),
+					getByUsername: vi.fn( () => humanUser ),
 				},
 				issues: {
-					createComment: jest.fn(),
+					createComment: vi.fn(),
 				},
 			},
 		};

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
@@ -1,7 +1,15 @@
 /**
- * Internal dependencies
+ * Node dependencies
  */
-import firstTimeContributorLabel from '../';
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire( import.meta.url );
+const firstTimeContributorLabel = require( '../' );
 
 describe( 'firstTimeContributorLabel', () => {
 	const payload = {
@@ -34,10 +42,10 @@ describe( 'firstTimeContributorLabel', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn(),
+					listCommits: vi.fn(),
 				},
 				search: {
-					commits: jest.fn(),
+					commits: vi.fn(),
 				},
 			},
 		};
@@ -52,7 +60,7 @@ describe( 'firstTimeContributorLabel', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn( () =>
+					listCommits: vi.fn( () =>
 						Promise.resolve( {
 							data: [
 								{
@@ -63,11 +71,11 @@ describe( 'firstTimeContributorLabel', () => {
 					),
 				},
 				search: {
-					commits: jest.fn(),
+					commits: vi.fn(),
 				},
 				issues: {
-					addLabels: jest.fn(),
-					createComment: jest.fn(),
+					addLabels: vi.fn(),
+					createComment: vi.fn(),
 				},
 			},
 		};
@@ -88,12 +96,10 @@ describe( 'firstTimeContributorLabel', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn( () =>
-						Promise.resolve( { data: [] } )
-					),
+					listCommits: vi.fn( () => Promise.resolve( { data: [] } ) ),
 				},
 				search: {
-					commits: jest.fn( () =>
+					commits: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								total_count: 1,
@@ -107,8 +113,8 @@ describe( 'firstTimeContributorLabel', () => {
 					),
 				},
 				issues: {
-					addLabels: jest.fn(),
-					createComment: jest.fn(),
+					addLabels: vi.fn(),
+					createComment: vi.fn(),
 				},
 			},
 		};
@@ -127,12 +133,10 @@ describe( 'firstTimeContributorLabel', () => {
 		const octokit = {
 			rest: {
 				repos: {
-					listCommits: jest.fn( () =>
-						Promise.resolve( { data: [] } )
-					),
+					listCommits: vi.fn( () => Promise.resolve( { data: [] } ) ),
 				},
 				search: {
-					commits: jest.fn( () =>
+					commits: vi.fn( () =>
 						Promise.resolve( {
 							data: {
 								total_count: 0,
@@ -142,8 +146,8 @@ describe( 'firstTimeContributorLabel', () => {
 					),
 				},
 				issues: {
-					addLabels: jest.fn(),
-					createComment: jest.fn(),
+					addLabels: vi.fn(),
+					createComment: vi.fn(),
 				},
 			},
 		};

--- a/packages/project-management-automation/lib/test/get-associated-pull-request.js
+++ b/packages/project-management-automation/lib/test/get-associated-pull-request.js
@@ -1,7 +1,15 @@
 /**
- * Internal dependencies
+ * Node dependencies
  */
-import getAssociatedPullRequest from '../get-associated-pull-request';
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire( import.meta.url );
+const getAssociatedPullRequest = require( '../get-associated-pull-request' );
 
 /** @typedef {import('../get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
 

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -38,7 +38,8 @@
 		"@octokit/webhooks-types": "^5.8.0"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39"
+		"@types/node": "^20.19.39",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -84,6 +84,7 @@
 					"packages/postcss-themes",
 					"packages/preferences",
 					"packages/prettier-config",
+					"packages/project-management-automation",
 					"packages/readable-js-assets-webpack-plugin",
 					"packages/redux-routine",
 					"packages/stylelint-config",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -110,7 +110,6 @@ export default defineConfig( {
 			filter: ( id ) =>
 				[
 					`${ ROOT_DIR }/packages/env/lib/`,
-					`${ ROOT_DIR }/packages/project-management-automation/lib/`,
 					`${ ROOT_DIR }/packages/scripts/utils/`,
 					`${ ROOT_DIR }/tools/release/commands/changelog.js`,
 				].some( ( directory ) => id.startsWith( directory ) ) &&


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, native Node `createRequire()` boundaries, a localized CommonJS dependency mock, Node routing, direct Vitest ownership, and removal of this package from Vitest’s CommonJS conversion filter.

See #80855.

This migrates the complete `@wordpress/project-management-automation` test suite: five files and 18 tests.

## Why?

This published GitHub Action remains CommonJS for consumers, but Vitest does not need to transform the whole package to test it. Isolating that existing contract behind native Node boundaries preserves compatibility while shrinking the repository’s `vite-plugin-commonjs` execution surface.

## How?

- imports all Vitest APIs explicitly and replaces Jest mock functions with `vi.fn()`;
- loads the package’s published CommonJS modules through local `createRequire(import.meta.url)` boundaries;
- installs the one `has-wordpress-profile` dependency mock in the local Node module cache before loading its CommonJS consumer;
- routes the complete package test directory through the Node project and declares Vitest in the owning workspace;
- removes the Project Management Automation directory from the Vitest CommonJS conversion filter.

No production implementation, GitHub Action behavior, package exports, published module format, public API, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/project-management-automation
npm run test:unit:vitest -- --project node
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 5 files / 18 tests;
- migrated Vitest slice: 5 files / 18 tests pass;
- complete Node Vitest project after CommonJS-filter removal: 103 files / 1,295 tests pass;
- routing: 519 Jest / 484 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 484 Vitest tests, 500 ESM graph files, 78 workspace dependencies, and 309 TypeScript tests pass;
- remaining Jest partition: 518 suites / 28,297 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- all 228 remaining Jest snapshots pass and no snapshot files changed.

All focused and strict linting, formatting, package metadata, lockfile, generated-documentation, routing, conventions, Node-project Vitest, remaining Jest, and diff checks pass subject to the documented offline `wp-env` cases.

## Use of AI Tools

This PR was authored with Codex. The published CommonJS boundary, localized dependency mock, CommonJS-plugin scope reduction, and verification output were reviewed before publication.