### PR TITLE
Migrate Standalone Route and Tooling Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53914,7 +53914,8 @@
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
-				"@testing-library/user-event": "^14.6.1"
+				"@testing-library/user-event": "^14.6.1",
+				"vitest": "^4.1.10"
 			},
 			"peerDependencies": {
 				"react": "^18 || ^19"
@@ -53955,7 +53956,8 @@
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"vitest": "^4.1.10"
 			},
 			"peerDependencies": {
 				"react": "^18 || ^19"
@@ -54816,7 +54818,8 @@
 				"chalk": "^4.1.1",
 				"glob": "^7.1.2",
 				"jsonc-parser": "^3.3.1",
-				"simple-git": "^3.32.3"
+				"simple-git": "^3.32.3",
+				"vitest": "^4.1.10"
 			}
 		},
 		"tools/validation/node_modules/simple-git": {

--- a/routes/connectors-home/package.json
+++ b/routes/connectors-home/package.json
@@ -28,7 +28,8 @@
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
-		"@testing-library/user-event": "^14.6.1"
+		"@testing-library/user-event": "^14.6.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19"

--- a/routes/connectors-home/test/ai-plugin-callout.tsx
+++ b/routes/connectors-home/test/ai-plugin-callout.tsx
@@ -3,6 +3,8 @@
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -14,13 +16,16 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { AiPluginCallout } from '../ai-plugin-callout';
 
-jest.mock( '@wordpress/a11y', () => ( {
-	speak: jest.fn(),
-} ) );
+vi.mock(
+	import( '@wordpress/a11y' ),
+	() =>
+		( {
+			speak: vi.fn(),
+		} ) as unknown as typeof import('@wordpress/a11y')
+);
 
-jest.mock( '@wordpress/components', () => {
-	const { createElement, forwardRef } =
-		jest.requireActual( '@wordpress/element' );
+vi.mock( import( '@wordpress/components' ), async () => {
+	const { createElement, forwardRef } = await import( '@wordpress/element' );
 
 	return {
 		Button: forwardRef(
@@ -32,7 +37,7 @@ jest.mock( '@wordpress/components', () => {
 					disabled,
 				}: {
 					href?: string;
-					children: unknown;
+					children: ReactNode;
 					onClick?: () => void;
 					disabled?: boolean;
 				},
@@ -51,53 +56,80 @@ jest.mock( '@wordpress/components', () => {
 			children,
 		}: {
 			href: string;
-			children: unknown;
+			children: ReactNode;
 		} ) => createElement( 'a', { href }, children ),
-	};
+	} as unknown as typeof import('@wordpress/components');
 } );
 
-jest.mock( '@wordpress/core-data', () => ( {
-	store: 'core',
-} ) );
+vi.mock(
+	import( '@wordpress/core-data' ),
+	() =>
+		( {
+			store: 'core',
+		} ) as unknown as typeof import('@wordpress/core-data')
+);
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	useSelect: jest.fn(),
-	createSelector: jest.fn( ( fn ) => fn ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
-		const newState: Record< string, unknown > = {};
+vi.mock(
+	import( '@wordpress/data' ),
+	() =>
+		( {
+			useDispatch: vi.fn(),
+			useSelect: vi.fn(),
+			createSelector: vi.fn( ( fn ) => fn ),
+			createRegistrySelector: vi.fn( ( fn ) => fn ),
+			createReduxStore: vi.fn( () => ( {} ) ),
+			combineReducers: vi.fn(
+				(
+					reducers: Record<
+						string,
+						( state: unknown, action: unknown ) => unknown
+					>
+				) =>
+					(
+						state: Record< string, unknown > = {},
+						action: unknown
+					) => {
+						const newState: Record< string, unknown > = {};
 
-		Object.keys( reducers ).forEach( ( key ) => {
-			newState[ key ] = reducers[ key ](
-				( state as Record< string, unknown > )[ key ],
-				action
-			);
-		} );
+						Object.keys( reducers ).forEach( ( key ) => {
+							newState[ key ] = reducers[ key ](
+								state[ key ],
+								action
+							);
+						} );
 
-		return newState;
-	} ),
-	register: jest.fn(),
-	keyedReducer: jest.fn( () => ( reducer ) => reducer ),
-} ) );
+						return newState;
+					}
+			),
+			register: vi.fn(),
+			keyedReducer: vi.fn( () => ( reducer: unknown ) => reducer ),
+		} ) as unknown as typeof import('@wordpress/data')
+);
 
