### PR TITLE
Migrate Dependency Extraction Webpack Plugin to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50660,6 +50660,7 @@
 				"mini-css-extract-plugin": "^2.9.2",
 				"mkdirp": "^3.0.1",
 				"rimraf": "^5.0.10",
+				"vitest": "^4.1.10",
 				"webpack": "^5.108.1"
 			},
 			"engines": {

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -48,6 +48,7 @@
 		"mini-css-extract-plugin": "^2.9.2",
 		"mkdirp": "^3.0.1",
 		"rimraf": "^5.0.10",
+		"vitest": "^4.1.10",
 		"webpack": "^5.108.1"
 	},
 	"peerDependencies": {

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,11 +1,11 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`combine-assets\` > should produce expected output > Asset file 'assets.php' should match snapshot 1`] = `
 "<?php return array('fileA.mjs' => array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '5202d062e624638839cf', 'type' => 'module'), 'fileB.mjs' => array('dependencies' => array('@wordpress/token-list'), 'version' => '610e232865e99068a0be', 'type' => 'module'));
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`combine-assets\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -25,12 +25,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`combine-assets\` sh
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`cyclic-dependency-graph\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/interactivity'), 'version' => 'be216763535510675ce9', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`cyclic-dependency-graph\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "module",
@@ -40,12 +40,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dependency-g
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`cyclic-dynamic-dependency-graph\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => 'decbc01a27e4dbb98c28', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`cyclic-dynamic-dependency-graph\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "module",
@@ -55,12 +55,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-dynamic-depe
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`cyclic-external-deps\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '8160d5c123a7103eb3c5', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-deps\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`cyclic-external-deps\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "module",
@@ -70,12 +70,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`cyclic-external-dep
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`dynamic-import\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(array('id' => '@wordpress/blob', 'import' => 'dynamic')), 'version' => 'bb58caab8f1f94bf03ed', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`dynamic-import\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -85,7 +85,7 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`dynamic-import\` sh
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`error\` should produce expected output 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`error\` > should produce expected output 1`] = `
 "ERROR in ./index.js 1:0-23
 Module not found: Error: Attempted to use WordPress script in a module: jquery, which is not supported yet.
 
@@ -94,12 +94,12 @@ Module not found: Error: Attempted to use WordPress script in a module: @wordpre
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`function-output-filename\` > should produce expected output > Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`function-output-filename\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -114,12 +114,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`function-output-fil
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`has-extension-suffix\` > should produce expected output > Asset file 'index.min.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'ded8b9fa0ae5bbe26273', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffix\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`has-extension-suffix\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -134,12 +134,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`has-extension-suffi
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`module-renames\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '94912422ad4246a8b80d', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`module-renames\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -154,12 +154,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`module-renames\` sh
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`nested-dynamic-import\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '545e35ddcaa625ec66be', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`nested-dynamic-import\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "module",
@@ -169,26 +169,26 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`nested-dynamic-impo
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`no-default\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '1d4018004c72e23ff482', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`no-default\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`no-deps\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '47abc9f11d44c8d2ea89', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`no-deps\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`option-function-output-filename\` > should produce expected output > Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`option-function-output-filename\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -203,12 +203,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-function-out
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`option-output-filename\` > should produce expected output > Asset file 'main-foo.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`option-output-filename\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -223,9 +223,9 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"b3f94e0b15eab389ca33","type":"module"}"`;
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`output-format-json\` > should produce expected output > Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"b3f94e0b15eab389ca33","type":"module"}"`;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`output-format-json\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -235,12 +235,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`output-format-json\
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`overrides\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', '@wordpress/url', 'rxjs', 'rxjs/operators'), 'version' => '440538f4e5c478ec44e7', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`overrides\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -265,36 +265,36 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`polyfill-magic-comment\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-polyfill'), 'version' => 'ce3c6b76208e3e42fe21', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`polyfill-magic-comment\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment-minified\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`polyfill-magic-comment-minified\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-polyfill'), 'version' => '31d6cfe0d16ae931b73c', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`polyfill-magic-comment-minified\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`runtime-chunk-single\` > should produce expected output > Asset file 'a.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '00ad69a407b9d8fe017b', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-a');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`runtime-chunk-single\` > should produce expected output > Asset file 'b.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '8f3ca66c17c6a5908643', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-b');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`runtime-chunk-single\` > should produce expected output > Asset file 'runtime.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '5ab1f5b70c1a8b8e348b', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-runtime');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`runtime-chunk-single\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -309,12 +309,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-singl
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`style-cache-group\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob'), 'version' => '05ab538fc7abc794bf3a', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`style-cache-group\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -324,12 +324,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-cache-group\`
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`style-imports\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '92ea15aace211d977373', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`style-imports\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -344,12 +344,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`style-imports\` sho
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`wordpress\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '551652a9c62543494448', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`wordpress\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -364,12 +364,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`wordpress-interactivity\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', array('id' => '@wordpress/interactivity', 'import' => 'dynamic')), 'version' => '19d196fe140333588868', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`wordpress-interactivity\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -384,12 +384,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-interacti
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`wordpress-require\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => 'c794f84248de09f057b3', 'type' => 'module');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin modules > Webpack \`wordpress-require\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "import",
@@ -404,12 +404,12 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`wordpress-require\`
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`combine-assets\` > should produce expected output > Asset file 'assets.php' should match snapshot 1`] = `
 "<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'e1840d27f0719ffa42d3'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '7a1390bf33761ae364eb'));
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`combine-assets\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -435,12 +435,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`combine-assets\` sh
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`cyclic-dependency-graph\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-interactivity'), 'version' => '82601013091064d44360');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`cyclic-dependency-graph\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -453,12 +453,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dependency-g
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`cyclic-dynamic-dependency-graph\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'd76f4397b70cf8945132');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-dependency-graph\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`cyclic-dynamic-dependency-graph\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -471,12 +471,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-dynamic-depe
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`cyclic-external-deps\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'dfaa91b1f8015937bb82');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-deps\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`cyclic-external-deps\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -489,12 +489,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`cyclic-external-dep
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`dynamic-import\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-blob'), 'version' => 'b6e6a7f3f50454805aa6');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`dynamic-import\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -507,18 +507,18 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`dynamic-import\` sh
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`error\` should produce expected output 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`error\` > should produce expected output 1`] = `
 "ERROR in main
 Module not found: Error: Ensure error in script build.
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`function-output-filename\` > should produce expected output > Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`function-output-filename\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -536,12 +536,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`function-output-fil
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`has-extension-suffix\` > should produce expected output > Asset file 'index.min.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '91d6fc79d8288f1bd30f');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`has-extension-suffix\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`has-extension-suffix\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -559,12 +559,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`has-extension-suffi
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`module-renames\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('renamed--@my/module', 'renamed--other-module'), 'version' => '728ec64636a1f078764f');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`module-renames\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -585,12 +585,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`module-renames\` sh
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`nested-dynamic-import\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-interactivity'), 'version' => 'f106056c2c97892f532b');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`nested-dynamic-import\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -603,26 +603,26 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`nested-dynamic-impo
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`no-default\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '9eeb18bc6756ee01877b');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`no-default\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`no-deps\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => 'b922a4320dd8b7a352f4');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`no-deps\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`option-function-output-filename\` > should produce expected output > Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`option-function-output-filename\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -640,12 +640,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-function-out
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`option-output-filename\` > should produce expected output > Asset file 'main-foo.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`option-output-filename\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -663,9 +663,9 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`option-output-filen
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"e30269b38e67582b534d"}"`;
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`output-format-json\` > should produce expected output > Asset file 'main.asset.json' should match snapshot 1`] = `"{"dependencies":["lodash"],"version":"e30269b38e67582b534d"}"`;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`output-format-json\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -675,12 +675,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`output-format-json\
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`overrides\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-blob', 'wp-script-handle-for-rxjs', 'wp-url'), 'version' => '35e570db18559a76b3e6');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`overrides\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -714,36 +714,36 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`overrides\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`polyfill-magic-comment\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-polyfill'), 'version' => '48f720dd907eea75c1fd');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`polyfill-magic-comment\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment-minified\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`polyfill-magic-comment-minified\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-polyfill'), 'version' => '31d6cfe0d16ae931b73c');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`polyfill-magic-comment-minified\` > should produce expected output > External modules should match snapshot 1`] = `[]`;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`runtime-chunk-single\` > should produce expected output > Asset file 'a.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-blob'), 'version' => 'e8bba1440f7003e4988b', 'handle' => 'runtime-chunk-single-scripts-a');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`runtime-chunk-single\` > should produce expected output > Asset file 'b.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '8c8cea3e6127c51f6aac', 'handle' => 'runtime-chunk-single-scripts-b');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`runtime-chunk-single\` > should produce expected output > Asset file 'runtime.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array(), 'version' => '2028470a91d96d4f591d', 'handle' => 'runtime-chunk-single-scripts-runtime');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`runtime-chunk-single\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -761,12 +761,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-singl
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`style-cache-group\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-blob'), 'version' => 'fe584d4d3343f27d9d98');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`style-cache-group\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -779,12 +779,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-cache-group\`
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`style-imports\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'c2b6a03053f847f92d0c');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`style-imports\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -802,12 +802,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`style-imports\` sho
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`wordpress\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1d90caedf1e59da6332a');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`wordpress\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -825,12 +825,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress\` should 
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`wordpress-interactivity\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-interactivity'), 'version' => 'dfd7d906d8f46790f644');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interactivity\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`wordpress-interactivity\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",
@@ -848,12 +848,12 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-interacti
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`wordpress-require\` > should produce expected output > Asset file 'main.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'ae7e90ce0ad991a09a13');
 "
 `;
 
