### PR TITLE
Migrate Scripts Package Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52866,7 +52866,8 @@
 				"wp-scripts": "bin/wp-scripts.js"
 			},
 			"devDependencies": {
-				"rimraf": "^5.0.10"
+				"rimraf": "^5.0.10",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -89,7 +89,8 @@
 		"webpack-dev-server": "^5.2.1"
 	},
 	"devDependencies": {
-		"rimraf": "^5.0.10"
+		"rimraf": "^5.0.10",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@playwright/test": ">=1",

--- a/packages/scripts/scripts/test/__snapshots__/build-blocks-manifest.js.snap
+++ b/packages/scripts/scripts/test/__snapshots__/build-blocks-manifest.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`build-blocks-manifest script should generate expected blocks manifest 1`] = `
+exports[`build-blocks-manifest script > should generate expected blocks manifest 1`] = `
 "<?php
 // This file is generated. Do not modify it manually.
 return array(

--- a/packages/scripts/scripts/test/build-blocks-manifest.js
+++ b/packages/scripts/scripts/test/build-blocks-manifest.js
@@ -1,28 +1,36 @@
 /**
+ * Node dependencies
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-const fs = require( 'fs' );
-const path = require( 'path' );
-const { execSync } = require( 'child_process' );
-const rimraf = require( 'rimraf' ).sync;
+import { rimrafSync } from 'rimraf';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+const currentDirectory = path.dirname( fileURLToPath( import.meta.url ) );
 const fixturesPath = path.join(
-	__dirname,
+	currentDirectory,
 	'fixtures',
 	'build-blocks-manifest'
 );
-const outputPath = path.join( __dirname, 'build', 'test-blocks-manifest' );
+const outputPath = path.join(
+	currentDirectory,
+	'build',
+	'test-blocks-manifest'
+);
 
 describe( 'build-blocks-manifest script', () => {
 	beforeAll( () => {
-		if ( ! fs.existsSync( outputPath ) ) {
-			fs.mkdirSync( outputPath, { recursive: true } );
-		}
-		rimraf( outputPath );
+		rimrafSync( outputPath );
 	} );
 
 	afterAll( () => {
-		rimraf( outputPath );
+		rimrafSync( outputPath );
 	} );
 
 	it( 'should generate expected blocks manifest', () => {
@@ -31,13 +39,15 @@ describe( 'build-blocks-manifest script', () => {
 
 		// Run the build-blocks-manifest script
 		const scriptPath = path.resolve(
-			__dirname,
+			currentDirectory,
 			'..',
 			'build-blocks-manifest.js'
 		);
-		execSync(
-			`node ${ scriptPath } --input=${ inputDir } --output=${ outputFile }`
-		);
+		execFileSync( process.execPath, [
+			scriptPath,
+			`--input=${ inputDir }`,
+			`--output=${ outputFile }`,
+		] );
 
 		const generatedContent = fs.readFileSync( outputFile, 'utf8' );
 		expect( generatedContent ).toMatchSnapshot();
@@ -48,14 +58,19 @@ describe( 'build-blocks-manifest script', () => {
 		const outputFile = path.join( outputPath, 'empty-blocks-manifest.php' );
 
 		const scriptPath = path.resolve(
-			__dirname,
+			currentDirectory,
 			'..',
 			'build-blocks-manifest.js'
 		);
 		let error;
 		try {
-			execSync(
-				`node ${ scriptPath } --input=${ emptyInputDir } --output=${ outputFile }`,
+			execFileSync(
+				process.execPath,
+				[
+					scriptPath,
+					`--input=${ emptyInputDir }`,
+					`--output=${ outputFile }`,
+				],
 				{ encoding: 'utf8' }
 			);
 		} catch ( e ) {
@@ -77,14 +92,19 @@ describe( 'build-blocks-manifest script', () => {
 		const outputFile = path.join( outputPath, 'empty-blocks-manifest.php' );
 
 		const scriptPath = path.resolve(
-			__dirname,
+			currentDirectory,
 			'..',
 			'build-blocks-manifest.js'
 		);
 		let error;
 		try {
-			execSync(
-				`node ${ scriptPath } --input=${ nonExistentInputDir } --output=${ outputFile }`,
+			execFileSync(
+				process.execPath,
+				[
+					scriptPath,
+					`--input=${ nonExistentInputDir }`,
+					`--output=${ outputFile }`,
+				],
 				{ encoding: 'utf8' }
 			);
 		} catch ( e ) {

--- a/packages/scripts/utils/test/index.js
+++ b/packages/scripts/utils/test/index.js
@@ -1,60 +1,51 @@
 /**
- * External dependencies
+ * Node dependencies
  */
-import crossSpawn from 'cross-spawn';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
- * Internal dependencies
+ * External dependencies
  */
 import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	test,
+	vi,
+} from 'vitest';
+
+const require = createRequire( import.meta.url );
+const currentDirectory = path.dirname( fileURLToPath( import.meta.url ) );
+const crossSpawn = require( 'cross-spawn' );
+const processUtils = require( '../process' );
+const getArgsFromCLIMock = vi.spyOn( processUtils, 'getArgsFromCLI' );
+const exitMock = vi.spyOn( processUtils, 'exit' );
+const packageUtils = require( '../package' );
+const getPackagePathMock = vi.spyOn( packageUtils, 'getPackagePath' );
+const hasPackagePropMock = vi.spyOn( packageUtils, 'hasPackageProp' );
+const fileUtils = require( '../file' );
+const hasProjectFileMock = vi.spyOn( fileUtils, 'hasProjectFile' );
+const fromProjectRootMock = vi.spyOn( fileUtils, 'fromProjectRoot' );
+const fromConfigRootMock = vi.spyOn( fileUtils, 'fromConfigRoot' );
+const crossSpawnMock = vi.spyOn( crossSpawn, 'sync' );
+const {
 	hasArgInCLI,
 	hasProjectFile,
 	getJestOverrideConfigFile,
 	spawnScript,
-} from '../';
-import {
-	getPackagePath as getPackagePathMock,
-	hasPackageProp as hasPackagePropMock,
-} from '../package';
-import {
-	exit as exitMock,
-	getArgsFromCLI as getArgsFromCLIMock,
-} from '../process';
-import {
-	hasProjectFile as hasProjectFileMock,
-	fromProjectRoot as fromProjectRootMock,
-	fromConfigRoot as fromConfigRootMock,
-} from '../file';
+} = require( '../' );
 
