### PR TITLE
Unit Tests: Reorganise the jest config file.

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -71,6 +71,7 @@ module.exports = {
 			'packages/$1/src',
 	},
 	preset: require.resolve( '@wordpress/jest-preset-default' ),
+	testEnvironment: require.resolve( 'jest-environment-jsdom' ),
 	setupFiles: [
 		'<rootDir>/test/unit/config/global-mocks.js',
 		'<rootDir>/test/unit/config/gutenberg-env.js',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -24,16 +24,29 @@ const transpiledPackageNames = glob(
 // Make sure the tests run in UTC timezone, regardless of the system timezone.
 process.env.TZ = 'UTC';
 
+/*
+ * Resolved rather than hardcoded to `<rootDir>/node_modules`,
+ * which is empty under non-hoisting installs.
+ */
+const ariakitTestDir = path.dirname(
+	require.resolve( '@ariakit/test/package.json', {
+		paths: [ path.join( ROOT_DIR, 'packages/components' ) ],
+	} )
+);
+const ariakitUtilsDir = path.dirname(
+	require.resolve( '@ariakit/utils/package.json', {
+		paths: [ ariakitTestDir ],
+	} )
+);
+
 module.exports = {
 	rootDir: '../../',
 	moduleNameMapper: {
 		// Jest resolves dependencies from CommonJS and cannot select import-only
 		// package exports. Map Ariakit's ESM test helpers explicitly.
-		'^@ariakit/test$': '<rootDir>/node_modules/@ariakit/test/dist/index.js',
-		'^@ariakit/test/react$':
-			'<rootDir>/node_modules/@ariakit/test/dist/react.js',
-		'^@ariakit/utils$':
-			'<rootDir>/node_modules/@ariakit/utils/dist/index.js',
+		'^@ariakit/test$': path.join( ariakitTestDir, 'dist/index.js' ),
+		'^@ariakit/test/react$': path.join( ariakitTestDir, 'dist/react.js' ),
+		'^@ariakit/utils$': path.join( ariakitUtilsDir, 'dist/index.js' ),
 		// Mock @wordpress/vips/worker before the general pattern so it doesn't try to load the real file.
 		// The worker-code.ts file is auto-generated during full builds and is gitignored.
 		'@wordpress/vips/worker':

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -42,6 +42,9 @@ const ariakitUtilsDir = path.dirname(
 module.exports = {
 	rootDir: '../../',
 	moduleNameMapper: {
+		/**
+		 * Specific mappings first (before generic patterns)
+		 */
 		// Jest resolves dependencies from CommonJS and cannot select import-only
 		// package exports. Map Ariakit's ESM test helpers explicitly.
 		'^@ariakit/test$': path.join( ariakitTestDir, 'dist/index.js' ),
@@ -55,13 +58,17 @@ module.exports = {
 		// The worker-code.ts file is auto-generated during full builds and is gitignored.
 		'@wordpress/video-conversion/worker':
 			'<rootDir>/test/unit/config/video-conversion-worker-code-stub.js',
-		[ `@wordpress\\/(${ transpiledPackageNames.join( '|' ) })$` ]:
-			'packages/$1/src',
 		'@wordpress/theme/design-tokens.js':
 			'<rootDir>/packages/theme/prebuilt/js/design-tokens.mjs',
 		'@wordpress/block-library/build-module/(.*).mjs':
 			'<rootDir>/packages/block-library/src/$1.js',
 		'.+\\.wasm$': '<rootDir>/test/unit/config/wasm-stub.js',
+		// Map deep paths (e.g., @wordpress/block-editor/src/hooks/list-view)
+		[ `@wordpress\\/(${ transpiledPackageNames.join( '|' ) })\\/(.+)$` ]:
+			'packages/$1/$2',
+		// Then map exact package imports (e.g., @wordpress/compose)
+		[ `@wordpress\\/(${ transpiledPackageNames.join( '|' ) })$` ]:
+			'packages/$1/src',
 	},
 	preset: require.resolve( '@wordpress/jest-preset-default' ),
 	setupFiles: [

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -21,6 +21,19 @@ const transpiledPackageNames = glob(
 	return relative.split( path.sep )[ 1 ];
 } );
 
+const dependenciesToTransform = [
+	'@ariakit/test',
+	'@ariakit/utils',
+	'@preact',
+	'comctx',
+	'docker-compose',
+	'marked',
+	'parsel-js',
+	'preact',
+	'uuid',
+	'yaml',
+];
+
 // Make sure the tests run in UTC timezone, regardless of the system timezone.
 process.env.TZ = 'UTC';
 
@@ -99,7 +112,7 @@ module.exports = {
 		'^.+\\.m?[jt]sx?$': '<rootDir>/test/unit/scripts/babel-transformer.js',
 	},
 	transformIgnorePatterns: [
-		'/node_modules/(?!(docker-compose|yaml|preact|@preact|parsel-js|comctx|uuid|marked|@ariakit/(test|utils))/)',
+		`/node_modules/(?!(${ dependenciesToTransform.join( '|' ) })/)`,
 		'\\.pnp\\.[^\\/]+$',
 	],
 	snapshotSerializers: [

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -53,7 +53,7 @@ const ariakitUtilsDir = path.dirname(
 );
 
 module.exports = {
-	rootDir: '../../',
+	rootDir: ROOT_DIR,
 	moduleNameMapper: {
 		/**
 		 * Specific mappings first (before generic patterns)


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/80765#discussion_r3680765570

Some changes extracted from the isolated mode PR #75814

This PR updates the unit-test Jest configuration so module resolution works with isolated dependency installs as well as the default install layout. It also reorganizes `moduleNameMapper` and makes the list of dependencies transformed by Jest easier to maintain.

## Why?

The Ariakit mappings added in #80765 point directly to the root `node_modules` directory. Workspace-only dependencies are not available there when dependencies are installed in isolation, so Jest cannot resolve those modules.

Some other parts of the configuration also rely on hoisted dependencies or mapper ordering. Specific mappings need to be evaluated before generic `@wordpress/*` mappings, and deep package imports need their own mapping.

## How?

- Resolve `@ariakit/test` from the Components workspace and resolve `@ariakit/utils` from the installed Ariakit test package.
- Put specific module mappings before the generic WordPress package mappings.
- Add a mapping for deep imports from transpiled WordPress packages.
- Reuse the already computed absolute `ROOT_DIR` as Jest's `rootDir`.
- Resolve `jest-environment-jsdom` explicitly.
- Extract the dependencies that Jest must transform into a `dependenciesToTransform` array.

## Testing Instructions

- `npm run test:unit` should be happy, already checked by CI

### Testing Instructions for Keyboard

Not applicable. This PR does not change the user interface.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

OpenAI Codex, used _only_ to draft this PR description.
