### PR TITLE
Table of Contents: Show a placeholder in templates that don't render a single post

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
+-   Table of Contents: Show an explanatory placeholder when the block is placed in a template that does not render a single post or page (e.g. Archive, Search, 404), instead of the generic empty-headings message.
 
 ### Internal
 

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -36,7 +36,7 @@ import {
  */
 import TableOfContentsList from './list';
 import { linearToNestedHeadingList } from './utils';
-import { useObserveHeadings } from './hooks';
+import { useObserveHeadings, useTemplateContext } from './hooks';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 /** @typedef {import('./utils').HeadingData} HeadingData */
@@ -67,6 +67,7 @@ export default function TableOfContentsEdit( {
 } ) {
 	useObserveHeadings( clientId );
 
+	const templateContext = useTemplateContext();
 	const blockProps = useBlockProps();
 	const instanceId = useInstanceId(
 		TableOfContentsEdit,
@@ -221,19 +222,37 @@ export default function TableOfContentsEdit( {
 		</InspectorControls>
 	);
 
-	// If there are no headings or the only heading is empty.
-	// Note that the toolbar controls are intentionally omitted since the
-	// "Convert to static list" option is useless to the placeholder state.
-	if ( headings.length === 0 ) {
+	// Work out the placeholder message, if any. While editing a template there
+	// is no single post to preview against, so explain what the block will do
+	// on the front of site instead of showing a list built from unrelated
+	// template headings.
+	let instructions;
+	if ( templateContext === 'nonSingular' ) {
+		instructions = __(
+			'Table of Contents needs a single post or page to list headings.'
+		);
+	} else if ( templateContext === 'singular' ) {
+		instructions = __(
+			'This table of contents will show headings from the post being viewed.'
+		);
+	} else if ( headings.length === 0 ) {
+		// There are no headings, or the only heading is empty.
+		instructions = __(
+			'Start adding Heading blocks to create a table of contents. Headings with HTML anchors will be linked here.'
+		);
+	}
+
+	// The toolbar controls are intentionally omitted from the placeholder
+	// states since the "Convert to static list" option is useless without a
+	// rendered list.
+	if ( instructions ) {
 		return (
 			<>
 				<div { ...blockProps }>
 					<Placeholder
 						icon={ <BlockIcon icon={ icon } /> }
 						label={ __( 'Table of Contents' ) }
-						instructions={ __(
-							'Start adding Heading blocks to create a table of contents. Headings with HTML anchors will be linked here.'
-						) }
+						instructions={ instructions }
 					/>
 				</div>
 				{ inspectorControls }

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -6,11 +6,86 @@ import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 /**
  * WordPress dependencies
  */
-import { useRegistry } from '@wordpress/data';
+import { useRegistry, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useEffect } from '@wordpress/element';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Template slugs that resolve to a single post or page on the front of site,
+ * so the Table of Contents can list that post's headings when the block is
+ * placed in the template. Includes the specific slugs and the hierarchical
+ * prefixes (e.g. `single-book`, `page-about`, custom page templates).
+ */
+const SINGULAR_TEMPLATE_SLUGS = [
+	'single',
+	'page',
+	'singular',
+	'attachment',
+	'privacy-policy',
+];
+const SINGULAR_TEMPLATE_PREFIXES = [
+	'single-',
+	'page-',
+	'attachment-',
+	'wp-custom-template-',
+];
+
+function isSingularTemplateSlug( slug ) {
+	if ( ! slug ) {
+		return false;
+	}
+	return (
+		SINGULAR_TEMPLATE_SLUGS.includes( slug ) ||
+		SINGULAR_TEMPLATE_PREFIXES.some( ( prefix ) =>
+			slug.startsWith( prefix )
+		)
+	);
+}
+
+/**
+ * Detects the editing context of the Table of Contents block.
+ *
+ * The block lists headings from the post being viewed, which is resolved on the
+ * server from the current request. While editing a template directly there is
+ * no single post to preview against, so the editor can only explain what the
+ * block will do rather than show a live list. This hook reports which
+ * explanation applies:
+ *
+ * - `'singular'`: a template that renders one post or page (e.g. Single, Page).
+ * - `'nonSingular'`: a template with no single post (e.g. Archive, Search, 404).
+ * - `null`: not editing a template (an ordinary post or page), so the block can
+ *   show its live heading list as usual.
+ *
+ * @return {('singular'|'nonSingular'|null)} The template editing context.
+ */
+export function useTemplateContext() {
+	return useSelect( ( select ) => {
+		// FIXME: @wordpress/block-library should not depend on
+		// @wordpress/editor. Blocks can be loaded into a *non-post* block editor
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		const { getCurrentPostId, getCurrentPostType } =
+			select( 'core/editor' );
+
+		// Only treat the block as being in a template when the template itself
+		// is the edited entity. In the post editor `getCurrentPostType()`
+		// returns the post type (e.g. `post`/`page`), so ordinary editing keeps
+		// its normal behavior.
+		if ( getCurrentPostType() !== 'wp_template' ) {
+			return null;
+		}
+
+		const slug = select( coreStore ).getEditedEntityRecord(
+			'postType',
+			'wp_template',
+			getCurrentPostId()
+		)?.slug;
+
+		return isSingularTemplateSlug( slug ) ? 'singular' : 'nonSingular';
+	}, [] );
+}
 
 function getLatestHeadings( select, clientId ) {
 	const {

--- a/test/e2e/specs/editor/blocks/table-of-contents.spec.js
+++ b/test/e2e/specs/editor/blocks/table-of-contents.spec.js
@@ -965,36 +965,37 @@ test.describe( 'Table of Contents', () => {
 			}
 		);
 
-		// Desired behavior: ToC in templates without post content should show a specific editor explanation; trunk only shows the generic empty-heading placeholder.
-		test.fixme(
-			'templates that do not render post content show an editor placeholder and render nothing to readers',
-			async ( { admin, editor, page, requestUtils } ) => {
-				await requestUtils.createTemplate( 'wp_template', {
-					slug: 'archive',
-					title: 'Archive',
-					content: '<!-- wp:table-of-contents /-->',
-				} );
+		test( 'templates that do not render post content show an editor placeholder and render nothing to readers', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await requestUtils.createTemplate( 'wp_template', {
+				slug: 'archive',
+				title: 'Archive',
+				content: '<!-- wp:table-of-contents /-->',
+			} );
 
-				await admin.visitSiteEditor( {
-					postId: 'emptytheme//archive',
-					postType: 'wp_template',
-					canvas: 'edit',
-				} );
-				// TODO: Make this placeholder explain how users can fix the template, not only why no ToC can render.
-				await expect(
-					getTableOfContentsEditorBlock( editor )
-				).toContainText(
-					'Table of Contents needs a single post or page to list headings.'
-				);
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//archive',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+			// TODO: Make this placeholder explain how users can fix the template, not only why no ToC can render.
+			await expect(
+				getTableOfContentsEditorBlock( editor )
+			).toContainText(
+				'Table of Contents needs a single post or page to list headings.'
+			);
 
-				await page.goto( '/?m=202001' );
-				await expect(
-					page.getByRole( 'navigation', {
-						name: 'Table of Contents',
-					} )
-				).toHaveCount( 0 );
-			}
-		);
+			await page.goto( '/?m=202001' );
+			await expect(
+				page.getByRole( 'navigation', {
+					name: 'Table of Contents',
+				} )
+			).toHaveCount( 0 );
+		} );
 	} );
 
 	test.describe( 'Supporting content built with other blocks', () => {


### PR DESCRIPTION
## What?
Part of  #80784

Adds an editor placeholder when the Table of Contents block is placed in a template that doesn't render one specific post (Archive, Search, 404, etc.). On the front of site the block renders nothing there, as before.

## Why?
The block lists a post's headings, so in a template with no single post it has nothing to show. It previously fell back to the generic "add headings" message, which is misleading.

## How?
New `useTemplateContext()` hook detects the editing context from the template slug and `edit.js` shows the matching placeholder. No front-end change.

## Testing Instructions
1. In the Site Editor, edit the Archive template.
2. Insert a Table of Contents block.
3. Confirm it shows: "Table of Contents needs a single post or page to list headings."
4. Visit a date archive (e.g. `/?m=202001`) on the front of site and confirm no table of contents renders.

Automated: `npm run test:e2e -- test/e2e/specs/editor/blocks/table-of-contents.spec.js`

## Screenshot

- When adding a new post

<img width="1468" height="795" alt="image" src="https://github.com/user-attachments/assets/e8f1ba3c-1d80-4941-8381-636a98c6b066" />

- Inside Archive Template which is Non-Singular

<img width="1470" height="802" alt="Screenshot 2026-07-30 at 4 55 04 PM" src="https://github.com/user-attachments/assets/b06c049b-0035-46ee-8d4f-427d80c01748" />

- Inside a Singular Template

<img width="1464" height="805" alt="Screenshot 2026-07-30 at 4 56 23 PM" src="https://github.com/user-attachments/assets/fc2ed777-4c70-4cab-a43f-5994b79ce738" />
