### PR TITLE
Migrate JavaScript Integration Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54433,7 +54433,8 @@
 				"ajv": "^8.17.1",
 				"fast-glob": "^3.2.7",
 				"react": "^18.3.1",
-				"rimraf": "^5.0.10"
+				"rimraf": "^5.0.10",
+				"vitest": "^4.1.10"
 			}
 		},
 		"test/performance": {

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -1,54 +1,54 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Blocks raw handling pasteHandler apple 1`] = `"<strong>This is a</strong> title<br><br><br><strong>This is a <em>heading</em></strong><br><br><br>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.<br><br><br>A<br>Bulleted<br>Indented<br>List<br><br><br>One<br>Two<br>Three<br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br>An image:<br>"`;
+exports[`Blocks raw handling > pasteHandler > apple 1`] = `"<strong>This is a</strong> title<br><br><br><strong>This is a <em>heading</em></strong><br><br><br>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.<br><br><br>A<br>Bulleted<br>Indented<br>List<br><br><br>One<br>Two<br>Three<br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br>An image:<br>"`;
 
-exports[`Blocks raw handling pasteHandler classic 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
+exports[`Blocks raw handling > pasteHandler > classic 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
 
-exports[`Blocks raw handling pasteHandler evernote 1`] = `"This is a <em>paragraph</em>.<br><br><br>This is a <a href="https://w.org">link</a>.<br><br><br>An<br>Unordered<br>Indented<br>List<br><br><br>One<br>Two<br>Indented<br>Three<br><br><br><br><br><br><br>One<br>Two<br>Three<br>Four<br>Five<br>Six<br><img src="data:image/jpeg;base64,###">"`;
+exports[`Blocks raw handling > pasteHandler > evernote 1`] = `"This is a <em>paragraph</em>.<br><br><br>This is a <a href="https://w.org">link</a>.<br><br><br>An<br>Unordered<br>Indented<br>List<br><br><br>One<br>Two<br>Indented<br>Three<br><br><br><br><br><br><br>One<br>Two<br>Three<br>Four<br>Five<br>Six<br><img src="data:image/jpeg;base64,###">"`;
 
-exports[`Blocks raw handling pasteHandler google-docs 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br>"`;
+exports[`Blocks raw handling > pasteHandler > google-docs 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br>"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-link-spacing 1`] = `"This is a paragraph with a <a href="https://example.com/one">link in the middle</a> of the sentence, and it ends with <a href="https://example.com/two">another link</a> before the final words."`;
+exports[`Blocks raw handling > pasteHandler > google-docs-link-spacing 1`] = `"This is a paragraph with a <a href="https://example.com/one">link in the middle</a> of the sentence, and it ends with <a href="https://example.com/two">another link</a> before the final words."`;
 
-exports[`Blocks raw handling pasteHandler google-docs-list-only 1`] = `"My first list item<br>A sub list item<br>A second sub list item<br>My second list item<br>My third list item"`;
+exports[`Blocks raw handling > pasteHandler > google-docs-list-only 1`] = `"My first list item<br>A sub list item<br>A second sub list item<br>My second list item<br>My third list item"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-table 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
+exports[`Blocks raw handling > pasteHandler > google-docs-table 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-table-with-colspan 1`] = `"<br><br>Test colspan<br><br>"`;
+exports[`Blocks raw handling > pasteHandler > google-docs-table-with-colspan 1`] = `"<br><br>Test colspan<br><br>"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-table-with-comments 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
+exports[`Blocks raw handling > pasteHandler > google-docs-table-with-comments 1`] = `"<br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-table-with-rowspan 1`] = `"<br><br>Test rowspan<br><br>"`;
+exports[`Blocks raw handling > pasteHandler > google-docs-table-with-rowspan 1`] = `"<br><br>Test rowspan<br><br>"`;
 
-exports[`Blocks raw handling pasteHandler google-docs-with-comments 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br><br>"`;
+exports[`Blocks raw handling > pasteHandler > google-docs-with-comments 1`] = `"This is a <strong>title</strong><br><br>This is a <em>heading</em><br><br>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br><br>A<br>Bulleted<br>Indented<br>List<br><br>One<br>Two<br>Three<br><br><br><br><br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br><br><br><br><br><br>An image:<br><br><img src="https://lh4.googleusercontent.com/ID" width="544" height="184"><br><br>"`;
 
-exports[`Blocks raw handling pasteHandler grok-markdown 1`] = `"Heading<br>This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.<br>Subheading<br>Another paragraph with a <a href="https://example.com">link</a>."`;
+exports[`Blocks raw handling > pasteHandler > grok-markdown 1`] = `"Heading<br>This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.<br>Subheading<br>Another paragraph with a <a href="https://example.com">link</a>."`;
 
-exports[`Blocks raw handling pasteHandler gutenberg 1`] = `"Test"`;
+exports[`Blocks raw handling > pasteHandler > gutenberg 1`] = `"Test"`;
 
-exports[`Blocks raw handling pasteHandler iframe-embed 1`] = `""`;
+exports[`Blocks raw handling > pasteHandler > iframe-embed 1`] = `""`;
 
-exports[`Blocks raw handling pasteHandler markdown 1`] = `"This is a heading with <em>italic</em><br>This is a paragraph with a <a href="https://w.org/">link</a>, <strong>bold</strong>, and <del>strikethrough</del>.<br>Preserve<br>line breaks please.<br>Lists<br>A<br>Bulleted Indented<br>List<br>One<br>Two<br>Three<br>Table<br>First Header<br>Second Header<br>Content from cell 1<br>Content from cell 2<br>Content in the first column<br>Content in the second column<br><br><br><br>Table with empty cells.<br>Quote<br>First<br>Second<br>Code<br>Inline <code>code</code> tags should work.<br><code>This is a code block.</code>"`;
+exports[`Blocks raw handling > pasteHandler > markdown 1`] = `"This is a heading with <em>italic</em><br>This is a paragraph with a <a href="https://w.org/">link</a>, <strong>bold</strong>, and <del>strikethrough</del>.<br>Preserve<br>line breaks please.<br>Lists<br>A<br>Bulleted Indented<br>List<br>One<br>Two<br>Three<br>Table<br>First Header<br>Second Header<br>Content from cell 1<br>Content from cell 2<br>Content in the first column<br>Content in the second column<br><br><br><br>Table with empty cells.<br>Quote<br>First<br>Second<br>Code<br>Inline <code>code</code> tags should work.<br><code>This is a code block.</code>"`;
 
-exports[`Blocks raw handling pasteHandler mixed-content 1`] = `"Some heading<br><br>Content we need to preserve"`;
+exports[`Blocks raw handling > pasteHandler > mixed-content 1`] = `"Some heading<br><br>Content we need to preserve"`;
 
-exports[`Blocks raw handling pasteHandler ms-word 1`] = `"This is a title<br>&nbsp;<br>This is a subtitle<br>&nbsp;<br>This is a heading level 1<br>&nbsp;<br>This is a heading level 2<br>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href="https://w.org/">link</a>.<br>&nbsp;<br>A<br>Bulleted<br>Indented<br>List<br>&nbsp;<br>One<br>Two<br>Three<br>&nbsp;<br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br>&nbsp;<br>An image:<br>&nbsp;<br><img width="451" height="338" src="file:LOW-RES.png"><br><a href="#anchor">This is an anchor link</a> that leads to the next paragraph.<br><a id="anchor">This is the paragraph with the anchor.</a><br><a href="#nowhere">This is an anchor link</a> that leads nowhere.<br><a>This is a paragraph with an anchor with no link pointing to it.</a><br>This is a reference to a footnote<a href="#_ftn1" id="_ftnref1">[1]</a>.<br>This is a reference to an endnote<a href="#_edn1" id="_ednref1">[i]</a>.<br><br><br><a href="#_ftnref1" id="_ftn1">[1]</a> This is a footnote.<br><br><br><a href="#_ednref1" id="_edn1">[i]</a> This is an endnote."`;
+exports[`Blocks raw handling > pasteHandler > ms-word 1`] = `"This is a title<br>&nbsp;<br>This is a subtitle<br>&nbsp;<br>This is a heading level 1<br>&nbsp;<br>This is a heading level 2<br>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href="https://w.org/">link</a>.<br>&nbsp;<br>A<br>Bulleted<br>Indented<br>List<br>&nbsp;<br>One<br>Two<br>Three<br>&nbsp;<br>One<br>Two<br>Three<br>1<br>2<br>3<br>I<br>II<br>III<br>&nbsp;<br>An image:<br>&nbsp;<br><img width="451" height="338" src="file:LOW-RES.png"><br><a href="#anchor">This is an anchor link</a> that leads to the next paragraph.<br><a id="anchor">This is the paragraph with the anchor.</a><br><a href="#nowhere">This is an anchor link</a> that leads nowhere.<br><a>This is a paragraph with an anchor with no link pointing to it.</a><br>This is a reference to a footnote<a href="#_ftn1" id="_ftnref1">[1]</a>.<br>This is a reference to an endnote<a href="#_edn1" id="_ednref1">[i]</a>.<br><br><br><a href="#_ftnref1" id="_ftn1">[1]</a> This is a footnote.<br><br><br><a href="#_ednref1" id="_edn1">[i]</a> This is an endnote."`;
 
-exports[`Blocks raw handling pasteHandler ms-word-list 1`] = `"<a>This is a headline?</a><br>This is a text:<br>One<br>Two<br>Three<br><a>Lorem Ipsum.</a><br>&nbsp;"`;
+exports[`Blocks raw handling > pasteHandler > ms-word-list 1`] = `"<a>This is a headline?</a><br>This is a text:<br>One<br>Two<br>Three<br><a>Lorem Ipsum.</a><br>&nbsp;"`;
 
-exports[`Blocks raw handling pasteHandler ms-word-online 1`] = `"This is a <em>heading</em>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href="https://w.org/" target="_blank" rel="noopener">link</a>.&nbsp;<br>A&nbsp;<br>Bulleted&nbsp;<br>Indented&nbsp;<br>List&nbsp;<br>&nbsp;<br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br><br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br>1&nbsp;<br>2&nbsp;<br>3&nbsp;<br>I&nbsp;<br>II&nbsp;<br>III&nbsp;<br>&nbsp;<br>An image:&nbsp;<br><img src="data:image/jpeg;base64,###">&nbsp;"`;
+exports[`Blocks raw handling > pasteHandler > ms-word-online 1`] = `"This is a <em>heading</em>&nbsp;<br>This is a <strong>paragraph</strong> with a <a href="https://w.org/" target="_blank" rel="noopener">link</a>.&nbsp;<br>A&nbsp;<br>Bulleted&nbsp;<br>Indented&nbsp;<br>List&nbsp;<br>&nbsp;<br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br><br>One&nbsp;<br>Two&nbsp;<br>Three&nbsp;<br>1&nbsp;<br>2&nbsp;<br>3&nbsp;<br>I&nbsp;<br>II&nbsp;<br>III&nbsp;<br>&nbsp;<br>An image:&nbsp;<br><img src="data:image/jpeg;base64,###">&nbsp;"`;
 
-exports[`Blocks raw handling pasteHandler ms-word-styled 1`] = `"<br><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit&nbsp;</strong><br><br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque aliquet hendrerit auctor. Nam lobortis, est vel lacinia tincidunt, purus tellus vehicula ex, nec pharetra justo dui sed lorem. Nam congue laoreet massa, quis varius est tincidunt ut."`;
+exports[`Blocks raw handling > pasteHandler > ms-word-styled 1`] = `"<br><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit&nbsp;</strong><br><br><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque aliquet hendrerit auctor. Nam lobortis, est vel lacinia tincidunt, purus tellus vehicula ex, nec pharetra justo dui sed lorem. Nam congue laoreet massa, quis varius est tincidunt ut."`;
 
-exports[`Blocks raw handling pasteHandler nested-divs 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
+exports[`Blocks raw handling > pasteHandler > nested-divs 1`] = `"First paragraph<br><br>Second paragraph<br>Third paragraph<br>Fourth paragraph<br>Fifth paragraph<br>Sixth paragraph"`;
 
-exports[`Blocks raw handling pasteHandler one-image 1`] = `"<img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137">"`;
+exports[`Blocks raw handling > pasteHandler > one-image 1`] = `"<img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137">"`;
 
-exports[`Blocks raw handling pasteHandler plain 1`] = `"test<br>test<br><br>test"`;
+exports[`Blocks raw handling > pasteHandler > plain 1`] = `"test<br>test<br><br>test"`;
 
-exports[`Blocks raw handling pasteHandler shortcode-matching 1`] = `"[gallery ids="40,41,42"]<br>[gallery ids="1000"]<br>[gallery ids="42"]"`;
+exports[`Blocks raw handling > pasteHandler > shortcode-matching 1`] = `"[gallery ids="40,41,42"]<br>[gallery ids="1000"]<br>[gallery ids="42"]"`;
 
-exports[`Blocks raw handling pasteHandler should remove extra blank lines 1`] = `
+exports[`Blocks raw handling > pasteHandler > should remove extra blank lines 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>
 <!-- /wp:paragraph -->
@@ -58,15 +58,15 @@ exports[`Blocks raw handling pasteHandler should remove extra blank lines 1`] = 
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Blocks raw handling pasteHandler should strip HTML formatting space from inline text 1`] = `"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent a elit eget tortor molestie egestas. Donec pretium urna vitae mattis imperdiet. Praesent et lorem iaculis, volutpat odio vitae, ornare lacus. Donec ut felis tristique, pharetra erat id, viverra justo. Integer sit amet elementum arcu, eget pharetra felis. In malesuada enim est, sed placerat nulla feugiat at. Vestibulum feugiat vitae elit sit amet tincidunt. Pellentesque finibus sed dolor non facilisis. Curabitur accumsan ante ac hendrerit vestibulum."`;
+exports[`Blocks raw handling > pasteHandler > should strip HTML formatting space from inline text 1`] = `"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent a elit eget tortor molestie egestas. Donec pretium urna vitae mattis imperdiet. Praesent et lorem iaculis, volutpat odio vitae, ornare lacus. Donec ut felis tristique, pharetra erat id, viverra justo. Integer sit amet elementum arcu, eget pharetra felis. In malesuada enim est, sed placerat nulla feugiat at. Vestibulum feugiat vitae elit sit amet tincidunt. Pellentesque finibus sed dolor non facilisis. Curabitur accumsan ante ac hendrerit vestibulum."`;
 
-exports[`Blocks raw handling pasteHandler should strip some text-level elements 1`] = `
+exports[`Blocks raw handling > pasteHandler > should strip some text-level elements 1`] = `
 "<!-- wp:paragraph -->
 <p>This is ncorect</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Blocks raw handling pasteHandler should strip windows data 1`] = `
+exports[`Blocks raw handling > pasteHandler > should strip windows data 1`] = `
 "<!-- wp:heading -->
 <h2 class="wp-block-heading">Heading Win</h2>
 <!-- /wp:heading -->
@@ -76,15 +76,15 @@ exports[`Blocks raw handling pasteHandler should strip windows data 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Blocks raw handling pasteHandler slack-paragraphs 1`] = `"test with&nbsp;<a target="_blank" href="http://w.org/" rel="noopener">link</a><br>a new line<br><br>a new paragraph<br>another new line<br><br>another paragraph"`;
+exports[`Blocks raw handling > pasteHandler > slack-paragraphs 1`] = `"test with&nbsp;<a target="_blank" href="http://w.org/" rel="noopener">link</a><br>a new line<br><br>a new paragraph<br>another new line<br><br>another paragraph"`;
 
-exports[`Blocks raw handling pasteHandler slack-quote 1`] = `"Test with&nbsp;<a target="_blank" href="http://w.org/" rel="noopener">link</a>."`;
+exports[`Blocks raw handling > pasteHandler > slack-quote 1`] = `"Test with&nbsp;<a target="_blank" href="http://w.org/" rel="noopener">link</a>."`;
 
-exports[`Blocks raw handling pasteHandler two-images 1`] = `"<img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137"> <img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" width="300" height="248">"`;
+exports[`Blocks raw handling > pasteHandler > two-images 1`] = `"<img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137"> <img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" width="300" height="248">"`;
 
-exports[`Blocks raw handling pasteHandler wordpress 1`] = `"Howdy<br>This is a paragraph.<br>More tag<br><br>Shortcode<br>[gallery ids="1"]<br><img src="block.png" alt=""><br><img src="aligned.png" alt=""> test<br><img src="not-aligned.png" alt=""> test"`;
+exports[`Blocks raw handling > pasteHandler > wordpress 1`] = `"Howdy<br>This is a paragraph.<br>More tag<br><br>Shortcode<br>[gallery ids="1"]<br><img src="block.png" alt=""><br><img src="aligned.png" alt=""> test<br><img src="not-aligned.png" alt=""> test"`;
 
-exports[`Blocks raw handling should correctly handle quotes with mixed content 1`] = `
+exports[`Blocks raw handling > should correctly handle quotes with mixed content 1`] = `
 "<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:heading {"level":1} -->
 <h1 class="wp-block-heading">chicken</h1>
@@ -96,7 +96,7 @@ exports[`Blocks raw handling should correctly handle quotes with mixed content 1
 <!-- /wp:quote -->"
 `;
 
-exports[`rawHandler should convert HTML post to blocks with minimal content changes 1`] = `
+exports[`rawHandler > should convert HTML post to blocks with minimal content changes 1`] = `
 "<!-- wp:heading -->
 <h2 class="wp-block-heading">Howdy</h2>
 <!-- /wp:heading -->
@@ -163,25 +163,25 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 <!-- /wp:quote -->"
 `;
 
-exports[`rawHandler should convert a caption shortcode 1`] = `
+exports[`rawHandler > should convert a caption shortcode 1`] = `
 "<!-- wp:image {"id":122,"align":"none","className":"size-medium wp-image-122"} -->
 <figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption">test</figcaption></figure>
 <!-- /wp:image -->"
 `;
 
-exports[`rawHandler should convert a caption shortcode with caption 1`] = `
+exports[`rawHandler > should convert a caption shortcode with caption 1`] = `
 "<!-- wp:image {"id":122,"align":"none","className":"size-medium wp-image-122"} -->
 <figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption"><a href="https://w.org">test</a></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
-exports[`rawHandler should convert a caption shortcode with link 1`] = `
+exports[`rawHandler > should convert a caption shortcode with link 1`] = `
 "<!-- wp:image {"id":754,"align":"none"} -->
 <figure class="wp-block-image alignnone"><a href="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg"><img src="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg?w=604" alt="Bell on Wharf" class="wp-image-754"/></a><figcaption class="wp-element-caption">Bell on wharf in San Francisco</figcaption></figure>
 <!-- /wp:image -->"
 `;
 
-exports[`rawHandler should convert a list with attributes 1`] = `
+exports[`rawHandler > should convert a list with attributes 1`] = `
 "<!-- wp:list {"ordered":true,"type":"lower-roman","start":2,"reversed":true} -->
 <ol reversed start="2" style="list-style-type:lower-roman" class="wp-block-list"><!-- wp:list-item -->
 <li>1<!-- wp:list {"ordered":true,"type":"lower-roman","start":2,"reversed":true} -->
@@ -193,19 +193,19 @@ exports[`rawHandler should convert a list with attributes 1`] = `
 <!-- /wp:list -->"
 `;
 
-exports[`rawHandler should not strip any text-level elements 1`] = `
+exports[`rawHandler > should not strip any text-level elements 1`] = `
 "<!-- wp:paragraph -->
 <p>This is <u>ncorect</u></p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`rawHandler should preserve alignment 1`] = `
+exports[`rawHandler > should preserve alignment 1`] = `
 "<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"}}} -->
 <p class="has-text-align-center">center</p>
 <!-- /wp:paragraph -->"
 `;
 
-exports[`rawHandler should preserve all paragraphs 1`] = `
+exports[`rawHandler > should preserve all paragraphs 1`] = `
 "<!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -1,8 +1,14 @@
 /**
+ * Node dependencies
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
  * External dependencies
  */
-import fs from 'fs';
-import path from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -17,6 +23,13 @@ import {
 } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 
+/**
+ * Internal dependencies
+ */
+import '../../packages/editor/src/hooks';
+
+const currentDirectory = path.dirname( fileURLToPath( import.meta.url ) );
+
 function readFile( filePath ) {
 	return fs.existsSync( filePath )
 		? fs.readFileSync( filePath, 'utf8' ).trim()
@@ -25,8 +38,6 @@ function readFile( filePath ) {
 
 describe( 'Blocks raw handling', () => {
 	beforeAll( () => {
-		// Load all hooks that modify blocks.
-		require( '../../packages/editor/src/hooks' );
 		registerCoreBlocks();
 		registerBlockType( 'test/gallery', {
 			apiVersion: 3,
@@ -432,23 +443,22 @@ describe( 'Blocks raw handling', () => {
 			'slack-paragraphs',
 			'mixed-content',
 		].forEach( ( type ) => {
-			// eslint-disable-next-line jest/valid-title
 			it( type, () => {
 				const HTML = readFile(
 					path.join(
-						__dirname,
+						currentDirectory,
 						`fixtures/documents/${ type }-in.html`
 					)
 				);
 				const plainText = readFile(
 					path.join(
-						__dirname,
+						currentDirectory,
 						`fixtures/documents/${ type }-in.txt`
 					)
 				);
 				const output = readFile(
 					path.join(
-						__dirname,
+						currentDirectory,
 						`fixtures/documents/${ type }-out.html`
 					)
 				);
@@ -485,7 +495,7 @@ describe( 'Blocks raw handling', () => {
 		it( 'should remove extra blank lines', () => {
 			const HTML = readFile(
 				path.join(
-					__dirname,
+					currentDirectory,
 					'fixtures/documents/google-docs-blank-lines.html'
 				)
 			);
@@ -495,7 +505,7 @@ describe( 'Blocks raw handling', () => {
 
 		it( 'should strip windows data', () => {
 			const HTML = readFile(
-				path.join( __dirname, 'fixtures/documents/windows.html' )
+				path.join( currentDirectory, 'fixtures/documents/windows.html' )
 			);
 			expect( serialize( pasteHandler( { HTML } ) ) ).toMatchSnapshot();
 			expect( console ).toHaveLogged();
@@ -504,7 +514,7 @@ describe( 'Blocks raw handling', () => {
 		it( 'should strip HTML formatting space from inline text', () => {
 			const HTML = readFile(
 				path.join(
-					__dirname,
+					currentDirectory,
 					'fixtures/documents/inline-with-html-formatting-space.html'
 				)
 			);
@@ -517,14 +527,20 @@ describe( 'Blocks raw handling', () => {
 describe( 'rawHandler', () => {
 	it( 'should convert HTML post to blocks with minimal content changes', () => {
 		const HTML = readFile(
-			path.join( __dirname, 'fixtures/documents/wordpress-convert.html' )
+			path.join(
+				currentDirectory,
+				'fixtures/documents/wordpress-convert.html'
+			)
 		);
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
 
 	it( 'should convert a caption shortcode', () => {
 		const HTML = readFile(
-			path.join( __dirname, 'fixtures/documents/shortcode-caption.html' )
+			path.join(
+				currentDirectory,
+				'fixtures/documents/shortcode-caption.html'
+			)
 		);
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
@@ -532,7 +548,7 @@ describe( 'rawHandler', () => {
 	it( 'should convert a caption shortcode with link', () => {
 		const HTML = readFile(
 			path.join(
-				__dirname,
+				currentDirectory,
 				'fixtures/documents/shortcode-caption-with-link.html'
 			)
 		);
@@ -542,7 +558,7 @@ describe( 'rawHandler', () => {
 	it( 'should convert a caption shortcode with caption', () => {
 		const HTML = readFile(
 			path.join(
-				__dirname,
+				currentDirectory,
 				'fixtures/documents/shortcode-caption-with-caption-link.html'
 			)
 		);
@@ -552,7 +568,7 @@ describe( 'rawHandler', () => {
 	it( 'should convert a list with attributes', () => {
 		const HTML = readFile(
 			path.join(
-				__dirname,
+				currentDirectory,
 				'fixtures/documents/list-with-attributes.html'
 			)
 		);

--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -1,8 +1,14 @@
 /**
+ * Node dependencies
+ */
+import { readFileSync } from 'node:fs';
+
+/**
  * External dependencies
  */
 import Ajv from 'ajv';
 import glob from 'fast-glob';
+import { describe, expect, test } from 'vitest';
 
 /**
  * Internal dependencies
@@ -32,7 +38,9 @@ describe( 'block.json schema', () => {
 
 	test.each( jsonFiles )( 'validates schema for `%s`', ( filepath ) => {
 		// We want to validate the block.json file using the local schema.
-		const { $schema, ...blockMetadata } = require( filepath );
+		const { $schema, ...blockMetadata } = JSON.parse(
+			readFileSync( filepath, 'utf8' )
+		);
 
 		expect( $schema ).toBe( 'https://schemas.wp.org/trunk/block.json' );
 

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -1,8 +1,14 @@
 /**
+ * Node dependencies
+ */
+import { readFileSync } from 'node:fs';
+import { format } from 'node:util';
+
+/**
  * External dependencies
  */
-import { format } from 'util';
 import glob from 'fast-glob';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -59,7 +65,9 @@ describe( 'full post content fixture', () => {
 		);
 		const blockDefinitions = Object.fromEntries(
 			blockMetadataFiles.map( ( file ) => {
-				const { name, ...metadata } = require( file );
+				const { name, ...metadata } = JSON.parse(
+					readFileSync( file, 'utf8' )
+				);
 				return [ name, metadata ];
 			} )
 		);
@@ -84,7 +92,6 @@ describe( 'full post content fixture', () => {
 	}
 
 	blockBasenames.forEach( ( basename ) => {
-		// eslint-disable-next-line jest/valid-title
 		it( basename, () => {
 			const { filename: htmlFixtureFileName, file: htmlFixtureContent } =
 				getBlockFixtureHTML( basename );

--- a/test/integration/is-valid-block.test.js
+++ b/test/integration/is-valid-block.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createElement } from '@wordpress/element';
@@ -10,12 +15,12 @@ import {
 } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 
-describe( 'validateBlock', () => {
-	beforeAll( () => {
-		// Load all hooks that modify blocks.
-		require( '../../packages/editor/src/hooks' );
-	} );
+/**
+ * Internal dependencies
+ */
+import '../../packages/editor/src/hooks';
 
+describe( 'validateBlock', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );

--- a/test/integration/non-matched-tags-handling.test.js
+++ b/test/integration/non-matched-tags-handling.test.js
@@ -1,13 +1,21 @@
 /**
+ * External dependencies
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { pasteHandler, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 
+/**
+ * Internal dependencies
+ */
+import '../../packages/editor/src/hooks';
+
 describe( 'Handling of non matched tags in block transforms', () => {
 	beforeAll( () => {
-		// Load all hooks that modify blocks.
-		require( '../../packages/editor/src/hooks' );
 		registerCoreBlocks();
 	} );
 	it( 'correctly pastes preformatted tag even if preformatted block is removed', () => {

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -37,7 +37,8 @@
 		"ajv": "^8.17.1",
 		"fast-glob": "^3.2.7",
 		"react": "^18.3.1",
-		"rimraf": "^5.0.10"
+		"rimraf": "^5.0.10",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -1,8 +1,14 @@
 /**
+ * Node dependencies
+ */
+import { readFileSync } from 'node:fs';
+
+/**
  * External dependencies
  */
 import Ajv from 'ajv';
 import glob from 'fast-glob';
+import { describe, expect, it, test } from 'vitest';
 
 /**
  * Internal dependencies
@@ -40,7 +46,9 @@ describe( 'theme.json schema', () => {
 
 	test.each( jsonFiles )( 'validates schema for `%s`', ( filepath ) => {
 		// We want to validate the theme.json file using the local schema.
-		const { $schema, ...metadata } = require( filepath );
+		const { $schema, ...metadata } = JSON.parse(
+			readFileSync( filepath, 'utf8' )
+		);
 
 		// we expect the $schema property to be present in the theme.json file
 		expect( $schema ).toBeTruthy();
@@ -52,7 +60,9 @@ describe( 'theme.json schema', () => {
 
 	test.each( invalidFiles )( 'invalidates schema for `%s`', ( filepath ) => {
 		// We want to validate the theme.json file using the local schema.
-		const { $schema, ...metadata } = require( filepath );
+		const { $schema, ...metadata } = JSON.parse(
+			readFileSync( filepath, 'utf8' )
+		);
 
 		const result = ajv.validate( themeSchema, metadata );
 

--- a/test/integration/wp-env-schema.test.js
+++ b/test/integration/wp-env-schema.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import Ajv from 'ajv';
+import { describe, expect, test } from 'vitest';
 
 /**
  * Internal dependencies

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -72,7 +72,8 @@
 					"packages/warning",
 					"packages/widget-dashboard",
 					"packages/widget-primitives",
-					"packages/wordcount"
+					"packages/wordcount",
+					"test/integration"
 				]
 			},
 			"node": {


### PR DESCRIPTION
## What?

Follow-up to #80855.

**TL;DR:** Migrates all 8 JavaScript integration-test files: explicit Vitest imports, native ESM side-effect and JSON-fixture loading, direct workspace dependency ownership, and an audited snapshot-key normalization with unchanged payloads.

This moves 616 tests and 44 snapshots from Jest to the Vitest jsdom project.

## Why?

The integration directory was the last non-package test batch owned by Jest. Moving it as one bounded slice keeps its shared block-registration and fixture behavior together and leaves the remaining Jest inventory package-bounded.

## How?

- Replaces injected Jest runner globals with explicit Vitest imports.
- Replaces CommonJS `require()` and `__dirname` usage with static ESM side-effect imports, `node:fs`, and `import.meta.url`.
- Declares Vitest directly in `@wordpress/integration-tests`.
- Routes the directory to the jsdom project in the migration manifest.
- Normalizes 41 external snapshot keys to Vitest's hierarchy. Every payload was compared programmatically against the pre-migration snapshot and is byte-for-byte identical; the other 3 inline snapshots are unchanged.

## Testing Instructions

```sh
npm run test:unit:routing --workspace @wordpress/unit-tests
npm run test:unit:conventions --workspace @wordpress/unit-tests
npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest test/integration
npm run test:unit --workspace @wordpress/unit-tests -- --runInBand
npm run lint:js -- test/integration/blocks-raw-handling.test.js test/integration/blocks-schema.test.js test/integration/full-content/full-content.test.js test/integration/is-valid-block.test.js test/integration/non-matched-tags-handling.test.js test/integration/shortcode-converter.test.js test/integration/theme-schema.test.js test/integration/wp-env-schema.test.js
node tools/validation/validate-package-lock.cjs
```

Expected routing: 452 Jest tests and 551 Vitest tests, with all 996 baseline files owned exactly once.

### Testing Instructions for Keyboard

Not applicable; test infrastructure only, with no production UI behavior changes.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was implemented and verified with Codex. The author reviewed the generated changes, snapshot audit, and test results.