### PR TITLE
Migrate Env Package Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47401,57 +47401,6 @@
 				}
 			}
 		},
-		"node_modules/vite-plugin-commonjs": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/vite-plugin-commonjs/-/vite-plugin-commonjs-0.10.4.tgz",
-			"integrity": "sha512-eWQuvQKCcx0QYB5e5xfxBNjQKyrjEWZIR9UOkOV6JAgxVhtbZvCOF+FNC2ZijBJ3U3Px04ZMMyyMyFBVWIJ5+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.12.1",
-				"magic-string": "^0.30.11",
-				"vite-plugin-dynamic-import": "^1.6.0"
-			}
-		},
-		"node_modules/vite-plugin-commonjs/node_modules/acorn": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/vite-plugin-dynamic-import": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.6.0.tgz",
-			"integrity": "sha512-TM0sz70wfzTIo9YCxVFwS8OA9lNREsh+0vMHGSkWDTZ7bgd1Yjs5RV8EgB634l/91IsXJReg0xtmuQqP0mf+rg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.12.1",
-				"es-module-lexer": "^1.5.4",
-				"fast-glob": "^3.3.2",
-				"magic-string": "^0.30.11"
-			}
-		},
-		"node_modules/vite-plugin-dynamic-import/node_modules/acorn": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/vite/node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -51149,6 +51098,9 @@
 			"bin": {
 				"wp-env": "bin/wp-env"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -54543,7 +54495,6 @@
 				"resize-observer-polyfill": "^1.5.1",
 				"snapshot-diff": "^0.10.0",
 				"timezone-mock": "^1.3.6",
-				"vite-plugin-commonjs": "^0.10.4",
 				"vitest": "^4.1.10",
 				"vitest-browser-react": "^2.2.0",
 				"yargs": "^17.7.2"

--- a/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Config Integration should load local and override configuration files 1`] = `
+exports[`Config Integration > should load local and override configuration files 1`] = `
 {
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
@@ -85,7 +85,7 @@ exports[`Config Integration should load local and override configuration files 1
 }
 `;
 
-exports[`Config Integration should load local configuration file 1`] = `
+exports[`Config Integration > should load local configuration file 1`] = `
 {
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
@@ -170,7 +170,7 @@ exports[`Config Integration should load local configuration file 1`] = `
 }
 `;
 
-exports[`Config Integration should use default configuration 1`] = `
+exports[`Config Integration > should use default configuration 1`] = `
 {
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
@@ -255,7 +255,7 @@ exports[`Config Integration should use default configuration 1`] = `
 }
 `;
 
-exports[`Config Integration should use environment variables over local and override configuration files 1`] = `
+exports[`Config Integration > should use environment variables over local and override configuration files 1`] = `
 {
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,

--- a/packages/env/lib/config/test/add-or-replace-port.js
+++ b/packages/env/lib/config/test/add-or-replace-port.js
@@ -1,14 +1,20 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const addOrReplacePort = require( '../add-or-replace-port.js' );
 
 describe( 'addOrReplacePort', () => {
-	afterEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	it( 'should add or replace port with various inputs', () => {
 		const testMap = [
 			// Addition

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -1,50 +1,75 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
 
 /**
  * External dependencies
  */
-const { readFile } = require( 'fs' ).promises;
-const { existsSync } = require( 'fs' );
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const dns = require( 'node:dns' );
+const fs = require( 'node:fs' );
+const readFile = vi.spyOn( fs.promises, 'readFile' );
+const stat = vi.spyOn( fs.promises, 'stat' );
+vi.spyOn( fs.promises, 'mkdir' ).mockResolvedValue();
+vi.spyOn( fs.promises, 'writeFile' ).mockResolvedValue();
+const existsSync = vi.spyOn( fs, 'existsSync' );
+const resolveDns = vi.spyOn( dns.promises, 'resolve' );
+
+const gotPath = require.resolve( 'got' );
+const originalGot = require( gotPath );
+const got = vi.fn( ( url ) => ( {
+	json: () => {
+		if ( url === 'https://api.wordpress.org/core/stable-check/1.0/' ) {
+			return Promise.resolve( {
+				'1.0': 'insecure',
+				'99.1.1': 'outdated',
+				'100.0.0': 'latest',
+				'100.0.1': 'fancy',
+			} );
+		}
+	},
+} ) );
+require.cache[ gotPath ].exports = got;
+
+const detectDirectoryTypePath = require.resolve( '../detect-directory-type' );
+const originalDetectDirectoryType = require( detectDirectoryTypePath );
+const detectDirectoryType = vi.fn();
+require.cache[ detectDirectoryTypePath ].exports = detectDirectoryType;
+
 const loadConfig = require( '../load-config' );
-const detectDirectoryType = require( '../detect-directory-type' );
 const md5 = require( '../../md5' );
 
-jest.mock( 'fs', () => ( {
-	promises: {
-		readFile: jest.fn(),
-		stat: jest.fn().mockResolvedValue( true ),
-		mkdir: jest.fn(),
-		writeFile: jest.fn(),
-	},
-	existsSync: jest.fn().mockReturnValue( false ),
-} ) );
-
-// This mocks a small response with a format matching the stable-check API.
-// It makes getLatestWordPressVersion resolve to "100.0.0".
-jest.mock( 'got', () =>
-	jest.fn( ( url ) => ( {
-		json: () => {
-			if ( url === 'https://api.wordpress.org/core/stable-check/1.0/' ) {
-				return Promise.resolve( {
-					'1.0': 'insecure',
-					'99.1.1': 'outdated',
-					'100.0.0': 'latest',
-					'100.0.1': 'fancy',
-				} );
-			}
-		},
-	} ) )
-);
-
-jest.mock( '../detect-directory-type', () => jest.fn() );
+afterAll( () => {
+	require.cache[ gotPath ].exports = originalGot;
+	require.cache[ detectDirectoryTypePath ].exports =
+		originalDetectDirectoryType;
+	vi.restoreAllMocks();
+	delete require.cache[ require.resolve( '../load-config' ) ];
+	delete require.cache[ require.resolve( '../parse-config' ) ];
+	delete require.cache[ require.resolve( '../../wordpress' ) ];
+} );
 
 describe( 'Config Integration', () => {
 	beforeEach( () => {
+		vi.clearAllMocks();
 		process.env.WP_ENV_HOME = '/cache';
+		stat.mockResolvedValue( true );
+		existsSync.mockReturnValue( false );
+		resolveDns.mockResolvedValue( [ '198.143.164.252' ] );
 		detectDirectoryType.mockResolvedValue( null );
 	} );
 

--- a/packages/env/lib/config/test/get-cache-directory.js
+++ b/packages/env/lib/config/test/get-cache-directory.js
@@ -1,26 +1,40 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
 
 /**
  * External dependencies
  */
-const { stat } = require( 'fs' ).promises;
-const { homedir } = require( 'os' );
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const stat = vi.spyOn( fs.promises, 'stat' );
+const homedir = vi.spyOn( os, 'homedir' );
 const getCacheDirectory = require( '../get-cache-directory' );
 
-jest.mock( 'fs', () => ( {
-	promises: {
-		stat: jest.fn(),
-	},
-} ) );
-jest.mock( 'os', () => ( {
-	homedir: jest.fn(),
-} ) );
+afterAll( () => {
+	vi.restoreAllMocks();
+} );
 
 describe( 'getCacheDirectory', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
 	afterEach( () => {
 		delete process.env.WP_ENV_HOME;
 	} );

--- a/packages/env/lib/config/test/merge-configs.js
+++ b/packages/env/lib/config/test/merge-configs.js
@@ -1,7 +1,17 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const mergeConfigs = require( '../merge-configs' );
 
 describe( 'mergeConfigs', () => {

--- a/packages/env/lib/config/test/parse-config.js
+++ b/packages/env/lib/config/test/parse-config.js
@@ -1,19 +1,57 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
 /**
  * Internal dependencies
  */
-const { parseConfig } = require( '../parse-config' );
-const readRawConfigFile = require( '../read-raw-config-file' );
-const { getLatestWordPressVersion } = require( '../../wordpress' );
-const { ValidationError } = require( '../validate-config' );
-const detectDirectoryType = require( '../detect-directory-type' );
+const require = createRequire( import.meta.url );
+const gotPath = require.resolve( 'got' );
+const originalGot = require( gotPath );
+require.cache[ gotPath ].exports = vi.fn();
 
-jest.mock( 'got', () => jest.fn() );
-jest.mock( '../read-raw-config-file', () => jest.fn() );
-jest.mock( '../detect-directory-type', () => jest.fn() );
-jest.mock( '../../wordpress', () => ( {
-	getLatestWordPressVersion: jest.fn(),
-} ) );
+const readRawConfigFilePath = require.resolve( '../read-raw-config-file' );
+const originalReadRawConfigFile = require( readRawConfigFilePath );
+const readRawConfigFile = vi.fn();
+require.cache[ readRawConfigFilePath ].exports = readRawConfigFile;
+
+const detectDirectoryTypePath = require.resolve( '../detect-directory-type' );
+const originalDetectDirectoryType = require( detectDirectoryTypePath );
+const detectDirectoryType = vi.fn();
+require.cache[ detectDirectoryTypePath ].exports = detectDirectoryType;
+
+const wordpressModule = require( '../../wordpress' );
+const originalGetLatestWordPressVersion =
+	wordpressModule.getLatestWordPressVersion;
+const getLatestWordPressVersion = vi.fn();
+wordpressModule.getLatestWordPressVersion = getLatestWordPressVersion;
+
+const { parseConfig } = require( '../parse-config' );
+const { ValidationError } = require( '../validate-config' );
+
+afterAll( () => {
+	require.cache[ gotPath ].exports = originalGot;
+	require.cache[ readRawConfigFilePath ].exports = originalReadRawConfigFile;
+	require.cache[ detectDirectoryTypePath ].exports =
+		originalDetectDirectoryType;
+	wordpressModule.getLatestWordPressVersion =
+		originalGetLatestWordPressVersion;
+	delete require.cache[ require.resolve( '../parse-config' ) ];
+} );
 
 /**
  * Since our configurations are merged, we will want to refer to the parsed default config frequently.
@@ -77,7 +115,7 @@ describe( 'parseConfig', () => {
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		delete process.env.WP_ENV_PORT;
 		delete process.env.WP_ENV_TESTS_PORT;
 		delete process.env.WP_ENV_CORE;

--- a/packages/env/lib/config/test/parse-source-string.js
+++ b/packages/env/lib/config/test/parse-source-string.js
@@ -1,20 +1,26 @@
-'use strict';
-/* eslint-disable jest/no-conditional-expect */
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
 /**
  * External dependencies
  */
-const path = require( 'path' );
-const { homedir } = require( 'os' );
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const os = require( 'node:os' );
+const homedir = vi.spyOn( os, 'homedir' );
 const { ValidationError } = require( '../validate-config' );
 const { parseSourceString } = require( '../parse-source-string' );
 
-jest.mock( 'os', () => ( {
-	homedir: jest.fn(),
-} ) );
+afterAll( () => {
+	vi.restoreAllMocks();
+} );
 
 describe( 'parseSourceString', () => {
 	const options = {
@@ -151,4 +157,3 @@ describe( 'parseSourceString', () => {
 		} );
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */

--- a/packages/env/lib/config/test/post-process-config.js
+++ b/packages/env/lib/config/test/post-process-config.js
@@ -1,15 +1,21 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const { ValidationError } = require( '..' );
 const postProcessConfig = require( '../post-process-config' );
 
 describe( 'postProcessConfig', () => {
-	afterEach( () => {
-		jest.clearAllMocks();
-	} );
-
 	it( 'should merge relevant root options into environment options', async () => {
 		const processed = await postProcessConfig( {
 			port: 123,

--- a/packages/env/lib/config/test/read-raw-config-file.js
+++ b/packages/env/lib/config/test/read-raw-config-file.js
@@ -1,25 +1,29 @@
-'use strict';
-/* eslint-disable jest/no-conditional-expect */
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
 /**
  * External dependencies
  */
-const { readFile } = require( 'fs' ).promises;
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const fs = require( 'node:fs' );
+const readFile = vi.spyOn( fs.promises, 'readFile' );
 const readRawConfigFile = require( '../read-raw-config-file' );
 const { ValidationError } = require( '../validate-config' );
 
-jest.mock( 'fs', () => ( {
-	promises: {
-		readFile: jest.fn(),
-	},
-} ) );
+afterAll( () => {
+	vi.restoreAllMocks();
+} );
 
 describe( 'readRawConfigFile', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'returns null if it cannot find a file', async () => {
@@ -43,4 +47,3 @@ describe( 'readRawConfigFile', () => {
 		}
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */

--- a/packages/env/lib/config/test/validate-config.js
+++ b/packages/env/lib/config/test/validate-config.js
@@ -1,7 +1,17 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const {
 	ValidationError,
 	checkString,

--- a/packages/env/lib/test/__snapshots__/md5.js.snap
+++ b/packages/env/lib/test/__snapshots__/md5.js.snap
@@ -1,9 +1,9 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`md5 creates a hash of a number 1`] = `"55587a910882016321201e6ebbc9f595"`;
+exports[`md5 > creates a hash of a number 1`] = `"55587a910882016321201e6ebbc9f595"`;
 
-exports[`md5 creates a hash of a object 1`] = `"a0294b0e88367a0ff800d78413356538"`;
+exports[`md5 > creates a hash of a object 1`] = `"a0294b0e88367a0ff800d78413356538"`;
 
-exports[`md5 creates a hash of a string 1`] = `"5d41402abc4b2a76b9719d911017c592"`;
+exports[`md5 > creates a hash of a string 1`] = `"5d41402abc4b2a76b9719d911017c592"`;
 
-exports[`md5 creates a hash of null 1`] = `"37a6259cc0c1dae299a7866489dff0bd"`;
+exports[`md5 > creates a hash of null 1`] = `"37a6259cc0c1dae299a7866489dff0bd"`;

--- a/packages/env/lib/test/build-docker-compose-config.js
+++ b/packages/env/lib/test/build-docker-compose-config.js
@@ -1,13 +1,38 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const getHostUserPath = require.resolve( '../runtime/docker/get-host-user' );
+const originalGetHostUser = require( getHostUserPath );
+const getHostUser = vi.fn( () => ( {
+	name: 'test',
+	uid: 1,
+	gid: 2,
+	fullUser: '1:2',
+} ) );
+require.cache[ getHostUserPath ].exports = getHostUser;
 const buildDockerComposeConfig = require( '../runtime/docker/build-docker-compose-config' );
 const {
 	wordpressDockerFileContents,
 	getLoopbackPortConfig,
 } = require( '../runtime/docker/docker-config' );
-const getHostUser = require( '../runtime/docker/get-host-user' );
+
+afterAll( () => {
+	require.cache[ getHostUserPath ].exports = originalGetHostUser;
+	delete require.cache[
+		require.resolve( '../runtime/docker/build-docker-compose-config' )
+	];
+} );
 
 // The basic config keys which build docker compose config requires.
 const CONFIG = {
@@ -17,16 +42,6 @@ const CONFIG = {
 	port: 8888,
 	configDirectoryPath: '/path/to/config',
 };
-
-jest.mock( '../runtime/docker/get-host-user', () => jest.fn() );
-getHostUser.mockImplementation( () => {
-	return {
-		name: 'test',
-		uid: 1,
-		gid: 2,
-		fullUser: '1:2',
-	};
-} );
 
 describe( 'buildDockerComposeConfig', () => {
 	it( 'should map directories before individual sources', () => {

--- a/packages/env/lib/test/cache.js
+++ b/packages/env/lib/test/cache.js
@@ -1,12 +1,21 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
 /**
  * External dependencies
  */
-const { readFile, writeFile } = require( 'fs' ).promises;
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const fs = require( 'node:fs' );
+const readFile = vi.spyOn( fs.promises, 'readFile' );
+const writeFile = vi.spyOn( fs.promises, 'writeFile' );
+vi.spyOn( fs.promises, 'mkdir' ).mockResolvedValue();
 const {
 	didCacheChange,
 	setCache,
@@ -14,13 +23,9 @@ const {
 	getCacheFile,
 } = require( '../cache' );
 
-jest.mock( 'fs', () => ( {
-	promises: {
-		readFile: jest.fn(),
-		writeFile: jest.fn(),
-		mkdir: jest.fn(),
-	},
-} ) );
+afterAll( () => {
+	vi.restoreAllMocks();
+} );
 
 const cacheOptions = {
 	workDirectoryPath: '/a/b/c',
@@ -45,7 +50,7 @@ function setupWriteFile() {
 
 describe( 'cache file', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'didCacheChange', () => {

--- a/packages/env/lib/test/cli.js
+++ b/packages/env/lib/test/cli.js
@@ -1,36 +1,53 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
 /**
  * Internal dependencies
  */
-const cli = require( '../cli' );
-const env = require( '../env' );
-
-/**
- * Mocked dependencies
- */
-jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
-jest.mock( 'ora', () => () => {
-	const spinner = { text: '', succeed: jest.fn(), fail: jest.fn() };
+const require = createRequire( import.meta.url );
+const oraPath = require.resolve( 'ora' );
+const originalOra = require( oraPath );
+const createSpinner = vi.fn( () => {
+	const spinner = { text: '', succeed: vi.fn(), fail: vi.fn() };
 	spinner.start = () => spinner;
 	return spinner;
 } );
-jest.mock( '../env', () => {
-	const actual = jest.requireActual( '../env' );
-	return {
-		start: jest.fn( Promise.resolve.bind( Promise ) ),
-		stop: jest.fn( Promise.resolve.bind( Promise ) ),
-		reset: jest.fn( Promise.resolve.bind( Promise ) ),
-		clean: jest.fn( Promise.resolve.bind( Promise ) ),
-		run: jest.fn( Promise.resolve.bind( Promise ) ),
-		destroy: jest.fn( Promise.resolve.bind( Promise ) ),
-		cleanup: jest.fn( Promise.resolve.bind( Promise ) ),
-		ValidationError: actual.ValidationError,
-		LifecycleScriptError: actual.LifecycleScriptError,
-	};
+require.cache[ oraPath ].exports = createSpinner;
+
+const envPath = require.resolve( '../env' );
+const originalEnv = require( envPath );
+const env = {
+	start: vi.fn( Promise.resolve.bind( Promise ) ),
+	stop: vi.fn( Promise.resolve.bind( Promise ) ),
+	reset: vi.fn( Promise.resolve.bind( Promise ) ),
+	clean: vi.fn( Promise.resolve.bind( Promise ) ),
+	run: vi.fn( Promise.resolve.bind( Promise ) ),
+	destroy: vi.fn( Promise.resolve.bind( Promise ) ),
+	cleanup: vi.fn( Promise.resolve.bind( Promise ) ),
+	ValidationError: originalEnv.ValidationError,
+	LifecycleScriptError: originalEnv.LifecycleScriptError,
+};
+require.cache[ envPath ].exports = env;
+
+const processExit = vi.spyOn( process, 'exit' ).mockImplementation( () => {} );
+const cli = require( '../cli' );
+
+afterAll( () => {
+	require.cache[ oraPath ].exports = originalOra;
+	require.cache[ envPath ].exports = originalEnv;
+	processExit.mockRestore();
+	delete require.cache[ require.resolve( '../cli' ) ];
 } );
 
 describe( 'env cli', () => {
-	beforeEach( jest.clearAllMocks );
+	beforeEach( vi.clearAllMocks );
 
 	it( 'parses start commands.', () => {
 		cli().parse( [ 'start' ] );
@@ -154,20 +171,18 @@ describe( 'env cli', () => {
 		env.start.mockRejectedValueOnce( {
 			message: 'failure message',
 		} );
-		const consoleError = console.error;
-		console.error = jest.fn();
-		const processExit = process.exit;
-		process.exit = jest.fn();
+		const consoleError = vi
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
 
 		cli().parse( [ 'start' ] );
 		const { spinner } = env.start.mock.calls[ 0 ][ 0 ];
 		await env.start.mock.results[ 0 ].value.catch( () => {} );
 
 		expect( spinner.fail ).toHaveBeenCalledWith( 'failure message' );
-		expect( console.error ).toHaveBeenCalled();
-		expect( process.exit ).toHaveBeenCalledWith( 1 );
-		console.error = consoleError;
-		process.exit = processExit;
+		expect( consoleError ).toHaveBeenCalled();
+		expect( processExit ).toHaveBeenCalledWith( 1 );
+		consoleError.mockRestore();
 	} );
 	it( 'handles failed docker commands with errors.', async () => {
 		env.start.mockRejectedValueOnce( {
@@ -175,12 +190,12 @@ describe( 'env cli', () => {
 			out: 'message',
 			exitCode: 1,
 		} );
-		const consoleError = console.error;
-		console.error = jest.fn();
-		const processExit = process.exit;
-		process.exit = jest.fn();
-		const stderr = process.stderr.write;
-		process.stderr.write = jest.fn();
+		const stdout = vi
+			.spyOn( process.stdout, 'write' )
+			.mockImplementation( () => true );
+		const stderr = vi
+			.spyOn( process.stderr, 'write' )
+			.mockImplementation( () => true );
 
 		cli().parse( [ 'start' ] );
 		const { spinner } = env.start.mock.calls[ 0 ][ 0 ];
@@ -189,10 +204,10 @@ describe( 'env cli', () => {
 		expect( spinner.fail ).toHaveBeenCalledWith(
 			'Error while running docker compose command.'
 		);
-		expect( process.stderr.write ).toHaveBeenCalledWith( 'failure error' );
-		expect( process.exit ).toHaveBeenCalledWith( 1 );
-		console.error = consoleError;
-		process.exit = processExit;
-		process.stderr.write = stderr;
+		expect( stdout ).toHaveBeenCalledWith( 'message' );
+		expect( stderr ).toHaveBeenCalledWith( 'failure error' );
+		expect( processExit ).toHaveBeenCalledWith( 1 );
+		stdout.mockRestore();
+		stderr.mockRestore();
 	} );
 } );

--- a/packages/env/lib/test/execute-lifecycle-script.js
+++ b/packages/env/lib/test/execute-lifecycle-script.js
@@ -1,8 +1,17 @@
-'use strict';
-/* eslint-disable jest/no-conditional-expect */
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const {
 	LifecycleScriptError,
 	executeLifecycleScript,
@@ -10,11 +19,11 @@ const {
 
 describe( 'executeLifecycleScript', () => {
 	const spinner = {
-		info: jest.fn(),
+		info: vi.fn(),
 	};
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should do nothing without event option when debugging', async () => {
@@ -56,4 +65,3 @@ describe( 'executeLifecycleScript', () => {
 		}
 	} );
 } );
-/* eslint-enable jest/no-conditional-expect */

--- a/packages/env/lib/test/md5.js
+++ b/packages/env/lib/test/md5.js
@@ -1,7 +1,17 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const md5 = require( '../md5' );
 
 describe( 'md5', () => {

--- a/packages/env/lib/test/parse-spx-mode.js
+++ b/packages/env/lib/test/parse-spx-mode.js
@@ -1,8 +1,17 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const parseSpxMode = require( '../parse-spx-mode' );
 
 describe( 'parseSpxMode', () => {

--- a/packages/env/lib/test/parse-xdebug-mode.js
+++ b/packages/env/lib/test/parse-xdebug-mode.js
@@ -1,7 +1,17 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
 const parseXdebugMode = require( '../parse-xdebug-mode' );
 
 describe( 'parseXdebugMode', () => {

--- a/packages/env/lib/test/port-utils.js
+++ b/packages/env/lib/test/port-utils.js
@@ -1,12 +1,19 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
 /**
  * External dependencies
  */
-const net = require( 'net' );
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const net = require( 'node:net' );
+vi.spyOn( net, 'createServer' );
 const {
 	isPortAvailable,
 	findAvailablePort,
@@ -14,11 +21,13 @@ const {
 	DEFAULT_MAX_PORT,
 } = require( '../port-utils' );
 
-jest.mock( 'net' );
+afterAll( () => {
+	vi.restoreAllMocks();
+} );
 
 describe( 'port-utils', () => {
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	/**
@@ -32,7 +41,7 @@ describe( 'port-utils', () => {
 			let errorCb, listenCb;
 
 			const server = {
-				once: jest.fn( ( event, cb ) => {
+				once: vi.fn( ( event, cb ) => {
 					if ( event === 'error' ) {
 						errorCb = cb;
 					}
@@ -40,7 +49,7 @@ describe( 'port-utils', () => {
 						listenCb = cb;
 					}
 				} ),
-				listen: jest.fn( ( port ) => {
+				listen: vi.fn( ( port ) => {
 					if ( isAvailable( port ) ) {
 						server.close.mockImplementation( ( cb ) => cb() );
 						listenCb();
@@ -48,7 +57,7 @@ describe( 'port-utils', () => {
 						errorCb( { code: 'EADDRINUSE' } );
 					}
 				} ),
-				close: jest.fn(),
+				close: vi.fn(),
 			};
 
 			return server;
@@ -72,15 +81,15 @@ describe( 'port-utils', () => {
 			net.createServer.mockImplementation( () => {
 				let errorCb;
 				const server = {
-					once: jest.fn( ( event, cb ) => {
+					once: vi.fn( ( event, cb ) => {
 						if ( event === 'error' ) {
 							errorCb = cb;
 						}
 					} ),
-					listen: jest.fn( () => {
+					listen: vi.fn( () => {
 						errorCb( { code: 'EACCES' } );
 					} ),
-					close: jest.fn(),
+					close: vi.fn(),
 				};
 				return server;
 			} );

--- a/packages/env/lib/test/resolve-available-ports.js
+++ b/packages/env/lib/test/resolve-available-ports.js
@@ -1,18 +1,32 @@
-'use strict';
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+
+/**
+ * External dependencies
+ */
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
 /**
  * Internal dependencies
  */
+const require = createRequire( import.meta.url );
+const portUtils = require( '../port-utils' );
+const findAvailablePort = vi.spyOn( portUtils, 'findAvailablePort' );
+const isPortAvailable = vi.spyOn( portUtils, 'isPortAvailable' );
 const {
 	createPortResolver,
 	resolveConfigPorts,
 } = require( '../resolve-available-ports' );
-const { findAvailablePort, isPortAvailable } = require( '../port-utils' );
 
-jest.mock( '../port-utils' );
+afterAll( () => {
+	vi.restoreAllMocks();
+} );
 
 describe( 'resolve-available-ports', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'createPortResolver', () => {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -57,6 +57,9 @@
 		"simple-git": "^3.32.3",
 		"yargs": "^17.3.0"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -50,7 +50,6 @@
 		"resize-observer-polyfill": "^1.5.1",
 		"snapshot-diff": "^0.10.0",
 		"timezone-mock": "^1.3.6",
-		"vite-plugin-commonjs": "^0.10.4",
 		"vitest": "^4.1.10",
 		"vitest-browser-react": "^2.2.0",
 		"yargs": "^17.7.2"

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -89,6 +89,7 @@
 					"packages/design-system-mcp",
 					"packages/docgen",
 					"packages/eslint-plugin",
+					"packages/env",
 					"packages/global-styles-engine",
 					"packages/npm-package-json-lint-config",
 					"packages/postcss-themes",

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -11,7 +11,6 @@ import { fileURLToPath } from 'node:url';
 import { transformAsync } from '@babel/core';
 import { playwright } from '@vitest/browser-playwright';
 import globPackage from 'glob';
-import commonjs from 'vite-plugin-commonjs';
 import { defineConfig } from 'vitest/config';
 
 /**
@@ -104,13 +103,7 @@ function wordpressBabelTransform() {
 
 export default defineConfig( {
 	root: ROOT_DIR,
-	plugins: [
-		wordpressBabelTransform(),
-		commonjs( {
-			filter: ( id ) =>
-				id.startsWith( `${ ROOT_DIR }/packages/env/lib/` ),
-		} ),
-	],
+	plugins: [ wordpressBabelTransform() ],
 	resolve: {
 		alias: [
 			{


### PR DESCRIPTION
## What?

See #80855.

**TL;DR — migration class:** Published Node-package tests, native ESM test modules, explicit CommonJS boundaries, built-in and local module spies, CLI/process mocks, deterministic network behavior, direct Vitest ownership, eight-snapshot audit, and final `vite-plugin-commonjs` removal.

Migrates all 154 `@wordpress/env` tests across 18 files from Jest to the Vitest Node project and removes the now-unused CommonJS conversion plugin from the unit-test workspace.

## Why?

This completes the package's repository-owned tests, makes its config integration coverage independent of local network/cache state, and proves that the full Vitest Node project can execute published CommonJS code through native Node boundaries without rewriting production modules.

## How?

- converts every env test module to ESM with explicit Vitest imports
- loads the package's published CommonJS modules through `createRequire(import.meta.url)`
- replaces Jest module factories with targeted spies on Node built-ins or temporary CommonJS-cache exports installed before the module under test loads
- restores mutated exports and process/console/stream spies after their suites
- makes the config integration test explicitly resolve WordPress.org DNS so its existing mocked stable-check response deterministically returns WordPress `100.0.0`
- keeps real temporary behavior where appropriate, including lifecycle subprocess execution and config transformation coverage
- declares Vitest directly in the package workspace
- removes `vite-plugin-commonjs`, `vite-plugin-dynamic-import`, and their lockfile-only dependencies after the compatibility allowlist reaches zero
- converts eight snapshot headers/keys after confirming all payloads are byte-for-byte unchanged

The published `@wordpress/env` production package remains CommonJS. Changing that consumer contract remains a separate package compatibility decision and is not required by Vitest.

## Testing Instructions

1. `npm run test:unit:vitest -- --project node packages/env`
2. `npm run test:unit:vitest -- --project node`
3. `npm run test:unit:routing`
4. `npm run test:unit:conventions`
5. `npm run test:unit -- --runInBand`
6. Stage this PR's files and run `npm exec lint-staged -- --no-stash`

Expected local results:

- Focused Vitest: 18 files and 154 tests pass; 8 snapshots pass without network access.
- Full Node project: 133 files and 1,657 tests pass without `vite-plugin-commonjs`.
- Routing: exactly 464 Jest and 539 Vitest files.
- Conventions: 539 tests, 555 ESM graph files, 87 workspace dependencies, and 317 TypeScript tests pass validation.
- Remaining Jest: 464 suites / 25,688 tests / 103 snapshots pass with no exceptions.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was authored with Codex assistance and reviewed through the focused env suite, full Node project without CommonJS conversion, routing/convention validators, normalized byte-for-byte snapshot comparison, remaining Jest partition, offline lockfile installation, and strict staged checks.