### PR TITLE
Migrate Reusable Blocks to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52712,7 +52712,8 @@
 			},
 			"devDependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
-				"@wordpress/preferences": "file:../preferences"
+				"@wordpress/preferences": "file:../preferences",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -65,7 +65,8 @@
 	},
 	"devDependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",
-		"@wordpress/preferences": "file:../preferences"
+		"@wordpress/preferences": "file:../preferences",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19",

--- a/packages/reusable-blocks/src/store/test/__snapshots__/actions.js.snap
+++ b/packages/reusable-blocks/src/store/test/__snapshots__/actions.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Actions __experimentalConvertBlockToStatic should convert a static reusable into a static block 1`] = `
+exports[`Actions > __experimentalConvertBlockToStatic > should convert a static reusable into a static block 1`] = `
 [
   {
     "attributes": {
@@ -36,7 +36,7 @@ exports[`Actions __experimentalConvertBlockToStatic should convert a static reus
 ]
 `;
 
-exports[`Actions __experimentalConvertBlocksToReusable should convert a static block into a reusable block 1`] = `
+exports[`Actions > __experimentalConvertBlocksToReusable > should convert a static block into a reusable block 1`] = `
 [
   {
     "attributes": {

--- a/packages/reusable-blocks/src/store/test/actions.js
+++ b/packages/reusable-blocks/src/store/test/actions.js
@@ -1,4 +1,17 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
@@ -20,10 +33,11 @@ import { logged } from '@wordpress/deprecated';
  */
 import { store as reusableBlocksStore } from '../index';
 
-jest.mock( '@wordpress/api-fetch', () => ( {
-	__esModule: true,
-	default: jest.fn(),
+vi.mock( import( '@wordpress/api-fetch' ), () => ( {
+	default: vi.fn(),
 } ) );
+
+const mockedApiFetch = vi.mocked( apiFetch );
 
 function createRegistryWithStores() {
 	// Create a registry and register stores.
@@ -77,6 +91,8 @@ describe( 'Actions', () => {
 	} );
 
 	afterEach( () => {
+		mockedApiFetch.mockReset();
+
 		// Reset the deprecation cache so each test observes its own warning.
 		for ( const key in logged ) {
 			delete logged[ key ];
@@ -117,7 +133,7 @@ describe( 'Actions', () => {
 
 			const registry = createRegistryWithStores();
 			// Mock the api-fetch.
-			apiFetch.mockImplementation( async ( args ) => {
+			mockedApiFetch.mockImplementation( async ( args ) => {
 				const { path, data } = args;
 				switch ( path ) {
 					case '/wp/v2/reusable-blocks':
@@ -175,7 +191,7 @@ describe( 'Actions', () => {
 
 			const registry = createRegistryWithStores();
 			// Mock the api-fetch.
-			apiFetch.mockImplementation( async ( args ) => {
+			mockedApiFetch.mockImplementation( async ( args ) => {
 				const { path, data } = args;
 				switch ( path ) {
 					case '/wp/v2/reusable-blocks/123':
@@ -236,7 +252,7 @@ describe( 'Actions', () => {
 
 			const registry = createRegistryWithStores();
 			// Mock the api-fetch.
-			apiFetch.mockImplementation( async ( args ) => {
+			mockedApiFetch.mockImplementation( async ( args ) => {
 				const { path, data, method } = args;
 				if (
 					path.startsWith( '/wp/v2/reusable-blocks' ) &&

--- a/packages/reusable-blocks/src/store/test/reducer.js
+++ b/packages/reusable-blocks/src/store/test/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { isEditingReusableBlock } from '../reducer';

--- a/packages/reusable-blocks/src/store/test/selectors.js
+++ b/packages/reusable-blocks/src/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { logged } from '@wordpress/deprecated';

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -50,6 +50,7 @@
 					"packages/preferences-persistence",
 					"packages/priority-queue",
 					"packages/private-apis",
+					"packages/reusable-blocks",
 					"packages/server-side-render",
 					"packages/shortcode",
 					"packages/style-engine",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, an ESM-aware API Fetch mock with per-test reset, jsdom routing, direct Vitest ownership, and an individually audited two-snapshot key-format conversion.

See #80855.

This migrates the complete `@wordpress/reusable-blocks` test suite: three files and eight tests.

## Why?

Reusable Blocks combines data-store actions, deprecation assertions, API Fetch behavior, and serialized block snapshots. Migrating the complete package together keeps those contracts under one runner and preserves the exactly-one-runner invariant.

## How?

- imports every Vitest API explicitly;
- replaces the Jest API Fetch mock with Vitest's ESM-aware dynamic mock API and a `vi.mocked()` handle;
- resets the API Fetch mock after each test while preserving the existing deprecation-cache cleanup;
- routes the complete package through the jsdom project and declares Vitest in the owning workspace;
- converts the two external snapshot headers and hierarchical keys to Vitest's format.

No production implementation, package exports, public API, test expectations, or serialized snapshot payload changes. The two snapshot diffs contain only the runner header and Vitest's `>` suite-name separators; both payloads were reviewed and remain unchanged.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/reusable-blocks/src
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
npm run test:unit -- packages/block-editor/src/components/url-input/test/index.js --runInBand --testNamePattern "should fall back to the fetch handler from the block editor settings"
```

Focused results:

- Jest baseline before migration: 3 files / 8 tests / 2 snapshots;
- migrated Vitest slice: 3 files / 8 tests / 2 snapshots pass;
- routing: 505 Jest / 498 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 498 Vitest tests, 514 ESM graph files, 80 workspace dependencies, and 309 TypeScript tests pass;
- remaining Jest partition: 503 of 505 suites and 28,255 of 28,265 tests passed; the failures were the 9 pre-existing network-restricted `wp-env` integration cases plus one unrelated URLInput debounce timing failure;
- the unrelated URLInput test passed on an immediate focused rerun;
- all 223 remaining Jest snapshots and both migrated Vitest snapshots pass.

All focused and strict linting, formatting, package metadata, lockfile, generated-documentation, routing, conventions, migrated Vitest, remaining Jest, snapshot, and diff checks pass subject to the documented offline `wp-env` cases and isolated URLInput suite-order flake.

## Use of AI Tools

This PR was authored with Codex. The ESM mock boundary, deprecation cleanup, snapshot key conversion, serialized payloads, and verification output were reviewed before publication.