### PR TITLE
Migrate Block Library Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49779,7 +49779,8 @@
 				"@testing-library/user-event": "^14.6.1",
 				"@wordpress/integration-tests": "file:../../test/integration",
 				"@wordpress/stylelint-tools": "file:../../tools/stylelint",
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Internal
 
+-   Migrate unit tests from Jest to Vitest.
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 -   Image: Check only `window.__clientSideMediaProcessing` for sideloading status, following the removal of the redundant `window.__heicUploadSupport` flag ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -149,7 +149,8 @@
 		"@testing-library/user-event": "^14.6.1",
 		"@wordpress/integration-tests": "file:../../test/integration",
 		"@wordpress/stylelint-tools": "file:../../tools/stylelint",
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/block-library/src/button/test/get-experimental-label.js
+++ b/packages/block-library/src/button/test/get-experimental-label.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { settings } from '..';

--- a/packages/block-library/src/button/test/get-updated-link-attributes.js
+++ b/packages/block-library/src/button/test/get-updated-link-attributes.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getUpdatedLinkAttributes } from '../get-updated-link-attributes';

--- a/packages/block-library/src/button/test/utils.js
+++ b/packages/block-library/src/button/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getWidthClasses, isPercentageWidth } from '../utils';

--- a/packages/block-library/src/code/test/utils.js
+++ b/packages/block-library/src/code/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { escape } from '../utils';

