### PR TITLE
Migrate Core Data Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50291,13 +50291,11 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
-				"@jest/globals": "^30.4.1",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
-				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39",
 				"@wordpress/block-library": "file:../block-library",
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Internal
 
+-   Migrate unit tests from Jest to Vitest and use platform timer types.
 -   Rename JSX-bearing source files to use the `.jsx` extension.
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -76,13 +76,11 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
-		"@jest/globals": "^30.4.1",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
-		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39",
 		"@wordpress/block-library": "file:../block-library",
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/core-data/src/awareness/awareness-state.ts
+++ b/packages/core-data/src/awareness/awareness-state.ts
@@ -146,7 +146,8 @@ export abstract class AwarenessState<
 	 * value -- even if it hasn't yet been set on the awareness instance.
 	 */
 	private myThrottledState: Partial< State > = {};
-	private throttleTimeouts: Map< string, NodeJS.Timeout > = new Map();
+	private throttleTimeouts: Map< string, ReturnType< typeof setTimeout > > =
+		new Map();
 
 	/** CUSTOM METHODS */
 

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -81,7 +81,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 		// in the subscription.
 		let selectionStart = getSelectionStart();
 		let selectionEnd = getSelectionEnd();
-		let localCursorTimeout: NodeJS.Timeout | null = null;
+		let localCursorTimeout: ReturnType< typeof setTimeout > | null = null;
 
 		// During rapid selection changes (e.g. undo restoring content and
 		// selection), the debounce discards intermediate events. If we use the

--- a/packages/core-data/src/awareness/test/awareness-state.ts
+++ b/packages/core-data/src/awareness/test/awareness-state.ts
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	describe,
-	expect,
-	test,
-	jest,
-	beforeEach,
-	afterEach,
-} from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -69,13 +62,13 @@ describe( 'AwarenessState', () => {
 	let awareness: TestAwarenessState;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		doc = new Y.Doc();
 		awareness = new TestAwarenessState( doc );
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 		doc.destroy();
 	} );
 
