### PR TITLE
Migrate DataViews Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50547,10 +50547,10 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/jest": "^30.0.0",
 				"@wordpress/format-library": "file:../format-library",
 				"esbuild": "^0.27.2",
-				"storybook": "^10.4.3"
+				"storybook": "^10.4.3",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/dataviews/global.d.ts
+++ b/packages/dataviews/global.d.ts
@@ -2,4 +2,4 @@
 // type definitions found in the specified directories.
 // To ensure that global types are included, we need to
 // explicitly reference them here.
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -82,10 +82,10 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/jest": "^30.0.0",
 		"@wordpress/format-library": "file:../format-library",
 		"esbuild": "^0.27.2",
-		"storybook": "^10.4.3"
+		"storybook": "^10.4.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
+++ b/packages/dataviews/src/components/dataform-controls/richtext/test/control.tsx
@@ -3,6 +3,16 @@
  */
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import type { MutableRefObject } from 'react';
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from 'vitest';
 
 /**
  * WordPress dependencies
@@ -273,7 +283,7 @@ describe( 'RichTextControl', () => {
 
 	describe( 'line breaks', () => {
 		it( 'blocks Enter from inserting line breaks when `disableLineBreaks` is set', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const { container } = render(
 				<RichTextControl
 					label="Single line"
@@ -298,7 +308,7 @@ describe( 'RichTextControl', () => {
 		] )(
 			'inserts a single line break into the value on %s',
 			async ( _label, modifiers ) => {
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				const { container } = render(
 					<RichTextControl
 						label="Note"
@@ -334,7 +344,7 @@ describe( 'RichTextControl', () => {
 		] )(
 			'leaves Enter presses from an IME %s to the browser',
 			async ( _label, eventInit ) => {
-				const onChange = jest.fn();
+				const onChange = vi.fn();
 				const { container } = render(
 					<RichTextControl
 						label="Note"
@@ -363,7 +373,7 @@ describe( 'RichTextControl', () => {
 		);
 
 		it( 'leaves Enter presses with a meta or ctrl modifier to consumers', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const { container } = render(
 				<RichTextControl
 					label="Note"
@@ -428,7 +438,7 @@ describe( 'RichTextControl', () => {
 		// format type can be registered once in `beforeAll` (avoiding store
 		// updates during render that would re-fire `useSelect` outside
 		// `act(...)`), while each test can still assert on a fresh mock.
-		let currentOnUse: jest.Mock;
+		let currentOnUse: Mock;
 
 		// Re-implement `RichTextShortcut` locally to keep the assertion on
 		// the registration contract explicit. It registers a callback into
@@ -490,7 +500,7 @@ describe( 'RichTextControl', () => {
 		} );
 
 		beforeEach( () => {
-			currentOnUse = jest.fn();
+			currentOnUse = vi.fn();
 		} );
 
 		// Dispatch a `primary+b` keydown — on non-Apple platforms (jsdom's
@@ -659,7 +669,7 @@ describe( 'RichTextControl', () => {
 
 	describe( 'disabled and validation states', () => {
 		it( 'renders a non-editable field with a disabled state when `disabled`', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const { container } = render(
 				<RichTextControl
 					label="Summary"
@@ -872,7 +882,7 @@ describe( 'RichTextControl', () => {
 		} );
 
 		it( 'runs registered format input rules on insertText input events', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const { container } = render(
 				<RichTextControl
 					label="Input rule"
@@ -895,7 +905,7 @@ describe( 'RichTextControl', () => {
 		} );
 
 		it( 'ignores non-text input events', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const { container } = render(
 				<RichTextControl
 					label="Input rule ignore"

--- a/packages/dataviews/src/components/dataform-controls/test/richtext.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/richtext.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 // The rich-text assembly (`./control`) wires `@wordpress/rich-text`'s
 // useRichText hook (format types, event listeners, etc.) into the
@@ -10,8 +11,7 @@ import userEvent from '@testing-library/user-event';
 // integration-heavy. Mock the assembly entirely so this file can verify the
 // dataform control's prop wiring in isolation without standing up the real
 // editing pipeline.
-jest.mock( '../richtext/control', () => ( {
-	__esModule: true,
+vi.mock( import( '../richtext/control' ), () => ( {
 	default( props: any ) {
 		const handleChange = ( event: any ) =>
 			props.onChange( event.target.value );
@@ -81,7 +81,7 @@ describe( 'dataform-controls/richtext', () => {
 			<RichText< TestItem >
 				data={ { content: 'Hello world' } }
 				field={ buildField() as any }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				hideLabelFromVision={ false }
 				config={ {} }
 			/>
@@ -97,7 +97,7 @@ describe( 'dataform-controls/richtext', () => {
 
 	it( 'invokes onChange with the result of field.setValue when the value changes', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render(
 			<RichText< TestItem >
 				data={ { content: '' } }
@@ -117,7 +117,7 @@ describe( 'dataform-controls/richtext', () => {
 
 	it( 'normalizes a null field value to an empty string and still sets string values', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render(
 			<RichText< { content: string | null } >
 				data={ { content: null } }
@@ -145,7 +145,7 @@ describe( 'dataform-controls/richtext', () => {
 			<RichText< TestItem >
 				data={ { content: '' } }
 				field={ buildField( { placeholder: 'No title' } ) as any }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				hideLabelFromVision={ false }
 				config={ {} }
 			/>
@@ -160,7 +160,7 @@ describe( 'dataform-controls/richtext', () => {
 			<RichText< TestItem >
 				data={ { content: '' } }
 				field={ buildField() as any }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				hideLabelFromVision
 				config={ {
 					clientId: 'abc-123',
@@ -190,7 +190,7 @@ describe( 'dataform-controls/richtext', () => {
 			<RichText< TestItem >
 				data={ { content: '' } }
 				field={ buildField( { isDisabled: () => true } ) as any }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				hideLabelFromVision={ false }
 				config={ {} }
 			/>
@@ -209,7 +209,7 @@ describe( 'dataform-controls/richtext', () => {
 						isValid: { required: {} },
 					} ) as any
 				}
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				hideLabelFromVision={ false }
 				markWhenOptional
 				config={ {} }
@@ -233,7 +233,7 @@ describe( 'dataform-controls/richtext', () => {
 			<RichText< TestItem >
 				data={ { content: 'x' } }
 				field={ buildField() as any }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				hideLabelFromVision={ false }
 				config={ undefined }
 			/>

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import normalizeForm from '../normalize-form';

--- a/packages/dataviews/src/components/dataviews-layouts/utils/test/use-selection-props.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/test/use-selection-props.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/dataviews/src/dataform/test/dataform.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.tsx
@@ -3,6 +3,7 @@
  */
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -16,7 +17,10 @@ import { speak } from '@wordpress/a11y';
 import Dataform from '../index';
 import useFormValidity from '../../hooks/use-form-validity';
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+vi.mock( import( '@wordpress/a11y' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	speak: vi.fn(),
+} ) );
 
 const noop = () => {};
 
