### PR TITLE
Migrate Block Editor Package Tests to Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49688,7 +49688,8 @@
 				"@types/postcss-prefix-selector": "^1.16.3",
 				"@wordpress/block-library": "file:../block-library",
 				"deep-freeze": "^0.0.1",
-				"storybook": "^10.4.3"
+				"storybook": "^10.4.3",
+				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Internal
 
+-   Migrate unit tests from Jest to Vitest.
 -   Gate the inherited Global Styles treatment in the block inspector on the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances until the experiment is turned on ([#80555](https://github.com/WordPress/gutenberg/pull/80555), [#80815](https://github.com/WordPress/gutenberg/pull/80815)).
 -   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -119,7 +119,8 @@
 		"@types/postcss-prefix-selector": "^1.16.3",
 		"@wordpress/block-library": "file:../block-library",
 		"deep-freeze": "^0.0.1",
-		"storybook": "^10.4.3"
+		"storybook": "^10.4.3",
+		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/block-editor/src/autocompleters/test/block.js
+++ b/packages/block-editor/src/autocompleters/test/block.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AlignmentUI should allow custom alignment controls to be specified 1`] = `
+exports[`AlignmentUI > should allow custom alignment controls to be specified 1`] = `
 <div>
   <div
     class="components-toolbar"
@@ -59,7 +59,7 @@ exports[`AlignmentUI should allow custom alignment controls to be specified 1`] 
 </div>
 `;
 
-exports[`AlignmentUI should match snapshot when controls are hidden 1`] = `
+exports[`AlignmentUI > should match snapshot when controls are hidden 1`] = `
 <div>
   <div
     class="components-dropdown components-dropdown-menu components-toolbar"
@@ -91,7 +91,7 @@ exports[`AlignmentUI should match snapshot when controls are hidden 1`] = `
 </div>
 `;
 
-exports[`AlignmentUI should match snapshot when controls are visible 1`] = `
+exports[`AlignmentUI > should match snapshot when controls are visible 1`] = `
 <div>
   <div
     class="components-toolbar"

--- a/packages/block-editor/src/components/alignment-control/test/index.jsx
+++ b/packages/block-editor/src/components/alignment-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -16,7 +17,7 @@ import AlignmentUI from '../ui';
 
 describe( 'AlignmentUI', () => {
 	const alignment = 'left';
-	const onChangeSpy = jest.fn();
+	const onChangeSpy = vi.fn();
 
 	afterEach( () => {
 		onChangeSpy.mockClear();

--- a/packages/block-editor/src/components/background-image-control/test/index.js
+++ b/packages/block-editor/src/components/background-image-control/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 

--- a/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BlockAlignmentUI should match snapshot when controls are hidden 1`] = `
+exports[`BlockAlignmentUI > should match snapshot when controls are hidden 1`] = `
 <div>
   <div
     class="components-dropdown components-dropdown-menu components-toolbar"
@@ -32,7 +32,7 @@ exports[`BlockAlignmentUI should match snapshot when controls are hidden 1`] = `
 </div>
 `;
 
-exports[`BlockAlignmentUI should match snapshot when controls are visible 1`] = `
+exports[`BlockAlignmentUI > should match snapshot when controls are visible 1`] = `
 <div>
   <div
     class="components-toolbar"

--- a/packages/block-editor/src/components/block-alignment-control/test/index.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -11,7 +12,7 @@ import BlockAlignmentUI from '../ui';
 
 describe( 'BlockAlignmentUI', () => {
 	const alignment = 'left';
-	const onChange = jest.fn();
+	const onChange = vi.fn();
 
 	afterEach( () => {
 		onChange.mockClear();

--- a/packages/block-editor/src/components/block-bindings/test/use-block-bindings-utils.js
+++ b/packages/block-editor/src/components/block-bindings/test/use-block-bindings-utils.js
@@ -1,19 +1,20 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { registerCoreBlocks } from '@wordpress/block-library';
 import { dispatch, select } from '@wordpress/data';
 import {
 	createBlock,
 	getBlockTypes,
 	unregisterBlockType,
 } from '@wordpress/blocks';
-import { registerCoreBlocks } from '@wordpress/block-library';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BlockBreadcrumb should render correctly 1`] = `
+exports[`BlockBreadcrumb > should render correctly 1`] = `
 <div>
   <ul
     aria-label="Block breadcrumb"

--- a/packages/block-editor/src/components/block-breadcrumb/test/index.jsx
+++ b/packages/block-editor/src/components/block-breadcrumb/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/block-compare/test/__snapshots__/block-view.jsx.snap
+++ b/packages/block-editor/src/components/block-compare/test/__snapshots__/block-view.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BlockView should match snapshot 1`] = `
+exports[`BlockView > should match snapshot 1`] = `
 <div>
   <div
     class="class"

--- a/packages/block-editor/src/components/block-compare/test/block-view.jsx
+++ b/packages/block-editor/src/components/block-compare/test/block-view.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/block-controls/test/index.jsx
+++ b/packages/block-editor/src/components/block-controls/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/block-edit/test/edit.jsx
+++ b/packages/block-editor/src/components/block-edit/test/edit.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/block-icon/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/block-icon/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BlockIcon renders a Icon 1`] = `
+exports[`BlockIcon > renders a Icon 1`] = `
 <div>
   <span
     class="block-editor-block-icon"

--- a/packages/block-editor/src/components/block-icon/test/index.jsx
+++ b/packages/block-editor/src/components/block-icon/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/block-mover/test/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/test/mover-description.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/block-preview/test/index.jsx
+++ b/packages/block-editor/src/components/block-preview/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/block-selection-clearer/test/index.jsx
+++ b/packages/block-editor/src/components/block-selection-clearer/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
@@ -14,29 +15,25 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import BlockSelectionClearer from '../';
 
 const defaultUseSelectValues = {
-	hasSelectedBlock: jest.fn().mockReturnValue( false ),
-	hasMultiSelection: jest.fn().mockReturnValue( false ),
-	getSettings: jest.fn().mockReturnValue( {
+	hasSelectedBlock: vi.fn().mockReturnValue( false ),
+	hasMultiSelection: vi.fn().mockReturnValue( false ),
+	getSettings: vi.fn().mockReturnValue( {
 		clearBlockSelection: true,
 	} ),
 };
 
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: jest.fn(),
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useDispatch: vi.fn(),
+	useSelect: vi.fn(),
 } ) );
-
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
 
 describe( 'BlockSelectionClearer component', () => {
 	it( 'should clear the selected block when a selected block exists', () => {
-		const mockClearSelectedBlock = jest.fn();
+		const mockClearSelectedBlock = vi.fn();
 		useSelect.mockImplementation( () => ( {
 			...defaultUseSelectValues,
-			hasSelectedBlock: jest.fn().mockReturnValue( true ),
+			hasSelectedBlock: vi.fn().mockReturnValue( true ),
 		} ) );
 		useDispatch.mockImplementation( () => ( {
 			clearSelectedBlock: mockClearSelectedBlock,
@@ -54,10 +51,10 @@ describe( 'BlockSelectionClearer component', () => {
 	} );
 
 	it( 'should clear the selected block when multiple blocks are selected', () => {
-		const mockClearSelectedBlock = jest.fn();
+		const mockClearSelectedBlock = vi.fn();
 		useSelect.mockImplementation( () => ( {
 			...defaultUseSelectValues,
-			hasMultiSelection: jest.fn().mockReturnValue( true ),
+			hasMultiSelection: vi.fn().mockReturnValue( true ),
 		} ) );
 		useDispatch.mockImplementation( () => ( {
 			clearSelectedBlock: mockClearSelectedBlock,
@@ -75,7 +72,7 @@ describe( 'BlockSelectionClearer component', () => {
 	} );
 
 	it( 'should not clear the block selection when no blocks are selected', () => {
-		const mockClearSelectedBlock = jest.fn();
+		const mockClearSelectedBlock = vi.fn();
 		useSelect.mockImplementation( () => defaultUseSelectValues );
 		useDispatch.mockImplementation( () => ( {
 			clearSelectedBlock: mockClearSelectedBlock,
@@ -93,11 +90,11 @@ describe( 'BlockSelectionClearer component', () => {
 	} );
 
 	it( 'should not clear the block selection when the feature is disabled', () => {
-		const mockClearSelectedBlock = jest.fn();
+		const mockClearSelectedBlock = vi.fn();
 		useSelect.mockImplementation( () => ( {
 			...defaultUseSelectValues,
-			hasSelectedBlock: jest.fn().mockReturnValue( true ),
-			getSettings: jest.fn().mockReturnValue( {
+			hasSelectedBlock: vi.fn().mockReturnValue( true ),
+			getSettings: vi.fn().mockReturnValue( {
 				clearBlockSelection: false,
 			} ),
 		} ) );

--- a/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.jsx
+++ b/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,10 @@ import { useSelect } from '@wordpress/data';
  */
 import BlockModeToggle from '../block-mode-toggle';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 function setupUseSelectMock( mode, blockType, codeEditingEnabled = true ) {
 	useSelect.mockImplementation( () => {

--- a/packages/block-editor/src/components/block-styles/test/utils.js
+++ b/packages/block-editor/src/components/block-styles/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/block-switcher/test/index.jsx
+++ b/packages/block-editor/src/components/block-switcher/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -16,10 +17,13 @@ import { copy } from '@wordpress/icons';
  */
 import { BlockSwitcher } from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '../../block-title/use-block-display-title', () =>
-	jest.fn().mockReturnValue( 'Block Name' )
-);
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
+vi.mock( import( '../../block-title/use-block-display-title' ), () => ( {
+	default: vi.fn().mockReturnValue( 'Block Name' ),
+} ) );
 
 describe( 'BlockSwitcher', () => {
 	const headingBlock1 = {

--- a/packages/block-editor/src/components/block-switcher/test/use-transformed.patterns.js
+++ b/packages/block-editor/src/components/block-switcher/test/use-transformed.patterns.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { unregisterBlockType, registerBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/components/block-switcher/test/utils.js
+++ b/packages/block-editor/src/components/block-switcher/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { unregisterBlockType, registerBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/components/block-title/test/index.jsx
+++ b/packages/block-editor/src/components/block-title/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -30,8 +31,8 @@ const blockLabelMap = {
 	'Reusable Block': 'Reuse me!',
 };
 
-jest.mock( '@wordpress/blocks', () => {
-	const actualImplementation = jest.requireActual( '@wordpress/blocks' );
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const actualImplementation = await importOriginal();
 	return {
 		...actualImplementation,
 		isReusableBlock( { title } ) {
@@ -44,7 +45,10 @@ jest.mock( '@wordpress/blocks', () => {
 } );
 
 // This allows us to tweak the returned value on each test.
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 describe( 'BlockTitle', () => {
 	it( 'renders nothing if name is falsey', () => {

--- a/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.jsx
+++ b/packages/block-editor/src/components/block-toolbar/test/block-toolbar-icon.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -14,8 +15,8 @@ import { paragraph } from '@wordpress/icons';
  */
 import BlockToolbarIcon from '../block-toolbar-icon';
 
-jest.mock( '@wordpress/blocks', () => {
-	const actualImplementation = jest.requireActual( '@wordpress/blocks' );
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => {
+	const actualImplementation = await importOriginal();
 	return {
 		...actualImplementation,
 		getBlockType: ( name ) => ( {
@@ -25,34 +26,39 @@ jest.mock( '@wordpress/blocks', () => {
 		} ),
 	};
 } );
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '../../../lock-unlock', () => ( {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
+vi.mock( import( '../../../lock-unlock' ), () => ( {
 	unlock: ( value ) => ( {
-		registerPrivateActions: jest.fn(),
-		registerPrivateSelectors: jest.fn(),
+		registerPrivateActions: vi.fn(),
+		registerPrivateSelectors: vi.fn(),
 		...value,
 	} ),
 } ) );
-jest.mock( '../../block-title/use-block-display-title', () =>
-	jest.fn().mockReturnValue( 'Block Name' )
-);
-jest.mock( '../../block-icon', () =>
-	jest.fn( ( { icon } ) => <span data-testid="block-icon">{ icon }</span> )
-);
-jest.mock( '../../block-switcher', () =>
-	jest.fn( ( { children } ) => (
+vi.mock( import( '../../block-title/use-block-display-title' ), () => ( {
+	default: vi.fn().mockReturnValue( 'Block Name' ),
+} ) );
+vi.mock( import( '../../block-icon' ), () => ( {
+	default: vi.fn( ( { icon } ) => (
+		<span data-testid="block-icon">{ icon }</span>
+	) ),
+} ) );
+vi.mock( import( '../../block-switcher' ), () => ( {
+	default: vi.fn( ( { children } ) => (
 		<div data-testid="block-switcher">{ children }</div>
-	) )
-);
-jest.mock( '../pattern-overrides-dropdown', () =>
-	jest.fn( ( { clientIds } ) => (
+	) ),
+} ) );
+vi.mock( import( '../pattern-overrides-dropdown' ), () => ( {
+	default: vi.fn( ( { clientIds } ) => (
 		<div data-testid="pattern-overrides-dropdown">
 			{ clientIds.length === 1
 				? 'Block Name'
 				: 'Multiple blocks selected' }
 		</div>
-	) )
-);
+	) ),
+} ) );
 
 describe( 'BlockToolbarIcon', () => {
 	const defaultProps = {
@@ -87,7 +93,7 @@ describe( 'BlockToolbarIcon', () => {
 	};
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'when variant is "switcher"', () => {

--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BlockVerticalAlignmentUI should match snapshot when controls are hidden 1`] = `
+exports[`BlockVerticalAlignmentUI > should match snapshot when controls are hidden 1`] = `
 <div>
   <div
     class="components-dropdown components-dropdown-menu components-toolbar"
@@ -32,7 +32,7 @@ exports[`BlockVerticalAlignmentUI should match snapshot when controls are hidden
 </div>
 `;
 
-exports[`BlockVerticalAlignmentUI should match snapshot when controls are visible 1`] = `
+exports[`BlockVerticalAlignmentUI > should match snapshot when controls are visible 1`] = `
 <div>
   <div
     class="components-toolbar"

--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/index.jsx
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -11,7 +12,7 @@ import BlockVerticalAlignmentUI from '../ui';
 
 describe( 'BlockVerticalAlignmentUI', () => {
 	const alignment = 'top';
-	const onChange = jest.fn();
+	const onChange = vi.fn();
 
 	afterEach( () => {
 		onChange.mockClear();

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
@@ -9,9 +10,9 @@ import { renderHook } from '@testing-library/react';
 import { useMediaQuery } from '@wordpress/compose';
 
 // Mock WordPress dependencies before importing the hook
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
-	useMediaQuery: jest.fn(),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useMediaQuery: vi.fn(),
 } ) );
 
 /**
@@ -38,7 +39,7 @@ describe( 'useBlockVisibility', () => {
 
 	beforeEach( () => {
 		// Reset all mocks before each test
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	describe( 'Device type overrides', () => {

--- a/packages/block-editor/src/components/block-visibility/test/utils.js
+++ b/packages/block-editor/src/components/block-visibility/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -79,7 +84,7 @@ describe( 'block-visibility utils', () => {
 
 		it( 'should return null when some blocks are hidden for viewport', () => {
 			// Suppress console.log from getViewportCheckboxState
-			const consoleSpy = jest
+			const consoleSpy = vi
 				.spyOn( console, 'log' )
 				.mockImplementation( () => {} );
 

--- a/packages/block-editor/src/components/border-radius-control/test/index.jsx
+++ b/packages/block-editor/src/components/border-radius-control/test/index.jsx
@@ -21,6 +21,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -34,7 +35,7 @@ import userEvent from '@testing-library/user-event';
 import BorderRadiusControl from '../index';
 
 describe( 'BorderRadiusControl', () => {
-	const mockOnChange = jest.fn();
+	const mockOnChange = vi.fn();
 	const mockPresets = {
 		default: [
 			{ name: 'None', slug: '0', size: 0 },

--- a/packages/block-editor/src/components/border-radius-control/test/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/child-layout-control/test/index.jsx
+++ b/packages/block-editor/src/components/child-layout-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,12 +15,13 @@ import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
  */
 import ChildLayoutControl from '../';
 
-jest.mock( '../../use-settings', () => ( {
+vi.mock( import( '../../use-settings' ), () => ( {
 	useSettings: () => [ undefined ],
 } ) );
 
-jest.mock( '@wordpress/data/src/components/use-select', () =>
-	jest.fn( ( mapSelect ) => {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn( ( mapSelect ) => {
 		if ( typeof mapSelect === 'function' ) {
 			return mapSelect( () => ( {
 				getBlockRootClientId: () => 'root-client-id',
@@ -30,19 +32,16 @@ jest.mock( '@wordpress/data/src/components/use-select', () =>
 			getBlockAttributes: () => ( {} ),
 			getBlockOrder: () => [],
 		};
-	} )
-);
-
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	} ),
 	useDispatch: () => ( {
-		__unstableMarkNextChangeAsNotPersistent: jest.fn(),
-		moveBlocksToPosition: jest.fn(),
+		__unstableMarkNextChangeAsNotPersistent: vi.fn(),
+		moveBlocksToPosition: vi.fn(),
 	} ),
 } ) );
 
 describe( 'ChildLayoutControl', () => {
 	const baseProps = {
-		onChange: jest.fn(),
+		onChange: vi.fn(),
 		parentLayout: {
 			type: 'grid',
 		},
@@ -51,14 +50,14 @@ describe( 'ChildLayoutControl', () => {
 	};
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	function renderControl( props ) {
 		return render(
 			<ToolsPanel
 				label="Dimensions"
-				resetAll={ jest.fn() }
+				resetAll={ vi.fn() }
 				panelId="client-id"
 			>
 				<ChildLayoutControl { ...baseProps } { ...props } />
@@ -107,7 +106,7 @@ describe( 'ChildLayoutControl', () => {
 
 	it( 'sets a numeric span when entering 1 into an empty span control', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		renderControl( {
 			value: {},
@@ -145,7 +144,7 @@ describe( 'ChildLayoutControl', () => {
 
 	it( 'sets fixedNoShrink when selecting fixed flex sizing', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		renderControl( {
 			parentLayout: {
@@ -166,7 +165,7 @@ describe( 'ChildLayoutControl', () => {
 
 	it( 'sets legacy fixed when selecting max sizing', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		renderControl( {
 			parentLayout: {

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.jsx.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ColorPaletteControl matches the snapshot 1`] = `
+exports[`ColorPaletteControl > matches the snapshot 1`] = `
 .emotion-0 {
   font-family: -apple-system,system-ui,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
   font-size: 13px;

--- a/packages/block-editor/src/components/color-palette/test/control.jsx
+++ b/packages/block-editor/src/components/color-palette/test/control.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, waitFor, queryByAttribute } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/colors-gradients/test/control.jsx
+++ b/packages/block-editor/src/components/colors-gradients/test/control.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import { click, render } from '@ariakit/test/react';
 
@@ -167,7 +168,7 @@ describe( 'ColorPaletteControl', () => {
 		} );
 
 		it( 'calls onColorChange with (color, slug) when a swatch is clicked (color-only palette)', async () => {
-			const onColorChange = jest.fn();
+			const onColorChange = vi.fn();
 
 			await render(
 				<ColorGradientControl
@@ -190,8 +191,8 @@ describe( 'ColorPaletteControl', () => {
 		} );
 
 		it( 'calls onColorChange with (color, slug) and calls onGradientChange() when both colors and gradients are available', async () => {
-			const onColorChange = jest.fn();
-			const onGradientChange = jest.fn();
+			const onColorChange = vi.fn();
+			const onGradientChange = vi.fn();
 
 			await render(
 				<ColorGradientControl

--- a/packages/block-editor/src/components/colors/test/utils.js
+++ b/packages/block-editor/src/components/colors/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/colors/test/with-colors.jsx
+++ b/packages/block-editor/src/components/colors/test/with-colors.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,7 +15,7 @@ describe( 'createCustomColorsHOC', () => {
 		const withCustomColors = createCustomColorsHOC( [
 			{ name: 'Red', slug: 'red', color: 'ff0000' },
 		] );
-		const BaseComponent = jest.fn( () => <div /> );
+		const BaseComponent = vi.fn( () => <div /> );
 		const EnhancedComponent =
 			withCustomColors( 'backgroundColor' )( BaseComponent );
 
@@ -54,7 +55,7 @@ describe( 'createCustomColorsHOC', () => {
 			)
 		);
 
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 
 		render(
 			<EnhancedComponent
@@ -84,7 +85,7 @@ describe( 'createCustomColorsHOC', () => {
 			)
 		);
 
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 
 		render(
 			<EnhancedComponent

--- a/packages/block-editor/src/components/contrast-checker/test/index.jsx
+++ b/packages/block-editor/src/components/contrast-checker/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,7 @@ import { speak } from '@wordpress/a11y';
  */
 import ContrastChecker from '../';
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+vi.mock( import( '@wordpress/a11y' ), () => ( { speak: vi.fn() } ) );
 
 describe( 'ContrastChecker', () => {
 	const backgroundColor = '#ffffff';

--- a/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/default-block-appender/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
+exports[`DefaultBlockAppender > should append a default block when input focused 1`] = `
 <div>
   <div
     class="block-editor-default-block-appender has-visible-prompt"
@@ -18,7 +18,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
 </div>
 `;
 
-exports[`DefaultBlockAppender should match snapshot 1`] = `
+exports[`DefaultBlockAppender > should match snapshot 1`] = `
 <div>
   <div
     class="block-editor-default-block-appender has-visible-prompt"
@@ -36,7 +36,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
 </div>
 `;
 
-exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
+exports[`DefaultBlockAppender > should optionally show without prompt 1`] = `
 <div>
   <div
     class="block-editor-default-block-appender"

--- a/packages/block-editor/src/components/default-block-appender/test/index.jsx
+++ b/packages/block-editor/src/components/default-block-appender/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -10,18 +11,18 @@ import userEvent from '@testing-library/user-event';
 import DefaultBlockAppender, { ZWNBSP } from '../';
 import * as blockEditorActions from '../../../store/actions';
 import * as blockEditorSelectors from '../../../store/selectors';
-jest.mock( '../../../store/actions', () => {
-	const actions = jest.requireActual( '../../../store/actions' );
+vi.mock( import( '../../../store/actions' ), async ( importOriginal ) => {
+	const actions = await importOriginal();
 	return {
 		...actions,
-		startTyping: jest.fn( actions.startTyping ),
+		startTyping: vi.fn( actions.startTyping ),
 	};
 } );
-jest.mock( '../../../store/selectors', () => {
-	const selectors = jest.requireActual( '../../../store/selectors' );
+vi.mock( import( '../../../store/selectors' ), async ( importOriginal ) => {
+	const selectors = await importOriginal();
 	return {
 		...selectors,
-		getBlockCount: jest.fn( selectors.getBlockCount ),
+		getBlockCount: vi.fn( selectors.getBlockCount ),
 	};
 } );
 
@@ -33,7 +34,7 @@ describe( 'DefaultBlockAppender', () => {
 	} );
 
 	it( 'should append a default block when input focused', async () => {
-		const startTyping = jest.spyOn( blockEditorActions, 'startTyping' );
+		const startTyping = vi.spyOn( blockEditorActions, 'startTyping' );
 		const user = userEvent.setup();
 
 		const { container } = render( <DefaultBlockAppender /> );

--- a/packages/block-editor/src/components/dimensions-tool/test/index.jsx
+++ b/packages/block-editor/src/components/dimensions-tool/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -84,7 +85,7 @@ function ControlledExample( { value, onChange, ...props } ) {
 describe( 'DimensionsTool', () => {
 	describe( 'controlled values', () => {
 		it( 'updates the aspect ratio control when the value prop changes', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const { rerender } = render(
 				<ControlledExample
 					value={ { aspectRatio: '16/9' } }
@@ -118,7 +119,7 @@ describe( 'DimensionsTool', () => {
 	describe( 'updating aspectRatio', () => {
 		it( 'when starting with empty initial state, setting aspectRatio also sets scale (0000) -> (1100)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -158,7 +159,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with just height, setting aspectRatio also sets scale (0001) -> (1101)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -198,7 +199,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with just width, setting aspectRatio also sets scale (0010) -> (1110)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -238,7 +239,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with scale, width, and height, setting aspectRatio also clears height (0111) -> (1110)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -278,7 +279,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with aspectRatio and scale, setting aspectRatio to "Original" also clears scale (1100) -> (0000)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				aspectRatio: '16/9',
@@ -310,7 +311,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with aspectRatio, scale, and height, setting aspectRatio to "Original" also clears scale (1101) -> (0001)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				aspectRatio: '16/9',
@@ -344,7 +345,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with aspectRatio, scale, and width, setting aspectRatio to "Original" also clears scale (1110) -> (0010)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				aspectRatio: '16/9',
@@ -380,7 +381,7 @@ describe( 'DimensionsTool', () => {
 	describe( 'updating scale', () => {
 		it( 'when default scale is cover, setting scale to fill preserves the fill value', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				aspectRatio: '16/9',
@@ -407,7 +408,7 @@ describe( 'DimensionsTool', () => {
 	describe( 'updating dimensions', () => {
 		it( 'when starting with just height, setting width also sets scale (0001) -> (0111)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -447,7 +448,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with just width, setting height also sets scale (0010) -> (0111)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -487,7 +488,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with scale, width, and height, clearing width also clears scale (0111) -> (0001)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -521,7 +522,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with scale, width, and height, clearing height also clears scale (0111) -> (0010)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				// aspectRatio,
@@ -555,7 +556,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with aspectRatio, scale, and height, setting width also clears aspectRatio (1101) -> (0111)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				aspectRatio: '16/9',
@@ -601,7 +602,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when starting with aspectRatio, scale, and width, setting height also clears aspectRatio (1110) -> (0111)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const initialValue = {
 				aspectRatio: '16/9',
@@ -649,7 +650,7 @@ describe( 'DimensionsTool', () => {
 	describe( 'internal component state', () => {
 		it( 'when aspect ratio is change to custom by setting width and height then removing a width value should return the original aspect ratio (1100) -> (1110) -> (0111) -> (1101)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const value = {
 				aspectRatio: '16/9',
@@ -688,7 +689,7 @@ describe( 'DimensionsTool', () => {
 
 		it( 'when custom scale is set then aspect ratio is set to original and then aspect ratio is changed back (1100) -> (1100) -> (0000) -> (1100)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			const value = {
 				aspectRatio: '16/9',

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { logged } from '@wordpress/deprecated';

--- a/packages/block-editor/src/components/font-sizes/test/utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { logged } from '@wordpress/deprecated';

--- a/packages/block-editor/src/components/global-styles/inheritance/test/index.jsx
+++ b/packages/block-editor/src/components/global-styles/inheritance/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { click } from '@ariakit/test';
 
@@ -29,7 +30,7 @@ describe( 'InheritanceResetButton', () => {
 	} );
 
 	test( 'invokes the reset handler when activated', async () => {
-		const onResetToInherited = jest.fn();
+		const onResetToInherited = vi.fn();
 		render(
 			<InheritanceResetButton onResetToInherited={ onResetToInherited } />
 		);
@@ -241,7 +242,7 @@ describe( 'InheritanceToolsPanelItem local-override reset dot', () => {
 	} );
 
 	test( 'the reset dot invokes the deselect handler', async () => {
-		const onDeselect = jest.fn();
+		const onDeselect = vi.fn();
 		renderItem( { hasLocalOverride: true, onDeselect } );
 		await click(
 			screen.getByRole( 'button', { name: 'Reset to inherited value' } )

--- a/packages/block-editor/src/components/global-styles/test/background-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/test/background-panel.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -173,7 +174,7 @@ describe( 'BackgroundPanel — duplicate gradient preset slug identity', () => {
 
 	it( 'commits the inherited preset slug when accepting the preselected inherited gradient', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<BackgroundPanel
@@ -210,7 +211,7 @@ describe( 'BackgroundPanel — duplicate gradient preset slug identity', () => {
 				} }
 				inheritedValue={ {} }
 				settings={ duplicateGradientSettings }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				panelId="test-panel"
 			/>
 		);
@@ -264,7 +265,7 @@ describe( 'BackgroundPanel — inherited Global Styles label treatment', () => {
 						'linear-gradient(135deg, rgb(74, 0, 224) 0%, rgb(142, 45, 226) 100%)',
 				},
 			};
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<BackgroundPanel
@@ -330,7 +331,7 @@ describe( 'BackgroundPanel — inherited Global Styles label treatment', () => {
 					},
 				},
 			};
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<BackgroundPanel
@@ -373,7 +374,7 @@ describe( 'BackgroundPanel — inherited Global Styles label treatment', () => {
 					},
 				},
 			};
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			render(
 				<BackgroundPanel

--- a/packages/block-editor/src/components/global-styles/test/border-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -132,7 +133,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 		} );
 
 		it( 'does not invoke onChange on mount when only an inherited radius is present (display-without-commit)', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = { border: { radius: '8px' } };
 
 			render(
@@ -150,7 +151,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 
 		it( 'commits a typed local radius override without copying any inherited values (strip-not-copy)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				border: { radius: '8px' },
 				shadow: 'var:preset|shadow|soft',
@@ -179,7 +180,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 
 		it( 'does not bake the inherited border color/style/width into the local override when only a radius is set', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				border: {
 					color: '#000000',
@@ -259,7 +260,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 			// renders the blue dot) even though the user never
 			// customised the radius.
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				border: {
 					color: '#000000',
@@ -296,7 +297,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 		} );
 
 		it( 'does not invoke onChange on mount when only an inherited border is present', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				border: {
 					color: '#000000',
@@ -344,7 +345,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 		} );
 
 		it( 'does not invoke onChange on mount when only an inherited shadow is present', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				shadow: 'var:preset|shadow|soft',
 			};

--- a/packages/block-editor/src/components/global-styles/test/color-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/test/color-panel.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { render, renderHook, screen } from '@testing-library/react';
 import { click, render as renderAriakit } from '@ariakit/test/react';
 

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.jsx
@@ -2,8 +2,14 @@
 /**
  * External dependencies
  */
-import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,11 +32,11 @@ afterEach( () => {
 // full set of inherited and selectable ratios without spinning up a
 // store registry. Per-call resolution lets the same mock answer all
 // of the paths the tool requests on a single render.
-jest.mock( '../../use-settings', () => {
-	const actual = jest.requireActual( '../../use-settings' );
+vi.mock( import( '../../use-settings' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 	return {
 		...actual,
-		useSettings: jest.fn( ( ...paths ) =>
+		useSettings: vi.fn( ( ...paths ) =>
 			paths.map( ( path ) => {
 				switch ( path ) {
 					case 'dimensions.aspectRatios.default':
@@ -246,7 +252,7 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 
 		it( 'commits a local contentSize override on user input without copying any inherited value into other paths (strip-not-copy)', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			renderPanel( {
 				value: {},
@@ -456,7 +462,7 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 		} );
 
 		it( 'does not call `onChange` on mount of an at-rest minHeight', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			renderPanel( {
 				value: {},
 				inheritedValue: { dimensions: { minHeight: '320px' } },
@@ -469,7 +475,7 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 
 		it( 'commits a local minHeight override on user input without copying any inherited value into other paths', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			renderPanel( {
 				value: {},
@@ -528,7 +534,7 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 		} );
 
 		it( 'does not call `onChange` on mount of an at-rest aspectRatio', () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			renderPanel( {
 				value: {},
 				inheritedValue: { dimensions: { aspectRatio: '16/9' } },
@@ -541,7 +547,7 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 
 		it( 'commits a local aspectRatio override on user selection of a different option without copying any inherited value into other paths', async () => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 
 			renderPanel( {
 				value: {},
@@ -651,13 +657,10 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 		} );
 
 		it( '(padding) commits to local on slider activation and the displayed value follows the new local value', () => {
-			const { fireEvent } = require( '@testing-library/react' );
-
 			// Controlled wrapper so we can verify the slider follows local
 			// value updates after onChange writes through.
 			function Wrapper() {
-				const [ value, setValue ] =
-					require( '@wordpress/element' ).useState( {} );
+				const [ value, setValue ] = useState( {} );
 				return (
 					<DimensionsPanel
 						value={ value }

--- a/packages/block-editor/src/components/global-styles/test/filters-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/test/filters-panel.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -108,7 +109,7 @@ describe( 'FiltersPanel — visual treatment and display-without-commit', () => 
 	} );
 
 	it( 'does not invoke onChange on mount when only inherited duotone is present (display-without-commit)', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const inheritedValue = {
 			filter: { duotone: [ '#000000', '#ffffff' ] },
 		};
@@ -128,7 +129,7 @@ describe( 'FiltersPanel — visual treatment and display-without-commit', () => 
 
 	it( 'commits the inherited value when the user clicks the preselected duotone preset', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const inheritedValue = {
 			filter: { duotone: [ '#000000', '#ffffff' ] },
 		};
@@ -174,7 +175,7 @@ describe( 'FiltersPanel — visual treatment and display-without-commit', () => 
 	} );
 
 	it( 'does not invoke onChange on mount when a local duotone is set (no spurious commit)', () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const value = {
 			filter: { duotone: [ '#8c00b7', '#fcff41' ] },
 		};

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context-core.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
@@ -30,28 +31,28 @@ afterEach( () => {
 
 // Only `useSelect` is called by the hook. The other four are needed at import
 // time by the store modules this file pulls in transitively.
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	register: jest.fn(),
-	createReduxStore: jest.fn(),
-	createSelector: jest.fn( ( callback ) => callback ),
-	combineReducers: jest.fn( ( reducers ) => reducers ),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useSelect: vi.fn(),
+	register: vi.fn(),
+	createReduxStore: vi.fn(),
+	createSelector: vi.fn( ( callback ) => callback ),
+	combineReducers: vi.fn( ( reducers ) => reducers ),
 } ) );
 
-jest.mock( '../../../store', () => ( {
+vi.mock( import( '../../../store' ), () => ( {
 	store: { name: 'core/block-editor' },
 } ) );
 
 // `inherited-value-context.js` imports the blocks store for
 // `useVariationAndElements`. Its real import chain needs data-module exports
 // the stub above does not provide, so stub the blocks module too.
-jest.mock( '@wordpress/blocks', () => ( {
+vi.mock( import( '@wordpress/blocks' ), () => ( {
 	store: { name: 'core/blocks' },
 	getBlockType: ( blockName ) =>
 		( { 'core/heading': { title: 'Heading' } } )[ blockName ],
 } ) );
 
-jest.mock( '../../../hooks/block-style-variation', () => ( {
+vi.mock( import( '../../../hooks/block-style-variation' ), () => ( {
 	getVariationNameFromClass: ( className ) => {
 		const match = /is-style-([\w-]+)/.exec( className || '' );
 		return match ? match[ 1 ] : null;

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context.jsx
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -28,23 +29,23 @@ afterEach( () => {
 	delete window.__experimentalGlobalStylesInheritanceUI;
 } );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
-	useDispatch: jest.fn( () => ( {} ) ),
-	useRegistry: jest.fn( () => ( {} ) ),
-	createSelector: jest.fn( ( callback ) => callback ),
-	createReduxStore: jest.fn(),
-	createRegistry: jest.fn(),
-	register: jest.fn(),
-	select: jest.fn(),
-	dispatch: jest.fn(),
-	combineReducers: jest.fn( ( reducers ) => reducers ),
-	subscribe: jest.fn(),
+vi.mock( import( '@wordpress/data' ), () => ( {
+	useSelect: vi.fn(),
+	useDispatch: vi.fn( () => ( {} ) ),
+	useRegistry: vi.fn( () => ( {} ) ),
+	createSelector: vi.fn( ( callback ) => callback ),
+	createReduxStore: vi.fn(),
+	createRegistry: vi.fn(),
+	register: vi.fn(),
+	select: vi.fn(),
+	dispatch: vi.fn(),
+	combineReducers: vi.fn( ( reducers ) => reducers ),
+	subscribe: vi.fn(),
 	RegistryProvider: ( { children } ) => children,
 	RegistryConsumer: ( { children } ) => children( {} ),
 	AsyncModeProvider: ( { children } ) => children,
-	useRegistrySelect: jest.fn(),
-	useRegistryDispatch: jest.fn( () => ( {} ) ),
+	useRegistrySelect: vi.fn(),
+	useRegistryDispatch: vi.fn( () => ( {} ) ),
 	withSelect: ( mapStateToProps ) => ( Component ) => ( props ) =>
 		Component( {
 			...props,
@@ -54,7 +55,7 @@ jest.mock( '@wordpress/data', () => ( {
 	withRegistry: ( Component ) => Component,
 } ) );
 
-jest.mock( '../../../store', () => ( {
+vi.mock( import( '../../../store' ), () => ( {
 	store: { name: 'core/block-editor' },
 } ) );
 
@@ -63,7 +64,7 @@ jest.mock( '../../../store', () => ( {
 // transitive import chain fails under this file's `@wordpress/data` mock
 // (missing `createSelector`), so stub the blocks module with just the shape
 // needed.
-jest.mock( '@wordpress/blocks', () => ( {
+vi.mock( import( '@wordpress/blocks' ), () => ( {
 	store: { name: 'core/blocks' },
 	getBlockType: ( blockName ) =>
 		( {
@@ -77,7 +78,7 @@ jest.mock( '@wordpress/blocks', () => ( {
 // `className`; map `is-style-<slug>` to `<slug>` for these tests. The
 // variation-ref resolution itself now lives in `resolveStyle`
 // (`@wordpress/global-styles-engine`) and is covered by its own tests.
-jest.mock( '../../../hooks/block-style-variation', () => ( {
+vi.mock( import( '../../../hooks/block-style-variation' ), () => ( {
 	getVariationNameFromClass: ( className ) => {
 		const match = /is-style-([\w-]+)/.exec( className || '' );
 		return match ? match[ 1 ] : null;

--- a/packages/block-editor/src/components/global-styles/test/state-control-badges.jsx
+++ b/packages/block-editor/src/components/global-styles/test/state-control-badges.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -8,8 +9,8 @@ import { render, screen } from '@testing-library/react';
  */
 import StateControlBadges from '../state-control-badges';
 
-jest.mock( '@wordpress/ui', () => {
-	const actual = jest.requireActual( '@wordpress/ui' );
+vi.mock( import( '@wordpress/ui' ), async ( importOriginal ) => {
+	const actual = await importOriginal();
 
 	return {
 		...actual,

--- a/packages/block-editor/src/components/global-styles/test/typography-panel-core.jsx
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel-core.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { click, render as renderAriakit } from '@ariakit/test/react';
 
@@ -106,7 +107,7 @@ describe( 'TypographyPanel — experiment off', () => {
 				inheritedValue={ { color: { text: 'var:preset|color|red' } } }
 				settings={ PALETTE_SETTINGS }
 				panelId="test"
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 			/>
 		);
 
@@ -123,7 +124,7 @@ describe( 'TypographyPanel — experiment off', () => {
 
 describe( 'TypographyPanel — experiment off, setTextColor link sync', () => {
 	async function pickRed( value, inheritedValue ) {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		await renderAriakit(
 			<TypographyPanel
 				value={ value }

--- a/packages/block-editor/src/components/global-styles/test/typography-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { click, render as renderAriakit } from '@ariakit/test/react';
@@ -205,7 +206,7 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 		// A local commit writes only the path the user touched. The
 		// inherited value is never copied into local attributes by typing.
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const inheritedValue = {
 			typography: { textColumns: 3, lineHeight: '1.7' },
 		};
@@ -412,7 +413,7 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 			// never invoke the parent `onChange`. Otherwise the act
 			// of opening the inspector would silently commit every
 			// inherited value into the local block attributes.
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				typography: {
 					textDecoration: 'underline',
@@ -442,7 +443,7 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 			// bypasses the inner ToggleGroupControl's equality
 			// short-circuit which would otherwise emit `undefined`.
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				typography: { textDecoration: 'underline' },
 			};
@@ -532,7 +533,7 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 
 	describe( 'Font appearance (composite ToggleGroup-like select)', () => {
 		it( 'mounting an at-rest font appearance does not call onChange (display-without-commit)', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				typography: { fontStyle: 'italic', fontWeight: '700' },
 			};
@@ -549,7 +550,7 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 
 	describe( 'FontFamily (CustomSelect archetype)', () => {
 		it( 'mounting an at-rest font family does not call onChange (display-without-commit)', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				typography: { fontFamily: 'Georgia, serif' },
 			};
@@ -623,7 +624,7 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 
 	describe( 'FontSize (preset picker + custom-size input)', () => {
 		it( 'mounting an at-rest font size does not call onChange (display-without-commit)', async () => {
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			const inheritedValue = {
 				typography: { fontSize: 'var:preset|font-size|large' },
 			};
@@ -762,7 +763,7 @@ async function openTextColorDropdown() {
 
 describe( 'TypographyPanel — duplicate-hex preset slug identity', () => {
 	it( 'commits the inherited preset slug when accepting the preselected inherited color', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		await renderAriakit(
 			<TypographyPanel
@@ -793,7 +794,7 @@ describe( 'TypographyPanel — duplicate-hex preset slug identity', () => {
 				value={ { color: { text: 'var:preset|color|dark-text' } } }
 				settings={ DUPLICATE_PALETTE_SETTINGS }
 				panelId="test"
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 			/>
 		);
 
@@ -807,7 +808,7 @@ describe( 'TypographyPanel — duplicate-hex preset slug identity', () => {
 
 describe( 'TypographyPanel — setTextColor link sync', () => {
 	it( 'syncs the link color when text and link share the same raw preset reference', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const sharedRef = 'var:preset|color|dark-background';
 
 		await renderAriakit(
@@ -836,7 +837,7 @@ describe( 'TypographyPanel — setTextColor link sync', () => {
 	} );
 
 	it( 'does NOT sync the link color when text and link have different raw refs, even if their decoded hex values match', async () => {
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		await renderAriakit(
 			<TypographyPanel
@@ -871,7 +872,7 @@ describe( 'TypographyPanel — setTextColor link sync', () => {
 		// color the user set on the block instance must survive a
 		// subsequent text color change instead of being overwritten to
 		// track the text color.
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		await renderAriakit(
 			<TypographyPanel
@@ -906,7 +907,7 @@ describe( 'TypographyPanel — setTextColor link sync', () => {
 	it( 'keeps a local link color tracking when it currently matches the local text color', async () => {
 		// When the local link color equals the local text color it is
 		// still tracking, so a text color change carries the link along.
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 		const sharedRef = 'var:preset|color|blue';
 		const distinctPaletteSettings = {
 			color: {

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/image-editor/test/index.js
+++ b/packages/block-editor/src/components/image-editor/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { expect, test } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { ratioToNumber } from '../aspect-ratio-dropdown';

--- a/packages/block-editor/src/components/image-size-control/test/index.jsx
+++ b/packages/block-editor/src/components/image-size-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -10,12 +11,12 @@ import userEvent from '@testing-library/user-event';
 import ImageSizeControl from '../index';
 
 describe( 'ImageSizeControl', () => {
-	const mockOnChange = jest.fn();
-	const mockOnChangeImage = jest.fn();
+	const mockOnChange = vi.fn();
+	const mockOnChangeImage = vi.fn();
 
 	afterEach( () => {
 		// Cleanup on exiting.
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'returns custom dimensions when they exist', () => {

--- a/packages/block-editor/src/components/inner-blocks/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/inner-blocks/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`InnerBlocks should force serialize for invalid block with inner blocks 1`] = `
+exports[`InnerBlocks > should force serialize for invalid block with inner blocks 1`] = `
 "<!-- wp:test-block -->
 <p>Invalid<!-- wp:test-block -->
 <p></p>
@@ -8,7 +8,7 @@ exports[`InnerBlocks should force serialize for invalid block with inner blocks 
 <!-- /wp:test-block -->"
 `;
 
-exports[`InnerBlocks should return element as string, with inner blocks 1`] = `
+exports[`InnerBlocks > should return element as string, with inner blocks 1`] = `
 "<div>Bananas<!-- wp:fruit {"fruit":"Apples"} -->
 <div>Apples</div>
 <!-- /wp:fruit --></div>"

--- a/packages/block-editor/src/components/inner-blocks/test/index.jsx
+++ b/packages/block-editor/src/components/inner-blocks/test/index.jsx
@@ -1,6 +1,11 @@
 /* eslint-disable testing-library/render-result-naming-convention */
 
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-editor/src/components/inner-content/test/index.jsx
+++ b/packages/block-editor/src/components/inner-content/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
 /**
@@ -10,17 +11,17 @@ import { useDelayedLoading, useMediaResults } from '../hooks';
 
 describe( 'useDelayedLoading', () => {
 	beforeEach( () => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 	} );
 	afterEach( () => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	} );
 
 	it( 'does not surface loading before the delay elapses', () => {
 		const { result } = renderHook( () => useDelayedLoading( true, 400 ) );
 		expect( result.current ).toBe( false );
 		act( () => {
-			jest.advanceTimersByTime( 399 );
+			vi.advanceTimersByTime( 399 );
 		} );
 		expect( result.current ).toBe( false );
 	} );
@@ -28,7 +29,7 @@ describe( 'useDelayedLoading', () => {
 	it( 'surfaces loading once the delay elapses', () => {
 		const { result } = renderHook( () => useDelayedLoading( true, 400 ) );
 		act( () => {
-			jest.advanceTimersByTime( 400 );
+			vi.advanceTimersByTime( 400 );
 		} );
 		expect( result.current ).toBe( true );
 	} );
@@ -39,11 +40,11 @@ describe( 'useDelayedLoading', () => {
 			{ initialProps: { isLoading: true } }
 		);
 		act( () => {
-			jest.advanceTimersByTime( 200 );
+			vi.advanceTimersByTime( 200 );
 		} );
 		rerender( { isLoading: false } );
 		act( () => {
-			jest.advanceTimersByTime( 400 );
+			vi.advanceTimersByTime( 400 );
 		} );
 		expect( result.current ).toBe( false );
 	} );
@@ -54,7 +55,7 @@ describe( 'useDelayedLoading', () => {
 			{ initialProps: { isLoading: true } }
 		);
 		act( () => {
-			jest.advanceTimersByTime( 400 );
+			vi.advanceTimersByTime( 400 );
 		} );
 		expect( result.current ).toBe( true );
 		rerender( { isLoading: false } );
@@ -65,7 +66,7 @@ describe( 'useDelayedLoading', () => {
 describe( 'useMediaResults', () => {
 	const createCategory = ( name, items ) => ( {
 		name,
-		fetch: jest.fn( async () => items ),
+		fetch: vi.fn( async () => items ),
 	} );
 
 	it( 'fetches and returns media for the query', async () => {
@@ -126,7 +127,7 @@ describe( 'useMediaResults', () => {
 	it( 'surfaces paging totals from a source that returns them', async () => {
 		const category = {
 			name: 'images',
-			fetch: jest.fn( async () => ( {
+			fetch: vi.fn( async () => ( {
 				mediaItems: [ { id: 1 } ],
 				totalItems: 42,
 				totalPages: 3,
@@ -214,7 +215,7 @@ describe( 'useMediaResults', () => {
 		let resolveFetch;
 		const secondCategory = {
 			name: 'attached-images',
-			fetch: jest.fn(
+			fetch: vi.fn(
 				() =>
 					new Promise( ( resolve ) => {
 						resolveFetch = resolve;
@@ -238,7 +239,7 @@ describe( 'useMediaResults', () => {
 	} );
 
 	it( 'does not refetch when only the category wrapper changes', async () => {
-		const fetch = jest.fn( async () => [ { id: 1 } ] );
+		const fetch = vi.fn( async () => [ { id: 1 } ] );
 		const { result, rerender } = renderHook(
 			( { category } ) => useMediaResults( category, { search: '' }, 0 ),
 			{

--- a/packages/block-editor/src/components/inserter/media-tab/test/media-panel.jsx
+++ b/packages/block-editor/src/components/inserter/media-tab/test/media-panel.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -10,7 +11,7 @@ import { MediaCategoryPanel } from '../media-panel';
 
 // Keep the panel's data + async surface out of the test: return a small,
 // non-empty result set so the grid (and the detach affordance) render.
-jest.mock( '../hooks', () => ( {
+vi.mock( import( '../hooks' ), () => ( {
 	useMediaResults: () => ( {
 		mediaList: [
 			{ id: 1, title: 'Example', url: 'https://example.com/1' },
@@ -22,7 +23,7 @@ jest.mock( '../hooks', () => ( {
 
 // Replace `MediaList` with a marker that only reports whether it was wired for
 // detach, so the gate can be asserted without the full preview/dropdown tree.
-jest.mock( '../media-list', () => ( {
+vi.mock( import( '../media-list' ), () => ( {
 	__esModule: true,
 	default: ( { onDetach } ) => (
 		<div
@@ -34,11 +35,11 @@ jest.mock( '../media-list', () => ( {
 
 // The attach button renders through MediaUpload's render prop behind a
 // capability check; stub both so the real Button (and its label) render.
-jest.mock( '../../../media-upload', () => ( {
+vi.mock( import( '../../../media-upload' ), () => ( {
 	__esModule: true,
 	default: ( { render: renderProp } ) => renderProp( { open: () => {} } ),
 } ) );
-jest.mock( '../../../media-upload/check', () => ( {
+vi.mock( import( '../../../media-upload/check' ), () => ( {
 	__esModule: true,
 	default: ( { children } ) => children,
 } ) );
@@ -47,17 +48,17 @@ const baseCategory = {
 	name: 'attached-images',
 	labels: { name: 'Attached images', search_items: 'Search attachments' },
 	mediaType: 'image',
-	fetch: jest.fn(),
-	attach: jest.fn(),
-	detach: jest.fn(),
-	invalidate: jest.fn(),
+	fetch: vi.fn(),
+	attach: vi.fn(),
+	detach: vi.fn(),
+	invalidate: vi.fn(),
 };
 
 function renderPanel( category ) {
 	return render(
 		<MediaCategoryPanel
 			rootClientId=""
-			onInsert={ jest.fn() }
+			onInsert={ vi.fn() }
 			category={ category }
 		/>
 	);
@@ -95,8 +96,8 @@ describe( 'MediaCategoryPanel attach/detach gating', () => {
 
 describe( 'MediaCategoryPanel subscription gating', () => {
 	it( 'subscribes a local source to media changes and unsubscribes on unmount', () => {
-		const unsubscribe = jest.fn();
-		const subscribe = jest.fn( () => unsubscribe );
+		const unsubscribe = vi.fn();
+		const subscribe = vi.fn( () => unsubscribe );
 
 		const { unmount } = renderPanel( { ...baseCategory, subscribe } );
 
@@ -118,7 +119,7 @@ describe( 'MediaCategoryPanel subscription gating', () => {
 		// `subscribe` is core-only, gated like `attach`/`detach`: an
 		// extender-registered source is always external, so it cannot hook into
 		// the panel's refresh cycle just by setting the prop.
-		const subscribe = jest.fn();
+		const subscribe = vi.fn();
 
 		renderPanel( { ...baseCategory, subscribe, isExternalResource: true } );
 

--- a/packages/block-editor/src/components/inserter/test/get-appender-label.js
+++ b/packages/block-editor/src/components/inserter/test/get-appender-label.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getAppenderLabel } from '../get-appender-label';
@@ -17,7 +22,7 @@ describe( 'getAppenderLabel', () => {
 	it( 'should return null when defaultBlock.attributes is missing', () => {
 		const defaultBlock = { name: 'core/test' };
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn(),
+			__experimentalLabel: vi.fn(),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -55,7 +60,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { type: 'page', kind: 'post-type' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => 'Add page' ),
+			__experimentalLabel: vi.fn( () => 'Add page' ),
 		};
 
 		getAppenderLabel( defaultBlock, defaultBlockType );
@@ -73,7 +78,7 @@ describe( 'getAppenderLabel', () => {
 		};
 		const fullLabel = 'Add page';
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => fullLabel ),
+			__experimentalLabel: vi.fn( () => fullLabel ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -87,7 +92,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { foo: 'bar' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => 'This is a test' ),
+			__experimentalLabel: vi.fn( () => 'This is a test' ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -101,7 +106,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { type: 'page' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => null ),
+			__experimentalLabel: vi.fn( () => null ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -115,7 +120,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { type: 'page' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => undefined ),
+			__experimentalLabel: vi.fn( () => undefined ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -129,7 +134,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { type: 'page' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => 123 ),
+			__experimentalLabel: vi.fn( () => 123 ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -143,7 +148,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { type: 'page' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => ( { label: 'page' } ) ),
+			__experimentalLabel: vi.fn( () => ( { label: 'page' } ) ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -158,7 +163,7 @@ describe( 'getAppenderLabel', () => {
 		};
 		const longLabel = 'a'.repeat( 50 );
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => longLabel ),
+			__experimentalLabel: vi.fn( () => longLabel ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -173,7 +178,7 @@ describe( 'getAppenderLabel', () => {
 		};
 		const label49chars = 'a'.repeat( 49 );
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => label49chars ),
+			__experimentalLabel: vi.fn( () => label49chars ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );
@@ -187,7 +192,7 @@ describe( 'getAppenderLabel', () => {
 			attributes: { type: 'page' },
 		};
 		const defaultBlockType = {
-			__experimentalLabel: jest.fn( () => '' ),
+			__experimentalLabel: vi.fn( () => '' ),
 		};
 
 		const result = getAppenderLabel( defaultBlock, defaultBlockType );

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import items, {

--- a/packages/block-editor/src/components/line-height-control/test/index.jsx
+++ b/packages/block-editor/src/components/line-height-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/block-editor/src/components/link-control/test/index.jsx
+++ b/packages/block-editor/src/components/link-control/test/index.jsx
@@ -2,6 +2,16 @@
  * External dependencies
  */
 import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+import {
 	fireEvent,
 	render as baseRender,
 	screen,
@@ -27,7 +37,7 @@ import {
 	uniqueId,
 } from './fixtures';
 
-const mockFetchSearchSuggestions = jest.fn();
+const mockFetchSearchSuggestions = vi.fn();
 
 function getExpectedVisualTypeName( type ) {
 	const builtInLabels = {
@@ -50,23 +60,19 @@ function getExpectedVisualTypeName( type ) {
  */
 let mockFetchRichUrlData;
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useDispatch: () => ( { saveEntityRecords: vi.fn() } ),
+	useSelect: vi.fn(),
+} ) );
 useSelect.mockImplementation( () => ( {
 	fetchSearchSuggestions: mockFetchSearchSuggestions,
 	fetchRichUrlData: mockFetchRichUrlData,
 } ) );
 
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
-} ) );
-
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
-	useReducedMotion: jest.fn( () => true ),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useReducedMotion: vi.fn( () => true ),
 } ) );
 
 beforeEach( () => {
@@ -414,7 +420,7 @@ describe( 'Basic rendering', () => {
 
 		it( 'should show "Unlink" button if a onRemove handler is provided', async () => {
 			const user = userEvent.setup();
-			const mockOnRemove = jest.fn();
+			const mockOnRemove = vi.fn();
 
 			render(
 				<LinkControl
@@ -435,7 +441,7 @@ describe( 'Basic rendering', () => {
 
 		it( 'should revert to "editing" mode when onRemove is triggered', async () => {
 			const user = userEvent.setup();
-			const mockOnRemove = jest.fn();
+			const mockOnRemove = vi.fn();
 
 			render(
 				<LinkControl
@@ -822,7 +828,7 @@ describe( 'Manual link entry', () => {
 
 	describe( 'Handling cancellation', () => {
 		it( 'should not show cancellation button during link creation', async () => {
-			const mockOnRemove = jest.fn();
+			const mockOnRemove = vi.fn();
 
 			render( <LinkControl onRemove={ mockOnRemove } /> );
 
@@ -920,7 +926,7 @@ describe( 'Manual link entry', () => {
 
 		it( 'should call onCancel callback when cancelling if provided', async () => {
 			const user = userEvent.setup();
-			const mockOnCancel = jest.fn();
+			const mockOnCancel = vi.fn();
 
 			render(
 				<LinkControl
@@ -1064,7 +1070,7 @@ describe( 'Link submission', () => {
 
 	it( 'should disable Apply button when URL is cleared', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		const existingLink = { url: 'https://example.com', title: 'Example' };
 		render(
@@ -1467,7 +1473,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 			render(
 				<LinkControl
 					showInitialSuggestions // Should show even if we're not showing initial suggestions.
-					createSuggestion={ jest.fn() }
+					createSuggestion={ vi.fn() }
 				/>
 			);
 
@@ -1493,7 +1499,7 @@ describe( 'Creating Entities (eg: Posts, Pages)', () => {
 			'should not show option to "Create Page" when text is a form of direct entry (eg: %s)',
 			async ( inputText ) => {
 				const user = userEvent.setup();
-				render( <LinkControl createSuggestion={ jest.fn() } /> );
+				render( <LinkControl createSuggestion={ vi.fn() } /> );
 
 				// Search Input UI.
 				const searchInput = screen.getByRole( 'combobox', {
@@ -1773,7 +1779,6 @@ describe( 'Selecting links', () => {
 					} );
 
 					// We should have highlighted the first item using the keyboard
-					// eslint-disable-next-line jest/no-conditional-expect
 					expect( selectedSearchResultElement ).toBe(
 						secondSearchSuggestion
 					);
@@ -1786,7 +1791,6 @@ describe( 'Selecting links', () => {
 					} );
 
 					// We should be back to highlighting the first search result again
-					// eslint-disable-next-line jest/no-conditional-expect
 					expect( selectedSearchResultElement ).toBe(
 						firstSearchSuggestion
 					);
@@ -2042,7 +2046,7 @@ describe( 'Addition Settings UI', () => {
 	it( 'should require settings changes to be submitted/applied', async () => {
 		const user = userEvent.setup();
 
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		const selectedLink = {
 			...fauxEntitySuggestions[ 0 ],
@@ -2170,11 +2174,11 @@ describe( 'Rich link previews', () => {
 	beforeAll( () => {
 		/**
 		 * These tests require that we exercise the `fetchRichUrlData` function.
-		 * We are therefore overwriting the mock "placeholder" with a true jest mock
+		 * We are therefore overwriting the mock "placeholder" with a true vi mock
 		 * which will cause the code under test to execute the code which fetches
 		 * rich previews.
 		 */
-		mockFetchRichUrlData = jest.fn();
+		mockFetchRichUrlData = vi.fn();
 	} );
 
 	it( 'should not fetch or display rich previews by default', async () => {
@@ -2497,7 +2501,7 @@ describe( 'Controlling link title text', () => {
 
 	it( "should ensure title value matching the text input's current value is included in onChange handler value on submit", async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 		const textValue = 'My new text value';
 
 		render(
@@ -2534,7 +2538,7 @@ describe( 'Controlling link title text', () => {
 	it( 'should allow `ENTER` keypress within the text field to trigger submission of value', async () => {
 		const user = userEvent.setup();
 		const newTextValue = 'My new text value';
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		render(
 			<LinkControl
@@ -2573,7 +2577,7 @@ describe( 'Controlling link title text', () => {
 	it( 'should reset state upon controlled value change', async () => {
 		const user = userEvent.setup();
 		const textValue = 'My new text value';
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		const { rerender } = render(
 			<LinkControl
@@ -2729,7 +2733,7 @@ describe( 'Entity handling', () => {
 			type: 'page',
 		};
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<LinkControl
@@ -2788,7 +2792,7 @@ describe( 'Entity handling', () => {
 			kind: 'post-type',
 		};
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<LinkControl
@@ -2852,7 +2856,7 @@ describe( 'Entity handling', () => {
 			kind: 'post-type',
 		};
 
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		// Mock search suggestions to return a custom URL
 		// URL suggestions have an id and type but no 'kind' (which indicates entity metadata)
@@ -2922,7 +2926,7 @@ describe( 'Entity handling', () => {
 
 	it( 'should clear entity metadata when pressing Enter for direct entry (without clicking suggestion)', async () => {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		const pageLink = {
 			id: 123,
@@ -3073,7 +3077,7 @@ describe( 'Entity handling', () => {
 describe( 'Custom settings rendering', () => {
 	it( 'renders custom settings with valid render functions', async () => {
 		const user = userEvent.setup();
-		const mockRender = jest.fn(
+		const mockRender = vi.fn(
 			// eslint-disable-next-line no-unused-vars
 			( setting, value, onChange ) =>
 				createElement(
@@ -3116,7 +3120,7 @@ describe( 'Custom settings rendering', () => {
 
 	it( 'renders only valid settings when mixed with invalid ones', async () => {
 		const user = userEvent.setup();
-		const validRender = jest.fn(
+		const validRender = vi.fn(
 			// eslint-disable-next-line no-unused-vars
 			( setting, value, onChange ) =>
 				createElement(
@@ -3194,9 +3198,9 @@ describe( 'Custom settings rendering', () => {
 
 	it( 'allows custom render functions to call onChange in LinkControl', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
-		const mockRender = jest.fn( ( setting, value, onChange ) => {
+		const mockRender = vi.fn( ( setting, value, onChange ) => {
 			return createElement(
 				'button',
 				{
@@ -3260,7 +3264,7 @@ describe( 'Custom settings rendering', () => {
 
 describe( 'URL validation', () => {
 	const user = userEvent.setup();
-	const mockOnChange = jest.fn();
+	const mockOnChange = vi.fn();
 
 	beforeEach( () => {
 		mockOnChange.mockClear();
@@ -3587,7 +3591,7 @@ describe( 'inputValue prop', () => {
 
 	it( 'should call onInputChange when user types, with observable pattern', async () => {
 		const user = userEvent.setup();
-		const onInputChange = jest.fn();
+		const onInputChange = vi.fn();
 
 		render(
 			<LinkControl

--- a/packages/block-editor/src/components/link-control/test/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/test/is-url-like.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import isURLLike, { isHashLink, isRelativePath } from '../is-url-like';

--- a/packages/block-editor/src/components/link-control/test/url-normalization.test.jsx
+++ b/packages/block-editor/src/components/link-control/test/url-normalization.test.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -16,24 +17,21 @@ import { useSelect } from '@wordpress/data';
 import LinkControl from '../';
 import { fetchFauxEntitySuggestions } from './fixtures';
 
-const mockFetchSearchSuggestions = jest.fn();
+const mockFetchSearchSuggestions = vi.fn();
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useDispatch: () => ( { saveEntityRecords: vi.fn() } ),
+	useSelect: vi.fn(),
+} ) );
 
 useSelect.mockImplementation( () => ( {
 	fetchSearchSuggestions: mockFetchSearchSuggestions,
 } ) );
 
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
-} ) );
-
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
-	useReducedMotion: jest.fn( () => true ),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useReducedMotion: vi.fn( () => true ),
 } ) );
 
 beforeEach( () => {
@@ -51,7 +49,7 @@ function renderWithProvider( ui ) {
 describe( 'URL normalization consistency', () => {
 	it( 'should normalize bare domain (wordpress.org) to https:// when clicking Apply', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		// Start with existing link to show Apply button
 		renderWithProvider(
@@ -89,7 +87,7 @@ describe( 'URL normalization consistency', () => {
 
 	it( 'should normalize www domain (www.wordpress.org) to https:// when clicking Apply', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		// Start with existing link to show Apply button
 		renderWithProvider(
@@ -127,7 +125,7 @@ describe( 'URL normalization consistency', () => {
 
 	it( 'should preserve explicit http:// protocol', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		renderWithProvider(
 			<LinkControl
@@ -162,7 +160,7 @@ describe( 'URL normalization consistency', () => {
 
 	it( 'should preserve mailto: links without normalization', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		renderWithProvider(
 			<LinkControl
@@ -196,7 +194,7 @@ describe( 'URL normalization consistency', () => {
 
 	it( 'should preserve relative paths without normalization', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		renderWithProvider(
 			<LinkControl
@@ -230,7 +228,7 @@ describe( 'URL normalization consistency', () => {
 
 	it( 'should preserve hash links without normalization', async () => {
 		const user = userEvent.setup();
-		const mockOnChange = jest.fn();
+		const mockOnChange = vi.fn();
 
 		renderWithProvider(
 			<LinkControl

--- a/packages/block-editor/src/components/link-picker/test/index.jsx
+++ b/packages/block-editor/src/components/link-picker/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -14,25 +15,22 @@ import { useSelect } from '@wordpress/data';
  */
 import { LinkPicker } from '../';
 
-const mockFetchSearchSuggestions = jest.fn();
+const mockFetchSearchSuggestions = vi.fn();
 
 // Mock useSelect for search suggestions
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	const mock = jest.fn();
-	return mock;
-} );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useDispatch: () => ( { saveEntityRecords: vi.fn() } ),
+	useSelect: vi.fn(),
+} ) );
 
 useSelect.mockImplementation( () => ( {
 	fetchSearchSuggestions: mockFetchSearchSuggestions,
 } ) );
 
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
-} ) );
-
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
-	useReducedMotion: jest.fn( () => true ),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useReducedMotion: vi.fn( () => true ),
 } ) );
 
 // Helper to create mock suggestions
@@ -77,7 +75,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview() }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -96,7 +94,7 @@ describe( 'LinkPicker', () => {
 						url: 'example.com',
 						badges: [],
 					} }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -115,7 +113,7 @@ describe( 'LinkPicker', () => {
 						url: 'example.com',
 						badges: [ { label: 'Page', intent: 'default' } ],
 					} }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -135,7 +133,7 @@ describe( 'LinkPicker', () => {
 						image: 'https://example.com/image.jpg',
 						badges: [ { label: 'Page', intent: 'default' } ],
 					} }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -155,7 +153,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link to"
 				/>
 			);
@@ -167,7 +165,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 					help="Synced with the selected page."
 				/>
@@ -186,7 +184,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -213,7 +211,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -237,7 +235,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -274,7 +272,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 					help="This is help text"
 				/>
@@ -295,7 +293,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview( { url: 'example.com' } ) }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -310,7 +308,7 @@ describe( 'LinkPicker', () => {
 	describe( 'Selection behavior', () => {
 		it( 'should call onSelect with suggestion data when a suggestion is selected', async () => {
 			const user = userEvent.setup();
-			const onSelect = jest.fn();
+			const onSelect = vi.fn();
 
 			render(
 				<LinkPicker
@@ -359,7 +357,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview() }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					label="Link"
 				/>
 			);
@@ -403,7 +401,7 @@ describe( 'LinkPicker', () => {
 			render(
 				<LinkPicker
 					preview={ createMockPreview() }
-					onSelect={ jest.fn() }
+					onSelect={ vi.fn() }
 					suggestionsQuery={ customQuery }
 					label="Link"
 				/>
@@ -434,7 +432,7 @@ describe( 'LinkPicker', () => {
 	describe( 'Integration scenarios', () => {
 		it( 'should handle changing from empty link to entity link', async () => {
 			const user = userEvent.setup();
-			const onSelect = jest.fn();
+			const onSelect = vi.fn();
 
 			render(
 				<LinkPicker

--- a/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/test/use-list-view-drop-zone.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/list-view/test/utils.js
+++ b/packages/block-editor/src/components/list-view/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getCommonDepthClientIds, getDragDisplacementValues } from '../utils';

--- a/packages/block-editor/src/components/media-placeholder/test/get-computed-accept-attribute.js
+++ b/packages/block-editor/src/components/media-placeholder/test/get-computed-accept-attribute.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getComputedAcceptAttribute } from '../utils';

--- a/packages/block-editor/src/components/media-placeholder/test/index.jsx
+++ b/packages/block-editor/src/components/media-placeholder/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -8,8 +9,13 @@ import { render } from '@testing-library/react';
  */
 import { MediaPlaceholder } from '../';
 
-jest.mock( '../../media-upload/check', () => () => null );
-jest.mock( '@wordpress/data/src/components/use-select', () => () => ( {} ) );
+vi.mock( import( '../../media-upload/check' ), () => ( {
+	default: () => null,
+} ) );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: () => ( {} ),
+} ) );
 
 describe( 'MediaPlaceholder', () => {
 	it( 'renders successfully when allowedTypes property is not specified', () => {

--- a/packages/block-editor/src/components/media-replace-flow/test/index.jsx
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/block-editor/src/components/panel-color-settings/test/index.jsx
+++ b/packages/block-editor/src/components/panel-color-settings/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/preset-input-control/test/index.jsx
+++ b/packages/block-editor/src/components/preset-input-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -10,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 import PresetInputControl from '../index';
 
 describe( 'PresetInputControl', () => {
-	const mockOnChange = jest.fn();
+	const mockOnChange = vi.fn();
 
 	const defaultProps = {
 		ariaLabel: 'Spacing control',
@@ -26,7 +27,7 @@ describe( 'PresetInputControl', () => {
 	];
 
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'renders preset selection controls', () => {

--- a/packages/block-editor/src/components/preset-input-control/test/utils.js
+++ b/packages/block-editor/src/components/preset-input-control/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/provider/test/experimental-provider.jsx
+++ b/packages/block-editor/src/components/provider/test/experimental-provider.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 /**
  * WordPress dependencies
@@ -73,7 +74,7 @@ describe( 'BlockEditorProvider', () => {
 		expect( settings ).toHaveProperty( 'stableSetting' );
 	} );
 	it( 'preserves deprecated getters incoming from the settings reducer', async () => {
-		const consoleWarn = jest
+		const consoleWarn = vi
 			.spyOn( global.console, 'warn' )
 			.mockImplementation();
 

--- a/packages/block-editor/src/components/provider/test/use-block-sync.jsx
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.jsx
@@ -6,6 +6,7 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * External dependencies
  */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -16,13 +17,13 @@ import withRegistryProvider from '../with-registry-provider';
 import * as blockEditorActions from '../../../store/actions';
 
 import { store as blockEditorStore } from '../../../store';
-jest.mock( '../../../store/actions', () => {
-	const actions = jest.requireActual( '../../../store/actions' );
+vi.mock( import( '../../../store/actions' ), async ( importOriginal ) => {
+	const actions = await importOriginal();
 	return {
 		...actions,
-		resetBlocks: jest.fn( actions.resetBlocks ),
-		replaceInnerBlocks: jest.fn( actions.replaceInnerBlocks ),
-		setHasControlledInnerBlocks: jest.fn(
+		resetBlocks: vi.fn( actions.resetBlocks ),
+		replaceInnerBlocks: vi.fn( actions.replaceInnerBlocks ),
+		setHasControlledInnerBlocks: vi.fn(
 			actions.setHasControlledInnerBlocks
 		),
 	};
@@ -48,18 +49,18 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'resets the block-editor blocks when the controlled value changes', async () => {
 		const fakeBlocks = [];
-		const resetBlocks = jest.spyOn( blockEditorActions, 'resetBlocks' );
-		const replaceInnerBlocks = jest.spyOn(
+		const resetBlocks = vi.spyOn( blockEditorActions, 'resetBlocks' );
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		const { rerender, unmount } = render(
 			<TestWrapper
@@ -105,13 +106,13 @@ describe( 'useBlockSync hook', () => {
 
 	it( 'replaces the inner blocks of a block when the controlled value changes if a clientId is passed', async () => {
 		const fakeBlocks = [];
-		const replaceInnerBlocks = jest.spyOn(
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
-		const resetBlocks = jest.spyOn( blockEditorActions, 'resetBlocks' );
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const resetBlocks = vi.spyOn( blockEditorActions, 'resetBlocks' );
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		const { rerender, unmount } = render(
 			<TestWrapper
@@ -167,12 +168,12 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	it( 'does not add the controlled blocks to the block-editor store if the store already contains them', async () => {
-		const replaceInnerBlocks = jest.spyOn(
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		const value1 = [
 			{
@@ -225,7 +226,7 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	it( 'sets a block as an inner block controller if a clientId is provided', async () => {
-		const setAsController = jest.spyOn(
+		const setAsController = vi.spyOn(
 			blockEditorActions,
 			'setHasControlledInnerBlocks'
 		);
@@ -234,16 +235,16 @@ describe( 'useBlockSync hook', () => {
 			<TestWrapper
 				clientId="test"
 				value={ [] }
-				onChange={ jest.fn() }
-				onInput={ jest.fn() }
+				onChange={ vi.fn() }
+				onInput={ vi.fn() }
 			/>
 		);
 		expect( setAsController ).toHaveBeenCalledWith( 'test', true );
 	} );
 
 	it( 'calls onInput when a non-persistent block change occurs', async () => {
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 		const value1 = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];
@@ -278,8 +279,8 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	it( 'passes undoIgnore when a non-persistent block change ignores history', async () => {
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 		const value1 = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];
@@ -318,8 +319,8 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	it( 'calls onChange if a persistent change occurs', async () => {
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		const value1 = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
@@ -352,13 +353,13 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	it( 'avoids updating the parent if there is a pending incoming change', async () => {
-		const replaceInnerBlocks = jest.spyOn(
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
 
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		const value1 = [
 			{
@@ -397,13 +398,13 @@ describe( 'useBlockSync hook', () => {
 	} );
 
 	it( 'avoids updating the block-editor store if there is a pending outgoint change', async () => {
-		const replaceInnerBlocks = jest.spyOn(
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
 
-		const onChange = jest.fn();
-		const onInput = jest.fn();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		const value1 = [
 			{
@@ -453,8 +454,8 @@ describe( 'useBlockSync hook', () => {
 		const fakeBlocks = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];
-		const onChange1 = jest.fn();
-		const onInput = jest.fn();
+		const onChange1 = vi.fn();
+		const onInput = vi.fn();
 
 		let registry;
 		const setRegistry = ( reg ) => {
@@ -490,7 +491,7 @@ describe( 'useBlockSync hook', () => {
 
 		// Reset it so that we can test that it was not called after this point.
 		onChange1.mockReset();
-		const onChange2 = jest.fn();
+		const onChange2 = vi.fn();
 
 		// Update the component to point at a "different entity" (e.g. different
 		// blocks and onChange handler.)
@@ -522,8 +523,8 @@ describe( 'useBlockSync hook', () => {
 		const fakeBlocks = [
 			{ clientId: 'a', innerBlocks: [], attributes: { foo: 1 } },
 		];
-		const onChange1 = jest.fn();
-		const onInput = jest.fn();
+		const onChange1 = vi.fn();
+		const onInput = vi.fn();
 
 		let registry;
 		const setRegistry = ( reg ) => {
@@ -543,7 +544,7 @@ describe( 'useBlockSync hook', () => {
 			{ clientId: 'b', innerBlocks: [], attributes: { foo: 1 } },
 		];
 
-		const onChange2 = jest.fn();
+		const onChange2 = vi.fn();
 
 		// Update the component to point at a "different entity" (e.g. different
 		// blocks and onChange handler.)
@@ -574,9 +575,9 @@ describe( 'useBlockSync hook', () => {
 	it( 'preserves external client IDs in onChange callback for inner block controllers', async () => {
 		const originalClientId = 'original-external-id';
 		const innerBlockClientId = 'inner-external-id';
-		const onChange = jest.fn();
-		const onInput = jest.fn();
-		const replaceInnerBlocks = jest.spyOn(
+		const onChange = vi.fn();
+		const onInput = vi.fn();
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
@@ -642,7 +643,7 @@ describe( 'useBlockSync hook', () => {
 
 	it( 'clones blocks with new internal IDs for inner block controllers', async () => {
 		const originalClientId = 'original-external-id';
-		const replaceInnerBlocks = jest.spyOn(
+		const replaceInnerBlocks = vi.spyOn(
 			blockEditorActions,
 			'replaceInnerBlocks'
 		);
@@ -661,8 +662,8 @@ describe( 'useBlockSync hook', () => {
 			<TestWrapper
 				clientId="test-controller"
 				value={ controlledBlocks }
-				onChange={ jest.fn() }
-				onInput={ jest.fn() }
+				onChange={ vi.fn() }
+				onInput={ vi.fn() }
 			/>
 		);
 

--- a/packages/block-editor/src/components/recursion-provider/test/index.jsx
+++ b/packages/block-editor/src/components/recursion-provider/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/components/responsive-block-control/test/index.jsx
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -209,7 +210,7 @@ describe( 'Default and Responsive modes', () => {
 			},
 		];
 
-		const mockRenderDefaultControl = jest.fn(
+		const mockRenderDefaultControl = vi.fn(
 			renderTestDefaultControlComponent
 		);
 
@@ -296,9 +297,9 @@ describe( 'Default and Responsive modes', () => {
 	} );
 
 	it( 'should render custom responsive controls when renderResponsiveControls prop is provided and in responsive mode', () => {
-		const spyRenderDefaultControl = jest.fn();
+		const spyRenderDefaultControl = vi.fn();
 
-		const mockRenderResponsiveControls = jest.fn( ( viewports ) => {
+		const mockRenderResponsiveControls = vi.fn( ( viewports ) => {
 			return viewports.map( ( { id, label } ) => {
 				return (
 					<Fragment key={ `${ inputId }-${ id }` }>

--- a/packages/block-editor/src/components/spacing-sizes-control/test/index.jsx
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/index.jsx
@@ -23,6 +23,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -35,14 +36,18 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import SpacingSizesControl from '../index';
+import useSpacingSizes from '../hooks/use-spacing-sizes';
 
 // Mock useSelect
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
 
 // Mock useSpacingSizes hook
-jest.mock( '../hooks/use-spacing-sizes', () => ( {
+vi.mock( import( '../hooks/use-spacing-sizes' ), () => ( {
 	__esModule: true,
-	default: jest.fn( () => [
+	default: vi.fn( () => [
 		{ name: 'None', slug: '0', size: 0 },
 		{ name: 'Small', slug: '20', size: '0.5rem' },
 		{ name: 'Medium', slug: '40', size: '1rem' },
@@ -52,8 +57,8 @@ jest.mock( '../hooks/use-spacing-sizes', () => ( {
 } ) );
 
 // Mock useSettings hook
-jest.mock( '../../use-settings', () => ( {
-	useSettings: jest.fn( ( ...keys ) => {
+vi.mock( import( '../../use-settings' ), () => ( {
+	useSettings: vi.fn( ( ...keys ) => {
 		const defaults = {
 			'spacing.units': [ 'px', 'em', 'rem' ],
 			'spacing.spacingSizes.custom': [],
@@ -66,7 +71,7 @@ jest.mock( '../../use-settings', () => ( {
 } ) );
 
 describe( 'SpacingSizesControl', () => {
-	const mockOnChange = jest.fn();
+	const mockOnChange = vi.fn();
 	const defaultProps = {
 		label: 'Padding',
 		onChange: mockOnChange,
@@ -733,15 +738,11 @@ describe( 'SpacingSizesControl', () => {
 
 		// Mock the large preset set
 		beforeEach( () => {
-			jest.requireMock(
-				'../hooks/use-spacing-sizes'
-			).default.mockReturnValue( largeSpacingSizes );
+			useSpacingSizes.mockReturnValue( largeSpacingSizes );
 		} );
 
 		afterEach( () => {
-			jest.requireMock(
-				'../hooks/use-spacing-sizes'
-			).default.mockReturnValue( [
+			useSpacingSizes.mockReturnValue( [
 				{ name: 'None', slug: '0', size: 0 },
 				{ name: 'Small', slug: '20', size: '0.5rem' },
 				{ name: 'Medium', slug: '40', size: '1rem' },
@@ -903,8 +904,8 @@ describe( 'SpacingSizesControl', () => {
 		} );
 
 		it( 'calls onMouseOver and onMouseOut callbacks', async () => {
-			const mockOnMouseOver = jest.fn();
-			const mockOnMouseOut = jest.fn();
+			const mockOnMouseOver = vi.fn();
+			const mockOnMouseOut = vi.fn();
 			const user = userEvent.setup();
 
 			render(
@@ -967,9 +968,7 @@ describe( 'SpacingSizesControl', () => {
 				{ name: 'Huge', slug: '100', size: '5rem' },
 			];
 
-			jest.requireMock(
-				'../hooks/use-spacing-sizes'
-			).default.mockReturnValueOnce( customSpacingSizes );
+			useSpacingSizes.mockReturnValueOnce( customSpacingSizes );
 
 			render(
 				<SpacingSizesControl { ...defaultProps } values={ undefined } />
@@ -985,9 +984,7 @@ describe( 'SpacingSizesControl', () => {
 				{ name: 'Theme Large', slug: 'theme-lg', size: '2.25rem' },
 			];
 
-			jest.requireMock(
-				'../hooks/use-spacing-sizes'
-			).default.mockReturnValueOnce( themeSpacingSizes );
+			useSpacingSizes.mockReturnValueOnce( themeSpacingSizes );
 
 			render(
 				<SpacingSizesControl

--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/components/url-input/test/button.jsx
+++ b/packages/block-editor/src/components/url-input/test/button.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -78,7 +79,7 @@ describe( 'URLInputButton', () => {
 
 	it( 'should call `onChange` function once per each value change', async () => {
 		const user = userEvent.setup();
-		const onChangeMock = jest.fn();
+		const onChangeMock = vi.fn();
 
 		render( <URLInputButton onChange={ onChangeMock } /> );
 

--- a/packages/block-editor/src/components/url-input/test/index.jsx
+++ b/packages/block-editor/src/components/url-input/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -18,7 +19,7 @@ import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import URLInput from '../';
 import { store as blockEditorStore } from '../../../store';
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+vi.mock( import( '@wordpress/a11y' ), () => ( { speak: vi.fn() } ) );
 
 const SUGGESTIONS = [
 	{
@@ -78,16 +79,16 @@ describe( 'URLInput', () => {
 	let fetchLinkSuggestions;
 
 	beforeEach( () => {
-		fetchLinkSuggestions = jest.fn().mockResolvedValue( SUGGESTIONS );
+		fetchLinkSuggestions = vi.fn().mockResolvedValue( SUGGESTIONS );
 	} );
 
 	afterEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	function renderURLInput( props = {} ) {
 		const user = userEvent.setup();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render(
 			<ControlledURLInput
@@ -418,7 +419,7 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should select and submit the active suggestion when pressing Enter', async () => {
-			const onSubmit = jest.fn();
+			const onSubmit = vi.fn();
 			const { input, onChange } = await renderWithSuggestions( {
 				onSubmit,
 			} );
@@ -438,7 +439,7 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should submit without a suggestion when pressing Enter with no active suggestion', async () => {
-			const onSubmit = jest.fn();
+			const onSubmit = vi.fn();
 			const { input } = await renderWithSuggestions( { onSubmit } );
 
 			fireEvent.keyDown( input, KEY_EVENTS.enter );
@@ -447,8 +448,8 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should submit without a suggestion when pressing Enter and there are no suggestions', async () => {
-			const onSubmit = jest.fn();
-			const onKeyDown = jest.fn();
+			const onSubmit = vi.fn();
+			const onKeyDown = vi.fn();
 			const { input } = renderURLInput( {
 				value: 'hello',
 				disableSuggestions: true,
@@ -512,7 +513,7 @@ describe( 'URLInput', () => {
 
 	describe( 'custom rendering', () => {
 		it( 'should render the control via `__experimentalRenderControl`', () => {
-			const renderControl = jest
+			const renderControl = vi
 				.fn()
 				.mockReturnValue( <div>Custom control</div> );
 
@@ -533,7 +534,7 @@ describe( 'URLInput', () => {
 		} );
 
 		it( 'should render suggestions via `__experimentalRenderSuggestions`', async () => {
-			const renderSuggestions = jest.fn( ( { suggestions } ) => (
+			const renderSuggestions = vi.fn( ( { suggestions } ) => (
 				<ul>
 					{ suggestions.map( ( suggestion ) => (
 						<li key={ suggestion.id }>{ suggestion.title }</li>

--- a/packages/block-editor/src/components/use-block-display-information/test/index.jsx
+++ b/packages/block-editor/src/components/use-block-display-information/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 /**
@@ -15,11 +16,14 @@ import { symbol } from '@wordpress/icons';
  */
 import useBlockDisplayInformation from '../';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '../../../lock-unlock', () => ( {
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useSelect: vi.fn(),
+} ) );
+vi.mock( import( '../../../lock-unlock' ), () => ( {
 	unlock: ( value ) => ( {
-		registerPrivateActions: jest.fn(),
-		registerPrivateSelectors: jest.fn(),
+		registerPrivateActions: vi.fn(),
+		registerPrivateSelectors: vi.fn(),
 		...value,
 	} ),
 } ) );
@@ -75,12 +79,12 @@ function setupUseSelect( {
 
 describe( 'useBlockDisplayInformation', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	} );
 
 	it( 'displays pattern information for a pattern section that is not being edited', () => {
 		setupUseSelect();
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <TestComponent onChange={ onChange } /> );
 
@@ -96,7 +100,7 @@ describe( 'useBlockDisplayInformation', () => {
 
 	it( 'displays block information for a pattern section that is being edited', () => {
 		setupUseSelect( { isSectionBlock: false } );
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <TestComponent onChange={ onChange } /> );
 
@@ -120,7 +124,7 @@ describe( 'useBlockDisplayInformation', () => {
 			},
 			isSectionBlock: false,
 		} );
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <TestComponent onChange={ onChange } /> );
 
@@ -138,7 +142,7 @@ describe( 'useBlockDisplayInformation', () => {
 		setupUseSelect( {
 			isSectionBlock: false,
 		} );
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <TestComponent onChange={ onChange } /> );
 
@@ -163,7 +167,7 @@ describe( 'useBlockDisplayInformation', () => {
 				description: 'A template part.',
 			},
 		} );
-		const onChange = jest.fn();
+		const onChange = vi.fn();
 
 		render( <TestComponent onChange={ onChange } /> );
 

--- a/packages/block-editor/src/components/use-block-drop-zone/test/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getDropTargetPosition } from '..';

--- a/packages/block-editor/src/components/use-on-block-drop/test/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/test/index.js
@@ -1,21 +1,25 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { parseDropEvent, onFilesDrop, onHTMLDrop, onBlockDrop } from '..';
+import { describe, expect, it, vi } from 'vitest';
+
 /**
  * WordPress dependencies
  */
 import { findTransform, pasteHandler } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { parseDropEvent, onFilesDrop, onHTMLDrop, onBlockDrop } from '..';
+
 const noop = () => {};
 
-jest.mock( '@wordpress/blocks/src/api/factory', () => ( {
-	findTransform: jest.fn(),
-	getBlockTransforms: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/blocks/src/api/raw-handling', () => ( {
-	pasteHandler: jest.fn(),
+vi.mock( import( '@wordpress/blocks' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	findTransform: vi.fn(),
+	getBlockTransforms: vi.fn(),
+	pasteHandler: vi.fn(),
 } ) );
 
 describe( 'parseDropEvent', () => {
@@ -98,7 +102,7 @@ describe( 'onBlockDrop', () => {
 		const targetBlockIndex = 0;
 		const getBlockIndex = noop;
 		const getClientIdsOfDescendants = noop;
-		const moveBlocks = jest.fn();
+		const moveBlocks = vi.fn();
 
 		const event = {
 			dataTransfer: {
@@ -126,9 +130,9 @@ describe( 'onBlockDrop', () => {
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
 		// Target and source block index is the same.
-		const getBlockIndex = jest.fn( () => targetBlockIndex );
+		const getBlockIndex = vi.fn( () => targetBlockIndex );
 		const getClientIdsOfDescendants = noop;
-		const moveBlocks = jest.fn();
+		const moveBlocks = vi.fn();
 
 		const event = {
 			dataTransfer: {
@@ -158,9 +162,9 @@ describe( 'onBlockDrop', () => {
 	it( 'does nothing if the block is dropped as a child of itself', () => {
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
-		const getBlockIndex = jest.fn( () => 6 );
+		const getBlockIndex = vi.fn( () => 6 );
 		const getClientIdsOfDescendants = noop;
-		const moveBlocks = jest.fn();
+		const moveBlocks = vi.fn();
 
 		const event = {
 			dataTransfer: {
@@ -190,12 +194,10 @@ describe( 'onBlockDrop', () => {
 	it( 'does nothing if the block is dropped as a descendant of itself', () => {
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
-		const getBlockIndex = jest.fn( () => 1 );
+		const getBlockIndex = vi.fn( () => 1 );
 		// Dragged block is being dropped as a descendant of itself.
-		const getClientIdsOfDescendants = jest.fn( () => [
-			targetRootClientId,
-		] );
-		const moveBlocks = jest.fn();
+		const getClientIdsOfDescendants = vi.fn( () => [ targetRootClientId ] );
+		const moveBlocks = vi.fn();
 
 		const event = {
 			dataTransfer: {
@@ -226,9 +228,9 @@ describe( 'onBlockDrop', () => {
 		const sourceRootClientId = '0';
 		const targetRootClientId = '1';
 		const targetBlockIndex = 0;
-		const getBlockIndex = jest.fn( () => 1 );
+		const getBlockIndex = vi.fn( () => 1 );
 		const getClientIdsOfDescendants = () => [];
-		const moveBlocks = jest.fn();
+		const moveBlocks = vi.fn();
 
 		const event = {
 			dataTransfer: {
@@ -263,10 +265,10 @@ describe( 'onBlockDrop', () => {
 		const sourceRootClientId = '0';
 		const targetRootClientId = sourceRootClientId;
 		const targetBlockIndex = 5;
-		const getBlockIndex = jest.fn( () => 1 );
+		const getBlockIndex = vi.fn( () => 1 );
 		// Dragged block is being dropped as a descendant of itself.
 		const getClientIdsOfDescendants = () => [];
-		const moveBlocks = jest.fn();
+		const moveBlocks = vi.fn();
 
 		const event = {
 			dataTransfer: {
@@ -302,11 +304,11 @@ describe( 'onBlockDrop', () => {
 
 describe( 'onFilesDrop', () => {
 	it( 'does nothing if hasUploadPermissions is false', () => {
-		const updateBlockAttributes = jest.fn();
+		const updateBlockAttributes = vi.fn();
 		const canInsertBlockType = noop;
-		const insertOrReplaceBlocks = jest.fn();
+		const insertOrReplaceBlocks = vi.fn();
 		const targetRootClientId = '1';
-		const getSettings = jest.fn( () => ( {} ) );
+		const getSettings = vi.fn( () => ( {} ) );
 
 		const onFileDropHandler = onFilesDrop(
 			targetRootClientId,
@@ -326,10 +328,10 @@ describe( 'onFilesDrop', () => {
 		// to have no return value.
 		findTransform.mockImplementation( noop );
 		const updateBlockAttributes = noop;
-		const insertOrReplaceBlocks = jest.fn();
+		const insertOrReplaceBlocks = vi.fn();
 		const canInsertBlockType = noop;
 		const targetRootClientId = '1';
-		const getSettings = jest.fn( () => ( {
+		const getSettings = vi.fn( () => ( {
 			mediaUpload: true,
 		} ) );
 
@@ -351,13 +353,13 @@ describe( 'onFilesDrop', () => {
 		// of the transform isn't important just that there is a callable 'transform'
 		// function that returns a value.
 		const blocks = 'blocks';
-		const transformation = { transform: jest.fn( () => blocks ) };
+		const transformation = { transform: vi.fn( () => blocks ) };
 		findTransform.mockImplementation( () => transformation );
 		const updateBlockAttributes = noop;
 		const canInsertBlockType = noop;
-		const insertOrReplaceBlocks = jest.fn();
+		const insertOrReplaceBlocks = vi.fn();
 		const targetRootClientId = '1';
-		const getSettings = jest.fn( () => ( {
+		const getSettings = vi.fn( () => ( {
 			mediaUpload: true,
 		} ) );
 
@@ -383,7 +385,7 @@ describe( 'onFilesDrop', () => {
 describe( 'onHTMLDrop', () => {
 	it( 'does nothing if the HTML cannot be converted into blocks', () => {
 		pasteHandler.mockImplementation( () => [] );
-		const insertOrReplaceBlocks = jest.fn();
+		const insertOrReplaceBlocks = vi.fn();
 
 		const eventHandler = onHTMLDrop( insertOrReplaceBlocks );
 		eventHandler();
@@ -394,7 +396,7 @@ describe( 'onHTMLDrop', () => {
 	it( 'inserts blocks if the HTML can be converted into blocks', () => {
 		const blocks = [ 'blocks' ];
 		pasteHandler.mockImplementation( () => blocks );
-		const insertOrReplaceBlocks = jest.fn();
+		const insertOrReplaceBlocks = vi.fn();
 
 		const eventHandler = onHTMLDrop( insertOrReplaceBlocks );
 		eventHandler();

--- a/packages/block-editor/src/components/warning/test/__snapshots__/index.jsx.snap
+++ b/packages/block-editor/src/components/warning/test/__snapshots__/index.jsx.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Warning should match snapshot 1`] = `
+exports[`Warning > should match snapshot 1`] = `
 <div>
   <div
     style="display: contents; all: initial;"

--- a/packages/block-editor/src/components/warning/test/index.jsx
+++ b/packages/block-editor/src/components/warning/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/block-editor/src/components/writing-flow/test/index.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';

--- a/packages/block-editor/src/elements/test/index.js
+++ b/packages/block-editor/src/elements/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { __experimentalGetElementClassName } from '@wordpress/block-editor';

--- a/packages/block-editor/src/hooks/test/align.jsx
+++ b/packages/block-editor/src/hooks/test/align.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';

--- a/packages/block-editor/src/hooks/test/allowed-blocks.js
+++ b/packages/block-editor/src/hooks/test/allowed-blocks.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/anchor.js
+++ b/packages/block-editor/src/hooks/test/anchor.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';

--- a/packages/block-editor/src/hooks/test/auto-inspector-controls.js
+++ b/packages/block-editor/src/hooks/test/auto-inspector-controls.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/block-style-state.js
+++ b/packages/block-editor/src/hooks/test/block-style-state.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {
@@ -156,7 +161,7 @@ describe( 'setStyleForState', () => {
 
 describe( 'scopeResetAllFilterToState', () => {
 	it( 'passes only the selected state style to the reset filter', () => {
-		const innerReset = jest.fn( ( attributes ) => ( {
+		const innerReset = vi.fn( ( attributes ) => ( {
 			...attributes,
 			style: {
 				...attributes.style,
@@ -216,7 +221,7 @@ describe( 'scopeResetAllFilterToState', () => {
 	} );
 
 	it( 'calls the reset filter with an empty style when no state styles exist', () => {
-		const innerReset = jest.fn( ( attributes ) => attributes );
+		const innerReset = vi.fn( ( attributes ) => attributes );
 		const attributes = {
 			style: { color: { text: '#000000' } },
 		};
@@ -230,7 +235,7 @@ describe( 'scopeResetAllFilterToState', () => {
 	} );
 
 	it( 'passes only the selected viewport pseudo state style to the reset filter', () => {
-		const innerReset = jest.fn( () => ( { style: undefined } ) );
+		const innerReset = vi.fn( () => ( { style: undefined } ) );
 		const attributes = {
 			style: {
 				color: { text: '#000000' },

--- a/packages/block-editor/src/hooks/test/cross-origin-isolation.js
+++ b/packages/block-editor/src/hooks/test/cross-origin-isolation.js
@@ -1,18 +1,25 @@
+/**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 describe( 'cross-origin-isolation', () => {
 	let originalCrossOriginIsolated;
 	let originalBody;
 	let observeSpy;
 
 	beforeEach( () => {
+		vi.resetModules();
+
 		// Save original values
 		originalCrossOriginIsolated = window.crossOriginIsolated;
 		originalBody = document.body;
 
 		// Clear any existing filters
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 
 		// Spy on MutationObserver.observe
-		observeSpy = jest.spyOn( window.MutationObserver.prototype, 'observe' );
+		observeSpy = vi.spyOn( window.MutationObserver.prototype, 'observe' );
 	} );
 
 	afterEach( () => {
@@ -34,10 +41,9 @@ describe( 'cross-origin-isolation', () => {
 		}
 
 		observeSpy.mockRestore();
-		jest.resetModules();
 	} );
 
-	it( 'should not observe when crossOriginIsolated is false', () => {
+	it( 'should not observe when crossOriginIsolated is false', async () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: false,
 			writable: true,
@@ -45,14 +51,12 @@ describe( 'cross-origin-isolation', () => {
 		} );
 
 		// Re-import the module to trigger the side effects
-		jest.isolateModules( () => {
-			require( '../cross-origin-isolation' );
-		} );
+		await import( '../cross-origin-isolation' );
 
 		expect( observeSpy ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should observe document.body when crossOriginIsolated is true and body exists', () => {
+	it( 'should observe document.body when crossOriginIsolated is true and body exists', async () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: true,
 			writable: true,
@@ -66,9 +70,7 @@ describe( 'cross-origin-isolation', () => {
 		} );
 
 		// Re-import the module to trigger the side effects
-		jest.isolateModules( () => {
-			require( '../cross-origin-isolation' );
-		} );
+		await import( '../cross-origin-isolation' );
 
 		expect( observeSpy ).toHaveBeenCalledWith( document.body, {
 			childList: true,
@@ -77,7 +79,7 @@ describe( 'cross-origin-isolation', () => {
 		} );
 	} );
 
-	it( 'should wait for DOMContentLoaded when body is not available and document is loading', () => {
+	it( 'should wait for DOMContentLoaded when body is not available and document is loading', async () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: true,
 			writable: true,
@@ -98,12 +100,10 @@ describe( 'cross-origin-isolation', () => {
 			configurable: true,
 		} );
 
-		const addEventListenerSpy = jest.spyOn( document, 'addEventListener' );
+		const addEventListenerSpy = vi.spyOn( document, 'addEventListener' );
 
 		// Re-import the module to trigger the side effects
-		jest.isolateModules( () => {
-			require( '../cross-origin-isolation' );
-		} );
+		await import( '../cross-origin-isolation' );
 
 		// Should not observe immediately
 		expect( observeSpy ).not.toHaveBeenCalled();
@@ -117,7 +117,7 @@ describe( 'cross-origin-isolation', () => {
 		addEventListenerSpy.mockRestore();
 	} );
 
-	it( 'should not throw error when body is null and document is complete', () => {
+	it( 'should not throw error when body is null and document is complete', async () => {
 		Object.defineProperty( window, 'crossOriginIsolated', {
 			value: true,
 			writable: true,
@@ -138,11 +138,9 @@ describe( 'cross-origin-isolation', () => {
 		} );
 
 		// This should not throw an error
-		expect( () => {
-			jest.isolateModules( () => {
-				require( '../cross-origin-isolation' );
-			} );
-		} ).not.toThrow();
+		await expect(
+			import( '../cross-origin-isolation' )
+		).resolves.toBeDefined();
 
 		// Should not attempt to observe null
 		expect( observeSpy ).not.toHaveBeenCalled();
@@ -156,9 +154,7 @@ describe( 'cross-origin-isolation', () => {
 		} );
 
 		// Re-import the module to trigger the side effects
-		jest.isolateModules( () => {
-			require( '../cross-origin-isolation' );
-		} );
+		await import( '../cross-origin-isolation' );
 
 		// Create an image and add it to the DOM
 		const img = document.createElement( 'img' );

--- a/packages/block-editor/src/hooks/test/custom-class-name.jsx
+++ b/packages/block-editor/src/hooks/test/custom-class-name.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';

--- a/packages/block-editor/src/hooks/test/dimensions.js
+++ b/packages/block-editor/src/hooks/test/dimensions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/duotone.js
+++ b/packages/block-editor/src/hooks/test/duotone.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/font-size.js
+++ b/packages/block-editor/src/hooks/test/font-size.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**

--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getGapCSSValue, getGapBoxControlValueFromStyle } from '../gap';

--- a/packages/block-editor/src/hooks/test/generate-fields-from-attributes.js
+++ b/packages/block-editor/src/hooks/test/generate-fields-from-attributes.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { generateFieldsFromAttributes } from '../generate-fields-from-attributes';

--- a/packages/block-editor/src/hooks/test/generated-class-name.js
+++ b/packages/block-editor/src/hooks/test/generated-class-name.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';

--- a/packages/block-editor/src/hooks/test/inherited-value-wiring.jsx
+++ b/packages/block-editor/src/hooks/test/inherited-value-wiring.jsx
@@ -1,7 +1,23 @@
 /**
  * External dependencies
  */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { TypographyPanel } from '../typography';
+import { ElementsEdit } from '../elements';
+import { BorderPanel } from '../border';
+import { DimensionsPanel } from '../dimensions';
+import { BackgroundImagePanel } from '../background';
 
 /**
  * Tests the wiring between inspector hook wrappers and shared
@@ -14,24 +30,31 @@ import { render } from '@testing-library/react';
  * intentionally mocked out so each test exercises only the wiring contract.
  */
 
-// Jest hoists `jest.mock` factories; proxies for spies need to satisfy
-// the `/^mock/i` naming convention.
+// Vitest hoists `vi.mock` factories, so recorder values are exposed through
+// mutable objects that the factories can close over safely.
 const mockHookRecorder = { calls: [] };
 const mockPanelRecorder = { calls: [] };
 const mockInheritedReturn = { value: {} };
 
-jest.mock( '../../components/global-styles/inherited-value-context', () => ( {
-	__esModule: true,
-	useResolvedStyle: ( blockName, className, selectedState ) => {
-		mockHookRecorder.calls.push( { blockName, className, selectedState } );
-		return {
-			value: mockInheritedReturn.value,
-			sources: {},
-		};
-	},
-} ) );
+vi.mock(
+	import( '../../components/global-styles/inherited-value-context' ),
+	() => ( {
+		__esModule: true,
+		useResolvedStyle: ( blockName, className, selectedState ) => {
+			mockHookRecorder.calls.push( {
+				blockName,
+				className,
+				selectedState,
+			} );
+			return {
+				value: mockInheritedReturn.value,
+				sources: {},
+			};
+		},
+	} )
+);
 
-jest.mock( '../../components/global-styles/typography-panel', () => ( {
+vi.mock( import( '../../components/global-styles/typography-panel' ), () => ( {
 	__esModule: true,
 	default: ( props ) => {
 		mockPanelRecorder.calls.push( [ 'typography', props ] );
@@ -39,7 +62,7 @@ jest.mock( '../../components/global-styles/typography-panel', () => ( {
 	},
 	useHasTypographyPanel: () => true,
 } ) );
-jest.mock( '../../components/global-styles/color-panel', () => ( {
+vi.mock( import( '../../components/global-styles/color-panel' ), () => ( {
 	__esModule: true,
 	default: ( { children, ...rest } ) => {
 		mockPanelRecorder.calls.push( [ 'color', rest ] );
@@ -47,7 +70,7 @@ jest.mock( '../../components/global-styles/color-panel', () => ( {
 	},
 	useHasColorPanel: () => true,
 } ) );
-jest.mock( '../../components/global-styles/border-panel', () => ( {
+vi.mock( import( '../../components/global-styles/border-panel' ), () => ( {
 	__esModule: true,
 	default: ( props ) => {
 		mockPanelRecorder.calls.push( [ 'border', props ] );
@@ -56,7 +79,7 @@ jest.mock( '../../components/global-styles/border-panel', () => ( {
 	useHasBorderPanel: () => true,
 	useHasBorderPanelControls: () => ( {} ),
 } ) );
-jest.mock( '../../components/global-styles/dimensions-panel', () => ( {
+vi.mock( import( '../../components/global-styles/dimensions-panel' ), () => ( {
 	__esModule: true,
 	default: ( props ) => {
 		mockPanelRecorder.calls.push( [ 'dimensions', props ] );
@@ -64,7 +87,7 @@ jest.mock( '../../components/global-styles/dimensions-panel', () => ( {
 	},
 	useHasDimensionsPanel: () => true,
 } ) );
-jest.mock( '../../components/global-styles/background-panel', () => ( {
+vi.mock( import( '../../components/global-styles/background-panel' ), () => ( {
 	__esModule: true,
 	default: ( props ) => {
 		mockPanelRecorder.calls.push( [ 'background', props ] );
@@ -78,7 +101,7 @@ jest.mock( '../../components/global-styles/background-panel', () => ( {
 // The Typography, Background and Elements wrappers now request a contrast
 // warning (relocated color controls). The hook pulls the data store into its
 // import graph, so stub it to a no-op for these wiring-only tests.
-jest.mock( '../contrast-checker', () => ( {
+vi.mock( import( '../contrast-checker' ), () => ( {
 	__esModule: true,
 	default: () => undefined,
 } ) );
@@ -86,9 +109,9 @@ jest.mock( '../contrast-checker', () => ( {
 // Stub the minimal `@wordpress/data` surface the wrappers call into
 // directly. The real store + persistence machinery is intentionally
 // elided. The prop plumbing is testable with the mocked selector surface.
-jest.mock( '@wordpress/data', () => ( {
+vi.mock( import( '@wordpress/data' ), () => ( {
 	__esModule: true,
-	useSelect: jest.fn(),
+	useSelect: vi.fn(),
 	useDispatch: () => ( {} ),
 	useRegistry: () => ( {} ),
 	createSelector: ( fn ) => fn,
@@ -107,12 +130,12 @@ jest.mock( '@wordpress/data', () => ( {
 	withDispatch: () => ( c ) => c,
 } ) );
 
-jest.mock( '@wordpress/blocks', () => ( {
+vi.mock( import( '@wordpress/blocks' ), () => ( {
 	__esModule: true,
-	getBlockSupport: jest.fn( () => undefined ),
-	hasBlockSupport: jest.fn( () => false ),
-	getBlockType: jest.fn( () => null ),
-	getBlockTypes: jest.fn( () => [] ),
+	getBlockSupport: vi.fn( () => undefined ),
+	hasBlockSupport: vi.fn( () => false ),
+	getBlockType: vi.fn( () => null ),
+	getBlockTypes: vi.fn( () => [] ),
 	store: { name: 'core/blocks' },
 } ) );
 
@@ -122,14 +145,14 @@ jest.mock( '@wordpress/blocks', () => ( {
 // not carry the private-API marker. Short-circuit to a passthrough so
 // these tests can exercise the wrapper wiring without threading
 // the full private-API handshake through every stub.
-jest.mock( '@wordpress/private-apis', () => ( {
+vi.mock( import( '@wordpress/private-apis' ), () => ( {
 	__esModule: true,
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules: () => ( {
 		lock: () => {},
-		unlock: ( value ) =>
-			new Proxy( value ?? {}, {
-				get: () => () => undefined,
-			} ),
+		unlock: () => ( {
+			hideBlockInterface: () => undefined,
+			showBlockInterface: () => undefined,
+		} ),
 	} ),
 } ) );
 
@@ -138,12 +161,12 @@ jest.mock( '@wordpress/private-apis', () => ( {
 // is already mocked to a Proxy-driven stub and never actually touches
 // the store. Providing a stub avoids the private-APIs unlock that
 // the real `store/index.js` performs at module load.
-jest.mock( '../../store', () => ( {
+vi.mock( import( '../../store' ), () => ( {
 	__esModule: true,
 	store: { name: 'core/block-editor' },
 } ) );
 
-jest.mock( '../../store/private-keys', () => ( {
+vi.mock( import( '../../store/private-keys' ), () => ( {
 	__esModule: true,
 	globalStylesDataKey: Symbol( 'globalStylesDataKey' ),
 	globalStylesLinksDataKey: Symbol( 'globalStylesLinksDataKey' ),
@@ -152,14 +175,11 @@ jest.mock( '../../store/private-keys', () => ( {
 
 // Short-circuit the block-editor components barrel (`../../components`),
 // which pulls the data store into its import graph transitively.
-jest.mock(
-	'../../components',
-	() => new Proxy( {}, { get: () => () => null } )
-);
+vi.mock( import( '../../components' ), () => ( {} ) );
 
 // `InspectorControls` is a slot-fill component with registry dependencies.
 // Mock it to a passthrough div.
-jest.mock( '../../components/inspector-controls', () => ( {
+vi.mock( import( '../../components/inspector-controls' ), () => ( {
 	__esModule: true,
 	default: ( { children } ) => (
 		<div data-testid="inspector-controls">{ children }</div>
@@ -174,7 +194,6 @@ beforeEach( () => {
 	mockPanelRecorder.calls = [];
 	mockInheritedReturn.value = {};
 	mockUseSelectImpl.fn = () => undefined;
-	const { useSelect } = require( '@wordpress/data' );
 	useSelect.mockImplementation( ( mapSelect ) => {
 		// Feed mapSelect a synthetic `select()` that returns an object
 		// whose methods all yield what the current test configured.
@@ -193,9 +212,6 @@ beforeEach( () => {
 
 describe( 'inspector hook wrappers thread inheritedValue into the panel', () => {
 	test( 'TypographyPanel calls useResolvedStyle with the block name and threads inheritedValue', () => {
-		// Imported inside the test so the `jest.mock` factories are
-		// applied before the wrapper's module graph is resolved.
-		const { TypographyPanel } = require( '../typography' );
 		mockUseSelectImpl.fn = () => ( {
 			style: { typography: { fontSize: '14px' } },
 			fontFamily: undefined,
@@ -233,7 +249,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 	// and background color are wired through the Typography and Background
 	// wrappers and covered above/below.
 	test( 'ElementsEdit wires block-scoped Global Styles into the Color panel', () => {
-		const { ElementsEdit } = require( '../elements' );
 		mockUseSelectImpl.fn = () => ( {
 			style: undefined,
 			className: undefined,
@@ -261,7 +276,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 	} );
 
 	test( 'BorderPanel threads a border-scoped inheritedValue into the panel', () => {
-		const { BorderPanel } = require( '../border' );
 		mockUseSelectImpl.fn = () => ( {
 			style: undefined,
 			borderColor: undefined,
@@ -289,7 +303,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 	} );
 
 	test( 'DimensionsPanel threads spacing inheritedValue into the panel', () => {
-		const { DimensionsPanel } = require( '../dimensions' );
 		mockUseSelectImpl.fn = () => ( {
 			value: undefined,
 			className: undefined,
@@ -316,10 +329,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 	} );
 
 	test( 'BackgroundImagePanel replaces its pre-feature partial wiring with a full inherited payload', () => {
-		const {
-			hasBlockSupport,
-			getBlockSupport,
-		} = require( '@wordpress/blocks' );
 		getBlockSupport.mockImplementation( ( _n, key ) => {
 			if ( key === 'background' ) {
 				return { backgroundImage: true };
@@ -328,7 +337,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 		} );
 		hasBlockSupport.mockReturnValue( true );
 
-		const { BackgroundImagePanel } = require( '../background' );
 		mockUseSelectImpl.fn = () => ( {
 			style: undefined,
 			className: undefined,
@@ -355,7 +363,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 	} );
 
 	test( 'wrappers forward the block className to useResolvedStyle', () => {
-		const { TypographyPanel } = require( '../typography' );
 		mockUseSelectImpl.fn = () => ( {
 			style: undefined,
 			fontFamily: undefined,
@@ -381,7 +388,6 @@ describe( 'inspector hook wrappers thread inheritedValue into the panel', () => 
 	} );
 
 	test( 'wrappers fall back to empty inheritedValue during hydration', () => {
-		const { TypographyPanel } = require( '../typography' );
 		mockUseSelectImpl.fn = () => ( {
 			style: undefined,
 			fontFamily: undefined,

--- a/packages/block-editor/src/hooks/test/layout-child.js
+++ b/packages/block-editor/src/hooks/test/layout-child.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getChildLayoutStyleRules } from '../layout-child';

--- a/packages/block-editor/src/hooks/test/layout.js
+++ b/packages/block-editor/src/hooks/test/layout.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/metadata.js
+++ b/packages/block-editor/src/hooks/test/metadata.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/preset-round-trip.js
+++ b/packages/block-editor/src/hooks/test/preset-round-trip.js
@@ -8,6 +8,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/settings.jsx
+++ b/packages/block-editor/src/hooks/test/settings.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';

--- a/packages/block-editor/src/hooks/test/state-utils.js
+++ b/packages/block-editor/src/hooks/test/state-utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/hooks/test/style.jsx
+++ b/packages/block-editor/src/hooks/test/style.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/hooks/test/text-align.jsx
+++ b/packages/block-editor/src/hooks/test/text-align.jsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {

--- a/packages/block-editor/src/hooks/test/use-typography-props.js
+++ b/packages/block-editor/src/hooks/test/use-typography-props.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getTypographyClassesAndStyles } from '../use-typography-props';

--- a/packages/block-editor/src/hooks/test/utils.js
+++ b/packages/block-editor/src/hooks/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { cleanEmptyObject } from '../utils';

--- a/packages/block-editor/src/layouts/test/constrained.jsx
+++ b/packages/block-editor/src/layouts/test/constrained.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -19,11 +20,11 @@ const PANEL_ID = 'test-panel';
 
 function renderInspectorControls( props = {} ) {
 	return render(
-		<ToolsPanel label="Layout" resetAll={ jest.fn() } panelId={ PANEL_ID }>
+		<ToolsPanel label="Layout" resetAll={ vi.fn() } panelId={ PANEL_ID }>
 			<ConstrainedLayoutInspectorControls
 				clientId={ PANEL_ID }
 				layout={ {} }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				{ ...props }
 			/>
 		</ToolsPanel>
@@ -85,7 +86,7 @@ describe( 'ConstrainedLayoutInspectorControls', () => {
 		'preserves a cleared %s value for viewport layout overrides',
 		async ( label, layoutKey ) => {
 			const user = userEvent.setup();
-			const onChange = jest.fn();
+			const onChange = vi.fn();
 			renderInspectorControls( {
 				layout: { type: 'constrained', [ layoutKey ]: '800px' },
 				resetLayout: { type: 'constrained', [ layoutKey ]: '800px' },

--- a/packages/block-editor/src/layouts/test/flex.jsx
+++ b/packages/block-editor/src/layouts/test/flex.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -19,11 +20,11 @@ const PANEL_ID = 'test-panel';
 
 function renderInspectorControls( props = {} ) {
 	return render(
-		<ToolsPanel label="Layout" resetAll={ jest.fn() } panelId={ PANEL_ID }>
+		<ToolsPanel label="Layout" resetAll={ vi.fn() } panelId={ PANEL_ID }>
 			<FlexLayoutInspectorControls
 				clientId={ PANEL_ID }
 				layout={ {} }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				{ ...props }
 			/>
 		</ToolsPanel>

--- a/packages/block-editor/src/layouts/test/flow.js
+++ b/packages/block-editor/src/layouts/test/flow.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import flow from '../flow';

--- a/packages/block-editor/src/layouts/test/grid.jsx
+++ b/packages/block-editor/src/layouts/test/grid.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -18,11 +19,11 @@ const PANEL_ID = 'test-panel';
 
 function renderInspectorControls( props = {} ) {
 	return render(
-		<ToolsPanel label="Layout" resetAll={ jest.fn() } panelId={ PANEL_ID }>
+		<ToolsPanel label="Layout" resetAll={ vi.fn() } panelId={ PANEL_ID }>
 			<GridLayoutInspectorControls
 				clientId={ PANEL_ID }
 				layout={ {} }
-				onChange={ jest.fn() }
+				onChange={ vi.fn() }
 				{ ...props }
 			/>
 		</ToolsPanel>

--- a/packages/block-editor/src/layouts/test/utils.js
+++ b/packages/block-editor/src/layouts/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { appendSelectors, getBlockGapCSS } from '../utils';

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -72,7 +73,7 @@ describe( 'actions', () => {
 
 	describe( 'resetBlocks', () => {
 		it( 'should dispatch the RESET_BLOCKS action', () => {
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 			const blocks = [];
 			resetBlocks( blocks )( { dispatch } );
 			expect( dispatch ).toHaveBeenCalledWith( {
@@ -172,7 +173,7 @@ describe( 'actions', () => {
 					return 0;
 				},
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			multiSelect( start, end )( { select, dispatch } );
 
@@ -202,7 +203,7 @@ describe( 'actions', () => {
 					return 0;
 				},
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			multiSelect( start, end )( { select, dispatch } );
 
@@ -231,8 +232,8 @@ describe( 'actions', () => {
 				canInsertBlockType: () => true,
 				getBlockCount: () => 1,
 			};
-			const dispatch = jest.fn();
-			dispatch.ensureDefaultBlock = jest.fn();
+			const dispatch = vi.fn();
+			dispatch.ensureDefaultBlock = vi.fn();
 			const registry = createRegistry();
 
 			replaceBlock( 'chicken', block )( { select, dispatch, registry } );
@@ -273,7 +274,7 @@ describe( 'actions', () => {
 					}
 				},
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			replaceBlocks( [ 'chicken' ], blocks )( { select, dispatch } );
 
@@ -298,8 +299,8 @@ describe( 'actions', () => {
 				canInsertBlockType: () => true,
 				getBlockCount: () => 1,
 			};
-			const dispatch = jest.fn();
-			dispatch.ensureDefaultBlock = jest.fn();
+			const dispatch = vi.fn();
+			dispatch.ensureDefaultBlock = vi.fn();
 			const registry = createRegistry();
 
 			replaceBlocks(
@@ -336,8 +337,8 @@ describe( 'actions', () => {
 				canInsertBlockType: () => true,
 				getBlockCount: () => 1,
 			};
-			const dispatch = jest.fn();
-			dispatch.ensureDefaultBlock = jest.fn();
+			const dispatch = vi.fn();
+			dispatch.ensureDefaultBlock = vi.fn();
 			const registry = createRegistry();
 
 			replaceBlocks(
@@ -372,7 +373,7 @@ describe( 'actions', () => {
 				getSettings: () => null,
 				canInsertBlockType: () => true,
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			insertBlock(
 				block,
@@ -424,7 +425,7 @@ describe( 'actions', () => {
 					}
 				},
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			insertBlocks(
 				blocks,
@@ -459,7 +460,7 @@ describe( 'actions', () => {
 				getSettings: () => null,
 				canInsertBlockType: () => false,
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			insertBlocks(
 				blocks,
@@ -502,7 +503,7 @@ describe( 'actions', () => {
 					}
 				},
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			insertBlocks(
 				blocks,
@@ -544,8 +545,8 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 				getBlockRemovalRules: () => false,
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlock: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				selectPreviousBlock: vi.fn(),
 			} );
 			const registry = createRegistry();
 
@@ -568,7 +569,7 @@ describe( 'actions', () => {
 			const select = {
 				canMoveBlocks: () => false,
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			moveBlocksToPosition(
 				[ 'chicken' ],
@@ -586,7 +587,7 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 				canInsertBlocks: () => true,
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			moveBlocksToPosition(
 				[ 'chicken' ],
@@ -610,7 +611,7 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 				canInsertBlocks: () => false,
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			moveBlocksToPosition(
 				[ 'chicken' ],
@@ -628,7 +629,7 @@ describe( 'actions', () => {
 			const select = {
 				canMoveBlocks: () => true,
 			};
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 
 			moveBlocksToPosition(
 				'chicken',
@@ -656,8 +657,8 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 				getBlockRemovalRules: () => false,
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlock: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				selectPreviousBlock: vi.fn(),
 			} );
 			const registry = createRegistry();
 			removeBlock( clientId )( { select, dispatch, registry } );
@@ -681,8 +682,8 @@ describe( 'actions', () => {
 				canRemoveBlocks: () => true,
 				getBlockRemovalRules: () => false,
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				selectPreviousBlock: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				selectPreviousBlock: vi.fn(),
 			} );
 
 			const registry = createRegistry();
@@ -870,9 +871,9 @@ describe( 'actions', () => {
 				getBlockEditingMode: () => 'default',
 				isBlockSelected: () => false,
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				selectBlock: jest.fn(),
-				removeBlock: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				selectBlock: vi.fn(),
+				removeBlock: vi.fn(),
 			} );
 
 			mergeBlocks(
@@ -924,9 +925,9 @@ describe( 'actions', () => {
 				} ),
 				getBlockEditingMode: () => 'default',
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				replaceBlocks: jest.fn(),
-				selectionChange: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				replaceBlocks: vi.fn(),
+				selectionChange: vi.fn(),
 			} );
 
 			mergeBlocks(
@@ -996,8 +997,8 @@ describe( 'actions', () => {
 				} ),
 				getBlockEditingMode: () => 'default',
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				replaceBlocks: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				replaceBlocks: vi.fn(),
 			} );
 
 			mergeBlocks(
@@ -1075,9 +1076,9 @@ describe( 'actions', () => {
 				} ),
 				getBlockEditingMode: () => 'default',
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				replaceBlocks: jest.fn(),
-				selectionChange: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				replaceBlocks: vi.fn(),
+				selectionChange: vi.fn(),
 			} );
 
 			mergeBlocks(
@@ -1151,9 +1152,9 @@ describe( 'actions', () => {
 				} ),
 				getBlockEditingMode: ( clientId ) => modes[ clientId ],
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				replaceBlocks: jest.fn(),
-				selectionChange: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				replaceBlocks: vi.fn(),
+				selectionChange: vi.fn(),
 			} );
 
 			mergeBlocks(
@@ -1211,9 +1212,9 @@ describe( 'actions', () => {
 				} ),
 				getBlockEditingMode: ( clientId ) => modes[ clientId ],
 			};
-			const dispatch = Object.assign( jest.fn(), {
-				replaceBlocks: jest.fn(),
-				selectionChange: jest.fn(),
+			const dispatch = Object.assign( vi.fn(), {
+				replaceBlocks: vi.fn(),
+				selectionChange: vi.fn(),
 			} );
 
 			mergeBlocks(
@@ -1302,7 +1303,7 @@ describe( 'actions', () => {
 
 	describe( 'updateSettings', () => {
 		it( 'warns when setting the deprecated __unstableIsPreviewMode property and sets the stable property instead', () => {
-			const consoleWarn = jest
+			const consoleWarn = vi
 				.spyOn( global.console, 'warn' )
 				.mockImplementation();
 
@@ -1427,7 +1428,7 @@ describe( 'actions', () => {
 			const inserterMediaCategories = [
 				{ name: 'a', labels: { name: 'a' } },
 			];
-			const dispatch = jest.fn();
+			const dispatch = vi.fn();
 			registerInserterMediaCategory( category )( {
 				select: {
 					getRegisteredInserterMediaCategories: () =>

--- a/packages/block-editor/src/store/test/array.js
+++ b/packages/block-editor/src/store/test/array.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { insertAt, moveTo } from '../array';

--- a/packages/block-editor/src/store/test/get-block-settings.js
+++ b/packages/block-editor/src/store/test/get-block-settings.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';

--- a/packages/block-editor/src/store/test/performance.js
+++ b/packages/block-editor/src/store/test/performance.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -1,4 +1,18 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -436,10 +450,10 @@ describe( 'private selectors', () => {
 			derivedBlockEditingModes: new Map(),
 		};
 
-		const hasContentRoleAttribute = jest.fn( () => false );
-		const get = jest.fn( () => 'edit' );
+		const hasContentRoleAttribute = vi.fn( () => false );
+		const get = vi.fn( () => 'edit' );
 		getBlockEditingMode.registry = {
-			select: jest.fn( () => ( {
+			select: vi.fn( () => ( {
 				hasContentRoleAttribute,
 				get,
 			} ) ),
@@ -651,7 +665,7 @@ describe( 'private selectors', () => {
 			] ),
 		};
 		getEnabledClientIdsTree.registry = {
-			select: jest.fn( () => ( {} ) ),
+			select: vi.fn( () => ( {} ) ),
 		};
 
 		it( 'should return tree containing only clientId and innerBlocks', () => {
@@ -946,7 +960,7 @@ describe( 'private selectors', () => {
 
 		beforeEach( () => {
 			getListViewClientIdsTree.registry = {
-				select: jest.fn( () => ( {} ) ),
+				select: vi.fn( () => ( {} ) ),
 			};
 		} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1,6 +1,15 @@
 /**
  * External dependencies
  */
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -51,18 +60,38 @@ import { sectionRootClientIdKey, isIsolatedEditorKey } from '.././private-keys';
 
 const { isContentBlock } = unlock( privateApis );
 
-jest.mock( '@wordpress/data/src/select', () => {
-	const actualSelect = jest.requireActual( '@wordpress/data/src/select' );
+const { mockIsContentBlock } = vi.hoisted( () => ( {
+	mockIsContentBlock: vi.fn(),
+} ) );
+
+vi.mock( import( '@wordpress/data' ), async ( importOriginal ) => {
+	const actualData = await importOriginal();
 
 	return {
-		select: jest.fn( ( ...args ) => actualSelect.select( ...args ) ),
+		...actualData,
+		select: vi.fn( ( ...args ) => actualData.select( ...args ) ),
 	};
 } );
 
-jest.mock( '@wordpress/blocks/src/api/utils', () => {
+vi.mock( import( '../../lock-unlock' ), async ( importOriginal ) => {
+	const actualLockUnlock = await importOriginal();
+
 	return {
-		...jest.requireActual( '@wordpress/blocks/src/api/utils' ),
-		isContentBlock: jest.fn(),
+		...actualLockUnlock,
+		unlock: ( value ) => {
+			const unlocked = actualLockUnlock.unlock( value );
+			if (
+				unlocked &&
+				typeof unlocked === 'object' &&
+				'isContentBlock' in unlocked
+			) {
+				return {
+					...unlocked,
+					isContentBlock: mockIsContentBlock,
+				};
+			}
+			return unlocked;
+		},
 	};
 } );
 
@@ -3456,7 +3485,7 @@ describe( 'state', () => {
 
 	describe( 'settings', () => {
 		it( 'should warn about __unstableIsPreviewMode deprecation', () => {
-			const consoleWarn = jest
+			const consoleWarn = vi
 				.spyOn( global.console, 'warn' )
 				.mockImplementation();
 

--- a/packages/block-editor/src/store/test/registry-selectors.js
+++ b/packages/block-editor/src/store/test/registry-selectors.js
@@ -1,4 +1,17 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';

--- a/packages/block-editor/src/store/test/selectors.jsx
+++ b/packages/block-editor/src/store/test/selectors.jsx
@@ -1,4 +1,18 @@
 /**
+ * External dependencies
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -5253,8 +5267,8 @@ describe( 'getBlockEditingMode', () => {
 		derivedBlockEditingModes: new Map(),
 	};
 
-	const hasContentRoleAttribute = jest.fn( () => false );
-	const get = jest.fn( () => 'edit' );
+	const hasContentRoleAttribute = vi.fn( () => false );
+	const get = vi.fn( () => 'edit' );
 
 	const mockedSelectors = { get };
 
@@ -5263,7 +5277,7 @@ describe( 'getBlockEditingMode', () => {
 	} );
 
 	getBlockEditingMode.registry = {
-		select: jest.fn( () => mockedSelectors ),
+		select: vi.fn( () => mockedSelectors ),
 	};
 
 	it( 'should return default by default', () => {

--- a/packages/block-editor/src/utils/test/block-bindings.js
+++ b/packages/block-editor/src/utils/test/block-bindings.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/utils/test/color-values.js
+++ b/packages/block-editor/src/utils/test/color-values.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/utils/test/dom.jsx
+++ b/packages/block-editor/src/utils/test/dom.jsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, vi } from 'vitest';
+
 import { render, screen } from '@testing-library/react';
 // eslint-disable-next-line @wordpress/use-recommended-components -- Required for testing
 import { VisuallyHidden as WCVisuallyHidden } from '@wordpress/components';
@@ -9,7 +14,7 @@ import {
 } from '../dom';
 
 function mockVisibleBoundingClientRect( element ) {
-	element.getBoundingClientRect = jest.fn().mockReturnValue( {
+	element.getBoundingClientRect = vi.fn().mockReturnValue( {
 		left: 0,
 		top: 0,
 		right: 100,
@@ -84,7 +89,7 @@ describe( 'dom', () => {
 		} );
 		it( 'should clip left and right values when an element is larger than the viewport width', () => {
 			const element = window.document.createElement( 'div' );
-			element.getBoundingClientRect = jest.fn().mockReturnValue( {
+			element.getBoundingClientRect = vi.fn().mockReturnValue( {
 				left: -10,
 				top: 0,
 				right: window.innerWidth + 10,
@@ -105,7 +110,7 @@ describe( 'dom', () => {
 		} );
 		it( 'should return the parent DOMRectReadOnly object if the parent block type is not supported', () => {
 			const element = window.document.createElement( 'div' );
-			element.getBoundingClientRect = jest.fn().mockReturnValue( {
+			element.getBoundingClientRect = vi.fn().mockReturnValue( {
 				left: 0,
 				top: 0,
 				right: 100,
@@ -115,7 +120,7 @@ describe( 'dom', () => {
 			} );
 			element.setAttribute( 'data-type', 'test' );
 			const childElement = window.document.createElement( 'div' );
-			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
+			childElement.getBoundingClientRect = vi.fn().mockReturnValue( {
 				left: 0,
 				top: 0,
 				right: 333,
@@ -141,7 +146,7 @@ describe( 'dom', () => {
 		describe( 'With known block type', () => {
 			it( 'should return the child DOMRectReadOnly object if it is visible and a known block type', () => {
 				const element = window.document.createElement( 'div' );
-				element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				element.getBoundingClientRect = vi.fn().mockReturnValue( {
 					left: 0,
 					top: 0,
 					right: 100,
@@ -154,18 +159,16 @@ describe( 'dom', () => {
 					WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
 				);
 				const childElement = window.document.createElement( 'div' );
-				childElement.getBoundingClientRect = jest
-					.fn()
-					.mockReturnValue( {
-						left: 0,
-						top: 0,
-						right: 333,
-						bottom: 333,
-						width: 333,
-						height: 333,
-						x: 0,
-						y: 0,
-					} );
+				childElement.getBoundingClientRect = vi.fn().mockReturnValue( {
+					left: 0,
+					top: 0,
+					right: 333,
+					bottom: 333,
+					width: 333,
+					height: 333,
+					x: 0,
+					y: 0,
+				} );
 				element.appendChild( childElement );
 
 				expect( getElementBounds( element ).toJSON() ).toEqual( {
@@ -187,7 +190,7 @@ describe( 'dom', () => {
 				);
 				element.style.overflowX = 'auto';
 				element.style.overflowY = 'auto';
-				element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				element.getBoundingClientRect = vi.fn().mockReturnValue( {
 					left: 0,
 					top: 0,
 					right: 100,
@@ -196,18 +199,16 @@ describe( 'dom', () => {
 					height: 100,
 				} );
 				const childElement = window.document.createElement( 'div' );
-				childElement.getBoundingClientRect = jest
-					.fn()
-					.mockReturnValue( {
-						left: 0,
-						top: 0,
-						right: 333,
-						bottom: 333,
-						width: 333,
-						height: 333,
-						x: 0,
-						y: 0,
-					} );
+				childElement.getBoundingClientRect = vi.fn().mockReturnValue( {
+					left: 0,
+					top: 0,
+					right: 333,
+					bottom: 333,
+					width: 333,
+					height: 333,
+					x: 0,
+					y: 0,
+				} );
 				element.appendChild( childElement );
 
 				expect( getElementBounds( element ).toJSON() ).toEqual( {
@@ -223,7 +224,7 @@ describe( 'dom', () => {
 			} );
 			it( 'should return the parent DOMRectReadOnly object if the child element is not visible', () => {
 				const element = window.document.createElement( 'div' );
-				element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				element.getBoundingClientRect = vi.fn().mockReturnValue( {
 					left: 0,
 					top: 0,
 					right: 100,
@@ -236,18 +237,16 @@ describe( 'dom', () => {
 					WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
 				);
 				const childElement = window.document.createElement( 'div' );
-				childElement.getBoundingClientRect = jest
-					.fn()
-					.mockReturnValue( {
-						left: 0,
-						top: 0,
-						right: 333,
-						bottom: 333,
-						width: 333,
-						height: 333,
-						x: 0,
-						y: 0,
-					} );
+				childElement.getBoundingClientRect = vi.fn().mockReturnValue( {
+					left: 0,
+					top: 0,
+					right: 333,
+					bottom: 333,
+					width: 333,
+					height: 333,
+					x: 0,
+					y: 0,
+				} );
 				childElement.style.display = 'none';
 				element.appendChild( childElement );
 

--- a/packages/block-editor/src/utils/test/format-font-style.js
+++ b/packages/block-editor/src/utils/test/format-font-style.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { formatFontStyle } from '../format-font-style';

--- a/packages/block-editor/src/utils/test/format-font-weight.js
+++ b/packages/block-editor/src/utils/test/format-font-weight.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { formatFontWeight } from '../format-font-weight';

--- a/packages/block-editor/src/utils/test/get-font-styles-and-weights.js
+++ b/packages/block-editor/src/utils/test/get-font-styles-and-weights.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getFontStylesAndWeights } from '../get-font-styles-and-weights';

--- a/packages/block-editor/src/utils/test/math.js
+++ b/packages/block-editor/src/utils/test/math.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { getDistanceFromPointToEdge, getDistanceToNearestEdge } from '../math';

--- a/packages/block-editor/src/utils/test/object.js
+++ b/packages/block-editor/src/utils/test/object.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { setImmutably } from '../object';

--- a/packages/block-editor/src/utils/test/pasting.js
+++ b/packages/block-editor/src/utils/test/pasting.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { shouldDismissPastedFiles } from '../pasting';

--- a/packages/block-editor/src/utils/test/selection.js
+++ b/packages/block-editor/src/utils/test/selection.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import {

--- a/packages/block-editor/src/utils/test/sorting.js
+++ b/packages/block-editor/src/utils/test/sorting.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { orderBy } from '../sorting';

--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import transformStyles from '../transform-styles';
@@ -8,7 +13,7 @@ describe( 'transformStyles', () => {
 		beforeEach( () => {
 			// Intentionally suppress the expected console errors and warnings to reduce
 			// noise in the test output.
-			jest.spyOn( console, 'warn' ).mockImplementation( jest.fn() );
+			vi.spyOn( console, 'warn' ).mockImplementation( vi.fn() );
 		} );
 
 		it( 'should not throw error in case of invalid css', () => {

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -25,6 +25,7 @@
 					"packages/autop",
 					"packages/blob",
 					"packages/block-directory",
+					"packages/block-editor",
 					"packages/block-library",
 					"packages/blocks",
 					"packages/connectors",


### PR DESCRIPTION
## What?

Follow up to #80855.

TL;DR: This migrates all 133 `@wordpress/block-editor` unit-test files from Jest to Vitest. The necessary change classes are explicit Vitest imports, ESM-aware module mocks and module lifecycle, public-package partial mocks in place of deep source mocks, modern fake timers, and Vitest snapshot metadata.

## Why?

This is the next bounded package slice in the repository-wide Jest-to-Vitest migration. Keeping the package migration in one independently revertible PR preserves the exactly-one-runner invariant while making its module-mocking and snapshot differences reviewable in context.

## How?

- Routes `packages/block-editor` to the Vitest jsdom project and adds the package-local Vitest development dependency.
- Converts Jest globals and mocks to explicit Vitest imports and ESM-compatible `vi.mock( import( … ) )` factories.
- Replaces deep `@wordpress/data` and `@wordpress/blocks` source mocks with public-package partial mocks.
- Reworks the few module-reset/isolation cases around dynamic ESM imports.
- Uses modern Vitest fake timers for the inserter media hooks.
- Updates 17 snapshots only for the Vitest header and hierarchical test-name keys; an entry-by-entry audit found zero snapshot-body differences.
- Keeps Testing Library unchanged. The five existing `@ariakit/test` consumers remain on jsdom intentionally and will move to Vitest Browser Mode in a separate browser-focused PR.

## Testing Instructions

1. Run the focused package suite:
   `npm run test:unit:vitest -- --project jsdom packages/block-editor`
2. Validate routing and conventions:
   `npm run --workspace @wordpress/unit-tests test:unit:routing`
   `npm run --workspace @wordpress/unit-tests test:unit:conventions`
3. Run package and lockfile checks:
   `npm run lint:pkg-json -- packages/block-editor/package.json`
   `npm run lint:lockfile`
4. Run the complete Vitest suite:
   `npm run test:unit:vitest`

Verified locally:

- Focused Block Editor suite: 133 files, 2,132 tests, 17 snapshots.
- Complete suite: 998 passed and 2 skipped files; 34,719 passed and 8 skipped tests, including the Chromium browser project.
- Residual Jest partition: 3 suites, 33 tests, 0 snapshots.
- Routing: 996 baseline tests owned exactly once; 1,000 Vitest tests and 3 Jest tests, with 164 tracked renames and 7 additions.
- Convention graph: 1,000 Vitest tests, 1,016 ESM graph files, 102 workspace dependencies, and 402 TypeScript tests.
- All changed test files passed strict JavaScript lint; package metadata and lockfile checks passed.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inventory the package tests, apply the mechanical runner conversion, investigate Vitest-specific module differences, and run the verification commands. The resulting diff and snapshot entries were reviewed directly.
