### PR TITLE
Migrate Release Tools Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54817,6 +54817,9 @@
 				"simple-git": "^3.32.3",
 				"sprintf-js": "^1.1.1"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"bin": {
 				"release-cli": "cli.js"
 			}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -103,7 +103,8 @@
 					"packages/vips",
 					"packages/views",
 					"packages/worker-threads",
-					"packages/wp-build"
+					"packages/wp-build",
+					"tools/release"
 				]
 			}
 		}

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -108,10 +108,7 @@ export default defineConfig( {
 		wordpressBabelTransform(),
 		commonjs( {
 			filter: ( id ) =>
-				[
-					`${ ROOT_DIR }/packages/env/lib/`,
-					`${ ROOT_DIR }/tools/release/commands/changelog.js`,
-				].some( ( directory ) => id.startsWith( directory ) ),
+				id.startsWith( `${ ROOT_DIR }/packages/env/lib/` ),
 		} ),
 	],
 	resolve: {

--- a/tools/release/commands/test/__snapshots__/changelog.js.snap
+++ b/tools/release/commands/test/__snapshots__/changelog.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`getChangelog verify that the changelog is properly formatted 1`] = `
+exports[`getChangelog > verify that the changelog is properly formatted 1`] = `
 "## Changelog
 
 ### Features
@@ -287,7 +287,7 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 "
 `;
 
-exports[`getContributorList verify that the contributors list is properly formatted 1`] = `
+exports[`getContributorList > verify that the contributors list is properly formatted 1`] = `
 "
 
 ## Contributors
@@ -297,7 +297,7 @@ The following contributors merged PRs in this release:
 @aaronrobertshaw @adamsilverstein @alexstine @andrewhayward @andrewserong @annezazu @anton-vlasenko @artemiomorales @aurooba @bangank36 @brookewp @c4rl0sbr4v0 @carolinan @chad1008 @ciampo @dcalhoun @derekblank @draganescu @ellatrix @fluiddot @fullofcaffeine @geriux @getdave @glendaviesnz @gziolo @jameskoster @jeryj @jsnajdr @juhi123 @kevin940726 @leemyongpakvn @madhusudhand @MaggieCabrera @Mamaduka @matiasbenedetto @michalczaplinski @mirka @mtias @mujuonly @ndiego @noahtallen @noisysocks @ntsekouras @oandregal @ockham @pbking @priethor @ramonjd @richtabor @scruffian @SiobhyB @spacedmonkey @stokesman @swissspidy @t-hamano @tellthemachines @tellyworth @them-es @torounit @tyxla @westonruter @WunderBart @youknowriad"
 `;
 
-exports[`getContributorProps verify that the contributors props are properly formatted 1`] = `
+exports[`getContributorProps > verify that the contributors props are properly formatted 1`] = `
 "## First-time contributors
 
 The following PRs were merged by first-time contributors:

--- a/tools/release/commands/test/changelog.js
+++ b/tools/release/commands/test/changelog.js
@@ -1,19 +1,46 @@
 /**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { afterAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
-jest.mock( '@octokit/rest' );
-jest.mock( '../../lib/milestone' );
-jest.mock( '../../lib/logger', () => ( {
-	log: jest.fn(),
-	warn: jest.fn(),
-	formats: {
-		title: jest.fn( ( message ) => message ),
-		error: jest.fn( ( message ) => message ),
-		warning: jest.fn( ( message ) => message ),
-	},
-} ) );
+import _pullRequests from './fixtures/pull-requests.json';
+import botPullRequestFixture from './fixtures/bot-pull-requests.json';
 
-import {
+const require = createRequire( import.meta.url );
+const octokitModule = require( '@octokit/rest' );
+const originalOctokit = octokitModule.Octokit;
+const Octokit = vi.fn();
+octokitModule.Octokit = Octokit;
+
+const milestoneModule = require( '../../lib/milestone' );
+const originalGetMilestoneByTitle = milestoneModule.getMilestoneByTitle;
+const originalGetIssuesByMilestone = milestoneModule.getIssuesByMilestone;
+const getMilestoneByTitle = vi.fn();
+const getIssuesByMilestone = vi.fn();
+milestoneModule.getMilestoneByTitle = getMilestoneByTitle;
+milestoneModule.getIssuesByMilestone = getIssuesByMilestone;
+
+const loggerModule = require( '../../lib/logger' );
+const originalLogger = { ...loggerModule };
+const log = vi.fn();
+const warn = vi.fn();
+loggerModule.log = log;
+loggerModule.warn = warn;
+loggerModule.formats = {
+	title: vi.fn( ( message ) => message ),
+	error: vi.fn( ( message ) => message ),
+	warning: vi.fn( ( message ) => message ),
+};
+
+const {
 	getNormalizedTitle,
 	reword,
 	addTrailingPeriod,
@@ -35,16 +62,15 @@ import {
 	createChangelog,
 	fetchAllPullRequests,
 	getManualChangelogInstructions,
-} from '../changelog';
-import _pullRequests from './fixtures/pull-requests.json';
-import botPullRequestFixture from './fixtures/bot-pull-requests.json';
+} = require( '../changelog' );
 
-const { Octokit } = require( '@octokit/rest' );
-const {
-	getMilestoneByTitle,
-	getIssuesByMilestone,
-} = require( '../../lib/milestone' );
-const { log, warn } = require( '../../lib/logger' );
+afterAll( () => {
+	octokitModule.Octokit = originalOctokit;
+	milestoneModule.getMilestoneByTitle = originalGetMilestoneByTitle;
+	milestoneModule.getIssuesByMilestone = originalGetIssuesByMilestone;
+	Object.assign( loggerModule, originalLogger );
+	delete require.cache[ require.resolve( '../changelog' ) ];
+} );
 
 /**
  * pull-requests.json is a static snapshot of real data from the GitHub API.
@@ -61,22 +87,24 @@ const pullRequests = _pullRequests.concat( botPullRequestFixture );
  *
  * @return {Object} Octokit stub.
  */
-const createOctokitWithoutReleases = () => ( {
-	repos: {
-		listReleases: {
-			endpoint: {
-				merge: jest.fn().mockReturnValue( {} ),
+function createOctokitWithoutReleases() {
+	return {
+		repos: {
+			listReleases: {
+				endpoint: {
+					merge: vi.fn().mockReturnValue( {} ),
+				},
 			},
 		},
-	},
-	paginate: {
-		iterator: jest.fn().mockReturnValue(
-			( async function* () {
-				yield { data: [] };
-			} )()
-		),
-	},
-} );
+		paginate: {
+			iterator: vi.fn().mockReturnValue(
+				( async function* () {
+					yield { data: [] };
+				} )()
+			),
+		},
+	};
+}
 
 describe( 'createChangelog', () => {
 	const settings = {
@@ -87,8 +115,10 @@ describe( 'createChangelog', () => {
 	};
 
 	beforeEach( () => {
-		jest.clearAllMocks();
-		Octokit.mockImplementation( () => ( {} ) );
+		vi.clearAllMocks();
+		Octokit.mockImplementation( function () {
+			return {};
+		} );
 	} );
 
 	it( 'keeps successful changelog output unchanged', async () => {

--- a/tools/release/commands/test/common.js
+++ b/tools/release/commands/test/common.js
@@ -1,7 +1,18 @@
 /**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
-import { calculateVersionBumpFromChangelog } from '../common';
+const require = createRequire( import.meta.url );
+const { calculateVersionBumpFromChangelog } = require( '../common' );
 
 describe( 'calculateVersionBumpFromChangelog', () => {
 	it( 'should return null when no lines provided', () => {

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -1,7 +1,18 @@
 /**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
-import {
+const require = createRequire( import.meta.url );
+const {
 	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
@@ -17,7 +28,7 @@ import {
 	runNpmReleasePhase,
 	runPackagesRelease,
 	verifyRemotePackageTags,
-} from '../packages';
+} = require( '../packages' );
 
 describe( 'prepareNpmRelease', () => {
 	it.each( [
@@ -32,12 +43,12 @@ describe( 'prepareNpmRelease', () => {
 				gitWorkingDirectoryPath: '/repo',
 				releaseType,
 			};
-			const checkoutNpmReleaseBranchFn = jest.fn();
-			const findPluginReleaseBranchNameFn = jest
+			const checkoutNpmReleaseBranchFn = vi.fn();
+			const findPluginReleaseBranchNameFn = vi
 				.fn()
 				.mockResolvedValue( 'release/23.5' );
-			const runNpmReleaseBranchSyncStepFn = jest.fn();
-			const updatePackagesFn = jest
+			const runNpmReleaseBranchSyncStepFn = vi.fn();
+			const updatePackagesFn = vi
 				.fn()
 				.mockResolvedValue( 'changelog-sha' );
 
@@ -79,7 +90,7 @@ describe( 'finalizePreparedNpmRelease', () => {
 		'finalizes a %s release',
 		async ( releaseType, pluginReleaseBranch, expectedBranches ) => {
 			const config = { releaseType };
-			const backportCommitsToBranchFn = jest.fn();
+			const backportCommitsToBranchFn = vi.fn();
 			const commits = [ 'changelog-sha', 'publish-sha' ];
 
 			await finalizePreparedNpmRelease(
@@ -110,11 +121,11 @@ describe( 'runPackagesRelease', () => {
 			interactive: false,
 		};
 		const releaseState = { changelogCommit: 'changelog-sha' };
-		const prepareNpmReleaseFn = jest.fn().mockResolvedValue( releaseState );
-		const publishPreparedPackagesToNpmFn = jest
+		const prepareNpmReleaseFn = vi.fn().mockResolvedValue( releaseState );
+		const publishPreparedPackagesToNpmFn = vi
 			.fn()
 			.mockResolvedValue( 'publish-sha' );
-		const finalizePreparedNpmReleaseFn = jest.fn();
+		const finalizePreparedNpmReleaseFn = vi.fn();
 
 		await runPackagesRelease( config, [], {
 			finalizePreparedNpmReleaseFn,
@@ -173,7 +184,7 @@ describe( 'getNpmReleasePackages', () => {
 			},
 		};
 		const git = {
-			raw: jest
+			raw: vi
 				.fn()
 				.mockResolvedValue(
 					[
@@ -187,7 +198,7 @@ describe( 'getNpmReleasePackages', () => {
 		await expect(
 			getNpmReleasePackages( '/repo', {
 				git,
-				globFn: jest.fn().mockResolvedValue( files ),
+				globFn: vi.fn().mockResolvedValue( files ),
 				readJSON: ( file ) => packageJsonByPath[ file ],
 			} )
 		).resolves.toEqual( [
@@ -258,7 +269,7 @@ describe( 'getNpmReleaseGitRecoveryCommands', () => {
 describe( 'getRemoteBranchSha', () => {
 	it( 'returns the exact remote branch ref SHA', async () => {
 		const git = {
-			raw: jest
+			raw: vi
 				.fn()
 				.mockResolvedValue(
 					[
@@ -283,7 +294,7 @@ describe( 'getRemoteBranchSha', () => {
 describe( 'getRemoteTagShas', () => {
 	it( 'fetches tag refs in one call and prefers peeled SHAs', async () => {
 		const git = {
-			raw: jest
+			raw: vi
 				.fn()
 				.mockResolvedValue(
 					[
@@ -329,7 +340,7 @@ describe( 'verifyRemotePackageTags', () => {
 					publishCommit: 'expected-sha',
 				},
 				{
-					getRemoteTagShasFn: jest.fn().mockResolvedValue(
+					getRemoteTagShasFn: vi.fn().mockResolvedValue(
 						new Map( [
 							[ '@wordpress/a11y@4.50.0', 'expected-sha' ],
 							[ '@wordpress/blocks@14.20.0', 'other-sha' ],
@@ -348,7 +359,7 @@ describe( 'runNpmPublishPreflight', () => {
 	const WHOAMI = { stdout: 'wp-user\n' };
 
 	it( 'verifies npm authentication before checking registry state', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
 			.mockRejectedValueOnce( {
@@ -382,7 +393,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'fails without checking registry state when npm authentication fails', async () => {
-		const commandFn = jest.fn().mockRejectedValueOnce(
+		const commandFn = vi.fn().mockRejectedValueOnce(
 			Object.assign( new Error( 'Command failed: npm whoami' ), {
 				stderr: 'npm ERR! code ENEEDAUTH',
 			} )
@@ -406,7 +417,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'accepts a published version from the prepared commit with the expected dist-tag', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
 			.mockResolvedValueOnce( {
@@ -431,7 +442,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'fails when a published version came from another commit', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
 			.mockResolvedValueOnce( {
@@ -457,7 +468,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'fails with an actionable error when a published version has no gitHead', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
 			.mockResolvedValueOnce( {
@@ -483,7 +494,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'fails when a published version has the wrong dist-tag', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
 			.mockResolvedValueOnce( {
@@ -509,7 +520,7 @@ describe( 'runNpmPublishPreflight', () => {
 	} );
 
 	it( 'fails when the registry returns a different version', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockResolvedValueOnce( WHOAMI )
 			.mockResolvedValueOnce( {
@@ -537,11 +548,11 @@ describe( 'runNpmPublishPreflight', () => {
 
 describe( 'runNpmReleasePhase', () => {
 	it( 'retries a failed phase before surfacing success', async () => {
-		const task = jest
+		const task = vi
 			.fn()
 			.mockRejectedValueOnce( new Error( 'transient failure' ) )
 			.mockResolvedValueOnce();
-		const wait = jest.fn();
+		const wait = vi.fn();
 
 		await runNpmReleasePhase( 'Package tag push', task, { wait } );
 
@@ -553,10 +564,10 @@ describe( 'runNpmReleasePhase', () => {
 
 describe( 'pushNpmReleaseGitMetadata', () => {
 	it( 'pushes the branch before pushing and verifying package tags', async () => {
-		const git = { raw: jest.fn().mockResolvedValue() };
-		const runPhase = jest.fn( async ( _label, task ) => task() );
-		const verifyRemoteNpmReleaseBranchFn = jest.fn();
-		const verifyRemotePackageTagsFn = jest.fn();
+		const git = { raw: vi.fn().mockResolvedValue() };
+		const runPhase = vi.fn( async ( _label, task ) => task() );
+		const verifyRemoteNpmReleaseBranchFn = vi.fn();
+		const verifyRemotePackageTagsFn = vi.fn();
 
 		await pushNpmReleaseGitMetadata(
 			{
@@ -614,19 +625,19 @@ describe( 'pushNpmReleaseGitMetadata', () => {
 
 describe( 'publishVersionedPackagesToNpm', () => {
 	it( 'preflights, publishes from package, and pushes metadata', async () => {
-		const commandFn = jest.fn().mockResolvedValue();
-		const getNpmReleasePackagesFn = jest
+		const commandFn = vi.fn().mockResolvedValue();
+		const getNpmReleasePackagesFn = vi
 			.fn()
 			.mockResolvedValue( [
 				{ name: '@wordpress/a11y', tagName: '@wordpress/a11y@4.50.0' },
 			] );
-		const runNpmPublishPreflightFn = jest
+		const runNpmPublishPreflightFn = vi
 			.fn()
 			.mockResolvedValueOnce( [] )
 			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
-		const pushNpmReleaseGitMetadataFn = jest.fn();
+		const pushNpmReleaseGitMetadataFn = vi.fn();
 		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+			revparse: vi.fn().mockResolvedValue( 'publish-sha' ),
 		};
 
 		await publishVersionedPackagesToNpm(
@@ -674,11 +685,11 @@ describe( 'publishVersionedPackagesToNpm', () => {
 	} );
 
 	it( 'rechecks registry state before retrying from-package', async () => {
-		const commandFn = jest
+		const commandFn = vi
 			.fn()
 			.mockRejectedValueOnce( new Error( 'partial publish' ) )
 			.mockResolvedValueOnce();
-		const runNpmPublishPreflightFn = jest
+		const runNpmPublishPreflightFn = vi
 			.fn()
 			.mockResolvedValueOnce( [] )
 			.mockResolvedValueOnce( [ '@wordpress/a11y' ] )
@@ -687,8 +698,8 @@ describe( 'publishVersionedPackagesToNpm', () => {
 				'@wordpress/blocks',
 			] );
 		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
-			reset: jest.fn(),
+			revparse: vi.fn().mockResolvedValue( 'publish-sha' ),
+			reset: vi.fn(),
 		};
 
 		await publishVersionedPackagesToNpm(
@@ -701,7 +712,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+				getNpmReleasePackagesFn: vi.fn().mockResolvedValue( [
 					{
 						name: '@wordpress/a11y',
 						tagName: '@wordpress/a11y@4.50.0-next.0',
@@ -712,7 +723,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 					},
 				] ),
 				git,
-				pushNpmReleaseGitMetadataFn: jest.fn(),
+				pushNpmReleaseGitMetadataFn: vi.fn(),
 				runNpmPublishPreflightFn,
 			}
 		);
@@ -727,9 +738,9 @@ describe( 'publishVersionedPackagesToNpm', () => {
 	} );
 
 	it( 'skips Lerna when all package versions are already published', async () => {
-		const commandFn = jest.fn();
+		const commandFn = vi.fn();
 		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+			revparse: vi.fn().mockResolvedValue( 'publish-sha' ),
 		};
 
 		await publishVersionedPackagesToNpm(
@@ -742,15 +753,15 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+				getNpmReleasePackagesFn: vi.fn().mockResolvedValue( [
 					{
 						name: '@wordpress/a11y',
 						tagName: '@wordpress/a11y@4.50.0',
 					},
 				] ),
 				git,
-				pushNpmReleaseGitMetadataFn: jest.fn(),
-				runNpmPublishPreflightFn: jest
+				pushNpmReleaseGitMetadataFn: vi.fn(),
+				runNpmPublishPreflightFn: vi
 					.fn()
 					.mockResolvedValue( [ '@wordpress/a11y' ] ),
 			}
@@ -761,12 +772,12 @@ describe( 'publishVersionedPackagesToNpm', () => {
 	} );
 
 	it( 'does not push metadata when final registry verification is incomplete', async () => {
-		const commandFn = jest.fn().mockResolvedValue();
-		const pushNpmReleaseGitMetadataFn = jest.fn();
-		const runNpmPublishPreflightFn = jest.fn().mockResolvedValue( [] );
-		const runPhase = jest.fn( async ( _label, task ) => task() );
+		const commandFn = vi.fn().mockResolvedValue();
+		const pushNpmReleaseGitMetadataFn = vi.fn();
+		const runNpmPublishPreflightFn = vi.fn().mockResolvedValue( [] );
+		const runPhase = vi.fn( async ( _label, task ) => task() );
 		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+			revparse: vi.fn().mockResolvedValue( 'publish-sha' ),
 		};
 
 		await expect(
@@ -780,7 +791,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 				},
 				{
 					commandFn,
-					getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+					getNpmReleasePackagesFn: vi.fn().mockResolvedValue( [
 						{
 							name: '@wordpress/a11y',
 							tagName: '@wordpress/a11y@4.50.0',
@@ -807,18 +818,18 @@ describe( 'publishVersionedPackagesToNpm', () => {
 	} );
 
 	it( 'retries final registry verification after propagation lag', async () => {
-		const commandFn = jest.fn().mockResolvedValue();
-		const pushNpmReleaseGitMetadataFn = jest.fn();
-		const runNpmPublishPreflightFn = jest
+		const commandFn = vi.fn().mockResolvedValue();
+		const pushNpmReleaseGitMetadataFn = vi.fn();
+		const runNpmPublishPreflightFn = vi
 			.fn()
 			.mockResolvedValueOnce( [] )
 			.mockResolvedValueOnce( [] )
 			.mockResolvedValueOnce( [ '@wordpress/a11y' ] );
-		const wait = jest.fn();
+		const wait = vi.fn();
 		const runPhase = ( label, task ) =>
 			runNpmReleasePhase( label, task, { wait } );
 		const git = {
-			revparse: jest.fn().mockResolvedValue( 'publish-sha' ),
+			revparse: vi.fn().mockResolvedValue( 'publish-sha' ),
 		};
 
 		await publishVersionedPackagesToNpm(
@@ -831,7 +842,7 @@ describe( 'publishVersionedPackagesToNpm', () => {
 			},
 			{
 				commandFn,
-				getNpmReleasePackagesFn: jest.fn().mockResolvedValue( [
+				getNpmReleasePackagesFn: vi.fn().mockResolvedValue( [
 					{
 						name: '@wordpress/a11y',
 						tagName: '@wordpress/a11y@4.50.0',
@@ -890,14 +901,14 @@ describe( 'publishPackagesToNpm', () => {
 	] )(
 		'routes %s releases through the shared metadata publishing path',
 		async ( releaseType, versionCommand, distTag, npmReleaseBranch ) => {
-			const commandFn = jest.fn().mockResolvedValue();
+			const commandFn = vi.fn().mockResolvedValue();
 			const git = {
-				revparse: jest
+				revparse: vi
 					.fn()
 					.mockResolvedValueOnce( 'before-sha' )
 					.mockResolvedValueOnce( 'after-sha' ),
 			};
-			const publishVersionedPackagesToNpmFn = jest.fn();
+			const publishVersionedPackagesToNpmFn = vi.fn();
 			const config = {
 				...getConfig( releaseType ),
 				distTag,

--- a/tools/release/lib/test/version.js
+++ b/tools/release/lib/test/version.js
@@ -1,7 +1,18 @@
 /**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
-import { getNextMajorVersion } from '../version';
+const require = createRequire( import.meta.url );
+const { getNextMajorVersion } = require( '../version' );
 
 describe( 'getNextMajorVersion', () => {
 	it( 'increases the minor number by default', () => {

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -35,6 +35,9 @@
 		"simple-git": "^3.32.3",
 		"sprintf-js": "^1.1.1"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/tools/release/test/cherry-pick.js
+++ b/tools/release/test/cherry-pick.js
@@ -1,21 +1,26 @@
 /**
+ * Node dependencies
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
  * External dependencies
  */
-const fs = require( 'node:fs' );
-const os = require( 'node:os' );
-const path = require( 'node:path' );
-const { spawnSync } = require( 'node:child_process' );
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
-const {
+import {
 	cherryPickAll,
 	cherryPickOne,
 	isGhVersionSupported,
 	parseGhVersion,
 	MINIMUM_GH_VERSION,
-} = require( '../cherry-pick.mjs' );
+} from '../cherry-pick.mjs';
 
 const LOCAL_AUTHOR = {
 	name: 'Marco Ciampini',

--- a/tools/release/test/cli.js
+++ b/tools/release/test/cli.js
@@ -1,10 +1,19 @@
 /**
+ * Node dependencies
+ */
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-const path = require( 'path' );
-const { spawnSync } = require( 'child_process' );
+import { describe, expect, it } from 'vitest';
 
-const cliPath = path.resolve( __dirname, '../cli.js' );
+const require = createRequire( import.meta.url );
+const currentDirectory = path.dirname( fileURLToPath( import.meta.url ) );
+const cliPath = path.resolve( currentDirectory, '../cli.js' );
 /*
  * Resolve from this file: an `-e` script resolves requires from the cwd,
  * which is the repo root under Jest and has no `commander` installed.


### PR DESCRIPTION
## What?

See #80855.

**TL;DR — migration class:** Internal Node release tooling, native ESM test modules, explicit CommonJS boundaries, advanced module interception, dependency-injected mocks, CLI subprocess coverage, direct Vitest ownership, CommonJS-transform retirement, and a three-snapshot audit.

Migrates all 107 tests in the six remaining `@wordpress/release-tools` test files from Jest to the Vitest Node project and removes the release changelog command from Vitest's CommonJS conversion filter.

## Why?

This completes the repository's internal release-tool tests and removes another legacy source-transform exception while preserving the CommonJS format of the production release commands.

## How?

- converts the release-tool test modules to ESM with explicit Vitest imports
- loads CommonJS production commands through narrow `createRequire(import.meta.url)` boundaries
- installs Vitest mocks into Node's CommonJS module cache before loading the changelog command, then restores the original exports after the suite
- retains the package-release tests' existing dependency-injection seams with `vi.fn()` mocks
- imports the ESM cherry-pick command directly and keeps its real temporary-Git-repository coverage
- resolves the CommonJS CLI subprocess from `import.meta.url` without relying on Jest's `__dirname`
- declares Vitest directly in the private release-tools workspace
- removes `tools/release/commands/changelog.js` from the `vite-plugin-commonjs` filter
- converts three snapshot headers/keys after confirming every payload is byte-for-byte unchanged

The production release commands remain CommonJS in this slice. Their module format is an application concern separate from runner migration; the tests now expose that boundary explicitly without asking Vite to rewrite production code.

## Testing Instructions

1. `npm run test:unit:vitest -- --project node tools/release`
2. `npm run test:unit:vitest -- --project node`
3. `npm run test:unit:routing`
4. `npm run test:unit:conventions`
5. `npm run test:unit -- --runInBand`
6. Stage this PR's files and run `npm exec lint-staged -- --no-stash`

Expected local results:

- Focused Vitest: 6 files and 107 tests pass; 3 snapshots pass.
- Full Node project: 115 files and 1,503 tests pass.
- Routing: exactly 482 Jest and 521 Vitest files.
- Conventions: 521 tests, 537 ESM graph files, 86 workspace dependencies, and 317 TypeScript tests pass validation.
- Remaining Jest: 481 suites / 25,833 tests / 107 snapshots pass. The nine `packages/env/lib/config/test/config-integration.js` tests fail only because the current WordPress version is unavailable in the offline local cache.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was authored with Codex assistance and reviewed through the focused release suite, full Node project, routing/convention validators, per-snapshot payload comparison, remaining Jest partition, and strict staged checks.