### PR TITLE
Migrate First Components Interaction Tests to Browser Mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Internal
 
+-   Run the first interaction-test batch in Vitest Browser Mode.
 -   Rename the JSX-bearing context system provider source file from `.js` to `.jsx`.
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Internal
 
--   Run the first interaction-test batch in Vitest Browser Mode.
+-   Run the first interaction-test batch in Vitest Browser Mode ([#80983](https://github.com/WordPress/gutenberg/pull/80983)).
 -   Rename the JSX-bearing context system provider source file from `.js` to `.jsx`.
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).

--- a/packages/components/src/alignment-matrix-control/test/index.tsx
+++ b/packages/components/src/alignment-matrix-control/test/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render, screen, waitFor, within } from '@testing-library/react';
-import { press, click } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -40,7 +40,7 @@ describe( 'AlignmentMatrixControl', () => {
 		it( 'should be centered by default', async () => {
 			await renderAndInitCompositeStore( <AlignmentMatrixControl /> );
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( getCell( 'center center' ) ).toHaveFocus();
 		} );
@@ -70,7 +70,7 @@ describe( 'AlignmentMatrixControl', () => {
 
 					const cell = getCell( alignment );
 
-					await click( cell );
+					await userEvent.click( cell );
 
 					expect( cell ).toHaveFocus();
 					expect( spy ).toHaveBeenCalledWith( alignment );
@@ -88,7 +88,7 @@ describe( 'AlignmentMatrixControl', () => {
 
 					const cell = getCell( 'center center' );
 
-					await click( cell );
+					await userEvent.click( cell );
 
 					expect( cell ).toHaveFocus();
 					expect( spy ).not.toHaveBeenCalled();
@@ -110,8 +110,8 @@ describe( 'AlignmentMatrixControl', () => {
 						<AlignmentMatrixControl onChange={ spy } />
 					);
 
-					await press.Tab();
-					await press[ keyRef ]();
+					await userEvent.tab();
+					await userEvent.keyboard( `{${ keyRef }}` );
 
 					expect( getCell( cellRef ) ).toHaveFocus();
 					expect( spy ).toHaveBeenCalledWith( cellRef );
@@ -132,8 +132,8 @@ describe( 'AlignmentMatrixControl', () => {
 					);
 
 					const cell = getCell( cellRef );
-					await click( cell );
-					await press[ keyRef ]();
+					await userEvent.click( cell );
+					await userEvent.keyboard( `{${ keyRef }}` );
 
 					expect( cell ).toHaveFocus();
 					expect( spy ).toHaveBeenCalledWith( cellRef );

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { describe, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 import { render, screen } from '@testing-library/react';
 
 /**
@@ -13,7 +14,6 @@ import { plusCircle } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { press } from '@ariakit/test';
 import _Button from '..';
 import Tooltip from '../../tooltip';
 import cleanupTooltip from '../../tooltip/test/utils';
@@ -87,7 +87,7 @@ describe( 'Button', () => {
 			render( <Button icon={ plusCircle }>Children</Button> );
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.getByRole( 'button' ) ).toHaveClass( 'has-text' );
 		} );
@@ -135,7 +135,7 @@ describe( 'Button', () => {
 				name: 'Tooltip anchor',
 			} );
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( anchor ).toHaveFocus();
 
@@ -145,17 +145,20 @@ describe( 'Button', () => {
 
 			expect( tooltip ).toBeVisible();
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect(
 				screen.getByRole( 'button', { name: 'Focus me' } )
 			).toHaveFocus();
 
-			expect(
-				screen.queryByRole( 'tooltip', {
-					name: 'Tooltip text',
-				} )
-			).not.toBeInTheDocument();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'tooltip', {
+						name: 'Tooltip text',
+					} )
+				)
+				.not.toBeInTheDocument();
 		} );
 
 		it( 'should render correctly as a tooltip anchor, ignoring its internal tooltip in favour of the external tooltip', async () => {
@@ -172,7 +175,7 @@ describe( 'Button', () => {
 				name: 'Button label',
 			} );
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( anchor ).toHaveFocus();
 
@@ -189,17 +192,20 @@ describe( 'Button', () => {
 				} )
 			).not.toBeInTheDocument();
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect(
 				screen.getByRole( 'button', { name: 'Focus me' } )
 			).toHaveFocus();
 
-			expect(
-				screen.queryByRole( 'tooltip', {
-					name: 'Tooltip text',
-				} )
-			).not.toBeInTheDocument();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'tooltip', {
+						name: 'Tooltip text',
+					} )
+				)
+				.not.toBeInTheDocument();
 		} );
 
 		it( 'should not trash the rendered HTML elements when toggling between showing and not showing a tooltip', async () => {
@@ -213,7 +219,7 @@ describe( 'Button', () => {
 
 			expect( button ).toBeVisible();
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( button ).toHaveFocus();
 
@@ -314,7 +320,7 @@ describe( 'Button', () => {
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.getByText( 'WordPress' ) ).toBeVisible();
 		} );
@@ -349,7 +355,7 @@ describe( 'Button', () => {
 			expect( screen.queryByText( 'Label' ) ).not.toBeInTheDocument();
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.getByText( 'Label' ) ).toBeVisible();
 
@@ -374,7 +380,7 @@ describe( 'Button', () => {
 				} )
 			).toBeVisible();
 
-			await press.Tab();
+			await userEvent.tab();
 
 			expect(
 				screen.getByRole( 'tooltip', {
@@ -401,7 +407,7 @@ describe( 'Button', () => {
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 		} );
@@ -414,7 +420,7 @@ describe( 'Button', () => {
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.getByText( 'WordPress' ) ).toBeVisible();
 
@@ -431,7 +437,7 @@ describe( 'Button', () => {
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 		} );
@@ -446,7 +452,7 @@ describe( 'Button', () => {
 			expect( screen.queryByText( 'WordPress' ) ).not.toBeInTheDocument();
 
 			// Move focus to the button
-			await press.Tab();
+			await userEvent.tab();
 
 			expect( screen.getByText( 'WordPress' ) ).toBeVisible();
 

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render, screen } from '@testing-library/react';
-import { press } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -72,11 +72,11 @@ describe( 'CircularOptionPicker', () => {
 				/>
 			);
 
-			await press.Tab();
+			await userEvent.tab();
 			expect( getOption( 'Option One' ) ).toHaveFocus();
-			await press.ArrowRight();
+			await userEvent.keyboard( '{ArrowRight}' );
 			expect( getOption( 'Option Two' ) ).toHaveFocus();
-			await press.ArrowRight();
+			await userEvent.keyboard( '{ArrowRight}' );
 			expect( getOption( 'Option One' ) ).toHaveFocus();
 		} );
 	} );
@@ -91,11 +91,11 @@ describe( 'CircularOptionPicker', () => {
 				/>
 			);
 
-			await press.Tab();
+			await userEvent.tab();
 			expect( getOption( 'Option One' ) ).toHaveFocus();
-			await press.ArrowRight();
+			await userEvent.keyboard( '{ArrowRight}' );
 			expect( getOption( 'Option Two' ) ).toHaveFocus();
-			await press.ArrowRight();
+			await userEvent.keyboard( '{ArrowRight}' );
 			expect( getOption( 'Option One' ) ).toHaveFocus();
 		} );
 	} );
@@ -110,11 +110,11 @@ describe( 'CircularOptionPicker', () => {
 				/>
 			);
 
-			await press.Tab();
+			await userEvent.tab();
 			expect( getOption( 'Option One' ) ).toHaveFocus();
-			await press.ArrowRight();
+			await userEvent.keyboard( '{ArrowRight}' );
 			expect( getOption( 'Option Two' ) ).toHaveFocus();
-			await press.ArrowRight();
+			await userEvent.keyboard( '{ArrowRight}' );
 			expect( getOption( 'Option Two' ) ).toHaveFocus();
 		} );
 	} );

--- a/packages/components/src/search-control/test/index.tsx
+++ b/packages/components/src/search-control/test/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render, screen } from '@testing-library/react';
-import { click, type } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -46,7 +46,7 @@ describe( 'SearchControl', () => {
 			render( <Component onChange={ onChangeSpy } /> );
 
 			const searchInput = screen.getByRole( 'searchbox' );
-			await type( 'test', searchInput );
+			await userEvent.type( searchInput, 'test' );
 			expect( searchInput ).toHaveValue( 'test' );
 			expect( onChangeSpy ).toHaveBeenLastCalledWith( 'test' );
 		} );
@@ -63,7 +63,7 @@ describe( 'SearchControl', () => {
 			const paddingInlineEndWithoutSuffix =
 				getComputedStyle( searchInput ).paddingInlineEnd;
 
-			await type( 'test', searchInput );
+			await userEvent.type( searchInput, 'test' );
 			const resetButton = screen.getByRole( 'button', {
 				name: 'Reset search',
 			} );
@@ -72,7 +72,7 @@ describe( 'SearchControl', () => {
 				paddingInlineEndWithoutSuffix
 			);
 
-			await click( resetButton );
+			await userEvent.click( resetButton );
 			expect( searchInput ).toHaveValue( '' );
 			expect( onChangeSpy ).toHaveBeenLastCalledWith( '' );
 			expect( getComputedStyle( searchInput ).paddingInlineEnd ).toBe(
@@ -98,7 +98,7 @@ describe( 'SearchControl', () => {
 			).not.toBeInTheDocument();
 
 			const searchInput = screen.getByRole( 'searchbox' );
-			await type( 'test', searchInput );
+			await userEvent.type( searchInput, 'test' );
 
 			expect(
 				screen.queryByRole( 'button', { name: 'Close search' } )
@@ -108,7 +108,7 @@ describe( 'SearchControl', () => {
 			).not.toBeInTheDocument();
 			expect( onChangeSpy ).toHaveBeenCalledTimes( 'test'.length );
 
-			await click(
+			await userEvent.click(
 				screen.getByRole( 'button', { name: 'Close search' } )
 			);
 			expect( onCloseSpy ).toHaveBeenCalledTimes( 1 );

--- a/packages/components/src/snackbar/test/index.tsx
+++ b/packages/components/src/snackbar/test/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render, screen, within } from '@testing-library/react';
-import { click } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -77,7 +77,7 @@ describe( 'Snackbar', () => {
 			'Dismiss this notice'
 		);
 
-		await click( snackbar );
+		await userEvent.click( snackbar );
 
 		expect( onRemove ).toHaveBeenCalledTimes( 1 );
 		expect( onDismiss ).toHaveBeenCalledTimes( 1 );
@@ -108,7 +108,7 @@ describe( 'Snackbar', () => {
 			'components-snackbar-explicit-dismiss'
 		);
 
-		await click( snackbar );
+		await userEvent.click( snackbar );
 
 		expect( onRemove ).not.toHaveBeenCalled();
 		expect( onDismiss ).not.toHaveBeenCalled();
@@ -133,7 +133,7 @@ describe( 'Snackbar', () => {
 			name: 'Dismiss this notice',
 		} );
 
-		await click( closeButton );
+		await userEvent.click( closeButton );
 
 		expect( onRemove ).toHaveBeenCalledTimes( 1 );
 		expect( onDismiss ).toHaveBeenCalledTimes( 1 );
@@ -197,7 +197,7 @@ describe( 'Snackbar', () => {
 				name: 'View post',
 			} );
 
-			await click( button );
+			await userEvent.click( button );
 
 			expect( onClick ).toHaveBeenCalledTimes( 1 );
 		} );

--- a/packages/components/src/snackbar/test/list.tsx
+++ b/packages/components/src/snackbar/test/list.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render, screen } from '@testing-library/react';
-import { click } from '@ariakit/test';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ describe( 'SnackbarList', () => {
 			/>
 		);
 
-		await click(
+		await userEvent.click(
 			screen.getAllByRole( 'button', {
 				name: 'Dismiss this notice',
 			} )[ 0 ]

--- a/packages/components/src/tooltip/test/utils/index.tsx
+++ b/packages/components/src/tooltip/test/utils/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { click, press } from '@ariakit/test';
+import { userEvent } from 'vitest/browser';
 
 // TODO: may need to be tested with Playwright; further context:
 // https://github.com/WordPress/gutenberg/pull/52133#issuecomment-1613691258
@@ -14,7 +14,7 @@ import { click, press } from '@ariakit/test';
  *
  */
 export default async function cleanupTooltip() {
-	await press.Tab();
-	await press.Tab();
-	await click( document.body );
+	await userEvent.tab();
+	await userEvent.tab();
+	await userEvent.click( document.body );
 }

--- a/test/unit/config/browser.vitest.js
+++ b/test/unit/config/browser.vitest.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/vitest';
+// eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Run browser tests with the same development feature flags as the jsdom
+// project. Browser-native platform APIs intentionally remain untouched.
+// eslint-disable-next-line @wordpress/wp-global-usage
+globalThis.SCRIPT_DEBUG = true;
+
+globalThis.tinyMCEPreInit = {
+	baseURL: 'about:blank',
+};
+globalThis.userSettings = { uid: 1 };
+
+afterEach( cleanup );

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -102,10 +102,33 @@ export function discoverTestFiles( rootDir ) {
 	].sort();
 }
 
+export function excludeExplicitFileOverrides(
+	projectName,
+	testPaths,
+	manifest
+) {
+	const testsExplicitlyOwnedByOtherProjects = new Set(
+		VITEST_PROJECT_NAMES.filter(
+			( otherProjectName ) => otherProjectName !== projectName
+		).flatMap( ( otherProjectName ) => [
+			...manifest.vitest.projects[ otherProjectName ].files,
+			...manifest.added.vitest[ otherProjectName ],
+		] )
+	);
+
+	return testPaths.filter(
+		( testPath ) => ! testsExplicitlyOwnedByOtherProjects.has( testPath )
+	);
+}
+
 export function getVitestTestsForProject( rootDir, manifest, projectName ) {
 	const discoveredTests = discoverTestFiles( rootDir );
 	const project = manifest.vitest.projects[ projectName ];
-	const directoryTests = discoveredTests.filter( ( testPath ) =>
+	const directoryTests = excludeExplicitFileOverrides(
+		projectName,
+		discoveredTests,
+		manifest
+	).filter( ( testPath ) =>
 		project.directories.some(
 			( directoryPath ) =>
 				testPath === directoryPath ||

--- a/test/unit/scripts/test/discover-test-files.js
+++ b/test/unit/scripts/test/discover-test-files.js
@@ -9,6 +9,7 @@ import { describe, expect, test } from 'vitest';
 import {
 	assertVitestProjectNames,
 	canonicalizeRenamedTestFiles,
+	excludeExplicitFileOverrides,
 	findOverlappingVitestProjectTests,
 } from '../discover-test-files.mjs';
 
@@ -57,6 +58,39 @@ describe( 'Vitest project routing', () => {
 		).toEqual( [
 			'packages/components/src/test/index.js: browser, jsdom',
 		] );
+	} );
+
+	test( 'lets explicit file ownership override directory ownership', () => {
+		const manifest = {
+			vitest: {
+				projects: {
+					browser: {
+						files: [ 'packages/example/test/browser.js' ],
+					},
+					jsdom: {
+						files: [],
+					},
+					node: {
+						files: [],
+					},
+				},
+			},
+			added: {
+				vitest: {
+					browser: [],
+					jsdom: [],
+					node: [],
+				},
+			},
+		};
+		const directoryTests = [
+			'packages/example/test/browser.js',
+			'packages/example/test/jsdom.js',
+		];
+
+		expect(
+			excludeExplicitFileOverrides( 'jsdom', directoryTests, manifest )
+		).toEqual( [ 'packages/example/test/jsdom.js' ] );
 	} );
 
 	test( 'preserves baseline identities for renamed tests', () => {

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -1,11 +1,4 @@
 /**
- * External dependencies
- */
-import { parseSync } from '@babel/core';
-import traverseModule from '@babel/traverse';
-import globPackage from 'glob';
-
-/**
  * Node dependencies
  */
 import { execFileSync } from 'node:child_process';
@@ -19,6 +12,13 @@ import {
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/**
+ * External dependencies
+ */
+import { parseSync } from '@babel/core';
+import traverseModule from '@babel/traverse';
+import globPackage from 'glob';
 
 /**
  * Internal dependencies
@@ -311,6 +311,19 @@ for ( const projectName of VITEST_PROJECT_NAMES ) {
 			temporaryDirectory,
 			'compatibility.d.ts'
 		);
+		const setupTypeFiles = [];
+		if ( projectName === 'browser' ) {
+			setupTypeFiles.push(
+				path.join( ROOT_DIR, 'test/unit/config/browser.vitest.js' )
+			);
+		} else if ( projectName === 'jsdom' ) {
+			setupTypeFiles.push(
+				path.join(
+					ROOT_DIR,
+					'test/unit/config/testing-library.vitest.js'
+				)
+			);
+		}
 		const typecheckConfig = {
 			extends: baseConfigPath,
 			compilerOptions: {
@@ -326,25 +339,15 @@ for ( const projectName of VITEST_PROJECT_NAMES ) {
 					path.join( ROOT_DIR, 'typings' ),
 					path.join( ROOT_DIR, 'node_modules/@types' ),
 				],
-				types:
-					projectName === 'jsdom'
-						? [
-								...commonTypes,
-								...( needsNodeTypes ? [ 'node' ] : [] ),
-								'gutenberg-vitest-test-env',
-						  ]
-						: [ ...commonTypes, 'node' ],
+				types: [
+					...commonTypes,
+					...( needsNodeTypes ? [ 'node' ] : [] ),
+					'gutenberg-vitest-test-env',
+				],
 			},
 			files: [
 				compatibilityTypesPath,
-				...( projectName === 'jsdom'
-					? [
-							path.join(
-								ROOT_DIR,
-								'test/unit/config/testing-library.vitest.js'
-							),
-					  ]
-					: [] ),
+				...setupTypeFiles,
 				...typeScriptTests.map( ( file ) =>
 					path.join( ROOT_DIR, file )
 				),

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -6,7 +6,14 @@
 	"vitest": {
 		"projects": {
 			"browser": {
-				"files": [],
+				"files": [
+					"packages/components/src/alignment-matrix-control/test/index.tsx",
+					"packages/components/src/button/test/index.tsx",
+					"packages/components/src/circular-option-picker/test/index.tsx",
+					"packages/components/src/search-control/test/index.tsx",
+					"packages/components/src/snackbar/test/index.tsx",
+					"packages/components/src/snackbar/test/list.tsx"
+				],
 				"directories": []
 			},
 			"jsdom": {

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -31,6 +31,10 @@ const testMigration = JSON.parse(
 const vitestTests = getVitestTestsByProject( ROOT_DIR, testMigration );
 const { sync: glob } = globPackage;
 const reporters = [ 'default' ];
+const styleMockAlias = {
+	find: /^.*\.(?:css|scss)$/,
+	replacement: path.join( ROOT_DIR, 'test/unit/config/style-mock.vitest.js' ),
+};
 
 if ( process.env.GITHUB_ACTIONS === 'true' ) {
 	reporters.push( 'github-actions' );
@@ -107,13 +111,6 @@ export default defineConfig( {
 	resolve: {
 		alias: [
 			{
-				find: /^.*\.(?:css|scss)$/,
-				replacement: path.join(
-					ROOT_DIR,
-					'test/unit/config/style-mock.vitest.js'
-				),
-			},
-			{
 				find: /^yargs$/,
 				replacement: path.join(
 					ROOT_DIR,
@@ -183,12 +180,38 @@ export default defineConfig( {
 					entries: vitestTests.browser,
 					// Babel injects the automatic JSX runtime after Vite's
 					// dependency scan, so declare it directly.
-					include: [ 'react/jsx-runtime' ],
+					include: [
+						'@emotion/cache',
+						'@emotion/styled/base',
+						'@floating-ui/react-dom',
+						'@testing-library/jest-dom/vitest',
+						'@testing-library/react',
+						'@use-gesture/react',
+						'deepmerge',
+						'fast-deep-equal/es6/index.js',
+						'highlight-words-core',
+						'react/jsx-runtime',
+						'uuid',
+					],
 				},
 				test: {
 					name: 'browser',
 					attachmentsDir: 'test-results/vitest-browser-attachments',
 					include: vitestTests.browser,
+					setupFiles: [
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/browser.vitest.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/gutenberg-env.js'
+						),
+						path.join(
+							ROOT_DIR,
+							'test/unit/config/console.vitest.js'
+						),
+					],
 					browser: {
 						enabled: true,
 						headless: true,
@@ -206,6 +229,9 @@ export default defineConfig( {
 			},
 			{
 				extends: true,
+				resolve: {
+					alias: [ styleMockAlias ],
+				},
 				test: {
 					// The Flakiness.io reporter uses the project name as part
 					// of its environment identity. Preserve the historical
@@ -249,6 +275,9 @@ export default defineConfig( {
 			},
 			{
 				extends: true,
+				resolve: {
+					alias: [ styleMockAlias ],
+				},
 				test: {
 					name: 'node',
 					environment: 'node',


### PR DESCRIPTION
## What?

Follow up to #80855.

TL;DR: This migrates the first six Components interaction-test files from `@ariakit/test` under jsdom to Vitest Browser Mode. The necessary change classes are file-level browser routing, browser-safe setup without web-platform shims, native browser CSS, direct `vitest/browser` interactions, retryable browser assertions, and browser-specific TypeScript setup types.

## Why?

Real browser execution lets interaction tests exercise focus, keyboard, layout, styles, and other platform behavior without extending the jsdom mock layer. This bounded pilot proves the routing and setup needed for the remaining Components and Block Editor `@ariakit/test` consumers before moving more complex suites.

## How?

- Lets explicit file ownership override package-directory ownership in the migration manifest, while preserving exactly-one-runner validation.
- Adds a Browser Mode setup that keeps Gutenberg feature globals and Testing Library cleanup but does not install platform polyfills or mocks.
- Routes six Components test files to Chromium and replaces seven `@ariakit/test` imports, including the shared tooltip cleanup helper, with `vitest/browser` `userEvent`.
- Uses native CSS in Browser Mode while retaining the existing CSS proxy for jsdom and node tests.
- Pre-optimizes the browser dependency graph so Vite does not reload mid-test.
- Uses a retryable browser locator for delayed tooltip teardown.
- Includes the Browser Mode setup in TypeScript graph validation without leaking Node types into browser tests.
- Keeps Testing Library for rendering and semantic DOM queries; this PR changes the interaction driver, not the component-testing library.

Thirteen Components `@ariakit/test` consumer files remain for bounded follow-up PRs.

## Testing Instructions

1. Run the Browser Mode project:
   `npm run test:unit:vitest -- --project browser`
2. Validate routing and conventions:
   `npm run --workspace @wordpress/unit-tests test:unit:routing`
   `npm run --workspace @wordpress/unit-tests test:unit:conventions`
3. Verify the jsdom CSS proxy remains intact:
   `npm run test:unit:vitest -- --project jsdom packages/components/src/toggle-group-control/test/index.tsx`
4. Run the complete Vitest suite:
   `npm run test:unit:vitest`

Verified locally:

- Browser project: 7 files and 96 tests passed in Chromium.
- Complete suite: 998 passed and 2 skipped files; 34,720 passed and 8 skipped tests.
- Residual Jest partition: 3 suites, 33 tests, 0 snapshots.
- Routing: 996 baseline tests owned exactly once; 1,000 Vitest tests and 3 Jest tests, with 164 tracked renames and 7 additions.
- Convention graph: 1,000 Vitest tests, 1,017 ESM graph files, 102 workspace dependencies, and 402 TypeScript tests.
- Strict JavaScript lint and diff checks passed for all changed files.
- No snapshots changed.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inventory the interaction-test consumers, implement the Browser Mode routing and setup, convert the bounded test slice, investigate browser-specific failures, and run the verification commands. The resulting diff was reviewed directly.