-jest.mock( '../package', () => {
-	const module = jest.requireActual( '../package' );
-
-	jest.spyOn( module, 'getPackagePath' );
-	jest.spyOn( module, 'hasPackageProp' );
-
-	return module;
-} );
-jest.mock( '../process', () => {
-	const module = jest.requireActual( '../process' );
-
-	jest.spyOn( module, 'exit' );
-	jest.spyOn( module, 'getArgsFromCLI' );
-
-	return module;
-} );
-jest.mock( '../file', () => {
-	const module = jest.requireActual( '../file' );
-
-	jest.spyOn( module, 'hasProjectFile' );
-	jest.spyOn( module, 'fromProjectRoot' );
-	jest.spyOn( module, 'fromConfigRoot' );
-
-	return module;
+afterAll( () => {
+	vi.restoreAllMocks();
 } );
 
 describe( 'utils', () => {
-	const crossSpawnMock = jest.spyOn( crossSpawn, 'sync' );
-
 	describe( 'hasArgInCLI', () => {
 		beforeAll( () => {
 			getArgsFromCLIMock.mockReturnValue( [
@@ -87,13 +78,13 @@ describe( 'utils', () => {
 
 	describe( 'hasProjectFile', () => {
 		test( 'should return false for the current directory and unknown file', () => {
-			getPackagePathMock.mockReturnValueOnce( __dirname );
+			getPackagePathMock.mockReturnValueOnce( currentDirectory );
 
 			expect( hasProjectFile( 'unknown-file.name' ) ).toBe( false );
 		} );
 
 		test( 'should return true for the current directory and this file', () => {
-			getPackagePathMock.mockReturnValueOnce( __dirname );
+			getPackagePathMock.mockReturnValueOnce( currentDirectory );
 
 			expect( hasProjectFile( 'index.js' ) ).toBe( true );
 		} );
@@ -104,8 +95,12 @@ describe( 'utils', () => {
 			getArgsFromCLIMock.mockReturnValue( [] );
 			hasPackagePropMock.mockReturnValue( false );
 			hasProjectFileMock.mockReturnValue( false );
-			fromProjectRootMock.mockImplementation( ( path ) => '/p/' + path );
-			fromConfigRootMock.mockImplementation( ( path ) => '/c/' + path );
+			fromProjectRootMock.mockImplementation(
+				( filePath ) => '/p/' + filePath
+			);
+			fromConfigRootMock.mockImplementation(
+				( filePath ) => '/c/' + filePath
+			);
 		} );
 
 		afterEach( () => {

--- a/packages/scripts/utils/test/license.js
+++ b/packages/scripts/utils/test/license.js
@@ -1,20 +1,33 @@
 /**
+ * Node dependencies
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-const fs = require( 'fs' );
-const path = require( 'path' );
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
-import { detectTypeFromLicenseText, checkAllCompatible } from '../license';
+const { detectTypeFromLicenseText, checkAllCompatible } = createRequire(
+	import.meta.url
+)( '../license' );
+
+const currentDirectory = path.dirname( fileURLToPath( import.meta.url ) );
 
 describe( 'detectTypeFromLicenseText', () => {
 	let licenseText;
 
 	it( "should return 'Apache 2.0' when the license text is the Apache 2.0 license", () => {
 		licenseText = fs
-			.readFileSync( path.resolve( __dirname, 'licenses/apache2.txt' ) )
+			.readFileSync(
+				path.resolve( currentDirectory, 'licenses/apache2.txt' )
+			)
 			.toString();
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'Apache-2.0' );
@@ -23,7 +36,7 @@ describe( 'detectTypeFromLicenseText', () => {
 	it( "should return 'BSD' when the license text is the BSD 3-clause license", () => {
 		licenseText = fs
 			.readFileSync(
-				path.resolve( __dirname, 'licenses/bsd3clause.txt' )
+				path.resolve( currentDirectory, 'licenses/bsd3clause.txt' )
 			)
 			.toString();
 
@@ -32,7 +45,9 @@ describe( 'detectTypeFromLicenseText', () => {
 
 	it( "should return 'BSD-3-Clause-W3C' when the license text is the W3C variation of the BSD 3-clause license", () => {
 		licenseText = fs
-			.readFileSync( path.resolve( __dirname, 'licenses/w3cbsd.txt' ) )
+			.readFileSync(
+				path.resolve( currentDirectory, 'licenses/w3cbsd.txt' )
+			)
 			.toString();
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe(
@@ -42,7 +57,9 @@ describe( 'detectTypeFromLicenseText', () => {
 
 	it( "should return 'MIT' when the license text is the MIT license", () => {
 		licenseText = fs
-			.readFileSync( path.resolve( __dirname, 'licenses/mit.txt' ) )
+			.readFileSync(
+				path.resolve( currentDirectory, 'licenses/mit.txt' )
+			)
 			.toString();
 
 		expect( detectTypeFromLicenseText( licenseText ) ).toBe( 'MIT' );
@@ -51,7 +68,7 @@ describe( 'detectTypeFromLicenseText', () => {
 	it( "should return 'Apache2 AND MIT' when the license text is Apache2 followed by MIT license", () => {
 		licenseText = fs
 			.readFileSync(
-				path.resolve( __dirname, 'licenses/apache2-mit.txt' )
+				path.resolve( currentDirectory, 'licenses/apache2-mit.txt' )
 			)
 			.toString();
 

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -97,6 +97,7 @@
 					"packages/project-management-automation",
 					"packages/readable-js-assets-webpack-plugin",
 					"packages/redux-routine",
+					"packages/scripts",
 					"packages/stylelint-config",
 					"packages/video-conversion",
 					"packages/vips",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -110,10 +110,8 @@ export default defineConfig( {
 			filter: ( id ) =>
 				[
 					`${ ROOT_DIR }/packages/env/lib/`,
-					`${ ROOT_DIR }/packages/scripts/utils/`,
 					`${ ROOT_DIR }/tools/release/commands/changelog.js`,
-				].some( ( directory ) => id.startsWith( directory ) ) &&
-				! id.endsWith( '/packages/scripts/utils/license.js' ),
+				].some( ( directory ) => id.startsWith( directory ) ),
 		} ),
 	],
 	resolve: {
@@ -265,10 +263,16 @@ export default defineConfig( {
 					name: 'node',
 					environment: 'node',
 					include: vitestTests.node,
-					setupFiles: path.join(
-						ROOT_DIR,
-						'test/unit/config/gutenberg-env.js'
-					),
+					setupFiles: [
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/gutenberg-env.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/console.vitest.js'
+						),
+					],
 				},
 			},
 		],


### PR DESCRIPTION
## What?

See #80855.

**TL;DR — migration class:** Node CLI/build tests, native CommonJS boundaries, shared Node console parity, explicit Vitest imports, safer subprocess invocation, direct dependency ownership, and a one-snapshot audit.

Migrates all 32 remaining `@wordpress/scripts` package tests from Jest to the Vitest Node project and removes `packages/scripts/utils` from Vitest's CommonJS conversion filter.

## Why?

This completes the package's repository-owned tests and removes a concrete legacy transform exception without changing the published package format or current `wp-scripts test-unit-js` behavior.

## How?

- converts the three test modules to ESM with explicit Vitest imports
- loads the package's published CommonJS modules through narrow `createRequire(import.meta.url)` boundaries
- replaces Jest's partial-module mocks with spies installed in Node's CommonJS cache before the modules under test load
- adds the shared Vitest console setup to the Node project, preserving custom console matchers and fail-on-unexpected-console behavior for all Node tests
- replaces shell-string execution in the blocks-manifest test with `execFileSync(process.execPath, args)`
- declares Vitest directly in the package workspace
- removes the package-specific `vite-plugin-commonjs` filter entry
- converts the external snapshot header/key after confirming its payload is unchanged

The package's Jest dependencies and Jest-config discovery behavior remain intentional published compatibility. Changing the `wp-scripts` default and retiring those dependencies remains reserved for the explicit tooling major tracked in #80855.

## Testing Instructions

1. `npm run test:unit:vitest -- packages/scripts/scripts/test/build-blocks-manifest.js packages/scripts/utils/test/index.js packages/scripts/utils/test/license.js`
2. `npm run test:unit:vitest -- --project node`
3. `npm run test:unit:routing`
4. `npm run test:unit:conventions`
5. `npm run test:unit -- --runInBand`
6. Stage this PR's files and run `npm exec lint-staged -- --no-stash`

Expected local results:

- Focused Vitest: 3 files and 32 tests pass; 1 snapshot passes.
- Full Node project: 109 files and 1,396 tests pass with console enforcement active.
- Routing: exactly 488 Jest and 515 Vitest files.
- Conventions: 515 tests, 531 ESM graph files, 85 workspace dependencies, and 317 TypeScript tests pass validation.
- Remaining Jest: 487 suites / 25,940 tests / 111 snapshots pass. The nine `packages/env/lib/config/test/config-integration.js` tests fail only because the current WordPress version is unavailable in the offline local cache.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was authored with Codex assistance and reviewed through the focused package suite, full Node project, routing/convention validators, snapshot comparison, remaining Jest partition, and strict staged checks.