### PR TITLE
Migrate Upload Media Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53552,6 +53552,9 @@
 				"@wordpress/vips": "file:../vips",
 				"uuid": "^14.0.0"
 			},
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -61,6 +61,9 @@
 		"@wordpress/vips": "file:../vips",
 		"uuid": "^14.0.0"
 	},
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",
 		"react": "^18 || ^19",

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -1,4 +1,17 @@
 /**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
@@ -8,48 +21,56 @@ type WPDataRegistry = ReturnType< typeof createRegistry >;
  * Internal dependencies
  */
 import { store as uploadStore } from '..';
-import { ItemStatus, OperationType } from '../types';
+import { ItemStatus, OperationType, type QueueItem } from '../types';
 import { unlock } from '../../lock-unlock';
+import { UploadError } from '../../upload-error';
 
-jest.mock( '@wordpress/blob', () => ( {
-	__esModule: true,
-	createBlobURL: jest.fn( () => 'blob:foo' ),
-	isBlobURL: jest.fn( ( str: string ) => str.startsWith( 'blob:' ) ),
-	revokeBlobURL: jest.fn(),
-} ) );
+vi.mock(
+	import( '@wordpress/blob' ),
+	() =>
+		( {
+			createBlobURL: vi.fn( () => 'blob:foo' ),
+			isBlobURL: vi.fn( ( str: string ) => str.startsWith( 'blob:' ) ),
+			revokeBlobURL: vi.fn(),
+		} ) as unknown as typeof import('@wordpress/blob')
+);
 
-jest.mock( '../utils', () => ( {
-	vipsCancelOperations: jest.fn( () => Promise.resolve( true ) ),
-	vipsResizeImage: jest.fn( () =>
-		Promise.resolve(
-			new File( [ 'resized' ], 'example-100x100.jpg', {
-				type: 'image/jpeg',
-			} )
-		)
-	),
-	vipsRotateImage: jest.fn(),
-	vipsHasTransparency: jest.fn( () => Promise.resolve( false ) ),
-	vipsConvertImageFormat: jest.fn(),
-	terminateVipsWorker: jest.fn(),
-} ) );
+vi.mock(
+	import( '../utils' ),
+	() =>
+		( {
+			vipsCancelOperations: vi.fn( () => Promise.resolve( true ) ),
+			vipsResizeImage: vi.fn( () =>
+				Promise.resolve(
+					new File( [ 'resized' ], 'example-100x100.jpg', {
+						type: 'image/jpeg',
+					} )
+				)
+			),
+			vipsRotateImage: vi.fn(),
+			vipsHasTransparency: vi.fn( () => Promise.resolve( false ) ),
+			vipsConvertImageFormat: vi.fn(),
+			terminateVipsWorker: vi.fn(),
+		} ) as unknown as typeof import('../utils')
+);
 
 /*
  * actions.ts transitively imports private-actions, which also pulls in
  * convertGifToVideo / isUnsupportedConversionError, so the mock must cover the
  * whole module surface. isUnsupportedConversionError is kept real.
  */
