### PR TITLE
Migrate Media Editor Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52008,7 +52008,8 @@
 				"@storybook/react-vite": "^10.4.3",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
-				"@testing-library/user-event": "^14.6.1"
+				"@testing-library/user-event": "^14.6.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -54773,11 +54774,11 @@
 				"simple-git": "^3.32.3",
 				"sprintf-js": "^1.1.1"
 			},
-			"devDependencies": {
-				"vitest": "^4.1.10"
-			},
 			"bin": {
 				"release-cli": "cli.js"
+			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
 			}
 		},
 		"tools/release/node_modules/simple-git": {

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -68,7 +68,8 @@
 		"@storybook/react-vite": "^10.4.3",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
-		"@testing-library/user-event": "^14.6.1"
+		"@testing-library/user-event": "^14.6.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, type Mock, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
@@ -17,7 +18,7 @@ function setupCropPanel(
 ) {
 	const props: MediaEditorCropPanelProps = {
 		aspectRatioValue: '1',
-		onAspectRatioChange: jest.fn(),
+		onAspectRatioChange: vi.fn(),
 		aspectRatioOptions: [
 			{ label: 'Free', value: 0 },
 			{ label: 'Original', value: -1 },
@@ -47,7 +48,7 @@ describe( 'MediaEditorCropPanel', () => {
 
 		expect( controls.onAspectRatioChange ).toHaveBeenCalled();
 		expect(
-			( controls.onAspectRatioChange as jest.Mock ).mock.calls[ 0 ][ 0 ]
+			( controls.onAspectRatioChange as Mock ).mock.calls[ 0 ][ 0 ]
 		).toBe( '0' );
 	} );
 

--- a/packages/media-editor/src/components/media-editor-image-controls/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-image-controls/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 /**

--- a/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
+++ b/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
@@ -56,6 +56,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { mat2d, vec2 } from 'gl-matrix';
 
 /**

--- a/packages/media-editor/src/components/media-editor-modal/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/test/index.tsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -14,7 +16,12 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { MediaEditorModal } from '../index';
 
-let mockSaveResult = {
+let mockSaveResult: {
+	id: number;
+	url: string;
+	media: { id: number; source_url: string };
+	previous?: { id: number; url: string };
+} = {
 	id: 11,
 	url: 'edited.jpg',
 	media: { id: 11, source_url: 'edited.jpg' },
@@ -23,50 +30,73 @@ let mockSaveResult = {
 		url: 'original.jpg',
 	},
 };
-const mockOnUpdate = jest.fn();
-const mockOnClose = jest.fn();
-const mockCloseMediaEditorModal = jest.fn();
-const mockCreateSuccessNotice = jest.fn();
+const mockOnUpdate = vi.fn();
+const mockOnClose = vi.fn();
+const mockCloseMediaEditorModal = vi.fn();
+const mockCreateSuccessNotice = vi.fn();
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	useSelect: jest.fn(),
-} ) );
+vi.mock(
+	import( '@wordpress/data' ),
+	() =>
+		( {
+			useDispatch: vi.fn(),
+			useSelect: vi.fn(),
+		} ) as unknown as typeof import('@wordpress/data')
+);
 
-jest.mock( '@wordpress/components', () => ( {
-	Modal: ( { children } ) => children,
-} ) );
+vi.mock(
+	import( '@wordpress/components' ),
+	() =>
+		( {
+			Modal: ( { children }: { children: ReactNode } ) => children,
+		} ) as unknown as typeof import('@wordpress/components')
+);
 
-jest.mock( '@wordpress/keyboard-shortcuts', () => ( {
-	ShortcutProvider: ( { children } ) => children,
-} ) );
+vi.mock(
+	import( '@wordpress/keyboard-shortcuts' ),
+	() =>
+		( {
+			ShortcutProvider: ( { children }: { children: ReactNode } ) =>
+				children,
+		} ) as unknown as typeof import('@wordpress/keyboard-shortcuts')
+);
 
-jest.mock( '@wordpress/notices', () => ( {
-	store: { name: 'notices' },
-} ) );
+vi.mock(
+	import( '@wordpress/notices' ),
+	() =>
+		( {
+			store: { name: 'notices' },
+		} ) as unknown as typeof import('@wordpress/notices')
+);
 
-jest.mock( '../../../store', () => ( {
-	store: { name: 'media-editor' },
-} ) );
+vi.mock(
+	import( '../../../store' ),
+	() =>
+		( {
+			store: { name: 'media-editor' },
+		} ) as unknown as typeof import('../../../store')
+);
 
-jest.mock( '../../media-editor', () => {
-	const { createElement } = jest.requireActual( '@wordpress/element' );
+vi.mock( import( '../../media-editor' ), async () => {
+	const { createElement } =
+		await vi.importActual< typeof import('@wordpress/element') >(
+			'@wordpress/element'
+		);
 
 	return {
-		__esModule: true,
-		default: jest.fn( ( props ) =>
+		default: vi.fn( ( props ) =>
 			createElement(
 				'button',
 				{ onClick: () => props.onSaved( mockSaveResult ) },
 				'Save result'
 			)
 		),
-	};
+	} as unknown as typeof import('../../media-editor');
 } );
 
 describe( 'MediaEditorModal', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockSaveResult = {
 			id: 11,
 			url: 'edited.jpg',
@@ -77,7 +107,7 @@ describe( 'MediaEditorModal', () => {
 			},
 		};
 
-		( useSelect as jest.Mock ).mockImplementation( ( mapSelect ) =>
+		( useSelect as Mock ).mockImplementation( ( mapSelect ) =>
 			mapSelect( () => ( {
 				isOpen: () => true,
 				getId: () => 10,
@@ -85,7 +115,7 @@ describe( 'MediaEditorModal', () => {
 				getOnClose: () => mockOnClose,
 			} ) )
 		);
-		( useDispatch as jest.Mock ).mockImplementation( ( store ) =>
+		( useDispatch as Mock ).mockImplementation( ( store ) =>
 			store === noticesStore
 				? { createSuccessNotice: mockCreateSuccessNotice }
 				: { closeMediaEditorModal: mockCloseMediaEditorModal }

--- a/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
+++ b/packages/media-editor/src/components/media-editor/test/use-crop-options.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**

--- a/packages/media-editor/src/components/rotation-ruler/test/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -60,7 +61,7 @@ describe( 'RotationRuler', () => {
 
 	it( 'fires onChange with value + step on ArrowRight', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render(
 			<RotationRuler
 				value={ 0 }
@@ -77,7 +78,7 @@ describe( 'RotationRuler', () => {
 
 	it( 'fires onChange with value + step / 2 on Shift+ArrowRight', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render(
 			<RotationRuler
 				value={ 0 }
@@ -93,7 +94,7 @@ describe( 'RotationRuler', () => {
 
 	it( 'does not fire onChange when disabled', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		render(
 			<RotationRuler
 				value={ 0 }

--- a/packages/media-editor/src/image-editor/core/export/test/canvas-renderer.ts
+++ b/packages/media-editor/src/image-editor/core/export/test/canvas-renderer.ts
@@ -1,6 +1,19 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from 'vitest';
+
 import type { CropperState } from '../../types';
 import { DEFAULT_STATE } from '../../constants';
 import {
@@ -17,18 +30,18 @@ import {
  */
 function createMockContext() {
 	return {
-		setTransform: jest.fn(),
-		translate: jest.fn(),
-		rotate: jest.fn(),
-		scale: jest.fn(),
-		drawImage: jest.fn(),
-		getImageData: jest.fn(),
-		putImageData: jest.fn(),
-		beginPath: jest.fn(),
-		closePath: jest.fn(),
-		moveTo: jest.fn(),
-		lineTo: jest.fn(),
-		clip: jest.fn(),
+		setTransform: vi.fn(),
+		translate: vi.fn(),
+		rotate: vi.fn(),
+		scale: vi.fn(),
+		drawImage: vi.fn(),
+		getImageData: vi.fn(),
+		putImageData: vi.fn(),
+		beginPath: vi.fn(),
+		closePath: vi.fn(),
+		moveTo: vi.fn(),
+		lineTo: vi.fn(),
+		clip: vi.fn(),
 	};
 }
 
@@ -41,9 +54,9 @@ function createMockCanvas( ctx: ReturnType< typeof createMockContext > ) {
 	const canvas = {
 		width: 0,
 		height: 0,
-		getContext: jest.fn().mockReturnValue( ctx ),
-		toBlob: jest.fn(),
-		toDataURL: jest.fn().mockReturnValue( 'data:image/png;base64,abc' ),
+		getContext: vi.fn().mockReturnValue( ctx ),
+		toBlob: vi.fn(),
+		toDataURL: vi.fn().mockReturnValue( 'data:image/png;base64,abc' ),
 	};
 	return canvas as unknown as HTMLCanvasElement;
 }
@@ -71,7 +84,7 @@ function createTestState( overrides?: Partial< CropperState > ): CropperState {
 describe( 'loadImage', () => {
 	it( 'should create an image element with crossOrigin set', async () => {
 		const mockImage = {
-			addEventListener: jest.fn(),
+			addEventListener: vi.fn(),
 			set crossOrigin( value: string ) {
 				this._crossOrigin = value;
 			},
@@ -97,7 +110,9 @@ describe( 'loadImage', () => {
 
 		// Replace global Image constructor.
 		const originalImage = global.Image;
-		global.Image = jest.fn( () => mockImage ) as unknown as typeof Image;
+		global.Image = vi.fn( function Image() {
+			return mockImage;
+		} ) as unknown as typeof Image;
 
 		try {
 			const result = await loadImage( 'https://example.com/test.jpg' );
@@ -120,7 +135,7 @@ describe( 'loadImage', () => {
 	it( 'should reject when the image fails to load', async () => {
 		const loadError = new Error( 'Network error' );
 		const mockImage = {
-			addEventListener: jest.fn(),
+			addEventListener: vi.fn(),
 			set crossOrigin( _value: string ) {},
 			set src( _value: string ) {
 				// Simulate error on next tick.
@@ -134,7 +149,9 @@ describe( 'loadImage', () => {
 		};
 
 		const originalImage = global.Image;
-		global.Image = jest.fn( () => mockImage ) as unknown as typeof Image;
+		global.Image = vi.fn( function Image() {
+			return mockImage;
+		} ) as unknown as typeof Image;
 
 		try {
 			await expect(
@@ -155,7 +172,7 @@ describe( 'renderToCanvas', () => {
 		canvasCount = 0;
 
 		// Mock document.createElement to return our mock canvases.
-		jest.spyOn( document, 'createElement' ).mockImplementation(
+		vi.spyOn( document, 'createElement' ).mockImplementation(
 			( tag: string ) => {
 				if ( tag === 'canvas' ) {
 					canvasCount++;
@@ -169,7 +186,7 @@ describe( 'renderToCanvas', () => {
 	} );
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	it( 'should call setTransform and drawImage', () => {
@@ -214,8 +231,8 @@ describe( 'renderToCanvas', () => {
 		} );
 		const mockCtxNoFlip = createMockContext();
 		const canvasCountRef = { value: 0 };
-		jest.restoreAllMocks();
-		jest.spyOn( document, 'createElement' ).mockImplementation(
+		vi.restoreAllMocks();
+		vi.spyOn( document, 'createElement' ).mockImplementation(
 			( tag: string ) => {
 				if ( tag === 'canvas' ) {
 					canvasCountRef.value++;
@@ -255,8 +272,8 @@ describe( 'renderToCanvas', () => {
 		const mockCtxRotated = createMockContext();
 		const mockCtxNormal = createMockContext();
 		const canvasCountRef = { value: 0 };
-		jest.restoreAllMocks();
-		jest.spyOn( document, 'createElement' ).mockImplementation(
+		vi.restoreAllMocks();
+		vi.spyOn( document, 'createElement' ).mockImplementation(
 			( tag: string ) => {
 				if ( tag === 'canvas' ) {
 					canvasCountRef.value++;
@@ -290,7 +307,7 @@ describe( 'canvasToBlob', () => {
 	it( 'should call canvas.toBlob with the correct arguments', async () => {
 		const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
 		const mockCanvas = {
-			toBlob: jest.fn( ( callback: BlobCallback ) => {
+			toBlob: vi.fn( ( callback: BlobCallback ) => {
 				callback( mockBlob );
 			} ),
 		} as unknown as HTMLCanvasElement;
@@ -308,7 +325,7 @@ describe( 'canvasToBlob', () => {
 	it( 'should use default mime type and quality when not specified', async () => {
 		const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
 		const mockCanvas = {
-			toBlob: jest.fn( ( callback: BlobCallback ) => {
+			toBlob: vi.fn( ( callback: BlobCallback ) => {
 				callback( mockBlob );
 			} ),
 		} as unknown as HTMLCanvasElement;
@@ -324,7 +341,7 @@ describe( 'canvasToBlob', () => {
 
 	it( 'should reject when toBlob returns null', async () => {
 		const mockCanvas = {
-			toBlob: jest.fn( ( callback: BlobCallback ) => {
+			toBlob: vi.fn( ( callback: BlobCallback ) => {
 				callback( null );
 			} ),
 		} as unknown as HTMLCanvasElement;
@@ -338,9 +355,7 @@ describe( 'canvasToBlob', () => {
 describe( 'canvasToDataURL', () => {
 	it( 'should call canvas.toDataURL with correct arguments', () => {
 		const mockCanvas = {
-			toDataURL: jest
-				.fn()
-				.mockReturnValue( 'data:image/jpeg;base64,abc' ),
+			toDataURL: vi.fn().mockReturnValue( 'data:image/jpeg;base64,abc' ),
 		} as unknown as HTMLCanvasElement;
 
 		const result = canvasToDataURL( mockCanvas, 'image/jpeg', 0.85 );
@@ -354,7 +369,7 @@ describe( 'canvasToDataURL', () => {
 
 	it( 'should use default mime type and quality when not specified', () => {
 		const mockCanvas = {
-			toDataURL: jest.fn().mockReturnValue( 'data:image/png;base64,xyz' ),
+			toDataURL: vi.fn().mockReturnValue( 'data:image/png;base64,xyz' ),
 		} as unknown as HTMLCanvasElement;
 
 		canvasToDataURL( mockCanvas );
@@ -376,7 +391,7 @@ describe( 'exportCroppedImage', () => {
 		const mockImage = {
 			naturalWidth: 800,
 			naturalHeight: 600,
-			addEventListener: jest.fn(),
+			addEventListener: vi.fn(),
 			_crossOrigin: '',
 			set crossOrigin( value: string ) {
 				this._crossOrigin = value;
@@ -398,16 +413,18 @@ describe( 'exportCroppedImage', () => {
 				return this._src;
 			},
 		};
-		global.Image = jest.fn( () => mockImage ) as unknown as typeof Image;
+		global.Image = vi.fn( function Image() {
+			return mockImage;
+		} ) as unknown as typeof Image;
 
 		// Mock document.createElement for renderToCanvas.
 		const mockBlob = new Blob( [ 'test' ], { type: 'image/png' } );
 		const mockCtx = createMockContext();
-		jest.spyOn( document, 'createElement' ).mockImplementation(
+		vi.spyOn( document, 'createElement' ).mockImplementation(
 			( tag: string ) => {
 				if ( tag === 'canvas' ) {
 					const canvas = createMockCanvas( mockCtx );
-					( canvas as any ).toBlob = jest.fn(
+					( canvas as any ).toBlob = vi.fn(
 						( callback: BlobCallback ) => {
 							callback( mockBlob );
 						}
@@ -421,7 +438,7 @@ describe( 'exportCroppedImage', () => {
 
 	afterEach( () => {
 		global.Image = originalImage;
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	it( 'should chain loadImage, renderToCanvas, and canvasToBlob', async () => {
@@ -439,7 +456,7 @@ describe( 'exportCroppedImage', () => {
 	it( 'throws when image fails to load', async () => {
 		// Override Image to simulate a load error.
 		const errorImage = {
-			addEventListener: jest.fn(),
+			addEventListener: vi.fn(),
 			set crossOrigin( _value: string ) {},
 			set src( _value: string ) {
 				const errorHandler = this.addEventListener.mock.calls.find(
@@ -450,7 +467,9 @@ describe( 'exportCroppedImage', () => {
 				}
 			},
 		};
-		global.Image = jest.fn( () => errorImage ) as unknown as typeof Image;
+		global.Image = vi.fn( function Image() {
+			return errorImage;
+		} ) as unknown as typeof Image;
 
 		const state = createTestState();
 		await expect(
@@ -462,22 +481,20 @@ describe( 'exportCroppedImage', () => {
 		// Mock Image to resolve (simulating a successful load even from
 		// a tainted source — the browser doesn't flag the load itself,
 		// only the later toBlob call).
-		global.Image = jest.fn( () => {
+		global.Image = vi.fn( function Image() {
 			const img: {
-				addEventListener: jest.Mock;
+				addEventListener: Mock;
 				crossOrigin: string;
 				src: string;
 				naturalWidth: number;
 				naturalHeight: number;
 			} = {
-				addEventListener: jest.fn(
-					( event: string, fn: () => void ) => {
-						if ( event === 'load' ) {
-							// Fire load synchronously after src is set.
-							queueMicrotask( fn );
-						}
+				addEventListener: vi.fn( ( event: string, fn: () => void ) => {
+					if ( event === 'load' ) {
+						// Fire load synchronously after src is set.
+						queueMicrotask( fn );
 					}
-				),
+				} ),
 				crossOrigin: '',
 				src: '',
 				naturalWidth: 800,
@@ -490,18 +507,18 @@ describe( 'exportCroppedImage', () => {
 		const corsCanvas = {
 			width: 0,
 			height: 0,
-			getContext: jest.fn( () => ( {
-				setTransform: jest.fn(),
-				drawImage: jest.fn(),
+			getContext: vi.fn( () => ( {
+				setTransform: vi.fn(),
+				drawImage: vi.fn(),
 			} ) ),
-			toBlob: jest.fn( () => {
+			toBlob: vi.fn( () => {
 				throw new DOMException(
 					'Tainted canvases may not be exported',
 					'SecurityError'
 				);
 			} ),
 		};
-		jest.spyOn( document, 'createElement' ).mockImplementation( ( (
+		vi.spyOn( document, 'createElement' ).mockImplementation( ( (
 			tag: string
 		) => {
 			if ( tag === 'canvas' ) {
@@ -518,7 +535,7 @@ describe( 'exportCroppedImage', () => {
 			)
 		).rejects.toMatchObject( { name: 'SecurityError' } );
 
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	it( 'throws descriptive error when canvas context is unavailable', () => {
@@ -526,9 +543,9 @@ describe( 'exportCroppedImage', () => {
 		const noCtxCanvas = {
 			width: 0,
 			height: 0,
-			getContext: jest.fn( () => null ),
+			getContext: vi.fn( () => null ),
 		};
-		jest.spyOn( document, 'createElement' ).mockImplementation( ( (
+		vi.spyOn( document, 'createElement' ).mockImplementation( ( (
 			tag: string
 		) => {
 			if ( tag === 'canvas' ) {
@@ -547,7 +564,7 @@ describe( 'exportCroppedImage', () => {
 			/2D context/i
 		);
 
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 } );
 
@@ -556,7 +573,7 @@ describe( 'renderToCanvas — export matrix verification', () => {
 
 	function setupMockCanvas() {
 		mockCtx = createMockContext();
-		jest.spyOn( document, 'createElement' ).mockImplementation(
+		vi.spyOn( document, 'createElement' ).mockImplementation(
 			( tag: string ) => {
 				if ( tag === 'canvas' ) {
 					return createMockCanvas(
@@ -569,7 +586,7 @@ describe( 'renderToCanvas — export matrix verification', () => {
 	}
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	it( 'identity state (no rotation, no zoom, full crop) should produce a 1:1 mapping', () => {
@@ -655,7 +672,7 @@ describe( 'renderToCanvas — export matrix verification', () => {
 		const [ a1, , , d1 ] = mockCtx.setTransform.mock.calls[ 0 ];
 
 		// Reset for zoom=2.
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 		setupMockCanvas();
 		const stateZ2 = createTestState( {
 			rotation: 0,
@@ -691,7 +708,7 @@ describe( 'renderToCanvas — export matrix verification', () => {
 		const [ aNoFlip ] = mockCtx.setTransform.mock.calls[ 0 ];
 
 		// Reset for horizontal flip.
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 		setupMockCanvas();
 		const stateFlip = createTestState( {
 			rotation: 0,
@@ -719,7 +736,7 @@ describe( 'applyToCanvas — export matrix verification', () => {
 		mockCtx = createMockContext();
 		canvasWidths = [];
 		canvasHeights = [];
-		jest.spyOn( document, 'createElement' ).mockImplementation(
+		vi.spyOn( document, 'createElement' ).mockImplementation(
 			( tag: string ) => {
 				if ( tag === 'canvas' ) {
 					const canvas = createMockCanvas( mockCtx );
@@ -750,7 +767,7 @@ describe( 'applyToCanvas — export matrix verification', () => {
 	}
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	it( 'should create a canvas with correct dimensions and call setTransform', () => {

--- a/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
+++ b/packages/media-editor/src/image-editor/core/math/test/sanitize.ts
@@ -1,6 +1,11 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import {
 	isValidSize,
 	safeBoundedNumber,

--- a/packages/media-editor/src/image-editor/core/test/camera.ts
+++ b/packages/media-editor/src/image-editor/core/test/camera.ts
@@ -1,3 +1,9 @@
+/**
+ * External dependencies
+ */
+import { mat2d as m2d, vec2 } from 'gl-matrix';
+import { describe, expect, it } from 'vitest';
+
 import {
 	createCamera,
 	worldToScreen,
@@ -302,7 +308,6 @@ describe( 'createExportCamera', () => {
 		const state = makeState();
 		const outputSize = { width: 400, height: 225 };
 		const camera = createExportCamera( state, IMAGE, outputSize );
-		const { vec2 } = require( 'gl-matrix' );
 		const out = vec2.create();
 		vec2.transformMat2d(
 			out,
@@ -317,7 +322,6 @@ describe( 'createExportCamera', () => {
 		const state = makeState();
 		const outputSize = { width: IMAGE.width, height: IMAGE.height };
 		const camera = createExportCamera( state, IMAGE, outputSize );
-		const { vec2 } = require( 'gl-matrix' );
 		const topLeft = vec2.create();
 		vec2.transformMat2d( topLeft, [ 0, 0 ], camera );
 		expect( topLeft[ 0 ] ).toBeCloseTo( 0, 0 );
@@ -381,7 +385,6 @@ describe( 'createExportCamera', () => {
 		// output canvas.
 		const outputSize = { width: 400, height: 300 };
 		const exportCamera = createExportCamera( state, IMAGE, outputSize );
-		const { mat2d: m2d, vec2 } = require( 'gl-matrix' );
 		const inv = m2d.create();
 		m2d.invert( inv, exportCamera );
 		const exportPxVec = vec2.create();

--- a/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/test/interaction-controller.ts
@@ -1,6 +1,20 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mocked,
+	vi,
+} from 'vitest';
+
 import {
 	InteractionController,
 	type CropperInteractionActions,
@@ -55,7 +69,7 @@ function createPointerEvent(
 		clientX: 0,
 		clientY: 0,
 		pointerId: 1,
-		preventDefault: jest.fn(),
+		preventDefault: vi.fn(),
 		...overrides,
 	} as unknown as PointerEvent;
 }
@@ -70,16 +84,16 @@ function createMockElement(): HTMLElement & {
 } {
 	const listeners: Record< string, EventListener[] > = {};
 	return {
-		focus: jest.fn(),
-		setPointerCapture: jest.fn(),
-		releasePointerCapture: jest.fn(),
-		addEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+		focus: vi.fn(),
+		setPointerCapture: vi.fn(),
+		releasePointerCapture: vi.fn(),
+		addEventListener: vi.fn( ( type: string, fn: EventListener ) => {
 			if ( ! listeners[ type ] ) {
 				listeners[ type ] = [];
 			}
 			listeners[ type ].push( fn );
 		} ),
-		removeEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+		removeEventListener: vi.fn( ( type: string, fn: EventListener ) => {
 			if ( listeners[ type ] ) {
 				listeners[ type ] = listeners[ type ].filter(
 					( l ) => l !== fn
@@ -109,7 +123,7 @@ function createWheelEvent(
 	overrides: Partial< WheelEvent > & { currentTarget?: unknown } = {}
 ): WheelEvent {
 	return {
-		preventDefault: jest.fn(),
+		preventDefault: vi.fn(),
 		deltaY: 0,
 		clientX: 0,
 		clientY: 0,
@@ -130,7 +144,7 @@ function createKeyboardEvent(
 ): KeyboardEvent {
 	return {
 		key,
-		preventDefault: jest.fn(),
+		preventDefault: vi.fn(),
 		...overrides,
 	} as unknown as KeyboardEvent;
 }
@@ -147,7 +161,7 @@ function createTouchEvent(
 	overrides: Partial< TouchEvent > = {}
 ): TouchEvent {
 	return {
-		preventDefault: jest.fn(),
+		preventDefault: vi.fn(),
 		touches,
 		...overrides,
 	} as unknown as TouchEvent;
@@ -169,7 +183,7 @@ function createContainerRect( overrides: Partial< DOMRect > = {} ): DOMRect {
 		bottom: 300,
 		x: 0,
 		y: 0,
-		toJSON: jest.fn(),
+		toJSON: vi.fn(),
 		...overrides,
 	} as DOMRect;
 }
@@ -185,13 +199,13 @@ function createMockDocument(): Document & {
 } {
 	const listeners: Record< string, EventListener[] > = {};
 	return {
-		addEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+		addEventListener: vi.fn( ( type: string, fn: EventListener ) => {
 			if ( ! listeners[ type ] ) {
 				listeners[ type ] = [];
 			}
 			listeners[ type ].push( fn );
 		} ),
-		removeEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+		removeEventListener: vi.fn( ( type: string, fn: EventListener ) => {
 			if ( listeners[ type ] ) {
 				listeners[ type ] = listeners[ type ].filter(
 					( l ) => l !== fn
@@ -211,7 +225,7 @@ function createMockDocument(): Document & {
 describe( 'InteractionController', () => {
 	const containerSize: Size = { width: 500, height: 300 };
 	const imageSize: Size = { width: 500, height: 300 };
-	let actionMocks: jest.Mocked< CropperInteractionActions >;
+	let actionMocks: Mocked< CropperInteractionActions >;
 
 	// Store original requestAnimationFrame so we can restore it.
 	const originalRAF = globalThis.requestAnimationFrame;
@@ -223,7 +237,7 @@ describe( 'InteractionController', () => {
 			cb( 0 );
 			return 0;
 		};
-		globalThis.cancelAnimationFrame = jest.fn();
+		globalThis.cancelAnimationFrame = vi.fn();
 	} );
 
 	afterAll( () => {
@@ -233,11 +247,11 @@ describe( 'InteractionController', () => {
 
 	beforeEach( () => {
 		actionMocks = {
-			setPan: jest.fn(),
-			setZoom: jest.fn(),
-			setZoomAtPoint: jest.fn(),
-			snapRotate90: jest.fn(),
-			toggleFlip: jest.fn(),
+			setPan: vi.fn(),
+			setZoom: vi.fn(),
+			setZoomAtPoint: vi.fn(),
+			snapRotate90: vi.fn(),
+			toggleFlip: vi.fn(),
 		};
 	} );
 
@@ -293,8 +307,8 @@ describe( 'InteractionController', () => {
 
 		it( 'ignores touch pointerdown so touch gestures own touch input', () => {
 			const state = makeState( { zoom: 2 } );
-			const onGestureStart = jest.fn();
-			const onStatusChange = jest.fn();
+			const onGestureStart = vi.fn();
+			const onStatusChange = vi.fn();
 			const { controller } = createController( state, {
 				onGestureStart,
 				onStatusChange,
@@ -336,7 +350,7 @@ describe( 'InteractionController', () => {
 			// Simulate pointerup.
 			el._fire( 'pointerup', createPointerEvent() );
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			// Another pointermove should not dispatch because the listener
 			// was removed after pointerup.
@@ -353,8 +367,8 @@ describe( 'InteractionController', () => {
 
 		it( 'calls onGestureStart on pointerdown and onGestureEnd on pointerup', () => {
 			const state = makeState( { zoom: 2 } );
-			const onGestureStart = jest.fn();
-			const onGestureEnd = jest.fn();
+			const onGestureStart = vi.fn();
+			const onGestureEnd = vi.fn();
 			const { controller } = createController( state, {
 				onGestureStart,
 				onGestureEnd,
@@ -383,7 +397,7 @@ describe( 'InteractionController', () => {
 
 		it( 'reports isDragging via onStatusChange', () => {
 			const state = makeState( { zoom: 2 } );
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 			const { controller } = createController( state, {
 				onStatusChange,
 			} );
@@ -508,7 +522,7 @@ describe( 'InteractionController', () => {
 				el
 			);
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			const wheelEvent = createWheelEvent( {
 				deltaY: -100,
@@ -524,12 +538,12 @@ describe( 'InteractionController', () => {
 		} );
 
 		it( 'calls onGestureStart on first wheel, onGestureEnd after debounce', () => {
-			jest.useFakeTimers( {
-				doNotFake: [ 'requestAnimationFrame', 'cancelAnimationFrame' ],
+			vi.useFakeTimers( {
+				toFake: [ 'setTimeout', 'clearTimeout' ],
 			} );
 			const state = makeState( { zoom: 2 } );
-			const onGestureStart = jest.fn();
-			const onGestureEnd = jest.fn();
+			const onGestureStart = vi.fn();
+			const onGestureEnd = vi.fn();
 			const { controller } = createController( state, {
 				onGestureStart,
 				onGestureEnd,
@@ -549,11 +563,11 @@ describe( 'InteractionController', () => {
 			expect( onGestureStart ).toHaveBeenCalledTimes( 1 );
 
 			// Advance past the 300ms debounce.
-			jest.advanceTimersByTime( 350 );
+			vi.advanceTimersByTime( 350 );
 
 			expect( onGestureEnd ).toHaveBeenCalledTimes( 1 );
 
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 	} );
 
@@ -851,8 +865,8 @@ describe( 'InteractionController', () => {
 
 		it( 'calls onGestureStart/onGestureEnd for single-finger pan', () => {
 			const state = makeState( { zoom: 2 } );
-			const onGestureStart = jest.fn();
-			const onGestureEnd = jest.fn();
+			const onGestureStart = vi.fn();
+			const onGestureEnd = vi.fn();
 			const { controller } = createController( state, {
 				onGestureStart,
 				onGestureEnd,
@@ -876,7 +890,7 @@ describe( 'InteractionController', () => {
 
 		it( 'reports isDragging on first single-finger move', () => {
 			const state = makeState( { zoom: 2 } );
-			const onStatusChange = jest.fn();
+			const onStatusChange = vi.fn();
 			const { controller } = createController( state, {
 				onStatusChange,
 			} );
@@ -990,8 +1004,8 @@ describe( 'InteractionController', () => {
 
 		it( 'calls onGestureStart for pinch, onGestureEnd on touchend', () => {
 			const state = makeState( { zoom: 1 } );
-			const onGestureStart = jest.fn();
-			const onGestureEnd = jest.fn();
+			const onGestureStart = vi.fn();
+			const onGestureEnd = vi.fn();
 			const { controller } = createController( state, {
 				onGestureStart,
 				onGestureEnd,
@@ -1034,7 +1048,7 @@ describe( 'InteractionController', () => {
 				createTouchEvent( [ { clientX: 210, clientY: 155 } ] )
 			);
 			expect( actionMocks.setPan ).toHaveBeenCalled();
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			// Second finger arrives via touchstart.
 			controller.handleTouchStart(
@@ -1125,7 +1139,7 @@ describe( 'InteractionController', () => {
 				] )
 			);
 
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			// One finger lifts — move with 1 touch should NOT pan
 			// because didPinch is true.
@@ -1228,7 +1242,7 @@ describe( 'InteractionController', () => {
 				createPointerEvent( { clientX: 100, clientY: 100 } ),
 				el
 			);
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 
 			controller.destroy();
 

--- a/packages/media-editor/src/image-editor/core/test/preview-export-parity.ts
+++ b/packages/media-editor/src/image-editor/core/test/preview-export-parity.ts
@@ -28,6 +28,11 @@
  * sideways during fine rotation would have been caught by this test —
  * the center would agree (symmetric bug) but the corners would drift.
  */
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import { mat2d, vec2 } from 'gl-matrix';
 
 import {

--- a/packages/media-editor/src/image-editor/core/test/render-camera-bridge.ts
+++ b/packages/media-editor/src/image-editor/core/test/render-camera-bridge.ts
@@ -24,6 +24,11 @@
  *
  * ...run these tests to verify the two paths still agree.
  */
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import {
 	createCamera,
 	worldToScreen,

--- a/packages/media-editor/src/image-editor/core/test/state.ts
+++ b/packages/media-editor/src/image-editor/core/test/state.ts
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import type { CropperState, Size } from '../types';
 import { ABSOLUTE_MIN_ZOOM, DEFAULT_STATE, MAX_ZOOM } from '../constants';
 import { cropperReducer, enforceContainment, isStateDirty } from '../state';

--- a/packages/media-editor/src/image-editor/core/test/stencil-math.ts
+++ b/packages/media-editor/src/image-editor/core/test/stencil-math.ts
@@ -1,6 +1,11 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 import {
 	computeFreeResizeRect,
 	computeLockedResizeRect,

--- a/packages/media-editor/src/image-editor/core/transforms/test/pipeline.ts
+++ b/packages/media-editor/src/image-editor/core/transforms/test/pipeline.ts
@@ -1,6 +1,11 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import type { CropperState, TransformOperation } from '../../types';
 import { DEFAULT_STATE } from '../../constants';
 import { applyOperationToState, stateFromPipeline } from '../pipeline';

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.tsx
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import { RectangleStencil } from '../rectangle-stencil';
-import type { NormalizedRect, Size } from '../../../../core/types';
+import type {
+	HandlePosition,
+	NormalizedRect,
+	Size,
+} from '../../../../core/types';
 import { DEFAULT_KEYBOARD_STEP } from '../../../../core/constants';
 
 const DEFAULT_CROP_RECT: NormalizedRect = {
@@ -29,10 +34,10 @@ const CROP_BOUNDS = { minX: 0, minY: 0, maxX: 1, maxY: 1 };
 function renderStencil(
 	overrides: Partial< React.ComponentProps< typeof RectangleStencil > > = {}
 ) {
-	const onCropChange = jest.fn();
-	const onResizeStart = jest.fn();
-	const onResizeEnd = jest.fn();
-	const onEscape = jest.fn();
+	const onCropChange = vi.fn();
+	const onResizeStart = vi.fn();
+	const onResizeEnd = vi.fn();
+	const onEscape = vi.fn();
 	const props = {
 		cropRect: DEFAULT_CROP_RECT,
 		containerSize: CONTAINER_SIZE,
@@ -63,10 +68,10 @@ describe( 'RectangleStencil', () => {
 	// handle drag tests work. Same pattern as core/test/interaction-controller.ts.
 	beforeAll( () => {
 		if ( ! HTMLElement.prototype.setPointerCapture ) {
-			HTMLElement.prototype.setPointerCapture = jest.fn();
+			HTMLElement.prototype.setPointerCapture = vi.fn();
 		}
 		if ( ! HTMLElement.prototype.releasePointerCapture ) {
-			HTMLElement.prototype.releasePointerCapture = jest.fn();
+			HTMLElement.prototype.releasePointerCapture = vi.fn();
 		}
 		// Without a PointerEvent constructor, fireEvent.pointerDown falls back to
 		// the base Event class which has no `button` property. The stencil's
@@ -133,8 +138,8 @@ describe( 'RectangleStencil', () => {
 
 	describe( 'keyboard — Escape', () => {
 		it( 'handles Escape on a handle without bubbling', () => {
-			const onKeyDown = jest.fn();
-			const onEscape = jest.fn();
+			const onKeyDown = vi.fn();
+			const onEscape = vi.fn();
 			render(
 				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div onKeyDown={ onKeyDown }>
@@ -142,7 +147,7 @@ describe( 'RectangleStencil', () => {
 						cropRect={ DEFAULT_CROP_RECT }
 						containerSize={ CONTAINER_SIZE }
 						imageSize={ IMAGE_SIZE }
-						onCropChange={ jest.fn() }
+						onCropChange={ vi.fn() }
 						onEscape={ onEscape }
 						freeformCrop
 						cropBounds={ CROP_BOUNDS }
@@ -170,7 +175,7 @@ describe( 'RectangleStencil', () => {
 
 	describe( 'keyboard — arrow keys (fine step)', () => {
 		it( 'calls onResizeStart once and onResizeEnd after keyboard resize settles', () => {
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 			const { onResizeStart, onResizeEnd } = renderStencil();
 			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
 
@@ -181,11 +186,11 @@ describe( 'RectangleStencil', () => {
 			expect( onResizeEnd ).not.toHaveBeenCalled();
 
 			act( () => {
-				jest.advanceTimersByTime( 500 );
+				vi.advanceTimersByTime( 500 );
 			} );
 
 			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'moves the right edge right by KEYBOARD_STEP on ArrowRight (no Shift)', () => {
@@ -223,7 +228,12 @@ describe( 'RectangleStencil', () => {
 		} );
 
 		it( 'applies snapCropRect to freeform resize output', () => {
-			const snapCropRect = jest.fn( ( rect: NormalizedRect ) => ( {
+			const snapCropRect = vi.fn<
+				(
+					rect: NormalizedRect,
+					handle: HandlePosition
+				) => NormalizedRect
+			>( ( rect ) => ( {
 				...rect,
 				width: 0.82,
 			} ) );
@@ -318,7 +328,7 @@ describe( 'RectangleStencil', () => {
 		} );
 
 		it( 'does not apply snapCropRect while resizing a locked aspect ratio', () => {
-			const snapCropRect = jest.fn( ( rect: NormalizedRect ) => rect );
+			const snapCropRect = vi.fn( ( rect: NormalizedRect ) => rect );
 			renderStencil( { aspectRatio: 1, snapCropRect } );
 			const nwHandle = screen.getByRole( 'button', {
 				name: 'Resize from top-left corner',
@@ -357,7 +367,7 @@ describe( 'RectangleStencil', () => {
 			renderStencil();
 			const [ firstHandle ] = screen.getAllByRole( 'button' );
 
-			jest.spyOn( firstHandle, 'focus' );
+			vi.spyOn( firstHandle, 'focus' );
 
 			fireEvent.pointerDown( firstHandle, {
 				button: 0,
@@ -413,14 +423,14 @@ describe( 'RectangleStencil', () => {
 		} );
 
 		it( 'only stops touchstart propagation for single-touch handle gestures', () => {
-			const onTouchStart = jest.fn();
+			const onTouchStart = vi.fn();
 			render(
 				<div onTouchStart={ onTouchStart }>
 					<RectangleStencil
 						cropRect={ DEFAULT_CROP_RECT }
 						containerSize={ CONTAINER_SIZE }
 						imageSize={ IMAGE_SIZE }
-						onCropChange={ jest.fn() }
+						onCropChange={ vi.fn() }
 						freeformCrop
 						cropBounds={ CROP_BOUNDS }
 					/>

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -2,6 +2,15 @@
  * External dependencies
  */
 import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from 'vitest';
+import {
 	act,
 	fireEvent,
 	render,
@@ -32,22 +41,22 @@ function createController(): CropperController {
 				naturalHeight: 400,
 			},
 		},
-		setImage: jest.fn(),
-		setPan: jest.fn(),
-		setZoom: jest.fn(),
-		setZoomAtPoint: jest.fn(),
-		setRotation: jest.fn(),
-		setFlip: jest.fn(),
-		toggleFlip: jest.fn(),
-		snapRotate90: jest.fn(),
-		setCropRect: jest.fn(),
-		settleCrop: jest.fn(),
-		applyOperation: jest.fn(),
-		reset: jest.fn(),
+		setImage: vi.fn(),
+		setPan: vi.fn(),
+		setZoom: vi.fn(),
+		setZoomAtPoint: vi.fn(),
+		setRotation: vi.fn(),
+		setFlip: vi.fn(),
+		toggleFlip: vi.fn(),
+		snapRotate90: vi.fn(),
+		setCropRect: vi.fn(),
+		settleCrop: vi.fn(),
+		applyOperation: vi.fn(),
+		reset: vi.fn(),
 		isDirty: false,
-		getCroppedImage: jest.fn(),
-		setVisualSize: jest.fn(),
-		adjustCropRectForViewport: jest.fn(),
+		getCroppedImage: vi.fn(),
+		setVisualSize: vi.fn(),
+		adjustCropRectForViewport: vi.fn(),
 	};
 }
 
@@ -56,10 +65,10 @@ describe( 'Cropper', () => {
 
 	beforeAll( () => {
 		if ( ! HTMLElement.prototype.setPointerCapture ) {
-			HTMLElement.prototype.setPointerCapture = jest.fn();
+			HTMLElement.prototype.setPointerCapture = vi.fn();
 		}
 		if ( ! HTMLElement.prototype.releasePointerCapture ) {
-			HTMLElement.prototype.releasePointerCapture = jest.fn();
+			HTMLElement.prototype.releasePointerCapture = vi.fn();
 		}
 		if ( typeof ( globalThis as any ).PointerEvent === 'undefined' ) {
 			( globalThis as any ).PointerEvent = class PointerEvent extends (
@@ -296,8 +305,8 @@ describe( 'Cropper', () => {
 		await screen.findByRole( 'button', {
 			name: 'Resize from top-left corner',
 		} );
-		( controller.setCropRect as jest.Mock ).mockClear();
-		( controller.adjustCropRectForViewport as jest.Mock ).mockClear();
+		( controller.setCropRect as Mock ).mockClear();
+		( controller.adjustCropRectForViewport as Mock ).mockClear();
 
 		rerender(
 			<Cropper
@@ -345,8 +354,8 @@ describe( 'Cropper', () => {
 		);
 	} );
 
-	it( 'clears settling state when a new resize starts before the settle fallback fires', async () => {
-		jest.useFakeTimers();
+	it( 'clears settling state when a new resize starts before the settle fallback fires', () => {
+		vi.useFakeTimers();
 
 		render(
 			<Cropper
@@ -357,7 +366,7 @@ describe( 'Cropper', () => {
 			/>
 		);
 
-		const handle = await screen.findByRole( 'button', {
+		const handle = screen.getByRole( 'button', {
 			name: 'Resize from top-left corner',
 		} );
 		// The settle transition and viewport pan live on the stage, not the
@@ -391,18 +400,18 @@ describe( 'Cropper', () => {
 
 		// Advance past the old settle fallback; it was cancelled so the stage
 		// should still have no transition.
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 		expect( stage ).not.toHaveStyle(
 			'transition: transform 200ms ease-out'
 		);
 
 		fireEvent.pointerUp( handle, { pointerId: 1 } );
 
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
-	it( 'keeps settling active until the settle transform transition ends', async () => {
-		jest.useFakeTimers();
+	it( 'keeps settling active until the settle transform transition ends', () => {
+		vi.useFakeTimers();
 
 		render(
 			<Cropper
@@ -413,7 +422,7 @@ describe( 'Cropper', () => {
 			/>
 		);
 
-		const handle = await screen.findByRole( 'button', {
+		const handle = screen.getByRole( 'button', {
 			name: 'Resize from top-left corner',
 		} );
 		const stage = screen.getByTestId( 'cropper-stage' );
@@ -428,7 +437,7 @@ describe( 'Cropper', () => {
 
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
-		act( () => jest.advanceTimersByTime( 200 ) );
+		act( () => vi.advanceTimersByTime( 200 ) );
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
 		// The transform transition runs on the image and bubbles up to the
@@ -446,11 +455,11 @@ describe( 'Cropper', () => {
 			'transition: transform 200ms ease-out'
 		);
 
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
-	it( 'clears settling via the fallback timer when no transitionend fires', async () => {
-		jest.useFakeTimers();
+	it( 'clears settling via the fallback timer when no transitionend fires', () => {
+		vi.useFakeTimers();
 
 		render(
 			<Cropper
@@ -461,7 +470,7 @@ describe( 'Cropper', () => {
 			/>
 		);
 
-		const handle = await screen.findByRole( 'button', {
+		const handle = screen.getByRole( 'button', {
 			name: 'Resize from top-left corner',
 		} );
 		const stage = screen.getByTestId( 'cropper-stage' );
@@ -477,20 +486,20 @@ describe( 'Cropper', () => {
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
 		// Without a transitionend, settling persists past the CSS duration...
-		act( () => jest.advanceTimersByTime( 200 ) );
+		act( () => vi.advanceTimersByTime( 200 ) );
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
 		// ...and is cleared by the fallback timer (CSS duration + 100ms).
-		act( () => jest.advanceTimersByTime( 100 ) );
+		act( () => vi.advanceTimersByTime( 100 ) );
 		expect( stage ).not.toHaveStyle(
 			'transition: transform 200ms ease-out'
 		);
 
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
-	it( 'ignores non-transform transitionend events while settling', async () => {
-		jest.useFakeTimers();
+	it( 'ignores non-transform transitionend events while settling', () => {
+		vi.useFakeTimers();
 
 		render(
 			<Cropper
@@ -501,7 +510,7 @@ describe( 'Cropper', () => {
 			/>
 		);
 
-		const handle = await screen.findByRole( 'button', {
+		const handle = screen.getByRole( 'button', {
 			name: 'Resize from top-left corner',
 		} );
 		const stage = screen.getByTestId( 'cropper-stage' );
@@ -527,11 +536,11 @@ describe( 'Cropper', () => {
 
 		expect( stage ).toHaveStyle( 'transition: transform 200ms ease-out' );
 
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
-	it( 'pans the canvas when a keyboard resize extends the crop past the canvas edge', async () => {
-		jest.useFakeTimers();
+	it( 'pans the canvas when a keyboard resize extends the crop past the canvas edge', () => {
+		vi.useFakeTimers();
 
 		// zoom: 2 so the image bounds extend past [0, 1] in normalized space,
 		// allowing the crop to be resized beyond the canvas edge.
@@ -548,7 +557,7 @@ describe( 'Cropper', () => {
 		);
 
 		// East handle (4th button clockwise: nw, n, ne, e).
-		const eHandle = await screen.findByRole( 'button', {
+		const eHandle = screen.getByRole( 'button', {
 			name: 'Resize from right edge',
 		} );
 		const stage = screen.getByTestId( 'cropper-stage' );
@@ -567,7 +576,7 @@ describe( 'Cropper', () => {
 		expect( Number( match?.[ 1 ] ) ).toBeCloseTo( -2, 4 );
 		expect( Number( match?.[ 2 ] ) ).toBeCloseTo( 0, 5 );
 
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	it( 'ignores wheel zoom while a crop resize is active', async () => {
@@ -654,11 +663,11 @@ describe( 'Cropper', () => {
 			cb( 0 );
 			return 0;
 		};
-		globalThis.cancelAnimationFrame = jest.fn();
+		globalThis.cancelAnimationFrame = vi.fn();
 
 		try {
 			const controller = createController();
-			const onGestureEnd = jest.fn();
+			const onGestureEnd = vi.fn();
 			render(
 				<Cropper
 					src="test.jpg"
@@ -685,7 +694,7 @@ describe( 'Cropper', () => {
 				isPrimary: true,
 			} );
 
-			( controller.setPan as jest.Mock ).mockClear();
+			( controller.setPan as Mock ).mockClear();
 			fireEvent.pointerDown( canvas, {
 				button: 0,
 				clientX: 250,
@@ -719,8 +728,8 @@ describe( 'Cropper', () => {
 			expect( controller.settleCrop ).not.toHaveBeenCalled();
 			expect( onGestureEnd ).not.toHaveBeenCalled();
 
-			( controller.setCropRect as jest.Mock ).mockClear();
-			( controller.setZoomAtPoint as jest.Mock ).mockClear();
+			( controller.setCropRect as Mock ).mockClear();
+			( controller.setZoomAtPoint as Mock ).mockClear();
 
 			fireEvent.pointerMove( resizeHandle, {
 				button: 0,
@@ -930,8 +939,7 @@ describe( 'Cropper', () => {
 		} );
 		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
 
-		const rect = ( controller.setCropRect as jest.Mock ).mock
-			.calls[ 0 ][ 0 ];
+		const rect = ( controller.setCropRect as Mock ).mock.calls[ 0 ][ 0 ];
 		const region = getSourceRegion(
 			{ ...controller.state, cropRect: rect },
 			{ width: image.naturalWidth, height: image.naturalHeight }
@@ -970,11 +978,10 @@ describe( 'Cropper', () => {
 		const handle = await screen.findByRole( 'button', {
 			name: 'Resize from right edge',
 		} );
-		( controller.setCropRect as jest.Mock ).mockClear();
+		( controller.setCropRect as Mock ).mockClear();
 		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
 
-		const rect = ( controller.setCropRect as jest.Mock ).mock
-			.calls[ 0 ][ 0 ];
+		const rect = ( controller.setCropRect as Mock ).mock.calls[ 0 ][ 0 ];
 		const region = getSourceRegion(
 			{ ...controller.state, cropRect: rect },
 			{ width: image.naturalWidth, height: image.naturalHeight }
@@ -1007,8 +1014,7 @@ describe( 'Cropper', () => {
 		} );
 		fireEvent.keyDown( handle, { key: 'ArrowRight' } );
 
-		const rect = ( controller.setCropRect as jest.Mock ).mock
-			.calls[ 0 ][ 0 ];
+		const rect = ( controller.setCropRect as Mock ).mock.calls[ 0 ][ 0 ];
 		const region = getSourceRegion(
 			{ ...controller.state, cropRect: rect },
 			{ width: image.naturalWidth, height: image.naturalHeight }
@@ -1063,8 +1069,7 @@ describe( 'Cropper', () => {
 		await waitFor( () =>
 			expect( controller.setCropRect ).toHaveBeenCalledTimes( 1 )
 		);
-		const rect = ( controller.setCropRect as jest.Mock ).mock
-			.calls[ 0 ][ 0 ];
+		const rect = ( controller.setCropRect as Mock ).mock.calls[ 0 ][ 0 ];
 		const region = getSourceRegion(
 			{ ...controller.state, cropRect: rect },
 			{ width: image.naturalWidth, height: image.naturalHeight }

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-aria-announcer.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-aria-announcer.ts
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
 /**
@@ -15,9 +24,13 @@ import { useAriaAnnouncer } from '../use-aria-announcer';
 import { DEFAULT_STATE } from '../../../core/constants';
 import type { CropperState } from '../../../core/types';
 
-jest.mock( '@wordpress/a11y', () => ( {
-	speak: jest.fn(),
-} ) );
+vi.mock(
+	import( '@wordpress/a11y' ),
+	() =>
+		( {
+			speak: vi.fn(),
+		} ) as unknown as typeof import('@wordpress/a11y')
+);
 
 function makeState( overrides: Partial< CropperState > = {} ): CropperState {
 	return {
@@ -36,12 +49,12 @@ function makeState( overrides: Partial< CropperState > = {} ): CropperState {
 
 describe( 'useAriaAnnouncer', () => {
 	beforeEach( () => {
-		jest.useFakeTimers();
-		( speak as jest.Mock ).mockClear();
+		vi.useFakeTimers();
+		( speak as Mock ).mockClear();
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	it( 'announces horizontal flip changes', () => {
@@ -50,14 +63,14 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
 				flip: { horizontal: true, vertical: false },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Flipped horizontally' );
 
@@ -66,7 +79,7 @@ describe( 'useAriaAnnouncer', () => {
 				flip: { horizontal: false, vertical: false },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Flip removed' );
 	} );
@@ -77,14 +90,14 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
 				flip: { horizontal: true, vertical: true },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Flipped horizontally and vertically'
@@ -102,7 +115,7 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState( { image } ) } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
@@ -110,7 +123,7 @@ describe( 'useAriaAnnouncer', () => {
 				cropRect: { x: 0, y: 0, width: 0.8, height: 0.5 },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Crop 800 by 400 pixels' );
 	} );
@@ -133,7 +146,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		// 0.5 → 0.5005 of a 2000px-wide image is a one-pixel change (1000 →
 		// 1001), well under the old ~0.5% percentage threshold.
@@ -143,7 +156,7 @@ describe( 'useAriaAnnouncer', () => {
 				cropRect: { x: 0, y: 0, width: 0.5005, height: 0.5 },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Crop 1001 by 500 pixels' );
 	} );
@@ -166,7 +179,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
@@ -175,7 +188,7 @@ describe( 'useAriaAnnouncer', () => {
 				zoom: 1.5,
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Zoom 150%' );
 	} );
@@ -202,7 +215,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
@@ -211,7 +224,7 @@ describe( 'useAriaAnnouncer', () => {
 				cropRect: { x: 0, y: 0, width: 0.5005, height: 0.5 },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Crop 1001 by 400 pixels' );
 	} );
@@ -222,12 +235,12 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( { rotation: 15 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Rotated 15 degrees clockwise' );
 	} );
@@ -244,7 +257,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		// With a single-axis flip, rotation 10 appears as -10 visually.
 		rerender( {
@@ -253,7 +266,7 @@ describe( 'useAriaAnnouncer', () => {
 				flip: { horizontal: true, vertical: false },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Rotated 10 degrees counterclockwise'
@@ -272,7 +285,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		// Flip horizontal, then rotate 90° clockwise: the reducer negates the
 		// visual direction for the field, so it stores 270 (normalized -90).
@@ -283,7 +296,7 @@ describe( 'useAriaAnnouncer', () => {
 				flip: { horizontal: true, vertical: false },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Rotated 90 degrees clockwise' );
 	} );
@@ -300,7 +313,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
@@ -308,7 +321,7 @@ describe( 'useAriaAnnouncer', () => {
 				flip: { horizontal: false, vertical: true },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Rotated 90 degrees clockwise' );
 	} );
@@ -327,7 +340,7 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( {
@@ -335,7 +348,7 @@ describe( 'useAriaAnnouncer', () => {
 				flip: { horizontal: true, vertical: true },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Rotated 90 degrees counterclockwise'
@@ -348,12 +361,12 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( { rotation: 90, zoom: 1.5 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Rotated 90 degrees clockwise, Zoom 150%'
@@ -366,12 +379,12 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState( { rotation: 15 } ) } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( { rotation: 0 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Rotation 0 degrees' );
 	} );
@@ -382,13 +395,13 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		// 90° CW snap + 15° fine = 105° stored.
 		rerender( {
 			state: makeState( { rotation: 105 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Rotated 105 degrees clockwise' );
 	} );
@@ -399,14 +412,14 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		// 90° CCW snap (270°) + 15° CCW fine (255° stored).
 		// visualRotation = 255 → normalized to -105.
 		rerender( {
 			state: makeState( { rotation: 255 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Rotated 105 degrees counterclockwise'
@@ -419,14 +432,14 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		// -10° from 0° is stored as 350° after normalization.
 		// visualRotation = -10 → counterclockwise.
 		rerender( {
 			state: makeState( { rotation: 350 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Rotated 10 degrees counterclockwise'
@@ -448,9 +461,9 @@ describe( 'useAriaAnnouncer', () => {
 			}
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
-		( speak as jest.Mock ).mockClear();
+		( speak as Mock ).mockClear();
 
 		// Only change crop — zoom and rotation should be suppressed.
 		rerender( {
@@ -460,7 +473,7 @@ describe( 'useAriaAnnouncer', () => {
 				cropRect: { x: 0, y: 0, width: 0.5, height: 0.5 },
 			} ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Crop 500 by 400 pixels' );
 		expect( speak ).not.toHaveBeenCalledWith(
@@ -477,12 +490,12 @@ describe( 'useAriaAnnouncer', () => {
 			{ initialProps: { state: makeState() } }
 		);
 
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		rerender( {
 			state: makeState( { zoom: 1.5 } ),
 		} );
-		act( () => jest.advanceTimersByTime( 300 ) );
+		act( () => vi.advanceTimersByTime( 300 ) );
 
 		expect( speak ).toHaveBeenCalledWith( 'Zoom 150%' );
 	} );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-reducer.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-reducer.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 /**

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-interaction.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
 /**
@@ -27,13 +28,13 @@ function makeState( overrides: Partial< CropperState > = {} ): CropperState {
 	};
 }
 
-function createActions(): jest.Mocked< CropperInteractionActions > {
+function createActions(): Mocked< CropperInteractionActions > {
 	return {
-		setPan: jest.fn(),
-		setZoom: jest.fn(),
-		setZoomAtPoint: jest.fn(),
-		snapRotate90: jest.fn(),
-		toggleFlip: jest.fn(),
+		setPan: vi.fn(),
+		setZoom: vi.fn(),
+		setZoomAtPoint: vi.fn(),
+		snapRotate90: vi.fn(),
+		toggleFlip: vi.fn(),
 	};
 }
 
@@ -41,7 +42,7 @@ function createWheelEvent(
 	overrides: Partial< WheelEvent > & { currentTarget?: unknown } = {}
 ): WheelEvent {
 	return {
-		preventDefault: jest.fn(),
+		preventDefault: vi.fn(),
 		deltaY: -100,
 		clientX: 0,
 		clientY: 0,
@@ -55,7 +56,7 @@ function createKeyboardEvent( key: string ): React.KeyboardEvent {
 		key,
 		nativeEvent: {
 			key,
-			preventDefault: jest.fn(),
+			preventDefault: vi.fn(),
 		},
 	} as unknown as React.KeyboardEvent;
 }
@@ -64,7 +65,7 @@ function createTouchEvent(
 	touches: Array< { clientX: number; clientY: number } >
 ): TouchEvent {
 	return {
-		preventDefault: jest.fn(),
+		preventDefault: vi.fn(),
 		touches,
 	} as unknown as TouchEvent;
 }
@@ -74,13 +75,13 @@ function createTouchDocument(): Document & {
 } {
 	const listeners: Record< string, EventListener[] > = {};
 	return {
-		addEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+		addEventListener: vi.fn( ( type: string, fn: EventListener ) => {
 			if ( ! listeners[ type ] ) {
 				listeners[ type ] = [];
 			}
 			listeners[ type ].push( fn );
 		} ),
-		removeEventListener: jest.fn( ( type: string, fn: EventListener ) => {
+		removeEventListener: vi.fn( ( type: string, fn: EventListener ) => {
 			if ( listeners[ type ] ) {
 				listeners[ type ] = listeners[ type ].filter(
 					( listener ) => listener !== fn
@@ -111,11 +112,11 @@ function createTouchTarget( ownerDocument: Document ) {
 
 describe( 'useInteraction grid placement signal', () => {
 	afterEach( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	it( 'sets isPlacementActive during keyboard pan, then clears it after idle', () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		const { result } = renderHook( () =>
 			useInteraction(
 				makeState(),
@@ -134,7 +135,7 @@ describe( 'useInteraction grid placement signal', () => {
 		expect( result.current.isPlacementActive ).toBe( true );
 
 		act( () => {
-			jest.advanceTimersByTime( 300 );
+			vi.advanceTimersByTime( 300 );
 		} );
 
 		expect( result.current.isPlacementActive ).toBe( false );
@@ -161,7 +162,7 @@ describe( 'useInteraction grid placement signal', () => {
 	);
 
 	it( 'sets isPlacementActive during wheel zoom, then clears it after the wheel debounce', () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		const { result } = renderHook( () =>
 			useInteraction(
 				makeState(),
@@ -180,7 +181,7 @@ describe( 'useInteraction grid placement signal', () => {
 		expect( result.current.isPlacementActive ).toBe( true );
 
 		act( () => {
-			jest.advanceTimersByTime( 300 );
+			vi.advanceTimersByTime( 300 );
 		} );
 
 		expect( result.current.isPlacementActive ).toBe( false );

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-transform-style.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-transform-style.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**

--- a/packages/media-editor/src/state/test/use-media-editor-state.ts
+++ b/packages/media-editor/src/state/test/use-media-editor-state.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
 /**

--- a/packages/media-editor/src/store/test/reducer.ts
+++ b/packages/media-editor/src/store/test/reducer.ts
@@ -1,6 +1,11 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
 import reducer, { DEFAULT_STATE } from '../reducer';
 
 describe( 'core/media-editor reducer', () => {
@@ -10,8 +15,8 @@ describe( 'core/media-editor reducer', () => {
 	} );
 
 	it( 'opens the modal with id and onUpdate', () => {
-		const onUpdate = jest.fn();
-		const onClose = jest.fn();
+		const onUpdate = vi.fn();
+		const onClose = vi.fn();
 		const state = reducer( undefined, {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 42,
@@ -27,10 +32,10 @@ describe( 'core/media-editor reducer', () => {
 	} );
 
 	it( 'replaces state on a subsequent open (new onUpdate)', () => {
-		const firstOnUpdate = jest.fn();
-		const firstOnClose = jest.fn();
-		const secondOnUpdate = jest.fn();
-		const secondOnClose = jest.fn();
+		const firstOnUpdate = vi.fn();
+		const firstOnClose = vi.fn();
+		const secondOnUpdate = vi.fn();
+		const secondOnClose = vi.fn();
 		const first = reducer( undefined, {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 42,
@@ -55,8 +60,8 @@ describe( 'core/media-editor reducer', () => {
 		const opened = reducer( undefined, {
 			type: 'OPEN_MEDIA_EDITOR_MODAL',
 			id: 42,
-			onUpdate: jest.fn(),
-			onClose: jest.fn(),
+			onUpdate: vi.fn(),
+			onClose: vi.fn(),
 		} );
 		const closed = reducer( opened, {
 			type: 'CLOSE_MEDIA_EDITOR_MODAL',

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -52,6 +52,7 @@
 					"packages/interactivity-router",
 					"packages/is-shallow-equal",
 					"packages/keycodes",
+					"packages/media-editor",
 					"packages/media-fields",
 					"packages/media-utils",
 					"packages/notices",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** This package migration replaces Jest globals and types with explicit Vitest imports across all Media Editor tests, converts module mocks and CommonJS lookups to typed ESM APIs, adapts fake-timer and constructor-mock usage to Vitest, and adds direct Vitest dependency ownership.

This draft is stacked on #80948.

## Why?

Media Editor is one of the remaining Jest-owned packages in the repository migration. Moving the complete package preserves exactly-one-runner ownership while exercising the migration's more demanding timer, canvas, interaction, and TypeScript paths.

## How?

- Route all 23 Media Editor test files to the Vitest jsdom project.
- Replace Jest mocks, spies, timer APIs, and mock types with Vitest equivalents.
- Use typed dynamic ESM module mocks and static ESM imports instead of Jest/CommonJS helpers.
- Keep Testing Library for React rendering and user-facing queries.
- Replace async role polling performed under fake timers with synchronous role queries where the elements render immediately.
- Mock `Image` with constructable functions, and scope fake timers to the timeout APIs each test needs.
- Declare Vitest directly in `@wordpress/media-editor`.

## Testing Instructions

1. Run `npm run test:unit:vitest -- --project vitest packages/media-editor`.
2. Run `npm run test:unit:routing`.
3. Run `npm run test:unit:conventions`.
4. Run `npm run test:unit:vitest -- --project vitest --project node`.
5. Run `npm run test:unit -- --runInBand`.

Expected results:

- Media Editor: 23 files and 18,762 tests pass.
- Routing: 389 Jest files and 614 Vitest files are owned exactly once.
- Conventions/type checking: 614 Vitest tests, 630 ESM graph files, 95 workspace dependencies, and 363 TypeScript tests validate.
- Full Vitest jsdom/Node partition: 611 files pass, 2 skip; 29,089 tests pass, 8 skip.
- Remaining Jest partition: 389 suites, 5,661 tests, and 59 snapshots pass.

### Testing Instructions for Keyboard

Not applicable; this PR only changes test infrastructure and test implementation.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inspect the existing tests, perform the mechanical runner migration, identify Jest/Vitest compatibility differences, and run the verification gates. The resulting changes were reviewed against the repository's strict lint, routing, and TypeScript checks.
