### PR TITLE
Migrate Report Flaky Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52556,8 +52556,8 @@
 				"jest-message-util": "^30.4.1"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39"
+				"@types/node": "^20.19.39",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -42,8 +42,8 @@
 		"jest-message-util": "^30.4.1"
 	},
 	"devDependencies": {
-		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39"
+		"@types/node": "^20.19.39",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/report-flaky-tests/src/__tests__/__snapshots__/markdown.test.ts.snap
+++ b/packages/report-flaky-tests/src/__tests__/__snapshots__/markdown.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`formatTestErrorMessage should format test error message for @playwright/test 1`] = `
+exports[`formatTestErrorMessage > should format test error message for @playwright/test 1`] = `
 "Error: Snapshot comparison failed:
 
   <!-- wp:paragraph -->
@@ -28,7 +28,7 @@ Received: /home/runner/work/gutenberg/gutenberg/artifacts/test-results/editor-va
     at /home/runner/work/gutenberg/gutenberg/test/e2e/specs/editor/various/copy-cut-paste.spec.js:253:52"
 `;
 
-exports[`formatTestErrorMessage should format test error message for jest-circus 1`] = `
+exports[`formatTestErrorMessage > should format test error message for jest-circus 1`] = `
 "  ● Template Part › Template part block › Template part placeholder › Should insert new template part on creation
 
     expect(jest.fn()).not.toHaveErrored(expected)
@@ -69,7 +69,7 @@ exports[`formatTestErrorMessage should format test error message for jest-circus
 "
 `;
 
-exports[`parseIssueBody should parse issue body 1`] = `
+exports[`parseIssueBody > should parse issue body 1`] = `
 "<!-- __META_DATA__:{"failedTimes":5,"totalCommits":95} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 

--- a/packages/report-flaky-tests/src/__tests__/__snapshots__/run.test.ts.snap
+++ b/packages/report-flaky-tests/src/__tests__/__snapshots__/run.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Report flaky tests should report flaky tests to issue on pull request: Updated existing flaky issue 1`] = `
+exports[`Report flaky tests > should report flaky tests to issue on pull request > Updated existing flaky issue 1`] = `
 "<!-- __META_DATA__:{"failedTimes":58,"totalCommits":134,"baseCommit":"32bb60d08b75486341d8a63b9e786152889aa02d"} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 
@@ -121,7 +121,7 @@ Received: /home/runner/work/gutenberg/gutenberg/artifacts/test-results/editor-va
 "
 `;
 
-exports[`Report flaky tests should report flaky tests to issue on push: Created new flaky issue 1`] = `
+exports[`Report flaky tests > should report flaky tests to issue on push > Created new flaky issue 1`] = `
 "<!-- __META_DATA__:{} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 
@@ -183,7 +183,7 @@ Should insert new template part on creation
 "
 `;
 
-exports[`Report flaky tests should report flaky tests to issue on push: Updated existing flaky issue 1`] = `
+exports[`Report flaky tests > should report flaky tests to issue on push > Updated existing flaky issue 1`] = `
 "<!-- __META_DATA__:{"failedTimes":58,"totalCommits":134,"baseCommit":"32bb60d08b75486341d8a63b9e786152889aa02d"} -->
 **Flaky test detected. This is an auto-generated issue by GitHub Actions. Please do NOT edit this manually.**
 

