### PR TITLE
Migrate Preferences Persistence to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52368,6 +52368,9 @@
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -45,6 +45,9 @@
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/preferences-persistence/src/create/test/debounce-async.js
+++ b/packages/preferences-persistence/src/create/test/debounce-async.js
@@ -1,87 +1,98 @@
 /**
+ * Node dependencies
+ */
+import { setImmediate as setImmediateCallback } from 'node:timers';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import debounceAsync from '../debounce-async';
 
-// See https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function.
-// Jest fake timers and async functions don't mix too well, since queued up
-// promises can prevent jest from calling timeouts.
-// This function flushes promises in the queue.
+// Let promise callbacks settle without advancing the faked timeout clock.
 function flushPromises() {
-	return new Promise( jest.requireActual( 'timers' ).setImmediate );
+	return new Promise( setImmediateCallback );
 }
 
-// Promisify a timeout for use with jest.fn.
+// Promisify a timeout for use with vi.fn.
 function timeout( milliseconds ) {
 	return new Promise( ( resolve ) => setTimeout( resolve, milliseconds ) );
 }
 
 describe( 'debounceAsync', () => {
 	it( 'uses a leading debounce, the first call happens immediately', () => {
-		const fn = jest.fn( async () => {} );
+		const fn = vi.fn( async () => {} );
 		const debounced = debounceAsync( fn, 20 );
 		debounced();
 		expect( fn ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'calls the function on the leading edge and then once on the trailing edge when there are multiple calls', async () => {
-		jest.useFakeTimers();
-		const fn = jest.fn( async () => {} );
-		const debounced = debounceAsync( fn, 20 );
+		vi.useFakeTimers( { toFake: [ 'setTimeout', 'clearTimeout' ] } );
+		try {
+			const fn = vi.fn( async () => {} );
+			const debounced = debounceAsync( fn, 20 );
 
-		debounced( 'A' );
+			debounced( 'A' );
 
-		expect( fn ).toHaveBeenCalledTimes( 1 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
 
-		debounced( 'B' );
-		debounced( 'C' );
-		debounced( 'D' );
+			debounced( 'B' );
+			debounced( 'C' );
+			debounced( 'D' );
 
-		await flushPromises();
-		jest.runAllTimers();
+			await flushPromises();
+			vi.runAllTimers();
 
-		expect( fn ).toHaveBeenCalledTimes( 2 );
-		expect( fn ).toHaveBeenCalledWith( 'A' );
-		expect( fn ).toHaveBeenCalledWith( 'D' );
-
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
+			expect( fn ).toHaveBeenCalledTimes( 2 );
+			expect( fn ).toHaveBeenCalledWith( 'A' );
+			expect( fn ).toHaveBeenCalledWith( 'D' );
+		} finally {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
 	} );
 
 	it( 'ensures the delay has elapsed between calls', async () => {
-		jest.useFakeTimers();
-		const fn = jest.fn( async () => timeout( 10 ) );
-		const debounced = debounceAsync( fn, 20 );
+		vi.useFakeTimers( { toFake: [ 'setTimeout', 'clearTimeout' ] } );
+		try {
+			const fn = vi.fn( async () => timeout( 10 ) );
+			const debounced = debounceAsync( fn, 20 );
 
-		// The first call has been triggered, but will take 10ms to resolve.
-		debounced();
-		debounced();
-		debounced();
-		debounced();
-		expect( fn ).toHaveBeenCalledTimes( 1 );
+			// The first call has been triggered, but will take 10ms to resolve.
+			debounced();
+			debounced();
+			debounced();
+			debounced();
+			expect( fn ).toHaveBeenCalledTimes( 1 );
 
-		// The first call has resolved. The delay period has started but has yet to finish.
-		await flushPromises();
-		jest.advanceTimersByTime( 11 );
-		expect( fn ).toHaveBeenCalledTimes( 1 );
+			// The first call has resolved. The delay period has started but has yet to finish.
+			await flushPromises();
+			vi.advanceTimersByTime( 11 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
 
-		// The second call is about to commence, but hasn't yet.
-		await flushPromises();
-		jest.advanceTimersByTime( 18 );
-		expect( fn ).toHaveBeenCalledTimes( 1 );
+			// The second call is about to commence, but hasn't yet.
+			await flushPromises();
+			vi.advanceTimersByTime( 18 );
+			expect( fn ).toHaveBeenCalledTimes( 1 );
 
-		// The second call has now commenced.
-		await flushPromises();
-		jest.advanceTimersByTime( 2 );
-		expect( fn ).toHaveBeenCalledTimes( 2 );
+			// The second call has now commenced.
+			await flushPromises();
+			vi.advanceTimersByTime( 2 );
+			expect( fn ).toHaveBeenCalledTimes( 2 );
 
-		// No more calls happen.
-		await flushPromises();
-		jest.runAllTimers();
-		expect( fn ).toHaveBeenCalledTimes( 2 );
-
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
+			// No more calls happen.
+			await flushPromises();
+			vi.runAllTimers();
+			expect( fn ).toHaveBeenCalledTimes( 2 );
+		} finally {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
 	} );
 
 	it( 'is thenable, returning any data from promise resolution of the debounced function', async () => {
@@ -108,21 +119,11 @@ describe( 'debounceAsync', () => {
 
 		const debounced = debounceAsync( fn, 20 );
 
-		// Test traditional try/catch.
-		try {
-			await debounced();
-		} catch ( error ) {
-			// Disable reason - the test uses `expect.assertions` to ensure
-			// conditional assertions are called.
-			// eslint-disable-next-line jest/no-conditional-expect
-			expect( error ).toBe( expectedError );
-		}
+		// Test awaiting a rejection.
+		await expect( debounced() ).rejects.toBe( expectedError );
 
 		// Test chained .catch().
 		await debounced().catch( ( error ) => {
-			// Disable reason - the test uses `expect.assertions` to ensure
-			// conditional assertions are called.
-			// eslint-disable-next-line jest/no-conditional-expect
 			expect( error ).toBe( expectedError );
 		} );
 	} );

--- a/packages/preferences-persistence/src/create/test/index.js
+++ b/packages/preferences-persistence/src/create/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -8,17 +13,22 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import create from '..';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( import( '@wordpress/api-fetch' ), () => ( {
+	default: vi.fn(),
+} ) );
+
+const mockedApiFetch = vi.mocked( apiFetch );
 
 describe( 'create', () => {
 	afterEach( () => {
-		apiFetch.mockReset();
+		mockedApiFetch.mockReset();
+		vi.restoreAllMocks();
 	} );
 
 	describe( 'set', () => {
 		it( 'stores backup restoration data in localStorage', () => {
-			apiFetch.mockResolvedValueOnce();
-			const spy = jest.spyOn( global.Storage.prototype, 'setItem' );
+			mockedApiFetch.mockResolvedValueOnce();
+			const spy = vi.spyOn( global.Storage.prototype, 'setItem' );
 
 			const localStorageRestoreKey = 'test';
 			const { set } = create( { localStorageRestoreKey } );
@@ -40,14 +50,14 @@ describe( 'create', () => {
 		} );
 
 		it( 'sends data to the `users/me` endpoint', () => {
-			apiFetch.mockResolvedValueOnce();
+			mockedApiFetch.mockResolvedValueOnce();
 
 			const { set } = create();
 
 			const data = { test: 1 };
 			set( data );
 
-			expect( apiFetch ).toHaveBeenCalledWith( {
+			expect( mockedApiFetch ).toHaveBeenCalledWith( {
 				path: '/wp/v2/users/me',
 				method: 'PUT',
 				keepalive: true,
@@ -62,38 +72,32 @@ describe( 'create', () => {
 
 	describe( 'get', () => {
 		it( 'avoids using the REST API or local storage when data is preloaded', async () => {
-			const getItemSpy = jest.spyOn(
-				global.Storage.prototype,
-				'getItem'
-			);
+			const getItemSpy = vi.spyOn( global.Storage.prototype, 'getItem' );
 
 			const preloadedData = { preloaded: true };
 			const { get } = create( { preloadedData } );
 			expect( await get() ).toBe( preloadedData );
 			expect( getItemSpy ).not.toHaveBeenCalled();
-			expect( apiFetch ).not.toHaveBeenCalled();
+			expect( mockedApiFetch ).not.toHaveBeenCalled();
 		} );
 
 		it( 'returns from a local cache once `set` has been called', async () => {
-			const getItemSpy = jest.spyOn(
-				global.Storage.prototype,
-				'getItem'
-			);
-			apiFetch.mockResolvedValueOnce();
+			const getItemSpy = vi.spyOn( global.Storage.prototype, 'getItem' );
+			mockedApiFetch.mockResolvedValueOnce();
 
 			const data = { cached: true };
 			const { get, set } = create();
 
 			// apiFetch was called as a result of calling `set`.
 			set( data );
-			expect( apiFetch ).toHaveBeenCalled();
-			apiFetch.mockClear();
+			expect( mockedApiFetch ).toHaveBeenCalled();
+			mockedApiFetch.mockClear();
 
 			// Neither localStorage.getItem or apiFetch are called as a result
 			// of the call to `get`. A local cache is used.
 			expect( await get() ).toEqual( expect.objectContaining( data ) );
 			expect( getItemSpy ).not.toHaveBeenCalled();
-			expect( apiFetch ).not.toHaveBeenCalled();
+			expect( mockedApiFetch ).not.toHaveBeenCalled();
 		} );
 
 		it( 'returns data from the users/me endpoint if there is no data in localStorage', async () => {
@@ -101,14 +105,13 @@ describe( 'create', () => {
 				__timestamp: 0,
 				test: 2,
 			};
-			apiFetch.mockResolvedValueOnce( {
+			mockedApiFetch.mockResolvedValueOnce( {
 				meta: { persisted_preferences: data },
 			} );
 
-			jest.spyOn(
-				global.Storage.prototype,
-				'getItem'
-			).mockReturnValueOnce( 'null' );
+			vi.spyOn( global.Storage.prototype, 'getItem' ).mockReturnValueOnce(
+				'null'
+			);
 
 			const { get } = create();
 			expect( await get() ).toEqual( data );
@@ -119,14 +122,11 @@ describe( 'create', () => {
 				_modified: '2022-04-22T00:00:00.000Z',
 				test: 'api',
 			};
-			apiFetch.mockResolvedValueOnce( {
+			mockedApiFetch.mockResolvedValueOnce( {
 				meta: { persisted_preferences: data },
 			} );
 
-			jest.spyOn(
-				global.Storage.prototype,
-				'getItem'
-			).mockReturnValueOnce(
+			vi.spyOn( global.Storage.prototype, 'getItem' ).mockReturnValueOnce(
 				JSON.stringify( {
 					_modified: '2022-04-21T00:00:00.000Z',
 					test: 'localStorage',
@@ -138,7 +138,7 @@ describe( 'create', () => {
 		} );
 
 		it( 'returns data from localStorage if it has a more recent modified date than data from the REST API', async () => {
-			apiFetch.mockResolvedValueOnce( {
+			mockedApiFetch.mockResolvedValueOnce( {
 				meta: {
 					persisted_preferences: {
 						_modified: '2022-04-21T00:00:00.000Z',
@@ -151,25 +151,23 @@ describe( 'create', () => {
 				_modified: '2022-04-22T00:00:00.000Z',
 				test: 'localStorage',
 			};
-			jest.spyOn(
-				global.Storage.prototype,
-				'getItem'
-			).mockReturnValueOnce( JSON.stringify( data ) );
+			vi.spyOn( global.Storage.prototype, 'getItem' ).mockReturnValueOnce(
+				JSON.stringify( data )
+			);
 
 			const { get } = create();
 			expect( await get() ).toEqual( data );
 		} );
 
 		it( 'returns an empty object if neither local storage or the REST API return any data', async () => {
-			apiFetch.mockResolvedValueOnce( {
+			mockedApiFetch.mockResolvedValueOnce( {
 				meta: {
 					persisted_preferences: null,
 				},
 			} );
-			jest.spyOn(
-				global.Storage.prototype,
-				'getItem'
-			).mockReturnValueOnce( 'null' );
+			vi.spyOn( global.Storage.prototype, 'getItem' ).mockReturnValueOnce(
+				'null'
+			);
 
 			const { get } = create();
 			expect( await get() ).toEqual( {} );

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/convert-edit-post-panels.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/convert-edit-post-panels.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import convertEditPostPanels from '../convert-edit-post-panels';

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/index.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { convertLegacyData } from '..';

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-feature-preferences.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-feature-preferences.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import moveFeaturePreferences from '../move-feature-preferences';

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-individual-preference.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-individual-preference.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import moveIndividualPreference from '../move-individual-preference';

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-interface-enable-items.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-interface-enable-items.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import moveInterfaceEnableItems from '../move-interface-enable-items';

--- a/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-third-party-feature-preferences.js
+++ b/packages/preferences-persistence/src/migrations/legacy-local-storage-data/test/move-third-party-feature-preferences.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import moveThirdPartyFeaturePreferences from '../move-third-party-feature-preferences';

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/test/convert-complementary-areas.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/test/convert-complementary-areas.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import convertComplementaryAreas from '../convert-complementary-areas';

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/test/convert-editor-settings.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/test/convert-editor-settings.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import convertEditorSettings from '../convert-editor-settings';

--- a/packages/preferences-persistence/src/migrations/preferences-package-data/test/index.js
+++ b/packages/preferences-persistence/src/migrations/preferences-package-data/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import convertPreferencesPackageData from '../';

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -47,6 +47,7 @@
 					"packages/notices",
 					"packages/nux",
 					"packages/plugins",
+					"packages/preferences-persistence",
 					"packages/priority-queue",
 					"packages/private-apis",
 					"packages/server-side-render",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, Vitest-native API Fetch mocking and spy restoration, scoped fake timers with native promise-queue flushing, jsdom routing, direct Vitest ownership, and unchanged inline snapshots.

See #80855.

This migrates the complete `@wordpress/preferences-persistence` test suite: 11 files and 33 tests.

## Why?

Preferences Persistence exercises browser storage, asynchronous REST persistence, debounce timing, and migration snapshots. Moving the complete package together preserves those coupled behaviors while advancing the exactly-one-runner migration without changing production code.

## How?

- imports all Vitest APIs explicitly and replaces Jest mocks and spies with `vi` equivalents;
- mocks `@wordpress/api-fetch` through Vitest's ESM-aware dynamic mock API and restores storage spies after each test;
- scopes fake timers to `setTimeout` and `clearTimeout`, while using Node's real `setImmediate` to flush promise callbacks without advancing the debounce clock;
- replaces a conditional rejection assertion with Vitest's `rejects` matcher;
- routes the complete package through the jsdom project and declares Vitest in the owning workspace.

No production implementation, package exports, public API, test expectations, or snapshot output change. All three inline snapshots remain unchanged.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/preferences-persistence/src
npm run test:unit:vitest -- --project vitest
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 11 files / 33 tests;
- migrated Vitest slice: 11 files / 33 tests pass;
- complete jsdom Vitest project: 391 files / 5,190 tests pass, including the debounce tests in suite order;
- routing: 508 Jest / 495 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 495 Vitest tests, 511 ESM graph files, 79 workspace dependencies, and 309 TypeScript tests pass;
- remaining Jest partition: 507 of 508 suites and 28,264 of 28,273 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- all 225 remaining Jest snapshots pass, all three migrated inline snapshots pass unchanged, and no snapshot files changed.

All focused and strict linting, formatting, package metadata, lockfile, generated-documentation, routing, conventions, jsdom-project Vitest, remaining Jest, and diff checks pass subject to the documented offline `wp-env` cases.

## Use of AI Tools

This PR was authored with Codex. The ESM mock boundary, timer semantics, inline snapshot parity, and verification output were reviewed before publication.