### PR TITLE
Migrate Media Utils Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52090,7 +52090,8 @@
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@wordpress/preferences": "file:../preferences"
+				"@wordpress/preferences": "file:../preferences",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -68,7 +68,8 @@
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@wordpress/preferences": "file:../preferences"
+		"@wordpress/preferences": "file:../preferences",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.test.tsx
@@ -3,6 +3,15 @@
  */
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from 'vitest';
 
 /**
  * WordPress dependencies
@@ -20,9 +29,10 @@ import { unlock } from '../../../lock-unlock';
 
 const preferenceKey = 'dataviews-postType-attachment-media-modal';
 
-jest.mock( '@wordpress/core-data', () => {
-	const { __dangerousOptInToUnstableAPIsOnlyForCoreModules } =
-		jest.requireActual( '@wordpress/private-apis' );
+vi.mock( import( '@wordpress/core-data' ), async () => {
+	const { __dangerousOptInToUnstableAPIsOnlyForCoreModules } = await import(
+		'@wordpress/private-apis'
+	);
 	const { lock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/core-data'
@@ -30,7 +40,7 @@ jest.mock( '@wordpress/core-data', () => {
 	// Keep the private API contract real while replacing only the data hook.
 	const privateApis = {};
 	lock( privateApis, {
-		useEntityRecordsWithPermissions: jest.fn(),
+		useEntityRecordsWithPermissions: vi.fn(),
 	} );
 
 	return {
@@ -38,11 +48,11 @@ jest.mock( '@wordpress/core-data', () => {
 		store: {
 			name: 'core',
 		},
-	};
+	} as unknown as typeof import('@wordpress/core-data');
 } );
 
 const mockUseEntityRecordsWithPermissions = unlock( coreDataPrivateApis )
-	.useEntityRecordsWithPermissions as jest.Mock;
+	.useEntityRecordsWithPermissions as Mock;
 
 const IMAGE_RECORDS = [
 	{
@@ -72,15 +82,15 @@ function mockRecords( records: unknown[] ) {
 	} );
 }
 
-type ModalProps = { isOpen?: boolean; value?: number | number[] };
+type ModalProps = { isOpen: boolean; value?: number | number[] };
 
-function renderModal( { isOpen = true, value }: ModalProps = {} ) {
+function renderModal( { isOpen = true, value }: Partial< ModalProps > = {} ) {
 	const registry = createRegistry();
 	registry.register( noticesStore );
 	registry.register( preferencesStore );
 
-	const onSelect = jest.fn();
-	const onClose = jest.fn();
+	const onSelect = vi.fn();
+	const onClose = vi.fn();
 
 	const view = render(
 		<RegistryProvider value={ registry }>
@@ -119,7 +129,7 @@ describe( 'MediaUploadModal', () => {
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'resets page and search when the modal is closed and reopened', async () => {

--- a/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
+++ b/packages/media-utils/src/components/media-upload-modal/test/use-upload-status.test.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
@@ -38,9 +39,13 @@ type BatchCallbacks = ReturnType<
 >;
 
 // isBlobURL from @wordpress/blob checks for the "blob:" prefix.
-jest.mock( '@wordpress/blob', () => ( {
-	isBlobURL: ( url: string ) => url.startsWith( 'blob:' ),
-} ) );
+vi.mock(
+	import( '@wordpress/blob' ),
+	() =>
+		( {
+			isBlobURL: ( url: string ) => url.startsWith( 'blob:' ),
+		} ) as unknown as typeof import('@wordpress/blob')
+);
 
 describe( 'useUploadStatus', () => {
 	it( 'should start with empty state', () => {
@@ -169,7 +174,7 @@ describe( 'useUploadStatus', () => {
 		} );
 
 		it( 'should call onBatchComplete exactly once even if onFileChange fires multiple times', () => {
-			const onBatchComplete = jest.fn();
+			const onBatchComplete = vi.fn();
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
@@ -197,7 +202,7 @@ describe( 'useUploadStatus', () => {
 			// When __clientSideMediaProcessing is true, blob URLs are not
 			// created. onFileChange is called with a growing array as each
 			// file completes: [att1], [att1, att2], [att1, att2, att3].
-			const onBatchComplete = jest.fn();
+			const onBatchComplete = vi.fn();
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
@@ -344,7 +349,7 @@ describe( 'useUploadStatus', () => {
 			// 2-3. Partial completions with blobs (ignored)
 			// 4. c.png fails → onFileChange([a, b]), successCount = 2
 			// 5. onError(c.png) → errorCount = 1, total = 3 = batchSize
-			const onBatchComplete = jest.fn();
+			const onBatchComplete = vi.fn();
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);
@@ -409,7 +414,7 @@ describe( 'useUploadStatus', () => {
 		} );
 
 		it( 'should handle all files erroring', () => {
-			const onBatchComplete = jest.fn();
+			const onBatchComplete = vi.fn();
 			const { result } = renderHook( () =>
 				useUploadStatus( { onBatchComplete } )
 			);

--- a/packages/media-utils/src/components/media-upload/test/index.js
+++ b/packages/media-utils/src/components/media-upload/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
@@ -9,19 +14,19 @@ import { select, dispatch } from '@wordpress/data';
 import MediaUpload from '../index';
 import { invalidateAttachmentResolutions } from '../../../utils/invalidate-attachment-resolutions';
 
-jest.mock( '../../../utils/invalidate-attachment-resolutions' );
+vi.mock( import( '../../../utils/invalidate-attachment-resolutions' ) );
 
 describe( 'MediaUpload', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'onClose', () => {
 		it( 'invalidates the cached attachment resolutions against the default registry', () => {
-			const instance = new MediaUpload( { onClose: jest.fn() } );
+			const instance = new MediaUpload( { onClose: vi.fn() } );
 			// `onClose` detaches the underlying wp.media frame; stub it so the
 			// method can run without the global media library being present.
-			instance.frame = { detach: jest.fn() };
+			instance.frame = { detach: vi.fn() };
 
 			instance.onClose();
 
@@ -38,7 +43,7 @@ describe( 'MediaUpload', () => {
 
 		it( 'invalidates even when no onClose prop is provided', () => {
 			const instance = new MediaUpload( {} );
-			instance.frame = { detach: jest.fn() };
+			instance.frame = { detach: vi.fn() };
 
 			instance.onClose();
 
@@ -52,9 +57,9 @@ describe( 'MediaUpload', () => {
 		} );
 
 		it( 'calls the onClose prop before detaching the frame', () => {
-			const onClose = jest.fn();
+			const onClose = vi.fn();
 			const instance = new MediaUpload( { onClose } );
-			instance.frame = { detach: jest.fn() };
+			instance.frame = { detach: vi.fn() };
 
 			instance.onClose();
 

--- a/packages/media-utils/src/utils/test/flatten-form-data.ts
+++ b/packages/media-utils/src/utils/test/flatten-form-data.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { flattenFormData } from '../flatten-form-data';

--- a/packages/media-utils/src/utils/test/get-mime-types-array.ts
+++ b/packages/media-utils/src/utils/test/get-mime-types-array.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getMimeTypesArray } from '../get-mime-types-array';

--- a/packages/media-utils/src/utils/test/invalidate-attachment-resolutions.ts
+++ b/packages/media-utils/src/utils/test/invalidate-attachment-resolutions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { invalidateAttachmentResolutions } from '../invalidate-attachment-resolutions';
@@ -14,7 +19,7 @@ type Registry = Parameters< typeof invalidateAttachmentResolutions >[ 0 ];
 function createRegistryStub(
 	entityRecords: Map< unknown[], { status: string } > | undefined
 ) {
-	const invalidateResolution = jest.fn();
+	const invalidateResolution = vi.fn();
 	const registry = {
 		select: () => ( {
 			getCachedResolvers: () => ( { getEntityRecords: entityRecords } ),

--- a/packages/media-utils/src/utils/test/sideload-media.ts
+++ b/packages/media-utils/src/utils/test/sideload-media.ts
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { sideloadMedia } from '../sideload-media';
 import { sideloadToServer } from '../sideload-to-server';
 
-jest.mock( '../sideload-to-server', () => ( {
-	sideloadToServer: jest.fn(),
+vi.mock( import( '../sideload-to-server' ), () => ( {
+	sideloadToServer: vi.fn(),
 } ) );
 
 const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
@@ -14,7 +19,7 @@ const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
 
 describe( 'sideloadMedia', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should sideload to server and call onSuccess with sub-size data', async () => {
@@ -26,10 +31,10 @@ describe( 'sideloadMedia', () => {
 			mime_type: 'image/jpeg',
 			filesize: 5000,
 		};
-		( sideloadToServer as jest.Mock ).mockResolvedValue( mockSubSizeData );
+		( sideloadToServer as Mock ).mockResolvedValue( mockSubSizeData );
 
-		const onError = jest.fn();
-		const onSuccess = jest.fn();
+		const onError = vi.fn();
+		const onSuccess = vi.fn();
 		await sideloadMedia( {
 			file: imageFile,
 			attachmentId: 1,

--- a/packages/media-utils/src/utils/test/upload-error.ts
+++ b/packages/media-utils/src/utils/test/upload-error.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { UploadError } from '../upload-error';

--- a/packages/media-utils/src/utils/test/upload-media.ts
+++ b/packages/media-utils/src/utils/test/upload-media.ts
@@ -1,18 +1,27 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { uploadMedia } from '../upload-media';
 import { UploadError } from '../upload-error';
 import { uploadToServer } from '../upload-to-server';
 
-jest.mock( '../upload-to-server', () => ( {
-	uploadToServer: jest.fn(),
+vi.mock( import( '../upload-to-server' ), () => ( {
+	uploadToServer: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/blob', () => ( {
-	createBlobURL: jest.fn(),
-	revokeBlobURL: jest.fn(),
-} ) );
+vi.mock(
+	import( '@wordpress/blob' ),
+	() =>
+		( {
+			createBlobURL: vi.fn(),
+			revokeBlobURL: vi.fn(),
+		} ) as unknown as typeof import('@wordpress/blob')
+);
 
 const xmlFile = new window.File( [ 'fake_file' ], 'test.xml', {
 	type: 'text/xml',
@@ -23,12 +32,12 @@ const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
 
 describe( 'uploadMedia', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should do nothing on no files', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			filesList: [],
 			onError,
@@ -40,8 +49,8 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should error if allowedTypes contains a partial mime type and the validation fails', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'image' ],
 			filesList: [ xmlFile ],
@@ -61,8 +70,8 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should error if allowedTypes contains a complete mime type and the validation fails', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'image/gif' ],
 			filesList: [ imageFile ],
@@ -75,15 +84,15 @@ describe( 'uploadMedia', () => {
 				code: 'MIME_TYPE_NOT_SUPPORTED',
 				message:
 					'test.jpeg: Sorry, this file type is not supported here.',
-				file: xmlFile,
+				file: imageFile,
 			} )
 		);
 		expect( uploadToServer ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should work if allowedTypes contains a complete mime type and the validation succeeds', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'image/jpeg' ],
 			filesList: [ imageFile ],
@@ -97,8 +106,8 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should error if allowedTypes contains multiple types and the validation fails', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'video', 'image' ],
 			filesList: [ xmlFile ],
@@ -118,8 +127,8 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should work if allowedTypes contains multiple types and the validation succeeds', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'video', 'image' ],
 			filesList: [ imageFile ],
@@ -133,8 +142,8 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should only fail the invalid file and still allow others to succeed when uploading multiple files', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'image' ],
 			filesList: [ imageFile, xmlFile ],
@@ -145,7 +154,7 @@ describe( 'uploadMedia', () => {
 
 		expect( onError ).toHaveBeenCalledWith(
 			new UploadError( {
-				code: 'MIME_TYPE_NOT_SUPPORTED',
+				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
 				message:
 					'test.xml: Sorry, you are not allowed to upload this file type.',
 				file: xmlFile,
@@ -155,8 +164,8 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should error if the file size is greater than the maximum', () => {
-		const onError = jest.fn();
-		const onFileChange = jest.fn();
+		const onError = vi.fn();
+		const onFileChange = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'image' ],
 			filesList: [ imageFile ],
@@ -178,7 +187,7 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should call error handler with the correct error object if file type is not allowed for user', () => {
-		const onError = jest.fn();
+		const onError = vi.fn();
 		uploadMedia( {
 			allowedTypes: [ 'image' ],
 			filesList: [ imageFile ],
@@ -198,7 +207,7 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should throw error when multiple files are selected in single file upload mode', () => {
-		const onError = jest.fn();
+		const onError = vi.fn();
 		uploadMedia( {
 			filesList: [ imageFile, xmlFile ],
 			onError,
@@ -212,14 +221,14 @@ describe( 'uploadMedia', () => {
 	} );
 
 	it( 'should return error that is not an Error object', () => {
-		( uploadToServer as jest.Mock ).mockImplementation( () => {
+		( uploadToServer as Mock ).mockImplementation( () => {
 			throw {
 				code: 'fetch_error',
 				message: 'Could not get a valid response from the server.',
 			};
 		} );
 
-		const onError = jest.fn();
+		const onError = vi.fn();
 		uploadMedia( {
 			filesList: [ imageFile ],
 			onError,

--- a/packages/media-utils/src/utils/test/validate-file-size.ts
+++ b/packages/media-utils/src/utils/test/validate-file-size.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateFileSize } from '../validate-file-size';
@@ -14,7 +19,7 @@ const emptyFile = new window.File( [], 'test.jpeg', {
 
 describe( 'validateFileSize', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should error if the file is empty', () => {
@@ -24,7 +29,7 @@ describe( 'validateFileSize', () => {
 			new UploadError( {
 				code: 'EMPTY_FILE',
 				message: 'test.jpeg: This file is empty.',
-				file: imageFile,
+				file: emptyFile,
 			} )
 		);
 	} );

--- a/packages/media-utils/src/utils/test/validate-mime-type-for-user.ts
+++ b/packages/media-utils/src/utils/test/validate-mime-type-for-user.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateMimeTypeForUser } from '../validate-mime-type-for-user';
@@ -10,7 +15,7 @@ const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
 
 describe( 'validateMimeTypeForUser', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should not error if  wpAllowedMimeTypes is null or missing', async () => {

--- a/packages/media-utils/src/utils/test/validate-mime-type.ts
+++ b/packages/media-utils/src/utils/test/validate-mime-type.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateMimeType } from '../validate-mime-type';
@@ -13,7 +18,7 @@ const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
 
 describe( 'validateMimeType', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should error if allowedTypes contains a partial mime type and the validation fails', async () => {
@@ -37,7 +42,7 @@ describe( 'validateMimeType', () => {
 				code: 'MIME_TYPE_NOT_SUPPORTED',
 				message:
 					'test.jpeg: Sorry, this file type is not supported here.',
-				file: xmlFile,
+				file: imageFile,
 			} )
 		);
 	} );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -52,6 +52,7 @@
 					"packages/is-shallow-equal",
 					"packages/keycodes",
 					"packages/media-fields",
+					"packages/media-utils",
 					"packages/notices",
 					"packages/nux",
 					"packages/plugins",


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the complete `@wordpress/media-utils` test package from Jest globals and CommonJS-style mocks to explicit Vitest imports, typed ESM mocks, and package-owned Vitest dependency metadata.

- Routes all 12 Media Utils test files through Vitest's jsdom project.
- Keeps Testing Library and existing user-facing test behavior.
- Uses dynamic-import `vi.mock` factories and typed mock functions for Core Data, Blob, sideload, and upload boundaries.
- Corrects four latent `UploadError` expectation typos that Jest's Error equality did not expose, and makes the modal rerender helper's required `isOpen` prop explicit.
- Contains no production-code or snapshot changes.

This draft is stacked on #80942. Part of #80855.

## Why?

This is a bounded package slice of the repository-wide Jest-to-Vitest migration. Media Utils exercises DOM rendering plus upload/network module boundaries, so migrating it as a complete package keeps the exactly-one-runner invariant reviewable and independently revertible.

## How?

The migration manifest assigns `packages/media-utils` to the Vitest jsdom project. Tests import runner APIs locally, mocks use ESM-aware Vitest factories, and `vitest` is declared by the workspace that consumes it.

## Testing Instructions

- `npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest packages/media-utils`
  - 12 files, 60 tests passed.
- `npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest --project node --reporter=dot`
  - 571 files passed, 2 skipped; 10,107 tests passed, 8 skipped.
- `npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project browser`
  - 1 file, 2 tests passed in Chromium.
- `npm run test:unit --workspace @wordpress/unit-tests -- --runInBand`
  - Remaining Jest partition: 429 suites, 24,643 tests, 59 snapshots passed.
- `npm run test:unit:routing --workspace @wordpress/unit-tests`
  - 996 baseline tests: 429 Jest, 574 Vitest, no overlap or missing entries.
- `npm run test:unit:conventions --workspace @wordpress/unit-tests`
- `npm run lint:lockfile`
- `npm run lint:js -- packages/media-utils`
- `npm exec lint-staged`