--- a/packages/report-flaky-tests/src/__tests__/markdown.test.ts
+++ b/packages/report-flaky-tests/src/__tests__/markdown.test.ts
@@ -2,6 +2,15 @@
  * External dependencies
  */
 import * as core from '@actions/core';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 
 /**
  * Internal dependencies
@@ -17,9 +26,25 @@ import {
 } from '../markdown';
 import type { ReportedIssue } from '../types';
 
-jest.useFakeTimers( 'modern' ).setSystemTime( new Date( '2020-05-10' ) );
+vi.mock( import( '@actions/core' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	error: vi.fn(),
+} ) );
 
-jest.spyOn( core, 'error' ).mockImplementation( () => {} );
+const mockedCoreError = vi.mocked( core.error );
+
+beforeAll( () => {
+	vi.useFakeTimers();
+	vi.setSystemTime( new Date( '2020-05-10' ) );
+} );
+
+afterEach( () => {
+	mockedCoreError.mockClear();
+} );
+
+afterAll( () => {
+	vi.useRealTimers();
+} );
 
 describe( 'formatTestErrorMessage', () => {
 	it( 'should format test error message for jest-circus', async () => {
@@ -206,7 +231,7 @@ describe( 'parseIssueBody', () => {
 
 		const parsed = parseIssueBody( view );
 
-		expect( core.error ).toHaveBeenCalledTimes( 1 );
+		expect( mockedCoreError ).toHaveBeenCalledTimes( 1 );
 
 		expect( parsed ).toEqual( {
 			meta,

--- a/packages/report-flaky-tests/src/__tests__/run.test.ts
+++ b/packages/report-flaky-tests/src/__tests__/run.test.ts
@@ -2,13 +2,20 @@
  * External dependencies
  */
 import * as core from '@actions/core';
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 
 /**
  * Internal dependencies
  */
 import { run } from '../run';
-
-jest.useFakeTimers( 'modern' ).setSystemTime( new Date( '2020-05-10' ) );
 
 const mockPushEventContext = {
 	runId: 100,
@@ -39,42 +46,77 @@ const mockPullRequestEventContext = {
 		},
 	},
 };
