### PR TITLE
Migrate Data Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50475,7 +50475,8 @@
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -63,7 +63,8 @@
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/data/src/components/use-dispatch/test/use-dispatch.jsx
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.jsx
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/data/src/components/use-select/test/index.jsx
+++ b/packages/data/src/components/use-select/test/index.jsx
@@ -2,6 +2,16 @@
  * External dependencies
  */
 import { act, render, fireEvent, screen } from '@testing-library/react';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 
 /**
  * WordPress dependencies
@@ -58,8 +68,8 @@ describe( 'useSelect', () => {
 			},
 		} );
 
-		const selectSpy = jest.fn();
-		const TestComponent = jest.fn( ( props ) => {
+		const selectSpy = vi.fn();
+		const TestComponent = vi.fn( ( props ) => {
 			selectSpy.mockImplementation( ( select ) => ( {
 				results: select( 'testStore' ).testSelector( props.keyName ),
 			} ) );
@@ -88,9 +98,9 @@ describe( 'useSelect', () => {
 			},
 		} );
 
-		const selectSpyFoo = jest.fn( () => 'foo' );
-		const selectSpyBar = jest.fn( () => 'bar' );
-		const TestComponent = jest.fn( ( props ) => {
+		const selectSpyFoo = vi.fn( () => 'foo' );
+		const selectSpyBar = vi.fn( () => 'bar' );
+		const TestComponent = vi.fn( ( props ) => {
 			const mapSelect = props.change ? selectSpyFoo : selectSpyBar;
 			const data = useSelect( mapSelect, [ props.keyName ] );
 			return <div role="status">{ data }</div>;
@@ -152,14 +162,14 @@ describe( 'useSelect', () => {
 
 		const mapSelect = ( select ) => select( 'toggler' ).get();
 
-		const mapSelectChild = jest.fn( mapSelect );
-		const Child = jest.fn( () => {
+		const mapSelectChild = vi.fn( mapSelect );
+		const Child = vi.fn( () => {
 			const show = useSelect( mapSelectChild, [] );
 			return show ? 'yes' : 'no';
 		} );
 
-		const mapSelectParent = jest.fn( mapSelect );
-		const Parent = jest.fn( () => {
+		const mapSelectParent = vi.fn( mapSelect );
+		const Parent = vi.fn( () => {
 			const show = useSelect( mapSelectParent, [] );
 			return show ? <Child /> : 'none';
 		} );
@@ -207,7 +217,7 @@ describe( 'useSelect', () => {
 		registry.registerStore( 'store-even', counterStore( 0, 2 ) );
 		registry.registerStore( 'store-odd', counterStore( 1, 2 ) );
 
-		const mapSelect = jest.fn( ( select ) => {
+		const mapSelect = vi.fn( ( select ) => {
 			const first = select( 'store-main' ).get();
 			// select from other stores depending on whether main value is even or odd
 			const secondStore = first % 2 === 1 ? 'store-odd' : 'store-even';
@@ -215,7 +225,7 @@ describe( 'useSelect', () => {
 			return first + ':' + second;
 		} );
 
-		const TestComponent = jest.fn( () => {
+		const TestComponent = vi.fn( () => {
 			const data = useSelect( mapSelect, [] );
 			return <div role="status">{ data }</div>;
 		} );
@@ -284,10 +294,10 @@ describe( 'useSelect', () => {
 		};
 
 		let TestComponent;
-		const mapSelectSpy = jest.fn( ( select ) =>
+		const mapSelectSpy = vi.fn( ( select ) =>
 			select( 'testStore' ).testSelector()
 		);
-		const selectorSpy = jest.fn();
+		const selectorSpy = vi.fn();
 
 		beforeEach( () => {
 			registry.registerStore( 'testStore', {
@@ -355,10 +365,10 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-1', counterStore() );
 			registry.registerStore( 'store-2', counterStore() );
 
-			const selectCount1 = jest.fn();
-			const selectCount2 = jest.fn();
+			const selectCount1 = vi.fn();
+			const selectCount2 = vi.fn();
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const count1 = useSelect(
 					( select ) => selectCount1() || select( 'store-1' ).get(),
 					[]
@@ -409,9 +419,9 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-2', counterStore() );
 			registry.registerStore( 'store-3', counterStore() );
 
-			const selectCount1And2 = jest.fn();
+			const selectCount1And2 = vi.fn();
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const { count1, count2 } = useSelect(
 					( select ) =>
 						selectCount1And2() || {
@@ -458,9 +468,9 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-3', counterStore() );
 
 			let dep, setDep;
-			const selectCount1AndDep = jest.fn();
+			const selectCount1AndDep = vi.fn();
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				[ dep, setDep ] = useState( 0 );
 				const state = useSelect(
 					( select ) =>
@@ -511,11 +521,11 @@ describe( 'useSelect', () => {
 		it( 'captures state changes scheduled between render and subscription', () => {
 			registry.registerStore( 'store-1', counterStore() );
 
-			const selectCount1 = jest.fn( ( select ) => ( {
+			const selectCount1 = vi.fn( ( select ) => ( {
 				count1: select( 'store-1' ).get(),
 			} ) );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const { count1 } = useSelect( selectCount1, [] );
 
 				// Increment the store value from 0 to 1 after render and before subscription
@@ -622,9 +632,9 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-1', store1Spec );
 			registry.registerStore( 'store-2', counterStore() );
 
-			const selectCount1And2 = jest.fn();
+			const selectCount1And2 = vi.fn();
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const state = useSelect(
 					( select ) =>
 						selectCount1And2() ||
@@ -664,10 +674,10 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-1', counterStore() );
 			registry.registerStore( 'store-2', counterStore() );
 
-			const selectCount1 = jest.fn();
-			const selectCount2 = jest.fn();
+			const selectCount1 = vi.fn();
+			const selectCount2 = vi.fn();
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const [ shouldSelectCount1, toggle ] = useReducer(
 					( should ) => ! should,
 					false
@@ -736,7 +746,7 @@ describe( 'useSelect', () => {
 			const subRegistry = createRegistry( {}, registry );
 			subRegistry.registerStore( 'child-store', counterStore() );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const state = useSelect(
 					( select ) => ( {
 						parentCount: select( 'parent-store' ).get(),
@@ -776,7 +786,7 @@ describe( 'useSelect', () => {
 		it( 'handles non-existing stores', () => {
 			registry.registerStore( 'store-1', counterStore() );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const state = useSelect(
 					( select ) => ( {
 						count1: select( 'store-1' ).get(),
@@ -815,7 +825,7 @@ describe( 'useSelect', () => {
 		} );
 
 		it( 'handles registration of a non-existing store during rendering', () => {
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const state = useSelect(
 					( select ) =>
 						select( 'not-yet-registered-store' )?.get() ?? 'blank',
@@ -856,7 +866,7 @@ describe( 'useSelect', () => {
 		it( 'handles registration of a non-existing store of sub-registry during rendering', () => {
 			const subRegistry = createRegistry( {}, registry );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const state = useSelect(
 					( select ) =>
 						select( 'not-yet-registered-child-store' )?.get() ??
@@ -931,7 +941,7 @@ describe( 'useSelect', () => {
 
 			registry.register( customStore );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const state = useSelect(
 					( select ) => select( customStore ).get(),
 					[]
@@ -964,11 +974,9 @@ describe( 'useSelect', () => {
 		} );
 
 		it( 'renders with async mode', async () => {
-			const selectSpy = jest.fn( ( select ) =>
-				select( 'counter' ).get()
-			);
+			const selectSpy = vi.fn( ( select ) => select( 'counter' ).get() );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const count = useSelect( selectSpy, [] );
 				return <div role="status">{ count }</div>;
 			} );
@@ -1004,11 +1012,9 @@ describe( 'useSelect', () => {
 
 		// Tests render queue fixes done in https://github.com/WordPress/gutenberg/pull/19286
 		it( 'catches updates while switching from async to sync', () => {
-			const selectSpy = jest.fn( ( select ) =>
-				select( 'counter' ).get()
-			);
+			const selectSpy = vi.fn( ( select ) => select( 'counter' ).get() );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const count = useSelect( selectSpy, [] );
 				return <div role="status">{ count }</div>;
 			} );
@@ -1046,14 +1052,14 @@ describe( 'useSelect', () => {
 		} );
 
 		it( 'cancels scheduled updates when mapSelect function changes', async () => {
-			const selectA = jest.fn(
+			const selectA = vi.fn(
 				( select ) => 'a:' + select( 'counter' ).get()
 			);
-			const selectB = jest.fn(
+			const selectB = vi.fn(
 				( select ) => 'b:' + select( 'counter' ).get()
 			);
 
-			const TestComponent = jest.fn( ( { variant } ) => {
+			const TestComponent = vi.fn( ( { variant } ) => {
 				const count = useSelect( variant === 'a' ? selectA : selectB, [
 					variant,
 				] );
@@ -1096,11 +1102,9 @@ describe( 'useSelect', () => {
 		} );
 
 		it( 'cancels scheduled updates when unmounting', async () => {
-			const selectSpy = jest.fn( ( select ) =>
-				select( 'counter' ).get()
-			);
+			const selectSpy = vi.fn( ( select ) => select( 'counter' ).get() );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const count = useSelect( selectSpy, [] );
 				return <div role="status">{ count }</div>;
 			} );
@@ -1141,11 +1145,9 @@ describe( 'useSelect', () => {
 			const registry2 = createRegistry();
 			registry2.registerStore( 'counter', counterStore( 100 ) );
 
-			const selectSpy = jest.fn( ( select ) =>
-				select( 'counter' ).get()
-			);
+			const selectSpy = vi.fn( ( select ) => select( 'counter' ).get() );
 
-			const TestComponent = jest.fn( () => {
+			const TestComponent = vi.fn( () => {
 				const count = useSelect( selectSpy, [] );
 				return <div role="status">{ count }</div>;
 			} );
@@ -1248,7 +1250,7 @@ describe( 'useSelect', () => {
 		it( 'can read the current value from store', () => {
 			registry.registerStore( 'testStore', counterStore() );
 
-			const record = jest.fn();
+			const record = vi.fn();
 
 			function TestComponent() {
 				const { get } = useSelect( 'testStore' );

--- a/packages/data/src/components/use-select/test/suspense.jsx
+++ b/packages/data/src/components/use-select/test/suspense.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -194,7 +195,7 @@ describe( 'useSuspenseSelect', () => {
 		const registry = createRegistry();
 		registry.register( store );
 
-		const FastUI = jest.fn( () => {
+		const FastUI = vi.fn( () => {
 			const data = useSuspenseSelect(
 				( select ) => select( store ).getData( 'fast' ),
 				[]
@@ -202,7 +203,7 @@ describe( 'useSuspenseSelect', () => {
 			return <div aria-label="fast loaded">{ data }</div>;
 		} );
 
-		const SlowUI = jest.fn( () => {
+		const SlowUI = vi.fn( () => {
 			const data = useSuspenseSelect(
 				( select ) => select( store ).getData( 'slow' ),
 				[]

--- a/packages/data/src/components/with-dispatch/test/index.jsx
+++ b/packages/data/src/components/with-dispatch/test/index.jsx
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -37,25 +38,21 @@ describe( 'withDispatch', () => {
 		const registry = createRegistry();
 		registry.registerStore( 'counter', storeOptions );
 
-		const ButtonSpy = jest.fn( ( { onClick } ) => (
+		const ButtonSpy = vi.fn( ( { onClick } ) => (
 			<button onClick={ onClick } />
 		) );
 		const Button = memo( ButtonSpy );
+		let actionReturnedFromDispatch;
 
 		const Component = withDispatch( ( dispatch, ownProps ) => {
 			const { count } = ownProps;
 
 			return {
 				increment: () => {
-					const actionReturnedFromDispatch = Promise.resolve(
+					actionReturnedFromDispatch = Promise.resolve(
 						dispatch( 'counter' ).increment( count )
 					);
-					return expect(
-						actionReturnedFromDispatch
-					).resolves.toEqual( {
-						type: 'inc',
-						count,
-					} );
+					return actionReturnedFromDispatch;
 				},
 			};
 		} )( ( props ) => (
@@ -81,6 +78,10 @@ describe( 'withDispatch', () => {
 		expect( ButtonSpy ).toHaveBeenCalledTimes( 1 );
 
 		await user.click( screen.getByRole( 'button' ) );
+		await expect( actionReturnedFromDispatch ).resolves.toEqual( {
+			type: 'inc',
+			count: 2,
+		} );
 		expect( registry.select( 'counter' ).getCount() ).toBe( 2 );
 	} );
 

--- a/packages/data/src/components/with-select/test/index.jsx
+++ b/packages/data/src/components/with-select/test/index.jsx
@@ -3,6 +3,7 @@
  */
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -47,11 +48,11 @@ describe( 'withSelect', () => {
 		// including both `withSelect` and `select` in the same scope, which
 		// shouldn't occur for a typical component, and if it did might wrongly
 		// encourage the developer to use `select` within the component itself.
-		const mapSelectToProps = jest.fn( ( _select, ownProps ) => ( {
+		const mapSelectToProps = vi.fn( ( _select, ownProps ) => ( {
 			data: _select( 'reactReducer' ).reactSelector( ownProps.keyName ),
 		} ) );
 
-		const OriginalComponent = jest.fn( ( props ) => (
+		const OriginalComponent = vi.fn( ( props ) => (
 			<div role="status">{ props.data }</div>
 		) );
 
@@ -92,15 +93,15 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn( ( _select ) => ( {
+		const mapSelectToProps = vi.fn( ( _select ) => ( {
 			count: _select( 'counter' ).getCount(),
 		} ) );
 
-		const mapDispatchToProps = jest.fn( ( _dispatch ) => ( {
+		const mapDispatchToProps = vi.fn( ( _dispatch ) => ( {
 			increment: _dispatch( 'counter' ).increment,
 		} ) );
 
-		const OriginalComponent = jest.fn( ( props ) => (
+		const OriginalComponent = vi.fn( ( props ) => (
 			<button onClick={ props.increment }>{ props.count }</button>
 		) );
 
@@ -175,13 +176,13 @@ describe( 'withSelect', () => {
 			}
 		}
 
-		const renderSpy = jest.spyOn( OriginalComponent.prototype, 'render' );
+		const renderSpy = vi.spyOn( OriginalComponent.prototype, 'render' );
 
-		const mapSelectToProps = jest.fn( ( _select ) => ( {
+		const mapSelectToProps = vi.fn( ( _select ) => ( {
 			count: _select( 'counter' ).getCount(),
 		} ) );
 
-		const mapDispatchToProps = jest.fn( ( _dispatch ) => ( {
+		const mapDispatchToProps = vi.fn( ( _dispatch ) => ( {
 			increment: _dispatch( 'counter' ).increment,
 		} ) );
 
@@ -240,11 +241,11 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn( ( _select, ownProps ) => ( {
+		const mapSelectToProps = vi.fn( ( _select, ownProps ) => ( {
 			count: _select( 'counter' ).getCount( ownProps.offset ),
 		} ) );
 
-		const OriginalComponent = jest.fn( ( props ) => (
+		const OriginalComponent = vi.fn( ( props ) => (
 			<div role="status">{ props.count }</div>
 		) );
 
@@ -280,8 +281,8 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn();
-		const OriginalComponent = jest.fn( () => <div /> );
+		const mapSelectToProps = vi.fn();
+		const OriginalComponent = vi.fn( () => <div /> );
 
 		const DataBoundComponent = compose( [
 			withSelect( mapSelectToProps ),
@@ -322,11 +323,11 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn( ( _select ) => ( {
+		const mapSelectToProps = vi.fn( ( _select ) => ( {
 			value: _select( 'demo' ).getUnchangingValue(),
 		} ) );
 
-		const OriginalComponent = jest.fn( () => <div /> );
+		const OriginalComponent = vi.fn( () => <div /> );
 
 		const DataBoundComponent =
 			withSelect( mapSelectToProps )( OriginalComponent );
@@ -355,8 +356,8 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn();
-		const OriginalComponent = jest.fn( () => <div /> );
+		const mapSelectToProps = vi.fn();
+		const OriginalComponent = vi.fn( () => <div /> );
 
 		const DataBoundComponent = compose( [
 			withSelect( mapSelectToProps ),
@@ -390,8 +391,8 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn();
-		const OriginalComponent = jest.fn( () => <div /> );
+		const mapSelectToProps = vi.fn();
+		const OriginalComponent = vi.fn( () => <div /> );
 
 		const DataBoundComponent = compose( [
 			withSelect( mapSelectToProps ),
@@ -421,13 +422,13 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn( ( _select, ownProps ) => {
+		const mapSelectToProps = vi.fn( ( _select, ownProps ) => {
 			return {
 				[ ownProps.propName ]: _select( 'demo' ).getValue(),
 			};
 		} );
 
-		const OriginalComponent = jest.fn( ( props ) => (
+		const OriginalComponent = vi.fn( ( props ) => (
 			<div role="status">{ JSON.stringify( props ) }</div>
 		) );
 
@@ -475,7 +476,7 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn( ( _select, ownProps ) => {
+		const mapSelectToProps = vi.fn( ( _select, ownProps ) => {
 			if ( ownProps.pass ) {
 				return {
 					count: _select( 'demo' ).getValue(),
@@ -483,7 +484,7 @@ describe( 'withSelect', () => {
 			}
 		} );
 
-		const OriginalComponent = jest.fn( ( props ) => (
+		const OriginalComponent = vi.fn( ( props ) => (
 			<div role="status">{ props.count || 'Unknown' }</div>
 		) );
 
@@ -534,13 +535,13 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const childMapSelectToProps = jest.fn();
-		const parentMapSelectToProps = jest.fn( ( _select ) => ( {
+		const childMapSelectToProps = vi.fn();
+		const parentMapSelectToProps = vi.fn( ( _select ) => ( {
 			isRenderingChild: _select( 'childRender' ).getValue(),
 		} ) );
 
-		const ChildOriginalComponent = jest.fn( () => <div /> );
-		const ParentOriginalComponent = jest.fn( ( props ) => (
+		const ChildOriginalComponent = vi.fn( () => <div /> );
+		const ParentOriginalComponent = vi.fn( ( props ) => (
 			<div>{ props.isRenderingChild ? <Child /> : null }</div>
 		) );
 
@@ -583,11 +584,11 @@ describe( 'withSelect', () => {
 			},
 		} );
 
-		const mapSelectToProps = jest.fn( ( _select ) => ( {
+		const mapSelectToProps = vi.fn( ( _select ) => ( {
 			value: _select( 'demo' ).getValue(),
 		} ) );
 
-		const OriginalComponent = jest.fn( ( props ) => (
+		const OriginalComponent = vi.fn( ( props ) => (
 			<div role="status">{ props.value }</div>
 		) );
 

--- a/packages/data/src/plugins/persistence/storage/test/object.js
+++ b/packages/data/src/plugins/persistence/storage/test/object.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import objectStorage from '../object';

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ describe( 'persistence', () => {
 	let registry;
 
 	beforeAll( () => {
-		jest.spyOn( objectStorage, 'setItem' );
+		vi.spyOn( objectStorage, 'setItem' );
 	} );
 
 	beforeEach( () => {
@@ -350,7 +351,7 @@ describe( 'persistence', () => {
 
 	describe( 'withLazySameState', () => {
 		it( 'should call the original reducer if action.nextState differs from state', () => {
-			const reducer = jest
+			const reducer = vi
 				.fn()
 				.mockImplementation( ( state, action ) => action.nextState );
 			const enhanced = withLazySameState( reducer );
@@ -364,7 +365,7 @@ describe( 'persistence', () => {
 		} );
 
 		it( 'should not call the original reducer if action.nextState equals state', () => {
-			const reducer = jest
+			const reducer = vi
 				.fn()
 				.mockImplementation( ( state, action ) => action.nextState );
 			const enhanced = withLazySameState( reducer );

--- a/packages/data/src/redux-store/metadata/test/reducer.js
+++ b/packages/data/src/redux-store/metadata/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
@@ -458,7 +463,7 @@ describe( 'Selector arguments normalization', () => {
 	} );
 
 	it( 'should call normalization method on target selector if exists', () => {
-		const normalizationFunction = jest.fn( ( args ) => {
+		const normalizationFunction = vi.fn( ( args ) => {
 			return args.map( Number );
 		} );
 		getFooSelector.__unstableNormalizeArgs = normalizationFunction;

--- a/packages/data/src/redux-store/metadata/test/utils.js
+++ b/packages/data/src/redux-store/metadata/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { selectorArgsToStateKey } from '../utils';

--- a/packages/data/src/redux-store/test/combine-reducers.js
+++ b/packages/data/src/redux-store/test/combine-reducers.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { combineReducers } from '../combine-reducers';

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createRegistry } from '../../registry';
@@ -13,7 +18,7 @@ describe( 'controls', () => {
 
 	describe( 'should call registry-aware controls', () => {
 		it( 'registers multiple selectors to the public API', () => {
-			const action1 = jest.fn( () => ( { type: 'NOTHING' } ) );
+			const action1 = vi.fn( () => ( { type: 'NOTHING' } ) );
 			const action2 = function* () {
 				yield { type: 'DISPATCH', store: 'store1', action: 'action1' };
 			};
@@ -82,7 +87,6 @@ describe( 'controls', () => {
 					.hasFinishedResolution( 'getItems' );
 				if ( isFinished ) {
 					const items = registry.select( 'store' ).getItems();
-					// eslint-disable-next-line jest/no-conditional-expect
 					expect( items ).toEqual( [ 1, 2, 3 ] );
 				}
 				resolve();
@@ -94,7 +98,7 @@ describe( 'controls', () => {
 	describe( 'selectors have expected value for the `hasResolver` property', () => {
 		it( 'when custom store has resolvers defined', () => {
 			registry.registerStore( 'store', {
-				reducer: jest.fn(),
+				reducer: vi.fn(),
 				selectors: {
 					getItems: ( state ) => state,
 					getItem: ( state ) => state,
@@ -114,7 +118,7 @@ describe( 'controls', () => {
 		} );
 		it( 'when custom store does not have resolvers defined', () => {
 			registry.registerStore( 'store', {
-				reducer: jest.fn(),
+				reducer: vi.fn(),
 				selectors: {
 					getItems: ( state ) => state,
 				},
@@ -311,7 +315,7 @@ describe( 'resolveSelect', () => {
 	} );
 
 	it( 'handles isFulfilled with arguments correctly', async () => {
-		const fulfilledResolver = jest.fn();
+		const fulfilledResolver = vi.fn();
 		fulfilledResolver.isFulfilled = ( state, id ) => state.pages?.[ id ];
 
 		const resolvedState = {
@@ -348,7 +352,7 @@ describe( 'resolveSelect', () => {
 	} );
 
 	it( 'does not change Redux state when isFulfilled returns true', async () => {
-		const fulfill = jest.fn();
+		const fulfill = vi.fn();
 		const isFulfilled = () => true;
 
 		registry.registerStore( 'demo', {
@@ -361,7 +365,7 @@ describe( 'resolveSelect', () => {
 			},
 		} );
 
-		const listener = jest.fn();
+		const listener = vi.fn();
 		const unsubscribe = registry.subscribe( listener );
 
 		// Call the selector — isFulfilled is true, so no resolution should happen.
@@ -377,11 +381,11 @@ describe( 'resolveSelect', () => {
 	} );
 
 	it( 'calls resolver when isFulfilled returns false', async () => {
-		const fulfill = jest.fn().mockImplementation( () => ( {
+		const fulfill = vi.fn().mockImplementation( () => ( {
 			type: 'SET_DATA',
 			data: 'resolved data',
 		} ) );
-		const isFulfilled = jest.fn( ( state ) => state.hasData );
+		const isFulfilled = vi.fn( ( state ) => state.hasData );
 
 		registry.registerStore( 'demo', {
 			reducer: ( state = { hasData: false }, action ) => {
@@ -417,7 +421,7 @@ describe( 'normalizing args', () => {
 		const registry = createRegistry();
 		const selector = () => {};
 
-		const normalizingFunction = jest.fn( ( ...args ) => args );
+		const normalizingFunction = vi.fn( ( ...args ) => args );
 
 		selector.__unstableNormalizeArgs = normalizingFunction;
 
@@ -445,7 +449,7 @@ describe( 'normalizing args', () => {
 		const registry = createRegistry();
 		const selector = () => {};
 
-		selector.__unstableNormalizeArgs = jest.fn( ( ...args ) => args );
+		selector.__unstableNormalizeArgs = vi.fn( ( ...args ) => args );
 
 		registry.registerStore( 'store', {
 			reducer: () => {},
@@ -467,7 +471,7 @@ describe( 'normalizing args', () => {
 		const registry = createRegistry();
 		const selector = () => {};
 
-		selector.__unstableNormalizeArgs = jest.fn( ( ...args ) => args );
+		selector.__unstableNormalizeArgs = vi.fn( ( ...args ) => args );
 
 		registry.registerStore( 'store', {
 			reducer: () => {},

--- a/packages/data/src/redux-store/test/keyed-reducer.js
+++ b/packages/data/src/redux-store/test/keyed-reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { keyedReducer } from '../keyed-reducer';

--- a/packages/data/src/test/controls.js
+++ b/packages/data/src/test/controls.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createRegistry, controls } from '..';

--- a/packages/data/src/test/privateAPIs.js
+++ b/packages/data/src/test/privateAPIs.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createRegistry } from '../registry';

--- a/packages/data/src/test/registry-selectors.js
+++ b/packages/data/src/test/registry-selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createRegistry } from '../registry';

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -1,14 +1,17 @@
 /* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "subscribeUntil"] }] */
 
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createRegistry } from '../registry';
 import { createRegistrySelector } from '../factory';
 import createReduxStore from '../redux-store';
 import coreDataStore from '../store';
-
-jest.useFakeTimers( { legacyFakeTimers: true } );
 
 describe( 'createRegistry', () => {
 	let registry;
@@ -32,6 +35,7 @@ describe( 'createRegistry', () => {
 	}
 
 	beforeEach( () => {
+		vi.useFakeTimers();
 		registry = createRegistry();
 	} );
 
@@ -40,6 +44,7 @@ describe( 'createRegistry', () => {
 		while ( ( unsubscribe = unsubscribes.shift() ) ) {
 			unsubscribe();
 		}
+		vi.useRealTimers();
 	} );
 
 	describe( 'registerGenericStore', () => {
@@ -108,7 +113,7 @@ describe( 'createRegistry', () => {
 
 		describe( 'getActions', () => {
 			it( 'should make actions available via registry.dispatch', () => {
-				const dispatch = jest.fn();
+				const dispatch = vi.fn();
 
 				function setPrice( itemName, price ) {
 					return { type: 'SET_PRICE', itemName, price };
@@ -155,7 +160,7 @@ describe( 'createRegistry', () => {
 
 		describe( 'subscribe', () => {
 			it( 'should send out updates to listeners of the registry', () => {
-				const registryListener = jest.fn();
+				const registryListener = vi.fn();
 
 				let listener = () => {};
 				const storeChanged = () => {
@@ -251,7 +256,7 @@ describe( 'createRegistry', () => {
 		} );
 
 		it( 'should behave as a side effect for the given selector, with arguments', () => {
-			const resolver = jest.fn();
+			const resolver = vi.fn();
 			registry.registerStore( 'demo', {
 				reducer: ( state = 'OK' ) => state,
 				selectors: {
@@ -263,19 +268,19 @@ describe( 'createRegistry', () => {
 			} );
 
 			const value = registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			expect( value ).toBe( 'OK' );
 			expect( resolver ).toHaveBeenCalledWith( 'arg1', 'arg2' );
 			registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			expect( resolver ).toHaveBeenCalledTimes( 1 );
 			registry.select( 'demo' ).getValue( 'arg3', 'arg4' );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			expect( resolver ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'should support the object resolver descriptor', () => {
-			const resolver = jest.fn();
+			const resolver = vi.fn();
 			registry.registerStore( 'demo', {
 				reducer: ( state = 'OK' ) => state,
 				selectors: {
@@ -287,12 +292,12 @@ describe( 'createRegistry', () => {
 			} );
 
 			const value = registry.select( 'demo' ).getValue( 'arg1', 'arg2' );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			expect( value ).toBe( 'OK' );
 		} );
 
 		it( 'should use isFulfilled definition before calling the side effect', () => {
-			const fulfill = jest.fn().mockImplementation( ( state, page ) => {
+			const fulfill = vi.fn().mockImplementation( ( state, page ) => {
 				return { type: 'SET_PAGE', page, result: [] };
 			} );
 
@@ -323,29 +328,29 @@ describe( 'createRegistry', () => {
 
 			store.dispatch( { type: 'SET_PAGE', page: 4, result: [] } );
 			registry.select( 'demo' ).getPage( 1 );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			expect( fulfill ).toHaveBeenCalledTimes( 2 );
 
 			registry.select( 'demo' ).getPage( 1 );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getPage( 3, {} );
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			// Expected: First and second page fulfillments already triggered, so
 			// should only be one more than previous assertion set.
 			expect( fulfill ).toHaveBeenCalledTimes( 3 );
 
 			registry.select( 'demo' ).getPage( 1 );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getPage( 2 );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getPage( 3, {} );
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getPage( 4 );
 
 			// Expected:
@@ -380,7 +385,7 @@ describe( 'createRegistry', () => {
 			] );
 
 			registry.select( 'demo' ).getValue();
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			return promise;
 		} );
@@ -407,7 +412,7 @@ describe( 'createRegistry', () => {
 			] );
 
 			registry.select( 'demo' ).getValue();
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			return promise;
 		} );
@@ -432,9 +437,9 @@ describe( 'createRegistry', () => {
 			);
 
 			registry.select( 'demo' ).getValue();
-			jest.runAllTimers();
+			vi.runAllTimers();
 			registry.select( 'demo' ).getValue();
-			jest.runAllTimers();
+			vi.runAllTimers();
 
 			return promise;
 		} );
@@ -465,7 +470,7 @@ describe( 'createRegistry', () => {
 				() => registry.select( 'demo' ).getValue() === 'OK'
 			);
 			registry.select( 'demo' ).getValue(); // Triggers resolver switches to OK.
-			jest.runAllTimers();
+			vi.runAllTimers();
 			await promise;
 
 			// Invalidate the cache
@@ -475,7 +480,7 @@ describe( 'createRegistry', () => {
 				() => registry.select( 'demo' ).getValue() === 'NOTOK'
 			);
 			registry.select( 'demo' ).getValue(); // Triggers the resolver again and switch to NOTOK.
-			jest.runAllTimers();
+			vi.runAllTimers();
 			await promise;
 		} );
 	} );
@@ -529,8 +534,8 @@ describe( 'createRegistry', () => {
 
 	describe( 'select', () => {
 		it( 'registers multiple selectors to the public API', () => {
-			const selector1 = jest.fn( () => 'result1' );
-			const selector2 = jest.fn( () => 'result2' );
+			const selector1 = vi.fn( () => 'result1' );
+			const selector2 = vi.fn( () => 'result2' );
 			const store = registry.registerStore( 'reducer1', {
 				reducer: () => 'state1',
 				selectors: {
@@ -633,8 +638,8 @@ describe( 'createRegistry', () => {
 			const store = registry.registerStore( 'myAwesomeReducer', {
 				reducer: ( state = 0 ) => state + 1,
 			} );
-			const secondListener = jest.fn();
-			const firstListener = jest.fn( () => {
+			const secondListener = vi.fn();
+			const firstListener = vi.fn( () => {
 				subscribeWithUnsubscribe( secondListener );
 			} );
 
@@ -649,10 +654,10 @@ describe( 'createRegistry', () => {
 			const store = registry.registerStore( 'myAwesomeReducer', {
 				reducer: ( state = 0 ) => state + 1,
 			} );
-			const firstListener = jest.fn( () => {
+			const firstListener = vi.fn( () => {
 				secondUnsubscribe();
 			} );
-			const secondListener = jest.fn();
+			const secondListener = vi.fn();
 
 			subscribeWithUnsubscribe( firstListener );
 			const secondUnsubscribe =
@@ -667,7 +672,7 @@ describe( 'createRegistry', () => {
 			const store = registry.registerStore( 'unchanging', {
 				reducer: ( state = {} ) => state,
 			} );
-			const listener = jest.fn();
+			const listener = vi.fn();
 			subscribeWithUnsubscribe( listener );
 
 			store.dispatch( { type: 'dummy' } );
@@ -708,7 +713,7 @@ describe( 'createRegistry', () => {
 			const store = registry.registerStore( 'myAwesomeReducer', {
 				reducer: ( state = 0 ) => state + 1,
 			} );
-			const listener = jest.fn();
+			const listener = vi.fn();
 			subscribeWithUnsubscribe( listener );
 
 			registry.batch( () => {} );
@@ -720,7 +725,7 @@ describe( 'createRegistry', () => {
 			} );
 			expect( listener ).toHaveBeenCalledTimes( 1 );
 
-			const listener2 = jest.fn();
+			const listener2 = vi.fn();
 			// useSelect subscribes to the stores differently,
 			// This test ensures batching works in this case as well.
 			const unsubscribe = registry.subscribe(
@@ -739,7 +744,7 @@ describe( 'createRegistry', () => {
 			const store = registry.registerStore( 'myAwesomeReducer', {
 				reducer: ( state = 0 ) => state + 1,
 			} );
-			const listener = jest.fn();
+			const listener = vi.fn();
 			subscribeWithUnsubscribe( listener );
 
 			registry.batch( () => {} );
@@ -760,7 +765,7 @@ describe( 'createRegistry', () => {
 			const store = registry.registerStore( 'myAwesomeReducer', {
 				reducer: ( state = 0 ) => state + 1,
 			} );
-			const listener = jest.fn();
+			const listener = vi.fn();
 			const error = new Error( 'Whoops' );
 			subscribeWithUnsubscribe( listener );
 
@@ -828,8 +833,8 @@ describe( 'createRegistry', () => {
 
 	describe( 'parent registry', () => {
 		it( 'should call parent registry selectors/actions if defined', () => {
-			const mySelector = jest.fn();
-			const myAction = jest.fn();
+			const mySelector = vi.fn();
+			const myAction = vi.fn();
 			const getSelectors = () => ( { mySelector } );
 			const getActions = () => ( { myAction } );
 			const subscribe = () => {};
@@ -852,8 +857,8 @@ describe( 'createRegistry', () => {
 		} );
 
 		it( 'should override existing store in parent registry', () => {
-			const mySelector = jest.fn();
-			const myAction = jest.fn();
+			const mySelector = vi.fn();
+			const myAction = vi.fn();
 			const getSelectors = () => ( { mySelector } );
 			const getActions = () => ( { myAction } );
 			const subscribe = () => {};
@@ -867,8 +872,8 @@ describe( 'createRegistry', () => {
 			} );
 
 			const subRegistry = createRegistry( {}, registry );
-			const mySelector2 = jest.fn();
-			const myAction2 = jest.fn();
+			const mySelector2 = vi.fn();
+			const myAction2 = vi.fn();
 			const getSelectors2 = () => ( { mySelector: mySelector2 } );
 			const getActions2 = () => ( { myAction: myAction2 } );
 			const subscribe2 = () => {};

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -30,6 +30,7 @@
 					"packages/compose",
 					"packages/core-commands",
 					"packages/customize-widgets",
+					"packages/data",
 					"packages/date",
 					"packages/dataviews",
 					"packages/deprecated",


### PR DESCRIPTION
## What?

**TL;DR:** Migrates the complete `@wordpress/data` test package from Jest globals and legacy fake timers to explicit Vitest imports, modern per-test timer lifecycle, and package-owned Vitest dependency metadata.

- Routes all 17 Data test files through Vitest's jsdom project.
- Keeps Testing Library, semantic queries, `userEvent.setup()`, and existing data/registry behavior.
- Replaces Jest spies and mock functions with Vitest APIs; these tests require no module-mocking compatibility layer.
- Replaces suite-global legacy fake timers with isolated `vi.useFakeTimers()` / `vi.useRealTimers()` lifecycle.
- Moves one previously unawaited promise assertion to the async test boundary, which Vitest surfaced as a warning.
- Contains no production-code or snapshot changes.

This draft is stacked on #80947. Part of #80855.

## Why?

This is the next complete-package slice of the repository-wide Jest-to-Vitest migration. Keeping Data together preserves coverage of its React bindings, registries, controls, persistence, and Redux-store metadata while maintaining exactly one runner per test.

## How?

The migration manifest assigns `packages/data` to the Vitest jsdom project. Every test imports its runner APIs locally, and the Data workspace declares its direct Vitest development dependency.

## Testing Instructions

- `npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest packages/data/src`
  - 17 files, 220 tests passed; no snapshots.
- `npm run test:unit:vitest --workspace @wordpress/unit-tests -- --project vitest --project node --reporter=dot`
  - 588 files passed, 2 skipped; 10,327 tests passed, 8 skipped.
- `npm run test:unit --workspace @wordpress/unit-tests -- --runInBand`
  - Remaining Jest partition: 412 suites, 24,423 tests, 59 snapshots passed.
- `npm run test:unit:routing --workspace @wordpress/unit-tests`
  - 996 baseline tests: 412 Jest, 591 Vitest, no overlap or missing entries.
- `npm run test:unit:conventions --workspace @wordpress/unit-tests`
- `npm run lint:jsx-extensions`
- `npm run lint:lockfile`
- `npm run lint:js -- packages/data`
- `npm exec lint-staged`
