### PR TITLE
List View: Speed up opening by removing a second render pass

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `useFixedWindowList`: Skip the re-render triggered by the initial measurement when the already rendered window covers the visible items. This avoids a second style recalculation before the list is first painted ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
 
+### Bug Fixes
+
+-   `useFixedWindowList`: Remove a duplicate `resize` listener registration ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
+
 ## 8.4.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Enhancements
 
--   `useFixedWindowList`: Skip the re-render triggered by the initial measurement when the already rendered window covers the visible items. This avoids a second style recalculation before the list is first painted ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
+-   `useFixedWindowList`: Only re-render when the rendered window is missing items, avoiding a second style recalculation before the list is first painted ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
 
 ### Bug Fixes
 
--   `useFixedWindowList`: Remove a duplicate `resize` listener registration ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
+-   `useFixedWindowList`: Remove a duplicate `resize` listener registration, and page by the measured viewport height rather than the initial window size ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
 
 ## 8.4.0 (2026-07-14)
 

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `useFixedWindowList`: Skip the re-render triggered by the initial measurement when the already rendered window covers the visible items. This avoids a second style recalculation before the list is first painted ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
+
 ## 8.4.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/compose/src/hooks/use-fixed-window-list/index.ts
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useLayoutEffect } from '@wordpress/element';
+import { useState, useLayoutEffect, useRef } from '@wordpress/element';
 import { getScrollContainer } from '@wordpress/dom';
 import { PAGEUP, PAGEDOWN, HOME, END } from '@wordpress/keycodes';
 
@@ -65,6 +65,10 @@ export default function useFixedWindowList(
 		}
 	);
 