-jest.mock( '../default-connectors', () => ( {
-	getConnectorData: jest.fn( () => ( {
-		openai: {
-			type: 'ai_provider',
-			authentication: {
-				method: 'api_key',
-				settingName: 'connectors_ai_openai_api_key',
-				isConnected: false,
-			},
-		},
-	} ) ),
-} ) );
+vi.mock(
+	import( '../default-connectors' ),
+	() =>
+		( {
+			getConnectorData: vi.fn( () => ( {
+				openai: {
+					type: 'ai_provider',
+					authentication: {
+						method: 'api_key',
+						settingName: 'connectors_ai_openai_api_key',
+						isConnected: false,
+					},
+				},
+			} ) ),
+		} ) as unknown as typeof import('../default-connectors')
+);
 
-jest.mock( '../wp-logo-decoration', () => ( {
-	WpLogoDecoration: () => null,
-} ) );
+vi.mock(
+	import( '../wp-logo-decoration' ),
+	() =>
+		( {
+			WpLogoDecoration: () => null,
+		} ) as unknown as typeof import('../wp-logo-decoration')
+);
 
 type StoreState = {
 	canCreate: boolean;
@@ -106,16 +138,18 @@ type StoreState = {
 	siteSettings?: Record< string, string >;
 };
 
-const mockSaveEntityRecord = jest.fn();
-const mockCreateSuccessNotice = jest.fn();
-const mockCreateErrorNotice = jest.fn();
+const mockSaveEntityRecord = vi.fn();
+const mockCreateSuccessNotice = vi.fn();
+const mockCreateErrorNotice = vi.fn();
+const mockedUseSelect = vi.mocked( useSelect ) as Mock;
+const mockedUseDispatch = vi.mocked( useDispatch ) as Mock;
 
 describe( 'AiPluginCallout', () => {
 	let storeState: StoreState;
 	let selectorStore: {
-		canUser: jest.Mock;
-		getEntityRecord: jest.Mock;
-		hasFinishedResolution: jest.Mock;
+		canUser: Mock;
+		getEntityRecord: Mock;
+		hasFinishedResolution: Mock;
 	};
 
 	beforeEach( () => {
@@ -130,8 +164,8 @@ describe( 'AiPluginCallout', () => {
 		};
 
 		selectorStore = {
-			canUser: jest.fn( () => storeState.canCreate ),
-			getEntityRecord: jest.fn(
+			canUser: vi.fn( () => storeState.canCreate ),
+			getEntityRecord: vi.fn(
 				( kind: string, name: string, id?: string ) => {
 					if ( kind === 'root' && name === 'site' ) {
 						return storeState.siteSettings;
@@ -148,12 +182,12 @@ describe( 'AiPluginCallout', () => {
 					return undefined;
 				}
 			),
-			hasFinishedResolution: jest.fn(
+			hasFinishedResolution: vi.fn(
 				() => storeState.hasFinishedResolution
 			),
 		};
 
-		( useSelect as jest.Mock ).mockImplementation(
+		mockedUseSelect.mockImplementation(
 			( mapSelect: ( select: () => typeof selectorStore ) => unknown ) =>
 				mapSelect( () => selectorStore )
 		);
@@ -162,7 +196,7 @@ describe( 'AiPluginCallout', () => {
 		mockSaveEntityRecord.mockResolvedValue( undefined );
 		mockCreateSuccessNotice.mockReset();
 		mockCreateErrorNotice.mockReset();
-		( useDispatch as jest.Mock ).mockReturnValue( {
+		mockedUseDispatch.mockReturnValue( {
 			saveEntityRecord: mockSaveEntityRecord,
 			createSuccessNotice: mockCreateSuccessNotice,
 			createErrorNotice: mockCreateErrorNotice,

--- a/routes/dashboard/hooks/use-dashboard-layout/test/use-dashboard-layout.test.ts
+++ b/routes/dashboard/hooks/use-dashboard-layout/test/use-dashboard-layout.test.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -16,9 +17,16 @@ import type { DashboardWidget } from '@wordpress/widget-dashboard';
  */
 import { useDashboardLayout } from '../';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( import( '@wordpress/api-fetch' ), async ( importOriginal ) => {
+	const original = await importOriginal();
 
-const mockedApiFetch = apiFetch as unknown as jest.Mock;
+	return {
+		...original,
+		default: vi.fn(),
+	} as unknown as typeof original;
+} );
+
+const mockedApiFetch = vi.mocked( apiFetch );
 
 const SCOPE = 'core/dashboard';
 const KEY = 'dashboardLayout';

--- a/routes/dashboard/package.json
+++ b/routes/dashboard/package.json
@@ -31,7 +31,8 @@
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
-		"@testing-library/react": "^16.3.2"
+		"@testing-library/react": "^16.3.2",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19"

--- a/test/unit/scripts/test/resolver.js
+++ b/test/unit/scripts/test/resolver.js
@@ -1,9 +1,20 @@
-const nodePath = require( 'node:path' );
+/**
+ * Node dependencies
+ */
+import { createRequire } from 'node:module';
+import nodePath from 'node:path';
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire( import.meta.url );
 const resolver = require( '../resolver' );
 
 describe( 'unit test resolver', () => {
 	it( 'resolves WordPress source imports without package exports', () => {
-		const defaultResolver = jest.fn( ( request ) => request );
+		const defaultResolver = vi.fn( ( request ) => request );
 
 		resolver( '@wordpress/block-editor/src/hooks/list-view', {
 			defaultResolver,

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -12,7 +12,9 @@
 			"jsdom": {
 				"files": [
 					"packages/html-entities/src/test/entities.ts",
-					"packages/report-flaky-tests/src/__tests__/markdown.test.ts"
+					"packages/report-flaky-tests/src/__tests__/markdown.test.ts",
+					"routes/connectors-home/test/ai-plugin-callout.tsx",
+					"routes/dashboard/hooks/use-dashboard-layout/test/use-dashboard-layout.test.ts"
 				],
 				"directories": [
 					"packages/a11y",
@@ -75,7 +77,9 @@
 			},
 			"node": {
 				"files": [
-					"packages/report-flaky-tests/src/__tests__/run.test.ts"
+					"packages/report-flaky-tests/src/__tests__/run.test.ts",
+					"test/unit/scripts/test/resolver.js",
+					"tools/validation/validate-package-contents.test.js"
 				],
 				"directories": [
 					"packages/babel-plugin-import-jsx-pragma",

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -30,7 +30,8 @@
 		"chalk": "^4.1.1",
 		"glob": "^7.1.2",
 		"jsonc-parser": "^3.3.1",
-		"simple-git": "^3.32.3"
+		"simple-git": "^3.32.3",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/tools/validation/validate-package-contents.test.js
+++ b/tools/validation/validate-package-contents.test.js
@@ -1,14 +1,19 @@
-/* global afterEach, expect, test */
+/**
+ * Node dependencies
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * External dependencies
  */
-const { spawnSync } = require( 'node:child_process' );
-const { mkdtempSync, mkdirSync, rmSync, writeFileSync } = require( 'node:fs' );
-const { tmpdir } = require( 'node:os' );
-const { dirname, join } = require( 'node:path' );
+import { afterEach, expect, test } from 'vitest';
 
-const validatorPath = join( __dirname, 'validate-package-contents.mjs' );
+const currentDirectory = dirname( fileURLToPath( import.meta.url ) );
+const validatorPath = join( currentDirectory, 'validate-package-contents.mjs' );
 const temporaryRoots = [];
 
 afterEach( () => {


### PR DESCRIPTION
## What?

Follow-up to #80855.

**TL;DR:** Migrates the remaining standalone route and repository-tooling tests: Testing Library stays in place, Jest globals become explicit Vitest imports, route mocks become typed ESM module mocks, Node tests use native ESM with narrow `createRequire` boundaries, and each owning workspace declares Vitest directly.

This moves 4 files / 13 tests from Jest to Vitest:

- Connectors Home's AI plugin callout
- Dashboard's layout hook
- the unit-test source resolver
- package-content validation

## Why?

These were the final isolated Jest-owned files outside the larger package and integration-test batches. Migrating them leaves the remaining work package-bounded while preserving each test's existing environment and behavior.

## How?

- Routes stay in jsdom and continue using Testing Library and semantic queries.
- Jest module factories become type-checked `vi.mock( import( ... ) )` factories.
- Node helpers use native `node:` imports and `import.meta.url`; the CommonJS resolver is loaded through `createRequire` at its actual compatibility boundary.
- The migration manifest routes every baseline test to exactly one runner.
- Vitest is declared by the three workspaces that now own Vitest tests.

## Testing Instructions

```sh
npm run test:unit:routing --workspace @wordpress/unit-tests
npm run test:unit:conventions --workspace @wordpress/unit-tests
npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest --project node
npm run test:unit --workspace @wordpress/unit-tests -- --runInBand
npm run lint:js -- routes/connectors-home/test/ai-plugin-callout.tsx routes/dashboard/hooks/use-dashboard-layout/test/use-dashboard-layout.test.ts test/unit/scripts/test/resolver.js tools/validation/validate-package-contents.test.js
npm run lint:pkg-json
node tools/validation/validate-package-lock.cjs
```

Expected routing: 460 Jest tests and 543 Vitest tests, with all 996 baseline files owned exactly once.

### Testing Instructions for Keyboard

Not applicable; test infrastructure only, with no production UI behavior changes.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was implemented and verified with Codex. The author reviewed the generated changes and test results.