### PR TITLE
Custom HTML: show placeholder when block renders no visible HTML content

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   Custom HTML: Show a named placeholder when the block contains only JavaScript or CSS, preventing it from collapsing to zero height in the editor ([#80934](https://github.com/WordPress/gutenberg/pull/80934)).
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
 
 ### Internal

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -136,10 +136,10 @@ export default function HTMLEdit( { clientId, attributes } ) {
 		);
 	}
 
-	// When the block contains only JavaScript or CSS, both stripped by
-	// `safeHTML` before canvas injection, `InnerContent` collapses to zero
-	// height, making the block invisible. Show a named placeholder instead so
-	// editors always see something on the canvas and can reach the modal.
+	// Scripts and Styles get stripped before canvas injection, which
+	// leaves the InnerContent empty and the block becomes invisible.
+	// Show a named placeholder instead, so it's always visible and the
+	// modal stays reachable.
 	const { html: visibleHtml } = parseContent( content );
 	if ( ! visibleHtml ) {
 		return (
@@ -159,7 +159,7 @@ export default function HTMLEdit( { clientId, attributes } ) {
 							variant="secondary"
 							onClick={ () => setIsModalOpen( true ) }
 						>
-							{ __( 'Edit code' ) }
+							{ __( 'Show code' ) }
 						</Button>
 					</VStack>
 				</InspectorControls>

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -159,7 +159,7 @@ export default function HTMLEdit( { clientId, attributes } ) {
 							variant="secondary"
 							onClick={ () => setIsModalOpen( true ) }
 						>
-							{ __( 'Show code' ) }
+							{ __( 'Edit code' ) }
 						</Button>
 					</VStack>
 				</InspectorControls>
@@ -175,7 +175,7 @@ export default function HTMLEdit( { clientId, attributes } ) {
 						variant="primary"
 						onClick={ () => setIsModalOpen( true ) }
 					>
-						{ __( 'Edit code' ) }
+						{ __( 'Show code' ) }
 					</Button>
 				</Placeholder>
 				{ isModalOpen && (

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -28,6 +28,7 @@ import { code } from '@wordpress/icons';
  */
 import { unlock } from '../lock-unlock';
 import HTMLEditModal from './modal';
+import { parseContent } from './utils';
 
 const { InnerContent } = unlock( blockEditorPrivateApis );
 
@@ -122,6 +123,59 @@ export default function HTMLEdit( { clientId, attributes } ) {
 						onClick={ () => setIsModalOpen( true ) }
 					>
 						{ __( 'Edit HTML' ) }
+					</Button>
+				</Placeholder>
+				{ isModalOpen && (
+					<HTMLEditModal
+						onRequestClose={ () => setIsModalOpen( false ) }
+						content={ content }
+						onUpdate={ onUpdate }
+					/>
+				) }
+			</div>
+		);
+	}
+
+	// When the block contains only JavaScript or CSS — both stripped by
+	// `safeHTML` before canvas injection — `InnerContent` collapses to zero
+	// height, making the block invisible. Show a named placeholder instead so
+	// editors always see something on the canvas and can reach the modal.
+	const { html: visibleHtml } = parseContent( content );
+	if ( ! visibleHtml ) {
+		return (
+			<div { ...blockProps }>
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton onClick={ () => setIsModalOpen( true ) }>
+							{ __( 'Edit code' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+				<InspectorControls>
+					<VStack className="block-library-html__edit-code" expanded>
+						<Button
+							className="block-library-html__edit-code-button"
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => setIsModalOpen( true ) }
+						>
+							{ __( 'Edit code' ) }
+						</Button>
+					</VStack>
+				</InspectorControls>
+				<Placeholder
+					icon={ <BlockIcon icon={ code } /> }
+					label={ __( 'Custom HTML' ) }
+					instructions={ __(
+						'This block contains JavaScript or CSS that cannot be previewed in the editor.'
+					) }
+				>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						onClick={ () => setIsModalOpen( true ) }
+					>
+						{ __( 'Edit code' ) }
 					</Button>
 				</Placeholder>
 				{ isModalOpen && (

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -136,8 +136,8 @@ export default function HTMLEdit( { clientId, attributes } ) {
 		);
 	}
 
-	// When the block contains only JavaScript or CSS — both stripped by
-	// `safeHTML` before canvas injection — `InnerContent` collapses to zero
+	// When the block contains only JavaScript or CSS, both stripped by
+	// `safeHTML` before canvas injection, `InnerContent` collapses to zero
 	// height, making the block invisible. Show a named placeholder instead so
 	// editors always see something on the canvas and can reach the modal.
 	const { html: visibleHtml } = parseContent( content );

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -106,7 +106,7 @@ export default function HTMLEdit( { clientId, attributes } ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ attributes.content ] );
 
-	// Show placeholder when content is empty
+	// Show placeholder when content is empty.
 	if ( ! content?.trim() ) {
 		return (
 			<div { ...blockProps }>


### PR DESCRIPTION

## What?

Closes https://github.com/WordPress/gutenberg/issues/80843

When a Custom HTML block contains only JavaScript or CSS, with no visible HTML markup, and the editor canvas collapses the block to zero height. The block saves and renders correctly on the frontend, but is completely invisible in the editor: only a detached toolbar badge indicates it exists. Multiple such blocks on a page produce a blank editing experience.

## Why?


The redesign stores JS as <script data-wp-block-html="js"> and CSS as <style data-wp-block-html="css"> inside the block's inner content. When painting the canvas, InnerContent passes all markup, which strips <script> tags. A JS-only block then has nothing to inject into the DOM, gets a height of zero, and collapses silently.


## How?

Adds a new early-return branch in HTMLEdit between the existing empty-content check and the normal InnerContent render:

- After confirming the block has content, call `parseContent(content)`.
- If the html field is empty (all content is JS/CSS), render a named Placeholder instead of <InnerContent>. The Placeholder shows the block icon, a clear message ("This block contains JavaScript or CSS that cannot be previewed in the editor."), and an "Edit code" CTA.
- BlockControls and InspectorControls are preserved in this branch so the toolbar and sidebar panel remain fully reachable, consistent with the existing non-empty path.

The block content is not modified. Only the editor-side visual representation changes.


### Testing Instructions

- Add a Custom HTML block.
- Open the modal → JavaScript tab → enter any JS (e.g. console.log('hello')).
- Click Update.
- Verify: the block is visible on the canvas as a Placeholder with label and "Edit code" button (previously: invisible).
- Click the canvas Placeholder's "Edit code" button → modal opens with JS content intact.
- Add some HTML in the HTML tab as well → verify the block switches back to the live InnerContent preview path (Placeholder disappears).
- Verify the frontend still renders correctly (JS runs on the published page).


## Screenshots or screencast <!-- if applicable -->



### Before 




https://github.com/user-attachments/assets/0a870713-a190-4e3a-8818-ad64507baa38




### After 





https://github.com/user-attachments/assets/a8e9785a-931e-4d2a-8e3c-8669c53af37f





https://github.com/user-attachments/assets/27695f02-f4f3-4f1f-9488-b6bbc037708c