@@ -129,7 +133,7 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should call onChange with the correct value for each typed character', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			render(
 				<Dataform
 					onChange={ onChange }
@@ -154,7 +158,7 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should allow decimal input for number fields', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const fieldsWithNumber = [
 				...fields,
 				{
@@ -368,7 +372,7 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should apply changes and close modal when apply button is clicked', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const formWithModalPanel = {
 				...form,
 				layout: {
@@ -413,7 +417,7 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should call onChange with the correct value for each typed character', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			render(
 				<Dataform
 					onChange={ onChange }
@@ -780,7 +784,7 @@ describe( 'DataForm component', () => {
 			await user.click(
 				screen.getByRole( 'button', { name: /main card/i } )
 			);
-			jest.mocked( speak ).mockClear();
+			vi.mocked( speak ).mockClear();
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Outside' } )
@@ -910,7 +914,7 @@ describe( 'DataForm component', () => {
 			await act( async () => {
 				details!.open = false;
 			} );
-			jest.mocked( speak ).mockClear();
+			vi.mocked( speak ).mockClear();
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Outside' } )

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -34,7 +35,7 @@ type Data = {
 	order?: number;
 };
 
-const onChangeSelection = jest.fn();
+const onChangeSelection = vi.fn();
 
 const data: Data[] = [
 	{
@@ -57,7 +58,7 @@ const data: Data[] = [
 	},
 ];
 
-const singleSelectCallback = jest.fn();
+const singleSelectCallback = vi.fn();
 const singleSelectActions: ActionButton< Data >[] = [
 	{
 		id: 'confirm',
@@ -68,7 +69,7 @@ const singleSelectActions: ActionButton< Data >[] = [
 	},
 ];
 
-const multiSelectCallback = jest.fn();
+const multiSelectCallback = vi.fn();
 const multiSelectActions: ActionButton< Data >[] = [
 	{
 		id: 'confirm',

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -3,6 +3,7 @@
  */
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -150,17 +151,17 @@ function DataViewWrapper( {
 	return <DataViews { ...dataViewProps } />;
 }
 
-// jest.useFakeTimers();
-
 // Tests run against a DataView which is 500px wide.
-const mockUseViewportMatch = jest.fn(
+const mockUseViewportMatch = vi.fn(
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	( _viewport: string, _operator: string ) => false
 );
-jest.mock( '@wordpress/compose', () => {
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => {
+	const original = await importOriginal();
+
 	return {
-		...jest.requireActual( '@wordpress/compose' ),
-		useResizeObserver: jest.fn( ( callback ) => {
+		...original,
+		useResizeObserver: vi.fn( ( callback ) => {
 			setTimeout( () => {
 				callback( [
 					{
@@ -172,7 +173,7 @@ jest.mock( '@wordpress/compose', () => {
 		} ),
 		useViewportMatch: ( viewport: string, operator: string ): boolean =>
 			mockUseViewportMatch( viewport, operator ),
-	};
+	} as unknown as typeof original;
 } );
 
 describe( 'DataViews component', () => {
@@ -241,14 +242,17 @@ describe( 'DataViews component', () => {
 	} );
 
 	it( 'should trigger infinite scroll when the layout container scrolls', async () => {
-		const onChangeView = jest.fn();
+		const onChangeView = vi.fn();
 
-		if ( typeof global.IntersectionObserver === 'undefined' ) {
-			( global as any ).IntersectionObserver = jest.fn( () => ( {
-				observe: jest.fn(),
-				unobserve: jest.fn(),
-				disconnect: jest.fn(),
-			} ) );
+		if ( typeof globalThis.IntersectionObserver === 'undefined' ) {
+			class IntersectionObserverMock {
+				observe = vi.fn();
+				unobserve = vi.fn();
+				disconnect = vi.fn();
+			}
+
+			globalThis.IntersectionObserver =
+				IntersectionObserverMock as unknown as typeof IntersectionObserver;
 		}
 
 		const { container } = render(
@@ -338,7 +342,7 @@ describe( 'DataViews component', () => {
 		} );
 
 		it( 'should trigger the onClickItem callback if isItemClickable returns true and title field is clicked', async () => {
-			const onClickItemCallback = jest.fn();
+			const onClickItemCallback = vi.fn();
 
 			render(
 				<DataViewWrapper
@@ -575,7 +579,7 @@ describe( 'DataViews component', () => {
 		} );
 
 		it( 'swallows modifier clicks on non-selectable items and skips them in ranges', async () => {
-			const onClickItem = jest.fn();
+			const onClickItem = vi.fn();
 			render(
 				<DataViewWrapper
 					view={ {
@@ -678,7 +682,7 @@ describe( 'DataViews component', () => {
 		} );
 
 		it( 'should trigger the onClickItem callback if isItemClickable returns true and a media field is clicked', async () => {
-			const mediaClickItemCallback = jest.fn();
+			const mediaClickItemCallback = vi.fn();
 
 			render(
 				<DataViewWrapper

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import normalizeFields from '../index';

--- a/packages/dataviews/src/hooks/test/use-data.ts
+++ b/packages/dataviews/src/hooks/test/use-data.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/src/utils/test/filter-sort-and-paginate.js
+++ b/packages/dataviews/src/utils/test/filter-sort-and-paginate.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { subDays, subYears } from 'date-fns';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -4,8 +4,7 @@
 	"compilerOptions": {
 		"types": [
 			"gutenberg-env",
-			"gutenberg-test-env",
-			"jest",
+			"gutenberg-vitest-test-env",
 			"style-imports",
 			"react-css-custom-properties"
 		]

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -31,6 +31,7 @@
 					"packages/core-commands",
 					"packages/customize-widgets",
 					"packages/date",
+					"packages/dataviews",
 					"packages/deprecated",
 					"packages/dom",
 					"packages/dom-ready",


### PR DESCRIPTION
## What?

Follow-up to #80855.

**TL;DR:** Completes the DataViews package migration: explicit Vitest imports, typed ESM partial-module mocks, Vitest-native matcher/types wiring, removal of `@types/jest`, and an explicit constructable `IntersectionObserver` test double in place of Jest-specific mock behavior.

This moves 11 files / 356 tests from Jest to the Vitest jsdom project.

## Why?

DataViews was the smallest remaining complete package boundary. Migrating it removes its Jest type dependency and validates its Testing Library-heavy component and hook coverage under the canonical Vitest configuration.

## How?

- Keeps Testing Library, `userEvent.setup()`, and semantic queries.
- Replaces Jest globals and mocks with explicit Vitest APIs and type-checked `vi.mock( import( ... ) )` factories.
- Replaces an arrow-function mock that Jest treated as constructable with a local `IntersectionObserver` class matching the intended platform contract.
- Switches package test types and jest-dom matcher augmentation to the Vitest variants.
- Declares Vitest directly and routes the complete package through the migration manifest.

No snapshots change.

## Testing Instructions

```sh
npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest packages/dataviews
npm run test:unit:conventions --workspace @wordpress/unit-tests
npm run test:unit:routing --workspace @wordpress/unit-tests
npm run test:unit --workspace @wordpress/unit-tests -- --runInBand
npm run lint:js -- packages/dataviews/src
node tools/validation/validate-package-lock.cjs
```

Expected routing: 441 Jest tests and 562 Vitest tests, with all 996 baseline files owned exactly once.

### Testing Instructions for Keyboard

Not applicable; test infrastructure only, with no production UI behavior changes.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This PR was implemented and verified with Codex. The author reviewed the generated changes and test results.