### PR TITLE
List View: Speed up opening by removing a forced style recalculation

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Internal
 
+-   `ListView`: Reimplement the Firefox description-recomputation workaround in `AriaReferencedText` by keying the element on its text, so React replaces it instead of updating the existing text node in place ([#80929](https://github.com/WordPress/gutenberg/pull/80929).
 -   Gate the inherited Global Styles treatment in the block inspector on the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances until the experiment is turned on ([#80555](https://github.com/WordPress/gutenberg/pull/80555), [#80815](https://github.com/WordPress/gutenberg/pull/80815)).
 -   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 

--- a/packages/block-editor/src/components/list-view/aria-referenced-text.js
+++ b/packages/block-editor/src/components/list-view/aria-referenced-text.js
@@ -1,29 +1,22 @@
 /**
- * WordPress dependencies
- */
-import { useRef, useEffect } from '@wordpress/element';
-
-/**
  * A component specifically designed to be used as an element referenced
  * by ARIA attributes such as `aria-labelledby` or `aria-describedby`.
  *
- * @param {Object}          props          Props.
- * @param {React.ReactNode} props.children
+ * Keying on the text is what makes this component more than a plain `div`:
+ * it makes React replace the element rather than update the existing text
+ * node in place. Firefox fails to recompute the accessible description when
+ * only the text node of a hidden element changes, so screen readers announce
+ * a stale value.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/51035
+ *
+ * @param {Object} props          Props.
+ * @param {string} props.children Text to reference. Must be a string, since
+ *                                it is used as the key.
  */
 export default function AriaReferencedText( { children, ...props } ) {
-	const ref = useRef();
-
-	useEffect( () => {
-		if ( ref.current ) {
-			// This seems like a no-op, but it fixes a bug in Firefox where
-			// it fails to recompute the text when only the text node changes.
-			// @see https://github.com/WordPress/gutenberg/pull/51035
-			ref.current.textContent = ref.current.textContent;
-		}
-	}, [ children ] );
-
 	return (
-		<div hidden { ...props } ref={ ref }>
+		<div hidden { ...props } key={ children }>
 			{ children }
 		</div>
 	);


### PR DESCRIPTION
## What?
PR replaces the imperative `textContent` self-assignment in `AriaReferencedText` with a `key` on the element, so React replaces the node instead of updating its text in place.

## Why?
`AriaReferencedText` renders once per List View row. Its `useEffect` set `textContent` on the node after every commit, invalidating the style for the whole document. Because that write lands between layout reads, the next reader pays for a full style recalculation, twice per open.

## Testing Instructions
Same as in #51035.

1. Use Firefox.
1. Create a post and add some blocks (5 paragraphs for instance).
2. Enable List view.
3. Try to navigate and delete a block inside the list view. (Using the options menu for deletion is recommended to ignore a known issue of screen readers sometimes skip announcing the focused element after deleting with keyboard shortcut for now.)
4. Expect the screen readers to announce the correct description for the focused element.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
The last two Perf checks on run CI for `listViewOpen` metric.

<img width="1063" height="219" alt="CleanShot 2026-07-30 at 13 37 47" src="https://github.com/user-attachments/assets/cf7f6365-a1cf-44d2-aede-7cc63e5f4a51" />

<img width="1067" height="172" alt="CleanShot 2026-07-30 at 14 24 03" src="https://github.com/user-attachments/assets/fd054d62-cdd1-4fab-9a90-84fc379d17b4" />


## Use of AI Tools

Assisted by Claude.
