### PR TITLE
RichText: don't apply input transform when there's no onReplace

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
+-   `RichText`: Skip the block input transforms in fields that are not passed an `onReplace`.
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
@@ -120,19 +120,21 @@ export default ( props ) => ( element ) => {
 
 		const value = getValue();
 
-		const transforms = getBlockTransforms( 'from' ).filter(
-			( transform ) => transform.type === 'input'
-		);
-		const transformation = findTransform( transforms, ( item ) => {
-			return item.regExp.test( value.text );
-		} );
+		if ( onReplace ) {
+			const transforms = getBlockTransforms( 'from' ).filter(
+				( transform ) => transform.type === 'input'
+			);
+			const transformation = findTransform( transforms, ( item ) =>
+				item.regExp.test( value.text )
+			);
 
-		if ( transformation ) {
-			onReplace( transformation.transform() );
-			registry
-				.dispatch( blockEditorStore )
-				.__unstableMarkAutomaticChange();
-			return;
+			if ( transformation ) {
+				onReplace( transformation.transform() );
+				registry
+					.dispatch( blockEditorStore )
+					.__unstableMarkAutomaticChange();
+				return;
+			}
 		}
 
 		const transformed = formatTypes.reduce(

--- a/test/e2e/specs/editor/blocks/separator.spec.js
+++ b/test/e2e/specs/editor/blocks/separator.spec.js
@@ -27,4 +27,30 @@ test.describe( 'Separator', () => {
 			},
 		] );
 	} );
+
+	test( 'is not created by three dashes when the block cannot be replaced', async ( {
+		editor,
+		page,
+	} ) => {
+		// A block that cannot be removed is passed an undefined `onReplace`,
+		// so there is no way to swap it for a separator.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { lock: { remove: true, move: false } },
+		} );
+
+		await editor.canvas
+			.getByRole( 'document', {
+				name: 'Empty block; start writing or type forward slash to choose a block',
+			} )
+			.click();
+		await page.keyboard.type( '---' );
+
+		// The dashes are left alone as text.
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [
+				{ name: 'core/paragraph', attributes: { content: '---' } },
+			] );
+	} );
 } );


### PR DESCRIPTION
Fixes a crash when a `RichText` field wants to apply an `input` transform, but there is no `onReplace` handler that would execute the transform, i.e., replace the current block with another one.

Steps to reproduce:
1. Create a `core/pullquote` block that has a field with text, but no ability to contain inner blocks. Or a locked `core/paragraph`, with locked removal.
2. Type `---` inside. This would normally convert the block to a separator, but in these cases the new block can't be created.
3. There is a crash:

<img width="434" height="66" alt="Screenshot 2026-07-30 at 16 39 34" src="https://github.com/user-attachments/assets/80f5f095-9c94-48e0-828f-c65649aac630" />

The fix is to guard the transform logic on `onReplace` and don't attempt transforms. The `inputRule` function in the same file already guards on `onReplace` when handling the `prefix` transforms.

This bug was reported in WP.com automated JS error reporting.