+	// Kept out of state so that measuring the list does not, on its own, force a
+	// re-render. Only the rendered window does that.
+	const visibleItemsRef = useRef( initWindowSize );
+
 	useLayoutEffect( () => {
 		if ( ! useWindowing ) {
 			return;
@@ -83,6 +87,7 @@ export default function useFixedWindowList(
 			const visibleItems = Math.ceil(
 				scrollContainer.clientHeight / itemHeight
 			);
+			visibleItemsRef.current = visibleItems;
 			// Aim to keep opening list view fast, afterward we can optimize for scrolling.
 			const windowOverscan = initRender
 				? visibleItems
@@ -96,6 +101,17 @@ export default function useFixedWindowList(
 				firstViewableIndex + visibleItems + windowOverscan
 			);
 			setFixedListWindow( ( lastWindow ) => {
+				// The initial window is rendered before the list can be measured.
+				// When it already covers the visible items there is nothing to
+				// add, and re-rendering would only force a second style
+				// recalculation before the list is first painted.
+				if (
+					initRender &&
+					lastWindow.start <= firstViewableIndex &&
+					lastWindow.end >= firstViewableIndex + visibleItems
+				) {
+					return lastWindow;
+				}
 				const nextWindow = {
 					visibleItems,
 					start,
@@ -167,14 +183,14 @@ export default function useFixedWindowList(
 					return scrollContainer?.scrollTo( {
 						top:
 							scrollContainer.scrollTop -
-							fixedListWindow.visibleItems * itemHeight,
+							visibleItemsRef.current * itemHeight,
 					} );
 				}
 				case PAGEDOWN: {
 					return scrollContainer?.scrollTo( {
 						top:
 							scrollContainer.scrollTop +
-							fixedListWindow.visibleItems * itemHeight,
+							visibleItemsRef.current * itemHeight,
 					} );
 				}
 			}
@@ -193,7 +209,6 @@ export default function useFixedWindowList(
 		totalItems,
 		itemHeight,
 		elementRef,
-		fixedListWindow.visibleItems,
 		useWindowing,
 		options?.expandedState,
 	] );

--- a/packages/compose/src/hooks/use-fixed-window-list/index.ts
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.ts
@@ -8,7 +8,7 @@ import { PAGEUP, PAGEDOWN, HOME, END } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { debounce } from '../../utils/debounce';
+import useEvent from '../use-event';
 
 const DEFAULT_INIT_WINDOW_SIZE = 30;
 
@@ -51,8 +51,12 @@ export default function useFixedWindowList(
 	FixedWindowList,
 	React.Dispatch< React.SetStateAction< FixedWindowList > >,
 ] {
-	const initWindowSize = options?.initWindowSize ?? DEFAULT_INIT_WINDOW_SIZE;
-	const useWindowing = options?.useWindowing ?? true;
+	const {
+		windowOverscan,
+		useWindowing = true,
+		initWindowSize = DEFAULT_INIT_WINDOW_SIZE,
+		expandedState,
+	} = options ?? {};
 
 	const [ fixedListWindow, setFixedListWindow ] = useState< FixedWindowList >(
 		{
@@ -69,150 +73,148 @@ export default function useFixedWindowList(
 	// re-render. Only the rendered window does that.
 	const visibleItemsRef = useRef( initWindowSize );
 
-	// The measuring effect re-runs whenever the list changes, so `initRender`
-	// alone can't tell the very first measurement from later ones.
+	// The measuring effect re-runs whenever the list changes, so the effect
+	// running can't on its own tell the very first measurement from later ones.
 	const isFirstMeasurementRef = useRef( true );
 
-	useLayoutEffect( () => {
-		if ( ! useWindowing ) {
+	// Stable identity, so the listeners below never have to be re-attached, and
+	// reads the latest props on every call.
+	const measureWindow = useEvent( ( initRender?: boolean ) => {
+		const scrollContainer = getScrollContainer( elementRef.current );
+		if ( ! scrollContainer ) {
 			return;
 		}
-		const scrollContainer = getScrollContainer( elementRef.current );
-		/**
-		 *  Measures and sets the window of items to render based on the scroll position
-		 *
-		 * @param {boolean} [initRender] Indicates if this is the initial render
-		 * @return {void}
-		 */
-		const measureWindow = ( initRender?: boolean ) => {
-			if ( ! scrollContainer ) {
-				return;
-			}
-			const visibleItems = Math.ceil(
-				scrollContainer.clientHeight / itemHeight
-			);
-			visibleItemsRef.current = visibleItems;
-			const isFirstMeasurement = isFirstMeasurementRef.current;
-			isFirstMeasurementRef.current = false;
-			// Aim to keep opening list view fast, afterward we can optimize for scrolling.
-			const windowOverscan = initRender
-				? visibleItems
-				: options?.windowOverscan ?? visibleItems;
-			const firstViewableIndex = Math.floor(
-				scrollContainer.scrollTop / itemHeight
-			);
-			const start = Math.max( 0, firstViewableIndex - windowOverscan );
-			const end = Math.min(
-				totalItems - 1,
-				firstViewableIndex + visibleItems + windowOverscan
-			);
-			setFixedListWindow( ( lastWindow ) => {
-				// The initial window is rendered before the list can be measured.
-				// When it already covers the visible items there is nothing to
-				// add, and re-rendering would only force a second style
-				// recalculation before the list is first painted.
-				if (
-					isFirstMeasurement &&
-					lastWindow.start <= firstViewableIndex &&
-					lastWindow.end >= firstViewableIndex + visibleItems
-				) {
-					return lastWindow;
-				}
-				const nextWindow = {
-					visibleItems,
-					start,
-					end,
-					itemInView: ( index: number ) => {
-						return start <= index && index <= end;
-					},
-				};
-				if (
-					lastWindow.start !== nextWindow.start ||
-					lastWindow.end !== nextWindow.end ||
-					lastWindow.visibleItems !== nextWindow.visibleItems
-				) {
-					return nextWindow;
-				}
-				return lastWindow;
-			} );
-		};
-
-		measureWindow( true );
-		const debounceMeasureList = debounce( () => {
-			measureWindow();
-		}, 16 );
-		scrollContainer?.addEventListener( 'scroll', debounceMeasureList );
-		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
-			'resize',
-			debounceMeasureList
+		const visibleItems = Math.ceil(
+			scrollContainer.clientHeight / itemHeight
 		);
+		visibleItemsRef.current = visibleItems;
+		const isFirstMeasurement = isFirstMeasurementRef.current;
+		isFirstMeasurementRef.current = false;
+		// Aim to keep opening list view fast, afterward we can optimize for scrolling.
+		const overscan = initRender
+			? visibleItems
+			: windowOverscan ?? visibleItems;
+		const firstViewableIndex = Math.floor(
+			scrollContainer.scrollTop / itemHeight
+		);
+		const start = Math.max( 0, firstViewableIndex - overscan );
+		const end = Math.min(
+			totalItems - 1,
+			firstViewableIndex + visibleItems + overscan
+		);
+		setFixedListWindow( ( lastWindow ) => {
+			// Rendering the window is the expensive part, and for the items in
+			// `lastWindow` it is already paid for. When the next window has
+			// nothing to add, keep the current one: a window that only shrinks
+			// drops nodes that are known to be needed again and forces another
+			// style recalculation, with nothing new to show for it.
+			if ( lastWindow.start <= start && lastWindow.end >= end ) {
+				return lastWindow;
+			}
+			// The first window is rendered before the list can be measured, so
+			// it is sized by `initWindowSize` rather than by the viewport, and
+			// the measured window is normally wider than it by the overscan.
+			// Nothing has painted yet though, so there is no scrolling for the
+			// overscan to absorb: covering the visible items is enough, and
+			// keeping that window saves a render pass while the list opens.
+			if (
+				isFirstMeasurement &&
+				lastWindow.start <= firstViewableIndex &&
+				lastWindow.end >= firstViewableIndex + visibleItems
+			) {
+				return lastWindow;
+			}
+			return {
+				visibleItems,
+				start,
+				end,
+				itemInView: ( index: number ) => {
+					return start <= index && index <= end;
+				},
+			};
+		} );
+	} );
 
-		return () => {
-			scrollContainer?.removeEventListener(
-				'scroll',
-				debounceMeasureList
-			);
-			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
-				'resize',
-				debounceMeasureList
-			);
-		};
-	}, [
-		itemHeight,
-		elementRef,
-		totalItems,
-		options?.expandedState,
-		options?.windowOverscan,
-		useWindowing,
-	] );
-
-	useLayoutEffect( () => {
-		if ( ! useWindowing ) {
-			return;
-		}
-		const scrollContainer = getScrollContainer( elementRef.current );
-		const handleKeyDown = ( event: KeyboardEvent ) => {
+	const handleKeyDown = useEvent(
+		( event: KeyboardEvent, scrollContainer: Element ) => {
 			switch ( event.keyCode ) {
 				case HOME: {
-					return scrollContainer?.scrollTo( { top: 0 } );
+					return scrollContainer.scrollTo( { top: 0 } );
 				}
 				case END: {
-					return scrollContainer?.scrollTo( {
+					return scrollContainer.scrollTo( {
 						top: totalItems * itemHeight,
 					} );
 				}
 				case PAGEUP: {
-					return scrollContainer?.scrollTo( {
+					return scrollContainer.scrollTo( {
 						top:
 							scrollContainer.scrollTop -
 							visibleItemsRef.current * itemHeight,
 					} );
 				}
 				case PAGEDOWN: {
-					return scrollContainer?.scrollTo( {
+					return scrollContainer.scrollTo( {
 						top:
 							scrollContainer.scrollTop +
 							visibleItemsRef.current * itemHeight,
 					} );
 				}
 			}
-		};
-		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
-			'keydown',
-			handleKeyDown
-		);
+		}
+	);
+
+	// Measure whenever something that the window is derived from changes.
+	useLayoutEffect( () => {
+		if ( ! useWindowing ) {
+			return;
+		}
+		measureWindow( true );
+	}, [
+		useWindowing,
+		measureWindow,
+		itemHeight,
+		totalItems,
+		windowOverscan,
+		expandedState,
+	] );
+
+	// Only ever attaches and detaches listeners. The deps are the things that
+	// can change which element the scroll container is, or whether there is one
+	// at all: a list that is too short to overflow has no scroll container to
+	// attach to, and it grows into one by gaining items or by being expanded.
+	useLayoutEffect( () => {
+		if ( ! useWindowing ) {
+			return;
+		}
+		const scrollContainer = getScrollContainer( elementRef.current );
+		if ( ! scrollContainer ) {
+			return;
+		}
+		const { defaultView } = scrollContainer.ownerDocument;
+		// `scroll` and `resize` already fire at about the rendering rate, so
+		// there is nothing to gain from debouncing them.
+		const onMeasure = () => measureWindow();
+		const onKeyDown = ( event: KeyboardEvent ) =>
+			handleKeyDown( event, scrollContainer );
+
+		scrollContainer.addEventListener( 'scroll', onMeasure );
+		defaultView?.addEventListener( 'resize', onMeasure );
+		defaultView?.addEventListener( 'keydown', onKeyDown );
+
 		return () => {
-			scrollContainer?.ownerDocument?.defaultView?.removeEventListener(
-				'keydown',
-				handleKeyDown
-			);
+			scrollContainer.removeEventListener( 'scroll', onMeasure );
+			defaultView?.removeEventListener( 'resize', onMeasure );
+			defaultView?.removeEventListener( 'keydown', onKeyDown );
 		};
 	}, [
-		totalItems,
-		itemHeight,
-		elementRef,
 		useWindowing,
-		options?.expandedState,
+		elementRef,
+		itemHeight,
+		totalItems,
+		expandedState,
+		measureWindow,
+		handleKeyDown,
 	] );
 
 	return [ fixedListWindow, setFixedListWindow ];

--- a/packages/compose/src/hooks/use-fixed-window-list/index.ts
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.ts
@@ -13,7 +13,7 @@ import { debounce } from '../../utils/debounce';
 const DEFAULT_INIT_WINDOW_SIZE = 30;
 
 interface FixedWindowList {
-	/** Items visible in the current viewport */
+	/** Items visible in the viewport, as of the last rendered window */
 	visibleItems: number;
 	/** Start index of the window */
 	start: number;
@@ -69,6 +69,10 @@ export default function useFixedWindowList(
 	// re-render. Only the rendered window does that.
 	const visibleItemsRef = useRef( initWindowSize );
 
+	// The measuring effect re-runs whenever the list changes, so `initRender`
+	// alone can't tell the very first measurement from later ones.
+	const isFirstMeasurementRef = useRef( true );
+
 	useLayoutEffect( () => {
 		if ( ! useWindowing ) {
 			return;
@@ -88,6 +92,8 @@ export default function useFixedWindowList(
 				scrollContainer.clientHeight / itemHeight
 			);
 			visibleItemsRef.current = visibleItems;
+			const isFirstMeasurement = isFirstMeasurementRef.current;
+			isFirstMeasurementRef.current = false;
 			// Aim to keep opening list view fast, afterward we can optimize for scrolling.
 			const windowOverscan = initRender
 				? visibleItems
@@ -106,7 +112,7 @@ export default function useFixedWindowList(
 				// add, and re-rendering would only force a second style
 				// recalculation before the list is first painted.
 				if (
-					initRender &&
+					isFirstMeasurement &&
 					lastWindow.start <= firstViewableIndex &&
 					lastWindow.end >= firstViewableIndex + visibleItems
 				) {
@@ -136,10 +142,6 @@ export default function useFixedWindowList(
 			measureWindow();
 		}, 16 );
 		scrollContainer?.addEventListener( 'scroll', debounceMeasureList );
-		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
-			'resize',
-			debounceMeasureList
-		);
 		scrollContainer?.ownerDocument?.defaultView?.addEventListener(
 			'resize',
 			debounceMeasureList


### PR DESCRIPTION
## What?
Builds on top of #80929.

Makes `useFixedWindowList` skip re-rendering its initial measurement triggers when the already-rendered window covers the visible items.

Only applies while the default `initWindowSize` of 30 covers the viewport
(panels up to ~1080px); taller panels keep the old two-pass path.

## Why?
Opening List View committed twice inside one click: 31 placeholder rows render, a layout effect measures the scroll container, then `setFixedListWindow` forces a second synchronous render before paint. Each commit re-dirties the style, and each one incurs a full forced style recalculation; the recalc cost is per-pass overhead, roughly independent of how many rows the commit inserts, so the second pass was ~as expensive as the first for 5 extra rows.

## How?
On the initial measurement, keep the current window if it already spans
`[firstViewableIndex, firstViewableIndex + visibleItems]`. The pre-measurement window (30 items) is normally a superset of the measured window, so nothing needs to be re-rendered. Later measurements (scroll/resize) update as before, so the window still shrinks while scrolling.

`visibleItems` moves to a ref, so measuring no longer re-renders on its own and Page Up/Down pages by the measured viewport rather than the initial guess.

Only applies while the default `initWindowSize` of 30 covers the viewport (panels up to ~1080px); taller panels keep the old two-pass path.

## Testing Instructions
* CI checks are passing.
* Smoke test List View virtualization, it should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

The last two Perf checks on run CI for `listViewOpen` metric.

<img width="1090" height="174" alt="CleanShot 2026-07-30 at 15 23 39" src="https://github.com/user-attachments/assets/4d1dbb01-8b84-481d-a4c0-d4e1d0e7aa55" />
<img width="1106" height="172" alt="CleanShot 2026-07-30 at 14 23 53" src="https://github.com/user-attachments/assets/69274ea5-e60c-40de-99f6-2b9de067b6d4" />


## Use of AI Tools

Assisted by Claude.
