### PR TITLE
Migrate Global Styles UI to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51501,7 +51501,8 @@
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -66,7 +66,8 @@
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
-		"@testing-library/react": "^16.3.2"
+		"@testing-library/react": "^16.3.2",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/global-styles-ui/src/test/shadow-utils.js
+++ b/packages/global-styles-ui/src/test/shadow-utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getShadowParts, shadowStringToObject } from '../shadow-utils';

--- a/packages/global-styles-ui/src/test/use-presets.js
+++ b/packages/global-styles-ui/src/test/use-presets.js
@@ -2,17 +2,19 @@
  * External dependencies
  */
 import { renderHook } from '@testing-library/react';
-
-jest.mock( '../hooks', () => ( {
-	useSetting: jest.fn(),
-} ) );
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
+import { useSetting } from '../hooks';
 import { usePresets } from '../presets/use-presets';
 
-const mockUseSetting = require( '../hooks' ).useSetting;
+vi.mock( import( '../hooks' ), () => ( {
+	useSetting: vi.fn(),
+} ) );
+
+const mockUseSetting = vi.mocked( useSetting );
 
 describe( 'usePresets', () => {
 	const presets = [
@@ -27,14 +29,14 @@ describe( 'usePresets', () => {
 	let setPresets;
 
 	beforeEach( () => {
-		setPresets = jest.fn();
-		jest.clearAllMocks();
+		setPresets = vi.fn();
+		vi.clearAllMocks();
 	} );
 
 	function mockSettings( value = presets, base = basePresets ) {
 		mockUseSetting.mockImplementation( ( path, blockName, readFrom ) => {
 			if ( readFrom === 'base' ) {
-				return [ base, jest.fn() ];
+				return [ base, vi.fn() ];
 			}
 			return [ value, setPresets ];
 		} );

--- a/packages/global-styles-ui/src/test/utils.js
+++ b/packages/global-styles-ui/src/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getNewIndexFromPresets } from '../utils';

--- a/packages/global-styles-ui/src/variations/test/variations-panel.js
+++ b/packages/global-styles-ui/src/variations/test/variations-panel.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -9,23 +10,24 @@ import { renderHook } from '@testing-library/react';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 
-// Only mock the internal hooks - let the real blocks store work
-jest.mock( '../../hooks', () => ( {
-	useStyle: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/components', () => ( {
-	__experimentalItemGroup: jest.fn( ( { children } ) => children ),
-} ) );
-
 /**
  * Internal dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
+import { useStyle } from '../../hooks';
 import { useBlockVariations } from '../variations-panel';
 
+// Only mock the internal hooks - let the real blocks store work.
+vi.mock( import( '../../hooks' ), () => ( {
+	useStyle: vi.fn(),
+} ) );
+
+vi.mock( import( '@wordpress/components' ), () => ( {
+	__experimentalItemGroup: vi.fn( ( { children } ) => children ),
+} ) );
+
 describe( 'useBlockVariations', () => {
-	const mockUseStyle = require( '../../hooks' ).useStyle;
+	const mockUseStyle = vi.mocked( useStyle );
 	let registry;
 
 	beforeEach( () => {
@@ -33,7 +35,7 @@ describe( 'useBlockVariations', () => {
 		registry = createRegistry();
 		// Register the blocks store so we can dispatch actions
 		registry.register( blocksStore );
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	function renderHookWithRegistry( hook, options = {} ) {
@@ -53,7 +55,7 @@ describe( 'useBlockVariations', () => {
 		];
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ {}, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ {}, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -70,7 +72,7 @@ describe( 'useBlockVariations', () => {
 		const variations = { outline: {}, fill: {} };
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ variations, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ variations, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -88,7 +90,7 @@ describe( 'useBlockVariations', () => {
 		const variations = { fill: {} };
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ variations, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ variations, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -101,7 +103,7 @@ describe( 'useBlockVariations', () => {
 	} );
 
 	it( 'should return empty array when block has no styles', () => {
-		mockUseStyle.mockReturnValue( [ {}, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ {}, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -116,7 +118,7 @@ describe( 'useBlockVariations', () => {
 		];
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ null, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ null, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -131,7 +133,7 @@ describe( 'useBlockVariations', () => {
 		];
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ undefined, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ undefined, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -147,7 +149,7 @@ describe( 'useBlockVariations', () => {
 		];
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ {}, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ {}, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -166,7 +168,7 @@ describe( 'useBlockVariations', () => {
 		const variations = { outline: {} };
 
 		registerBlockStyles( 'core/button', blockStyles );
-		mockUseStyle.mockReturnValue( [ variations, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ variations, vi.fn() ] );
 
 		const { result } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/button' )
@@ -188,7 +190,7 @@ describe( 'useBlockVariations', () => {
 
 		registerBlockStyles( 'core/paragraph', paragraphStyles );
 		registerBlockStyles( 'core/button', buttonStyles );
-		mockUseStyle.mockReturnValue( [ {}, jest.fn() ] );
+		mockUseStyle.mockReturnValue( [ {}, vi.fn() ] );
 
 		const { result: paragraphResult } = renderHookWithRegistry( () =>
 			useBlockVariations( 'core/paragraph' )

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -36,6 +36,7 @@
 					"packages/escape-html",
 					"packages/fields",
 					"packages/format-library",
+					"packages/global-styles-ui",
 					"packages/hooks",
 					"packages/i18n",
 					"packages/interface",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, ESM-aware internal hook and component mocks, `vi.mocked()` handles, retained Testing Library `renderHook()` coverage, jsdom routing, and direct Vitest ownership.

See #80855.

This migrates the complete `@wordpress/global-styles-ui` test suite: four files and 2,147 tests.

## Why?

Global Styles UI combines large parameterized utility coverage with React hook tests backed by WordPress data registries. Migrating the complete package preserves that behavior while removing Jest globals and CommonJS mock access from this test graph.

## How?

- imports every Vitest API explicitly;
- replaces string-based Jest hook mocks with Vitest's ESM-aware dynamic mock API and imported `vi.mocked()` handles;
- replaces CommonJS `require()` access to mocked hooks with native ESM imports;
- keeps Testing Library's `renderHook()` for hook behavior and the real WordPress blocks store for registry behavior;
- routes the complete package through the jsdom project and declares Vitest in the owning workspace.

No production implementation, package exports, public API, test expectations, Testing Library behavior, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/global-styles-ui/src
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 4 files / 2,147 tests;
- migrated Vitest slice: 4 files / 2,147 tests pass;
- routing: 501 Jest / 502 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions: 502 Vitest tests, 518 ESM graph files, 81 workspace dependencies, and 309 TypeScript tests pass;
- remaining Jest partition: 500 of 501 suites and 26,109 of 26,118 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- all 223 remaining Jest snapshots pass and no snapshot files changed.

All focused and strict linting, formatting, package metadata, lockfile, generated-documentation, routing, conventions, migrated Vitest, remaining Jest, and diff checks pass subject to the documented offline `wp-env` cases.

## Use of AI Tools

This PR was authored with Codex. The ESM mock boundaries, retained Testing Library coverage, real-store behavior, and verification output were reviewed before publication.