-jest.mock( '../utils/video-conversion', () => {
-	const actual = jest.requireActual( '../utils/video-conversion' );
+vi.mock( import( '../utils/video-conversion' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 	return {
-		convertGifToVideo: jest.fn(),
-		cancelGifToVideoOperations: jest.fn( () => Promise.resolve( true ) ),
-		terminateVideoConversionWorker: jest.fn(),
-		isUnsupportedConversionError: actual.isUnsupportedConversionError,
+		...actual,
+		convertGifToVideo: vi.fn(),
+		cancelGifToVideoOperations: vi.fn( () => Promise.resolve( true ) ),
+		terminateVideoConversionWorker: vi.fn(),
 	};
 } );
 
 // Import the mocked modules to access the mock functions.
-import { vipsCancelOperations } from '../utils';
+import { vipsCancelOperations, vipsResizeImage } from '../utils';
 import { cancelGifToVideoOperations } from '../utils/video-conversion';
 
 function createRegistryWithStores() {
@@ -104,7 +125,7 @@ describe( 'actions', () => {
 
 	describe( 'addItems', () => {
 		it( 'adds multiple items to the queue', () => {
-			const onError = jest.fn();
+			const onError = vi.fn();
 			registry.dispatch( uploadStore ).addItems( {
 				files: [ jpegFile, mp4File ],
 				onError,
@@ -411,7 +432,7 @@ describe( 'actions', () => {
 		it( 'does not pause sideload items targeting the same post', async () => {
 			// Configure mediaSideload so sideload uploads can proceed.
 			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
-				mediaSideload: jest.fn(),
+				mediaSideload: vi.fn(),
 			} );
 
 			// Use a fake parentId so we only test sideload scheduling.
@@ -438,7 +459,7 @@ describe( 'actions', () => {
 				registry.select( uploadStore )
 			).getAllItems();
 			const sideloadItems = items.filter(
-				( item ) => item.parentId === fakeParentId
+				( item: QueueItem ) => item.parentId === fakeParentId
 			);
 
 			// Neither sideload item should be paused.
@@ -448,7 +469,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'allows multiple sideloads to the same attachment to upload concurrently', async () => {
-			const mediaSideload = jest.fn();
+			const mediaSideload = vi.fn();
 
 			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 				mediaSideload,
@@ -481,7 +502,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'respects maxConcurrentUploads for sideloads', async () => {
-			const mediaSideload = jest.fn();
+			const mediaSideload = vi.fn();
 
 			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 				mediaSideload,
@@ -518,7 +539,7 @@ describe( 'actions', () => {
 			let onSuccessCallback:
 				| ( ( subSize: Record< string, unknown > ) => void )
 				| undefined;
-			const mediaSideload = jest.fn( ( { onSuccess } ) => {
+			const mediaSideload = vi.fn( ( { onSuccess } ) => {
 				// Capture the first callback to simulate completion later.
 				if ( ! onSuccessCallback ) {
 					onSuccessCallback = onSuccess;
@@ -582,13 +603,13 @@ describe( 'actions', () => {
 
 	describe( 'cancelItem', () => {
 		beforeEach( () => {
-			( vipsCancelOperations as jest.Mock ).mockClear();
-			( cancelGifToVideoOperations as jest.Mock ).mockClear();
+			( vipsCancelOperations as Mock ).mockClear();
+			( cancelGifToVideoOperations as Mock ).mockClear();
 		} );
 
 		it( 'calls vipsCancelOperations when cancelling', async () => {
 			// Suppress console.error that fires when there's no onError callback.
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
@@ -611,7 +632,7 @@ describe( 'actions', () => {
 
 		it( 'cancels any in-flight GIF-to-video conversion when cancelling', async () => {
 			// Suppress console.error that fires when there's no onError callback.
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
@@ -635,7 +656,7 @@ describe( 'actions', () => {
 
 		it( 'removes item from queue after cancelling', async () => {
 			// Suppress console.error that fires when there's no onError callback.
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
@@ -658,7 +679,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'calls onError callback when not silent', async () => {
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -677,7 +698,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'does not call onError when silent', async () => {
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -700,11 +721,11 @@ describe( 'actions', () => {
 			 * must not abort cancelItem, or the item would be stuck in the
 			 * queue forever with no error surfaced.
 			 */
-			( vipsCancelOperations as jest.Mock ).mockImplementationOnce( () =>
+			( vipsCancelOperations as Mock ).mockImplementationOnce( () =>
 				Promise.reject( new Error( 'Worker error: crashed' ) )
 			);
 
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -726,11 +747,11 @@ describe( 'actions', () => {
 		} );
 
 		it( 'still calls onError and removes the item when GIF-to-video cancellation rejects', async () => {
-			( cancelGifToVideoOperations as jest.Mock ).mockImplementationOnce(
-				() => Promise.reject( new Error( 'Worker error: crashed' ) )
+			( cancelGifToVideoOperations as Mock ).mockImplementationOnce( () =>
+				Promise.reject( new Error( 'Worker error: crashed' ) )
 			);
 
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -761,14 +782,14 @@ describe( 'actions', () => {
 			 * block on them, or the cancelled item lingers in the queue and
 			 * gates the parent's finalization the whole time.
 			 */
-			( vipsCancelOperations as jest.Mock ).mockImplementationOnce(
+			( vipsCancelOperations as Mock ).mockImplementationOnce(
 				() => new Promise( () => {} )
 			);
-			( cancelGifToVideoOperations as jest.Mock ).mockImplementationOnce(
+			( cancelGifToVideoOperations as Mock ).mockImplementationOnce(
 				() => new Promise( () => {} )
 			);
 
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -801,7 +822,7 @@ describe( 'actions', () => {
 				imageSize = 'medium',
 			}: {
 				parentSubSizes?: { name: string; id: number }[];
-				parentOnError?: jest.Mock;
+				parentOnError?: Mock;
 				imageSize?: string;
 			} = {} ) => {
 				unlock( registry.dispatch( uploadStore ) ).addItem( {
@@ -834,17 +855,17 @@ describe( 'actions', () => {
 
 				const child = unlock( registry.select( uploadStore ) )
 					.getAllItems()
-					.find( ( i ) => i.parentId === parent.id );
+					.find( ( i: QueueItem ) => i.parentId === parent.id );
 
 				return { parent, child };
 			};
 
 			it( 'deletes parent attachment and cancels parent for vips processing failures with no successful siblings', async () => {
-				const consoleErrorSpy = jest
+				const consoleErrorSpy = vi
 					.spyOn( console, 'error' )
 					.mockImplementation( () => {} );
-				const mediaDelete = jest.fn().mockResolvedValue( undefined );
-				const parentOnError = jest.fn();
+				const mediaDelete = vi.fn().mockResolvedValue( undefined );
+				const parentOnError = vi.fn();
 				unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 					mediaDelete,
 				} );
@@ -856,9 +877,7 @@ describe( 'actions', () => {
 				// resizeCropItem and rotateItem already wrap vips
 				// failures in an UploadError that carries the
 				// actionable user-facing message at the source.
-				const vipsError = new ( jest.requireActual(
-					'../../upload-error'
-				).UploadError )( {
+				const vipsError = new UploadError( {
 					code: 'IMAGE_TRANSCODING_ERROR',
 					message:
 						'The web server cannot generate responsive image sizes for this image. Convert it to JPEG or PNG before uploading.',
@@ -888,17 +907,15 @@ describe( 'actions', () => {
 			} );
 
 			it( 'propagates the underlying error message for non-vips sideload failures', async () => {
-				const mediaDelete = jest.fn().mockResolvedValue( undefined );
-				const parentOnError = jest.fn();
+				const mediaDelete = vi.fn().mockResolvedValue( undefined );
+				const parentOnError = vi.fn();
 				unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 					mediaDelete,
 				} );
 
 				const { child } = setUpParentAndChild( { parentOnError } );
 
-				const networkError = new ( jest.requireActual(
-					'../../upload-error'
-				).UploadError )( {
+				const networkError = new UploadError( {
 					code: 'GENERAL',
 					message: 'Network request failed: 503',
 					file: jpegFile,
@@ -918,8 +935,8 @@ describe( 'actions', () => {
 			} );
 
 			it( 'preserves the parent attachment when at least one sibling sub-size succeeded', async () => {
-				const mediaDelete = jest.fn().mockResolvedValue( undefined );
-				const parentOnError = jest.fn();
+				const mediaDelete = vi.fn().mockResolvedValue( undefined );
+				const parentOnError = vi.fn();
 				unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 					mediaDelete,
 				} );
@@ -929,9 +946,7 @@ describe( 'actions', () => {
 					parentSubSizes: [ { name: 'medium', id: 99 } ],
 				} );
 
-				const networkError = new ( jest.requireActual(
-					'../../upload-error'
-				).UploadError )( {
+				const networkError = new UploadError( {
 					code: 'GENERAL',
 					message: 'sideload of large size failed',
 					file: jpegFile,
@@ -954,8 +969,8 @@ describe( 'actions', () => {
 			} );
 
 			it( 'falls back to a generic message when the underlying error has no message', async () => {
-				const mediaDelete = jest.fn().mockResolvedValue( undefined );
-				const parentOnError = jest.fn();
+				const mediaDelete = vi.fn().mockResolvedValue( undefined );
+				const parentOnError = vi.fn();
 				unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 					mediaDelete,
 				} );
@@ -974,8 +989,8 @@ describe( 'actions', () => {
 			} );
 
 			it( 'keeps the parent GIF when its only child is a failed animated_video companion', async () => {
-				const mediaDelete = jest.fn().mockResolvedValue( undefined );
-				const parentOnError = jest.fn();
+				const mediaDelete = vi.fn().mockResolvedValue( undefined );
+				const parentOnError = vi.fn();
 				unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 					mediaDelete,
 				} );
@@ -1097,8 +1112,8 @@ describe( 'actions', () => {
 
 	describe( 'cancelItem retry integration', () => {
 		beforeEach( () => {
-			jest.useFakeTimers();
-			( vipsCancelOperations as jest.Mock ).mockClear();
+			vi.useFakeTimers();
+			( vipsCancelOperations as Mock ).mockClear();
 			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 				retry: {
 					maxRetryAttempts: 3,
@@ -1111,7 +1126,7 @@ describe( 'actions', () => {
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'schedules retry for retryable errors', async () => {
@@ -1155,7 +1170,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'does NOT schedule retry for non-retryable errors', async () => {
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
@@ -1180,7 +1195,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'does NOT schedule retry when retry settings are undefined', async () => {
-			const consoleErrorSpy = jest
+			const consoleErrorSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 
@@ -1210,7 +1225,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'clears pending retry timer on manual cancel', async () => {
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -1240,7 +1255,7 @@ describe( 'actions', () => {
 			).toHaveLength( 0 );
 
 			// Advance timers — the old retry timer should NOT fire.
-			await jest.runAllTimersAsync();
+			vi.runOnlyPendingTimers();
 
 			// Queue should still be empty (timer was cleared).
 			expect(
@@ -1251,7 +1266,7 @@ describe( 'actions', () => {
 
 	describe( 'scheduleRetry', () => {
 		beforeEach( () => {
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 				retry: {
 					maxRetryAttempts: 3,
@@ -1264,7 +1279,7 @@ describe( 'actions', () => {
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'sets item status to PendingRetry', async () => {
@@ -1362,7 +1377,7 @@ describe( 'actions', () => {
 			expect( updatedItem.status ).toBe( ItemStatus.PendingRetry );
 
 			// Fire all timers to trigger executeRetry.
-			await jest.runAllTimersAsync();
+			vi.runOnlyPendingTimers();
 
 			// Item should now be back in Processing status with incremented retryCount.
 			updatedItem = unlock(
@@ -1375,7 +1390,7 @@ describe( 'actions', () => {
 
 	describe( 'executeRetry', () => {
 		beforeEach( async () => {
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
 				retry: {
 					maxRetryAttempts: 3,
@@ -1391,7 +1406,7 @@ describe( 'actions', () => {
 		} );
 
 		afterEach( () => {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		} );
 
 		it( 'resets item to Processing status', async () => {
@@ -1539,7 +1554,7 @@ describe( 'actions', () => {
 
 			// Advance timers — the old retry timer must NOT re-add or
 			// touch the item.
-			await jest.runAllTimersAsync();
+			vi.runOnlyPendingTimers();
 
 			expect(
 				unlock( registry.select( uploadStore ) ).getAllItems()
@@ -1547,7 +1562,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'falls through to cancellation after exhausting max retries', async () => {
-			const onError = jest.fn();
+			const onError = vi.fn();
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,
 				onError,
@@ -1570,7 +1585,7 @@ describe( 'actions', () => {
 			// executes the retry (incrementing retryCount), then we simulate
 			// another failure.
 			for ( let attempt = 1; attempt <= 3; attempt++ ) {
-				await jest.runAllTimersAsync();
+				vi.runOnlyPendingTimers();
 
 				const inProgress = unlock(
 					registry.select( uploadStore )
@@ -1633,7 +1648,7 @@ describe( 'actions', () => {
 
 			// Fire the retry timer while paused — executeRetry should bail
 			// without mutating state.
-			await jest.runAllTimersAsync();
+			vi.runOnlyPendingTimers();
 
 			const pausedItem = unlock(
 				registry.select( uploadStore )
@@ -1667,8 +1682,7 @@ describe( 'actions', () => {
 				registry.select( uploadStore )
 			).getAllItems()[ 0 ];
 
-			const { vipsResizeImage } = require( '../utils' );
-			( vipsResizeImage as jest.Mock ).mockClear();
+			( vipsResizeImage as Mock ).mockClear();
 
 			await unlock( registry.dispatch( uploadStore ) ).resizeCropItem(
 				item.id,
@@ -1688,8 +1702,7 @@ describe( 'actions', () => {
 				registry.select( uploadStore )
 			).getAllItems()[ 0 ];
 
-			const { vipsResizeImage } = require( '../utils' );
-			( vipsResizeImage as jest.Mock ).mockClear();
+			( vipsResizeImage as Mock ).mockClear();
 
 			await unlock( registry.dispatch( uploadStore ) ).resizeCropItem(
 				item.id,
@@ -1721,10 +1734,10 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'generateThumbnails', () => {
-		const mockBitmapClose = jest.fn();
+		const mockBitmapClose = vi.fn();
 
 		function mockCreateImageBitmap( width: number, height: number ) {
-			global.createImageBitmap = jest.fn( () =>
+			global.createImageBitmap = vi.fn( () =>
 				Promise.resolve( {
 					width,
 					height,
@@ -1805,7 +1818,7 @@ describe( 'actions', () => {
 
 			// Should have sideload items for thumbnails, but NOT for 'scaled'.
 			const scaledItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'scaled'
+				( i: QueueItem ) => i.additionalData?.image_size === 'scaled'
 			);
 			expect( scaledItems ).toHaveLength( 0 );
 			expect( mockBitmapClose ).toHaveBeenCalled();
@@ -1833,7 +1846,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const scaledItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'scaled'
+				( i: QueueItem ) => i.additionalData?.image_size === 'scaled'
 			);
 			expect( scaledItems ).toHaveLength( 1 );
 			expect( scaledItems[ 0 ].additionalData.post ).toBe( 123 );
@@ -1862,7 +1875,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const scaledItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'scaled'
+				( i: QueueItem ) => i.additionalData?.image_size === 'scaled'
 			);
 			expect( scaledItems ).toHaveLength( 1 );
 		} );
@@ -1886,7 +1899,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const scaledItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'scaled'
+				( i: QueueItem ) => i.additionalData?.image_size === 'scaled'
 			);
 			expect( scaledItems ).toHaveLength( 0 );
 			// createImageBitmap should not have been called since threshold is not set.
@@ -1917,7 +1930,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const scaledItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'scaled'
+				( i: QueueItem ) => i.additionalData?.image_size === 'scaled'
 			);
 			expect( scaledItems ).toHaveLength( 0 );
 		} );
@@ -1944,10 +1957,10 @@ describe( 'actions', () => {
 
 			// Should have the original item plus 2 sideload items for thumbnail and medium.
 			const thumbnailItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'thumbnail'
+				( i: QueueItem ) => i.additionalData?.image_size === 'thumbnail'
 			);
 			const mediumItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'medium'
+				( i: QueueItem ) => i.additionalData?.image_size === 'medium'
 			);
 			expect( thumbnailItems ).toHaveLength( 1 );
 			expect( mediumItems ).toHaveLength( 1 );
@@ -1982,12 +1995,12 @@ describe( 'actions', () => {
 			// Should have the original item plus 2 sideload items (not 3),
 			// because medium and custom share the same dimensions.
 			const sideloadItems = allItems.filter(
-				( i ) => i.parentId === item.id
+				( i: QueueItem ) => i.parentId === item.id
 			);
 			expect( sideloadItems ).toHaveLength( 2 );
 
 			// The deduplicated group should pass both size names.
-			const mediumCustomItem = sideloadItems.find( ( i ) =>
+			const mediumCustomItem = sideloadItems.find( ( i: QueueItem ) =>
 				Array.isArray( i.additionalData?.image_size )
 			);
 			expect( mediumCustomItem ).toBeDefined();
@@ -2023,7 +2036,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const sideloadItems = allItems.filter(
-				( i ) => i.parentId === item.id
+				( i: QueueItem ) => i.parentId === item.id
 			);
 			// Two separate sideloads because crop differs.
 			expect( sideloadItems ).toHaveLength( 2 );
@@ -2035,7 +2048,7 @@ describe( 'actions', () => {
 				).toBe( true );
 			}
 			const imageSizes = sideloadItems.map(
-				( i ) => i.additionalData?.image_size
+				( i: QueueItem ) => i.additionalData?.image_size
 			);
 			expect( imageSizes ).toEqual(
 				expect.arrayContaining( [ 'soft', 'hard' ] )
@@ -2068,7 +2081,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const sideloadItems = allItems.filter(
-				( i ) => i.parentId === item.id
+				( i: QueueItem ) => i.parentId === item.id
 			);
 			// One sideload, all three names grouped together.
 			expect( sideloadItems ).toHaveLength( 1 );
@@ -2135,7 +2148,7 @@ describe( 'actions', () => {
 			).getAllItems();
 
 			const scaledItems = allItems.filter(
-				( i ) => i.additionalData?.image_size === 'scaled'
+				( i: QueueItem ) => i.additionalData?.image_size === 'scaled'
 			);
 			// Exactly at threshold means no scaling (condition is > not >=).
 			expect( scaledItems ).toHaveLength( 0 );
@@ -2180,7 +2193,7 @@ describe( 'actions', () => {
 			const thumbnailItems = unlock( registry.select( uploadStore ) )
 				.getAllItems()
 				.filter(
-					( i ) =>
+					( i: QueueItem ) =>
 						i.additionalData?.image_size === 'thumbnail' ||
 						i.additionalData?.image_size === 'medium'
 				);
@@ -2222,7 +2235,8 @@ describe( 'actions', () => {
 				const scaledItems = unlock( registry.select( uploadStore ) )
 					.getAllItems()
 					.filter(
-						( i ) => i.additionalData?.image_size === 'scaled'
+						( i: QueueItem ) =>
+							i.additionalData?.image_size === 'scaled'
 					);
 				expect( scaledItems ).toHaveLength( 1 );
 				// vipsResizeImage adds the `-scaled` suffix during the

--- a/packages/upload-media/src/store/test/private-actions.js
+++ b/packages/upload-media/src/store/test/private-actions.js
@@ -3,6 +3,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -35,47 +36,42 @@ import {
 } from '../utils/video-conversion';
 
 // Mock @wordpress/blob
-jest.mock( '@wordpress/blob', () => ( {
-	createBlobURL: jest.fn( () => 'blob:mock-url' ),
-	revokeBlobURL: jest.fn(),
+vi.mock( import( '@wordpress/blob' ), () => ( {
+	createBlobURL: vi.fn( () => 'blob:mock-url' ),
+	revokeBlobURL: vi.fn(),
 } ) );
 
 // Mock vips utilities. The real isAnimatedGif() is needed by prepareItem
 // so it is required from the actual module rather than stubbed out.
-jest.mock( '../utils', () => {
-	const actual = jest.requireActual( '../utils' );
+vi.mock( import( '../utils' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 	return {
-		vipsHasTransparency: jest.fn(),
-		vipsGetUltraHdrInfo: jest.fn(),
-		vipsRotateImage: jest.fn(),
-		terminateVipsWorker: jest.fn(),
-		maybeRecycleVipsWorker: jest.fn(),
-		isAnimatedGif: actual.isAnimatedGif,
-		cloneFile: actual.cloneFile,
-		convertBlobToFile: actual.convertBlobToFile,
-		renameFile: actual.renameFile,
+		...actual,
+		vipsHasTransparency: vi.fn(),
+		vipsGetUltraHdrInfo: vi.fn(),
+		vipsRotateImage: vi.fn(),
+		terminateVipsWorker: vi.fn(),
+		maybeRecycleVipsWorker: vi.fn(),
 	};
 } );
 
 // Mock the video-conversion wrapper so the dynamic worker import is never
 // executed. isUnsupportedConversionError is kept real so transcodeGifItem's
 // graceful-skip vs. hard-failure branching is genuinely exercised.
-jest.mock( '../utils/video-conversion', () => {
-	const actual = jest.requireActual( '../utils/video-conversion' );
+vi.mock( import( '../utils/video-conversion' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 	return {
-		convertGifToVideo: jest.fn(),
-		cancelGifToVideoOperations: jest.fn(),
-		terminateVideoConversionWorker: jest.fn(),
-		isUnsupportedConversionError: actual.isUnsupportedConversionError,
-		isSizeLimitConversionError: actual.isSizeLimitConversionError,
-		isConversionTimeoutError: actual.isConversionTimeoutError,
+		...actual,
+		convertGifToVideo: vi.fn(),
+		cancelGifToVideoOperations: vi.fn(),
+		terminateVideoConversionWorker: vi.fn(),
 	};
 } );
 
 describe( 'private actions', () => {
 	describe( 'getTranscodeImageOperation', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'should return transcode operation for valid format conversion', async () => {
@@ -340,8 +336,8 @@ describe( 'private actions', () => {
 		];
 
 		it( 'should call mediaFinalize with the attachment ID and sub-sizes', async () => {
-			const mediaFinalize = jest.fn().mockResolvedValue( undefined );
-			const finishOperation = jest.fn();
+			const mediaFinalize = vi.fn().mockResolvedValue( undefined );
+			const finishOperation = vi.fn();
 			const select = {
 				getItem: () => ( {
 					attachment: { id: 42 },
@@ -359,8 +355,8 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'should pass empty array when no sub-sizes accumulated', async () => {
-			const mediaFinalize = jest.fn().mockResolvedValue( undefined );
-			const finishOperation = jest.fn();
+			const mediaFinalize = vi.fn().mockResolvedValue( undefined );
+			const finishOperation = vi.fn();
 			const select = {
 				getItem: () => ( {
 					attachment: { id: 42 },
@@ -377,7 +373,7 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'should not call mediaFinalize when no callback is provided', async () => {
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const select = {
 				getItem: () => ( {
 					attachment: { id: 42 },
@@ -393,8 +389,8 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'should not call mediaFinalize when there is no attachment ID', async () => {
-			const mediaFinalize = jest.fn();
-			const finishOperation = jest.fn();
+			const mediaFinalize = vi.fn();
+			const finishOperation = vi.fn();
 			const select = {
 				getItem: () => ( {
 					attachment: {},
@@ -423,10 +419,10 @@ describe( 'private actions', () => {
 				id: 42,
 				url: 'https://example.com/wp-content/uploads/image-scaled.jpg',
 			};
-			const mediaFinalize = jest
+			const mediaFinalize = vi
 				.fn()
 				.mockResolvedValue( updatedAttachment );
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const select = {
 				getItem: () => ( {
 					attachment: {
@@ -449,11 +445,11 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'should handle mediaFinalize errors gracefully', async () => {
-			const mediaFinalize = jest
+			const mediaFinalize = vi
 				.fn()
 				.mockRejectedValue( new Error( 'Network error' ) );
-			const finishOperation = jest.fn();
-			const warnSpy = jest
+			const finishOperation = vi.fn();
+			const warnSpy = vi
 				.spyOn( console, 'warn' )
 				.mockImplementation( () => {} );
 			const select = {
@@ -478,7 +474,7 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'should return early when item is not found', async () => {
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const select = {
 				getItem: () => undefined,
 			};
@@ -526,8 +522,8 @@ describe( 'private actions', () => {
 					dispatchedOperations = action.operations;
 				}
 			};
-			dispatch.cancelItem = jest.fn();
-			dispatch.finishOperation = jest.fn();
+			dispatch.cancelItem = vi.fn();
+			dispatch.finishOperation = vi.fn();
 
 			const select = {
 				getItem: () => item,
@@ -645,8 +641,8 @@ describe( 'private actions', () => {
 					dispatchedOperations = action.operations;
 				}
 			};
-			dispatch.cancelItem = jest.fn();
-			dispatch.finishOperation = jest.fn();
+			dispatch.cancelItem = vi.fn();
+			dispatch.finishOperation = vi.fn();
 
 			const select = {
 				getItem: () => item,
@@ -684,8 +680,8 @@ describe( 'private actions', () => {
 					dispatchedOperations = action.operations;
 				}
 			};
-			dispatch.cancelItem = jest.fn();
-			dispatch.finishOperation = jest.fn();
+			dispatch.cancelItem = vi.fn();
+			dispatch.finishOperation = vi.fn();
 
 			const select = {
 				getItem: () => item,
@@ -709,13 +705,13 @@ describe( 'private actions', () => {
 		} );
 
 		function buildArgs() {
-			const dispatch = Object.assign( jest.fn(), {
-				finishOperation: jest.fn(),
-				cancelItem: jest.fn(),
-				addSideloadItem: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				finishOperation: vi.fn(),
+				cancelItem: vi.fn(),
+				addSideloadItem: vi.fn(),
 			} );
 			const select = {
-				getItem: jest.fn( () => ( {
+				getItem: vi.fn( () => ( {
 					id: 'gif-1',
 					file: gifFile,
 					parentId: 'parent-1',
@@ -731,10 +727,10 @@ describe( 'private actions', () => {
 		beforeEach( () => {
 			convertGifToVideo.mockReset();
 			createBlobURL.mockClear();
-			consoleError = jest
+			consoleError = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
-			consoleDebug = jest
+			consoleDebug = vi
 				.spyOn( console, 'debug' )
 				.mockImplementation( () => {} );
 		} );
@@ -947,7 +943,7 @@ describe( 'private actions', () => {
 
 		it( 'does nothing when the item is not in the queue', async () => {
 			const { dispatch } = buildArgs();
-			const select = { getItem: jest.fn( () => undefined ) };
+			const select = { getItem: vi.fn( () => undefined ) };
 
 			await transcodeGifItem( 'missing' )( { select, dispatch } );
 
@@ -959,9 +955,9 @@ describe( 'private actions', () => {
 
 	describe( 'generateThumbnails (animated GIF video sideload)', () => {
 		function runGenerate( { item, settings } ) {
-			const dispatchFn = jest.fn();
-			dispatchFn.finishOperation = jest.fn();
-			dispatchFn.addSideloadItem = jest.fn();
+			const dispatchFn = vi.fn();
+			dispatchFn.finishOperation = vi.fn();
+			dispatchFn.addSideloadItem = vi.fn();
 			const select = {
 				getItem: () => item,
 				getSettings: () => settings,
@@ -1064,7 +1060,7 @@ describe( 'private actions', () => {
 		} );
 
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		it( 'probes the file and finishes the operation when UltraHDR', async () => {
@@ -1073,7 +1069,7 @@ describe( 'private actions', () => {
 				height: 768,
 				hdrCapacity: 3,
 			} );
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const item = makeItem();
 			const select = { getItem: () => item };
 			const dispatch = { finishOperation };
@@ -1090,7 +1086,7 @@ describe( 'private actions', () => {
 
 		it( 'finishes cleanly when buffer is not UltraHDR', async () => {
 			vipsGetUltraHdrInfo.mockResolvedValue( null );
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const select = { getItem: () => makeItem() };
 			const dispatch = { finishOperation };
 
@@ -1104,7 +1100,7 @@ describe( 'private actions', () => {
 			vipsGetUltraHdrInfo.mockRejectedValue(
 				new Error( 'wasm module unavailable' )
 			);
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const select = { getItem: () => makeItem() };
 			const dispatch = { finishOperation };
 
@@ -1116,7 +1112,7 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'returns early when item is not found', async () => {
-			const finishOperation = jest.fn();
+			const finishOperation = vi.fn();
 			const select = { getItem: () => undefined };
 			const dispatch = { finishOperation };
 
@@ -1155,12 +1151,12 @@ describe( 'private actions', () => {
 		} );
 
 		const makeHarness = ( item, settings = {} ) => {
-			const addSideloadItem = jest.fn();
-			const finishOperation = jest.fn();
+			const addSideloadItem = vi.fn();
+			const finishOperation = vi.fn();
 			const dispatch = {
 				addSideloadItem,
 				finishOperation,
-				addItem: jest.fn(),
+				addItem: vi.fn(),
 			};
 			const select = {
 				getItem: () => item,
@@ -1186,7 +1182,7 @@ describe( 'private actions', () => {
 			vipsGetUltraHdrInfo.mockResolvedValue( ULTRAHDR_INFO );
 			await detectUltraHdr( item.id )( {
 				select: { getItem: () => item },
-				dispatch: { finishOperation: jest.fn() },
+				dispatch: { finishOperation: vi.fn() },
 			} );
 		};
 
@@ -1195,12 +1191,12 @@ describe( 'private actions', () => {
 		const clearTracking = async ( id ) => {
 			await removeItem( id )( {
 				select: { getItem: () => ( {} ), getAllItems: () => [] },
-				dispatch: jest.fn(),
+				dispatch: vi.fn(),
 			} );
 		};
 
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		afterEach( async () => {
@@ -1238,10 +1234,10 @@ describe( 'private actions', () => {
 
 		it( 'keeps the over-threshold -scaled full-size copy as UltraHDR (no transcode)', async () => {
 			const originalCreateImageBitmap = global.createImageBitmap;
-			global.createImageBitmap = jest.fn( async () => ( {
+			global.createImageBitmap = vi.fn( async () => ( {
 				width: 5000,
 				height: 4000,
-				close: jest.fn(),
+				close: vi.fn(),
 			} ) );
 
 			try {
@@ -1332,11 +1328,11 @@ describe( 'private actions', () => {
 		} );
 
 		const makeHarness = ( item ) => {
-			const addSideloadItem = jest.fn();
+			const addSideloadItem = vi.fn();
 			const dispatch = {
 				addSideloadItem,
-				finishOperation: jest.fn(),
-				addItem: jest.fn(),
+				finishOperation: vi.fn(),
+				addItem: vi.fn(),
 			};
 			const select = {
 				getItem: () => item,
@@ -1355,7 +1351,7 @@ describe( 'private actions', () => {
 			);
 
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 			vipsRotateImage.mockResolvedValue(
 				new File( [ 'rotated' ], 'photo-rotated.jpg', {
 					type: 'image/jpeg',
@@ -1468,7 +1464,7 @@ describe( 'private actions', () => {
 		} );
 
 		it( 'continues thumbnail generation when rotation fails', async () => {
-			const warnSpy = jest
+			const warnSpy = vi
 				.spyOn( console, 'warn' )
 				.mockImplementation( () => {} );
 			vipsRotateImage.mockRejectedValue( new Error( 'decode failed' ) );
@@ -1502,15 +1498,15 @@ describe( 'private actions', () => {
 			// The queue already counts its items for progress UI; the
 			// `mediaUpload` callback it delegates the server upload to must
 			// not count the same file again (see gutenberg#80369).
-			const mediaUpload = jest.fn();
+			const mediaUpload = vi.fn();
 			const file = new File( [ 'content' ], 'photo.jpg', {
 				type: 'image/jpeg',
 			} );
 			const item = { id: 'item-1', file, additionalData: {} };
 
-			const dispatch = jest.fn();
-			dispatch.finishOperation = jest.fn();
-			dispatch.cancelItem = jest.fn();
+			const dispatch = vi.fn();
+			dispatch.finishOperation = vi.fn();
+			dispatch.cancelItem = vi.fn();
 
 			await uploadItem( 'item-1' )( {
 				select: {
@@ -1531,7 +1527,7 @@ describe( 'private actions', () => {
 
 	describe( 'removeItem worker teardown', () => {
 		beforeEach( () => {
-			jest.clearAllMocks();
+			vi.clearAllMocks();
 		} );
 
 		const runRemove = async ( remaining ) =>
@@ -1540,7 +1536,7 @@ describe( 'private actions', () => {
 					getItem: () => ( {} ),
 					getAllItems: () => remaining,
 				},
-				dispatch: jest.fn(),
+				dispatch: vi.fn(),
 			} );
 
 		it( 'terminates both background workers once the queue empties', async () => {

--- a/packages/upload-media/src/store/test/reducer.ts
+++ b/packages/upload-media/src/store/test/reducer.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';
@@ -17,7 +22,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -39,6 +46,8 @@ describe( 'reducer', () => {
 				blobUrls: {},
 				settings: {
 					mediaUpload: expect.any( Function ),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -60,7 +69,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -84,6 +95,8 @@ describe( 'reducer', () => {
 				blobUrls: {},
 				settings: {
 					mediaUpload: expect.any( Function ),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -106,7 +119,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -129,6 +144,8 @@ describe( 'reducer', () => {
 				blobUrls: {},
 				settings: {
 					mediaUpload: expect.any( Function ),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -146,7 +163,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -167,6 +186,8 @@ describe( 'reducer', () => {
 				blobUrls: {},
 				settings: {
 					mediaUpload: expect.any( Function ),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -188,7 +209,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -214,6 +237,8 @@ describe( 'reducer', () => {
 				blobUrls: {},
 				settings: {
 					mediaUpload: expect.any( Function ),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -238,7 +263,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -262,6 +289,8 @@ describe( 'reducer', () => {
 				blobUrls: {},
 				settings: {
 					mediaUpload: expect.any( Function ),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -283,7 +312,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -312,7 +343,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -336,7 +369,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -362,7 +397,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -388,7 +425,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -423,7 +462,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -448,7 +489,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -474,7 +517,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -507,7 +552,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [],
 			};
@@ -523,7 +570,9 @@ describe( 'reducer', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [],
 			};
@@ -539,7 +588,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: { '1': [ 'blob:foo' ] },
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -563,7 +614,9 @@ describe( 'reducer', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [],
 			};
@@ -579,7 +632,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [],
 			};
@@ -595,7 +650,9 @@ describe( 'reducer', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{
@@ -623,7 +680,9 @@ describe( 'reducer', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 				queue: [
 					{

--- a/packages/upload-media/src/store/test/retry.ts
+++ b/packages/upload-media/src/store/test/retry.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { calculateRetryDelay, shouldRetryError } from '../utils/retry';
@@ -9,7 +14,7 @@ describe( 'calculateRetryDelay', () => {
 
 	beforeEach( () => {
 		// Force the jitter factor to 1 (no offset) for deterministic results.
-		Math.random = jest.fn( () => 0.5 );
+		Math.random = vi.fn( () => 0.5 );
 	} );
 
 	afterEach( () => {
@@ -82,7 +87,7 @@ describe( 'calculateRetryDelay', () => {
 		expect( delayWithMiddleJitter ).toBe( 1000 );
 
 		// Math.random = 0 → jitter factor = 1 + (0 * 2 - 1) * 0.1 = 0.9.
-		Math.random = jest.fn( () => 0 );
+		Math.random = vi.fn( () => 0 );
 		const delayWithMinJitter = calculateRetryDelay( {
 			attempt: 1,
 			initialDelay: 1000,
@@ -93,7 +98,7 @@ describe( 'calculateRetryDelay', () => {
 		expect( delayWithMinJitter ).toBe( 900 );
 
 		// Math.random = 1 → jitter factor = 1 + (1 * 2 - 1) * 0.1 = 1.1.
-		Math.random = jest.fn( () => 1 );
+		Math.random = vi.fn( () => 1 );
 		const delayWithMaxJitter = calculateRetryDelay( {
 			attempt: 1,
 			initialDelay: 1000,

--- a/packages/upload-media/src/store/test/selectors.ts
+++ b/packages/upload-media/src/store/test/selectors.ts
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import * as privateSelectors from '../private-selectors';
 import {
 	getItems,
 	isUploading,
@@ -33,7 +39,9 @@ describe( 'selectors', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -58,7 +66,9 @@ describe( 'selectors', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -83,7 +93,9 @@ describe( 'selectors', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -110,7 +122,9 @@ describe( 'selectors', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -142,7 +156,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -178,7 +194,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -197,7 +215,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -225,7 +245,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -281,7 +303,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -305,7 +329,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -337,7 +363,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -366,7 +394,9 @@ describe( 'selectors', () => {
 				queueStatus: 'active',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -378,13 +408,15 @@ describe( 'selectors', () => {
 
 	describe( 'removed selectors', () => {
 		it( 'isUploadingToPost is no longer exported', () => {
-			const privateSelectors = require( '../private-selectors' );
-			expect( privateSelectors.isUploadingToPost ).toBeUndefined();
+			expect( privateSelectors ).not.toHaveProperty(
+				'isUploadingToPost'
+			);
 		} );
 
 		it( 'getPausedUploadForPost is no longer exported', () => {
-			const privateSelectors = require( '../private-selectors' );
-			expect( privateSelectors.getPausedUploadForPost ).toBeUndefined();
+			expect( privateSelectors ).not.toHaveProperty(
+				'getPausedUploadForPost'
+			);
 		} );
 	} );
 
@@ -434,7 +466,9 @@ describe( 'selectors', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 
@@ -457,7 +491,9 @@ describe( 'selectors', () => {
 				queueStatus: 'paused',
 				blobUrls: {},
 				settings: {
-					mediaUpload: jest.fn(),
+					mediaUpload: vi.fn(),
+					maxConcurrentUploads: 5,
+					maxConcurrentImageProcessing: 2,
 				},
 			};
 

--- a/packages/upload-media/src/store/test/vips.ts
+++ b/packages/upload-media/src/store/test/vips.ts
@@ -1,19 +1,17 @@
 /**
  * External dependencies
  */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from 'vitest';
 
-// Mock the vips worker module.
-// The mock functions must be declared inside the factory to avoid hoisting issues.
-jest.mock( '@wordpress/vips/worker', () => ( {
-	vipsConvertImageFormat: jest.fn(),
-	vipsCompressImage: jest.fn(),
-	vipsHasTransparency: jest.fn(),
-	vipsResizeImage: jest.fn(),
-	vipsRotateImage: jest.fn(),
-	vipsCancelOperations: jest.fn(),
-} ) );
-
-// Import the mocked module to get access to the mock functions.
+// Vitest aliases the worker entry point to the repository's worker-code stub.
 import * as vipsWorker from '@wordpress/vips/worker';
 
 /**
@@ -32,13 +30,12 @@ import {
 	vipsCancelOperations,
 } from '../utils';
 
-// Cast to jest.Mock for type safety.
-const mockConvertImageFormat = vipsWorker.vipsConvertImageFormat as jest.Mock;
-const mockCompressImage = vipsWorker.vipsCompressImage as jest.Mock;
-const mockHasTransparency = vipsWorker.vipsHasTransparency as jest.Mock;
-const mockResizeImage = vipsWorker.vipsResizeImage as jest.Mock;
-const mockRotateImage = vipsWorker.vipsRotateImage as jest.Mock;
-const mockCancelOperations = vipsWorker.vipsCancelOperations as jest.Mock;
+const mockConvertImageFormat = vi.mocked( vipsWorker.vipsConvertImageFormat );
+const mockCompressImage = vi.mocked( vipsWorker.vipsCompressImage );
+const mockHasTransparency = vi.mocked( vipsWorker.vipsHasTransparency );
+const mockResizeImage = vi.mocked( vipsWorker.vipsResizeImage );
+const mockRotateImage = vi.mocked( vipsWorker.vipsRotateImage );
+const mockCancelOperations = vi.mocked( vipsWorker.vipsCancelOperations );
 
 const jpegFile = new File( [ 'test-content' ], 'test.jpg', {
 	type: 'image/jpeg',
@@ -52,7 +49,7 @@ const pngFile = new File( [ 'test-content' ], 'image.png', {
 
 describe( 'vips utilities', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'vipsConvertImageFormat', () => {
@@ -157,12 +154,12 @@ describe( 'vips utilities', () => {
 	} );
 
 	describe( 'vipsHasTransparency', () => {
-		let mockFetch: jest.Mock;
+		let mockFetch: Mock;
 		let originalFetch: typeof window.fetch;
 
 		beforeEach( () => {
 			originalFetch = window.fetch;
-			mockFetch = jest.fn().mockResolvedValue( {
+			mockFetch = vi.fn().mockResolvedValue( {
 				ok: true,
 				arrayBuffer: () => Promise.resolve( new ArrayBuffer( 0 ) ),
 			} as Response );
@@ -297,7 +294,7 @@ describe( 'vips utilities', () => {
 			expect( mockResizeImage.mock.calls[ 0 ][ 0 ] ).toBe( 'item-1' );
 			expect( mockResizeImage.mock.calls[ 0 ][ 2 ] ).toBe( 'image/jpeg' );
 			expect( mockResizeImage.mock.calls[ 0 ][ 3 ] ).toEqual( resize );
-			expect( mockResizeImage.mock.calls[ 0 ][ 4 ].smartCrop ).toBe(
+			expect( mockResizeImage.mock.calls[ 0 ][ 4 ]!.smartCrop ).toBe(
 				true
 			);
 		} );
@@ -320,10 +317,10 @@ describe( 'vips utilities', () => {
 				maxBitdepth: 8,
 			} );
 
-			expect( mockResizeImage.mock.calls[ 0 ][ 4 ].stripMeta ).toBe(
+			expect( mockResizeImage.mock.calls[ 0 ][ 4 ]!.stripMeta ).toBe(
 				false
 			);
-			expect( mockResizeImage.mock.calls[ 0 ][ 4 ].maxBitdepth ).toBe(
+			expect( mockResizeImage.mock.calls[ 0 ][ 4 ]!.maxBitdepth ).toBe(
 				8
 			);
 		} );
@@ -342,8 +339,8 @@ describe( 'vips utilities', () => {
 			expect( result ).toBeInstanceOf( ImageFile );
 			expect( result.name ).toBe( 'test-rotated.jpg' );
 			expect( result.type ).toBe( 'image/jpeg' );
-			expect( result.width ).toBe( 200 );
-			expect( result.height ).toBe( 300 );
+			expect( ( result as ImageFile ).width ).toBe( 200 );
+			expect( ( result as ImageFile ).height ).toBe( 300 );
 
 			expect( mockRotateImage ).toHaveBeenCalledTimes( 1 );
 			expect( mockRotateImage.mock.calls[ 0 ][ 0 ] ).toBe( 'item-1' );

--- a/packages/upload-media/src/store/utils/test/video-conversion.ts
+++ b/packages/upload-media/src/store/utils/test/video-conversion.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -88,15 +93,15 @@ describe( 'isConversionTimeoutError', () => {
  */
 describe( 'convertGifToVideo', () => {
 	beforeEach( () => {
-		jest.resetModules();
+		vi.resetModules();
 	} );
 
 	it( 'delegates to the worker and wraps mp4 output in a named File', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
+		const worker = await import( '@wordpress/video-conversion/worker' );
 		const buffer = new ArrayBuffer( 8 );
-		worker.convertGifToVideo.mockResolvedValue( buffer );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue( buffer );
 
-		const { convertGifToVideo } = require( '../video-conversion' );
+		const { convertGifToVideo } = await import( '../video-conversion' );
 		const gif = new File(
 			[ new Uint8Array( [ 1, 2, 3 ] ) ],
 			'my-anim.gif',
@@ -126,10 +131,12 @@ describe( 'convertGifToVideo', () => {
 	} );
 
 	it( 'uses a .webm extension for webm output', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockResolvedValue( new ArrayBuffer( 4 ) );
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 4 )
+		);
 
-		const { convertGifToVideo } = require( '../video-conversion' );
+		const { convertGifToVideo } = await import( '../video-conversion' );
 		const gif = new File( [ new Uint8Array( [ 0 ] ) ], 'clip.gif', {
 			type: 'image/gif',
 		} );
@@ -148,10 +155,12 @@ describe( 'convertGifToVideo', () => {
 	} );
 
 	it( 'defaults to a .mp4 extension for any non-webm output type', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockResolvedValue( new ArrayBuffer( 4 ) );
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 4 )
+		);
 
-		const { convertGifToVideo } = require( '../video-conversion' );
+		const { convertGifToVideo } = await import( '../video-conversion' );
 		const gif = new File( [ new Uint8Array( [ 0 ] ) ], 'clip.gif', {
 			type: 'image/gif',
 		} );
@@ -167,13 +176,34 @@ describe( 'convertGifToVideo', () => {
 } );
 
 describe( 'convertGifToVideo timeout', () => {
-	beforeEach( () => {
-		jest.resetModules();
-		jest.useFakeTimers();
+	let worker: typeof import('@wordpress/video-conversion/worker');
+	let convertGifToVideo: typeof import('../video-conversion').convertGifToVideo;
+
+	beforeEach( async () => {
+		vi.resetModules();
+
+		/*
+		 * Resolve the production module's lazy worker import before switching
+		 * to fake timers. Vitest's module loader schedules work through the
+		 * real event loop, so awaiting the first import while timers are faked
+		 * would make the test race the loader rather than the conversion timer
+		 * under test.
+		 */
+		worker = await import( '@wordpress/video-conversion/worker' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 0 )
+		);
+		( { convertGifToVideo } = await import( '../video-conversion' ) );
+		await convertGifToVideo( 'warmup', makeGif(), 'video/mp4', {
+			timeout: 0,
+		} );
+
+		vi.clearAllMocks();
+		vi.useFakeTimers();
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	function makeGif() {
@@ -182,20 +212,36 @@ describe( 'convertGifToVideo timeout', () => {
 		} );
 	}
 
-	it( 'abandons a conversion that exceeds the default 30s timeout and cancels the worker', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		// A conversion that never settles, like a huge GIF churning away.
-		worker.convertGifToVideo.mockReturnValue( new Promise( () => {} ) );
-		worker.cancelGifToVideoOperations.mockResolvedValue( true );
+	async function waitForWorkerCall(
+		workerModule: typeof import('@wordpress/video-conversion/worker')
+	) {
+		for (
+			let attempts = 0;
+			attempts < 10 &&
+			! vi.mocked( workerModule.convertGifToVideo ).mock.calls.length;
+			attempts++
+		) {
+			await Promise.resolve();
+		}
+		expect( workerModule.convertGifToVideo ).toHaveBeenCalled();
+	}
 
-		const { convertGifToVideo } = require( '../video-conversion' );
+	it( 'abandons a conversion that exceeds the default 30s timeout and cancels the worker', async () => {
+		// A conversion that never settles, like a huge GIF churning away.
+		vi.mocked( worker.convertGifToVideo ).mockReturnValue(
+			new Promise( () => {} )
+		);
+		vi.mocked( worker.cancelGifToVideoOperations ).mockResolvedValue(
+			true
+		);
 
 		const promise = convertGifToVideo( 'item-1', makeGif(), 'video/mp4' );
 		// Attach a handler before advancing time so the rejection is never
 		// reported as unhandled.
 		promise.catch( () => {} );
+		await waitForWorkerCall( worker );
 
-		await jest.advanceTimersByTimeAsync( 30_000 );
+		vi.advanceTimersByTime( 30_000 );
 
 		// The exact message is the isConversionTimeoutError contract.
 		await expect( promise ).rejects.toThrow(
@@ -209,57 +255,57 @@ describe( 'convertGifToVideo timeout', () => {
 	} );
 
 	it( 'does not time out a conversion that finishes in time', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockResolvedValue( new ArrayBuffer( 4 ) );
-
-		const { convertGifToVideo } = require( '../video-conversion' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 4 )
+		);
 
 		const promise = convertGifToVideo( 'item-2', makeGif(), 'video/mp4' );
-		await jest.advanceTimersByTimeAsync( 0 );
+		await waitForWorkerCall( worker );
+		vi.advanceTimersByTime( 0 );
 		const result = await promise;
 
 		expect( result ).toBeInstanceOf( File );
 		expect( worker.cancelGifToVideoOperations ).not.toHaveBeenCalled();
 		// The timeout timer was cleared; nothing left pending.
-		expect( jest.getTimerCount() ).toBe( 0 );
+		expect( vi.getTimerCount() ).toBe( 0 );
 	} );
 
 	it( 'honors a custom timeout', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockReturnValue( new Promise( () => {} ) );
-		worker.cancelGifToVideoOperations.mockResolvedValue( true );
-
-		const { convertGifToVideo } = require( '../video-conversion' );
+		vi.mocked( worker.convertGifToVideo ).mockReturnValue(
+			new Promise( () => {} )
+		);
+		vi.mocked( worker.cancelGifToVideoOperations ).mockResolvedValue(
+			true
+		);
 
 		const promise = convertGifToVideo( 'item-3', makeGif(), 'video/mp4', {
 			timeout: 5_000,
 		} );
 		promise.catch( () => {} );
+		await waitForWorkerCall( worker );
 
-		await jest.advanceTimersByTimeAsync( 5_000 );
+		vi.advanceTimersByTime( 5_000 );
 
 		await expect( promise ).rejects.toThrow( /timed out/i );
 	} );
 
 	it( 'treats a timeout of 0 as disabled', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
 		let resolveConversion: ( buffer: ArrayBuffer ) => void = () => {};
-		worker.convertGifToVideo.mockReturnValue(
+		vi.mocked( worker.convertGifToVideo ).mockReturnValue(
 			new Promise( ( resolve ) => {
 				resolveConversion = resolve;
 			} )
 		);
 
-		const { convertGifToVideo } = require( '../video-conversion' );
-
 		const promise = convertGifToVideo( 'item-4', makeGif(), 'video/mp4', {
 			timeout: 0,
 		} );
+		await waitForWorkerCall( worker );
 
 		// Way past the default timeout: nothing should reject because no
 		// timer was ever set.
-		await jest.advanceTimersByTimeAsync( 120_000 );
-		expect( jest.getTimerCount() ).toBe( 0 );
+		vi.advanceTimersByTime( 120_000 );
+		expect( vi.getTimerCount() ).toBe( 0 );
 
 		resolveConversion( new ArrayBuffer( 4 ) );
 		const result = await promise;
@@ -270,12 +316,14 @@ describe( 'convertGifToVideo timeout', () => {
 
 describe( 'cancelGifToVideoOperations', () => {
 	beforeEach( () => {
-		jest.resetModules();
+		vi.resetModules();
 	} );
 
 	it( 'returns false when the worker module has not been loaded yet', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		const { cancelGifToVideoOperations } = require( '../video-conversion' );
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		const { cancelGifToVideoOperations } = await import(
+			'../video-conversion'
+		);
 
 		await expect( cancelGifToVideoOperations( 'item-1' ) ).resolves.toBe(
 			false
@@ -284,14 +332,17 @@ describe( 'cancelGifToVideoOperations', () => {
 	} );
 
 	it( 'delegates to the worker once the module is loaded', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockResolvedValue( new ArrayBuffer( 4 ) );
-		worker.cancelGifToVideoOperations.mockResolvedValue( true );
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 4 )
+		);
+		vi.mocked( worker.cancelGifToVideoOperations ).mockResolvedValue(
+			true
+		);
 
-		const {
-			convertGifToVideo,
-			cancelGifToVideoOperations,
-		} = require( '../video-conversion' );
+		const { convertGifToVideo, cancelGifToVideoOperations } = await import(
+			'../video-conversion'
+		);
 
 		// Trigger a conversion to lazily load (and cache) the worker module.
 		await convertGifToVideo(
@@ -311,14 +362,17 @@ describe( 'cancelGifToVideoOperations', () => {
 	} );
 
 	it( 'delegates a cancel issued while the worker is still loading', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockResolvedValue( new ArrayBuffer( 4 ) );
-		worker.cancelGifToVideoOperations.mockResolvedValue( true );
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 4 )
+		);
+		vi.mocked( worker.cancelGifToVideoOperations ).mockResolvedValue(
+			true
+		);
 
-		const {
-			convertGifToVideo,
-			cancelGifToVideoOperations,
-		} = require( '../video-conversion' );
+		const { convertGifToVideo, cancelGifToVideoOperations } = await import(
+			'../video-conversion'
+		);
 
 		/*
 		 * Start a conversion but do NOT await it: the worker module is now
@@ -346,27 +400,27 @@ describe( 'cancelGifToVideoOperations', () => {
 
 describe( 'terminateVideoConversionWorker', () => {
 	beforeEach( () => {
-		jest.resetModules();
+		vi.resetModules();
 	} );
 
-	it( 'is a no-op when the worker module has not been loaded yet', () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		const {
-			terminateVideoConversionWorker,
-		} = require( '../video-conversion' );
+	it( 'is a no-op when the worker module has not been loaded yet', async () => {
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		const { terminateVideoConversionWorker } = await import(
+			'../video-conversion'
+		);
 
 		expect( () => terminateVideoConversionWorker() ).not.toThrow();
 		expect( worker.terminateVideoConversionWorker ).not.toHaveBeenCalled();
 	} );
 
 	it( 'terminates the worker once the module is loaded', async () => {
-		const worker = require( '@wordpress/video-conversion/worker' );
-		worker.convertGifToVideo.mockResolvedValue( new ArrayBuffer( 4 ) );
+		const worker = await import( '@wordpress/video-conversion/worker' );
+		vi.mocked( worker.convertGifToVideo ).mockResolvedValue(
+			new ArrayBuffer( 4 )
+		);
 
-		const {
-			convertGifToVideo,
-			terminateVideoConversionWorker,
-		} = require( '../video-conversion' );
+		const { convertGifToVideo, terminateVideoConversionWorker } =
+			await import( '../video-conversion' );
 
 		await convertGifToVideo(
 			'item-1',

--- a/packages/upload-media/src/test/canvas-utils.ts
+++ b/packages/upload-media/src/test/canvas-utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { canvasConvertToJpeg } from '../canvas-utils';
@@ -44,20 +49,22 @@ describe( 'canvasConvertToJpeg', () => {
 			const mockBitmap = {
 				width: 200,
 				height: 150,
-				close: jest.fn(),
+				close: vi.fn(),
 			};
 
 			const mockCtx = {
-				drawImage: jest.fn(),
+				drawImage: vi.fn(),
 			};
 
-			global.createImageBitmap = jest
+			global.createImageBitmap = vi.fn().mockResolvedValue( mockBitmap );
+			global.OffscreenCanvas = vi
 				.fn()
-				.mockResolvedValue( mockBitmap );
-			global.OffscreenCanvas = jest.fn().mockImplementation( () => ( {
-				getContext: jest.fn().mockReturnValue( mockCtx ),
-				convertToBlob: jest.fn().mockResolvedValue( jpegBlob ),
-			} ) );
+				.mockImplementation( function OffscreenCanvas() {
+					return {
+						getContext: vi.fn().mockReturnValue( mockCtx ),
+						convertToBlob: vi.fn().mockResolvedValue( jpegBlob ),
+					};
+				} );
 
 			const file = new File( [ 'heic-data' ], 'photo.heic', {
 				type: 'image/heic',
@@ -76,18 +83,20 @@ describe( 'canvasConvertToJpeg', () => {
 				type: 'image/jpeg',
 			} );
 
-			const mockConvertToBlob = jest.fn().mockResolvedValue( jpegBlob );
-			const mockBitmap = { width: 100, height: 100, close: jest.fn() };
+			const mockConvertToBlob = vi.fn().mockResolvedValue( jpegBlob );
+			const mockBitmap = { width: 100, height: 100, close: vi.fn() };
 
-			global.createImageBitmap = jest
+			global.createImageBitmap = vi.fn().mockResolvedValue( mockBitmap );
+			global.OffscreenCanvas = vi
 				.fn()
-				.mockResolvedValue( mockBitmap );
-			global.OffscreenCanvas = jest.fn().mockImplementation( () => ( {
-				getContext: jest
-					.fn()
-					.mockReturnValue( { drawImage: jest.fn() } ),
-				convertToBlob: mockConvertToBlob,
-			} ) );
+				.mockImplementation( function OffscreenCanvas() {
+					return {
+						getContext: vi
+							.fn()
+							.mockReturnValue( { drawImage: vi.fn() } ),
+						convertToBlob: mockConvertToBlob,
+					};
+				} );
 
 			const file = new File( [ 'data' ], 'photo.heic', {
 				type: 'image/heic',
@@ -104,17 +113,19 @@ describe( 'canvasConvertToJpeg', () => {
 			const jpegBlob = new Blob( [ 'jpeg-data' ], {
 				type: 'image/jpeg',
 			} );
-			const mockBitmap = { width: 10, height: 10, close: jest.fn() };
+			const mockBitmap = { width: 10, height: 10, close: vi.fn() };
 
-			global.createImageBitmap = jest
+			global.createImageBitmap = vi.fn().mockResolvedValue( mockBitmap );
+			global.OffscreenCanvas = vi
 				.fn()
-				.mockResolvedValue( mockBitmap );
-			global.OffscreenCanvas = jest.fn().mockImplementation( () => ( {
-				getContext: jest
-					.fn()
-					.mockReturnValue( { drawImage: jest.fn() } ),
-				convertToBlob: jest.fn().mockResolvedValue( jpegBlob ),
-			} ) );
+				.mockImplementation( function OffscreenCanvas() {
+					return {
+						getContext: vi
+							.fn()
+							.mockReturnValue( { drawImage: vi.fn() } ),
+						convertToBlob: vi.fn().mockResolvedValue( jpegBlob ),
+					};
+				} );
 
 			const file = new File( [ 'data' ], 'my-photo.HEIC', {
 				type: 'image/heic',
@@ -124,15 +135,17 @@ describe( 'canvasConvertToJpeg', () => {
 		} );
 
 		it( 'should close the bitmap even if canvas context fails', async () => {
-			const mockBitmap = { width: 10, height: 10, close: jest.fn() };
+			const mockBitmap = { width: 10, height: 10, close: vi.fn() };
 
-			global.createImageBitmap = jest
+			global.createImageBitmap = vi.fn().mockResolvedValue( mockBitmap );
+			global.OffscreenCanvas = vi
 				.fn()
-				.mockResolvedValue( mockBitmap );
-			global.OffscreenCanvas = jest.fn().mockImplementation( () => ( {
-				getContext: jest.fn().mockReturnValue( null ),
-				convertToBlob: jest.fn(),
-			} ) );
+				.mockImplementation( function OffscreenCanvas() {
+					return {
+						getContext: vi.fn().mockReturnValue( null ),
+						convertToBlob: vi.fn(),
+					};
+				} );
 
 			// Remove other decoders so it falls through to the final error.
 			delete ( global as any ).ImageDecoder;
@@ -152,7 +165,7 @@ describe( 'canvasConvertToJpeg', () => {
 	describe( 'fallback behavior', () => {
 		it( 'should throw when no strategy is available', async () => {
 			// createImageBitmap throws (doesn't support HEIC).
-			global.createImageBitmap = jest
+			global.createImageBitmap = vi
 				.fn()
 				.mockRejectedValue( new Error( 'Unsupported format' ) );
 			// No ImageDecoder or VideoDecoder.
@@ -170,13 +183,13 @@ describe( 'canvasConvertToJpeg', () => {
 
 		it( 'should fall through Strategy 1 failure to subsequent strategies', async () => {
 			// Strategy 1 fails.
-			global.createImageBitmap = jest
+			global.createImageBitmap = vi
 				.fn()
 				.mockRejectedValue( new Error( 'Unsupported' ) );
 
 			// Strategy 2: ImageDecoder not supported for this type.
 			( global as any ).ImageDecoder = {
-				isTypeSupported: jest.fn().mockResolvedValue( false ),
+				isTypeSupported: vi.fn().mockResolvedValue( false ),
 			};
 
 			// No VideoDecoder.

--- a/packages/upload-media/src/test/convert-blob-to-file.ts
+++ b/packages/upload-media/src/test/convert-blob-to-file.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { convertBlobToFile } from '../utils';

--- a/packages/upload-media/src/test/error-messages.ts
+++ b/packages/upload-media/src/test/error-messages.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getErrorMessage } from '../error-messages';

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -42,10 +47,10 @@ describe( 'feature-detection', () => {
 		} as unknown as typeof Worker;
 
 		// jsdom does not implement URL.createObjectURL/revokeObjectURL.
-		global.URL.createObjectURL = jest.fn(
+		global.URL.createObjectURL = vi.fn(
 			() => 'blob:http://localhost/test'
 		);
-		global.URL.revokeObjectURL = jest.fn();
+		global.URL.revokeObjectURL = vi.fn();
 
 		// Remove navigator.deviceMemory and navigator.connection by default
 		// so they don't interfere with unrelated tests.
@@ -317,9 +322,9 @@ describe( 'feature-detection', () => {
 
 		it( 'returns true when both createImageBitmap and OffscreenCanvas are available', () => {
 			global.createImageBitmap =
-				jest.fn() as unknown as typeof createImageBitmap;
+				vi.fn() as unknown as typeof createImageBitmap;
 			global.OffscreenCanvas =
-				jest.fn() as unknown as typeof OffscreenCanvas;
+				vi.fn() as unknown as typeof OffscreenCanvas;
 
 			expect( isHeicCanvasSupported() ).toBe( true );
 		} );
@@ -328,14 +333,14 @@ describe( 'feature-detection', () => {
 			// @ts-ignore
 			delete global.createImageBitmap;
 			global.OffscreenCanvas =
-				jest.fn() as unknown as typeof OffscreenCanvas;
+				vi.fn() as unknown as typeof OffscreenCanvas;
 
 			expect( isHeicCanvasSupported() ).toBe( false );
 		} );
 
 		it( 'returns false when OffscreenCanvas is unavailable', () => {
 			global.createImageBitmap =
-				jest.fn() as unknown as typeof createImageBitmap;
+				vi.fn() as unknown as typeof createImageBitmap;
 			// @ts-ignore
 			delete global.OffscreenCanvas;
 

--- a/packages/upload-media/src/test/get-file-basename.ts
+++ b/packages/upload-media/src/test/get-file-basename.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getFileBasename } from '../utils';

--- a/packages/upload-media/src/test/get-file-extension.ts
+++ b/packages/upload-media/src/test/get-file-extension.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getFileExtension } from '../utils';

--- a/packages/upload-media/src/test/get-file-name-from-url.ts
+++ b/packages/upload-media/src/test/get-file-name-from-url.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getFileNameFromUrl } from '../utils';

--- a/packages/upload-media/src/test/get-image-dimensions.ts
+++ b/packages/upload-media/src/test/get-image-dimensions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getImageDimensions } from '../get-image-dimensions';

--- a/packages/upload-media/src/test/get-mime-types-array.ts
+++ b/packages/upload-media/src/test/get-mime-types-array.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getMimeTypesArray } from '../get-mime-types-array';

--- a/packages/upload-media/src/test/heic-parser.ts
+++ b/packages/upload-media/src/test/heic-parser.ts
@@ -5,6 +5,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 
 /**
  * Internal dependencies
@@ -69,6 +70,13 @@ function concat( ...arrays: Uint8Array[] ): Uint8Array {
 		offset += a.length;
 	}
 	return result;
+}
+
+/** Copy bytes into an ArrayBuffer with an exact, non-shared backing store. */
+function toArrayBuffer( bytes: Uint8Array ): ArrayBuffer {
+	const buffer = new ArrayBuffer( bytes.byteLength );
+	new Uint8Array( buffer ).set( bytes );
+	return buffer;
 }
 
 /** Build a pitm box (Primary Item). */
@@ -287,7 +295,7 @@ function buildSingleImageHeic( {
 
 	// Assemble full file
 	const file = concat( ftyp, meta, mdat );
-	return file.buffer;
+	return toArrayBuffer( file );
 }
 
 // ---------------------------------------------------------------------------
@@ -520,7 +528,7 @@ describe( 'heic-parser', () => {
 			);
 			const mdat = buildBox( 'mdat', mdatPayload );
 
-			return concat( ftyp, meta, mdat ).buffer;
+			return toArrayBuffer( concat( ftyp, meta, mdat ) );
 		}
 
 		/** Build an iinf box with infe entries. */
@@ -666,7 +674,7 @@ describe( 'heic-parser', () => {
 				'ftyp',
 				new Uint8Array( [ 0x68, 0x65, 0x69, 0x63 ] )
 			);
-			expect( () => parseHeic( ftyp.buffer ) ).toThrow(
+			expect( () => parseHeic( toArrayBuffer( ftyp ) ) ).toThrow(
 				'No meta box found'
 			);
 		} );
@@ -675,7 +683,7 @@ describe( 'heic-parser', () => {
 			// meta box with only hdlr (no pitm, iloc, iprp)
 			const hdlr = buildHdlr();
 			const meta = buildFullBox( 'meta', 0, 0, hdlr );
-			expect( () => parseHeic( meta.buffer ) ).toThrow(
+			expect( () => parseHeic( toArrayBuffer( meta ) ) ).toThrow(
 				'Missing required boxes'
 			);
 		} );
@@ -692,7 +700,7 @@ describe( 'heic-parser', () => {
 				0,
 				concat( hdlr, pitm, iloc, emptyIprp )
 			);
-			expect( () => parseHeic( meta.buffer ) ).toThrow(
+			expect( () => parseHeic( toArrayBuffer( meta ) ) ).toThrow(
 				'Missing ipco or ipma'
 			);
 		} );
@@ -713,7 +721,7 @@ describe( 'heic-parser', () => {
 				0,
 				concat( hdlr, pitm, iloc, iprp )
 			);
-			expect( () => parseHeic( meta.buffer ) ).toThrow(
+			expect( () => parseHeic( toArrayBuffer( meta ) ) ).toThrow(
 				'No location data for primary item'
 			);
 		} );
@@ -734,7 +742,7 @@ describe( 'heic-parser', () => {
 				0,
 				concat( hdlr, pitm, iloc, iprp )
 			);
-			expect( () => parseHeic( meta.buffer ) ).toThrow(
+			expect( () => parseHeic( toArrayBuffer( meta ) ) ).toThrow(
 				'No property associations'
 			);
 		} );
@@ -827,7 +835,7 @@ describe( 'parseExifOrientation / getUnappliedExifOrientation', () => {
 		] );
 
 		// Optional native transform property associated with the primary item.
-		let iprp = new Uint8Array( 0 );
+		let iprp: Uint8Array< ArrayBufferLike > = new Uint8Array( 0 );
 		if ( withIrot ) {
 			const ipco = buildIpco( buildIspe( 10, 10 ), buildIrot( 1 ) );
 			const ipma = buildIpma( [ [ primaryItemId, [ 1, 2 ] ] ] );
@@ -853,7 +861,7 @@ describe( 'parseExifOrientation / getUnappliedExifOrientation', () => {
 		const meta = buildMeta( exifOffset );
 		const mdat = buildBox( 'mdat', exifPayload );
 
-		return concat( ftyp, meta, mdat ).buffer;
+		return toArrayBuffer( concat( ftyp, meta, mdat ) );
 	}
 
 	describe( 'parseExifOrientation', () => {

--- a/packages/upload-media/src/test/image-file.ts
+++ b/packages/upload-media/src/test/image-file.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { ImageFile } from '../image-file';

--- a/packages/upload-media/src/test/is-animated-gif.ts
+++ b/packages/upload-media/src/test/is-animated-gif.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { isAnimatedGif } from '../utils';

--- a/packages/upload-media/src/test/rename-and-clone-file.ts
+++ b/packages/upload-media/src/test/rename-and-clone-file.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { renameFile, cloneFile } from '../utils';

--- a/packages/upload-media/src/test/upload-error.ts
+++ b/packages/upload-media/src/test/upload-error.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { UploadError } from '../upload-error';

--- a/packages/upload-media/src/test/validate-file-size.ts
+++ b/packages/upload-media/src/test/validate-file-size.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateFileSize } from '../validate-file-size';
@@ -14,7 +19,7 @@ const emptyFile = new window.File( [], 'test.jpeg', {
 
 describe( 'validateFileSize', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should error if the file is empty', () => {
@@ -24,7 +29,7 @@ describe( 'validateFileSize', () => {
 			new UploadError( {
 				code: 'EMPTY_FILE',
 				message: 'test.jpeg: This file is empty.',
-				file: imageFile,
+				file: emptyFile,
 			} )
 		);
 	} );

--- a/packages/upload-media/src/test/validate-mime-type-for-user.ts
+++ b/packages/upload-media/src/test/validate-mime-type-for-user.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateMimeTypeForUser } from '../validate-mime-type-for-user';
@@ -10,7 +15,7 @@ const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
 
 describe( 'validateMimeTypeForUser', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should not error if  wpAllowedMimeTypes is null or missing', async () => {

--- a/packages/upload-media/src/test/validate-mime-type.ts
+++ b/packages/upload-media/src/test/validate-mime-type.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { validateMimeType } from '../validate-mime-type';
@@ -13,7 +18,7 @@ const imageFile = new window.File( [ 'fake_file' ], 'test.jpeg', {
 
 describe( 'validateMimeType', () => {
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should error if allowedTypes contains a partial mime type and the validation fails', async () => {
@@ -37,7 +42,7 @@ describe( 'validateMimeType', () => {
 				code: 'MIME_TYPE_NOT_SUPPORTED',
 				message:
 					'test.jpeg: Sorry, this file type is not supported here.',
-				file: xmlFile,
+				file: imageFile,
 			} )
 		);
 	} );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -71,6 +71,7 @@
 					"packages/token-list",
 					"packages/ui",
 					"packages/undo-manager",
+					"packages/upload-media",
 					"packages/url",
 					"packages/viewport",
 					"packages/warning",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** This is an advanced module-mocking, worker-boundary, fake-timer, and TypeScript-fixture migration. It moves all 24 Upload Media test files (366 tests) from Jest to Vitest.

It also declares Vitest as a direct development dependency of `@wordpress/upload-media` and routes the package through the Vitest jsdom project.

## Why?

Upload Media is one of the remaining Jest-owned packages in the tracked repository migration. Migrating it independently keeps the stack reviewable while preserving worker behavior, retry timing, and the residual Jest partition.

## How?

- Uses explicit Vitest imports and typed `vi.mocked` worker mocks.
- Replaces CommonJS and Jest module access with typed ESM imports and async mock factories.
- Keeps the repository worker stubs for VIPS and video conversion.
- Preserves timer behavior by resolving the lazy worker import on the real event loop, then advancing only the conversion timeout with Vitest's fake clock.
- Makes previously implicit queue-item, settings, and `ArrayBuffer` test fixtures type-safe under the Vitest TypeScript graph.

Testing Library remains unchanged where applicable; Vitest replaces the runner and mocking APIs, not the DOM testing library.

## Testing Instructions

- `npm run test:unit:vitest -- --run packages/upload-media` — 24 files, 366 tests passed.
- `npm run test:unit:routing` — 365 Jest / 638 Vitest; exactly-one-runner invariant passed.
- `npm run test:unit:conventions` — 638 Vitest tests, 654 ESM graph files, 96 workspace dependencies, and 386 TypeScript tests validated.
- `npm run lint:js -- packages/upload-media/src` — passed.
- `npm run test:unit:vitest -- --run --project vitest --project node` — repeated full run passed: 635 files, 29,455 tests; 2 files and 8 tests skipped.
- `npm run test:unit -- --runInBand` — residual Jest passed: 365 suites, 5,295 tests, 59 snapshots.
- `npm exec lint-staged` — formatting, package metadata, docs, lockfile, and strict ESLint checks passed.

### Testing Instructions for Keyboard

Not applicable; this PR changes test infrastructure only.

## Use of AI Tools

Codex was used to migrate tests, run verification, investigate runner differences, and draft this description. The resulting changes and test evidence were reviewed during implementation.