-exports[`DependencyExtractionWebpackPlugin scripts Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
+exports[`DependencyExtractionWebpackPlugin scripts > Webpack \`wordpress-require\` > should produce expected output > External modules should match snapshot 1`] = `
 [
   {
     "externalType": "window",

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -1,17 +1,39 @@
 /**
+ * Node dependencies
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-const fs = require( 'fs' );
-const path = require( 'path' );
-const glob = require( 'glob' ).sync;
-const mkdirp = require( 'mkdirp' ).mkdirp.sync;
-const rimraf = require( 'rimraf' ).sync;
-const webpack = require( 'webpack' );
+import globPackage from 'glob';
+import { mkdirpSync } from 'mkdirp';
+import { rimrafSync } from 'rimraf';
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from 'vitest';
+import webpack from 'webpack';
 
-const fixturesPath = path.join( __dirname, 'fixtures' );
+const require = createRequire( import.meta.url );
+const glob = globPackage.sync;
+const currentDirectory = path.dirname( fileURLToPath( import.meta.url ) );
+const fixturesPath = path.join( currentDirectory, 'fixtures' );
 const configFixtures = fs.readdirSync( fixturesPath ).sort();
 
-afterAll( () => rimraf( path.join( __dirname, 'build' ) ) );
+afterAll( () => rimrafSync( path.join( currentDirectory, 'build' ) ) );
+
+function expectCompilationError( stats ) {
+	expect( stats.hasErrors() ).toBe( true );
+	expect( stats.toString( { errors: true, all: false } ) ).toMatchSnapshot();
+}
 
 describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 	'DependencyExtractionWebpackPlugin %s',
@@ -19,19 +41,19 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 		describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 			const testDirectory = path.join( fixturesPath, configCase );
 			const outputDirectory = path.join(
-				__dirname,
+				currentDirectory,
 				'build',
 				moduleMode,
 				configCase
 			);
 
 			beforeEach( () => {
-				rimraf( outputDirectory );
-				mkdirp( outputDirectory );
+				rimrafSync( outputDirectory );
+				mkdirpSync( outputDirectory );
 			} );
 
 			// This afterEach is necessary to prevent watched tests from retriggering on every run.
-			afterEach( () => rimraf( outputDirectory ) );
+			afterEach( () => rimrafSync( outputDirectory ) );
 
 			test( 'should produce expected output', async () => {
 				const options = Object.assign(
@@ -72,15 +94,10 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 					} )
 				);
 
-				/* eslint-disable jest/no-conditional-expect */
 				if ( configCase.includes( 'error' ) ) {
-					expect( stats.hasErrors() ).toBe( true );
-					expect(
-						stats.toString( { errors: true, all: false } )
-					).toMatchSnapshot();
+					expectCompilationError( stats );
 					return;
 				}
-				/* eslint-enable jest/no-conditional-expect */
 
 				if ( stats.hasErrors() ) {
 					throw new Error(
@@ -139,7 +156,7 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 	( moduleMode ) => {
 		const fixtureDirectory = path.join( fixturesPath, 'style-cache-group' );
 		const workingDirectory = path.join(
-			__dirname,
+			currentDirectory,
 			'build',
 			moduleMode,
 			'style-cache-group-version'
@@ -147,8 +164,8 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 		const sourceDirectory = path.join( workingDirectory, 'src' );
 
 		beforeEach( () => {
-			rimraf( workingDirectory );
-			mkdirp( sourceDirectory );
+			rimrafSync( workingDirectory );
+			mkdirpSync( sourceDirectory );
 			for ( const file of [ 'index.js', 'style.css' ] ) {
 				fs.copyFileSync(
 					path.join( fixtureDirectory, file ),
@@ -157,7 +174,7 @@ describe.each( /** @type {const} */ ( [ 'scripts', 'modules' ] ) )(
 			}
 		} );
 
-		afterEach( () => rimraf( workingDirectory ) );
+		afterEach( () => rimrafSync( workingDirectory ) );
 
 		const build = async ( outputDirectory ) => {
 			const options = Object.assign(

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -1,11 +1,18 @@
 /**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
-const {
-	camelCaseDash,
-	defaultRequestToExternal,
-	defaultRequestToHandle,
-} = require( '../lib/util' );
+const { camelCaseDash, defaultRequestToExternal, defaultRequestToHandle } =
+	createRequire( import.meta.url )( '../lib/util' );
 
 describe( 'camelCaseDash', () => {
 	test( 'does not change a single word', () => {

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -85,6 +85,7 @@
 					"packages/block-serialization-spec-parser",
 					"packages/browserslist-config",
 					"packages/data-controls",
+					"packages/dependency-extraction-webpack-plugin",
 					"packages/design-system-mcp",
 					"packages/docgen",
 					"packages/eslint-plugin",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR — migration class:** Node build-tool tests, explicit Vitest imports, narrow CommonJS fixture boundaries, conditional-assertion cleanup, direct dependency ownership, and an individual 98-snapshot payload audit.

Migrates all 66 `@wordpress/dependency-extraction-webpack-plugin` unit/build tests from Jest to the Vitest Node project.

## Why?

This completes another published package's repository-owned test suite while keeping the migration independently revertible. These tests exercise webpack configurations and filesystem output, so the Node project is their canonical environment.

## How?

- converts both test modules to ESM and imports all Vitest APIs explicitly
- uses `createRequire(import.meta.url)` only where the tests load the package's published CommonJS implementation and CommonJS webpack fixtures
- replaces CommonJS imports of Node and compatible third-party utilities with ESM imports
- moves conditional compilation assertions into a helper and removes the Jest-specific lint suppression
- declares Vitest directly in the package workspace
- converts 98 snapshot headers/keys after verifying every ordered payload remains byte-for-byte unchanged
- leaves the plugin's published CommonJS contract and fixture behavior unchanged

## Testing Instructions

1. `npm run test:unit:vitest -- packages/dependency-extraction-webpack-plugin/test`
2. `npm run test:unit:routing`
3. `npm run test:unit:conventions`
4. `npm run test:unit -- --runInBand`
5. Stage this PR's files and run `npm exec lint-staged -- --no-stash`

Expected local results:

- Vitest: 2 files and 66 tests pass; 98 snapshots pass.
- Routing: exactly 491 Jest and 512 Vitest files.
- Conventions: 512 tests, 528 ESM graph files, 84 workspace dependencies, and 317 TypeScript tests pass validation.
- Remaining Jest: 490 suites / 25,972 tests / 112 snapshots pass. The nine `packages/env/lib/config/test/config-integration.js` tests fail only because the current WordPress version is unavailable in the offline local cache.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was authored with Codex assistance and reviewed through the focused build suite, routing/convention validators, ordered snapshot-payload comparison, remaining Jest partition, and strict staged checks.