### PR TITLE
Migrate Editor Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51026,7 +51026,8 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@wordpress/block-library": "file:../block-library",
-				"deep-freeze": "^0.0.1"
+				"deep-freeze": "^0.0.1",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -17,7 +17,9 @@
 
 ### Internal
 
+-   Migrate unit tests from Jest to Vitest.
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
+
 ## 14.51.0 (2026-07-14)
 
 ### New Features

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -122,7 +122,8 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@wordpress/block-library": "file:../block-library",
-		"deep-freeze": "^0.0.1"
+		"deep-freeze": "^0.0.1",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/editor/src/bindings/test/pattern-overrides.js
+++ b/packages/editor/src/bindings/test/pattern-overrides.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import patternOverridesBindings from '../pattern-overrides';

--- a/packages/editor/src/bindings/test/post-data.js
+++ b/packages/editor/src/bindings/test/post-data.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';

--- a/packages/editor/src/bindings/test/post-meta.js
+++ b/packages/editor/src/bindings/test/post-meta.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { lock } from '../../lock-unlock';

--- a/packages/editor/src/bindings/test/term-data.js
+++ b/packages/editor/src/bindings/test/term-data.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';

--- a/packages/editor/src/components/autocompleters/test/user.jsx
+++ b/packages/editor/src/components/autocompleters/test/user.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getUserLabel } from '../user';

--- a/packages/editor/src/components/autosave-monitor/test/index.jsx
+++ b/packages/editor/src/components/autosave-monitor/test/index.jsx
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -13,14 +22,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import AutosaveMonitor from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+	useDispatch: vi.fn(),
 } ) );
-
-jest.useFakeTimers();
-jest.spyOn( global, 'clearInterval' );
-jest.spyOn( global, 'setInterval' );
 
 // The current edited-post state, read live by the mocked selectors so it can be
 // changed between timer ticks without re-rendering the component.
@@ -37,7 +43,23 @@ function setState( overrides = {} ) {
 	};
 }
 
+function runAutosaveTimer() {
+	const callback = setInterval.mock.calls.at( -1 )[ 0 ];
+	callback();
+}
+
 describe( 'AutosaveMonitor', () => {
+	beforeAll( () => {
+		vi.useFakeTimers();
+		vi.spyOn( global, 'clearInterval' );
+		vi.spyOn( global, 'setInterval' );
+	} );
+
+	afterAll( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	} );
+
 	beforeEach( () => {
 		setState();
 		// `useSelect( store )` (static mode) returns bound selectors; the
@@ -59,7 +81,7 @@ describe( 'AutosaveMonitor', () => {
 			}
 			return selectors;
 		} );
-		useDispatch.mockReturnValue( { autosave: jest.fn() } );
+		useDispatch.mockReturnValue( { autosave: vi.fn() } );
 		setInterval.mockClear();
 		clearInterval.mockClear();
 	} );