-const mockGetContext = jest.fn(
-	(): typeof mockPushEventContext | typeof mockPullRequestEventContext =>
-		mockPullRequestEventContext
+const { mockGetContext, mockAPI, mockReaddir, mockReadFile } = vi.hoisted(
+	() => ( {
+		mockGetContext: vi.fn(),
+		mockAPI: {
+			fetchAllIssuesLabeledFlaky: vi.fn(),
+			findMergeBaseCommit: vi.fn(),
+			updateIssue: vi.fn(),
+			createIssue: vi.fn(),
+			createCommentOnPR: vi.fn(),
+			createCommentOnCommit: vi.fn(),
+		},
+		mockReaddir: vi.fn< ( path: string ) => Promise< string[] > >(),
+		mockReadFile:
+			vi.fn< ( path: string, encoding: string ) => Promise< string > >(),
+	} )
 );
-jest.mock( '@actions/github', () => ( {
+
+vi.mock( import( '@actions/github' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	get context() {
 		return mockGetContext();
 	},
 } ) );
 
-jest.mock( '@actions/core', () => ( {
-	error: jest.fn(),
-	info: jest.fn(),
-	getInput: jest.fn(),
+vi.mock( import( '@actions/core' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	error: vi.fn(),
+	info: vi.fn(),
+	getInput: vi.fn(),
 } ) );
 
-const mockAPI = {
-	fetchAllIssuesLabeledFlaky: jest.fn(),
-	findMergeBaseCommit: jest.fn(),
-	updateIssue: jest.fn(),
-	createIssue: jest.fn(),
-	createCommentOnPR: jest.fn(),
-	createCommentOnCommit: jest.fn(),
-};
-jest.mock( '../github-api', () => ( {
-	GitHubAPI: jest.fn( () => mockAPI ),
-} ) );
+vi.mock( import( '../github-api' ), async ( importOriginal ) => {
+	const original = await importOriginal();
 
-jest.mock( 'fs/promises', () => ( {
-	readdir: jest.fn(),
-	readFile: jest.fn(),
-} ) );
+	return {
+		...original,
+		GitHubAPI: vi.fn(
+			class MockGitHubAPI {
+				constructor() {
+					return mockAPI;
+				}
+			}
+		) as unknown as typeof original.GitHubAPI,
+	};
+} );
+
+vi.mock( import( 'fs/promises' ), async ( importOriginal ) => {
+	const original = await importOriginal();
+
+	return {
+		...original,
+		readdir: mockReaddir as unknown as typeof original.readdir,
+		readFile: mockReadFile as unknown as typeof original.readFile,
+	};
+} );
+
+const mockedGetInput = vi.mocked( core.getInput );
+
+beforeAll( () => {
+	vi.useFakeTimers();
+	vi.setSystemTime( new Date( '2020-05-10' ) );
+} );
+
+afterAll( () => {
+	vi.useRealTimers();
+} );
 
 describe( 'Report flaky tests', () => {
-	afterEach( () => {
-		jest.clearAllMocks();
+	beforeEach( () => {
+		vi.clearAllMocks();
+		mockGetContext.mockImplementation( () => mockPullRequestEventContext );
 	} );
 
 	it( 'should report flaky tests to issue on pull request', async () => {
@@ -88,7 +130,7 @@ describe( 'Report flaky tests', () => {
 			'../__fixtures__/flaky-issues.json'
 		).then( ( json ) => json.default );
 
-		( core.getInput as jest.Mock )
+		mockedGetInput
 			// token
 			.mockReturnValueOnce( 'repo-token' )
 			// artifact-path
@@ -102,14 +144,13 @@ describe( 'Report flaky tests', () => {
 			process.cwd()
 		);
 
-		const mockedFs = require( 'fs/promises' );
-		mockedFs.readdir.mockImplementationOnce( () =>
+		mockReaddir.mockImplementationOnce( () =>
 			Promise.resolve( [
 				`${ existingFlakyTest.title }.json`,
 				`${ newFlakyTest.title }.json`,
 			] )
 		);
-		mockedFs.readFile
+		mockReadFile
 			.mockImplementationOnce( () =>
 				Promise.resolve( JSON.stringify( existingFlakyTest ) )
 			)
@@ -180,7 +221,7 @@ describe( 'Report flaky tests', () => {
 			'../__fixtures__/flaky-issues.json'
 		).then( ( json ) => json.default );
 
-		( core.getInput as jest.Mock )
+		mockedGetInput
 			// token
 			.mockReturnValueOnce( 'repo-token' )
 			// artifact-path
@@ -194,14 +235,13 @@ describe( 'Report flaky tests', () => {
 			process.cwd()
 		);
 
-		const mockedFs = require( 'fs/promises' );
-		mockedFs.readdir.mockImplementationOnce( () =>
+		mockReaddir.mockImplementationOnce( () =>
 			Promise.resolve( [
 				`${ existingFlakyTest.title }.json`,
 				`${ newFlakyTest.title }.json`,
 			] )
 		);
-		mockedFs.readFile
+		mockReadFile
 			.mockImplementationOnce( () =>
 				Promise.resolve( JSON.stringify( existingFlakyTest ) )
 			)
@@ -267,8 +307,6 @@ describe( 'Report flaky tests', () => {
 		- #1 in \`/test/e2e/specs/editor/various/copy-cut-paste.spec.js\`
 		- #2 in \`specs/site-editor/template-part.test.js\`"
 	` );
-
-		mockGetContext.mockImplementation( () => mockPullRequestEventContext );
 	} );
 
 	it( 'should skip for outdated branches', async () => {
@@ -279,7 +317,7 @@ describe( 'Report flaky tests', () => {
 			'../__fixtures__/flaky-issues.json'
 		).then( ( json ) => json.default );
 
-		( core.getInput as jest.Mock )
+		mockedGetInput
 			.mockReturnValueOnce( 'repo-token' )
 			.mockReturnValueOnce( 'flaky-tests-report' )
 			.mockReturnValueOnce( '[Type] Flaky Test' );
@@ -290,11 +328,10 @@ describe( 'Report flaky tests', () => {
 			process.cwd()
 		);
 
-		const mockedFs = require( 'fs/promises' );
-		mockedFs.readdir.mockImplementationOnce( () =>
+		mockReaddir.mockImplementationOnce( () =>
 			Promise.resolve( [ `${ flakyTest.title }.json` ] )
 		);
-		mockedFs.readFile.mockImplementationOnce( () =>
+		mockReadFile.mockImplementationOnce( () =>
 			Promise.resolve( JSON.stringify( flakyTest ) )
 		);
 

--- a/packages/report-flaky-tests/tsconfig.json
+++ b/packages/report-flaky-tests/tsconfig.json
@@ -1,8 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"types": [ "jest" ]
-	},
 	"exclude": [ "src/__tests__", "src/__fixtures__" ]
 }

--- a/packages/report-flaky-tests/tsconfig.test.json
+++ b/packages/report-flaky-tests/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"emitDeclarationOnly": false,
+		"noEmit": true,
+		"rootDir": ".",
+		"types": [ "gutenberg-vitest-test-env", "node" ]
+	},
+	"references": [ { "path": "./tsconfig.json" } ],
+	"files": [],
+	"include": [ "src/__tests__/**/*.ts" ],
+	"exclude": []
+}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -10,7 +10,10 @@
 				"directories": []
 			},
 			"jsdom": {
-				"files": [ "packages/html-entities/src/test/entities.ts" ],
+				"files": [
+					"packages/html-entities/src/test/entities.ts",
+					"packages/report-flaky-tests/src/__tests__/markdown.test.ts"
+				],
 				"directories": [
 					"packages/a11y",
 					"packages/abilities",
@@ -71,7 +74,9 @@
 				]
 			},
 			"node": {
-				"files": [],
+				"files": [
+					"packages/report-flaky-tests/src/__tests__/run.test.ts"
+				],
 				"directories": [
 					"packages/babel-plugin-import-jsx-pragma",
 					"packages/babel-plugin-makepot",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR — migration class:** Node/jsdom split routing, hoisted ESM module mocks, fake-system-time lifecycle cleanup, typed filesystem test doubles, Jest type removal, and a 13-snapshot compatibility audit.

Migrates all 14 `@wordpress/report-flaky-tests` unit tests from Jest to Vitest. The Markdown tests run in jsdom because they render HTML through `document`; the GitHub Action runner tests run in the Node project.

## Why?

This is a bounded package slice of the repository-wide Jest-to-Vitest migration. Keeping the two environments explicit avoids giving a Node action an unnecessary browser-like runtime while preserving the Markdown rendering behavior.

## How?

- replaces Jest globals and CommonJS mock access with explicit Vitest imports, `vi.hoisted`, dynamic ESM mocks, and typed mock handles
- scopes fake system time to suite lifecycle hooks and restores real timers
- gives tests a dedicated Vitest TypeScript graph and removes `@types/jest` from the package
- routes the two files to their actual jsdom and Node environments
- converts six external snapshot headers/keys after individually confirming their payloads are unchanged; seven inline snapshots remain unchanged
- intentionally retains `@jest/test-result` and `jest-message-util`, which production code uses to format legacy Jest result payloads rather than to invoke Jest

## Testing Instructions

1. `npm run test:unit:vitest -- packages/report-flaky-tests/src`
2. `npm run test:unit:routing`
3. `npm run test:unit:conventions`
4. `npm run test:unit -- --runInBand`
5. `npm exec lint-staged -- --no-stash` with this PR's files staged

Expected local results:

- Vitest: 2 files and 14 tests pass.
- Routing: exactly 493 Jest and 510 Vitest files.
- Conventions: 510 tests, 526 ESM graph files, 83 workspace dependencies, and 317 TypeScript tests pass validation.
- Remaining Jest: 492 suites / 26,038 tests / 210 snapshots pass. The nine `packages/env/lib/config/test/config-integration.js` tests fail only because the current WordPress version is unavailable in the offline local cache.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was authored with Codex assistance and reviewed through the repository's focused tests, routing/convention validators, snapshot diff, and strict staged checks.