### PR TITLE
Migrate Rich Text Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52699,7 +52699,8 @@
 				"colord": "^2.9.3"
 			},
 			"devDependencies": {
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -64,7 +64,8 @@
 		"colord": "^2.9.3"
 	},
 	"devDependencies": {
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/rich-text/src/store/test/actions.js
+++ b/packages/rich-text/src/store/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { addFormatTypes, removeFormatTypes } from '../actions';

--- a/packages/rich-text/src/store/test/reducer.js
+++ b/packages/rich-text/src/store/test/reducer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/store/test/selectors.js
+++ b/packages/rich-text/src/store/test/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`recordToDom should create a value with formatting 1`] = `
+exports[`recordToDom > should create a value with formatting 1`] = `
 <body>
   <em
     data-rich-text-format-boundary="true"
@@ -11,7 +11,7 @@ exports[`recordToDom should create a value with formatting 1`] = `
 </body>
 `;
 
-exports[`recordToDom should create a value with formatting for split tags 1`] = `
+exports[`recordToDom > should create a value with formatting for split tags 1`] = `
 <body>
   <em
     data-rich-text-format-boundary="true"
@@ -22,7 +22,7 @@ exports[`recordToDom should create a value with formatting for split tags 1`] = 
 </body>
 `;
 
-exports[`recordToDom should create a value with formatting with attributes 1`] = `
+exports[`recordToDom > should create a value with formatting with attributes 1`] = `
 <body>
   <a
     data-rich-text-format-boundary="true"
@@ -34,7 +34,7 @@ exports[`recordToDom should create a value with formatting with attributes 1`] =
 </body>
 `;
 
-exports[`recordToDom should create a value with image object 1`] = `
+exports[`recordToDom > should create a value with image object 1`] = `
 <body>
   
   <img
@@ -44,7 +44,7 @@ exports[`recordToDom should create a value with image object 1`] = `
 </body>
 `;
 
-exports[`recordToDom should create a value with image object and formatting 1`] = `
+exports[`recordToDom > should create a value with image object and formatting 1`] = `
 <body>
   <em
     data-rich-text-format-boundary="true"
@@ -59,7 +59,7 @@ exports[`recordToDom should create a value with image object and formatting 1`] 
 </body>
 `;
 
-exports[`recordToDom should create a value with image object and text after 1`] = `
+exports[`recordToDom > should create a value with image object and text after 1`] = `
 <body>
   <em>
     
@@ -72,7 +72,7 @@ exports[`recordToDom should create a value with image object and text after 1`] 
 </body>
 `;
 
-exports[`recordToDom should create a value with image object and text before 1`] = `
+exports[`recordToDom > should create a value with image object and text before 1`] = `
 <body>
   te
   <em>
@@ -86,7 +86,7 @@ exports[`recordToDom should create a value with image object and text before 1`]
 </body>
 `;
 
-exports[`recordToDom should create a value with nested formatting 1`] = `
+exports[`recordToDom > should create a value with nested formatting 1`] = `
 <body>
   <em>
     <strong
@@ -99,27 +99,27 @@ exports[`recordToDom should create a value with nested formatting 1`] = `
 </body>
 `;
 
-exports[`recordToDom should create a value without formatting 1`] = `
+exports[`recordToDom > should create a value without formatting 1`] = `
 <body>
   test
 </body>
 `;
 
-exports[`recordToDom should create an empty value 1`] = `
+exports[`recordToDom > should create an empty value 1`] = `
 <body>
   
   ﻿
 </body>
 `;
 
-exports[`recordToDom should create an empty value from empty tags 1`] = `
+exports[`recordToDom > should create an empty value from empty tags 1`] = `
 <body>
   
   ﻿
 </body>
 `;
 
-exports[`recordToDom should disarm on* attribute 1`] = `
+exports[`recordToDom > should disarm on* attribute 1`] = `
 <body>
   
   <img
@@ -129,7 +129,7 @@ exports[`recordToDom should disarm on* attribute 1`] = `
 </body>
 `;
 
-exports[`recordToDom should disarm script 1`] = `
+exports[`recordToDom > should disarm script 1`] = `
 <body>
   
   <script
@@ -139,7 +139,7 @@ exports[`recordToDom should disarm script 1`] = `
 </body>
 `;
 
-exports[`recordToDom should filter format boundary attributes 1`] = `
+exports[`recordToDom > should filter format boundary attributes 1`] = `
 <body>
   <strong
     data-rich-text-format-boundary="true"