--- a/packages/block-library/src/columns/test/transforms.js
+++ b/packages/block-library/src/columns/test/transforms.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/block-library/src/comment-template/test/index.js
+++ b/packages/block-library/src/comment-template/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { convertToTree } from '../util';

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { screen, fireEvent, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/block-library/src/cover/test/transforms.js
+++ b/packages/block-library/src/cover/test/transforms.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it, test, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -26,7 +31,10 @@ import metadata from '../block.json';
 
 const { name: DEFAULT_EMBED_BLOCK, attributes } = metadata;
 
-jest.mock( '@wordpress/data/src/components/use-select', () => () => ( {} ) );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: () => ( {} ),
+} ) );
 
 describe( 'utils', () => {
 	beforeAll( () => {

--- a/packages/block-library/src/gallery/test/dynamic-source.js
+++ b/packages/block-library/src/gallery/test/dynamic-source.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getSourceQuery } from '../dynamic-source';

--- a/packages/block-library/src/gallery/test/transforms.js
+++ b/packages/block-library/src/gallery/test/transforms.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-library/src/gallery/test/use-get-new-images.jsx
+++ b/packages/block-library/src/gallery/test/use-get-new-images.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/block-library/src/group/test/placeholder.jsx
+++ b/packages/block-library/src/group/test/placeholder.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/block-library/src/heading/test/shared.js
+++ b/packages/block-library/src/heading/test/shared.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getLevelFromHeadingNodeName } from '../shared';

--- a/packages/block-library/src/html/test/index.js
+++ b/packages/block-library/src/html/test/index.js
@@ -1,4 +1,17 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-library/src/html/test/utils.js
+++ b/packages/block-library/src/html/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { parseContent, serializeContent } from '../utils';

--- a/packages/block-library/src/image/test/transforms.js
+++ b/packages/block-library/src/image/test/transforms.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { stripFirstImage } from '../transforms';

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
 /**
@@ -19,22 +20,22 @@ import {
 
 const mockOpenMediaEditorModalKey = 'openMediaEditorModal';
 
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: {},
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useRegistry: jest.fn(),
-	useSelect: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useRegistry: vi.fn(),
+	useSelect: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/block-editor', () => ( {
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	privateApis: {},
 	store: {},
 } ) );
 
-jest.mock( '../../lock-unlock', () => ( {
-	unlock: jest.fn( () => ( {
+vi.mock( import( '../../lock-unlock' ), () => ( {
+	unlock: vi.fn( () => ( {
 		openMediaEditorModalKey: 'openMediaEditorModal',
 	} ) ),
 } ) );
@@ -44,14 +45,14 @@ function createRegistry( {
 	resolveGetEntityRecord = () => undefined,
 } = {} ) {
 	const actions = {
-		invalidateResolution: jest.fn(),
+		invalidateResolution: vi.fn(),
 	};
 	return {
-		select: jest.fn( () => ( {
+		select: vi.fn( () => ( {
 			getEditedEntityRecord,
 		} ) ),
-		dispatch: jest.fn( () => actions ),
-		resolveSelect: jest.fn( () => ( {
+		dispatch: vi.fn( () => actions ),
+		resolveSelect: vi.fn( () => ( {
 			getEntityRecord: resolveGetEntityRecord,
 		} ) ),
 		actions,
@@ -84,8 +85,8 @@ async function runModalUpdate( {
 } ) {
 	const registry = createRegistry( registryOptions );
 	useRegistry.mockReturnValue( registry );
-	const setAttributes = jest.fn();
-	const openMediaEditorModal = jest.fn();
+	const setAttributes = vi.fn();
+	const openMediaEditorModal = vi.fn();
 	mockMediaEditorModalSetting( openMediaEditorModal );
 	const { result } = renderHook( () =>
 		useOpenImageMediaEditorModal( {
@@ -107,11 +108,11 @@ async function runModalUpdate( {
 
 describe( 'useOpenImageMediaEditorModal', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'notifies onUrlChange when the update switches to a new attachment URL', async () => {
-		const onUrlChange = jest.fn();
+		const onUrlChange = vi.fn();
 		await runModalUpdate( {
 			attributes: { id: 1, url: 'original.jpg', alt: '', caption: '' },
 			updatePayload: { id: 2, url: 'updated.jpg' },
@@ -122,7 +123,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'does not notify onUrlChange for a same-attachment update', async () => {
-		const onUrlChange = jest.fn();
+		const onUrlChange = vi.fn();
 		await runModalUpdate( {
 			attributes: { id: 1, url: 'original.jpg', alt: '', caption: '' },
 			updatePayload: { id: 1, url: 'original.jpg' },
@@ -132,7 +133,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'does not notify onUrlChange when the update carries no URL', async () => {
-		const onUrlChange = jest.fn();
+		const onUrlChange = vi.fn();
 		await runModalUpdate( {
 			attributes: { id: 1, url: 'original.jpg', alt: '', caption: '' },
 			updatePayload: { id: 2 },
@@ -153,7 +154,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 					alt: '',
 					caption: '',
 				},
-				setAttributes: jest.fn(),
+				setAttributes: vi.fn(),
 			} )
 		);
 
@@ -166,8 +167,8 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		document.body.append( cropButton, otherButton );
 		const registry = createRegistry();
 		useRegistry.mockReturnValue( registry );
-		const setAttributes = jest.fn();
-		const openMediaEditorModal = jest.fn();
+		const setAttributes = vi.fn();
+		const openMediaEditorModal = vi.fn();
 		mockMediaEditorModalSetting( openMediaEditorModal );
 		const onClose = () => cropButton.focus();
 		const { result } = renderHook( () =>
@@ -250,7 +251,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			alt_text: 'Updated alt',
 			caption: { raw: 'Updated caption' },
 		};
-		const resolveGetEntityRecord = jest
+		const resolveGetEntityRecord = vi
 			.fn()
 			.mockResolvedValueOnce( originalAttachment )
 			.mockResolvedValueOnce( updatedAttachment );
@@ -292,7 +293,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			alt_text: '',
 			caption: { raw: 'Updated attachment caption' },
 		};
-		const resolveGetEntityRecord = jest
+		const resolveGetEntityRecord = vi
 			.fn()
 			.mockResolvedValueOnce( originalAttachment )
 			.mockResolvedValueOnce( updatedAttachment );
@@ -333,7 +334,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			alt_text: '',
 			caption: { raw: 'Updated attachment caption' },
 		};
-		const resolveGetEntityRecord = jest
+		const resolveGetEntityRecord = vi
 			.fn()
 			.mockResolvedValueOnce( originalAttachment )
 			.mockResolvedValueOnce( updatedAttachment );
@@ -422,8 +423,8 @@ describe( 'useOpenImageMediaEditorModal', () => {
 				attachmentId === 2 ? deferredAttachment.promise : undefined,
 		} );
 		useRegistry.mockReturnValue( registry );
-		const setAttributes = jest.fn();
-		const openMediaEditorModal = jest.fn();
+		const setAttributes = vi.fn();
+		const openMediaEditorModal = vi.fn();
 		mockMediaEditorModalSetting( openMediaEditorModal );
 		const { result } = renderHook(
 			( { attributes } ) =>
@@ -534,7 +535,7 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'syncs metadata from an empty block when the original attachment is not cached', async () => {
-		const resolveGetEntityRecord = jest
+		const resolveGetEntityRecord = vi
 			.fn()
 			.mockResolvedValueOnce( {
 				id: 1,
@@ -656,8 +657,8 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			resolveGetEntityRecord: () => deferredAttachment.promise,
 		} );
 		useRegistry.mockReturnValue( registry );
-		const setAttributes = jest.fn();
-		const openMediaEditorModal = jest.fn();
+		const setAttributes = vi.fn();
+		const openMediaEditorModal = vi.fn();
 		mockMediaEditorModalSetting( openMediaEditorModal );
 		const { result, rerender } = renderHook(
 			( { attributes } ) =>

--- a/packages/block-library/src/latest-posts/test/deprecated.js
+++ b/packages/block-library/src/latest-posts/test/deprecated.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 // Load block support registration filters.

--- a/packages/block-library/src/media-text/test/image-fill.js
+++ b/packages/block-library/src/media-text/test/image-fill.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { imageFillStyles } from '../image-fill';

--- a/packages/block-library/src/navigation-link/shared/test/controls.jsx
+++ b/packages/block-library/src/navigation-link/shared/test/controls.jsx
@@ -1,42 +1,45 @@
 /**
  * External dependencies
  */
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import { Controls } from '../controls';
+import { useEntityBinding } from '../use-entity-binding';
+import { useIsInvalidLink } from '../use-is-invalid-link';
 
 // Mock the updateAttributes function
 let mockUpdateAttributes;
-jest.mock( '../update-attributes', () => ( {
+vi.mock( import( '../update-attributes' ), () => ( {
 	updateAttributes: ( ...args ) => mockUpdateAttributes( ...args ),
 } ) );
 
 // Mock the useToolsPanelDropdownMenuProps hook
-jest.mock( '../../../utils/hooks', () => ( {
+vi.mock( import( '../../../utils/hooks' ), () => ( {
 	useToolsPanelDropdownMenuProps: () => ( {} ),
 } ) );
 
 // Mock the useEntityBinding hook
-jest.mock( '../use-entity-binding', () => ( {
-	useEntityBinding: jest.fn( () => ( {
+vi.mock( import( '../use-entity-binding' ), () => ( {
+	useEntityBinding: vi.fn( () => ( {
 		hasUrlBinding: false,
 		isBoundEntityAvailable: false,
-		clearBinding: jest.fn(),
+		clearBinding: vi.fn(),
 	} ) ),
 } ) );
 
 // Mock the useIsInvalidLink hook
-jest.mock( '../use-is-invalid-link', () => ( {
-	useIsInvalidLink: jest.fn( () => [ false, false ] ),
+vi.mock( import( '../use-is-invalid-link' ), () => ( {
+	useIsInvalidLink: vi.fn( () => [ false, false ] ),
 } ) );
 
 describe( 'Controls', () => {
 	// Initialize the mock function
 	beforeAll( () => {
-		mockUpdateAttributes = jest.fn();
+		mockUpdateAttributes = vi.fn();
 	} );
 
 	const defaultProps = {
@@ -47,25 +50,23 @@ describe( 'Controls', () => {
 			rel: 'nofollow',
 			opensInNewTab: false,
 		},
-		setAttributes: jest.fn(),
-		setIsEditingControl: jest.fn(),
+		setAttributes: vi.fn(),
+		setIsEditingControl: vi.fn(),
 		clientId: 'test-client-id',
 	};
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockUpdateAttributes.mockClear();
 
 		// Reset useEntityBinding mock to default
-		const { useEntityBinding } = require( '../use-entity-binding' );
 		useEntityBinding.mockReturnValue( {
 			hasUrlBinding: false,
 			isBoundEntityAvailable: false,
-			clearBinding: jest.fn(),
+			clearBinding: vi.fn(),
 		} );
 
 		// Reset useIsInvalidLink mock to default
-		const { useIsInvalidLink } = require( '../use-is-invalid-link' );
 		useIsInvalidLink.mockReturnValue( [ false, false ] );
 	} );
 
@@ -133,11 +134,10 @@ describe( 'Controls', () => {
 
 	describe( 'URL binding help text', () => {
 		it( 'shows invalid link help text when bound entity is not available', () => {
-			const { useEntityBinding } = require( '../use-entity-binding' );
 			useEntityBinding.mockReturnValue( {
 				hasUrlBinding: true,
 				isBoundEntityAvailable: false,
-				clearBinding: jest.fn(),
+				clearBinding: vi.fn(),
 			} );
 
 			const propsWithCategoryBinding = {
@@ -159,7 +159,6 @@ describe( 'Controls', () => {
 		} );
 
 		it( 'shows draft help text for draft entities', () => {
-			const { useIsInvalidLink } = require( '../use-is-invalid-link' );
 			useIsInvalidLink.mockReturnValue( [ false, true ] ); // isInvalid: false, isDraft: true
 
 			const propsWithDraftPage = {
@@ -181,7 +180,6 @@ describe( 'Controls', () => {
 		} );
 
 		it( 'shows draft help text for different entity types', () => {
-			const { useIsInvalidLink } = require( '../use-is-invalid-link' );
 			useIsInvalidLink.mockReturnValue( [ false, true ] );
 
 			const propsWithDraftPost = {

--- a/packages/block-library/src/navigation-link/shared/test/update-attributes.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/update-attributes.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { updateAttributes } from '../update-attributes';
@@ -7,7 +12,7 @@ describe( 'updateAttributes', () => {
 	// Data shapes are linked to fetchLinkSuggestions from
 	// core-data/src/fetch/__experimental-fetch-link-suggestions.js.
 	it( 'can update a post link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			opensInNewTab: false,
 			id: 1337,
@@ -29,7 +34,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a page link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 2,
 			kind: 'post-type',
@@ -50,7 +55,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a tag link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 15,
 			kind: 'taxonomy',
@@ -71,7 +76,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a category link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 9,
 			kind: 'taxonomy',
@@ -92,7 +97,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a custom post type link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 131,
 			kind: 'post-type',
@@ -113,7 +118,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a custom tag link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 4,
 			kind: 'taxonomy',
@@ -134,7 +139,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a custom category link', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 2,
 			kind: 'taxonomy',
@@ -155,7 +160,7 @@ describe( 'updateAttributes', () => {
 	} );
 
 	it( 'can update a post format and ignores id slug', () => {
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 		const linkSuggestion = {
 			id: 'video',
 			kind: 'taxonomy',
@@ -178,7 +183,7 @@ describe( 'updateAttributes', () => {
 
 	describe( 'various link protocols save as custom links', () => {
 		it( 'when typing a url, but not selecting a search suggestion', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				opensInNewTab: false,
 				url: 'www.wordpress.org',
@@ -193,7 +198,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'url', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'www.wordpress.org',
 				opensInNewTab: false,
@@ -211,7 +216,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'email', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'mailto:foo@example.com',
 				opensInNewTab: false,
@@ -230,7 +235,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'anchor links (internal links)', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: '#foo',
 				opensInNewTab: false,
@@ -249,7 +254,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'telephone', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'tel:5555555',
 				opensInNewTab: false,
@@ -271,7 +276,7 @@ describe( 'updateAttributes', () => {
 	describe( 'link label', () => {
 		// https://github.com/WordPress/gutenberg/pull/19461
 		it( 'sets the url as a label if title is not provided', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'www.wordpress.org/foo bar',
 				opensInNewTab: false,
@@ -288,7 +293,7 @@ describe( 'updateAttributes', () => {
 			} );
 		} );
 		it( 'does not replace label when editing url without protocol', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'www.wordpress.org',
 				opensInNewTab: false,
@@ -305,7 +310,7 @@ describe( 'updateAttributes', () => {
 			} );
 		} );
 		it( 'does not replace label when editing url with protocol', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'www.wordpress.org',
 				opensInNewTab: false,
@@ -323,7 +328,7 @@ describe( 'updateAttributes', () => {
 		} );
 		// https://github.com/WordPress/gutenberg/pull/19679
 		it( 'url when escaped is still an actual link', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const linkSuggestion = {
 				id: 'http://wordpress.org/?s=',
 				opensInNewTab: false,
@@ -344,7 +349,7 @@ describe( 'updateAttributes', () => {
 	describe( 'does not overwrite props when only some props are passed', () => {
 		it( 'id is retained after toggling opensInNewTab', () => {
 			const mockState = {};
-			const setAttributes = jest.fn( ( attr ) =>
+			const setAttributes = vi.fn( ( attr ) =>
 				Object.assign( mockState, attr )
 			);
 			const linkSuggestion = {
@@ -385,7 +390,7 @@ describe( 'updateAttributes', () => {
 		} );
 		it( 'id is removed after editing url', () => {
 			const mockState = {};
-			const setAttributes = jest.fn( ( attr ) =>
+			const setAttributes = vi.fn( ( attr ) =>
 				Object.assign( mockState, attr )
 			);
 			const linkSuggestion = {
@@ -430,7 +435,7 @@ describe( 'updateAttributes', () => {
 	describe( 'ID handling when URL is manually changed', () => {
 		describe( 'URL modifications that should sever the entity link', () => {
 			it( 'should remove ID when URL path is changed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -459,7 +464,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should remove ID when changing to relative URL that does not match the path', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -488,7 +493,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should remove ID when URL domain is changed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -517,7 +522,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should remove ID when plain permalink post ID is changed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -546,7 +551,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should remove ID when changing from plain permalink to different plain permalink', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -577,7 +582,7 @@ describe( 'updateAttributes', () => {
 
 		describe( 'URL modifications that should preserve the entity link', () => {
 			it( 'should preserve ID when changing to relative URL that matches the path', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -609,7 +614,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when only query string is added', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -640,7 +645,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when only hash fragment is added', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -671,7 +676,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when both query string and hash are added', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -702,7 +707,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when query string is modified', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -733,7 +738,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when hash fragment is modified', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -764,7 +769,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when protocol changes from http to https', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -795,7 +800,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when protocol changes from https to http', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -826,7 +831,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when query string is removed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -857,7 +862,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when hash fragment is removed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -888,7 +893,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when both query string and hash are removed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -919,7 +924,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when adding query string to URL with hash fragment', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -950,7 +955,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should preserve ID when query string is partially removed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -982,7 +987,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'should remove ID when URL is changed without new ID', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const blockAttributes = {
 				id: 123,
 				type: 'page',
@@ -1007,7 +1012,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'should preserve ID when new ID is provided with URL', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const blockAttributes = {
 				id: 123,
 				type: 'page',
@@ -1031,7 +1036,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'should not remove ID when only label is changed', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const blockAttributes = {
 				id: 123,
 				type: 'page',
@@ -1055,7 +1060,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'should not remove ID when only opensInNewTab is changed', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const blockAttributes = {
 				id: 123,
 				type: 'page',
@@ -1079,7 +1084,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'should handle case where block has no existing ID', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const blockAttributes = {
 				type: 'page',
 				kind: 'post-type',
@@ -1106,7 +1111,7 @@ describe( 'updateAttributes', () => {
 		} );
 
 		it( 'should handle non-integer ID values', () => {
-			const setAttributes = jest.fn();
+			const setAttributes = vi.fn();
 			const blockAttributes = {
 				id: 'not-an-integer',
 				type: 'page',
@@ -1137,7 +1142,7 @@ describe( 'updateAttributes', () => {
 	describe( 'Return value metadata', () => {
 		describe( 'isEntityLink', () => {
 			it( 'should return true for entity links with id and non-custom kind', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const linkSuggestion = {
 					id: 123,
 					kind: 'post-type',
@@ -1158,7 +1163,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return false for custom links even with id', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const linkSuggestion = {
 					id: 123,
 					kind: 'custom',
@@ -1179,7 +1184,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return false for links without id', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const linkSuggestion = {
 					url: 'https://example.com',
 					title: 'Example',
@@ -1197,7 +1202,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return false when entity link is severed', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -1223,7 +1228,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return true when entity link is preserved through query string change', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const blockAttributes = {
 					id: 123,
 					type: 'page',
@@ -1249,7 +1254,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return false for mailto links', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const linkSuggestion = {
 					id: 'mailto:test@example.com',
 					type: 'mailto',
@@ -1270,7 +1275,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return false for tel links', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const linkSuggestion = {
 					id: 'tel:5555555',
 					type: 'tel',
@@ -1291,7 +1296,7 @@ describe( 'updateAttributes', () => {
 			} );
 
 			it( 'should return true for taxonomy links', () => {
-				const setAttributes = jest.fn();
+				const setAttributes = vi.fn();
 				const linkSuggestion = {
 					id: 5,
 					kind: 'taxonomy',

--- a/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -9,12 +15,10 @@ import { renderHook } from '@testing-library/react';
 import { useEnableLinkStatusValidation } from '../use-enable-link-status-validation';
 
 // Mock useSelect directly at the implementation level to avoid loading complex dependencies
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	const mock = jest.fn();
-	return mock;
-} );
-
-const { useSelect } = require( '@wordpress/data' );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 describe( 'useEnableLinkStatusValidation', () => {
 	const mockClientId = 'test-client-id';
@@ -22,7 +26,7 @@ describe( 'useEnableLinkStatusValidation', () => {
 	const mockSelectedBlockId = 'selected-block-id';
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should return true when root navigation block is selected', () => {

--- a/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 /**
@@ -21,22 +22,22 @@ import {
 } from '../use-entity-binding';
 
 // Mock the entire @wordpress/block-editor module
-jest.mock( '@wordpress/block-editor', () => ( {
-	useBlockBindingsUtils: jest.fn(),
-	useBlockEditingMode: jest.fn(),
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
+	useBlockBindingsUtils: vi.fn(),
+	useBlockEditingMode: vi.fn(),
 } ) );
 
 // Mock useSelect specifically to avoid needing to set up full data store
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 describe( 'useEntityBinding', () => {
-	const mockUpdateBlockBindings = jest.fn();
+	const mockUpdateBlockBindings = vi.fn();
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		useBlockBindingsUtils.mockReturnValue( {
 			updateBlockBindings: mockUpdateBlockBindings,
 		} );
@@ -336,9 +337,7 @@ describe( 'useEntityBinding', () => {
 		} );
 
 		it( 'handles invalid kind gracefully in createBinding', () => {
-			const consoleSpy = jest
-				.spyOn( console, 'warn' )
-				.mockImplementation();
+			const consoleSpy = vi.spyOn( console, 'warn' ).mockImplementation();
 
 			const attributes = {
 				metadata: {},

--- a/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
@@ -1,32 +1,33 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 // Mock the entire @wordpress/block-editor module
-jest.mock( '@wordpress/block-editor', () => ( {
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	store: {},
 } ) );
 
 // Mock the entire @wordpress/core-data module
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: {},
 } ) );
 
 // Mock useDispatch specifically to avoid needing to set up full data store
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	createSelector: jest.fn( ( fn ) => fn ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useDispatch: vi.fn(),
+	createSelector: vi.fn( ( fn ) => fn ),
+	createRegistrySelector: vi.fn( ( fn ) => fn ),
+	createReduxStore: vi.fn( () => ( {} ) ),
+	combineReducers: vi.fn( ( reducers ) => ( state = {}, action ) => {
 		const newState = {};
 		Object.keys( reducers ).forEach( ( key ) => {
 			newState[ key ] = reducers[ key ]( state[ key ], action );
 		} );
 		return newState;
 	} ),
-	register: jest.fn(),
+	register: vi.fn(),
 } ) );
 
 /**
@@ -42,8 +43,8 @@ import { updateAttributes } from '../update-attributes';
 import { useEntityBinding } from '../use-entity-binding';
 
 // Mock internal dependencies
-jest.mock( '../update-attributes' );
-jest.mock( '../use-entity-binding' );
+vi.mock( import( '../update-attributes' ) );
+vi.mock( import( '../use-entity-binding' ) );
 
 describe( 'useHandleLinkChange', () => {
 	let mockSetAttributes;
@@ -55,10 +56,10 @@ describe( 'useHandleLinkChange', () => {
 
 	beforeEach( () => {
 		// Reset mocks
-		mockSetAttributes = jest.fn();
-		mockUpdateBlockAttributes = jest.fn();
-		mockCreateBinding = jest.fn();
-		mockClearBinding = jest.fn();
+		mockSetAttributes = vi.fn();
+		mockUpdateBlockAttributes = vi.fn();
+		mockCreateBinding = vi.fn();
+		mockClearBinding = vi.fn();
 
 		// Mock useDispatch
 		useDispatch.mockReturnValue( {
@@ -84,7 +85,7 @@ describe( 'useHandleLinkChange', () => {
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'creating new entity links', () => {

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
@@ -9,16 +10,16 @@ import { renderHook } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 
 // Mock useRemoteUrlData from block-editor
-const mockUseRemoteUrlData = jest.fn();
+const mockUseRemoteUrlData = vi.fn();
 
-jest.mock( '@wordpress/block-editor', () => ( {
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	privateApis: {},
 	store: {},
 } ) );
 
 // Mock the unlock function to return useRemoteUrlData, isHashLink, and isRelativePath
-jest.mock( '../../../lock-unlock', () => ( {
-	unlock: jest.fn( () => ( {
+vi.mock( import( '../../../lock-unlock' ), () => ( {
+	unlock: vi.fn( () => ( {
 		useRemoteUrlData: ( ...args ) => mockUseRemoteUrlData( ...args ),
 		isHashLink: ( url ) => url?.startsWith( '#' ),
 		isRelativePath: ( url ) =>
@@ -37,12 +38,12 @@ import {
 } from '../use-link-preview';
 
 // Mock @wordpress/data
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useSelect: vi.fn(),
 } ) );
 
 // Mock @wordpress/core-data
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: {},
 } ) );
 
@@ -462,7 +463,7 @@ it( 'should show "Page" badge for internal custom links', () => {
 
 describe( 'useLinkPreview', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockUseRemoteUrlData.mockReturnValue( { richData: null } );
 		useSelect.mockReturnValue( null );
 	} );

--- a/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
+++ b/packages/block-library/src/navigation-link/test/__snapshots__/hooks.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`hooks enhanceNavigationLinkVariations enhances variations with icon and isActive functions 1`] = `
+exports[`hooks > enhanceNavigationLinkVariations > enhances variations with icon and isActive functions 1`] = `
 {
   "extraProp": "extraProp",
   "name": "core/navigation-link",

--- a/packages/block-library/src/navigation-link/test/block-labelling.js
+++ b/packages/block-library/src/navigation-link/test/block-labelling.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { _x, sprintf } from '@wordpress/i18n';

--- a/packages/block-library/src/navigation-link/test/hooks.js
+++ b/packages/block-library/src/navigation-link/test/hooks.js
@@ -1,11 +1,17 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { enhanceNavigationLinkVariations } from '../hooks';
+import { describe, expect, it } from 'vitest';
+
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { enhanceNavigationLinkVariations } from '../hooks';
 
 describe( 'hooks', () => {
 	describe( 'enhanceNavigationLinkVariations', () => {

--- a/packages/block-library/src/navigation/edit/test/are-blocks-dirty.js
+++ b/packages/block-library/src/navigation/edit/test/are-blocks-dirty.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { areBlocksDirty } from '../are-blocks-dirty';

--- a/packages/block-library/src/navigation/edit/test/layout-custom-properties.js
+++ b/packages/block-library/src/navigation/edit/test/layout-custom-properties.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
@@ -13,18 +14,18 @@ import { useSettings, useStyleOverride } from '@wordpress/block-editor';
  */
 import useLayoutCustomProperties from '../use-layout-custom-properties';
 
-const mockGetResponsiveMediaQueries = jest.fn();
+const mockGetResponsiveMediaQueries = vi.fn();
 
-jest.mock( '@wordpress/block-editor', () => ( {
-	useSettings: jest.fn(),
-	useStyleOverride: jest.fn(),
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
+	useSettings: vi.fn(),
+	useStyleOverride: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/global-styles-engine', () => ( {
+vi.mock( import( '@wordpress/global-styles-engine' ), () => ( {
 	privateApis: {},
 } ) );
 
-jest.mock( '../../../lock-unlock', () => ( {
+vi.mock( import( '../../../lock-unlock' ), () => ( {
 	unlock: () => ( {
 		getResponsiveMediaQueries: ( ...args ) =>
 			mockGetResponsiveMediaQueries( ...args ),
@@ -33,7 +34,7 @@ jest.mock( '../../../lock-unlock', () => ( {
 
 describe( 'Navigation layout custom properties', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		useSettings.mockReturnValue( [ { mobile: 480, tablet: 782 } ] );
 		mockGetResponsiveMediaQueries.mockReturnValue( {
 			'@tablet': '@media (480px < width <= 782px)',

--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.jsx
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -15,15 +16,15 @@ import { useEntityRecords } from '@wordpress/core-data';
 import NavigationMenuSelector from '../navigation-menu-selector';
 import useNavigationMenu from '../../use-navigation-menu';
 
-jest.mock( '../../use-navigation-menu', () => {
+vi.mock( import( '../../use-navigation-menu' ), () => {
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
+	const mock = vi.fn();
+	return { default: mock };
 } );
 
-jest.mock( '@wordpress/core-data', () => ( {
-	...jest.requireActual( '@wordpress/core-data' ),
-	useEntityRecords: jest.fn(),
+vi.mock( import( '@wordpress/core-data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useEntityRecords: vi.fn(),
 } ) );
 
 useEntityRecords.mockReturnValue( {
@@ -224,7 +225,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call handler callback and close popover when create menu button is clicked', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn();
+				const handler = vi.fn();
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: [],
@@ -251,7 +252,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should handle disabled state of the create menu button during the creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn();
+				const handler = vi.fn();
 
 				// at the start we have the menus and we're not waiting on network
 				useNavigationMenu.mockReturnValue( {
@@ -451,7 +452,7 @@ describe( 'NavigationMenuSelector', () => {
 			it( 'should call the handler when the Navigation Menu is selected', async () => {
 				const user = userEvent.setup();
 
-				const handler = jest.fn();
+				const handler = vi.fn();
 
 				useNavigationMenu.mockReturnValue( {
 					navigationMenus: navigationMenusFixture,
@@ -558,7 +559,7 @@ describe( 'NavigationMenuSelector', () => {
 
 			it( 'should call the handler when the classic menu item is selected and disable all options during the import/creation process', async () => {
 				const user = userEvent.setup();
-				const handler = jest.fn( async () => {} );
+				const handler = vi.fn( async () => {} );
 
 				// initially we have the menus, and we're not waiting on network
 				useNavigationMenu.mockReturnValue( {

--- a/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.jsx
+++ b/packages/block-library/src/navigation/edit/test/overlay-template-part-selector.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -8,7 +9,7 @@ import userEvent from '@testing-library/user-event';
  * WordPress dependencies
  */
 import { useEntityRecords } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,37 +18,37 @@ import OverlayTemplatePartSelector from '../overlay-template-part-selector';
 import useCreateOverlayTemplatePart from '../use-create-overlay';
 
 // Mock useEntityRecords
-jest.mock( '@wordpress/core-data', () => ( {
-	useEntityRecords: jest.fn(),
+vi.mock( import( '@wordpress/core-data' ), () => ( {
+	useEntityRecords: vi.fn(),
 	store: {},
 } ) );
 
 // Mock useCreateOverlayTemplatePart hook
-jest.mock( '../use-create-overlay', () => ( {
+vi.mock( import( '../use-create-overlay' ), () => ( {
 	__esModule: true,
-	default: jest.fn(),
+	default: vi.fn(),
 } ) );
 
 // Mock useDispatch and useSelect specifically to avoid needing to set up full data store
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	useSelect: jest.fn(),
-	createSelector: jest.fn( ( fn ) => fn ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useDispatch: vi.fn(),
+	useSelect: vi.fn(),
+	createSelector: vi.fn( ( fn ) => fn ),
+	createRegistrySelector: vi.fn( ( fn ) => fn ),
+	createReduxStore: vi.fn( () => ( {} ) ),
+	combineReducers: vi.fn( ( reducers ) => ( state = {}, action ) => {
 		const newState = {};
 		Object.keys( reducers ).forEach( ( key ) => {
 			newState[ key ] = reducers[ key ]( state[ key ], action );
 		} );
 		return newState;
 	} ),
-	register: jest.fn(),
-	keyedReducer: jest.fn( () => ( reducer ) => reducer ),
+	register: vi.fn(),
+	keyedReducer: vi.fn( () => ( reducer ) => reducer ),
 } ) );
 
-const mockSetAttributes = jest.fn();
-const mockOnNavigateToEntityRecord = jest.fn();
+const mockSetAttributes = vi.fn();
+const mockOnNavigateToEntityRecord = vi.fn();
 
 const defaultProps = {
 	overlay: undefined,
@@ -86,12 +87,11 @@ const templatePartOtherArea = {
 };
 
 describe( 'OverlayTemplatePartSelector', () => {
-	const mockCreateOverlayTemplatePart = jest.fn();
-	const mockCreateErrorNotice = jest.fn();
-	const { useSelect } = require( '@wordpress/data' );
+	const mockCreateOverlayTemplatePart = vi.fn();
+	const mockCreateErrorNotice = vi.fn();
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		useEntityRecords.mockReturnValue( {
 			records: [],
 			isResolving: false,

--- a/packages/block-library/src/navigation/edit/test/responsive-wrapper.jsx
+++ b/packages/block-library/src/navigation/edit/test/responsive-wrapper.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -15,34 +16,34 @@ import { useSelect } from '@wordpress/data';
 import ResponsiveWrapper from '../responsive-wrapper';
 
 // Mock block-editor to avoid private API issues
-jest.mock( '@wordpress/block-editor', () => ( {
-	getColorClassName: jest.fn( () => '' ),
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
+	getColorClassName: vi.fn( () => '' ),
 } ) );
 
 // Mock core-data store
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: {},
 } ) );
 
 // Mock useSelect
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	createSelector: jest.fn( ( fn ) => fn ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useSelect: vi.fn(),
+	createSelector: vi.fn( ( fn ) => fn ),
+	createRegistrySelector: vi.fn( ( fn ) => fn ),
+	createReduxStore: vi.fn( () => ( {} ) ),
+	combineReducers: vi.fn( ( reducers ) => ( state = {}, action ) => {
 		const newState = {};
 		Object.keys( reducers ).forEach( ( key ) => {
 			newState[ key ] = reducers[ key ]( state[ key ], action );
 		} );
 		return newState;
 	} ),
-	register: jest.fn(),
+	register: vi.fn(),
 } ) );
 
 describe( 'ResponsiveWrapper', () => {
-	const mockOnToggle = jest.fn();
-	const mockOnNavigateToEntityRecord = jest.fn();
+	const mockOnToggle = vi.fn();
+	const mockOnNavigateToEntityRecord = vi.fn();
 
 	const defaultProps = {
 		id: 'test-navigation',
@@ -60,7 +61,7 @@ describe( 'ResponsiveWrapper', () => {
 	};
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		// Mock useSelect - component calls: select( coreStore ).getCurrentTheme()?.stylesheet
 		useSelect.mockImplementation( ( selector ) => {
 			if ( typeof selector === 'function' ) {

--- a/packages/block-library/src/navigation/edit/test/use-create-overlay.js
+++ b/packages/block-library/src/navigation/edit/test/use-create-overlay.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock, parse, serialize } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,25 +17,25 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import useCreateOverlayTemplatePart from '../use-create-overlay';
 
 // Mock useDispatch and useSelect
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	useSelect: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useDispatch: vi.fn(),
+	useSelect: vi.fn(),
 } ) );
 
 // Mock coreStore
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: {},
 } ) );
 
 // Mock blockEditorStore
-jest.mock( '@wordpress/block-editor', () => ( {
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	store: {},
 } ) );
 
 // Mock @wordpress/blocks
-jest.mock( '@wordpress/blocks', () => ( {
-	serialize: jest.fn( ( blocks ) => JSON.stringify( blocks ) ),
-	parse: jest.fn( ( content ) => {
+vi.mock( import( '@wordpress/blocks' ), () => ( {
+	serialize: vi.fn( ( blocks ) => JSON.stringify( blocks ) ),
+	parse: vi.fn( ( content ) => {
 		// Return mock blocks when parsing pattern content
 		if ( content && typeof content === 'string' ) {
 			return [
@@ -45,7 +48,7 @@ jest.mock( '@wordpress/blocks', () => ( {
 		}
 		return [];
 	} ),
-	createBlock: jest.fn( ( name ) => ( {
+	createBlock: vi.fn( ( name ) => ( {
 		name,
 		attributes: {},
 		innerBlocks: [],
@@ -53,17 +56,17 @@ jest.mock( '@wordpress/blocks', () => ( {
 } ) );
 
 // Mock lock-unlock
-const mockUnlock = jest.fn();
-jest.mock( '../../../lock-unlock', () => ( {
+const mockUnlock = vi.fn();
+vi.mock( import( '../../../lock-unlock' ), () => ( {
 	unlock: ( select ) => mockUnlock( select ),
 } ) );
 
 describe( 'useCreateOverlayTemplatePart', () => {
-	const mockSaveEntityRecord = jest.fn();
-	const mockGetPatternBySlug = jest.fn();
+	const mockSaveEntityRecord = vi.fn();
+	const mockGetPatternBySlug = vi.fn();
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		useDispatch.mockReturnValue( {
 			saveEntityRecord: mockSaveEntityRecord,
 		} );
@@ -73,8 +76,8 @@ describe( 'useCreateOverlayTemplatePart', () => {
 		} );
 
 		useSelect.mockImplementation( ( selector ) => {
-			const mockSelect = jest.fn( ( store ) => {
-				if ( store === require( '@wordpress/block-editor' ).store ) {
+			const mockSelect = vi.fn( ( store ) => {
+				if ( store === blockEditorStore ) {
 					return {}; // Return mock block editor store
 				}
 				return {};
@@ -186,10 +189,6 @@ describe( 'useCreateOverlayTemplatePart', () => {
 
 		mockSaveEntityRecord.mockResolvedValue( createdOverlay );
 
-		// Import mocked functions
-		const blocksModule = require( '@wordpress/blocks' );
-		const { parse, serialize } = blocksModule;
-
 		const { result: createOverlayTemplatePart } = renderHook( () =>
 			useCreateOverlayTemplatePart( overlayTemplateParts )
 		);
@@ -223,10 +222,6 @@ describe( 'useCreateOverlayTemplatePart', () => {
 
 		mockSaveEntityRecord.mockResolvedValue( createdOverlay );
 		mockGetPatternBySlug.mockReturnValue( null );
-
-		// Import mocked functions
-		const blocksModule = require( '@wordpress/blocks' );
-		const { createBlock, serialize } = blocksModule;
 
 		const { result: createOverlayTemplatePart } = renderHook( () =>
 			useCreateOverlayTemplatePart( overlayTemplateParts )

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from '../utils';

--- a/packages/block-library/src/navigation/test/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/test/menu-items-to-blocks.js
@@ -1,11 +1,16 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import menuItemsToBlocks from '../menu-items-to-blocks';
 
 // Mock createBlock to avoid creating the blocks in test environment.
-jest.mock( '@wordpress/blocks', () => {
-	const blocks = jest.requireActual( '@wordpress/blocks' );
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const blocks = await importOriginal();
 
 	return {
 		...blocks,

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { createRegistry, useSelect } from '@wordpress/data';
@@ -31,11 +36,11 @@ function createRegistryWithStores() {
 	return registry;
 }
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+	useSelect: vi.fn(),
+} ) );
 
 function resolveRecords( registry, menus ) {
 	const dispatch = registry.dispatch( coreStore );

--- a/packages/block-library/src/navigation/test/view.js
+++ b/packages/block-library/src/navigation/test/view.js
@@ -1,7 +1,12 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 let mockRegisteredStore;
 let mockCurrentContext;
 
-jest.mock( '@wordpress/interactivity', () => ( {
+vi.mock( import( '@wordpress/interactivity' ), () => ( {
 	store: ( name, config ) => {
 		mockRegisteredStore = config;
 		return config;
@@ -13,7 +18,7 @@ jest.mock( '@wordpress/interactivity', () => ( {
 
 describe( 'Navigation view script', () => {
 	beforeEach( async () => {
-		jest.resetModules();
+		vi.resetModules();
 		mockRegisteredStore = null;
 		mockCurrentContext = null;
 		// Import the view.js script to register the store

--- a/packages/block-library/src/page-list/test/convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/test/convert-to-navigation-links.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 
@@ -16,8 +21,8 @@ const EXPECTED_ENTITY_BINDING = {
 
 // Mock createBlock to avoid creating the blocks in test environment
 // as convertToNavigationLinks calls this method internally.
-jest.mock( '@wordpress/blocks', () => {
-	const blocks = jest.requireActual( '@wordpress/blocks' );
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const blocks = await importOriginal();
 
 	return {
 		...blocks,

--- a/packages/block-library/src/pattern/test/index.js
+++ b/packages/block-library/src/pattern/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-library/src/playlist-track/test/edit.jsx
+++ b/packages/block-library/src/playlist-track/test/edit.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 
 /**
@@ -17,7 +18,7 @@ import { useUploadMediaFromBlobURL } from '../../utils/hooks';
 
 let mockMediaReplaceFlowProps;
 
-jest.mock( '@wordpress/block-editor', () => ( {
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	BlockControls: ( { children, group = 'default' } ) => (
 		<div data-testid={ `block-controls-${ group }` }>{ children }</div>
 	),
@@ -30,7 +31,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		return <button onClick={ () => onSelect( {} ) }>{ name }</button>;
 	},
 	MediaUpload: ( { render: renderMediaUpload } ) =>
-		renderMediaUpload( { open: jest.fn() } ),
+		renderMediaUpload( { open: vi.fn() } ),
 	MediaUploadCheck: ( { children } ) => <div>{ children }</div>,
 	PlainText: ( {
 		onChange,
@@ -40,30 +41,30 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		__experimentalVersion,
 		...props
 	} ) => <TagName { ...props }>{ value || placeholder }</TagName>,
-	useBlockProps: jest.fn( () => ( {} ) ),
+	useBlockProps: vi.fn( () => ( {} ) ),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useDispatch: vi.fn(),
+	combineReducers: vi.fn( ( reducers ) => ( state = {}, action ) => {
 		const newState = {};
 		Object.keys( reducers ).forEach( ( key ) => {
 			newState[ key ] = reducers[ key ]( state[ key ], action );
 		} );
 		return newState;
 	} ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	createSelector: jest.fn( ( fn ) => fn ),
-	register: jest.fn(),
+	createRegistrySelector: vi.fn( ( fn ) => fn ),
+	createReduxStore: vi.fn( () => ( {} ) ),
+	createSelector: vi.fn( ( fn ) => fn ),
+	register: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/notices', () => ( {
+vi.mock( import( '@wordpress/notices' ), () => ( {
 	store: 'core/notices',
 } ) );
 
-jest.mock( '../../utils/hooks', () => ( {
-	useUploadMediaFromBlobURL: jest.fn(),
+vi.mock( import( '../../utils/hooks' ), () => ( {
+	useUploadMediaFromBlobURL: vi.fn(),
 } ) );
 
 const defaultAttributes = {
@@ -78,8 +79,8 @@ const defaultAttributes = {
 };
 
 function renderEdit( props = {} ) {
-	const setAttributes = jest.fn();
-	const setCurrentTrackClientId = props.setCurrentTrackClientId || jest.fn();
+	const setAttributes = vi.fn();
+	const setCurrentTrackClientId = props.setCurrentTrackClientId || vi.fn();
 	const addTracks = props.addTracks;
 
 	render(
@@ -114,7 +115,7 @@ describe( 'PlaylistTrackEdit', () => {
 	beforeEach( () => {
 		mockMediaReplaceFlowProps = undefined;
 		useDispatch.mockReturnValue( {
-			createErrorNotice: jest.fn(),
+			createErrorNotice: vi.fn(),
 		} );
 		useUploadMediaFromBlobURL.mockClear();
 	} );
@@ -196,7 +197,7 @@ describe( 'PlaylistTrackEdit', () => {
 	} );
 
 	it( 'allows tracks to be added from the track toolbar', () => {
-		const addTracks = jest.fn();
+		const addTracks = vi.fn();
 		renderEdit( { addTracks } );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Add' } ) );
@@ -205,7 +206,7 @@ describe( 'PlaylistTrackEdit', () => {
 	} );
 
 	it( 'renders the add track control in a different toolbar group from replace', () => {
-		renderEdit( { addTracks: jest.fn() } );
+		renderEdit( { addTracks: vi.fn() } );
 
 		expect(
 			within( screen.getByTestId( 'block-controls-other' ) ).getByRole(

--- a/packages/block-library/src/playlist/test/edit-component.jsx
+++ b/packages/block-library/src/playlist/test/edit-component.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import PlaylistEdit from '../edit';
 
-jest.mock( '@wordpress/block-editor', () => ( {
+vi.mock( import( '@wordpress/block-editor' ), () => ( {
 	store: {},
 	BlockControls: ( { children } ) => <div>{ children }</div>,
 	BlockIcon: () => <span />,
@@ -34,19 +35,19 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	} ),
 } ) );
 
-jest.mock( '@wordpress/blocks', () => ( {
-	createBlock: jest.fn( ( name, attributes ) => ( {
+vi.mock( import( '@wordpress/blocks' ), () => ( {
+	createBlock: vi.fn( ( name, attributes ) => ( {
 		name,
 		attributes,
 		clientId: 'new-track',
 	} ) ),
 } ) );
 
-jest.mock( '@wordpress/blob', () => ( {
-	createBlobURL: jest.fn( () => 'blob:track' ),
+vi.mock( import( '@wordpress/blob' ), () => ( {
+	createBlobURL: vi.fn( () => 'blob:track' ),
 } ) );
 
-jest.mock( '@wordpress/components', () => ( {
+vi.mock( import( '@wordpress/components' ), () => ( {
 	Disabled: ( { children } ) => <div>{ children }</div>,
 	SelectControl: () => <div />,
 	ToggleControl: () => <div />,
@@ -54,33 +55,33 @@ jest.mock( '@wordpress/components', () => ( {
 	__experimentalToolsPanelItem: ( { children } ) => <div>{ children }</div>,
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	useSelect: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useDispatch: vi.fn(),
+	useSelect: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/i18n', () => ( {
+vi.mock( import( '@wordpress/i18n' ), () => ( {
 	__: ( text ) => text,
 	_x: ( text ) => text,
 } ) );
 
-jest.mock( '@wordpress/icons', () => ( {
+vi.mock( import( '@wordpress/icons' ), () => ( {
 	playlist: 'playlist',
 } ) );
 
-jest.mock( '@wordpress/notices', () => ( {
+vi.mock( import( '@wordpress/notices' ), () => ( {
 	store: {},
 } ) );
 
-jest.mock( '../../utils/caption', () => ( {
+vi.mock( import( '../../utils/caption' ), () => ( {
 	Caption: () => <figcaption />,
 } ) );
 
-jest.mock( '../../utils/hooks', () => ( {
+vi.mock( import( '../../utils/hooks' ), () => ( {
 	useToolsPanelDropdownMenuProps: () => ( {} ),
 } ) );
 
-jest.mock( '../../utils/waveform-player', () => ( {
+vi.mock( import( '../../utils/waveform-player' ), () => ( {
 	WaveformPlayer: () => <div />,
 } ) );
 
@@ -97,9 +98,9 @@ const defaultAttributes = {
 describe( 'PlaylistEdit', () => {
 	beforeEach( () => {
 		useDispatch.mockReturnValue( {
-			createErrorNotice: jest.fn(),
-			replaceInnerBlocks: jest.fn(),
-			selectBlock: jest.fn(),
+			createErrorNotice: vi.fn(),
+			replaceInnerBlocks: vi.fn(),
+			selectBlock: vi.fn(),
 		} );
 		useSelect.mockReturnValue( {
 			innerBlockTracks: [
@@ -123,9 +124,9 @@ describe( 'PlaylistEdit', () => {
 					showTracklist: false,
 				} }
 				clientId="playlist-1"
-				insertBlocksAfter={ jest.fn() }
+				insertBlocksAfter={ vi.fn() }
 				isSelected={ false }
-				setAttributes={ jest.fn() }
+				setAttributes={ vi.fn() }
 			/>
 		);
 

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getTrackAttributes } from '../utils';

--- a/packages/block-library/src/post-date/test/edit.js
+++ b/packages/block-library/src/post-date/test/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { is12HourFormat } from '../edit';

--- a/packages/block-library/src/query/test/utils.js
+++ b/packages/block-library/src/query/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { terms } from './fixtures';

--- a/packages/block-library/src/quote/test/migrate.js
+++ b/packages/block-library/src/quote/test/migrate.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-library/src/separator/test/edit.jsx
+++ b/packages/block-library/src/separator/test/edit.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -13,9 +14,9 @@ import { useBlockProps } from '@wordpress/block-editor';
  */
 import SeparatorEdit from '../edit';
 
-jest.mock( '@wordpress/block-editor', () => ( {
-	...jest.requireActual( '@wordpress/block-editor' ),
-	useBlockProps: jest.fn(),
+vi.mock( import( '@wordpress/block-editor' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useBlockProps: vi.fn(),
 } ) );
 
 const defaultAttributes = {
@@ -27,7 +28,7 @@ const defaultAttributes = {
 };
 const defaultProps = {
 	attributes: defaultAttributes,
-	setAttributes: jest.fn(),
+	setAttributes: vi.fn(),
 };
 
 describe( 'Separator block edit method', () => {

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/block-library/src/table/test/utils.js
+++ b/packages/block-library/src/table/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { normalizeRowColSpan } from '../utils';

--- a/packages/block-library/src/utils/test/search-patterns.js
+++ b/packages/block-library/src/utils/test/search-patterns.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-library/src/utils/test/style-state.js
+++ b/packages/block-library/src/utils/test/style-state.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-library/src/utils/test/waveform-player.jsx
+++ b/packages/block-library/src/utils/test/waveform-player.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 import { act, render } from '@testing-library/react';
 
 /**
@@ -14,11 +15,11 @@ import {
 	setupPlayButtonArtwork,
 } from '../waveform-utils';
 
-jest.mock( '../waveform-utils', () => ( {
-	applyWaveformPlayerStyles: jest.fn(),
-	initWaveformPlayer: jest.fn(),
-	setupPlayButtonArtwork: jest.fn(),
-	updateSeekControlLabel: jest.fn(),
+vi.mock( import( '../waveform-utils' ), () => ( {
+	applyWaveformPlayerStyles: vi.fn(),
+	initWaveformPlayer: vi.fn(),
+	setupPlayButtonArtwork: vi.fn(),
+	updateSeekControlLabel: vi.fn(),
 } ) );
 
 /**
@@ -58,8 +59,8 @@ function createFakePlayer( options, element ) {
 		titleEl,
 		artistEl: artistEl || null,
 		artworkEl: artworkEl || null,
-		pause: jest.fn(),
-		syncArtist: jest.fn( ( artist ) => {
+		pause: vi.fn(),
+		syncArtist: vi.fn( ( artist ) => {
 			if ( ! artist ) {
 				instance.artistEl?.remove();
 				instance.artistEl = null;
@@ -72,7 +73,7 @@ function createFakePlayer( options, element ) {
 			instance.artistEl.textContent = artist;
 			instance.artistEl.style.display = '';
 		} ),
-		syncArtwork: jest.fn( ( image, imageAlt = '' ) => {
+		syncArtwork: vi.fn( ( image, imageAlt = '' ) => {
 			if ( ! image ) {
 				instance.artworkEl?.remove();
 				instance.artworkEl = null;
@@ -85,7 +86,7 @@ function createFakePlayer( options, element ) {
 			instance.artworkEl.src = image;
 			instance.artworkEl.alt = imageAlt || '';
 		} ),
-		loadTrack: jest.fn( async ( src, title, artist, trackOptions ) => {
+		loadTrack: vi.fn( async ( src, title, artist, trackOptions ) => {
 			titleEl.textContent = title;
 			instance.syncArtist( artist );
 			instance.syncArtwork(
@@ -98,21 +99,21 @@ function createFakePlayer( options, element ) {
 	return {
 		instance,
 		container: element,
-		destroy: jest.fn(),
+		destroy: vi.fn(),
 	};
 }
 
 describe( 'WaveformPlayer', () => {
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		initWaveformPlayer.mockImplementation( ( element, options ) =>
 			createFakePlayer( options, element )
 		);
 	} );
 
 	afterEach( () => {
-		jest.runOnlyPendingTimers();
-		jest.useRealTimers();
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
 		applyWaveformPlayerStyles.mockReset();
 		initWaveformPlayer.mockReset();
 		setupPlayButtonArtwork.mockReset();
@@ -131,7 +132,7 @@ describe( 'WaveformPlayer', () => {
 		render( <WaveformPlayer { ...baseProps } /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( initWaveformPlayer ).toHaveBeenCalledTimes( 1 );
@@ -152,7 +153,7 @@ describe( 'WaveformPlayer', () => {
 		render( <WaveformPlayer { ...baseProps } showPlayButtonArtwork /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( initWaveformPlayer ).toHaveBeenCalledWith(
@@ -176,7 +177,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( initWaveformPlayer ).toHaveBeenCalledWith(
@@ -197,7 +198,7 @@ describe( 'WaveformPlayer', () => {
 		render( <WaveformPlayer { ...baseProps } showPlayButtonArtwork /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -211,7 +212,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -235,7 +236,7 @@ describe( 'WaveformPlayer', () => {
 		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -269,7 +270,7 @@ describe( 'WaveformPlayer', () => {
 		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -282,7 +283,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( player.destroy ).not.toHaveBeenCalled();
@@ -304,7 +305,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -312,7 +313,7 @@ describe( 'WaveformPlayer', () => {
 		rerender( <WaveformPlayer { ...baseProps } showPlayButtonArtwork /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
@@ -333,7 +334,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -341,7 +342,7 @@ describe( 'WaveformPlayer', () => {
 		rerender( <WaveformPlayer { ...baseProps } color="#0000ff" /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
@@ -360,7 +361,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -392,7 +393,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -405,7 +406,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( player.destroy ).toHaveBeenCalledTimes( 1 );
@@ -425,7 +426,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const firstPlayer = initWaveformPlayer.mock.results[ 0 ].value;
@@ -440,7 +441,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( firstPlayer.destroy ).not.toHaveBeenCalled();
@@ -455,7 +456,7 @@ describe( 'WaveformPlayer', () => {
 		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;
@@ -463,7 +464,7 @@ describe( 'WaveformPlayer', () => {
 		rerender( <WaveformPlayer { ...baseProps } image="" /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		expect( player.destroy ).not.toHaveBeenCalled();
@@ -477,7 +478,7 @@ describe( 'WaveformPlayer', () => {
 		);
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const firstPlayer = initWaveformPlayer.mock.results[ 0 ].value;
@@ -499,7 +500,7 @@ describe( 'WaveformPlayer', () => {
 		const { rerender } = render( <WaveformPlayer { ...baseProps } /> );
 
 		act( () => {
-			jest.advanceTimersByTime( 100 );
+			vi.advanceTimersByTime( 100 );
 		} );
 
 		const player = initWaveformPlayer.mock.results[ 0 ].value;

--- a/packages/block-library/src/utils/test/waveform-utils.js
+++ b/packages/block-library/src/utils/test/waveform-utils.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 
 /**
  * Internal dependencies
@@ -462,7 +463,7 @@ describe( 'Waveform utilities', () => {
 			const instance = {
 				container,
 				options: {},
-				applySeekLabel: jest.fn( ( label ) => {
+				applySeekLabel: vi.fn( ( label ) => {
 					seekControl.setAttribute( 'aria-label', label );
 				} ),
 			};
@@ -691,19 +692,19 @@ describe( 'Waveform utilities', () => {
 			// from running so the test only exercises the synchronous
 			// construction path, where the crossOrigin behavior is decided
 			// before any request is made.
-			jest.useFakeTimers();
+			vi.useFakeTimers();
 
 			// jsdom does not implement canvas rendering or media playback;
 			// stub them out so the library's construction and destroy paths
 			// do not emit "Not implemented" console errors.
 			jsdomStubs = [
-				jest
+				vi
 					.spyOn( window.HTMLCanvasElement.prototype, 'getContext' )
 					.mockReturnValue( null ),
-				jest
+				vi
 					.spyOn( window.HTMLMediaElement.prototype, 'pause' )
 					.mockImplementation( () => {} ),
-				jest
+				vi
 					.spyOn( window.HTMLMediaElement.prototype, 'load' )
 					.mockImplementation( () => {} ),
 			];
@@ -711,7 +712,7 @@ describe( 'Waveform utilities', () => {
 
 		afterEach( () => {
 			jsdomStubs.forEach( ( stub ) => stub.mockRestore() );
-			jest.useRealTimers();
+			vi.useRealTimers();
 			document.body.innerHTML = '';
 		} );
 
@@ -747,7 +748,7 @@ describe( 'Waveform utilities', () => {
 		let consoleErrorSpy;
 
 		beforeEach( () => {
-			consoleErrorSpy = jest
+			consoleErrorSpy = vi
 				.spyOn( console, 'error' )
 				.mockImplementation( () => {} );
 		} );

--- a/packages/block-library/src/video/test/variations.js
+++ b/packages/block-library/src/video/test/variations.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import variations, { isGifVariation } from '../variations';

--- a/test/integration/helpers/wait-for-store-resolvers.js
+++ b/test/integration/helpers/wait-for-store-resolvers.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { act } from '@testing-library/react';
+import { vi } from 'vitest';
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ export async function waitForStoreResolvers( fn ) {
 		const result = fn();
 
 		// Advance all timers allowing store resolvers to resolve.
-		act( () => jest.runAllTimers() );
+		act( () => vi.runAllTimers() );
 
 		// The store resolvers perform several API fetches during editor
 		// initialization. The most straightforward approach to ensure all of them

--- a/test/integration/helpers/with-fake-timers.js
+++ b/test/integration/helpers/with-fake-timers.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { vi } from 'vitest';
+
+/**
  * Set up fake timers for executing a function and restores them afterwards.
  *
  * @param {Function} fn Function to trigger.
@@ -6,22 +11,22 @@
  * @return {*} The result of the function call.
  */
 export async function withFakeTimers( fn ) {
-	const usingFakeTimers = jest.isMockFunction( setTimeout );
+	const usingFakeTimers = vi.isFakeTimers();
 
 	// Portions of the React Native Animation API rely upon these APIs. However,
-	// Jest's 'legacy' fake timers mutate these globals, which breaks the Animated
-	// API. We preserve the original implementations to restore them later.
+	// fake timers may mutate these globals, which breaks the Animated API. We
+	// preserve the original implementations to restore them later.
 	const requestAnimationFrameCopy = global.requestAnimationFrame;
 	const cancelAnimationFrameCopy = global.cancelAnimationFrame;
 
 	if ( ! usingFakeTimers ) {
-		jest.useFakeTimers( { legacyFakeTimers: true } );
+		vi.useFakeTimers();
 	}
 
 	const result = await fn();
 
 	if ( ! usingFakeTimers ) {
-		jest.useRealTimers();
+		vi.useRealTimers();
 
 		global.requestAnimationFrame = requestAnimationFrameCopy;
 		global.cancelAnimationFrame = cancelAnimationFrameCopy;

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -25,6 +25,7 @@
 					"packages/autop",
 					"packages/blob",
 					"packages/block-directory",
+					"packages/block-library",
 					"packages/blocks",
 					"packages/connectors",
 					"packages/components",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** This slice migrates Block Library's 55 unit-test files from Jest to Vitest. The required change classes are explicit Vitest imports, ESM-compatible dynamic mock factories, the Vitest Testing Library matcher entrypoint, shared integration fake-timer helpers, and an audited snapshot key/header update.

## Why?

Block Library was one of the four remaining Jest-owned areas in the repository. Migrating it reduces the residual Jest partition while preserving the package's 669 tests and its existing Testing Library-based authoring model.

## How?

- Routes `packages/block-library` through the private Vitest `jsdom` project.
- Replaces Jest globals and runtime `require` calls with explicit Vitest imports and ESM-compatible mocks.
- Keeps `@testing-library/react` and `@testing-library/user-event`; only the matcher registration changes to `@testing-library/jest-dom/vitest`.
- Ports the shared integration fake-timer helpers to Vitest's public timer APIs. Vitest modern timers replace the Jest-only legacy-timer mode.
- Updates the sole snapshot's runner header and hierarchical key. Its serialized body was compared byte-for-byte and is unchanged.
- Adds Vitest as a direct development dependency of the workspace that imports it.

## Testing Instructions

1. `npm run test:unit:vitest -- packages/block-library`
   - 55 files passed, 669 tests passed, 1 snapshot passed.
2. `npm run test:unit:vitest`
   - 806 files passed, 2 skipped; 31,852 tests passed, 8 skipped.
3. `npm run test:unit -- --runInBand`
   - 194 suites passed; 2,898 tests passed; 25 snapshots passed.
4. `npm run test:unit:validate-migration`
   - 194 Jest-owned and 809 Vitest-owned tests; no missing, overlapping, invalid, or orphaned entries.
5. `npm run test:unit:validate-vitest-conventions`
   - 809 Vitest tests and 825 ESM graph files pass the repository conventions.
6. Commit-time formatting, strict JavaScript lint, package metadata, lockfile, and generated API-doc checks pass.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This migration was implemented with Codex assistance. The resulting diff, snapshot, and verification output were reviewed before publication.
