### PR TITLE
List View: Collapse off-window placeholder rows into a single spacer row

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Performance
 
--   `ListView`: Collapse the placeholder rows that stand in for blocks outside of the render window into a single spacer row per run, instead of rendering a `<tr>`/`<td>` pair for every block. On a post with 1000 top-level blocks this removes ~1900 elements (about 60% of the List View's DOM and nearly half of the document's elements), which cuts the style recalculation and layout work done when the List View opens.
+-   `ListView`: Collapse the placeholder rows that stand in for blocks outside of the render window into a single spacer row per run, instead of rendering a `<tr>`/`<td>` pair for every block. On a post with 1000 top-level blocks this removes ~1900 elements (about 60% of the List View's DOM and nearly half of the document's elements), which cuts the style recalculation and layout work done when the List View opens ([#80953](https://github.com/WordPress/gutenberg/pull/80953)).
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,10 @@
 -   Inherited Global Styles now resolve the `link` element (`styles.elements.link`) for whole-block link blocks — those that render as a link — so their inspector controls reflect inherited link styles, mirroring the `button` element treatment for `core/button`. Covers `core/read-more`, `core/loginout`, `core/post-navigation-link`, `core/query-pagination-next`, `core/query-pagination-previous`, `core/query-pagination-numbers`, `core/comments-pagination-next`, `core/comments-pagination-previous`, `core/comments-pagination-numbers`, `core/comment-edit-link`, `core/comment-reply-link`, and `core/post-comments-link` [#80607](https://github.com/WordPress/gutenberg/pull/80607)).
 -   Add support for the `blockStatesEnabled` editor setting, which hides state controls for blocks when set to `false` ([#80956](https://github.com/WordPress/gutenberg/pull/80956)).
 
+### Performance
+
+-   `ListView`: Collapse the placeholder rows that stand in for blocks outside of the render window into a single spacer row per run, instead of rendering a `<tr>`/`<td>` pair for every block. On a post with 1000 top-level blocks this removes ~1900 elements (about 60% of the List View's DOM and nearly half of the document's elements), which cuts the style recalculation and layout work done when the List View opens.
+
 ### Internal
 
 -   `ListView`: Reimplement the Firefox description-recomputation workaround in `AriaReferencedText` by keying the element on its text, so React replaces it instead of updating the existing text node in place ([#80929](https://github.com/WordPress/gutenberg/pull/80929).

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -5,7 +5,7 @@ import {
 	__experimentalTreeGridRow as TreeGridRow,
 	__experimentalTreeGridCell as TreeGridCell,
 } from '@wordpress/components';
-import { memo, useRef } from '@wordpress/element';
+import { memo } from '@wordpress/element';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
 
 /**
@@ -127,8 +127,6 @@ function ListViewBranch( props ) {
 		draggedClientIds,
 	} = useListViewContext();
 
-	const nextPositionRef = useRef();
-
 	if ( ! canParentExpand ) {
 		return null;
 	}
@@ -139,7 +137,7 @@ function ListViewBranch( props ) {
 	const blockCount = filteredBlocks.length;
 	// The appender means an extra row in List View, so add 1 to the row count.
 	const rowCount = showAppender ? blockCount + 1 : blockCount;
-	nextPositionRef.current = listPosition;
+	let nextPosition = listPosition;
 
 	const rows = [];
 
@@ -171,7 +169,7 @@ function ListViewBranch( props ) {
 		const { clientId, innerBlocks } = block;
 
 		if ( index > 0 ) {
-			nextPositionRef.current += countBlocks(
+			nextPosition += countBlocks(
 				filteredBlocks[ index - 1 ],
 				expandedState,
 				draggedClientIds,
@@ -182,7 +180,7 @@ function ListViewBranch( props ) {
 		const isDragged = !! draggedClientIds?.includes( clientId );
 
 		const { itemInView } = fixedListWindow;
-		const blockInView = itemInView( nextPositionRef.current );
+		const blockInView = itemInView( nextPosition );
 
 		const position = index + 1;
 		const updatedPath =
@@ -259,7 +257,7 @@ function ListViewBranch( props ) {
 						showBlockMovers={ showBlockMovers }
 						path={ updatedPath }
 						isExpanded={ isDragged ? false : shouldExpand }
-						listPosition={ nextPositionRef.current }
+						listPosition={ nextPosition }
 						selectedClientIds={ selectedClientIds }
 						isSyncedBranch={ syncedBranch }
 						displacement={ displacement }
@@ -275,7 +273,7 @@ function ListViewBranch( props ) {
 						showBlockMovers={ showBlockMovers }
 						level={ level + 1 }
 						path={ updatedPath }
-						listPosition={ nextPositionRef.current + 1 }
+						listPosition={ nextPosition + 1 }
 						fixedListWindow={ fixedListWindow }
 						isBranchSelected={ isSelectedBranch }
 						selectedClientIds={ selectedClientIds }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -123,7 +123,9 @@ function ListViewBranch( props ) {
 	let placeholderRows = 0;
 	let placeholderKey;
 
-	const flushPlaceholders = () => {
+	// Adds the pending placeholder row, if there is one. Call before
+	// adding a real row.
+	const pushPlaceholderRow = () => {
 		if ( ! placeholderRows ) {
 			return;
 		}
@@ -201,7 +203,7 @@ function ListViewBranch( props ) {
 			}
 		}
 
-		flushPlaceholders();
+		pushPlaceholderRow();
 
 		// Determine the displacement of the block while dragging. This
 		// works out whether the current block should be displaced up or
@@ -260,7 +262,7 @@ function ListViewBranch( props ) {
 		);
 	} );
 
-	flushPlaceholders();
+	pushPlaceholderRow();
 
 	return (
 		<>

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -14,7 +14,11 @@ import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import { Appender } from './appender';
 import ListViewBlock from './block';
 import { useListViewContext } from './context';
-import { getDragDisplacementValues, isClientIdSelected } from './utils';
+import {
+	BLOCK_LIST_ITEM_HEIGHT,
+	getDragDisplacementValues,
+	isClientIdSelected,
+} from './utils';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayInformation from '../use-block-display-information';
 
@@ -137,121 +141,157 @@ function ListViewBranch( props ) {
 	const rowCount = showAppender ? blockCount + 1 : blockCount;
 	nextPositionRef.current = listPosition;
 
+	const rows = [];
+
+	// Blocks outside of the render window are represented by a placeholder row
+	// that preserves their height. Consecutive placeholders are collapsed into a
+	// single row, so that a long list does not pay for a DOM row per block.
+	let placeholderRows = 0;
+	let placeholderKey;
+
+	const flushPlaceholders = () => {
+		if ( ! placeholderRows ) {
+			return;
+		}
+		rows.push(
+			<tr key={ `placeholder-${ placeholderKey }` }>
+				<td
+					className="block-editor-list-view-placeholder"
+					style={ {
+						height: placeholderRows * BLOCK_LIST_ITEM_HEIGHT,
+					} }
+				/>
+			</tr>
+		);
+		placeholderRows = 0;
+		placeholderKey = undefined;
+	};
+
+	filteredBlocks.forEach( ( block, index ) => {
+		const { clientId, innerBlocks } = block;
+
+		if ( index > 0 ) {
+			nextPositionRef.current += countBlocks(
+				filteredBlocks[ index - 1 ],
+				expandedState,
+				draggedClientIds,
+				isExpanded
+			);
+		}
+
+		const isDragged = !! draggedClientIds?.includes( clientId );
+
+		const { itemInView } = fixedListWindow;
+		const blockInView = itemInView( nextPositionRef.current );
+
+		const position = index + 1;
+		const updatedPath =
+			path.length > 0 ? `${ path }_${ position }` : `${ position }`;
+		const hasNestedBlocks = !! innerBlocks?.length;
+
+		const shouldExpand =
+			hasNestedBlocks && shouldShowInnerBlocks
+				? expandedState[ clientId ] ?? isExpanded
+				: undefined;
+
+		// Make updates to the selected or dragged blocks synchronous,
+		// but asynchronous for any other block.
+		const isSelected = isClientIdSelected( clientId, selectedClientIds );
+		const isSelectedBranch =
+			isBranchSelected || ( isSelected && hasNestedBlocks );
+
+		// To avoid performance issues, we only render blocks that are in view,
+		// or blocks that are selected or dragged. If a block is selected,
+		// it is only counted if it is the first of the block selection.
+		// This prevents the entire tree from being rendered when a branch is
+		// selected, or a user selects all blocks, while still enabling scroll
+		// into view behavior when selecting a block or opening the list view.
+		// The first and last blocks of the list are always rendered, to ensure
+		// that Home and End keys work as expected.
+		const showBlock =
+			isDragged ||
+			blockInView ||
+			( isSelected && clientId === selectedClientIds[ 0 ] ) ||
+			index === 0 ||
+			index === blockCount - 1;
+
+		const showNestedBlocks = hasNestedBlocks && shouldExpand && ! isDragged;
+
+		if ( ! showBlock ) {
+			placeholderRows += 1;
+			placeholderKey ??= clientId;
+
+			// Inner blocks of a block outside of the render window may still be
+			// in view, so the placeholder run has to end before they render.
+			if ( ! showNestedBlocks ) {
+				return;
+			}
+		}
+
+		flushPlaceholders();
+
+		// Determine the displacement of the block while dragging. This
+		// works out whether the current block should be displaced up or
+		// down, relative to the dragged blocks and the drop target.
+		const { displacement, isAfterDraggedBlocks, isNesting } =
+			getDragDisplacementValues( {
+				blockIndexes,
+				blockDropTargetIndex,
+				blockDropPosition,
+				clientId,
+				firstDraggedBlockIndex,
+				isDragged,
+			} );
+
+		rows.push(
+			<AsyncModeProvider key={ clientId } value={ ! isSelected }>
+				{ showBlock && (
+					<ListViewBlock
+						block={ block }
+						selectBlock={ selectBlock }
+						isSelected={ isSelected }
+						isBranchSelected={ isSelectedBranch }
+						isDragged={ isDragged }
+						level={ level }
+						position={ position }
+						rowCount={ rowCount }
+						siblingBlockCount={ blockCount }
+						showBlockMovers={ showBlockMovers }
+						path={ updatedPath }
+						isExpanded={ isDragged ? false : shouldExpand }
+						listPosition={ nextPositionRef.current }
+						selectedClientIds={ selectedClientIds }
+						isSyncedBranch={ syncedBranch }
+						displacement={ displacement }
+						isAfterDraggedBlocks={ isAfterDraggedBlocks }
+						isNesting={ isNesting }
+					/>
+				) }
+				{ showNestedBlocks && (
+					<ListViewBranch
+						parentId={ clientId }
+						blocks={ innerBlocks }
+						selectBlock={ selectBlock }
+						showBlockMovers={ showBlockMovers }
+						level={ level + 1 }
+						path={ updatedPath }
+						listPosition={ nextPositionRef.current + 1 }
+						fixedListWindow={ fixedListWindow }
+						isBranchSelected={ isSelectedBranch }
+						selectedClientIds={ selectedClientIds }
+						isExpanded={ isExpanded }
+						isSyncedBranch={ syncedBranch }
+					/>
+				) }
+			</AsyncModeProvider>
+		);
+	} );
+
+	flushPlaceholders();
+
 	return (
 		<>
-			{ filteredBlocks.map( ( block, index ) => {
-				const { clientId, innerBlocks } = block;
-
-				if ( index > 0 ) {
-					nextPositionRef.current += countBlocks(
-						filteredBlocks[ index - 1 ],
-						expandedState,
-						draggedClientIds,
-						isExpanded
-					);
-				}
-
-				const isDragged = !! draggedClientIds?.includes( clientId );
-
-				// Determine the displacement of the block while dragging. This
-				// works out whether the current block should be displaced up or
-				// down, relative to the dragged blocks and the drop target.
-				const { displacement, isAfterDraggedBlocks, isNesting } =
-					getDragDisplacementValues( {
-						blockIndexes,
-						blockDropTargetIndex,
-						blockDropPosition,
-						clientId,
-						firstDraggedBlockIndex,
-						isDragged,
-					} );
-
-				const { itemInView } = fixedListWindow;
-				const blockInView = itemInView( nextPositionRef.current );
-
-				const position = index + 1;
-				const updatedPath =
-					path.length > 0
-						? `${ path }_${ position }`
-						: `${ position }`;
-				const hasNestedBlocks = !! innerBlocks?.length;
-
-				const shouldExpand =
-					hasNestedBlocks && shouldShowInnerBlocks
-						? expandedState[ clientId ] ?? isExpanded
-						: undefined;
-
-				// Make updates to the selected or dragged blocks synchronous,
-				// but asynchronous for any other block.
-				const isSelected = isClientIdSelected(
-					clientId,
-					selectedClientIds
-				);
-				const isSelectedBranch =
-					isBranchSelected || ( isSelected && hasNestedBlocks );
-
-				// To avoid performance issues, we only render blocks that are in view,
-				// or blocks that are selected or dragged. If a block is selected,
-				// it is only counted if it is the first of the block selection.
-				// This prevents the entire tree from being rendered when a branch is
-				// selected, or a user selects all blocks, while still enabling scroll
-				// into view behavior when selecting a block or opening the list view.
-				// The first and last blocks of the list are always rendered, to ensure
-				// that Home and End keys work as expected.
-				const showBlock =
-					isDragged ||
-					blockInView ||
-					( isSelected && clientId === selectedClientIds[ 0 ] ) ||
-					index === 0 ||
-					index === blockCount - 1;
-				return (
-					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
-						{ showBlock && (
-							<ListViewBlock
-								block={ block }
-								selectBlock={ selectBlock }
-								isSelected={ isSelected }
-								isBranchSelected={ isSelectedBranch }
-								isDragged={ isDragged }
-								level={ level }
-								position={ position }
-								rowCount={ rowCount }
-								siblingBlockCount={ blockCount }
-								showBlockMovers={ showBlockMovers }
-								path={ updatedPath }
-								isExpanded={ isDragged ? false : shouldExpand }
-								listPosition={ nextPositionRef.current }
-								selectedClientIds={ selectedClientIds }
-								isSyncedBranch={ syncedBranch }
-								displacement={ displacement }
-								isAfterDraggedBlocks={ isAfterDraggedBlocks }
-								isNesting={ isNesting }
-							/>
-						) }
-						{ ! showBlock && (
-							<tr>
-								<td className="block-editor-list-view-placeholder" />
-							</tr>
-						) }
-						{ hasNestedBlocks && shouldExpand && ! isDragged && (
-							<ListViewBranch
-								parentId={ clientId }
-								blocks={ innerBlocks }
-								selectBlock={ selectBlock }
-								showBlockMovers={ showBlockMovers }
-								level={ level + 1 }
-								path={ updatedPath }
-								listPosition={ nextPositionRef.current + 1 }
-								fixedListWindow={ fixedListWindow }
-								isBranchSelected={ isSelectedBranch }
-								selectedClientIds={ selectedClientIds }
-								isExpanded={ isExpanded }
-								isSyncedBranch={ syncedBranch }
-							/>
-						) }
-					</AsyncModeProvider>
-				);
-			} ) }
+			{ rows }
 			{ showAppender && (
 				<TreeGridRow
 					level={ level }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -46,44 +46,21 @@ function countBlocks(
 		return 0;
 	}
 	const isExpanded = expandedState[ block.clientId ] ?? isExpandedByDefault;
-
-	if ( isExpanded ) {
-		return (
-			1 +
-			block.innerBlocks.reduce(
-				countReducer(
-					expandedState,
-					draggedClientIds,
-					isExpandedByDefault
-				),
-				0
-			)
-		);
+	if ( ! isExpanded ) {
+		return 1;
 	}
-	return 1;
+	return block.innerBlocks.reduce(
+		( count, innerBlock ) =>
+			count +
+			countBlocks(
+				innerBlock,
+				expandedState,
+				draggedClientIds,
+				isExpandedByDefault
+			),
+		1
+	);
 }
-const countReducer =
-	( expandedState, draggedClientIds, isExpandedByDefault ) =>
-	( count, block ) => {
-		const isDragged = draggedClientIds?.includes( block.clientId );
-		if ( isDragged ) {
-			return count;
-		}
-		const isExpanded =
-			expandedState[ block.clientId ] ?? isExpandedByDefault;
-		if ( isExpanded && block.innerBlocks.length > 0 ) {
-			return (
-				count +
-				countBlocks(
-					block,
-					expandedState,
-					draggedClientIds,
-					isExpandedByDefault
-				)
-			);
-		}
-		return count + 1;
-	};
 
 const noop = () => {};
 
@@ -141,9 +118,8 @@ function ListViewBranch( props ) {
 
 	const rows = [];
 
-	// Blocks outside of the render window are represented by a placeholder row
-	// that preserves their height. Consecutive placeholders are collapsed into a
-	// single row, so that a long list does not pay for a DOM row per block.
+	// A run of blocks outside of the render window becomes one spacer row that
+	// stands in for their height.
 	let placeholderRows = 0;
 	let placeholderKey;
 
@@ -168,19 +144,19 @@ function ListViewBranch( props ) {
 	filteredBlocks.forEach( ( block, index ) => {
 		const { clientId, innerBlocks } = block;
 
-		if ( index > 0 ) {
-			nextPosition += countBlocks(
-				filteredBlocks[ index - 1 ],
-				expandedState,
-				draggedClientIds,
-				isExpanded
-			);
-		}
+		// The next sibling is offset by this block's subtree.
+		const blockListPosition = nextPosition;
+		nextPosition += countBlocks(
+			block,
+			expandedState,
+			draggedClientIds,
+			isExpanded
+		);
 
 		const isDragged = !! draggedClientIds?.includes( clientId );
 
 		const { itemInView } = fixedListWindow;
-		const blockInView = itemInView( nextPosition );
+		const blockInView = itemInView( blockListPosition );
 
 		const position = index + 1;
 		const updatedPath =
@@ -219,8 +195,7 @@ function ListViewBranch( props ) {
 			placeholderRows += 1;
 			placeholderKey ??= clientId;
 
-			// Inner blocks of a block outside of the render window may still be
-			// in view, so the placeholder run has to end before they render.
+			// Inner blocks of an off-window block may still be in view.
 			if ( ! showNestedBlocks ) {
 				return;
 			}
@@ -257,7 +232,7 @@ function ListViewBranch( props ) {
 						showBlockMovers={ showBlockMovers }
 						path={ updatedPath }
 						isExpanded={ isDragged ? false : shouldExpand }
-						listPosition={ nextPosition }
+						listPosition={ blockListPosition }
 						selectedClientIds={ selectedClientIds }
 						isSyncedBranch={ syncedBranch }
 						displacement={ displacement }
@@ -273,7 +248,7 @@ function ListViewBranch( props ) {
 						showBlockMovers={ showBlockMovers }
 						level={ level + 1 }
 						path={ updatedPath }
-						listPosition={ nextPosition + 1 }
+						listPosition={ blockListPosition + 1 }
 						fixedListWindow={ fixedListWindow }
 						isBranchSelected={ isSelectedBranch }
 						selectedClientIds={ selectedClientIds }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -39,7 +39,7 @@ import useListViewDropZone from './use-list-view-drop-zone';
 import useListViewExpandSelectedItem from './use-list-view-expand-selected-item';
 import { store as blockEditorStore } from '../../store';
 import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dropdown';
-import { focusListItem } from './utils';
+import { BLOCK_LIST_ITEM_HEIGHT, focusListItem } from './utils';
 import useClipboardHandler from './use-clipboard-handler';
 
 const expanded = ( state, action ) => {
@@ -60,8 +60,6 @@ const expanded = ( state, action ) => {
 	}
 	return state;
 };
-
-export const BLOCK_LIST_ITEM_HEIGHT = 32;
 
 /** @typedef {React.ComponentType} ComponentType */
 /** @typedef {React.Ref<HTMLElement>} Ref */
@@ -322,9 +320,6 @@ function ListViewComponent(
 		]
 	);
 
-	// List View renders a fixed number of items and relies on each having a fixed item height of 36px.
-	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
-	// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
 	const [ fixedListWindow ] = useFixedWindowList(
 		elementRef,
 		BLOCK_LIST_ITEM_HEIGHT,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -568,8 +568,7 @@ svg {
 .block-editor-list-view-placeholder {
 	padding: 0;
 	margin: 0;
-	// One row's worth of height. A placeholder that stands in for several rows
-	// outside of the render window sets its own height inline.
+	// One row. Spacers standing in for several rows set their height inline.
 	height: 32px;
 }
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -568,6 +568,8 @@ svg {
 .block-editor-list-view-placeholder {
 	padding: 0;
 	margin: 0;
+	// One row's worth of height. A placeholder that stands in for several rows
+	// outside of the render window sets its own height inline.
 	height: 32px;
 }
 

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -4,6 +4,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { focus } from '@wordpress/dom';
 
+// List View renders a fixed number of items and relies on each item having this
+// fixed height. It is also the height set for `.block-editor-list-view-block-contents`.
+// See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
+export const BLOCK_LIST_ITEM_HEIGHT = 32;
+
 export const getBlockPositionDescription = ( position, siblingCount, level ) =>
 	sprintf(
 		/* translators: 1: The numerical position of the block. 2: The total number of blocks. 3. The level of nesting for the block. */

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -4,8 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { focus } from '@wordpress/dom';
 
-// List View renders a fixed number of items and relies on each item having this
-// fixed height. It is also the height set for `.block-editor-list-view-block-contents`.
+// Must match the row height in `style.scss`; the windowing math relies on it.
 // See: https://github.com/WordPress/gutenberg/pull/35230 for additional context.
 export const BLOCK_LIST_ITEM_HEIGHT = 32;
 

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -265,11 +265,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-editor/src/components/list-view/branch.js": {
-		"react-hooks/refs": {
-			"count": 2
-		}
-	},
 	"packages/block-editor/src/components/list-view/drop-indicator.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
Related #80935 and #80929.

Off-window blocks in the List View each rendered their own `<tr><td class="…placeholder">`. This coalesces consecutive off-window blocks into a single spacer row sized to the run (`count × 32px`).

## Why?
On a 1000-block post, the placeholders were 962 rows / ~1900 elements — ~60% of the List View's DOM and ~48% of the whole document. Every style recalculated in the open frame, so they dominated the cost of opening the List View.

## How?
`ListViewBranch` accumulates off-window blocks and flushes them as one row, before any real row and before a nested branch (children of an off-window parent can still be in view). Spacer height is set inline, so `BLOCK_LIST_ITEM_HEIGHT` moved from `index.js` to `utils.js` (both already import from it — no cycle). Also drops a stale comment claiming rows are 36px; they are 32px.

No change to the windowing math, `windowOverscan`, or treegrid semantics: spacers carry no `role`, TreeGrid navigates `[role="row"]`, the drop zone uses `[data-block]`, and the first/last/selected/dragged rows still always render.

## Testing Instructions
1. Post with 1000 paragraphs → open the List View. Scroll top to bottom: no blank rows, scrollbar height unchanged (total height is still exactly `blocks × 32px`).
2. Post with ~15 blocks → no spacer rows are rendered at all; DOM unchanged.
3. Home/End jump to the true first/last block; arrow keys, expand/collapse, and drag and drop behave as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1042" height="208" alt="CleanShot 2026-07-30 at 16 29 54" src="https://github.com/user-attachments/assets/ad3585d3-0381-40a1-929b-f79254114813" />


## Use of AI Tools

Assisted by Claude.