@@ -150,7 +150,7 @@ exports[`recordToDom should filter format boundary attributes 1`] = `
 </body>
 `;
 
-exports[`recordToDom should handle br 1`] = `
+exports[`recordToDom > should handle br 1`] = `
 <body>
   
   <br
@@ -161,7 +161,7 @@ exports[`recordToDom should handle br 1`] = `
 </body>
 `;
 
-exports[`recordToDom should handle br with formatting 1`] = `
+exports[`recordToDom > should handle br with formatting 1`] = `
 <body>
   <em
     data-rich-text-format-boundary="true"
@@ -177,7 +177,7 @@ exports[`recordToDom should handle br with formatting 1`] = `
 </body>
 `;
 
-exports[`recordToDom should handle br with text 1`] = `
+exports[`recordToDom > should handle br with text 1`] = `
 <body>
   te
   <br
@@ -187,7 +187,7 @@ exports[`recordToDom should handle br with text 1`] = `
 </body>
 `;
 
-exports[`recordToDom should handle double br 1`] = `
+exports[`recordToDom > should handle double br 1`] = `
 <body>
   a
   <br
@@ -201,7 +201,7 @@ exports[`recordToDom should handle double br 1`] = `
 </body>
 `;
 
-exports[`recordToDom should handle selection before br 1`] = `
+exports[`recordToDom > should handle selection before br 1`] = `
 <body>
   a
   <br
@@ -215,13 +215,13 @@ exports[`recordToDom should handle selection before br 1`] = `
 </body>
 `;
 
-exports[`recordToDom should ignore manually added object replacement character 1`] = `
+exports[`recordToDom > should ignore manually added object replacement character 1`] = `
 <body>
   test
 </body>
 `;
 
-exports[`recordToDom should ignore manually added object replacement character with formatting 1`] = `
+exports[`recordToDom > should ignore manually added object replacement character with formatting 1`] = `
 <body>
   <em
     data-rich-text-format-boundary="true"
@@ -232,7 +232,7 @@ exports[`recordToDom should ignore manually added object replacement character w
 </body>
 `;
 
-exports[`recordToDom should not error with overlapping formats (1) 1`] = `
+exports[`recordToDom > should not error with overlapping formats (1) 1`] = `
 <body>
   <a
     href="#"
@@ -250,7 +250,7 @@ exports[`recordToDom should not error with overlapping formats (1) 1`] = `
 </body>
 `;
 
-exports[`recordToDom should not error with overlapping formats (2) 1`] = `
+exports[`recordToDom > should not error with overlapping formats (2) 1`] = `
 <body>
   <em>
     <a
@@ -272,7 +272,7 @@ exports[`recordToDom should not error with overlapping formats (2) 1`] = `
 </body>
 `;
 
-exports[`recordToDom should preserve comments 1`] = `
+exports[`recordToDom > should preserve comments 1`] = `
 <body>
   
   <span
@@ -287,13 +287,13 @@ exports[`recordToDom should preserve comments 1`] = `
 </body>
 `;
 
-exports[`recordToDom should preserve emoji 1`] = `
+exports[`recordToDom > should preserve emoji 1`] = `
 <body>
   🍒
 </body>
 `;
 
-exports[`recordToDom should preserve emoji in formatting 1`] = `
+exports[`recordToDom > should preserve emoji in formatting 1`] = `
 <body>
   <em
     data-rich-text-format-boundary="true"
@@ -304,7 +304,7 @@ exports[`recordToDom should preserve emoji in formatting 1`] = `
 </body>
 `;
 
-exports[`recordToDom should preserve funky comments 1`] = `
+exports[`recordToDom > should preserve funky comments 1`] = `
 <body>
   
   <span
@@ -319,20 +319,20 @@ exports[`recordToDom should preserve funky comments 1`] = `
 </body>
 `;
 
-exports[`recordToDom should preserve non breaking space 1`] = `
+exports[`recordToDom > should preserve non breaking space 1`] = `
 <body>
   test  test
 </body>
 `;
 
-exports[`recordToDom should remove padding 1`] = `
+exports[`recordToDom > should remove padding 1`] = `
 <body>
   
   ﻿
 </body>
 `;
 
-exports[`recordToDom should unwrap data-rich-text-bogus element but preserve child formatting 1`] = `
+exports[`recordToDom > should unwrap data-rich-text-bogus element but preserve child formatting 1`] = `
 <body>
   hello 
   <em>