@@ -107,7 +100,7 @@ describe( 'AwarenessState', () => {
 			awareness.setLocalStateField( 'count', 42 );
 
 			// Subscribe to trigger state update
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 			awareness.testUpdateSubscribers( true );
 
@@ -131,7 +124,7 @@ describe( 'AwarenessState', () => {
 			awareness.setLocalStateField( 'count', 1 );
 
 			// Subscribe and update to trigger state tracking
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 			awareness.testUpdateSubscribers( true );
 
@@ -146,7 +139,7 @@ describe( 'AwarenessState', () => {
 	describe( 'onStateChange', () => {
 		test( 'should register callback and receive updates', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			awareness.onStateChange( callback );
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -158,7 +151,7 @@ describe( 'AwarenessState', () => {
 
 		test( 'should return unsubscribe function', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			const unsubscribe = awareness.onStateChange( callback );
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -175,7 +168,7 @@ describe( 'AwarenessState', () => {
 
 		test( 'should not call callback when state has not changed', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			awareness.onStateChange( callback );
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -191,7 +184,7 @@ describe( 'AwarenessState', () => {
 
 		test( 'should call callback when forceUpdate is true', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			awareness.onStateChange( callback );
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -229,7 +222,7 @@ describe( 'AwarenessState', () => {
 			// Verify the value was updated
 			expect( awareness.getLocalStateField( 'name' ) ).toBe( 'Second' );
 
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 
 			// After throttle period, the value should still be the last set value
 			expect( awareness.getLocalStateField( 'name' ) ).toBe( 'Second' );
@@ -239,7 +232,7 @@ describe( 'AwarenessState', () => {
 	describe( 'setConnectionStatus', () => {
 		test( 'should trigger subscriber update when connection changes', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -258,7 +251,7 @@ describe( 'AwarenessState', () => {
 			awareness.setUp();
 			awareness.setLocalStateField( 'name', 'Same' );
 
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 			awareness.testUpdateSubscribers( true );
 			callback.mockClear();
@@ -274,7 +267,7 @@ describe( 'AwarenessState', () => {
 			awareness.setUp();
 			awareness.setLocalStateField( 'name', 'Original' );
 
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 			awareness.testUpdateSubscribers( true );
 			callback.mockClear();
@@ -369,7 +362,7 @@ describe( 'AwarenessState', () => {
 	describe( 'change event handling', () => {
 		test( 'should update subscribers on awareness change', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -389,7 +382,7 @@ describe( 'AwarenessState', () => {
 
 		test( 'should handle user removal and delayed cleanup', () => {
 			awareness.setUp();
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 
 			awareness.setLocalStateField( 'name', 'Test' );
@@ -410,7 +403,7 @@ describe( 'AwarenessState', () => {
 			callback.mockClear();
 
 			// After REMOVAL_DELAY_IN_MS, should trigger another update
-			jest.advanceTimersByTime( 5000 );
+			vi.advanceTimersByTime( 5000 );
 			expect( callback ).toHaveBeenCalled();
 		} );
 	} );

--- a/packages/core-data/src/awareness/test/base-awareness.ts
+++ b/packages/core-data/src/awareness/test/base-awareness.ts
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+	type Mock,
+} from 'vitest';
 import { Y } from '@wordpress/sync';
 import { resolveSelect } from '@wordpress/data';
 
@@ -16,8 +25,9 @@ import { areCollaboratorInfosEqual } from '../utils';
 import type { BaseState, CollaboratorInfo } from '../types';
 
 // Mock WordPress data
-jest.mock( '@wordpress/data', () => ( {
-	resolveSelect: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	resolveSelect: vi.fn(),
 } ) );
 
 // Mock window.navigator.userAgent
@@ -45,7 +55,7 @@ describe( 'BaseAwareness', () => {
 	let doc: Y.Doc;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		doc = new Y.Doc();
 
 		// Reset to Chrome
@@ -54,19 +64,19 @@ describe( 'BaseAwareness', () => {
 		);
 
 		// Mock Date.now for consistent timestamps
-		jest.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
+		vi.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
 
 		// Mock resolveSelect to return getCurrentUser
-		( resolveSelect as jest.Mock ).mockReturnValue( {
-			getCurrentUser: jest
+		( resolveSelect as Mock ).mockReturnValue( {
+			getCurrentUser: vi
 				.fn()
 				.mockResolvedValue( createMockCollaboratorInfo() ),
 		} );
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
-		jest.restoreAllMocks();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
 		doc.destroy();
 	} );
 
@@ -132,25 +142,25 @@ describe( 'BaseAwarenessState', () => {
 	let doc: Y.Doc;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		doc = new Y.Doc();
 
 		mockUserAgent(
 			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
 		);
 
-		jest.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
+		vi.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
 
-		( resolveSelect as jest.Mock ).mockReturnValue( {
-			getCurrentUser: jest
+		( resolveSelect as Mock ).mockReturnValue( {
+			getCurrentUser: vi
 				.fn()
 				.mockResolvedValue( createMockCollaboratorInfo() ),
 		} );
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
-		jest.restoreAllMocks();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
 		doc.destroy();
 	} );
 
@@ -249,7 +259,7 @@ describe( 'BaseAwarenessState', () => {
 			);
 
 			// Subscribe to detect updates
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 
 			// Set same collaboratorInfo
@@ -274,7 +284,7 @@ describe( 'BaseAwarenessState', () => {
 	describe( 'state subscription', () => {
 		test( 'should notify subscribers on state change', async () => {
 			const awareness = new TestBaseAwarenessState( doc );
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			awareness.onStateChange( callback );
 			awareness.setUp();

--- a/packages/core-data/src/awareness/test/block-lookup.ts
+++ b/packages/core-data/src/awareness/test/block-lookup.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi, type Mock } from 'vitest';
 import { Y } from '@wordpress/sync';
 import { renderHook } from '@testing-library/react';
 
@@ -21,7 +22,7 @@ type MockBlock = EditorStoreBlock & {
 	innerBlocks: MockBlock[];
 };
 
-let mockGetClientIdsTree: jest.Mock;
+let mockGetClientIdsTree: Mock;
 
 function mockFlattenBlocks( blocks: MockBlock[] ): MockBlock[] {
 	return blocks.flatMap( ( b ) => [
@@ -30,12 +31,13 @@ function mockFlattenBlocks( blocks: MockBlock[] ): MockBlock[] {
 	] );
 }
 
-jest.mock( '../../lock-unlock', () => ( {
+vi.mock( import( '../../lock-unlock' ), () => ( {
 	unlock: ( obj: any ) => obj,
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: ( selector: Function ) =>
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: ( ( selector: Function ) =>
 		selector( () => ( {
 			getClientIdsTree: ( ...args: any[] ) =>
 				mockGetClientIdsTree( ...args ),
@@ -43,10 +45,11 @@ jest.mock( '@wordpress/data', () => ( {
 				mockFlattenBlocks( mockGetClientIdsTree( '' ) )
 					.filter( ( b ) => b.name === blockName )
 					.map( ( b ) => b.clientId ),
-		} ) ),
+		} ) ) ) as unknown as typeof import('@wordpress/data').useSelect,
 } ) );
 
-jest.mock( '@wordpress/block-editor', () => ( {
+// @ts-expect-error @wordpress/block-editor does not publish TypeScript declarations.
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	store: 'core/block-editor',
 } ) );
 
@@ -405,7 +408,7 @@ describe( 'resolveBlockClientIdByPath', () => {
 			// Override getClientIdsTree to return post content blocks when
 			// called with the post-content clientId (mimicking controlled
 			// inner blocks behavior in useBlockSync).
-			mockGetClientIdsTree = jest.fn( ( rootClientId: string = '' ) => {
+			mockGetClientIdsTree = vi.fn( ( rootClientId: string = '' ) => {
 				if ( rootClientId === '' ) {
 					return templateBlocks;
 				}
@@ -440,7 +443,7 @@ describe( 'resolveBlockClientIdByPath', () => {
 				},
 			];
 
-			mockGetClientIdsTree = jest.fn( ( rootClientId: string = '' ) => {
+			mockGetClientIdsTree = vi.fn( ( rootClientId: string = '' ) => {
 				if ( rootClientId === '' ) {
 					return templateBlocks;
 				}
@@ -487,7 +490,7 @@ describe( 'resolveBlockClientIdByPath', () => {
 				},
 			];
 
-			mockGetClientIdsTree = jest.fn( ( rootClientId: string = '' ) => {
+			mockGetClientIdsTree = vi.fn( ( rootClientId: string = '' ) => {
 				if ( rootClientId === '' ) {
 					return templateBlocks;
 				}
@@ -519,7 +522,7 @@ describe( 'resolveBlockClientIdByPath', () => {
 				},
 			];
 
-			mockGetClientIdsTree = jest.fn( ( rootClientId: string = '' ) => {
+			mockGetClientIdsTree = vi.fn( ( rootClientId: string = '' ) => {
 				if ( rootClientId === '' ) {
 					return postContentBlocks;
 				}
@@ -551,7 +554,7 @@ describe( 'resolveBlockClientIdByPath', () => {
 				},
 			];
 
-			mockGetClientIdsTree = jest.fn( ( rootClientId: string = '' ) => {
+			mockGetClientIdsTree = vi.fn( ( rootClientId: string = '' ) => {
 				if ( rootClientId === '' ) {
 					return templateBlocks;
 				}

--- a/packages/core-data/src/awareness/test/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/test/post-editor-awareness.ts
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+	type Mock,
+} from 'vitest';
 import { Y } from '@wordpress/sync';
 import { dispatch, select, subscribe, resolveSelect } from '@wordpress/data';
 
@@ -18,19 +27,16 @@ import { CRDT_RECORD_MAP_KEY } from '../../sync';
 import type { CollaboratorInfo } from '../types';
 
 // Mock WordPress dependencies
-jest.mock( '@wordpress/data', () => ( {
-	dispatch: jest.fn(),
-	select: jest.fn(),
-	subscribe: jest.fn(),
-	resolveSelect: jest.fn(),
-	// Needed because @wordpress/rich-text initialises its store at import time.
-	combineReducers: jest.fn( () => jest.fn( () => ( {} ) ) ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	register: jest.fn(),
-	createSelector: ( selector: Function ) => selector,
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	dispatch: vi.fn(),
+	select: vi.fn(),
+	subscribe: vi.fn(),
+	resolveSelect: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/block-editor', () => ( {
+// @ts-expect-error @wordpress/block-editor does not publish TypeScript declarations.
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	store: 'core/block-editor',
 } ) );
 
@@ -63,10 +69,10 @@ type MockBlock = {
 
 interface MockBlockEditorOverrides {
 	blocks?: MockBlock[];
-	getBlocks?: jest.Mock;
+	getBlocks?: Mock;
 	getBlockName?: string;
-	getSelectionStart?: jest.Mock;
-	getSelectionEnd?: jest.Mock;
+	getSelectionStart?: Mock;
+	getSelectionEnd?: Mock;
 }
 
 type SeededRandom = {
@@ -150,19 +156,17 @@ function mockBlockEditorStore( overrides: MockBlockEditorOverrides = {} ) {
 
 	const getBlocks =
 		overrides.getBlocks ??
-		jest.fn().mockReturnValue( overrides.blocks ?? defaultBlocks );
+		vi.fn().mockReturnValue( overrides.blocks ?? defaultBlocks );
 
-	( select as jest.Mock ).mockReturnValue( {
+	( select as Mock ).mockReturnValue( {
 		getSelectionStart:
-			overrides.getSelectionStart ?? jest.fn().mockReturnValue( {} ),
+			overrides.getSelectionStart ?? vi.fn().mockReturnValue( {} ),
 		getSelectionEnd:
-			overrides.getSelectionEnd ?? jest.fn().mockReturnValue( {} ),
-		getSelectedBlocksInitialCaretPosition: jest
-			.fn()
-			.mockReturnValue( null ),
-		getBlockIndex: jest.fn().mockReturnValue( 0 ),
-		getBlockRootClientId: jest.fn().mockReturnValue( '' ),
-		getBlockName: jest
+			overrides.getSelectionEnd ?? vi.fn().mockReturnValue( {} ),
+		getSelectedBlocksInitialCaretPosition: vi.fn().mockReturnValue( null ),
+		getBlockIndex: vi.fn().mockReturnValue( 0 ),
+		getBlockRootClientId: vi.fn().mockReturnValue( '' ),
+		getBlockName: vi
 			.fn()
 			.mockReturnValue( overrides.getBlockName ?? 'core/paragraph' ),
 		getBlocks,
@@ -292,41 +296,41 @@ function createNestedAttributeBlock(
 describe( 'PostEditorAwareness', () => {
 	let doc: Y.Doc;
 	let subscribeCallback: ( () => void ) | null = null;
-	let mockEditEntityRecord: jest.Mock;
+	let mockEditEntityRecord: Mock;
 
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		doc = createTestDocWithBlocks();
 
 		mockUserAgent(
 			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
 		);
 
-		jest.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
+		vi.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
 
 		mockBlockEditorStore();
 
 		// Mock subscribe to capture the callback
-		( subscribe as jest.Mock ).mockImplementation( ( callback ) => {
+		( subscribe as Mock ).mockImplementation( ( callback ) => {
 			subscribeCallback = callback;
-			return jest.fn(); // unsubscribe
+			return vi.fn(); // unsubscribe
 		} );
 
 		// Mock dispatch
-		mockEditEntityRecord = jest.fn();
-		( dispatch as jest.Mock ).mockReturnValue( {
+		mockEditEntityRecord = vi.fn();
+		( dispatch as Mock ).mockReturnValue( {
 			editEntityRecord: mockEditEntityRecord,
 		} );
 
 		// Mock resolveSelect for getCurrentUser
-		( resolveSelect as jest.Mock ).mockReturnValue( {
-			getCurrentUser: jest.fn().mockResolvedValue( createMockUser() ),
+		( resolveSelect as Mock ).mockReturnValue( {
+			getCurrentUser: vi.fn().mockResolvedValue( createMockUser() ),
 		} );
 	} );
 
 	afterEach( () => {
-		jest.useRealTimers();
-		jest.restoreAllMocks();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
 		subscribeCallback = null;
 		doc.destroy();
 	} );
@@ -402,7 +406,7 @@ describe( 'PostEditorAwareness', () => {
 		} );
 
 		test( 'should trigger update when selection changes', () => {
-			const mockGetSelectionStart = jest
+			const mockGetSelectionStart = vi
 				.fn()
 				.mockReturnValueOnce( {} )
 				.mockReturnValueOnce( {
@@ -411,7 +415,7 @@ describe( 'PostEditorAwareness', () => {
 					offset: 5,
 				} );
 
-			const mockGetSelectionEnd = jest
+			const mockGetSelectionEnd = vi
 				.fn()
 				.mockReturnValueOnce( {} )
 				.mockReturnValueOnce( {
@@ -451,7 +455,7 @@ describe( 'PostEditorAwareness', () => {
 		} );
 
 		test( 'should debounce local cursor updates', () => {
-			const mockGetSelectionStart = jest
+			const mockGetSelectionStart = vi
 				.fn()
 				.mockReturnValueOnce( {} )
 				.mockReturnValueOnce( {
@@ -460,7 +464,7 @@ describe( 'PostEditorAwareness', () => {
 					offset: 5,
 				} );
 
-			const mockGetSelectionEnd = jest
+			const mockGetSelectionEnd = vi
 				.fn()
 				.mockReturnValueOnce( {} )
 				.mockReturnValueOnce( {
@@ -486,7 +490,7 @@ describe( 'PostEditorAwareness', () => {
 			subscribeCallback?.();
 
 			// Advance timers past debounce
-			jest.advanceTimersByTime( 10 );
+			vi.advanceTimersByTime( 10 );
 
 			// Should have processed the debounced update
 			expect( mockEditEntityRecord ).toHaveBeenCalled();
@@ -516,7 +520,7 @@ describe( 'PostEditorAwareness', () => {
 			} );
 
 			// Subscribe to track updates
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 
 			// Emit change event
@@ -558,7 +562,7 @@ describe( 'PostEditorAwareness', () => {
 
 			awareness.setLocalStateField( 'editorState', {} );
 
-			const callback = jest.fn();
+			const callback = vi.fn();
 			awareness.onStateChange( callback );
 
 			awareness.emit( 'change', [
@@ -884,7 +888,7 @@ describe( 'PostEditorAwareness', () => {
 				'post',
 				123
 			);
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			awareness.onStateChange( callback );
 			awareness.setUp();

--- a/packages/core-data/src/awareness/test/typed-awareness.ts
+++ b/packages/core-data/src/awareness/test/typed-awareness.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 /**
  * WordPress dependencies

--- a/packages/core-data/src/awareness/test/utils.ts
+++ b/packages/core-data/src/awareness/test/utils.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { areCollaboratorInfosEqual, generateCollaboratorInfo } from '../utils';
@@ -174,11 +179,11 @@ describe( 'Awareness Utils', () => {
 			mockUserAgent(
 				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
 			);
-			jest.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
+			vi.spyOn( Date, 'now' ).mockReturnValue( 1704067200000 );
 		} );
 
 		afterEach( () => {
-			jest.restoreAllMocks();
+			vi.restoreAllMocks();
 		} );
 
 		test( 'should generate collaboratorInfo with user properties', () => {

--- a/packages/core-data/src/batch/test/create-batch.js
+++ b/packages/core-data/src/batch/test/create-batch.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import createBatch from '../create-batch';
@@ -71,7 +76,7 @@ describe( 'createBatch', () => {
 	} );
 
 	test( 'running resets the batch when finished', async () => {
-		const processor = jest.fn( async ( inputs ) =>
+		const processor = vi.fn( async ( inputs ) =>
 			inputs.map( ( input ) => ( {
 				output: input,
 			} ) )

--- a/packages/core-data/src/batch/test/default-processor.js
+++ b/packages/core-data/src/batch/test/default-processor.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -8,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import defaultProcessor from '../default-processor';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/api-fetch' );
 
 describe( 'defaultProcessor', () => {
 	const preflightResponse = {

--- a/packages/core-data/src/components/entities-saved-states/test/use-is-dirty.js
+++ b/packages/core-data/src/components/entities-saved-states/test/use-is-dirty.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
 /**
@@ -8,12 +9,12 @@ import { act, renderHook } from '@testing-library/react';
  */
 import { useIsDirty } from '../hooks/use-is-dirty';
 
-jest.mock( '@wordpress/data', () => {
+vi.mock( '@wordpress/data', () => {
 	return {
-		useSelect: jest.fn().mockImplementation( ( fn ) => {
+		useSelect: vi.fn().mockImplementation( ( fn ) => {
 			const select = () => {
 				return {
-					__experimentalGetDirtyEntityRecords: jest
+					__experimentalGetDirtyEntityRecords: vi
 						.fn()
 						.mockReturnValue( [
 							{
@@ -29,10 +30,10 @@ jest.mock( '@wordpress/data', () => {
 								property: 'property',
 							},
 						] ),
-					getEntityRecordEdits: jest.fn().mockReturnValue( {
+					getEntityRecordEdits: vi.fn().mockReturnValue( {
 						title: 'My Site',
 					} ),
-					getEntityConfig: jest.fn().mockReturnValue( {
+					getEntityConfig: vi.fn().mockReturnValue( {
 						meta: { labels: { title: 'Title' } },
 					} ),
 				};

--- a/packages/core-data/src/entity-types/test/attachment.test.ts
+++ b/packages/core-data/src/entity-types/test/attachment.test.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Tests for the Attachment type against real REST API responses.
  *
  * These tests validate the Attachment type definition by comparing it with

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -7,8 +12,8 @@ import {
 	tokenize,
 } from '../__experimental-fetch-link-suggestions';
 
-jest.mock( '@wordpress/api-fetch', () =>
-	jest.fn( ( { path } ) => {
+vi.mock( '@wordpress/api-fetch', () => ( {
+	default: vi.fn( ( { path } ) => {
 		switch ( path ) {
 			case '/wp/v2/search?search=&per_page=20&type=post':
 			case '/wp/v2/search?search=Contact&per_page=20&type=post&subtype=page':
@@ -96,8 +101,8 @@ jest.mock( '@wordpress/api-fetch', () =>
 					},
 				] );
 		}
-	} )
-);
+	} ),
+} ) );
 
 describe( 'fetchLinkSuggestions', () => {
 	it( 'filters suggestions by post-type', () => {

--- a/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-url-data.js
@@ -1,13 +1,19 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import fetchUrlData from '../__experimental-fetch-url-data';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 
-jest.mock( '@wordpress/api-fetch' );
+/**
+ * Internal dependencies
+ */
+import fetchUrlData from '../__experimental-fetch-url-data';
+
+vi.mock( '@wordpress/api-fetch' );
 
 describe( 'fetchUrlData', () => {
 	afterEach( () => {

--- a/packages/core-data/src/hooks/test/use-entity-record.jsx
+++ b/packages/core-data/src/hooks/test/use-entity-record.jsx
@@ -1,10 +1,15 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/api-fetch' );
 
 /**
  * External dependencies

--- a/packages/core-data/src/hooks/test/use-entity-records.jsx
+++ b/packages/core-data/src/hooks/test/use-entity-records.jsx
@@ -1,10 +1,15 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/api-fetch' );
 
 /**
  * External dependencies

--- a/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
+++ b/packages/core-data/src/hooks/test/use-post-editor-awareness-state.ts
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+	type Mock,
+} from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 /**
@@ -24,16 +33,16 @@ import type {
 import type { SelectionCursor } from '../../types';
 
 // Mock the sync module
-jest.mock( '../../sync', () => ( {
-	getSyncManager: jest.fn(),
+vi.mock( import( '../../sync' ), () => ( {
+	getSyncManager: vi.fn(),
 } ) );
 
 const mockPostContentBlocks = [
 	{ clientId: 'block-1', name: 'core/paragraph', innerBlocks: [] },
 ];
 
-jest.mock( '../../awareness/block-lookup', () => ( {
-	usePostContentBlocks: jest.fn( () => mockPostContentBlocks ),
+vi.mock( import( '../../awareness/block-lookup' ), () => ( {
+	usePostContentBlocks: vi.fn( () => mockPostContentBlocks ),
 } ) );
 
 const mockAvatarUrls = {
@@ -72,17 +81,17 @@ const createMockDebugData = (): YDocDebugData => ( {
 
 describe( 'use-post-editor-awareness-state hooks', () => {
 	let mockAwareness: {
-		setUp: jest.Mock;
-		getCurrentState: jest.Mock;
-		onStateChange: jest.Mock;
-		convertSelectionStateToAbsolute: jest.Mock;
-		getDebugData: jest.Mock;
+		setUp: Mock;
+		getCurrentState: Mock;
+		onStateChange: Mock;
+		convertSelectionStateToAbsolute: Mock;
+		getDebugData: Mock;
 		doc: {
-			getMap: jest.Mock;
+			getMap: Mock;
 		};
 	};
 	let mockSyncManager: {
-		getAwareness: jest.Mock;
+		getAwareness: Mock;
 	};
 	let stateChangeCallback:
 		| ( ( newState: PostEditorAwarenessState[] ) => void )
@@ -100,28 +109,28 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		mockRecordMapData = {};
 
 		const mockStateMap = {
-			get: jest.fn( ( key: string ) => mockStateMapData[ key ] ),
-			observe: jest.fn( ( observer: typeof stateMapObserver ) => {
+			get: vi.fn( ( key: string ) => mockStateMapData[ key ] ),
+			observe: vi.fn( ( observer: typeof stateMapObserver ) => {
 				stateMapObserver = observer;
 			} ),
-			unobserve: jest.fn(),
+			unobserve: vi.fn(),
 		};
 
 		const mockRecordMap = {
-			get: jest.fn( ( key: string ) => mockRecordMapData[ key ] ),
+			get: vi.fn( ( key: string ) => mockRecordMapData[ key ] ),
 		};
 
 		mockAwareness = {
-			setUp: jest.fn(),
-			getCurrentState: jest.fn().mockReturnValue( [] ),
-			onStateChange: jest.fn( ( callback ) => {
+			setUp: vi.fn(),
+			getCurrentState: vi.fn().mockReturnValue( [] ),
+			onStateChange: vi.fn( ( callback ) => {
 				stateChangeCallback = callback;
-				return jest.fn(); // unsubscribe function
+				return vi.fn(); // unsubscribe function
 			} ),
-			convertSelectionStateToAbsolute: jest.fn().mockReturnValue( null ),
-			getDebugData: jest.fn().mockReturnValue( createMockDebugData() ),
+			convertSelectionStateToAbsolute: vi.fn().mockReturnValue( null ),
+			getDebugData: vi.fn().mockReturnValue( createMockDebugData() ),
 			doc: {
-				getMap: jest.fn( ( name: string ) => {
+				getMap: vi.fn( ( name: string ) => {
 					if ( name === 'state' ) {
 						return mockStateMap;
 					}
@@ -134,14 +143,14 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		};
 
 		mockSyncManager = {
-			getAwareness: jest.fn().mockReturnValue( mockAwareness ),
+			getAwareness: vi.fn().mockReturnValue( mockAwareness ),
 		};
 
-		( getSyncManager as jest.Mock ).mockReturnValue( mockSyncManager );
+		( getSyncManager as Mock ).mockReturnValue( mockSyncManager );
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'useActiveUsers', () => {
@@ -164,7 +173,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should return empty array when getSyncManager returns undefined', () => {
-			( getSyncManager as jest.Mock ).mockReturnValue( undefined );
+			( getSyncManager as Mock ).mockReturnValue( undefined );
 
 			const { result } = renderHook( () =>
 				useActiveCollaborators( 123, 'post' )
@@ -238,7 +247,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should unsubscribe when postId changes', () => {
-			const unsubscribe = jest.fn();
+			const unsubscribe = vi.fn();
 			mockAwareness.onStateChange.mockReturnValue( unsubscribe );
 
 			const { rerender } = renderHook(
@@ -254,7 +263,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should unsubscribe when postType changes', () => {
-			const unsubscribe = jest.fn();
+			const unsubscribe = vi.fn();
 			mockAwareness.onStateChange.mockReturnValue( unsubscribe );
 
 			const { rerender } = renderHook(
@@ -447,7 +456,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 
 	describe( 'hook cleanup', () => {
 		test( 'should unsubscribe on unmount', () => {
-			const unsubscribe = jest.fn();
+			const unsubscribe = vi.fn();
 			mockAwareness.onStateChange.mockReturnValue( unsubscribe );
 
 			const { unmount } = renderHook( () =>
@@ -558,7 +567,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire on initial mount', () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
@@ -567,7 +576,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire when collaborators load after initially empty state', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [] );
 
 			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
@@ -583,7 +592,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should fire callback when a new collaborator joins', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me ] );
 
 			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
@@ -599,7 +608,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire callback for the current user', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [] );
 
 			renderHook( () => useOnCollaboratorJoin( 123, 'post', callback ) );
@@ -620,7 +629,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire when postId is null', () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			renderHook( () => useOnCollaboratorJoin( null, 'post', callback ) );
 
@@ -650,7 +659,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should fire callback when a connected collaborator disconnects', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
@@ -669,7 +678,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should fire callback when a connected collaborator disappears from the list', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
@@ -685,7 +694,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire callback when an already-disconnected collaborator is removed', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			const disconnectedAlice = { ...alice, isConnected: false };
 			mockAwareness.getCurrentState.mockReturnValue( [
 				me,
@@ -705,7 +714,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire callback for the current user disconnecting', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
@@ -724,7 +733,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire on initial mount', () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnCollaboratorLeave( 123, 'post', callback ) );
@@ -753,7 +762,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should fire callback when a remote collaborator saves', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnPostSave( 123, 'post', callback ) );
@@ -786,7 +795,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should pass previous save event on subsequent saves', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnPostSave( 123, 'post', callback ) );
@@ -843,7 +852,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire callback when the current user saves', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnPostSave( 123, 'post', callback ) );
@@ -868,7 +877,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire callback when saver is not in the collaborator list', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me ] );
 
 			renderHook( () => useOnPostSave( 123, 'post', callback ) );
@@ -893,7 +902,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire duplicate callbacks for the same savedAt timestamp', async () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 			mockAwareness.getCurrentState.mockReturnValue( [ me, alice ] );
 
 			renderHook( () => useOnPostSave( 123, 'post', callback ) );
@@ -928,7 +937,7 @@ describe( 'use-post-editor-awareness-state hooks', () => {
 		} );
 
 		test( 'should not fire when postId is null', () => {
-			const callback = jest.fn();
+			const callback = vi.fn();
 
 			renderHook( () => useOnPostSave( null, 'post', callback ) );
 

--- a/packages/core-data/src/hooks/test/use-query-select.jsx
+++ b/packages/core-data/src/hooks/test/use-query-select.jsx
@@ -1,4 +1,18 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -6,11 +20,6 @@ import {
 	createRegistry,
 	RegistryProvider,
 } from '@wordpress/data';
-
-/**
- * External dependencies
- */
-import { render, screen, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -52,8 +61,8 @@ describe( 'useQuerySelect', () => {
 	};
 
 	it( 'passes the relevant data to the component', () => {
-		const selectSpy = jest.fn();
-		const TestComponent = jest
+		const selectSpy = vi.fn();
+		const TestComponent = vi
 			.fn()
 			.mockImplementation( getTestComponent( selectSpy, 'keyName' ) );
 		render(
@@ -71,7 +80,7 @@ describe( 'useQuerySelect', () => {
 
 	it( 'uses memoized selectors', () => {
 		const selectors = [];
-		const TestComponent = jest.fn().mockImplementation( ( props ) => {
+		const TestComponent = vi.fn().mockImplementation( ( props ) => {
 			useQuerySelect(
 				function ( query ) {
 					selectors.push( query( 'testStore' ) );
@@ -110,7 +119,7 @@ describe( 'useQuerySelect', () => {
 
 	it( 'returns the expected "response" details – no resolvers and arguments', () => {
 		let querySelectData;
-		const TestComponent = jest.fn().mockImplementation( () => {
+		const TestComponent = vi.fn().mockImplementation( () => {
 			querySelectData = useQuerySelect( function ( query ) {
 				return query( 'testStore' ).getFoo();
 			}, [] );
@@ -160,7 +169,7 @@ describe( 'useQuerySelect', () => {
 		);
 
 		let querySelectData;
-		const TestComponent = jest.fn().mockImplementation( () => {
+		const TestComponent = vi.fn().mockImplementation( () => {
 			querySelectData = useQuerySelect( function ( query ) {
 				return query( 'resolverStore' ).getResolvedFoo( 10 );
 			}, [] );

--- a/packages/core-data/src/hooks/test/use-resource-permissions.jsx
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.jsx
@@ -1,10 +1,15 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/api-fetch' );
 
 /**
  * External dependencies

--- a/packages/core-data/src/locks/test/engine.js
+++ b/packages/core-data/src/locks/test/engine.js
@@ -1,10 +1,12 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import createLocks from '../engine';
-
-// We correctly await all promises with expect calls, but the rule doesn't detect that.
-/* eslint-disable jest/valid-expect-in-promise */
 
 describe( 'Locks engine', () => {
 	it( 'does not grant two exclusive locks at once', async () => {
@@ -129,5 +131,3 @@ describe( 'Locks engine', () => {
 		expect( l2 ).not.toBeUndefined();
 	} );
 } );
-
-/* eslint-enable jest/valid-expect-in-promise */

--- a/packages/core-data/src/locks/test/reducer.js
+++ b/packages/core-data/src/locks/test/reducer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/core-data/src/locks/test/selectors.js
+++ b/packages/core-data/src/locks/test/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/core-data/src/locks/test/utils.js
+++ b/packages/core-data/src/locks/test/utils.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/core-data/src/queried-data/test/actions.js
+++ b/packages/core-data/src/queried-data/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { removeItems } from '../actions';

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getQueryParts } from '../get-query-parts';

--- a/packages/core-data/src/queried-data/test/reducer.js
+++ b/packages/core-data/src/queried-data/test/reducer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -90,7 +91,7 @@ describe( 'getMergedItemIds', () => {
 			perPage: 3,
 		} );
 
-		expect( result ).toEqual( [ 1, 2 ] );
+		expect( result ).toEqual( [ 1, 2, undefined ] );
 
 		original = deepFreeze( [ 1, 2, 3, 4, 5, 6 ] );
 		result = getMergedItemIds( original, [ 9 ], {

--- a/packages/core-data/src/queried-data/test/selectors.js
+++ b/packages/core-data/src/queried-data/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getQueriedItems } from '../selectors';

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,9 +1,14 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/api-fetch' );
 
 /**
  * Internal dependencies
@@ -21,8 +26,8 @@ import {
 } from '../actions';
 import { getSyncManager } from '../sync';
 
-jest.mock( '../batch', () => {
-	const { createBatch } = jest.requireActual( '../batch' );
+vi.mock( import( '../batch' ), async ( importOriginal ) => {
+	const { createBatch } = await importOriginal();
 	return {
 		createBatch() {
 			return createBatch( ( inputs ) => Promise.resolve( inputs ) );
@@ -30,8 +35,8 @@ jest.mock( '../batch', () => {
 	};
 } );
 
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
+vi.mock( '../sync', () => ( {
+	getSyncManager: vi.fn(),
 	LOCAL_EDITOR_ORIGIN: 'local-editor',
 	LOCAL_UNDO_IGNORED_ORIGIN: 'local-undo-ignored',
 } ) );
@@ -44,7 +49,7 @@ describe( 'editEntityRecord', () => {
 			id: 'someId',
 		};
 		const select = {
-			getEntityConfig: jest.fn(),
+			getEntityConfig: vi.fn(),
 		};
 		const fulfillment = async () =>
 			editEntityRecord(
@@ -60,7 +65,7 @@ describe( 'editEntityRecord', () => {
 	} );
 
 	it( 'dispatches the correct action for non-merged edits', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -78,7 +83,7 @@ describe( 'editEntityRecord', () => {
 				content: 'Original Content',
 			} ),
 			getUndoManager: () => ( {
-				addRecord: jest.fn(),
+				addRecord: vi.fn(),
 			} ),
 		};
 
@@ -97,7 +102,7 @@ describe( 'editEntityRecord', () => {
 	} );
 
 	it( 'merges edits for fields defined in mergedEdits config', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -116,7 +121,7 @@ describe( 'editEntityRecord', () => {
 				},
 			} ),
 			getUndoManager: () => ( {
-				addRecord: jest.fn(),
+				addRecord: vi.fn(),
 			} ),
 		};
 
@@ -143,7 +148,7 @@ describe( 'editEntityRecord', () => {
 	} );
 
 	it( 'handles both merged and non-merged edits together', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -161,7 +166,7 @@ describe( 'editEntityRecord', () => {
 				meta: { existingKey: 'existingValue' },
 			} ),
 			getUndoManager: () => ( {
-				addRecord: jest.fn(),
+				addRecord: vi.fn(),
 			} ),
 		};
 
@@ -186,7 +191,7 @@ describe( 'editEntityRecord', () => {
 	} );
 
 	it( 'clears edit when merged value equals persisted record', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -202,7 +207,7 @@ describe( 'editEntityRecord', () => {
 				meta: { key1: 'value1' },
 			} ),
 			getUndoManager: () => ( {
-				addRecord: jest.fn(),
+				addRecord: vi.fn(),
 			} ),
 		};
 
@@ -224,7 +229,7 @@ describe( 'editEntityRecord', () => {
 	} );
 
 	it( 'clears non-merged edit when value equals persisted record', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -240,7 +245,7 @@ describe( 'editEntityRecord', () => {
 				title: 'Edited Title',
 			} ),
 			getUndoManager: () => ( {
-				addRecord: jest.fn(),
+				addRecord: vi.fn(),
 			} ),
 		};
 
@@ -266,7 +271,7 @@ describe( 'editEntityRecord', () => {
 		beforeEach( () => {
 			// Create a mock sync manager
 			syncManager = {
-				update: jest.fn(),
+				update: vi.fn(),
 			};
 			getSyncManager.mockReturnValue( syncManager );
 		} );
@@ -276,7 +281,7 @@ describe( 'editEntityRecord', () => {
 		} );
 
 		it( 'passes merged edits to SyncManager#update for merged fields', () => {
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 			const select = {
 				getEntityConfig: () => ( {
 					kind: 'postType',
@@ -296,7 +301,7 @@ describe( 'editEntityRecord', () => {
 					},
 				} ),
 				getUndoManager: () => ( {
-					addRecord: jest.fn(),
+					addRecord: vi.fn(),
 				} ),
 			};
 
@@ -324,7 +329,7 @@ describe( 'editEntityRecord', () => {
 		} );
 
 		it( 'passes merged edits to SyncManager#update even when value equals persisted record', () => {
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 			const select = {
 				getEntityConfig: () => ( {
 					kind: 'postType',
@@ -341,7 +346,7 @@ describe( 'editEntityRecord', () => {
 					meta: { key1: 'value1' },
 				} ),
 				getUndoManager: () => ( {
-					addRecord: jest.fn(),
+					addRecord: vi.fn(),
 				} ),
 			};
 
@@ -377,7 +382,7 @@ describe( 'editEntityRecord', () => {
 		} );
 
 		it( 'passes merged and non-merged edits correctly to SyncManager#update', () => {
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 			const select = {
 				getEntityConfig: () => ( {
 					kind: 'postType',
@@ -396,7 +401,7 @@ describe( 'editEntityRecord', () => {
 					meta: { existingKey: 'existingValue' },
 				} ),
 				getUndoManager: () => ( {
-					addRecord: jest.fn(),
+					addRecord: vi.fn(),
 				} ),
 			};
 
@@ -422,7 +427,7 @@ describe( 'editEntityRecord', () => {
 		} );
 
 		it( 'does not call SyncManager#update when syncConfig is not defined', () => {
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 			const select = {
 				getEntityConfig: () => ( {
 					kind: 'postType',
@@ -439,7 +444,7 @@ describe( 'editEntityRecord', () => {
 					meta: { existingKey: 'existingValue' },
 				} ),
 				getUndoManager: () => ( {
-					addRecord: jest.fn(),
+					addRecord: vi.fn(),
 				} ),
 			};
 
@@ -459,7 +464,7 @@ describe( 'editEntityRecord', () => {
 describe( 'clearEntityRecordEdits', () => {
 	it( 'throws when the entity does not have a loaded config.', async () => {
 		const select = {
-			getEntityConfig: jest.fn(),
+			getEntityConfig: vi.fn(),
 		};
 		const fulfillment = async () =>
 			clearEntityRecordEdits(
@@ -473,7 +478,7 @@ describe( 'clearEntityRecordEdits', () => {
 	} );
 
 	it( 'does nothing when there are no edits', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -495,7 +500,7 @@ describe( 'clearEntityRecordEdits', () => {
 	} );
 
 	it( 'clears all edits for an entity record', () => {
-		const dispatch = jest.fn();
+		const dispatch = vi.fn();
 		const select = {
 			getEntityConfig: () => ( {
 				kind: 'postType',
@@ -545,12 +550,12 @@ describe( 'deleteEntityRecord', () => {
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		// Provide response
 		apiFetch.mockImplementation( () => deletedRecord );
@@ -596,12 +601,12 @@ describe( 'deleteEntityRecord', () => {
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => entities ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => entities ) };
 
 		// Provide response
 		apiFetch.mockImplementation( () => {
@@ -626,12 +631,12 @@ describe( 'deleteEntityRecord', () => {
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => entities ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => entities ) };
 
 		// Provide response
 		apiFetch.mockImplementation( () => {
@@ -671,10 +676,10 @@ describe( 'saveEditedEntityRecord', () => {
 			hasEditsForEntityRecord: () => true,
 		};
 
-		const dispatch = Object.assign( jest.fn(), {
-			saveEntityRecord: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			saveEntityRecord: vi.fn(),
 		} );
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		// Provide response
 		const updatedRecord = { ...item, menu: 10 };
@@ -711,10 +716,10 @@ describe( 'saveEditedEntityRecord', () => {
 			hasEditsForEntityRecord: () => true,
 		};
 
-		const dispatch = Object.assign( jest.fn(), {
-			saveEntityRecord: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			saveEntityRecord: vi.fn(),
 		} );
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		// Provide response
 		const updatedRecord = { ...item, menu: 10 };
@@ -742,10 +747,10 @@ describe( 'saveEntityRecord', () => {
 
 	beforeEach( async () => {
 		apiFetch.mockReset();
-		dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
 	} );
 
@@ -757,7 +762,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		// Provide response
 		const updatedRecord = { ...post, id: 10 };
@@ -822,7 +827,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => entities ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => entities ) };
 
 		// Provide response
 		apiFetch.mockImplementation( () => {
@@ -844,7 +849,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => entities ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => entities ) };
 
 		// Provide response
 		apiFetch.mockImplementation( () => {
@@ -866,7 +871,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		// Provide response
 		const updatedRecord = { ...post, id: 10 };
@@ -938,7 +943,7 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(
+			update: vi.fn(
 				( _objectType, _objectId, changes, _origin, options ) => {
 					if (
 						Object.prototype.hasOwnProperty.call( changes, 'title' )
@@ -954,7 +959,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => post,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		const staleSaveResponse = { ...post, title: 'initial title' };
 		apiFetch.mockImplementation( () => {
@@ -1002,12 +1007,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			...persistedRecord,
 			content: edits.content,
@@ -1068,12 +1073,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			...persistedRecord,
 			content: edits.content,
@@ -1137,12 +1142,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			id: 10,
 			meta: {
@@ -1198,9 +1203,9 @@ describe( 'saveEntityRecord', () => {
 			template: 'page-no-title',
 		};
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
-		const prePersist = jest.fn( async () => {
+		const prePersist = vi.fn( async () => {
 			expect( syncManager.update ).toHaveBeenCalledTimes( 1 );
 			expect( syncManager.update ).toHaveBeenLastCalledWith(
 				'postType/page',
@@ -1223,7 +1228,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			...persistedRecord,
 			...edits,
@@ -1274,12 +1279,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const error = new Error( 'API error' );
 		apiFetch.mockRejectedValue( error );
 		getSyncManager.mockReturnValue( syncManager );
@@ -1317,12 +1322,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			id: 10,
 			slug: 'needs-normalizing',
@@ -1374,12 +1379,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			id: 10,
 			title: { raw: 'Initial title', rendered: 'Initial title' },
@@ -1432,12 +1437,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			id: 10,
 			content: {
@@ -1487,12 +1492,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => persistedRecord,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		// The server strips disallowed markup from the sent content.
 		const updatedRecord = {
 			id: 10,
@@ -1536,12 +1541,12 @@ describe( 'saveEntityRecord', () => {
 			},
 		];
 		const syncManager = {
-			update: jest.fn(),
+			update: vi.fn(),
 		};
 		const select = {
 			getRawEntityRecord: () => undefined,
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 		const updatedRecord = {
 			id: 10,
 			content: 'Updated content',
@@ -1580,7 +1585,7 @@ describe( 'saveEntityRecord', () => {
 		const select = {
 			getRawEntityRecord: () => ( {} ),
 		};
-		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const resolveSelect = { getEntitiesConfig: vi.fn( () => configs ) };
 
 		// Provide response
 		apiFetch.mockImplementation( () => postType );
@@ -1691,19 +1696,19 @@ describe( 'receiveCurrentUser', () => {
 describe( '__experimentalBatch', () => {
 	it( 'batches multiple actions together', async () => {
 		const dispatch = {
-			saveEntityRecord: jest.fn(
+			saveEntityRecord: vi.fn(
 				( kind, name, record, { __unstableFetch } ) => {
 					__unstableFetch( {} );
 					return { id: 123, created: true };
 				}
 			),
-			saveEditedEntityRecord: jest.fn(
+			saveEditedEntityRecord: vi.fn(
 				( kind, name, recordId, { __unstableFetch } ) => {
 					__unstableFetch( {} );
 					return { id: 123, updated: true };
 				}
 			),
-			deleteEntityRecord: jest.fn(
+			deleteEntityRecord: vi.fn(
 				( kind, name, recordId, query, { __unstableFetch } ) => {
 					__unstableFetch( {} );
 					return { id: 123, deleted: true };

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
@@ -9,13 +14,13 @@ import { createRegistry } from '@wordpress/data';
  */
 import { store as coreDataStore } from '../index';
 
-jest.mock( '@wordpress/deprecated' );
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/deprecated' );
+vi.mock( '@wordpress/api-fetch' );
 
 // Use fake timers within this file.
 // logEntityDeprecation() uses setTimeout() to avoid spurious logging, so fake timers are used to
 // ensure that the deprecation warning is logged correctly.
-jest.useFakeTimers();
+vi.useFakeTimers();
 
 /**
  * Returns the expected arguments for the deprecated function call.
@@ -94,7 +99,7 @@ function createTestRegistry() {
 		.dispatch( coreDataStore )
 		.receiveEntityRecords( 'root', 'media', mediaRecord );
 
-	jest.runAllTimers();
+	vi.advanceTimersByTime( 0 );
 
 	return registry;
 }

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -1,16 +1,21 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 
-jest.mock( '@wordpress/api-fetch' );
-jest.mock( '../sync', () => ( {
-	...jest.requireActual( '../sync' ),
-	getSyncManager: jest.fn(),
+vi.mock( '@wordpress/api-fetch' );
+vi.mock( import( '../sync' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	getSyncManager: vi.fn(),
 } ) );
-jest.mock( '../utils/crdt', () => ( {
-	...jest.requireActual( '../utils/crdt' ),
-	applyPostChangesToCRDTDoc: jest.fn(),
+vi.mock( import( '../utils/crdt' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	applyPostChangesToCRDTDoc: vi.fn(),
 } ) );
 
 /**
@@ -111,7 +116,7 @@ describe( 'prePersistPostType', () => {
 	it( 'adds meta with serialized CRDT doc when createPersistedCRDTDoc returns a value', async () => {
 		const mockSerializedDoc = 'serialized-crdt-doc-data';
 		getSyncManager.mockReturnValue( {
-			createPersistedCRDTDoc: jest
+			createPersistedCRDTDoc: vi
 				.fn()
 				.mockReturnValue( mockSerializedDoc ),
 		} );

--- a/packages/core-data/src/test/entity-provider.jsx
+++ b/packages/core-data/src/test/entity-provider.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act, render } from '@testing-library/react';
 
 /**

--- a/packages/core-data/src/test/private-actions.js
+++ b/packages/core-data/src/test/private-actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -9,10 +14,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { editMediaEntity, setCollaborationSupported } from '../private-actions';
 import { getSyncManager, hasSyncManager } from '../sync';
 
-jest.mock( '@wordpress/api-fetch' );
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
-	hasSyncManager: jest.fn(),
+vi.mock( '@wordpress/api-fetch' );
+vi.mock( '../sync', () => ( {
+	getSyncManager: vi.fn(),
+	hasSyncManager: vi.fn(),
 } ) );
 
 describe( 'editMediaEntity', () => {
@@ -21,13 +26,13 @@ describe( 'editMediaEntity', () => {
 
 	beforeEach( () => {
 		apiFetch.mockReset();
-		dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn( () => 'test-lock' ),
-			__unstableReleaseStoreLock: jest.fn(),
+		dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn( () => 'test-lock' ),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
 		resolveSelect = {
-			getEntitiesConfig: jest.fn( () => [
+			getEntitiesConfig: vi.fn( () => [
 				{
 					kind: 'postType',
 					name: 'attachment',
@@ -184,7 +189,7 @@ describe( 'editMediaEntity', () => {
 	it( 'should use custom fetch function when provided', async () => {
 		const recordId = 123;
 		const edits = { src: 'https://example.com/image.jpg' };
-		const customFetch = jest.fn().mockResolvedValue( { id: recordId } );
+		const customFetch = vi.fn().mockResolvedValue( { id: recordId } );
 
 		await editMediaEntity( recordId, edits, {
 			__unstableFetch: customFetch,
@@ -225,10 +230,10 @@ describe( 'setCollaborationSupported', () => {
 
 	it( 'unloads sync and resets sync undo state when disabling collaboration', () => {
 		const syncManager = {
-			unloadAll: jest.fn(),
+			unloadAll: vi.fn(),
 		};
-		const dispatch = Object.assign( jest.fn(), {
-			__unstableNotifySyncUndoManagerChange: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			__unstableNotifySyncUndoManagerChange: vi.fn(),
 		} );
 		hasSyncManager.mockReturnValue( true );
 		getSyncManager.mockReturnValue( syncManager );

--- a/packages/core-data/src/test/private-selectors.js
+++ b/packages/core-data/src/test/private-selectors.js
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getUndoManager } from '../private-selectors';
 import { getSyncManager } from '../sync';
 
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
+vi.mock( '../sync', () => ( {
+	getSyncManager: vi.fn(),
 } ) );
 
 describe( 'getUndoManager', () => {
@@ -15,18 +20,18 @@ describe( 'getUndoManager', () => {
 
 	it( 'returns the sync undo manager when one is available', () => {
 		const syncUndoManager = {
-			addRecord: jest.fn(),
-			hasRedo: jest.fn(),
-			hasUndo: jest.fn(),
-			redo: jest.fn(),
-			undo: jest.fn(),
+			addRecord: vi.fn(),
+			hasRedo: vi.fn(),
+			hasUndo: vi.fn(),
+			redo: vi.fn(),
+			undo: vi.fn(),
 		};
 		const fallbackUndoManager = {
-			addRecord: jest.fn(),
-			hasRedo: jest.fn(),
-			hasUndo: jest.fn(),
-			redo: jest.fn(),
-			undo: jest.fn(),
+			addRecord: vi.fn(),
+			hasRedo: vi.fn(),
+			hasUndo: vi.fn(),
+			redo: vi.fn(),
+			undo: vi.fn(),
 		};
 		getSyncManager.mockReturnValue( {
 			undoManager: syncUndoManager,
@@ -45,11 +50,11 @@ describe( 'getUndoManager', () => {
 
 	it( 'returns the default undo manager when there is no sync undo manager', () => {
 		const fallbackUndoManager = {
-			addRecord: jest.fn(),
-			hasRedo: jest.fn(),
-			hasUndo: jest.fn(),
-			redo: jest.fn(),
-			undo: jest.fn(),
+			addRecord: vi.fn(),
+			hasRedo: vi.fn(),
+			hasUndo: vi.fn(),
+			redo: vi.fn(),
+			undo: vi.fn(),
 		};
 		getSyncManager.mockReturnValue( undefined );
 

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import triggerFetch from '@wordpress/api-fetch';
@@ -8,9 +13,9 @@ import triggerFetch from '@wordpress/api-fetch';
  */
 import { getSyncManager } from '../sync';
 
-jest.mock( '@wordpress/api-fetch' );
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
+vi.mock( '@wordpress/api-fetch' );
+vi.mock( '../sync', () => ( {
+	getSyncManager: vi.fn(),
 	LOCAL_UNDO_IGNORED_ORIGIN: 'local-undo-ignored',
 } ) );
 
@@ -39,25 +44,25 @@ describe( 'getEntityRecord', () => {
 		},
 	];
 	const registry = { batch: ( callback ) => callback() };
-	const resolveSelect = { getEntitiesConfig: jest.fn( () => ENTITIES ) };
+	const resolveSelect = { getEntitiesConfig: vi.fn( () => ENTITIES ) };
 
 	let dispatch;
 	let syncManager;
 
 	beforeEach( async () => {
-		dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
-			__unstableNotifySyncUndoManagerChange: jest.fn(),
-			receiveUserPermissions: jest.fn(),
-			finishResolutions: jest.fn(),
+		dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
+			__unstableNotifySyncUndoManagerChange: vi.fn(),
+			receiveUserPermissions: vi.fn(),
+			finishResolutions: vi.fn(),
 		} );
 		triggerFetch.mockReset();
 
 		syncManager = {
-			load: jest.fn(),
-			update: jest.fn(),
+			load: vi.fn(),
+			update: vi.fn(),
 		};
 		getSyncManager.mockImplementation( () => syncManager );
 	} );
@@ -147,8 +152,8 @@ describe( 'getEntityRecord', () => {
 		];
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn(),
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn(),
 		};
 
 		triggerFetch.mockImplementation( () => POST_RESPONSE );
@@ -199,10 +204,10 @@ describe( 'getEntityRecord', () => {
 		];
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
 		};
 		const select = {
-			isCollaborationSupported: jest.fn( () => false ),
+			isCollaborationSupported: vi.fn( () => false ),
 		};
 
 		triggerFetch.mockImplementation( () => POST_RESPONSE );
@@ -244,8 +249,8 @@ describe( 'getEntityRecord', () => {
 		];
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn(),
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn(),
 		};
 
 		triggerFetch.mockImplementation( () => POST_RESPONSE );
@@ -285,12 +290,12 @@ describe( 'getEntityRecord', () => {
 			},
 		];
 
-		dispatch.saveEntityRecord = jest.fn();
-		syncManager.createPersistedCRDTDoc = jest.fn();
+		dispatch.saveEntityRecord = vi.fn();
+		syncManager.createPersistedCRDTDoc = vi.fn();
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn( () =>
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn( () =>
 				Promise.resolve( EDITED_RECORD )
 			),
 		};
@@ -345,14 +350,14 @@ describe( 'getEntityRecord', () => {
 			},
 		];
 
-		dispatch.saveEntityRecord = jest.fn();
-		syncManager.createPersistedCRDTDoc = jest.fn( () =>
+		dispatch.saveEntityRecord = vi.fn();
+		syncManager.createPersistedCRDTDoc = vi.fn( () =>
 			Promise.resolve( SERIALIZED_DOC )
 		);
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn( () =>
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn( () =>
 				Promise.resolve( EDITED_RECORD )
 			),
 		};
@@ -414,15 +419,15 @@ describe( 'getEntityRecord', () => {
 			},
 		];
 
-		dispatch.saveEntityRecord = jest.fn();
-		syncManager.createPersistedCRDTDoc = jest.fn( () =>
+		dispatch.saveEntityRecord = vi.fn();
+		syncManager.createPersistedCRDTDoc = vi.fn( () =>
 			Promise.resolve( SERIALIZED_DOC )
 		);
 
 		// Return the same record (no edits) from getEditedEntityRecord.
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn( () =>
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn( () =>
 				Promise.resolve( POST_RECORD )
 			),
 		};
@@ -480,13 +485,13 @@ describe( 'getEntityRecord', () => {
 		];
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn( () =>
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn( () =>
 				Promise.resolve( EDITED_RECORD )
 			),
 		};
-		dispatch.saveEntityRecord = jest.fn();
-		syncManager.createPersistedCRDTDoc = jest.fn();
+		dispatch.saveEntityRecord = vi.fn();
+		syncManager.createPersistedCRDTDoc = vi.fn();
 
 		triggerFetch.mockImplementation( () => TERM_RESPONSE );
 
@@ -532,8 +537,8 @@ describe( 'getEntityRecord', () => {
 		];
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
-			getEditedEntityRecord: jest.fn(),
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: vi.fn(),
 		};
 
 		triggerFetch.mockImplementation( () => POST_RESPONSE );
@@ -584,7 +589,7 @@ describe( 'getEntityRecord', () => {
 		];
 
 		const resolveSelectWithSync = {
-			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
+			getEntitiesConfig: vi.fn( () => ENTITIES_WITH_SYNC ),
 		};
 
 		triggerFetch.mockImplementation( () => POST_RESPONSE );
@@ -631,17 +636,17 @@ describe( 'getEntityRecords', () => {
 		},
 	];
 	const registry = { batch: ( callback ) => callback() };
-	const resolveSelect = { getEntitiesConfig: jest.fn( () => ENTITIES ) };
+	const resolveSelect = { getEntitiesConfig: vi.fn( () => ENTITIES ) };
 
 	beforeEach( async () => {
 		triggerFetch.mockReset();
 	} );
 
 	it( 'dispatches the requested post type', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
 
 		// Provide response
@@ -670,10 +675,10 @@ describe( 'getEntityRecords', () => {
 	} );
 
 	it( 'Uses state locks', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
 
 		// Provide response
@@ -701,12 +706,12 @@ describe( 'getEntityRecords', () => {
 	} );
 
 	it( 'marks specific entity records as resolved', async () => {
-		const finishResolutions = jest.fn();
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			receiveUserPermissions: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const finishResolutions = vi.fn();
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			receiveUserPermissions: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 			finishResolutions,
 		} );
 
@@ -725,17 +730,17 @@ describe( 'getEntityRecords', () => {
 
 		// The record should have been received.
 		expect( finishResolutions ).toHaveBeenCalledWith( 'getEntityRecord', [
-			[ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ],
+			[ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2, undefined ],
 		] );
 	} );
 
 	it( 'caches permissions and marks entity records as resolved when using _fields', async () => {
-		const finishResolutions = jest.fn();
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			receiveUserPermissions: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const finishResolutions = vi.fn();
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			receiveUserPermissions: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 			finishResolutions,
 		} );
 
@@ -780,12 +785,12 @@ describe( 'getEntityRecords', () => {
 	} );
 
 	it( 'does not cache permissions when _links field is missing from response', async () => {
-		const finishResolutions = jest.fn();
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			receiveUserPermissions: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
+		const finishResolutions = vi.fn();
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			receiveUserPermissions: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
 			finishResolutions,
 		} );
 
@@ -821,11 +826,11 @@ describe( 'getEntityRecords', () => {
 	} );
 
 	it( 'provides pagination metadata and progressive loading during intermediate results fetching', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn(),
-			__unstableReleaseStoreLock: jest.fn(),
-			finishResolutions: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn(),
+			__unstableReleaseStoreLock: vi.fn(),
+			finishResolutions: vi.fn(),
 		} );
 
 		const mockPages = [
@@ -898,10 +903,10 @@ describe( 'taxonomy pagination', () => {
 	let dispatch, loadedTaxonomyEntities;
 
 	beforeEach( async () => {
-		dispatch = Object.assign( jest.fn(), {
-			receiveEntityRecords: jest.fn(),
-			__unstableAcquireStoreLock: jest.fn().mockResolvedValue( 'lock' ),
-			__unstableReleaseStoreLock: jest.fn(),
+		dispatch = Object.assign( vi.fn(), {
+			receiveEntityRecords: vi.fn(),
+			__unstableAcquireStoreLock: vi.fn().mockResolvedValue( 'lock' ),
+			__unstableReleaseStoreLock: vi.fn(),
 		} );
 		triggerFetch.mockReset();
 
@@ -923,7 +928,7 @@ describe( 'taxonomy pagination', () => {
 
 	it( 'should make paginated API calls with parse: false', async () => {
 		const resolveSelect = {
-			getEntitiesConfig: jest
+			getEntitiesConfig: vi
 				.fn()
 				.mockResolvedValue( loadedTaxonomyEntities ),
 		};
@@ -946,7 +951,7 @@ describe( 'taxonomy pagination', () => {
 
 	it( 'should extract pagination metadata from headers', async () => {
 		const resolveSelect = {
-			getEntitiesConfig: jest
+			getEntitiesConfig: vi
 				.fn()
 				.mockResolvedValue( loadedTaxonomyEntities ),
 		};
@@ -958,7 +963,7 @@ describe( 'taxonomy pagination', () => {
 					{ id: 2, name: 'Category 2' },
 				] ),
 			headers: {
-				get: jest.fn( ( header ) => {
+				get: vi.fn( ( header ) => {
 					if ( header === 'X-WP-Total' ) {
 						return '10';
 					}
@@ -999,8 +1004,8 @@ describe( 'getEmbedPreview', () => {
 	const UNEMBEDDABLE_URL = 'http://example.com/';
 
 	it( 'yields with fetched embed preview', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEmbedPreview: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEmbedPreview: vi.fn(),
 		} );
 
 		// Provide response
@@ -1015,8 +1020,8 @@ describe( 'getEmbedPreview', () => {
 	} );
 
 	it( 'yields false if the URL cannot be embedded', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveEmbedPreview: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveEmbedPreview: vi.fn(),
 		} );
 
 		// Provide response
@@ -1046,19 +1051,19 @@ describe( 'canUser', () => {
 			baseURLParams: { context: 'edit' },
 		},
 	];
-	const resolveSelect = { getEntitiesConfig: jest.fn( () => ENTITIES ) };
+	const resolveSelect = { getEntitiesConfig: vi.fn( () => ENTITIES ) };
 
 	let dispatch, registry;
 	beforeEach( async () => {
 		registry = {
-			select: jest.fn( () => ( {
+			select: vi.fn( () => ( {
 				hasStartedResolution: () => false,
 			} ) ),
 			batch: ( callback ) => callback(),
 		};
-		dispatch = Object.assign( jest.fn(), {
-			receiveUserPermissions: jest.fn(),
-			finishResolutions: jest.fn(),
+		dispatch = Object.assign( vi.fn(), {
+			receiveUserPermissions: vi.fn(),
+			finishResolutions: vi.fn(),
 		} );
 		triggerFetch.mockReset();
 	} );
@@ -1475,11 +1480,11 @@ describe( 'getAutosaves', () => {
 		};
 
 		triggerFetch.mockImplementation( () => SUCCESSFUL_RESPONSE );
-		const dispatch = Object.assign( jest.fn(), {
-			receiveAutosaves: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveAutosaves: vi.fn(),
 		} );
-		const resolveSelect = Object.assign( jest.fn(), {
-			getPostType: jest.fn( () => postEntityConfig ),
+		const resolveSelect = Object.assign( vi.fn(), {
+			getPostType: vi.fn( () => postEntityConfig ),
 		} );
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
@@ -1502,11 +1507,11 @@ describe( 'getAutosaves', () => {
 		};
 
 		triggerFetch.mockImplementation( () => [] );
-		const dispatch = Object.assign( jest.fn(), {
-			receiveAutosaves: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveAutosaves: vi.fn(),
 		} );
-		const resolveSelect = Object.assign( jest.fn(), {
-			getPostType: jest.fn( () => postEntityConfig ),
+		const resolveSelect = Object.assign( vi.fn(), {
+			getPostType: vi.fn( () => postEntityConfig ),
 		} );
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
@@ -1523,8 +1528,8 @@ describe( 'getCurrentUser', () => {
 	};
 
 	it( 'yields with fetched user', async () => {
-		const dispatch = Object.assign( jest.fn(), {
-			receiveCurrentUser: jest.fn(),
+		const dispatch = Object.assign( vi.fn(), {
+			receiveCurrentUser: vi.fn(),
 		} );
 
 		// Provide response

--- a/packages/core-data/src/test/rtc-rich-text-offset-space.test.jsx
+++ b/packages/core-data/src/test/rtc-rich-text-offset-space.test.jsx
@@ -1,15 +1,8 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	jest,
-} from '@jest/globals';
 
 /**
  * WordPress dependencies
@@ -26,9 +19,9 @@ import { Y } from '@wordpress/sync';
 /**
  * Mock sync manager accessor.
  */
-jest.mock( '../sync', () => ( {
-	...jest.requireActual( '../sync' ),
-	getSyncManager: jest.fn(),
+vi.mock( import( '../sync' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	getSyncManager: vi.fn(),
 	LOCAL_EDITOR_ORIGIN: 'local-editor',
 } ) );
 
@@ -41,7 +34,7 @@ import useEntityBlockEditor from '../hooks/use-entity-block-editor';
 import { applyPostChangesToCRDTDoc } from '../utils/crdt';
 import { getRootMap } from '../utils/crdt-utils';
 
-const mockGetSyncManager = jest.mocked( getSyncManager );
+const mockGetSyncManager = vi.mocked( getSyncManager );
 
 const postTypeConfig = {
 	kind: 'postType',
@@ -127,7 +120,7 @@ describe( 'useEntityBlockEditor RTC rich-text offset-space bug', () => {
 		} );
 
 		mockGetSyncManager.mockReturnValue( {
-			update: jest.fn( ( _objectType, _objectId, changes ) => {
+			update: vi.fn( ( _objectType, _objectId, changes ) => {
 				applyPostChangesToCRDTDoc(
 					crdtDoc,
 					changes,

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -29,8 +30,8 @@ import {
 } from '../selectors';
 import { getSyncManager } from '../sync';
 
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
+vi.mock( '../sync', () => ( {
+	getSyncManager: vi.fn(),
 } ) );
 
 describe( 'hasUndo/hasRedo', () => {
@@ -40,8 +41,8 @@ describe( 'hasUndo/hasRedo', () => {
 
 	it( 'reads undo availability from core-data state when a sync undo manager is available', () => {
 		const undoManager = {
-			hasUndo: jest.fn( () => false ),
-			hasRedo: jest.fn( () => false ),
+			hasUndo: vi.fn( () => false ),
+			hasRedo: vi.fn( () => false ),
 		};
 		getSyncManager.mockReturnValue( { undoManager } );
 
@@ -60,8 +61,8 @@ describe( 'hasUndo/hasRedo', () => {
 
 	it( 'falls back to the default undo manager when no sync undo manager is available', () => {
 		const undoManager = {
-			hasUndo: jest.fn( () => true ),
-			hasRedo: jest.fn( () => false ),
+			hasUndo: vi.fn( () => true ),
+			hasRedo: vi.fn( () => false ),
 		};
 		getSyncManager.mockReturnValue( undefined );
 

--- a/packages/core-data/src/test/store.js
+++ b/packages/core-data/src/test/store.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import triggerFetch from '@wordpress/api-fetch';
@@ -9,7 +14,7 @@ import { createRegistry } from '@wordpress/data';
  */
 import { store as coreDataStore } from '../index';
 
-jest.mock( '@wordpress/api-fetch' );
+vi.mock( '@wordpress/api-fetch' );
 
 function createTestRegistry() {
 	const registry = createRegistry();

--- a/packages/core-data/src/utils/test/block-selection-history.test.ts
+++ b/packages/core-data/src/utils/test/block-selection-history.test.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Y } from '@wordpress/sync';
 
 /**
@@ -97,7 +98,7 @@ describe( 'BlockSelectionHistory', () => {
 	} );
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	describe( 'initialization', () => {

--- a/packages/core-data/src/utils/test/clear-unchanged-edits.js
+++ b/packages/core-data/src/utils/test/clear-unchanged-edits.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import clearUnchangedEdits from '../clear-unchanged-edits';

--- a/packages/core-data/src/utils/test/conservative-map-item.js
+++ b/packages/core-data/src/utils/test/conservative-map-item.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import conservativeMapItem from '../conservative-map-item';

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -1,32 +1,26 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { Y } from '@wordpress/sync';
 
 /**
- * External dependencies
- */
-import {
-	describe,
-	expect,
-	it,
-	jest,
-	beforeEach,
-	afterEach,
-} from '@jest/globals';
-
-/**
  * Mock uuid module
  */
-jest.mock( 'uuid', () => ( {
+vi.mock( import( 'uuid' ), () => ( {
 	v4: () => 'mocked-uuid-' + Math.random(),
 } ) );
 
 /**
  * Mock @wordpress/blocks module
  */
-jest.mock( '@wordpress/blocks', () => ( {
-	getBlockTypes: () => [
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	getBlockTypes: ( () => [
 		{
 			name: 'core/paragraph',
 			attributes: { content: { type: 'rich-text' } },
@@ -99,7 +93,7 @@ jest.mock( '@wordpress/blocks', () => ( {
 				},
 			},
 		},
-	],
+	] ) as unknown as typeof import('@wordpress/blocks').getBlockTypes,
 } ) );
 
 /**
@@ -137,7 +131,7 @@ describe( 'crdt-blocks', () => {
 	beforeEach( () => {
 		doc = new Y.Doc();
 		yblocks = doc.getArray< YBlock >();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	afterEach( () => {
@@ -3112,10 +3106,10 @@ describe( 'crdt-blocks', () => {
 } );
 
 describe( 'getCachedRichTextData', () => {
-	let spy: ReturnType< typeof jest.spyOn >;
+	let spy: ReturnType< typeof vi.spyOn >;
 
 	beforeEach( () => {
-		spy = jest.spyOn( RichTextData, 'fromHTMLString' );
+		spy = vi.spyOn( RichTextData, 'fromHTMLString' );
 	} );
 
 	afterEach( () => {

--- a/packages/core-data/src/utils/test/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/test/crdt-user-selections.ts
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+	type Mock,
+} from 'vitest';
 import { Y } from '@wordpress/sync';
 import { select } from '@wordpress/data';
 
@@ -14,16 +23,13 @@ import {
 } from '../crdt-user-selections';
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
 
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn(),
-	// Needed because @wordpress/rich-text initialises its store at import time.
-	combineReducers: jest.fn( () => jest.fn( () => ( {} ) ) ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	register: jest.fn(),
-	createSelector: ( selector: Function ) => selector,
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	select: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/block-editor', () => ( {
+// @ts-expect-error @wordpress/block-editor does not publish TypeScript declarations.
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	store: 'core/block-editor',
 } ) );
 import type {
@@ -452,18 +458,18 @@ describe( 'getSelectionState', () => {
 	beforeEach( () => {
 		testDoc = createTestDocWithBlocks();
 
-		( select as jest.Mock ).mockReturnValue( {
-			getBlockIndex: jest
+		( select as Mock ).mockReturnValue( {
+			getBlockIndex: vi
 				.fn()
 				.mockImplementation(
 					( clientId: string ) => blockIndexMap[ clientId ] ?? -1
 				),
-			getBlockRootClientId: jest
+			getBlockRootClientId: vi
 				.fn()
 				.mockImplementation(
 					( clientId: string ) => blockParentMap[ clientId ] ?? ''
 				),
-			getBlockName: jest.fn().mockReturnValue( 'core/paragraph' ),
+			getBlockName: vi.fn().mockReturnValue( 'core/paragraph' ),
 		} );
 	} );
 

--- a/packages/core-data/src/utils/test/crdt-utils.ts
+++ b/packages/core-data/src/utils/test/crdt-utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it } from 'vitest';
 import { Y } from '@wordpress/sync';
 
 /**

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -1,12 +1,20 @@
 /**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { Y } from '@wordpress/sync';
-
-/**
- * External dependencies
- */
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 /**
  * Mock getBlockTypes so CRDT merging can identify rich-text attributes.
@@ -14,14 +22,11 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals';
  * (the real implementation returns "" without registered block types, which
  * isn't useful for asserting closure-capture behavior).
  */
-jest.mock( '@wordpress/blocks', () => {
-	const actual = jest.requireActual( '@wordpress/blocks' ) as Record<
-		string,
-		unknown
-	>;
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 	return {
 		...actual,
-		getBlockTypes: () => [
+		getBlockTypes: ( () => [
 			{
 				name: 'core/paragraph',
 				attributes: { content: { type: 'rich-text' } },
@@ -45,11 +50,11 @@ jest.mock( '@wordpress/blocks', () => {
 					},
 				},
 			},
-		],
+		] ) as unknown as typeof import('@wordpress/blocks').getBlockTypes,
 		// Mocked so tests can control what the Code Editor sync path "parses"
 		// from raw content without needing real block-type registration.
-		parse: jest.fn( () => [] ),
-		__unstableSerializeAndClean: jest.fn(
+		parse: vi.fn( () => [] ),
+		__unstableSerializeAndClean: vi.fn(
 			( blocks: unknown[] ) => `serialized:${ blocks?.length ?? 0 }`
 		),
 	};
@@ -182,13 +187,13 @@ describe( 'crdt', () => {
 
 	beforeEach( () => {
 		doc = new Y.Doc();
-		jest.clearAllMocks();
-		jest.useFakeTimers();
+		vi.clearAllMocks();
+		vi.useFakeTimers();
 	} );
 
 	afterEach( () => {
-		jest.runAllTimers();
-		jest.useRealTimers();
+		vi.runAllTimers();
+		vi.useRealTimers();
 		doc.destroy();
 	} );
 
@@ -391,7 +396,7 @@ describe( 'crdt', () => {
 			// only. `parse()` is mocked to return blocks with freshly minted
 			// clientIds — the sync layer must not let those overwrite the
 			// stable clientIds already in the Y.Array.
-			( parse as jest.Mock ).mockReturnValueOnce( [
+			( parse as Mock ).mockReturnValueOnce( [
 				{
 					name: 'core/paragraph',
 					attributes: { content: 'Hello' },

--- a/packages/core-data/src/utils/test/get-nested-value.js
+++ b/packages/core-data/src/utils/test/get-nested-value.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import getNestedValue from '../get-nested-value';

--- a/packages/core-data/src/utils/test/get-normalized-comma-separable.js
+++ b/packages/core-data/src/utils/test/get-normalized-comma-separable.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import getNormalizedCommaSeparable from '../get-normalized-comma-separable';

--- a/packages/core-data/src/utils/test/get-template-info.js
+++ b/packages/core-data/src/utils/test/get-template-info.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { footer, header, layout } from '@wordpress/icons';

--- a/packages/core-data/src/utils/test/if-matching-action.js
+++ b/packages/core-data/src/utils/test/if-matching-action.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/core-data/src/utils/test/is-numeric-id.js
+++ b/packages/core-data/src/utils/test/is-numeric-id.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import isNumericID from '../is-numeric-id';

--- a/packages/core-data/src/utils/test/log-entity-deprecation.js
+++ b/packages/core-data/src/utils/test/log-entity-deprecation.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
@@ -8,10 +13,10 @@ import deprecated from '@wordpress/deprecated';
  */
 import logEntityDeprecation from '../log-entity-deprecation';
 
-jest.useFakeTimers();
+vi.useFakeTimers();
 
 // Mock the deprecatedEntities import
-jest.mock( '../../entities', () => ( {
+vi.mock( '../../entities', () => ( {
 	deprecatedEntities: {
 		root: {
 			media: {
@@ -26,14 +31,14 @@ jest.mock( '../../entities', () => ( {
 } ) );
 
 // Mock the deprecated function
-jest.mock( '@wordpress/deprecated' );
+vi.mock( '@wordpress/deprecated' );
 
 describe( 'logEntityDeprecation', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 
 		// Ensure the timeout that prevents spurious logging is cleared.
-		jest.runAllTimers();
+		vi.advanceTimersByTime( 0 );
 	} );
 
 	it( 'should call deprecated when entity is deprecated', () => {

--- a/packages/core-data/src/utils/test/replace-action.js
+++ b/packages/core-data/src/utils/test/replace-action.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import replaceAction from '../replace-action';

--- a/packages/core-data/src/utils/test/rtc-rich-text-cursor-scope.test.js
+++ b/packages/core-data/src/utils/test/rtc-rich-text-cursor-scope.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -11,8 +11,8 @@ import { Y } from '@wordpress/sync';
 /**
  * Mock block schemas and sync providers.
  */
-jest.mock( '@wordpress/blocks', () => {
-	const actual = jest.requireActual( '@wordpress/blocks' );
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 
 	return {
 		...actual,
@@ -28,8 +28,8 @@ jest.mock( '@wordpress/blocks', () => {
 	};
 } );
 
-jest.mock( '../../../../sync/src/providers', () => ( {
-	getProviderCreators: jest.fn(),
+vi.mock( '../../../../sync/src/providers', () => ( {
+	getProviderCreators: vi.fn(),
 } ) );
 
 /**
@@ -42,7 +42,7 @@ import { applyPostChangesToCRDTDoc } from '../crdt';
 import { deserializeBlockAttributes, mergeCrdtBlocks } from '../crdt-blocks';
 import { getRootMap } from '../crdt-utils';
 
-const mockGetProviderCreators = jest.mocked( getProviderCreators );
+const mockGetProviderCreators = vi.mocked( getProviderCreators );
 
 const SYNCED_PROPERTIES = new Set( [ 'blocks' ] );
 const INITIAL_SECOND = '<em>b</em><em>i</em>';
@@ -159,11 +159,11 @@ function waitForNextTick() {
 
 describe( 'RTC rich-text cursor scope bug', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockGetProviderCreators.mockReturnValue( [
-			jest.fn( async () => ( {
-				destroy: jest.fn(),
-				on: jest.fn(),
+			vi.fn( async () => ( {
+				destroy: vi.fn(),
+				on: vi.fn(),
 			} ) ),
 		] );
 	} );
@@ -211,25 +211,25 @@ describe( 'RTC rich-text cursor scope bug', () => {
 		let capturedDoc;
 		const manager = createSyncManager();
 		const handlers = {
-			addUndoMeta: jest.fn(),
-			editRecord: jest.fn(),
-			getEditedRecord: jest.fn( async () => ( {
+			addUndoMeta: vi.fn(),
+			editRecord: vi.fn(),
+			getEditedRecord: vi.fn( async () => ( {
 				id: 1,
 				blocks: [ makeBlock( '', INITIAL_SECOND ) ],
 			} ) ),
-			onStatusChange: jest.fn(),
-			persistCRDTDoc: jest.fn(),
-			refetchRecord: jest.fn( async () => {} ),
-			restoreUndoMeta: jest.fn(),
+			onStatusChange: vi.fn(),
+			persistCRDTDoc: vi.fn(),
+			refetchRecord: vi.fn( async () => {} ),
+			restoreUndoMeta: vi.fn(),
 		};
 		const syncConfig = {
 			applyChangesToCRDTDoc: ( ydoc, changes ) => {
 				capturedDoc = ydoc;
 				applyPostChangesToCRDTDoc( ydoc, changes, SYNCED_PROPERTIES );
 			},
-			createAwareness: jest.fn(),
-			getChangesFromCRDTDoc: jest.fn( () => ( {} ) ),
-			getPersistedCRDTDoc: jest.fn( () => null ),
+			createAwareness: vi.fn(),
+			getChangesFromCRDTDoc: vi.fn( () => ( {} ) ),
+			getPersistedCRDTDoc: vi.fn( () => null ),
 		};
 
 		await manager.load(

--- a/packages/core-data/src/utils/test/rtc-rich-text-offset-space.test.js
+++ b/packages/core-data/src/utils/test/rtc-rich-text-offset-space.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * WordPress dependencies
@@ -11,8 +11,8 @@ import { Y } from '@wordpress/sync';
 /**
  * Mock block schemas and sync providers.
  */
-jest.mock( '@wordpress/blocks', () => {
-	const actual = jest.requireActual( '@wordpress/blocks' );
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 
 	return {
 		...actual,
@@ -27,8 +27,8 @@ jest.mock( '@wordpress/blocks', () => {
 	};
 } );
 
-jest.mock( '../../../../sync/src/providers', () => ( {
-	getProviderCreators: jest.fn(),
+vi.mock( '../../../../sync/src/providers', () => ( {
+	getProviderCreators: vi.fn(),
 } ) );
 
 /**
@@ -41,7 +41,7 @@ import { applyPostChangesToCRDTDoc } from '../crdt';
 import { mergeCrdtBlocks } from '../crdt-blocks';
 import { getRootMap, richTextOffsetToHtmlIndex } from '../crdt-utils';
 
-const mockGetProviderCreators = jest.mocked( getProviderCreators );
+const mockGetProviderCreators = vi.mocked( getProviderCreators );
 
 const SYNCED_PROPERTIES = new Set( [ 'blocks' ] );
 const OLD_HTML = '<em>italic</em><em>italic</em>';
@@ -200,11 +200,11 @@ function assertEqualWithContext( actual, expected, context ) {
 
 describe( 'RTC rich-text offset-space bug', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockGetProviderCreators.mockReturnValue( [
-			jest.fn( async () => ( {
-				destroy: jest.fn(),
-				on: jest.fn(),
+			vi.fn( async () => ( {
+				destroy: vi.fn(),
+				on: vi.fn(),
 			} ) ),
 		] );
 	} );
@@ -422,25 +422,25 @@ describe( 'RTC rich-text offset-space bug', () => {
 		let capturedDoc;
 		const manager = createSyncManager();
 		const handlers = {
-			addUndoMeta: jest.fn(),
-			editRecord: jest.fn(),
-			getEditedRecord: jest.fn( async () => ( {
+			addUndoMeta: vi.fn(),
+			editRecord: vi.fn(),
+			getEditedRecord: vi.fn( async () => ( {
 				id: 1,
 				blocks: [ makeParagraphBlock( OLD_HTML ) ],
 			} ) ),
-			onStatusChange: jest.fn(),
-			persistCRDTDoc: jest.fn(),
-			refetchRecord: jest.fn( async () => {} ),
-			restoreUndoMeta: jest.fn(),
+			onStatusChange: vi.fn(),
+			persistCRDTDoc: vi.fn(),
+			refetchRecord: vi.fn( async () => {} ),
+			restoreUndoMeta: vi.fn(),
 		};
 		const syncConfig = {
 			applyChangesToCRDTDoc: ( ydoc, changes ) => {
 				capturedDoc = ydoc;
 				applyPostChangesToCRDTDoc( ydoc, changes, SYNCED_PROPERTIES );
 			},
-			createAwareness: jest.fn(),
-			getChangesFromCRDTDoc: jest.fn( () => ( {} ) ),
-			getPersistedCRDTDoc: jest.fn( () => null ),
+			createAwareness: vi.fn(),
+			getChangesFromCRDTDoc: vi.fn( () => ( {} ) ),
+			getPersistedCRDTDoc: vi.fn( () => null ),
 		};
 
 		await manager.load(

--- a/packages/core-data/src/utils/test/save-crdt-doc.js
+++ b/packages/core-data/src/utils/test/save-crdt-doc.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -9,9 +14,9 @@ import apiFetch from '@wordpress/api-fetch';
 import { getSyncManager } from '../../sync';
 import { saveCRDTDoc } from '../save-crdt-doc';
 
-jest.mock( '@wordpress/api-fetch' );
-jest.mock( '../../sync', () => ( {
-	getSyncManager: jest.fn(),
+vi.mock( '@wordpress/api-fetch' );
+vi.mock( '../../sync', () => ( {
+	getSyncManager: vi.fn(),
 } ) );
 
 function createDeferred() {
@@ -35,7 +40,7 @@ describe( 'saveCRDTDoc', () => {
 	beforeEach( () => {
 		apiFetch.mockReset();
 		syncManager = {
-			createPersistedCRDTDoc: jest.fn(),
+			createPersistedCRDTDoc: vi.fn(),
 		};
 		getSyncManager.mockReturnValue( syncManager );
 	} );

--- a/packages/core-data/src/utils/test/set-nested-value.js
+++ b/packages/core-data/src/utils/test/set-nested-value.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import setNestedValue from '../set-nested-value';

--- a/packages/core-data/src/utils/test/with-weak-map-cache.js
+++ b/packages/core-data/src/utils/test/with-weak-map-cache.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import withWeakMapCache from '../with-weak-map-cache';
@@ -14,7 +19,7 @@ describe( 'withWeakMapCache', () => {
 	it( 'caches by weak reference', () => {
 		const a = {};
 		const b = {};
-		const fn = jest.fn().mockReturnValue( 'Called' );
+		const fn = vi.fn().mockReturnValue( 'Called' );
 		const cachedFn = withWeakMapCache( fn );
 
 		cachedFn( a );

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -4,7 +4,7 @@
 	"compilerOptions": {
 		"checkJs": false,
 		"noImplicitAny": false,
-		"types": [ "jest", "node" ]
+		"types": []
 	},
 	"references": [
 		{ "path": "../api-fetch" },

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -30,6 +30,7 @@
 					"packages/components",
 					"packages/compose",
 					"packages/core-commands",
+					"packages/core-data",
 					"packages/customize-widgets",
 					"packages/data",
 					"packages/date",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** Migrates Core Data through five Vitest change classes: explicit runner APIs, typed ESM module mocks, scoped fake-timer advancement, strict equality parity, and removal of package-local Jest types/dependencies.

This stacked draft contains only the Core Data runner migration and is based on #80958.

## Why?

Core Data was still part of the residual Jest partition. Migrating all 55 package tests removes 875 tests from that partition while preserving the exactly-one-runner invariant.

## How?

- Routes `packages/core-data` to the Vitest jsdom project.
- Uses explicit Vitest imports and typed dynamic-import mock factories.
- Keeps Testing Library unchanged.
- Replaces broad timer draining with zero-delay advancement where unrelated timers would otherwise keep the queue alive.
- Makes two expectations explicit where Jest's loose equality treated trailing `undefined` and sparse-like results as equivalent.
- Removes package-local Jest and Node types/dependencies, adds Vitest, and uses platform timer return types in browser code.

No snapshots change in this package.

## Testing Instructions

- `npm run test:unit:vitest -- --run --project vitest --project node packages/core-data`
  - 55 files and 875 tests pass.
- `npm run test:unit:conventions`
- `npm run test:unit:routing`
  - 249 Jest files and 754 Vitest files are owned exactly once.
- `npm run test:unit:vitest -- --run --project vitest --project node`
  - 751 files pass, 2 files skip; 31,183 tests pass and 8 skip.
- `npm run test:unit -- --runInBand`
  - The residual Jest partition passes 249 suites, 3,567 tests, and 26 snapshots.
- `npm exec lint-staged -- --no-stash`

## Use of AI Tools

This migration was implemented and verified with Codex. The package diff, typed mocks, timer behavior, strict-equality adjustments, runner ownership, dependency changes, and focused/full test output were reviewed before opening this draft.