### PR TITLE
Navigation: Don't repeat the block anchor id on the inner list

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -284,10 +284,7 @@ class WP_Navigation_Block_Renderer {
 
 			if ( $is_list_item && ! $is_list_open ) {
 				$is_list_open       = true;
-				$inner_blocks_html .= sprintf(
-					'<ul %1$s>',
-					$container_attributes
-				);
+				$inner_blocks_html .= static::get_list_open_tag( $container_attributes );
 			}
 
 			if ( ! $is_list_item && $is_list_open ) {
@@ -309,6 +306,36 @@ class WP_Navigation_Block_Renderer {
 		}
 
 		return $inner_blocks_html;
+	}
+
+	/**
+	 * Builds the opening tag for the navigation block's list element.
+	 *
+	 * The list is not the block's wrapper element, but it is still rendered with
+	 * `get_block_wrapper_attributes()` because Core generates the block's layout
+	 * and alignment styles with selectors that target the list rather than the
+	 * outer `<nav>`. Reusing the wrapper attributes keeps those styles working,
+	 * at the cost of repeating some of them on both elements.
+	 *
+	 * The `anchor` block support is the one attribute that must not be repeated.
+	 * It renders the user-supplied HTML anchor as `id`, so emitting the wrapper
+	 * attributes verbatim puts the same `id` on both the `<nav>` and the list,
+	 * which is invalid HTML. The outer `<nav>` keeps the anchor, so it is
+	 * removed from the list here.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $container_attributes The block wrapper attributes for the list element.
+	 * @return string The opening `<ul>` tag.
+	 */
+	private static function get_list_open_tag( $container_attributes ) {
+		$processor = new WP_HTML_Tag_Processor( sprintf( '<ul %1$s>', $container_attributes ) );
+
+		if ( $processor->next_tag( 'UL' ) ) {
+			$processor->remove_attribute( 'id' );
+		}
+
+		return $processor->get_updated_html();
 	}
 
 	/**

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -195,6 +195,90 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the list element does not repeat the block wrapper's anchor id.
+	 *
+	 * The list reuses the block wrapper attributes so that Core's layout styles
+	 * keep applying, but the `anchor` support's id belongs to the outer `<nav>`
+	 * alone. Repeating it would produce duplicate ids, which are invalid HTML.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_list_open_tag
+	 */
+	public function test_gutenberg_get_list_open_tag_removes_the_anchor_id() {
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$method     = $reflection->getMethod( 'get_list_open_tag' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$actual = $method->invoke(
+			$reflection,
+			'class="wp-block-navigation__container wp-block-navigation" id="header-navigation"'
+		);
+
+		$processor = new WP_HTML_Tag_Processor( $actual );
+		$processor->next_tag( 'UL' );
+
+		$this->assertNull(
+			$processor->get_attribute( 'id' ),
+			'The list element should not carry the block wrapper\'s anchor id.'
+		);
+	}
+
+	/**
+	 * Test that stripping the anchor id leaves the other wrapper attributes intact.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_list_open_tag
+	 */
+	public function test_gutenberg_get_list_open_tag_preserves_other_attributes() {
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$method     = $reflection->getMethod( 'get_list_open_tag' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$actual = $method->invoke(
+			$reflection,
+			'class="wp-block-navigation__container wp-block-navigation" style="color:red" id="header-navigation"'
+		);
+
+		$processor = new WP_HTML_Tag_Processor( $actual );
+		$processor->next_tag( 'UL' );
+
+		$this->assertTrue(
+			$processor->has_class( 'wp-block-navigation__container' ),
+			'The container class should be preserved.'
+		);
+		$this->assertSame(
+			'color:red',
+			$processor->get_attribute( 'style' ),
+			'Inline styles should be preserved.'
+		);
+	}
+
+	/**
+	 * Test that a list element without an anchor id is left unchanged.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_list_open_tag
+	 */
+	public function test_gutenberg_get_list_open_tag_without_an_anchor_is_unchanged() {
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$method     = $reflection->getMethod( 'get_list_open_tag' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$actual = $method->invoke( $reflection, 'class="wp-block-navigation__container"' );
+
+		$this->assertSame( '<ul class="wp-block-navigation__container">', $actual );
+	}
+
+	/**
 	 * Test that gutenberg_block_core_navigation_block_tree_has_block_type finds a block at the top level.
 	 *
 	 * @group navigation-renderer


### PR DESCRIPTION
## What?

Closes #80331

Stops the Navigation block from rendering a custom HTML Anchor on both the outer `<nav>` and the inner `<ul>`, which produced duplicate `id` attributes.

## Why?

Setting **Block Settings → Advanced → HTML Anchor** on a Navigation block emits the same `id` twice:

```html
<nav class="wp-block-navigation …" id="header-navigation">
  <ul class="wp-block-navigation__container wp-block-navigation" id="header-navigation">
```

```js
document.querySelectorAll('#header-navigation').length // 2
```

IDs must be unique in a document, so this is invalid HTML. It affects CSS selectors, JavaScript lookups, fragment links, and HTML/accessibility validators.

The root cause is that `get_inner_blocks_html()` calls `get_block_wrapper_attributes()` a second time for the list element, which re-applies everything the `anchor` block support contributed to the wrapper.

This is the same underlying call flagged in #62690, but that issue is about the repeated **class**. The two are worth separating:

* Removing the repeated class is risky. As discussed in #62690 and #63801, Core's layout and alignment styles are generated with selectors that target the `<ul>` rather than the `<nav>`, so the list genuinely relies on those wrapper attributes. Changing it can break theme styles and would need a dev note, and existing e2e tests assert the class is present.
* A duplicate `id` has none of those properties. It is unambiguously invalid, nothing depends on it, and no test asserts it.

So this PR fixes only the `id` and deliberately leaves the class duplication to #62690 / #63801.

## How?

`get_inner_blocks_html()` now builds the list's opening tag through a small `get_list_open_tag()` helper, which removes the `id` with `WP_HTML_Tag_Processor` and leaves every other wrapper attribute untouched. The anchor remains on the `<nav>`.

`WP_HTML_Tag_Processor` is used rather than a regular expression, per the concern raised on #63801 about regex-based attribute rewriting.

The helper carries a docblock explaining *why* the list is rendered with wrapper attributes at all — #62690 notes that this has never been documented, and it has caused repeated confusion.

Note for coordination: #63801 is open against the class half of this and edits the same function, so the two will need a trivial rebase depending on merge order.

## Testing Instructions

1. Using a block theme, add a Navigation block to a post or page with a few links.
2. Open **Block Settings → Advanced → HTML Anchor** and enter `header-navigation`.
3. Save and view the post on the front end.
4. View source, or run this in the browser console:

   ```js
   document.querySelectorAll('#header-navigation').length
   ```

5. Expected: `1`, and the `id` is on the outer `<nav>`. On trunk this returns `2`.
6. Confirm the menu still renders and is styled as before, and that `#header-navigation` still works as a fragment link target.

Also worth checking that a Navigation block with **no** HTML Anchor is unchanged.

### Testing Instructions for Keyboard

No UI or interaction changes — this only affects rendered front-end markup, so there is no keyboard-specific behaviour to test. Keyboard navigation through the menu links is unaffected.

## Screenshots or screencast

| Before | After |
|-|-|
| `document.querySelectorAll('#header-navigation').length === 2` — the anchor matches both the `<nav>` and the inner `<ul>`, so a single `#header-navigation` CSS rule paints two nested outlines. | `… === 1` — the anchor matches only the `<nav>` wrapper, and the same rule paints one outline. |

## Use of AI Tools

This pull request was authored with AI assistance (Claude, via Claude Code), and I have reviewed and take responsibility for its contents.

Specifically: the AI was used to locate the root cause, write the change and its docblock, draft the PHPUnit tests, and draft this description. I directed the work, reviewed the diff, and verified the behaviour myself.

One limitation to flag for reviewers: the PHPUnit suite could not be executed locally, as this environment has no Docker/`wp-env`. The new tests' assertions were instead verified by running them against the built class through WP-CLI on a local WordPress install, and the rendered-markup change was confirmed end to end on that site. CI will be the first true PHPUnit run. `PHPCS` passes cleanly on both changed files.