@@ -342,13 +342,13 @@ exports[`recordToDom should unwrap data-rich-text-bogus element but preserve chi
 </body>
 `;
 
-exports[`recordToDom should unwrap element with data-rich-text-bogus attribute 1`] = `
+exports[`recordToDom > should unwrap element with data-rich-text-bogus attribute 1`] = `
 <body>
   test
 </body>
 `;
 
-exports[`recordToDom should unwrap nested data-rich-text-bogus elements 1`] = `
+exports[`recordToDom > should unwrap nested data-rich-text-bogus elements 1`] = `
 <body>
   <strong>
     te

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/concat.js
+++ b/packages/rich-text/src/test/concat.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 import { create, removeReservedCharacters, RichTextData } from '../create';
 import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from '../special-characters';
 import { createElement } from '../create-element';
@@ -13,17 +19,11 @@ describe( 'create', () => {
 	const em = { type: 'em' };
 	const strong = { type: 'strong' };
 
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
-
 	spec.forEach( ( { description, html, createRange, record } ) => {
 		if ( html === undefined ) {
 			return;
 		}
 
-		// eslint-disable-next-line jest/valid-title
 		it( description, () => {
 			const element = createElement( document, html );
 			const range = createRange( element );
@@ -49,7 +49,6 @@ describe( 'create', () => {
 			html,
 			value: expectedValue,
 		} ) => {
-			// eslint-disable-next-line jest/valid-title
 			it( description, () => {
 				if ( formatName ) {
 					registerFormatType( formatName, formatType );

--- a/packages/rich-text/src/test/get-active-format.js
+++ b/packages/rich-text/src/test/get-active-format.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/packages/rich-text/src/test/get-active-object.js
+++ b/packages/rich-text/src/test/get-active-object.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/packages/rich-text/src/test/get-format-type.js
+++ b/packages/rich-text/src/test/get-format-type.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 import { getFormatType } from '../get-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
@@ -9,11 +15,6 @@ import { getFormatTypes } from '../get-format-types';
 const noop = () => {};
 
 describe( 'getFormatType', () => {
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
-
 	afterEach( () => {
 		getFormatTypes().forEach( ( format ) => {
 			unregisterFormatType( format.name );

--- a/packages/rich-text/src/test/get-format-types.js
+++ b/packages/rich-text/src/test/get-format-types.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 import { getFormatTypes } from '../get-format-types';
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
@@ -8,11 +14,6 @@ import { registerFormatType } from '../register-format-type';
 const noop = () => {};
 
 describe( 'getFormatTypes', () => {
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
-
 	afterEach( () => {
 		getFormatTypes().forEach( ( format ) => {
 			unregisterFormatType( format.name );

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -842,7 +842,7 @@ export const specWithRegistration = [
 		endPath: [ 0, 0, 1 ],
 		value: {
 			formats: [ [ math, mi ] ],
-			replacements: [],
+			replacements: [ , ],
 			text: 'x',
 		},
 	},

--- a/packages/rich-text/src/test/insert-object.js
+++ b/packages/rich-text/src/test/insert-object.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/insert.js
+++ b/packages/rich-text/src/test/insert.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/is-collapsed.js
+++ b/packages/rich-text/src/test/is-collapsed.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/packages/rich-text/src/test/is-empty.js
+++ b/packages/rich-text/src/test/is-empty.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/packages/rich-text/src/test/is-format-equal.js
+++ b/packages/rich-text/src/test/is-format-equal.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 
@@ -106,7 +111,6 @@ describe( 'isFormatEqual', () => {
 	];
 
 	spec.forEach( ( { format1, format2, isEqual, description } ) => {
-		// eslint-disable-next-line jest/valid-title
 		it( description, () => {
 			expect( isFormatEqual( format1, format2 ) ).toBe( isEqual );
 		} );

--- a/packages/rich-text/src/test/join.js
+++ b/packages/rich-text/src/test/join.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/normalise-formats.js
+++ b/packages/rich-text/src/test/normalise-formats.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/register-format-type.js
+++ b/packages/rich-text/src/test/register-format-type.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { dispatch, select } from '@wordpress/data';
@@ -21,9 +26,6 @@ const UNKNOWN_FORMAT = {
 
 describe( 'registerFormatType', () => {
 	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-
 		// Register "core/unknown" format
 		dispatch( richTextStore ).addFormatTypes( UNKNOWN_FORMAT );
 	} );

--- a/packages/rich-text/src/test/remove-format.js
+++ b/packages/rich-text/src/test/remove-format.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/replace.js
+++ b/packages/rich-text/src/test/replace.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/slice.js
+++ b/packages/rich-text/src/test/slice.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/split.js
+++ b/packages/rich-text/src/test/split.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -1,18 +1,18 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 import { toDom, applyValue } from '../to-dom';
 import { createElement } from '../create-element';
 import { spec } from './helpers';
 
 describe( 'recordToDom', () => {
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
-
 	spec.forEach( ( { description, record, startPath, endPath } ) => {
-		// eslint-disable-next-line jest/valid-title
 		it( description, () => {
 			const { body, selection } = toDom( {
 				value: record,
@@ -100,7 +100,6 @@ describe( 'applyValue', () => {
 	];
 
 	cases.forEach( ( { current, future, description, movedCount } ) => {
-		// eslint-disable-next-line jest/valid-title
 		it( description, () => {
 			const body = createElement( document, current ).cloneNode( true );
 			const futureBody = createElement( document, future ).cloneNode(

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 import { create } from '../create';
 import { toHTMLString } from '../to-html-string';
 import { registerFormatType } from '../register-format-type';
@@ -14,11 +20,6 @@ function createNode( HTML ) {
 }
 
 describe( 'toHTMLString', () => {
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
-
 	specWithRegistration.forEach(
 		( {
 			description,
@@ -32,7 +33,6 @@ describe( 'toHTMLString', () => {
 				return;
 			}
 
-			// eslint-disable-next-line jest/valid-title
 			it( description, () => {
 				if ( formatName ) {
 					registerFormatType( formatName, formatType );

--- a/packages/rich-text/src/test/toggle-format.js
+++ b/packages/rich-text/src/test/toggle-format.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/rich-text/src/test/unregister-format-type.js
+++ b/packages/rich-text/src/test/unregister-format-type.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
 import { getFormatTypes } from '../get-format-types';
@@ -15,11 +21,6 @@ describe( 'unregisterFormatType', () => {
 		tagName: 'test',
 		className: null,
 	};
-
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
 
 	afterEach( () => {
 		getFormatTypes().forEach( ( format ) => {

--- a/packages/rich-text/src/test/update-formats.js
+++ b/packages/rich-text/src/test/update-formats.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../store';
 
 import { updateFormats } from '../update-formats';
 import { create } from '../create';
@@ -11,11 +17,6 @@ import { getSparseArrayLength } from './helpers';
 
 describe( 'updateFormats', () => {
 	const em = { type: 'em' };
-
-	beforeAll( () => {
-		// Initialize the rich-text store.
-		require( '../store' );
-	} );
 
 	it( 'should update formats with empty array', () => {
 		const value = {

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -62,6 +62,7 @@
 					"packages/priority-queue",
 					"packages/private-apis",
 					"packages/reusable-blocks",
+					"packages/rich-text",
 					"packages/server-side-render",
 					"packages/shortcode",
 					"packages/style-engine",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** Migrates the Rich Text package through three Vitest change classes: ESM side-effect initialization, sparse-array equality parity, and snapshot-key migration.

This stacked draft contains only the Rich Text increment and is based on #80951.

## Why?

Rich Text was still part of the residual Jest partition. Migrating it reduces that partition by 27 files and 218 tests while preserving the exactly-one-runner invariant.

## How?

- Routes `packages/rich-text` to the Vitest jsdom project.
- Uses explicit Vitest imports and a package-owned Vitest dependency.
- Replaces runtime CommonJS store initialization with static ESM side-effect imports.
- Preserves the production sparse replacement array in the MathML fixture; Vitest correctly distinguishes it from a dense empty array.
- Updates the 32 snapshot keys to Vitest's nested `describe > test` format. Every snapshot body is byte-for-byte identical to the Jest baseline.

Testing Library is unchanged; this package does not need a runner-specific alternative.

## Testing Instructions

- `npm run test:unit:vitest -- --run packages/rich-text`
  - 27 files, 218 tests, and 32 snapshots pass.
- `npm run test:unit:routing`
  - 338 Jest files and 665 Vitest files are owned exactly once.
- `npm run test:unit:conventions`
- `npm run test:unit:vitest -- --run --project vitest --project node`
  - 662 files pass, 2 files skip; 29,673 tests pass and 8 skip.
- `npm run test:unit -- --runInBand`
  - The residual Jest partition passes 338 suites, 5,077 tests, and 27 snapshots.
- `npm run lint:js -- packages/rich-text/src/test packages/rich-text/src/store/test`
- `npm exec lint-staged -- --no-stash`

## Use of AI Tools

This migration was implemented and verified with Codex. The resulting diff, runner ownership, snapshot bodies, and focused/full test output were reviewed before opening this draft.