### PR TITLE
Migrate Blocks Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49858,7 +49858,8 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -78,7 +78,8 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/blocks/src/api/parser/test/apply-block-deprecated-versions.jsx
+++ b/packages/blocks/src/api/parser/test/apply-block-deprecated-versions.jsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
+import '../../../store';
 import { applyBlockDeprecatedVersions } from '../apply-block-deprecated-versions';
 import {
 	registerBlockType,
@@ -27,11 +29,6 @@ describe( 'applyBlockDeprecatedVersions', () => {
 		category: 'text',
 		title: 'block title',
 	};
-
-	beforeAll( () => {
-		// Initialize the block store.
-		require( '../../../store' );
-	} );
 
 	afterEach( () => {
 		setFreeformContentHandlerName( undefined );

--- a/packages/blocks/src/api/parser/test/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/test/convert-legacy-block.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { normalizeStyleStateAliases } from '../convert-legacy-block';

--- a/packages/blocks/src/api/parser/test/fix-custom-classname.jsx
+++ b/packages/blocks/src/api/parser/test/fix-custom-classname.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/blocks/src/api/parser/test/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/test/get-block-attributes.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { attr } from 'hpq';
 
 /**

--- a/packages/blocks/src/api/parser/test/index.jsx
+++ b/packages/blocks/src/api/parser/test/index.jsx
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../../../store';
 import { parseRawBlock, default as parse } from '../';
 import {
 	registerBlockType,
@@ -37,11 +43,6 @@ describe( 'block parser', () => {
 		},
 		save: ( { attributes } ) => attributes.content || null,
 	};
-
-	beforeAll( () => {
-		// Initialize the block store.
-		require( '../../../store' );
-	} );
 
 	afterEach( () => {
 		setFreeformContentHandlerName( undefined );

--- a/packages/blocks/src/api/parser/test/serialize-raw-block.js
+++ b/packages/blocks/src/api/parser/test/serialize-raw-block.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { serializeRawBlock } from '../serialize-raw-block';

--- a/packages/blocks/src/api/raw-handling/test/blockquote-normaliser.js
+++ b/packages/blocks/src/api/raw-handling/test/blockquote-normaliser.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import blockquoteNormaliser from '../blockquote-normaliser';

--- a/packages/blocks/src/api/raw-handling/test/comment-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/comment-remover.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import commentRemover from '../comment-remover';

--- a/packages/blocks/src/api/raw-handling/test/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/figure-content-reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import figureContentReducer from '../figure-content-reducer';

--- a/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import filter from '../html-formatting-remover';

--- a/packages/blocks/src/api/raw-handling/test/image-corrector.js
+++ b/packages/blocks/src/api/raw-handling/test/image-corrector.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import imageCorrector from '../image-corrector';

--- a/packages/blocks/src/api/raw-handling/test/is-inline-content.js
+++ b/packages/blocks/src/api/raw-handling/test/is-inline-content.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import isInlineContent from '../is-inline-content';

--- a/packages/blocks/src/api/raw-handling/test/latex-to-math.js
+++ b/packages/blocks/src/api/raw-handling/test/latex-to-math.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import isLatexMathMode from '../latex-to-math';

--- a/packages/blocks/src/api/raw-handling/test/list-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/list-reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import listReducer from '../list-reducer';

--- a/packages/blocks/src/api/raw-handling/test/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/markdown-converter.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import markdownConverter from '../markdown-converter';

--- a/packages/blocks/src/api/raw-handling/test/ms-list-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/ms-list-converter.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import msListConverter from '../ms-list-converter';

--- a/packages/blocks/src/api/raw-handling/test/normalise-blocks.js
+++ b/packages/blocks/src/api/raw-handling/test/normalise-blocks.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import normaliseBlocks from '../normalise-blocks';

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { pasteHandler, serialize } from '@wordpress/blocks';

--- a/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/phrasing-content-reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import phrasingContentReducer from '../phrasing-content-reducer';

--- a/packages/blocks/src/api/raw-handling/test/special-comment-converter.js
+++ b/packages/blocks/src/api/raw-handling/test/special-comment-converter.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import specialCommentConverter from '../special-comment-converter';

--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/blocks/src/api/test/children.js
+++ b/packages/blocks/src/api/test/children.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
 /* eslint-disable testing-library/render-result-naming-convention */
 
 /**

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
+import '../../store';
 import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
@@ -43,11 +45,6 @@ describe( 'block factory', () => {
 		category: 'text',
 		title: 'block title',
 	};
-
-	beforeAll( () => {
-		// Load blocks store.
-		require( '../../store' );
-	} );
 
 	beforeEach( () => {
 		// Reset warning logging so deduped warnings fire within each test.
@@ -1086,7 +1083,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'for a non multiblock transform, the isMatch function receives the source block’s attributes object and the block object as its arguments', () => {
-			const isMatch = jest.fn();
+			const isMatch = vi.fn();
 
 			registerBlockType( 'core/updated-text-block', {
 				apiVersion: 3,
@@ -1121,7 +1118,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'for a multiblock transform, the isMatch function receives an array containing every source block’s attributes and an array of source blocks as its arguments', () => {
-			const isMatch = jest.fn();
+			const isMatch = vi.fn();
 
 			registerBlockType( 'core/updated-text-block', {
 				apiVersion: 3,
@@ -2010,7 +2007,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should call "__experimentalConvert" with mixed block types and wildcard', () => {
-			const convertSpy = jest.fn( ( blocks ) => {
+			const convertSpy = vi.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map(
 					( { name, attributes, innerBlocks } ) => {
 						return createBlock( name, attributes, innerBlocks );
@@ -2023,7 +2020,7 @@ describe( 'block factory', () => {
 					groupInnerBlocks
 				);
 			} );
-			const transformSpy = jest.fn();
+			const transformSpy = vi.fn();
 
 			registerBlockType( 'core/test-group-block', {
 				apiVersion: 3,
@@ -2074,7 +2071,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should call "__experimentalConvert" with same block types', () => {
-			const convertSpy = jest.fn( ( blocks ) => {
+			const convertSpy = vi.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map(
 					( { name, attributes, innerBlocks } ) => {
 						return createBlock( name, attributes, innerBlocks );
@@ -2087,7 +2084,7 @@ describe( 'block factory', () => {
 					groupInnerBlocks
 				);
 			} );
-			const transformSpy = jest.fn();
+			const transformSpy = vi.fn();
 
 			registerBlockType( 'core/test-group-block', {
 				apiVersion: 3,
@@ -2135,7 +2132,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should not call "__experimentalConvert" with non-matching block types', () => {
-			const convertSpy = jest.fn( ( blocks ) => {
+			const convertSpy = vi.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map(
 					( { name, attributes, innerBlocks } ) => {
 						return createBlock( name, attributes, innerBlocks );
@@ -2148,7 +2145,7 @@ describe( 'block factory', () => {
 					groupInnerBlocks
 				);
 			} );
-			const transformSpy = jest.fn();
+			const transformSpy = vi.fn();
 
 			registerBlockType( 'core/test-group-block', {
 				apiVersion: 3,
@@ -2196,7 +2193,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should prefer "__experimentalConvert" method over "transform" method when running a transformation', () => {
-			const convertSpy = jest.fn( ( blocks ) => {
+			const convertSpy = vi.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map(
 					( { name, attributes, innerBlocks } ) => {
 						return createBlock( name, attributes, innerBlocks );
@@ -2209,7 +2206,7 @@ describe( 'block factory', () => {
 					groupInnerBlocks
 				);
 			} );
-			const transformSpy = jest.fn();
+			const transformSpy = vi.fn();
 
 			registerBlockType( 'core/test-group-block', {
 				apiVersion: 3,

--- a/packages/blocks/src/api/test/matchers.js
+++ b/packages/blocks/src/api/test/matchers.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { parse } from 'hpq';
 
 /**

--- a/packages/blocks/src/api/test/node.js
+++ b/packages/blocks/src/api/test/node.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getNamedNodeMapAsObject, toHTML, fromDOM } from '../node';

--- a/packages/blocks/src/api/test/registration.jsx
+++ b/packages/blocks/src/api/test/registration.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, test } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { addFilter, removeAllFilters, removeFilter } from '@wordpress/hooks';
@@ -869,7 +874,6 @@ describe( 'blocks', () => {
 						// Verify that for deprecations, the filter is called with a merge of pre-filter
 						// settings with deprecation keys omitted and the deprecation entry.
 						if ( i > 0 ) {
-							// eslint-disable-next-line jest/no-conditional-expect
 							expect( settings ).toEqual( {
 								...omit(
 									{

--- a/packages/blocks/src/api/test/serializer.jsx
+++ b/packages/blocks/src/api/test/serializer.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createElement, Component } from '@wordpress/element';
@@ -6,6 +11,7 @@ import { createElement, Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import '../../store';
 import serialize, {
 	getCommentAttributes,
 	getSaveContent,
@@ -24,11 +30,6 @@ import {
 import { createBlock } from '../';
 
 describe( 'block serializer', () => {
-	beforeAll( () => {
-		// Initialize the block store.
-		require( '../../store' );
-	} );
-
 	afterEach( () => {
 		setFreeformContentHandlerName( undefined );
 		setUnregisteredTypeHandlerName( undefined );

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../../store';
 import { createBlock } from '../factory';
 import {
 	getBlockTypes,
@@ -15,11 +21,6 @@ import {
 const noop = () => {};
 
 describe( 'templates', () => {
-	beforeAll( () => {
-		// Initialize the block store.
-		require( '../../store' );
-	} );
-
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../../store';
 import { createBlock } from '../factory';
 import {
 	getBlockTypes,
@@ -23,11 +29,6 @@ import {
 const noop = () => {};
 
 describe( 'block helpers', () => {
-	beforeAll( () => {
-		// Initialize the block store.
-		require( '../../store' );
-	} );
-
 	afterEach( () => {
 		setDefaultBlockName( undefined );
 		getBlockTypes().forEach( ( block ) => {
@@ -268,8 +269,8 @@ describe( 'sanitizeBlockAttributes', () => {
 	it( 'throws error if the block is not registered', () => {
 		expect( () => {
 			sanitizeBlockAttributes( 'core/not-registered-test-block', {} );
-		} ).toThrowErrorMatchingInlineSnapshot(
-			`"Block type 'core/not-registered-test-block' is not registered."`
+		} ).toThrow(
+			"Block type 'core/not-registered-test-block' is not registered."
 		);
 	} );
 

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -1,6 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
+import '../../store';
 import {
 	isValidCharacterReference,
 	DecodeEntityParser,
@@ -32,11 +38,6 @@ describe( 'validation', () => {
 		category: 'text',
 		title: 'block title',
 	};
-	beforeAll( () => {
-		// Initialize the block store.
-		require( '../../store' );
-	} );
-
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );

--- a/packages/blocks/src/store/test/actions.js
+++ b/packages/blocks/src/store/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { addBlockVariations, removeBlockVariations } from '../actions';

--- a/packages/blocks/src/store/test/private-selectors.js
+++ b/packages/blocks/src/store/test/private-selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/blocks/src/store/test/selectors.jsx
+++ b/packages/blocks/src/store/test/selectors.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, test } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -25,6 +25,7 @@
 					"packages/autop",
 					"packages/blob",
 					"packages/block-directory",
+					"packages/blocks",
 					"packages/connectors",
 					"packages/components",
 					"packages/compose",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** Migrates Blocks through four Vitest change classes: explicit runner APIs, ESM side-effect initialization, native Vitest spies, and removal of one runner-formatted error snapshot.

This stacked draft contains only the Blocks runner migration and is based on #80955.

## Why?

Blocks was still part of the residual Jest partition. Migrating all 34 package tests removes 635 tests from that partition while preserving the exactly-one-runner invariant.

## How?

- Routes `packages/blocks` to the Vitest jsdom project.
- Uses explicit Vitest imports and a package-owned Vitest dependency.
- Replaces runtime CommonJS store initialization with static ESM side-effect imports.
- Replaces ten `jest.fn()` spies with `vi.fn()`.
- Replaces one inline snapshot of a thrown error with an explicit `toThrow()` message assertion. Jest and Vitest serialize `Error` objects differently, while the intended error message is unchanged.

No Testing Library abstraction changes are needed in this package.

## Testing Instructions

- `npm run test:unit:vitest -- --run packages/blocks`
  - 34 files and 635 tests pass.
- `npm run test:unit:routing`
  - 304 Jest files and 699 Vitest files are owned exactly once.
- `npm run test:unit:conventions`
- `npm run test:unit:vitest -- --run --project vitest --project node`
  - 696 files pass, 2 files skip; 30,308 tests pass and 8 skip.
- `npm run test:unit -- --runInBand`
  - The residual Jest partition passes 304 suites, 4,442 tests, and 26 snapshots.
- `npm run lint:js -- packages/blocks/src/api packages/blocks/src/store/test`
- `npm exec lint-staged -- --no-stash`

## Use of AI Tools

This migration was implemented and verified with Codex. The package diff, runner ownership, store initialization, spy conversion, error assertion, and focused/full test output were reviewed before opening this draft.