### PR TITLE
Migrate Grid to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51536,10 +51536,10 @@
 				"@storybook/react-vite": "^10.4.3",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
-				"@types/jest": "^30.0.0",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/ui": "file:../ui",
-				"storybook": "^10.4.3"
+				"storybook": "^10.4.3",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -58,10 +58,10 @@
 		"@storybook/react-vite": "^10.4.3",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
-		"@types/jest": "^30.0.0",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/ui": "file:../ui",
-		"storybook": "^10.4.3"
+		"storybook": "^10.4.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/keyboard-activation.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/grid/src/dashboard-grid/test/resolve-fill-widths.test.ts
+++ b/packages/grid/src/dashboard-grid/test/resolve-fill-widths.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { resolveFillWidths } from '../resolve-fill-widths';

--- a/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/keyboard-activation.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/grid/src/dashboard-lanes/test/lane-placement.test.ts
+++ b/packages/grid/src/dashboard-lanes/test/lane-placement.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { computeLanePlacements } from '../lane-placement';

--- a/packages/grid/src/dashboard-lanes/test/use-lane-placement.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/use-lane-placement.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, act, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -89,7 +90,7 @@ function setNativeSupport( supported: boolean ) {
 			return supported;
 		}
 		return originalSupports
-			? originalSupports.call( CSS, property, value as string )
+			? originalSupports( property, value as string )
 			: false;
 	};
 }
@@ -104,7 +105,7 @@ function restoreSupport() {
 function flushRaf() {
 	// jsdom polyfills `requestAnimationFrame` via `setTimeout`; an
 	// `act` boundary lets React commit any state set inside the rAF.
-	jest.runAllTimers();
+	vi.runAllTimers();
 }
 
 beforeEach( () => {
@@ -112,11 +113,11 @@ beforeEach( () => {
 	originalRaf = global.requestAnimationFrame;
 	global.requestAnimationFrame = ( cb ) =>
 		setTimeout( () => cb( performance.now() ), 0 ) as unknown as number;
-	jest.useFakeTimers();
+	vi.useFakeTimers();
 } );
 
 afterEach( () => {
-	jest.useRealTimers();
+	vi.useRealTimers();
 	global.requestAnimationFrame = originalRaf;
 	restoreObserver();
 	restoreSupport();

--- a/packages/grid/src/shared/test/resize-snap.test.ts
+++ b/packages/grid/src/shared/test/resize-snap.test.ts
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
 import { clampResizeDelta, gridSpanToPixelSize } from '../resize-snap';
 
 describe( 'gridSpanToPixelSize', () => {

--- a/packages/grid/tsconfig.json
+++ b/packages/grid/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"types": [ "jest", "style-imports" ]
+		"types": [ "style-imports" ]
 	},
 	"references": [
 		{ "path": "../compose" },

--- a/packages/grid/tsconfig.test.json
+++ b/packages/grid/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"emitDeclarationOnly": false,
+		"noEmit": true,
+		"rootDir": ".",
+		"types": [ "gutenberg-vitest-test-env", "style-imports" ]
+	},
+	"references": [ { "path": "./tsconfig.json" } ],
+	"files": [],
+	"include": [ "src/**/test/**/*" ],
+	"exclude": []
+}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -37,6 +37,7 @@
 					"packages/fields",
 					"packages/format-library",
 					"packages/global-styles-ui",
+					"packages/grid",
 					"packages/hooks",
 					"packages/i18n",
 					"packages/interface",


### PR DESCRIPTION
## What?

TL;DR: Explicit Vitest imports, Vitest fake timers, deterministic local web-platform fixtures, retained Testing Library coverage, jsdom routing, dedicated test types, direct Vitest ownership, and removal of `@types/jest`.

See #80855.

This migrates the complete `@wordpress/grid` test suite: six TypeScript files and 57 tests.

## Why?

Grid covers pure placement algorithms, React layout hooks, rAF scheduling, ResizeObserver behavior, CSS feature detection, and keyboard-activator DOM structure. Migrating the complete package together preserves those coupled contracts and removes Jest types from its production TypeScript configuration.

## How?

- imports every Vitest API explicitly and replaces Jest fake-timer calls with `vi` equivalents;
- keeps Testing Library for React rendering and DOM-structure assertions;
- keeps local `ResizeObserver`, `CSS.supports`, and requestAnimationFrame fixtures to deterministically exercise native and polyfill branches;
- routes the package through jsdom because its keyboard tests assert activator placement rather than real keyboard input or browser layout;
- adds a dedicated `tsconfig.test.json`, removes Jest types from the production config, replaces `@types/jest` with direct Vitest ownership, and type-checks all six routed tests;
- uses the correctly typed direct `CSS.supports()` overload when delegating from the test fixture.

No production implementation, package exports, public API, test expectations, Testing Library behavior, or snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest -- packages/grid/src
npm run test:unit:routing
npm run test:unit:conventions
npm run test:unit -- --runInBand
```

Focused results:

- Jest baseline before migration: 6 files / 57 tests;
- migrated Vitest slice: 6 files / 57 tests pass;
- routing: 495 Jest / 508 Vitest, with all 996 baseline tests assigned exactly once plus 7 tracked additions;
- conventions and type checking: 508 Vitest tests, 524 ESM graph files, 82 workspace dependencies, and 315 TypeScript tests pass;
- remaining Jest partition: 494 of 495 suites and 26,052 of 26,061 tests pass; the only 9 failures are the pre-existing network-restricted `wp-env` integration cases;
- all 223 remaining Jest snapshots pass and no snapshot files changed.

All focused and strict linting, formatting, TypeScript configuration, type checking, package metadata, lockfile, generated-documentation, routing, conventions, migrated Vitest, remaining Jest, and diff checks pass subject to the documented offline `wp-env` cases.

## Use of AI Tools

This PR was authored with Codex. The environment choice, timer semantics, platform fixtures, test-only TypeScript configuration, Jest-type removal, and verification output were reviewed before publication.