@@ -115,39 +137,39 @@ describe( 'AutosaveMonitor', () => {
 	} );
 
 	it( 'should autosave a dirty, autosaveable post on the timer tick', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		setState( { isDirty: true, isAutosaveable: true } );
 		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
 		expect( autosave ).not.toHaveBeenCalled();
 
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should not autosave when the post is not dirty', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		setState( { isDirty: false, isAutosaveable: true } );
 		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 
 		expect( autosave ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not autosave while an autosave is already in progress', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		setState( { isDirty: true, isAutosaveable: true, isAutosaving: true } );
 		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 
 		expect( autosave ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should autosave edits made during an in-progress autosave once it finishes', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		setState( { isDirty: true, isAutosaveable: true } );
 		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
@@ -159,53 +181,53 @@ describe( 'AutosaveMonitor', () => {
 			isAutosaving: true,
 			editsReference: 2,
 		} );
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).not.toHaveBeenCalled();
 
 		// Once the autosave finishes, the pending edit must still be autosaved.
 		setState( { isDirty: true, isAutosaveable: true, editsReference: 2 } );
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should not autosave again until there are new edits', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		setState( { isDirty: true, isAutosaveable: true } );
 		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 
 		// No new edits: a subsequent tick should not autosave again.
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 
 		// A new distinct edit triggers another autosave.
 		setState( { isDirty: true, isAutosaveable: true, editsReference: 2 } );
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	it( 'should keep pending edits and retry once the post becomes autosaveable', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		setState( { isDirty: true, isAutosaveable: false, editsReference: 2 } );
 		render( <AutosaveMonitor autosave={ autosave } interval={ 5 } /> );
 
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).not.toHaveBeenCalled();
 
 		setState( { isDirty: true, isAutosaveable: true, editsReference: 2 } );
-		jest.advanceTimersByTime( 5000 );
+		runAutosaveTimer();
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should fall back to the editor store autosave action', () => {
-		const autosave = jest.fn();
+		const autosave = vi.fn();
 		useDispatch.mockReturnValue( { autosave } );
 		setState( { isDirty: true, isAutosaveable: true } );
 		render( <AutosaveMonitor interval={ 5 } /> );
 
-		jest.advanceTimersByTime( 5000 );
+		vi.advanceTimersByTime( 5000 );
 
 		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/packages/editor/src/components/collab-sidebar/test/board-store.js
+++ b/packages/editor/src/components/collab-sidebar/test/board-store.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { createBoardStore } from '../board-store';

--- a/packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js
+++ b/packages/editor/src/components/collab-sidebar/test/note-highlight-styles.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { buildHighlightCss } from '../note-highlight-styles';

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/editor/src/components/collaborators-presence/avatar-group/test/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar-group/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -131,7 +132,7 @@ describe( 'AvatarGroup', () => {
 	} );
 
 	it( 'should render with no children', () => {
-		render( <AvatarGroup data-testid="group" /> );
+		render( <AvatarGroup data-testid="group">{ null }</AvatarGroup> );
 		const group = screen.getByTestId( 'group' );
 		expect( group ).toBeInTheDocument();
 		expect( screen.queryByText( /^\+/ ) ).not.toBeInTheDocument();

--- a/packages/editor/src/components/collaborators-presence/avatar/test/index.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
+++ b/packages/editor/src/components/collaborators-presence/test/use-collaborator-notifications.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
@@ -13,29 +14,40 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { useCollaboratorNotifications } from '../use-collaborator-notifications';
 
+type NoticesStore = ( typeof import('@wordpress/notices') )[ 'store' ];
+type PreferencesStore = ( typeof import('@wordpress/preferences') )[ 'store' ];
+type EditorStore = ( typeof import('../../../store') )[ 'store' ];
+type Unlock = ( typeof import('../../../lock-unlock') )[ 'unlock' ];
+
 // --- Mocks ---
 //
 // These mocks isolate the hook from `@wordpress/data`, the editor store, and
 // the core-data private APIs it unlocks, so tests can drive the join/leave/
 // save callbacks directly instead of simulating real awareness events.
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	useDispatch: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useSelect: vi.fn(),
+	useDispatch: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/notices', () => ( { store: 'core/notices' } ) );
+vi.mock( import( '@wordpress/notices' ), () => ( {
+	store: 'core/notices' as unknown as NoticesStore,
+} ) );
 
-jest.mock( '@wordpress/preferences', () => ( { store: 'core/preferences' } ) );
+vi.mock( import( '@wordpress/preferences' ), () => ( {
+	store: 'core/preferences' as unknown as PreferencesStore,
+} ) );
 
 // Avoids pulling in the full editor store (blocks, rich-text, etc.).
-jest.mock( '../../../store', () => ( { store: 'core/editor' } ) );
+vi.mock( import( '../../../store' ), () => ( {
+	store: 'core/editor' as unknown as EditorStore,
+} ) );
 
-jest.mock( '@wordpress/core-data', () => ( { privateApis: {} } ) );
+vi.mock( import( '@wordpress/core-data' ), () => ( { privateApis: {} } ) );
 
 // Captures the callbacks and postIds the hook registers with each of the
 // three core-data subscriptions it unlocks. Must be prefixed with `mock`
-// so jest's module factory hoisting allows referencing it below.
+// so Vitest's module factory hoisting allows referencing it below.
 const mockRegistered: {
 	join: Function | null;
 	leave: Function | null;
@@ -52,8 +64,8 @@ const mockRegistered: {
 	savePostId: undefined,
 };
 
-jest.mock( '../../../lock-unlock', () => ( {
-	unlock: jest.fn( ( value: unknown ) => ( {
+vi.mock( import( '../../../lock-unlock' ), () => {
+	const unlock = vi.fn( ( value: unknown ) => ( {
 		...( value as object ),
 		useOnCollaboratorJoin: (
 			postId: unknown,
@@ -75,8 +87,10 @@ jest.mock( '../../../lock-unlock', () => ( {
 			mockRegistered.savePostId = postId;
 			mockRegistered.save = cb;
 		},
-	} ) ),
-} ) );
+	} ) ) as unknown as Unlock;
+
+	return { unlock };
+} );
 
 // --- Fixtures ---
 
@@ -113,7 +127,7 @@ const bob = makeCollaborator( 200, 'Bob', BASE_ENTERED_AT + 10000 );
 
 // --- Setup ---
 
-const mockCreateNotice = jest.fn();
+const mockCreateNotice = vi.fn();
 
 type PreferenceState = {
 	postStatus: string | undefined;
@@ -169,10 +183,10 @@ beforeEach( () => {
 	mockRegistered.leavePostId = undefined;
 	mockRegistered.savePostId = undefined;
 	mockCreateNotice.mockClear();
-	( useSelect as jest.Mock ).mockImplementation( ( selector: Function ) =>
+	( useSelect as Mock ).mockImplementation( ( selector: Function ) =>
 		selector( mockSelect )
 	);
-	( useDispatch as jest.Mock ).mockReturnValue( {
+	( useDispatch as Mock ).mockReturnValue( {
 		createNotice: mockCreateNotice,
 	} );
 } );

--- a/packages/editor/src/components/media-categories/test/index.js
+++ b/packages/editor/src/components/media-categories/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { dispatch, resolveSelect, select, subscribe } from '@wordpress/data';
@@ -8,20 +13,20 @@ import { dispatch, resolveSelect, select, subscribe } from '@wordpress/data';
  */
 import getInserterMediaCategories from '..';
 
-jest.mock( '@wordpress/data', () => ( {
-	dispatch: jest.fn(),
-	resolveSelect: jest.fn(),
-	select: jest.fn(),
-	subscribe: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	dispatch: vi.fn(),
+	resolveSelect: vi.fn(),
+	select: vi.fn(),
+	subscribe: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: 'core',
 } ) );
 
 describe( 'getInserterMediaCategories', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'does not include attached images for non-numeric post IDs', () => {
@@ -37,7 +42,7 @@ describe( 'getInserterMediaCategories', () => {
 	} );
 
 	it( 'fetches images attached to the current post', async () => {
-		const getEntityRecords = jest.fn().mockResolvedValue( [
+		const getEntityRecords = vi.fn().mockResolvedValue( [
 			{
 				id: 10,
 				source_url: 'https://example.com/image.jpg',
@@ -55,8 +60,8 @@ describe( 'getInserterMediaCategories', () => {
 			},
 		] );
 		resolveSelect.mockReturnValue( { getEntityRecords } );
-		const getEntityRecordsTotalItems = jest.fn().mockReturnValue( 1 );
-		const getEntityRecordsTotalPages = jest.fn().mockReturnValue( 1 );
+		const getEntityRecordsTotalItems = vi.fn().mockReturnValue( 1 );
+		const getEntityRecordsTotalPages = vi.fn().mockReturnValue( 1 );
 		select.mockReturnValue( {
 			getEntityRecordsTotalItems,
 			getEntityRecordsTotalPages,
@@ -106,7 +111,7 @@ describe( 'getInserterMediaCategories', () => {
 	} );
 
 	it( 'attaches and detaches attachment records', async () => {
-		const saveEntityRecord = jest.fn().mockResolvedValue( {} );
+		const saveEntityRecord = vi.fn().mockResolvedValue( {} );
 		dispatch.mockReturnValue( { saveEntityRecord } );
 
 		const [ attachedImagesCategory ] = getInserterMediaCategories(
@@ -203,14 +208,14 @@ describe( 'getInserterMediaCategories', () => {
 
 	it( 'refetches on the resolved -> unresolved edge and unsubscribes', () => {
 		let listener;
-		const unsubscribe = jest.fn();
+		const unsubscribe = vi.fn();
 		subscribe.mockImplementation( ( cb ) => {
 			listener = cb;
 			return unsubscribe;
 		} );
 		// Starts resolved: the grid has already fetched this query.
 		let resolved = true;
-		const hasFinishedResolution = jest
+		const hasFinishedResolution = vi
 			.fn()
 			.mockImplementation( () => resolved );
 		select.mockReturnValue( { hasFinishedResolution } );
@@ -219,7 +224,7 @@ describe( 'getInserterMediaCategories', () => {
 			42,
 			'Post'
 		);
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const returnedUnsubscribe = attachedImagesCategory.subscribe(
 			onChange,
 			{ per_page: 20 }
@@ -268,10 +273,10 @@ describe( 'getInserterMediaCategories', () => {
 		let listener;
 		subscribe.mockImplementation( ( cb ) => {
 			listener = cb;
-			return jest.fn();
+			return vi.fn();
 		} );
 		let resolved = true;
-		const hasFinishedResolution = jest
+		const hasFinishedResolution = vi
 			.fn()
 			.mockImplementation( () => resolved );
 		select.mockReturnValue( { hasFinishedResolution } );
@@ -284,7 +289,7 @@ describe( 'getInserterMediaCategories', () => {
 			( category ) => category.name === 'openverse'
 		);
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		images.subscribe( onChange, { per_page: 20 } );
 
 		// The Images source watches its own query (no `parent`) and still

--- a/packages/editor/src/components/page-attributes/test/order.jsx
+++ b/packages/editor/src/components/page-attributes/test/order.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,9 +15,10 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import PageAttributesOrder from '../order';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+	useDispatch: vi.fn(),
 } ) );
 
 function setupDataMock( order = 0 ) {
@@ -38,7 +40,7 @@ function setupDataMock( order = 0 ) {
 		} ) )
 	);
 
-	const editPost = jest.fn();
+	const editPost = vi.fn();
 	useDispatch.mockImplementation( () => ( {
 		editPost,
 	} ) );

--- a/packages/editor/src/components/plugin-post-publish-panel/test/__snapshots__/index.jsx.snap
+++ b/packages/editor/src/components/plugin-post-publish-panel/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PluginPostPublishPanel renders fill properly 1`] = `
+exports[`PluginPostPublishPanel > renders fill properly 1`] = `
 <div>
   <div
     class="components-panel__body my-plugin-post-publish-panel is-opened"

--- a/packages/editor/src/components/plugin-post-publish-panel/test/index.jsx
+++ b/packages/editor/src/components/plugin-post-publish-panel/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/editor/src/components/plugin-pre-publish-panel/test/index.jsx
+++ b/packages/editor/src/components/plugin-pre-publish-panel/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/editor/src/components/post-author/test/check.jsx
+++ b/packages/editor/src/components/post-author/test/check.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,11 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PostAuthorCheck from '../check';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( hasAssignAuthorAction ) {
 	useSelect.mockImplementation( ( cb ) => {

--- a/packages/editor/src/components/post-excerpt/test/plugin.jsx
+++ b/packages/editor/src/components/post-excerpt/test/plugin.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/editor/src/components/post-last-revision/test/check.jsx
+++ b/packages/editor/src/components/post-last-revision/test/check.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PostLastRevisionCheck from '../check';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupDataMock( id, count ) {
 	useSelect.mockImplementation( ( mapSelect ) =>

--- a/packages/editor/src/components/post-pending-status/test/check.jsx
+++ b/packages/editor/src/components/post-pending-status/test/check.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,11 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import { PostPendingStatusCheck } from '../check';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( hasPublishAction ) {
 	useSelect.mockImplementation( ( cb ) => {

--- a/packages/editor/src/components/post-preview-button/test/index.jsx
+++ b/packages/editor/src/components/post-preview-button/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,12 +15,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import PostPreviewButton, { PostPreviewMenuItem } from '..';
 
-jest.useRealTimers();
+vi.useRealTimers();
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
-	jest.fn()
-);
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useDispatch: vi.fn(),
+	useSelect: vi.fn(),
+} ) );
 
 function mockUseSelect( overrides ) {
 	useSelect.mockImplementation( ( map ) =>
@@ -39,14 +41,14 @@ function mockUseSelect( overrides ) {
 }
 
 describe( 'PostPreviewButton', () => {
-	const documentWrite = jest.fn();
-	const documentTitle = jest.fn();
-	const documentClose = jest.fn();
-	const setLocation = jest.fn();
+	const documentWrite = vi.fn();
+	const documentTitle = vi.fn();
+	const documentClose = vi.fn();
+	const setLocation = vi.fn();
 
 	beforeEach( () => {
-		global.open = jest.fn( () => ( {
-			focus: jest.fn(),
+		global.open = vi.fn( () => ( {
+			focus: vi.fn(),
 			document: {
 				write: documentWrite,
 				close: documentClose,

--- a/packages/editor/src/components/post-publish-button/test/index.jsx
+++ b/packages/editor/src/components/post-publish-button/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -17,23 +18,23 @@ import { store as editorStore } from '../../../store';
 
 describe( 'PostPublishButton', () => {
 	beforeEach( () => {
-		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+		vi.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
 			_links: {},
 		} );
-		jest.spyOn( dispatch( editorStore ), 'editPost' ).mockReturnValue();
-		jest.spyOn( dispatch( editorStore ), 'savePost' ).mockReturnValue();
+		vi.spyOn( dispatch( editorStore ), 'editPost' ).mockReturnValue();
+		vi.spyOn( dispatch( editorStore ), 'savePost' ).mockReturnValue();
 	} );
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	function mockSelector( name, value ) {
-		jest.spyOn( select( editorStore ), name ).mockReturnValue( value );
+		vi.spyOn( select( editorStore ), name ).mockReturnValue( value );
 	}
 
 	function mockHasPublishAction( hasPublishAction ) {
-		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+		vi.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
 			_links: hasPublishAction ? { 'wp:action-publish': true } : {},
 		} );
 	}

--- a/packages/editor/src/components/post-publish-button/test/label.js
+++ b/packages/editor/src/components/post-publish-button/test/label.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -8,11 +13,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PublishButtonLabel from '../label';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 describe( 'PublishButtonLabel', () => {
 	it( 'should show publishing if publishing in progress', () => {

--- a/packages/editor/src/components/post-publish-button/test/post-publish-button-or-toggle.jsx
+++ b/packages/editor/src/components/post-publish-button/test/post-publish-button-or-toggle.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -14,8 +15,14 @@ import { useSelect } from '@wordpress/data';
  */
 import PostPublishButtonOrToggle from '../post-publish-button-or-toggle';
 
-jest.mock( '@wordpress/compose/src/hooks/use-viewport-match' );
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useViewportMatch: vi.fn(),
+} ) );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 describe( 'PostPublishButtonOrToggle should render a', () => {
 	afterEach( () => {

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.jsx.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PostPublishPanel should render the post-publish panel if the post is published 1`] = `
+exports[`PostPublishPanel > should render the post-publish panel if the post is published 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -204,7 +204,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
 </div>
 `;
 
-exports[`PostPublishPanel should render the post-publish panel if the post is scheduled 1`] = `
+exports[`PostPublishPanel > should render the post-publish panel if the post is scheduled 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -386,7 +386,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
 </div>
 `;
 
-exports[`PostPublishPanel should render the pre-publish panel if post status is scheduled but date is before now 1`] = `
+exports[`PostPublishPanel > should render the pre-publish panel if post status is scheduled but date is before now 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -518,7 +518,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
 </div>
 `;
 
-exports[`PostPublishPanel should render the pre-publish panel if the post is not saving, published or scheduled 1`] = `
+exports[`PostPublishPanel > should render the pre-publish panel if the post is not saving, published or scheduled 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;
@@ -650,7 +650,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
 </div>
 `;
 
-exports[`PostPublishPanel should render the spinner if the post is being saved 1`] = `
+exports[`PostPublishPanel > should render the spinner if the post is being saved 1`] = `
 @keyframes animation-0 {
   from {
     -webkit-transform: rotate(0deg);

--- a/packages/editor/src/components/post-publish-panel/test/index.jsx
+++ b/packages/editor/src/components/post-publish-panel/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -17,19 +18,19 @@ import PostPublishPanel from '../index';
 
 describe( 'PostPublishPanel', () => {
 	beforeEach( () => {
-		jest.spyOn( select( coreStore ), 'getPostType' ).mockReturnValue( {
+		vi.spyOn( select( coreStore ), 'getPostType' ).mockReturnValue( {
 			labels: {
 				singular_name: 'post',
 			},
 		} );
 
-		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+		vi.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
 			link: 'https://wordpress.local/sample-page/',
 		} );
 	} );
 
 	afterEach( () => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	} );
 
 	it( 'should render the pre-publish panel if the post is not saving, published or scheduled', () => {
@@ -38,7 +39,7 @@ describe( 'PostPublishPanel', () => {
 	} );
 
 	it( 'should render the pre-publish panel if post status is scheduled but date is before now', () => {
-		jest.spyOn(
+		vi.spyOn(
 			select( editorStore ),
 			'isCurrentPostScheduled'
 		).mockReturnValue( true );
@@ -48,7 +49,7 @@ describe( 'PostPublishPanel', () => {
 	} );
 
 	it( 'should render the spinner if the post is being saved', () => {
-		jest.spyOn( select( editorStore ), 'isSavingPost' ).mockReturnValue(
+		vi.spyOn( select( editorStore ), 'isSavingPost' ).mockReturnValue(
 			true
 		);
 
@@ -57,7 +58,7 @@ describe( 'PostPublishPanel', () => {
 	} );
 
 	it( 'should render the post-publish panel if the post is published', () => {
-		jest.spyOn(
+		vi.spyOn(
 			select( editorStore ),
 			'isCurrentPostPublished'
 		).mockReturnValue( true );
@@ -67,11 +68,11 @@ describe( 'PostPublishPanel', () => {
 	} );
 
 	it( 'should render the post-publish panel if the post is scheduled', () => {
-		jest.spyOn(
+		vi.spyOn(
 			select( editorStore ),
 			'isCurrentPostScheduled'
 		).mockReturnValue( true );
-		jest.spyOn(
+		vi.spyOn(
 			select( editorStore ),
 			'isEditedPostBeingScheduled'
 		).mockReturnValue( true );

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/editor/src/components/post-revisions-preview/test/preserve-client-ids.js
+++ b/packages/editor/src/components/post-revisions-preview/test/preserve-client-ids.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { preserveClientIds } from '../preserve-client-ids';

--- a/packages/editor/src/components/post-revisions-timeline/test/index.jsx
+++ b/packages/editor/src/components/post-revisions-timeline/test/index.jsx
@@ -1,30 +1,33 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import PostRevisionsTimeline from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+	useDispatch: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/fields', () => ( {
+vi.mock( import( '@wordpress/fields' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
 	authorField: {
 		id: 'author',
 		label: 'Author',
 		getValue: ( { item } ) => item?._embedded?.author?.[ 0 ]?.name,
 		render: ( { item } ) => {
-			const { createElement } = require( '@wordpress/element' );
 			const authorName = item?._embedded?.author?.[ 0 ]?.name;
 
 			return createElement(
@@ -41,7 +44,7 @@ jest.mock( '@wordpress/fields', () => ( {
 	},
 } ) );
 
-jest.mock( '@wordpress/dataviews', () => {
+vi.mock( import( '@wordpress/dataviews' ), async ( importOriginal ) => {
 	const DataViewsPicker = ( { data, fields, getItemId, selection } ) => {
 		const titleField = fields.find( ( field ) => field.id === 'date' );
 
@@ -81,6 +84,7 @@ jest.mock( '@wordpress/dataviews', () => {
 	DataViewsPicker.Footer = () => null;
 
 	return {
+		...( await importOriginal() ),
 		DataViewsPicker,
 		filterSortAndPaginate: ( data ) => ( {
 			data,
@@ -89,17 +93,17 @@ jest.mock( '@wordpress/dataviews', () => {
 	};
 } );
 
-jest.mock( '../../../lock-unlock', () => ( {
+vi.mock( import( '../../../lock-unlock' ), () => ( {
 	unlock: ( object ) => {
 		return {
 			...object,
-			registerPrivateActions: jest.fn(),
-			registerPrivateSelectors: jest.fn(),
+			registerPrivateActions: vi.fn(),
+			registerPrivateSelectors: vi.fn(),
 		};
 	},
 } ) );
 
-jest.mock( '../../post-content-information', () => ( {
+vi.mock( import( '../../post-content-information' ), () => ( {
 	PostContentInformationUI: () => null,
 } ) );
 
@@ -138,7 +142,7 @@ describe( 'PostRevisionsTimeline', () => {
 			2: { name: 'Bob' },
 		};
 
-		getCurrentRevision = jest.fn( () => revisions[ 0 ] );
+		getCurrentRevision = vi.fn( () => revisions[ 0 ] );
 
 		useSelect.mockImplementation( ( mapSelect ) =>
 			mapSelect( () => ( {
@@ -152,7 +156,7 @@ describe( 'PostRevisionsTimeline', () => {
 				getEntityRecord: ( _kind, _name, id ) => users[ id ],
 			} ) )
 		);
-		useDispatch.mockReturnValue( { setCurrentRevisionId: jest.fn() } );
+		useDispatch.mockReturnValue( { setCurrentRevisionId: vi.fn() } );
 	} );
 
 	it( 'keeps the author field intact and labels autosaves', () => {

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.jsx.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PostSavedState returns a disabled button if the post is not saveable 1`] = `
+exports[`PostSavedState > returns a disabled button if the post is not saveable 1`] = `
 <button
   aria-disabled="true"
   aria-label="Save draft"
@@ -23,7 +23,7 @@ exports[`PostSavedState returns a disabled button if the post is not saveable 1`
 </button>
 `;
 
-exports[`PostSavedState should return Save button if edits to be saved 1`] = `
+exports[`PostSavedState > should return Save button if edits to be saved 1`] = `
 <button
   aria-label="Save draft"
   class="components-button editor-post-save-draft is-compact is-tertiary"

--- a/packages/editor/src/components/post-saved-state/test/index.jsx
+++ b/packages/editor/src/components/post-saved-state/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -15,30 +16,26 @@ import { useSelect } from '@wordpress/data';
  */
 import PostSavedState from '../';
 
-const mockSavePost = jest.fn();
+const mockSavePost = vi.fn();
 
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => {
 	return {
+		...( await importOriginal() ),
 		useDispatch: () => ( { savePost: mockSavePost } ),
-		useDispatchWithMap: jest.fn(),
+		useDispatchWithMap: vi.fn(),
+		useSelect: vi.fn(),
 	};
 } );
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useViewportMatch: vi.fn(),
+} ) );
 
-jest.mock( '@wordpress/compose/src/hooks/use-viewport-match', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
-
-jest.mock( '@wordpress/icons/src/icon', () => () => (
-	<div data-testid="test-icon" />
-) );
+vi.mock( import( '@wordpress/icons' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	Icon: () => <div data-testid="test-icon" />,
+} ) );
 
 describe( 'PostSavedState', () => {
 	it( 'should display saving while save in progress, even if not saveable', () => {

--- a/packages/editor/src/components/post-schedule/test/check.jsx
+++ b/packages/editor/src/components/post-schedule/test/check.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PostScheduleCheck from '../check';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupMockSelect( hasPublishAction ) {
 	useSelect.mockImplementation( ( mapSelect ) => {

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { getSettings, setSettings } from '@wordpress/date';
@@ -62,7 +67,7 @@ describe( 'getPostScheduleLabel', () => {
 
 	it( "should show full date if user timezone does not equal site's timezone", () => {
 		const now = new Date( '2022-04-28T13:00:00.000Z' );
-		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+		vi.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
 			() => 10 * -60 // UTC+10
 		);
 
@@ -79,7 +84,7 @@ describe( 'getPostScheduleLabel', () => {
 		} );
 
 		const now = new Date( '2022-04-28T03:00:00.000Z' );
-		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+		vi.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
 			() => 10 * -60 // UTC+10
 		);
 
@@ -100,7 +105,7 @@ describe( 'getPostScheduleLabel', () => {
 		} );
 
 		const now = new Date( '2022-04-28T03:00:00.000Z' );
-		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+		vi.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
 			() => 10 * -60 // UTC+10
 		);
 
@@ -121,7 +126,7 @@ describe( 'getPostScheduleLabel', () => {
 		} );
 
 		const now = new Date( '2022-04-28T03:00:00.000Z' );
-		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+		vi.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
 			() => 10 * -60 // UTC+10
 		);
 
@@ -142,7 +147,7 @@ describe( 'getPostScheduleLabel', () => {
 		} );
 
 		const now = new Date( '2022-04-28T03:00:00.000Z' );
-		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+		vi.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
 			() => 10 * -60 // UTC+10
 		);
 

--- a/packages/editor/src/components/post-sticky/test/index.jsx
+++ b/packages/editor/src/components/post-sticky/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,11 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PostStickyCheck from '../check';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( { hasStickyAction, postType } ) {
 	useSelect.mockImplementation( ( cb ) => {

--- a/packages/editor/src/components/post-taxonomies/test/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/test/hierarchical-term-selector.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/editor/src/components/post-taxonomies/test/index.jsx
+++ b/packages/editor/src/components/post-taxonomies/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -58,7 +59,7 @@ describe( 'PostTaxonomies', () => {
 	];
 
 	beforeEach( () => {
-		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+		vi.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
 			_links: {
 				'wp:action-create-categories': [
 					{
@@ -83,7 +84,7 @@ describe( 'PostTaxonomies', () => {
 			},
 		} );
 
-		jest.spyOn( select( coreStore ), 'getEntityRecord' ).mockImplementation(
+		vi.spyOn( select( coreStore ), 'getEntityRecord' ).mockImplementation(
 			( kind, name, slug ) => {
 				switch ( slug ) {
 					case 'category': {
@@ -100,15 +101,12 @@ describe( 'PostTaxonomies', () => {
 	it( 'should render no children if taxonomy data not available', () => {
 		const taxonomies = null;
 
-		jest.spyOn(
-			select( editorStore ),
-			'getCurrentPostType'
-		).mockReturnValue( 'page' );
-		jest.spyOn(
-			select( coreStore ),
-			'getEntityRecords'
-		).mockImplementation( ( kind, name ) =>
-			kind === 'root' && name === 'taxonomy' ? taxonomies : null
+		vi.spyOn( select( editorStore ), 'getCurrentPostType' ).mockReturnValue(
+			'page'
+		);
+		vi.spyOn( select( coreStore ), 'getEntityRecords' ).mockImplementation(
+			( kind, name ) =>
+				kind === 'root' && name === 'taxonomy' ? taxonomies : null
 		);
 
 		const { container } = render( <PostTaxonomies /> );
@@ -117,15 +115,12 @@ describe( 'PostTaxonomies', () => {
 	} );
 
 	it( 'should render taxonomy components for taxonomies assigned to post type', () => {
-		jest.spyOn(
-			select( editorStore ),
-			'getCurrentPostType'
-		).mockReturnValue( 'book' );
-		jest.spyOn(
-			select( coreStore ),
-			'getEntityRecords'
-		).mockImplementation( ( kind, name ) =>
-			kind === 'root' && name === 'taxonomy' ? allTaxonomies : null
+		vi.spyOn( select( editorStore ), 'getCurrentPostType' ).mockReturnValue(
+			'book'
+		);
+		vi.spyOn( select( coreStore ), 'getEntityRecords' ).mockImplementation(
+			( kind, name ) =>
+				kind === 'root' && name === 'taxonomy' ? allTaxonomies : null
 		);
 
 		render( <PostTaxonomies /> );
@@ -143,15 +138,12 @@ describe( 'PostTaxonomies', () => {
 	} );
 
 	it( 'should not render taxonomy components that hide their ui', () => {
-		jest.spyOn(
-			select( editorStore ),
-			'getCurrentPostType'
-		).mockReturnValue( 'book' );
-		jest.spyOn(
-			select( coreStore ),
-			'getEntityRecords'
-		).mockImplementation( ( kind, name ) =>
-			kind === 'root' && name === 'taxonomy' ? hidesUI : null
+		vi.spyOn( select( editorStore ), 'getCurrentPostType' ).mockReturnValue(
+			'book'
+		);
+		vi.spyOn( select( coreStore ), 'getEntityRecords' ).mockImplementation(
+			( kind, name ) =>
+				kind === 'root' && name === 'taxonomy' ? hidesUI : null
 		);
 
 		render( <PostTaxonomies /> );

--- a/packages/editor/src/components/post-text-editor/test/utils.js
+++ b/packages/editor/src/components/post-text-editor/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getAdjustedCursorPosition } from '../utils';

--- a/packages/editor/src/components/post-type-support-check/test/index.jsx
+++ b/packages/editor/src/components/post-type-support-check/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -13,11 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PostTypeSupportCheck from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( postType ) {
 	useSelect.mockImplementation( ( cb ) => {

--- a/packages/editor/src/components/post-view-link/test/index.jsx
+++ b/packages/editor/src/components/post-view-link/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import PostViewLink from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 const DEFAULTS = {
 	postType: { labels: { view_item: 'View Post' } },

--- a/packages/editor/src/components/post-visibility/test/check.jsx
+++ b/packages/editor/src/components/post-visibility/test/check.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -8,7 +9,10 @@ import { render, screen } from '@testing-library/react';
  */
 import { useSelect } from '@wordpress/data';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 /**
  * Internal dependencies

--- a/packages/editor/src/components/preferences-modal/test/index.jsx
+++ b/packages/editor/src/components/preferences-modal/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -22,8 +23,14 @@ import { store as editorStore } from '../../../store';
 import { lock } from '../../../lock-unlock';
 
 // This allows us to tweak the returned value on each test.
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '@wordpress/compose/src/hooks/use-viewport-match', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useViewportMatch: vi.fn(),
+} ) );
 
 function setupActiveModal( preferences = {} ) {
 	const user = userEvent.setup();

--- a/packages/editor/src/components/provider/test/use-network-reconnect.js
+++ b/packages/editor/src/components/provider/test/use-network-reconnect.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
@@ -13,19 +14,19 @@ import { useRegistry } from '@wordpress/data';
  */
 import useNetworkReconnect from '../use-network-reconnect';
 
-const mockPauseQueue = jest.fn();
-const mockResumeQueue = jest.fn();
+const mockPauseQueue = vi.fn();
+const mockResumeQueue = vi.fn();
 
-jest.mock( '@wordpress/data', () => ( {
-	useRegistry: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useRegistry: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/upload-media', () => ( {
+vi.mock( import( '@wordpress/upload-media' ), () => ( {
 	store: 'core/upload-media',
 } ) );
 
-jest.mock( '../../../lock-unlock', () => ( {
-	unlock: jest.fn( () => ( {
+vi.mock( import( '../../../lock-unlock' ), () => ( {
+	unlock: vi.fn( () => ( {
 		pauseQueue: mockPauseQueue,
 		resumeQueue: mockResumeQueue,
 	} ) ),
@@ -40,14 +41,14 @@ describe( 'useNetworkReconnect', () => {
 		mockPauseQueue.mockClear();
 		mockResumeQueue.mockClear();
 		listeners = {};
-		window.addEventListener = jest.fn( ( event, cb ) => {
+		window.addEventListener = vi.fn( ( event, cb ) => {
 			listeners[ event ] = cb;
 		} );
-		window.removeEventListener = jest.fn( ( event ) => {
+		window.removeEventListener = vi.fn( ( event ) => {
 			delete listeners[ event ];
 		} );
 		useRegistry.mockReturnValue( {
-			dispatch: jest.fn( () => ( {} ) ),
+			dispatch: vi.fn( () => ( {} ) ),
 		} );
 	} );
 

--- a/packages/editor/src/components/style-book/test/categories.js
+++ b/packages/editor/src/components/style-book/test/categories.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -7,7 +12,7 @@ import {
 } from '../categories';
 import { STYLE_BOOK_CATEGORIES } from '../constants';
 
-jest.mock( '@wordpress/blocks', () => {
+vi.mock( import( '@wordpress/blocks' ), () => {
 	return {
 		getCategories() {
 			return [

--- a/packages/editor/src/components/theme-support-check/test/index.jsx
+++ b/packages/editor/src/components/theme-support-check/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import ThemeSupportCheck from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( themeSupports = {}, postType = 'post' ) {
 	useSelect.mockImplementation( ( cb ) => {

--- a/packages/editor/src/components/upload-progress-snackbar/test/index.jsx
+++ b/packages/editor/src/components/upload-progress-snackbar/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, act } from '@testing-library/react';
 
 /**
@@ -14,26 +15,23 @@ import { useSelect } from '@wordpress/data';
 import UploadProgressSnackbar from '../';
 import { addFiles, advance, reset } from '../tracker';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	const mock = jest.fn();
-	return mock;
-} );
+const mockCreateNotice = vi.fn();
+const mockRemoveNotice = vi.fn();
 
-const mockCreateNotice = jest.fn();
-const mockRemoveNotice = jest.fn();
-
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => {
 	return {
-		useDispatch: jest.fn( () => ( {
+		...( await importOriginal() ),
+		useDispatch: vi.fn( () => ( {
 			createNotice: mockCreateNotice,
 			removeNotice: mockRemoveNotice,
 		} ) ),
-		useDispatchWithMap: jest.fn(),
+		useDispatchWithMap: vi.fn(),
+		useSelect: vi.fn(),
 	};
 } );
 
-jest.mock( '@wordpress/a11y', () => ( {
-	speak: jest.fn(),
+vi.mock( import( '@wordpress/a11y' ), () => ( {
+	speak: vi.fn(),
 } ) );
 
 function mockQueue( items ) {
@@ -56,7 +54,7 @@ function makeItem( id, name, { parentId } = {} ) {
 
 describe( 'UploadProgressSnackbar', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		reset();
 	} );
 
@@ -126,7 +124,7 @@ describe( 'UploadProgressSnackbar', () => {
 	} );
 
 	it( 'shows a completion notice and then removes it when uploads finish', () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 		try {
 			mockQueue( [] );
 			act( () => {
@@ -153,14 +151,14 @@ describe( 'UploadProgressSnackbar', () => {
 			expect( mockRemoveNotice ).not.toHaveBeenCalled();
 
 			act( () => {
-				jest.runAllTimers();
+				vi.runAllTimers();
 			} );
 
 			expect( mockRemoveNotice ).toHaveBeenCalledWith(
 				'upload-progress'
 			);
 		} finally {
-			jest.useRealTimers();
+			vi.useRealTimers();
 		}
 	} );
 

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/format-style-value.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getChangesToPush, getStylesUpdate } from '../index';

--- a/packages/editor/src/hooks/push-changes-to-global-styles/test/style-labels.js
+++ b/packages/editor/src/hooks/push-changes-to-global-styles/test/style-labels.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { capitalCase } from 'change-case';
 
 /**

--- a/packages/editor/src/hooks/test/default-autocompleters.js
+++ b/packages/editor/src/hooks/test/default-autocompleters.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -439,8 +444,8 @@ describe( 'Post actions', () => {
 				status: 'publish',
 			};
 
-			const dispatch = Object.assign( jest.fn(), {
-				savePost: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				savePost: vi.fn(),
 			} );
 			const select = {
 				getCurrentPostType: () => 'post',
@@ -448,8 +453,8 @@ describe( 'Post actions', () => {
 			};
 			const registry = {
 				dispatch: () => ( {
-					removeNotice: jest.fn(),
-					createErrorNotice: jest.fn(),
+					removeNotice: vi.fn(),
+					createErrorNotice: vi.fn(),
 				} ),
 				resolveSelect: () => ( {
 					getPostType: () => ( {

--- a/packages/editor/src/store/test/private-selectors.js
+++ b/packages/editor/src/store/test/private-selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -122,7 +127,7 @@ describe( 'isCollaborationEnabledForCurrentPost', () => {
 	}
 
 	it( 'returns true when the current post type sync config should sync', () => {
-		const shouldSync = jest.fn( () => true );
+		const shouldSync = vi.fn( () => true );
 		setupRegistry( {
 			syncConfig: { shouldSync, supportsPersistence: true },
 		} );
@@ -134,7 +139,7 @@ describe( 'isCollaborationEnabledForCurrentPost', () => {
 	} );
 
 	it( 'returns false when the current post type sync config does not support persistence', () => {
-		const shouldSync = jest.fn( () => true );
+		const shouldSync = vi.fn( () => true );
 		setupRegistry( { syncConfig: { shouldSync } } );
 
 		const state = { postType: 'book', postId: 123 };

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/editor/src/store/test/selectors.jsx
+++ b/packages/editor/src/store/test/selectors.jsx
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -30,7 +35,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 		actions: [],
 		type: 'snackbar',
 	};
-	[
+	it.each( [
 		[
 			'when previous post is not published and post will not be published',
 			[ 'draft', 'draft', false ],
@@ -81,25 +86,23 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 			[ 'publish', 'trash', true ],
 			[ 'trash', defaultExpectedAction ],
 		],
-	].forEach(
-		( [
-			description,
+	] )(
+		'%s',
+		(
+			_,
 			[ previousPostStatus, postStatus, isViewable ],
-			expectedValue,
-		] ) => {
-			// eslint-disable-next-line jest/valid-title
-			it( description, () => {
-				previousPost.status = previousPostStatus;
-				post.status = postStatus;
-				postType.viewable = isViewable;
-				expect(
-					getNotificationArgumentsForSaveSuccess( {
-						previousPost,
-						post,
-						postType,
-					} )
-				).toEqual( expectedValue );
-			} );
+			expectedValue
+		) => {
+			previousPost.status = previousPostStatus;
+			post.status = postStatus;
+			postType.viewable = isViewable;
+			expect(
+				getNotificationArgumentsForSaveSuccess( {
+					previousPost,
+					post,
+					postType,
+				} )
+			).toEqual( expectedValue );
 		}
 	);
 } );
@@ -108,7 +111,7 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 	const post = { status: 'publish' };
 	const edits = { status: 'publish' };
 	const defaultExpectedAction = { id: 'editor-save' };
-	[
+	it.each( [
 		[
 			'when error code is `rest_autosave_no_changes`',
 			'rest_autosave_no_changes',
@@ -148,31 +151,21 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 			[ 'publish', 'publish' ],
 			[ 'Updating failed. Something went wrong.', defaultExpectedAction ],
 		],
-	].forEach(
-		( [
-			description,
-			errorCode,
-			[ postStatus, editsStatus ],
-			expectedValue,
-		] ) => {
-			// eslint-disable-next-line jest/valid-title
-			it( description, () => {
-				post.status = postStatus;
-				error.code = errorCode;
-				edits.status = editsStatus;
-				expect(
-					getNotificationArgumentsForSaveFail( {
-						post,
-						edits,
-						error,
-					} )
-				).toEqual( expectedValue );
-			} );
-		}
-	);
+	] )( '%s', ( _, errorCode, [ postStatus, editsStatus ], expectedValue ) => {
+		post.status = postStatus;
+		error.code = errorCode;
+		edits.status = editsStatus;
+		expect(
+			getNotificationArgumentsForSaveFail( {
+				post,
+				edits,
+				error,
+			} )
+		).toEqual( expectedValue );
+	} );
 } );
 describe( 'getNotificationArgumentsForTrashFail()', () => {
-	[
+	it.each( [
 		[
 			'when there is an error message and the error code is not "unknown_error"',
 			{ message: 'foo', code: '' },
@@ -188,13 +181,10 @@ describe( 'getNotificationArgumentsForTrashFail()', () => {
 			{ code: 42 },
 			'Trashing failed',
 		],
-	].forEach( ( [ description, error, message ] ) => {
-		// eslint-disable-next-line jest/valid-title
-		it( description, () => {
-			const expectedValue = [ message, { id: 'editor-trash-fail' } ];
-			expect( getNotificationArgumentsForTrashFail( { error } ) ).toEqual(
-				expectedValue
-			);
-		} );
+	] )( '%s', ( _, error, message ) => {
+		const expectedValue = [ message, { id: 'editor-trash-fail' } ];
+		expect( getNotificationArgumentsForTrashFail( { error } ) ).toEqual(
+			expectedValue
+		);
 	} );
 } );

--- a/packages/editor/src/utils/media-finalize/test/index.js
+++ b/packages/editor/src/utils/media-finalize/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -8,7 +13,9 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import mediaFinalize from '..';
 
-jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+vi.mock( import( '@wordpress/api-fetch' ), () => ( {
+	default: vi.fn(),
+} ) );
 
 const mockRestAttachment = {
 	id: 123,
@@ -20,7 +27,7 @@ const mockRestAttachment = {
 
 describe( 'mediaFinalize', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'should call the finalize endpoint with the correct path, method, and sub_sizes', async () => {

--- a/packages/editor/src/utils/media-sideload-from-url/test/index.js
+++ b/packages/editor/src/utils/media-sideload-from-url/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -10,9 +15,11 @@ import { transformAttachment } from '@wordpress/media-utils';
  */
 import mediaSideloadFromUrl from '..';
 
-jest.mock( '@wordpress/api-fetch', () => jest.fn() );
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn(),
+vi.mock( import( '@wordpress/api-fetch' ), () => ( {
+	default: vi.fn(),
+} ) );
+vi.mock( import( '@wordpress/data' ), () => ( {
+	select: vi.fn(),
 } ) );
 /*
  * The store and transformAttachment are mocked so this unit test does not pull
@@ -21,9 +28,9 @@ jest.mock( '@wordpress/data', () => ( {
  * @wordpress/media-utils; here we only verify mediaSideloadFromUrl forwards
  * whatever it returns.
  */
-jest.mock( '../../../store', () => ( { store: 'core/editor' } ) );
-jest.mock( '@wordpress/media-utils', () => ( {
-	transformAttachment: jest.fn( ( attachment ) => ( {
+vi.mock( import( '../../../store' ), () => ( { store: 'core/editor' } ) );
+vi.mock( import( '@wordpress/media-utils' ), () => ( {
+	transformAttachment: vi.fn( ( attachment ) => ( {
 		id: attachment.id,
 		url: attachment.source_url,
 		alt: attachment.alt_text,
@@ -51,7 +58,7 @@ function mockCurrentPost( post ) {
 
 describe( 'mediaSideloadFromUrl', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockCurrentPost( { id: 42 } );
 	} );
 

--- a/packages/editor/src/utils/test/device-type.js
+++ b/packages/editor/src/utils/test/device-type.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/editor/src/utils/test/media-upload.js
+++ b/packages/editor/src/utils/test/media-upload.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import mediaUpload from '../media-upload';
@@ -7,42 +12,42 @@ import {
 	reset,
 } from '../../components/upload-progress-snackbar/tracker';
 
-jest.mock( '@wordpress/media-utils', () => ( {
-	uploadMedia: jest.fn(),
+vi.mock( import( '@wordpress/media-utils' ), () => ( {
+	uploadMedia: vi.fn(),
 } ) );
 
-jest.mock( '@wordpress/core-data', () => ( {
+vi.mock( import( '@wordpress/core-data' ), () => ( {
 	store: { name: 'core' },
 } ) );
 
-jest.mock( '../../store', () => ( {
+vi.mock( import( '../../store' ), () => ( {
 	store: { name: 'core/editor' },
 } ) );
 
-const mockLockPostSaving = jest.fn();
-const mockLockPostAutosaving = jest.fn();
+const mockLockPostSaving = vi.fn();
+const mockLockPostAutosaving = vi.fn();
 
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn( () => ( {
+vi.mock( import( '@wordpress/data' ), () => ( {
+	select: vi.fn( () => ( {
 		getCurrentPost: () => ( { id: 1 } ),
 		getEditorSettings: () => ( {
 			allowedMimeTypes: null,
 			maxUploadFileSize: 10 * 1024 * 1024,
 		} ),
 	} ) ),
-	dispatch: jest.fn( () => ( {
-		receiveEntityRecords: jest.fn(),
+	dispatch: vi.fn( () => ( {
+		receiveEntityRecords: vi.fn(),
 		lockPostSaving: mockLockPostSaving,
-		unlockPostSaving: jest.fn(),
+		unlockPostSaving: vi.fn(),
 		lockPostAutosaving: mockLockPostAutosaving,
-		unlockPostAutosaving: jest.fn(),
+		unlockPostAutosaving: vi.fn(),
 	} ) ),
 } ) );
 
 describe( 'mediaUpload', () => {
 	beforeEach( () => {
 		reset();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'registers files with the upload progress tracker and locks saving', () => {

--- a/packages/editor/src/utils/test/sync-error-messages.js
+++ b/packages/editor/src/utils/test/sync-error-messages.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getSyncErrorMessages } from '../sync-error-messages';

--- a/packages/editor/src/utils/test/terms.js
+++ b/packages/editor/src/utils/test/terms.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { buildTermsTree } from '../terms';

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -42,6 +42,7 @@
 					"packages/edit-post",
 					"packages/edit-site",
 					"packages/edit-widgets",
+					"packages/editor",
 					"packages/element",
 					"packages/escape-html",
 					"packages/fields",


### PR DESCRIPTION
## What?

See #80855.

**TL;DR:** This slice migrates all 58 Editor unit-test files from Jest to Vitest. The required change classes are explicit runner imports, ESM-compatible public-module mocks, typed TypeScript mock contracts, scoped timer handling for the autosave interval, Testing Library retention, and an eight-snapshot key/header audit.

## Why?

Editor was one of the three remaining Jest-owned areas after the Block Library migration. Moving the complete package preserves its 733-test behavioral baseline while reducing the residual Jest partition to Block Editor and the two published Jest-tooling packages.

## How?

- Routes `packages/editor` through the private Vitest `jsdom` project and declares Vitest in the importing workspace.
- Imports every used Vitest API explicitly; no Editor test relies on injected globals.
- Replaces Jest globals and string mocks with `vi` and type-checked dynamic-import mock paths.
- Replaces private Data, Compose, and Icons source-path mocks with partial mocks of their public modules.
- Types the TypeScript store and private-API mock boundaries so the complete routed TS/TSX graph passes `tsc`.
- Keeps `@testing-library/react` and `@testing-library/user-event`; Vitest replaces the runner, not the DOM-testing abstraction.
- Captures and invokes the autosave interval callback directly while scoping fake timers to the suite, avoiding recurring-timer advancement differences.
- Replaces dynamic-title Jest lint suppressions with native `it.each` tables.
- Updates eight snapshot keys and runner headers. Every old/new serialized body was paired and SHA-256 checked as byte-identical.

## Testing Instructions

1. `npm run test:unit:vitest -- packages/editor`
   - 58 files passed, 733 tests passed.
2. `npm run test:unit:vitest`
   - 865 files passed, 2 skipped; 32,587 tests passed, 8 skipped, including the 2-test Chromium project.
3. `npm run test:unit -- --runInBand`
   - 136 suites passed; 2,165 tests passed; 17 snapshots passed.
4. `npm run --workspace @wordpress/unit-tests test:unit:routing`
   - 136 Jest-owned and 867 Vitest-owned tests; no missing, overlapping, invalid, or orphaned entries.
5. `npm run --workspace @wordpress/unit-tests test:unit:conventions`
   - 867 Vitest tests, 883 ESM graph files, 101 workspace dependencies, and 402 TypeScript tests pass.
6. Commit-time formatting, strict JavaScript lint, package metadata, lockfile, and generated API-doc checks pass.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

This migration was implemented with Codex assistance. The resulting mocks, timer behavior, TypeScript graph, snapshots, and full partition results were reviewed before publication.
