### PR TITLE
Migrate Components Custom Select Tests to Browser Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50035,7 +50035,8 @@
 				"@wordpress/stylelint-tools": "file:../../tools/stylelint",
 				"storybook": "^10.4.3",
 				"timezone-mock": "^1.3.6",
-				"vitest": "^4.1.10"
+				"vitest": "^4.1.10",
+				"vitest-browser-react": "^2.2.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Internal
 
--   Run the custom-select interaction tests in Vitest Browser Mode.
+-   Run the custom-select interaction tests in Vitest Browser Mode ([#80985](https://github.com/WordPress/gutenberg/pull/80985)).
 -   Run the first interaction-test batch in Vitest Browser Mode ([#80983](https://github.com/WordPress/gutenberg/pull/80983)).
 -   Rename the JSX-bearing context system provider source file from `.js` to `.jsx`.
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Internal
 
+-   Run the custom-select interaction tests in Vitest Browser Mode.
 -   Run the first interaction-test batch in Vitest Browser Mode ([#80983](https://github.com/WordPress/gutenberg/pull/80983)).
 -   Rename the JSX-bearing context system provider source file from `.js` to `.jsx`.
 -   `Button`: Expand the Storybook e2e `VariantStates` matrix with compact, small, and with-icon rows ([#80793](https://github.com/WordPress/gutenberg/pull/80793)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -113,7 +113,8 @@
 		"@wordpress/stylelint-tools": "file:../../tools/stylelint",
 		"storybook": "^10.4.3",
 		"timezone-mock": "^1.3.6",
-		"vitest": "^4.1.10"
+		"vitest": "^4.1.10",
+		"vitest-browser-react": "^2.2.0"
 	},
 	"peerDependencies": {
 		"@types/react": "^18 || ^19",

--- a/packages/components/src/custom-select-control-v2/test/index.tsx
+++ b/packages/components/src/custom-select-control-v2/test/index.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { describe, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 import { screen } from '@testing-library/react';
-import { click, press, type } from '@ariakit/test';
-import { render } from '@ariakit/test/react';
+import { render } from 'vitest-browser-react';
 
 /**
  * WordPress dependencies
@@ -68,15 +68,16 @@ describe.each( [
 	const [ , Component ] = modeAndComponent;
 
 	it( 'Should replace the initial selection when a new item is selected', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...defaultProps } /> );
 
 		const currentSelectedItem = screen.getByRole( 'combobox', {
 			expanded: false,
 		} );
 
-		await click( currentSelectedItem );
+		await user.click( currentSelectedItem );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'option', {
 				name: 'crimson clover',
 			} )
@@ -84,9 +85,9 @@ describe.each( [
 
 		expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
 
-		await click( currentSelectedItem );
+		await user.click( currentSelectedItem );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'option', {
 				name: 'poppy',
 			} )
@@ -96,87 +97,97 @@ describe.each( [
 	} );
 
 	it( 'Should keep current selection if dropdown is closed without changing selection', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...defaultProps } /> );
 
 		const currentSelectedItem = screen.getByRole( 'combobox', {
 			expanded: false,
 		} );
 
-		await press.Tab();
-		await press.Enter();
-		expect(
-			screen.getByRole( 'listbox', {
-				name: defaultProps.label,
-			} )
-		).toBeVisible();
+		await user.tab();
+		await user.keyboard( '{Enter}' );
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'listbox', {
+					name: defaultProps.label,
+				} )
+			)
+			.toBeVisible();
 
-		await press.Escape();
-		expect(
-			screen.queryByRole( 'listbox', {
-				name: defaultProps.label,
-			} )
-		).not.toBeInTheDocument();
+		await user.keyboard( '{Escape}' );
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'listbox', {
+					name: defaultProps.label,
+				} )
+			)
+			.not.toBeInTheDocument();
 
 		expect( currentSelectedItem ).toHaveTextContent( items[ 0 ].value );
 	} );
 
 	describe( 'Keyboard behavior and accessibility', () => {
 		it( 'Should be able to change selection using keyboard', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...defaultProps } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
+			await user.tab();
 			expect( currentSelectedItem ).toHaveFocus();
 
-			await press.Enter();
+			await user.keyboard( '{Enter}' );
 			expect(
 				screen.getByRole( 'listbox', {
 					name: defaultProps.label,
 				} )
 			).toHaveFocus();
 
-			await press.ArrowDown();
-			await press.Enter();
+			await user.keyboard( '{ArrowDown}' );
+			await user.keyboard( '{Enter}' );
 
 			expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
 		} );
 
 		it( 'Should be able to type characters to select matching options', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...defaultProps } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
-			await press.Enter();
+			await user.tab();
+			await user.keyboard( '{Enter}' );
 			expect(
 				screen.getByRole( 'listbox', {
 					name: defaultProps.label,
 				} )
 			).toHaveFocus();
 
-			await type( 'a' );
-			await press.Enter();
+			await user.keyboard( 'a' );
+			await user.keyboard( '{Enter}' );
 			expect( currentSelectedItem ).toHaveTextContent( 'amber' );
 		} );
 
 		it( 'Can change selection with a focused input and closed dropdown if typed characters match an option', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...defaultProps } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
+			await user.tab();
 			expect( currentSelectedItem ).toHaveFocus();
 			expect( currentSelectedItem ).toHaveTextContent( 'violets' );
 
 			// Ideally we would test a multi-character typeahead, but anything more than a single character is flaky
-			await type( 'a' );
+			await user.keyboard( 'a' );
 
 			expect(
 				screen.queryByRole( 'listbox', {
@@ -185,55 +196,70 @@ describe.each( [
 				} )
 			).not.toBeInTheDocument();
 
-			// This Enter is a workaround for flakiness, and shouldn't be necessary in an actual browser
-			await press.Enter();
-
-			expect( currentSelectedItem ).toHaveTextContent( 'amber' );
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'combobox', {
+						expanded: false,
+					} )
+				)
+				.toHaveTextContent( 'amber' );
 		} );
 
 		it( 'Should have correct aria-selected value for selections', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...defaultProps } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
 			// assert that first item has aria-selected="true"
-			expect(
-				screen.getByRole( 'option', {
-					name: 'violets',
-					selected: true,
-				} )
-			).toBeVisible();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: 'violets',
+						selected: true,
+					} )
+				)
+				.toBeVisible();
 
 			// change the current selection
-			await click( screen.getByRole( 'option', { name: 'poppy' } ) );
+			await user.click( screen.getByRole( 'option', { name: 'poppy' } ) );
 
 			// click combobox to mount listbox with options again
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
 			// check that first item is has aria-selected="false" after new selection
-			expect(
-				screen.getByRole( 'option', {
-					name: 'violets',
-					selected: false,
-				} )
-			).toBeVisible();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: 'violets',
+						selected: false,
+					} )
+				)
+				.toBeVisible();
 
 			// check that new selected item now has aria-selected="true"
-			expect(
-				screen.getByRole( 'option', {
-					name: 'poppy',
-					selected: true,
-				} )
-			).toBeVisible();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: 'poppy',
+						selected: true,
+					} )
+				)
+				.toBeVisible();
 		} );
 	} );
 
 	describe( 'Multiple selection', () => {
 		it( 'Should be able to select multiple items when provided an array', async () => {
+			const user = userEvent.setup();
 			const onChangeMock = vi.fn();
 
 			// initial selection as defaultValue
@@ -274,21 +300,24 @@ describe.each( [
 				`${ defaultValues.length } items selected`
 			);
 
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
 			expect( screen.getByRole( 'listbox' ) ).toHaveAttribute(
 				'aria-multiselectable'
 			);
 
 			// ensure defaultValues are selected in list of items
-			defaultValues.forEach( ( value ) =>
-				expect(
-					screen.getByRole( 'option', {
-						name: value,
-						selected: true,
-					} )
-				).toBeVisible()
-			);
+			for ( const value of defaultValues ) {
+				await expect
+					.element(
+						// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+						page.getByRole( 'option', {
+							name: value,
+							selected: true,
+						} )
+					)
+					.toBeVisible();
+			}
 
 			// name of next selection
 			const nextSelectionName = 'rose blush';
@@ -299,14 +328,22 @@ describe.each( [
 			} );
 
 			// click next selection to add another item to current selection
-			await click( nextSelection );
+			await user.click( nextSelection );
 
 			// updated array containing defaultValues + the item just selected
 			const updatedSelection = defaultValues.concat( nextSelectionName );
 
 			expect( onChangeMock ).toHaveBeenCalledWith( updatedSelection );
 
-			expect( nextSelection ).toHaveAttribute( 'aria-selected' );
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: nextSelectionName,
+						selected: true,
+					} )
+				)
+				.toBeVisible();
 
 			// expect increased array length for current selection
 			expect( currentSelectedItem ).toHaveTextContent(
@@ -315,6 +352,7 @@ describe.each( [
 		} );
 
 		it( 'Should be able to deselect items when provided an array', async () => {
+			const user = userEvent.setup();
 			// initial selection as defaultValue
 			const defaultValues = [
 				'aurora borealis green',
@@ -341,7 +379,7 @@ describe.each( [
 				expanded: false,
 			} );
 
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
 			// Array containing items to deselect
 			const nextSelection = [
@@ -352,19 +390,21 @@ describe.each( [
 
 			// Deselect some items by clicking them to ensure that changes
 			// are reflected correctly
-			await Promise.all(
-				nextSelection.map( async ( value ) => {
-					await click(
-						screen.getByRole( 'option', { name: value } )
-					);
-					expect(
-						screen.getByRole( 'option', {
+			for ( const value of nextSelection ) {
+				await user.click(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', { name: value } )
+				);
+				await expect
+					.element(
+						// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+						page.getByRole( 'option', {
 							name: value,
 							selected: false,
 						} )
-					).toBeVisible();
-				} )
-			);
+					)
+					.toBeVisible();
+			}
 
 			// expect different array length from defaultValues due to deselecting items
 			expect( currentSelectedItem ).toHaveTextContent(
@@ -376,6 +416,7 @@ describe.each( [
 	} );
 
 	it( 'Should allow rendering a custom value when using `renderSelectedValue`', async () => {
+		const user = userEvent.setup();
 		const renderValue = ( value: string | readonly string[] ) => {
 			return <img src={ `${ value }.jpg` } alt={ value as string } />;
 		};
@@ -406,32 +447,44 @@ describe.each( [
 			screen.queryByRole( 'img', { name: 'july-9' } )
 		).not.toBeInTheDocument();
 
-		await click( currentSelectedItem );
+		await user.click( currentSelectedItem );
 
 		// expect that the other image is only visible after opening popover with options
-		expect( screen.getByRole( 'img', { name: 'july-9' } ) ).toBeVisible();
-		expect(
-			screen.getByRole( 'option', { name: 'july-9' } )
-		).toBeVisible();
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'img', { name: 'july-9' } )
+			)
+			.toBeVisible();
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'option', { name: 'july-9' } )
+			)
+			.toBeVisible();
 	} );
 
 	it( 'Should open the select popover when focussing the trigger button and pressing arrow down', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...defaultProps } /> );
 
 		const currentSelectedItem = screen.getByRole( 'combobox', {
 			expanded: false,
 		} );
 
-		await press.Tab();
+		await user.tab();
 		expect( currentSelectedItem ).toHaveFocus();
 		expect( currentSelectedItem ).toHaveTextContent( items[ 0 ].value );
 
-		await press.ArrowDown();
-		expect(
-			screen.getByRole( 'listbox', {
-				name: defaultProps.label,
-			} )
-		).toBeVisible();
+		await user.keyboard( '{ArrowDown}' );
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'listbox', {
+					name: defaultProps.label,
+				} )
+			)
+			.toBeVisible();
 	} );
 
 	it( 'Should label the component correctly even when the label is not visible', async () => {

--- a/packages/components/src/custom-select-control/test/index.tsx
+++ b/packages/components/src/custom-select-control/test/index.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { describe, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
 import { screen } from '@testing-library/react';
-import { click, press, sleep, type, waitFor } from '@ariakit/test';
-import { render } from '@ariakit/test/react';
+import { render } from 'vitest-browser-react';
 
 /**
  * WordPress dependencies
@@ -116,9 +116,6 @@ it( 'Should apply external controlled updates', async () => {
 
 	expect( currentSelectedItem ).toHaveTextContent( props.options[ 1 ].name );
 
-	// Necessary to wait for onChange to potentially fire
-	await sleep();
-
 	expect( mockOnChange ).not.toHaveBeenCalled();
 } );
 
@@ -137,9 +134,6 @@ describe.each( [
 				expanded: false,
 			} )
 		).toHaveTextContent( props.options[ 0 ].name );
-
-		// Necessary to wait for onChange to potentially fire
-		await sleep();
 
 		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
@@ -160,22 +154,20 @@ describe.each( [
 			} )
 		).toHaveTextContent( props.options[ 3 ].name );
 
-		// Necessary to wait for onChange to potentially fire
-		await sleep();
-
 		expect( mockOnChange ).not.toHaveBeenCalled();
 	} );
 
 	it( 'Should replace the initial selection when a new item is selected', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...props } /> );
 
 		const currentSelectedItem = screen.getByRole( 'combobox', {
 			expanded: false,
 		} );
 
-		await click( currentSelectedItem );
+		await user.click( currentSelectedItem );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'option', {
 				name: 'crimson clover',
 			} )
@@ -183,9 +175,9 @@ describe.each( [
 
 		expect( currentSelectedItem ).toHaveTextContent( 'crimson clover' );
 
-		await click( currentSelectedItem );
+		await user.click( currentSelectedItem );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'option', {
 				name: 'poppy',
 			} )
@@ -195,26 +187,33 @@ describe.each( [
 	} );
 
 	it( 'Should keep current selection if dropdown is closed without changing selection', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...props } /> );
 
 		const currentSelectedItem = screen.getByRole( 'combobox', {
 			expanded: false,
 		} );
 
-		await press.Tab();
-		await press.Enter();
-		expect(
-			screen.getByRole( 'listbox', {
-				name: props.label,
-			} )
-		).toBeVisible();
+		await user.tab();
+		await user.keyboard( '{Enter}' );
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'listbox', {
+					name: props.label,
+				} )
+			)
+			.toBeVisible();
 
-		await press.Escape();
-		expect(
-			screen.queryByRole( 'listbox', {
-				name: props.label,
-			} )
-		).not.toBeInTheDocument();
+		await user.keyboard( '{Escape}' );
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'listbox', {
+					name: props.label,
+				} )
+			)
+			.not.toBeInTheDocument();
 
 		expect( currentSelectedItem ).toHaveTextContent(
 			props.options[ 0 ].name
@@ -222,9 +221,10 @@ describe.each( [
 	} );
 
 	it( 'Should apply class only to options that have a className defined', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...props } /> );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'combobox', {
 				expanded: false,
 			} )
@@ -256,9 +256,10 @@ describe.each( [
 	} );
 
 	it( 'Should apply styles only to options that have styles defined', async () => {
+		const user = userEvent.setup();
 		await render( <Component { ...props } /> );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'combobox', {
 				expanded: false,
 			} )
@@ -303,11 +304,12 @@ describe.each( [
 				] }
 			/>
 		);
-		await waitFor( () =>
-			expect(
-				screen.getByRole( 'combobox', { name: 'Custom select' } )
-			).not.toHaveTextContent( 'Hint' )
-		);
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'combobox', { name: 'Custom select' } )
+			)
+			.not.toHaveTextContent( 'Hint' );
 	} );
 
 	it( 'shows selected hint when showSelectedHint is set', async () => {
@@ -326,16 +328,18 @@ describe.each( [
 			/>
 		);
 
-		await waitFor( () =>
-			expect(
-				screen.getByRole( 'combobox', {
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'combobox', {
 					expanded: false,
 				} )
-			).toHaveTextContent( 'Hint' )
-		);
+			)
+			.toHaveTextContent( 'Hint' );
 	} );
 
 	it( 'shows selected hint in list of options when added, regardless of showSelectedHint prop', async () => {
+		const user = userEvent.setup();
 		await render(
 			<Component
 				{ ...props }
@@ -350,25 +354,31 @@ describe.each( [
 			/>
 		);
 
-		await click(
+		await user.click(
 			screen.getByRole( 'combobox', { name: 'Custom select' } )
 		);
 
-		expect( screen.getByRole( 'option', { name: /hint/i } ) ).toBeVisible();
+		await expect
+			.element(
+				// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+				page.getByRole( 'option', { name: /hint/i } )
+			)
+			.toBeVisible();
 	} );
 
 	it( 'Should return object onChange', async () => {
+		const user = userEvent.setup();
 		const mockOnChange = vi.fn();
 
 		await render( <Component { ...props } onChange={ mockOnChange } /> );
 
-		await click(
+		await user.click(
 			screen.getByRole( 'combobox', {
 				expanded: false,
 			} )
 		);
 
-		await click(
+		await user.click(
 			screen.getByRole( 'option', {
 				name: 'aquamarine',
 			} )
@@ -388,19 +398,20 @@ describe.each( [
 	} );
 
 	it( 'Should return selectedItem object when specified onChange', async () => {
+		const user = userEvent.setup();
 		const mockOnChange = vi.fn();
 
 		await render( <Component { ...props } onChange={ mockOnChange } /> );
 
-		await press.Tab();
+		await user.tab();
 		expect(
 			screen.getByRole( 'combobox', {
 				expanded: false,
 			} )
 		).toHaveFocus();
 
-		await type( 'p' );
-		await press.Enter();
+		await user.keyboard( 'p' );
+		await user.keyboard( '{Enter}' );
 
 		expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
 		expect( mockOnChange ).toHaveBeenLastCalledWith(
@@ -414,6 +425,7 @@ describe.each( [
 	} );
 
 	it( "Should pass arbitrary props to onChange's selectedItem, but apply only style and className to DOM elements", async () => {
+		const user = userEvent.setup();
 		const onChangeMock = vi.fn();
 
 		await render( <Component { ...props } onChange={ onChangeMock } /> );
@@ -422,7 +434,7 @@ describe.each( [
 			expanded: false,
 		} );
 
-		await click( currentSelectedItem );
+		await user.click( currentSelectedItem );
 
 		const optionWithCustomAttributes = screen.getByRole( 'option', {
 			name: 'tomato (with custom props)',
@@ -436,7 +448,7 @@ describe.each( [
 			'aria-label'
 		);
 
-		await click( optionWithCustomAttributes );
+		await user.click( optionWithCustomAttributes );
 
 		expect( onChangeMock ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeMock ).toHaveBeenCalledWith(
@@ -465,6 +477,7 @@ describe.each( [
 
 	describe( 'Keyboard behavior and accessibility', () => {
 		it( 'Captures the keypress event and does not let it propagate', async () => {
+			const user = userEvent.setup();
 			const onKeyDown = vi.fn();
 
 			await render(
@@ -479,36 +492,41 @@ describe.each( [
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
-			const customSelect = screen.getByRole( 'listbox', {
-				name: props.label,
-			} );
-			await waitFor( () => expect( customSelect ).toHaveFocus() );
-			await press.Enter();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'listbox', {
+						name: props.label,
+					} )
+				)
+				.toHaveFocus();
+			await user.keyboard( '{Enter}' );
 
 			expect( onKeyDown ).toHaveBeenCalledTimes( 0 );
 		} );
 
 		it( 'Should be able to change selection using keyboard', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...props } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
+			await user.tab();
 			expect( currentSelectedItem ).toHaveFocus();
 
-			await press.Enter();
+			await user.keyboard( '{Enter}' );
 			expect(
 				screen.getByRole( 'listbox', {
 					name: props.label,
 				} )
 			).toHaveFocus();
 
-			await press.ArrowDown();
-			await press.Enter();
+			await user.keyboard( '{ArrowDown}' );
+			await user.keyboard( '{Enter}' );
 
 			expect( currentSelectedItem ).toHaveTextContent(
 				props.options[ 1 ].name
@@ -516,40 +534,42 @@ describe.each( [
 		} );
 
 		it( 'Should be able to type characters to select matching options', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...props } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
-			await press.Enter();
+			await user.tab();
+			await user.keyboard( '{Enter}' );
 			expect(
 				screen.getByRole( 'listbox', {
 					name: props.label,
 				} )
 			).toHaveFocus();
 
-			await type( 'a' );
-			await press.Enter();
+			await user.keyboard( 'a' );
+			await user.keyboard( '{Enter}' );
 			expect( currentSelectedItem ).toHaveTextContent( 'amber' );
 		} );
 
 		it( 'Can change selection with a focused input and closed dropdown if typed characters match an option', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...props } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
+			await user.tab();
 			expect( currentSelectedItem ).toHaveFocus();
 			expect( currentSelectedItem ).toHaveTextContent(
 				props.options[ 0 ].name
 			);
 
 			// Ideally we would test a multi-character typeahead, but anything more than a single character is flaky
-			await type( 'a' );
+			await user.keyboard( 'a' );
 
 			expect(
 				screen.queryByRole( 'listbox', {
@@ -558,27 +578,32 @@ describe.each( [
 				} )
 			).not.toBeInTheDocument();
 
-			// This Enter is a workaround for flakiness, and shouldn't be necessary in an actual browser
-			await press.Enter();
-
-			expect( currentSelectedItem ).toHaveTextContent( 'amber' );
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'combobox', {
+						expanded: false,
+					} )
+				)
+				.toHaveTextContent( 'amber' );
 		} );
 
 		it( 'Can change selection with a focused input and closed dropdown while pressing arrow keys', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...props } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await press.Tab();
+			await user.tab();
 			expect( currentSelectedItem ).toHaveFocus();
 			expect( currentSelectedItem ).toHaveTextContent(
 				props.options[ 0 ].name
 			);
 
-			await press.ArrowDown();
-			await press.ArrowDown();
+			await user.keyboard( '{ArrowDown}' );
+			await user.keyboard( '{ArrowDown}' );
 			expect(
 				screen.queryByRole( 'listbox', {
 					name: props.label,
@@ -591,13 +616,14 @@ describe.each( [
 		} );
 
 		it( 'Should have correct aria-selected value for selections', async () => {
+			const user = userEvent.setup();
 			await render( <Component { ...props } /> );
 
 			const currentSelectedItem = screen.getByRole( 'combobox', {
 				expanded: false,
 			} );
 
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
 			// get all items except for first option
 			const unselectedItems = props.options.filter(
@@ -605,44 +631,60 @@ describe.each( [
 			);
 
 			// assert that all other items have aria-selected="false"
-			unselectedItems.map( ( { name } ) =>
-				expect(
-					screen.getByRole( 'option', { name, selected: false } )
-				).toBeVisible()
-			);
+			for ( const { name } of unselectedItems ) {
+				await expect
+					.element(
+						// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+						page.getByRole( 'option', {
+							name,
+							selected: false,
+						} )
+					)
+					.toBeVisible();
+			}
 
 			// assert that first item has aria-selected="true"
-			expect(
-				screen.getByRole( 'option', {
-					name: props.options[ 0 ].name,
-					selected: true,
-				} )
-			).toBeVisible();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: props.options[ 0 ].name,
+						selected: true,
+					} )
+				)
+				.toBeVisible();
 
 			// change the current selection
-			await click( screen.getByRole( 'option', { name: 'poppy' } ) );
+			await user.click( screen.getByRole( 'option', { name: 'poppy' } ) );
 
 			// click combobox to mount listbox with options again
-			await click( currentSelectedItem );
+			await user.click( currentSelectedItem );
 
 			// check that first item is has aria-selected="false" after new selection
-			expect(
-				screen.getByRole( 'option', {
-					name: props.options[ 0 ].name,
-					selected: false,
-				} )
-			).toBeVisible();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: props.options[ 0 ].name,
+						selected: false,
+					} )
+				)
+				.toBeVisible();
 
 			// check that new selected item now has aria-selected="true"
-			expect(
-				screen.getByRole( 'option', {
-					name: 'poppy',
-					selected: true,
-				} )
-			).toBeVisible();
+			await expect
+				.element(
+					// eslint-disable-next-line testing-library/prefer-screen-queries -- Browser Mode locators provide retryable assertions.
+					page.getByRole( 'option', {
+						name: 'poppy',
+						selected: true,
+					} )
+				)
+				.toBeVisible();
 		} );
 
 		it( 'Should call custom event handlers', async () => {
+			const user = userEvent.setup();
 			const onFocusMock = vi.fn();
 			const onBlurMock = vi.fn();
 
@@ -661,12 +703,12 @@ describe.each( [
 				expanded: false,
 			} );
 
-			await press.Tab();
+			await user.tab();
 
 			expect( currentSelectedItem ).toHaveFocus();
 			expect( onFocusMock ).toHaveBeenCalledTimes( 1 );
 
-			await press.Tab();
+			await user.tab();
 			expect( currentSelectedItem ).not.toHaveFocus();
 			expect( onBlurMock ).toHaveBeenCalledTimes( 1 );
 		} );

--- a/test/unit/config/browser.vitest.js
+++ b/test/unit/config/browser.vitest.js
@@ -4,7 +4,12 @@
 import '@testing-library/jest-dom/vitest';
 // eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, expect } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import './matchers/to-match-style-diff-snapshot.vitest';
 
 // Run browser tests with the same development feature flags as the jsdom
 // project. Browser-native platform APIs intentionally remain untouched.
@@ -17,3 +22,14 @@ globalThis.tinyMCEPreInit = {
 globalThis.userSettings = { uid: 1 };
 
 afterEach( cleanup );
+
+expect.addSnapshotSerializer( {
+	test( value ) {
+		return (
+			typeof value === 'string' && value.startsWith( 'Snapshot Diff:\n' )
+		);
+	},
+	serialize( value ) {
+		return value;
+	},
+} );

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -10,6 +10,8 @@
 					"packages/components/src/alignment-matrix-control/test/index.tsx",
 					"packages/components/src/button/test/index.tsx",
 					"packages/components/src/circular-option-picker/test/index.tsx",
+					"packages/components/src/custom-select-control-v2/test/index.tsx",
+					"packages/components/src/custom-select-control/test/index.tsx",
 					"packages/components/src/search-control/test/index.tsx",
 					"packages/components/src/snackbar/test/index.tsx",
 					"packages/components/src/snackbar/test/list.tsx"


### PR DESCRIPTION
## What?

Follow up to #80855 and #80983.

TL;DR: This moves the two Components custom-select suites from Ariakit's jsdom helpers to canonical Vitest Browser Mode. The necessary change classes are `vitest-browser-react` rendering, per-test `userEvent.setup()`, retryable browser locators, sequential real pointer input, Browser Mode snapshot-matcher parity, and direct workspace dependency ownership.

## Why?

These suites exercise popovers, focus, keyboard selection, typeahead, CSS visibility, and multi-select behavior that benefit from a real browser. Migrating them separately makes the browser-only timing and interaction differences reviewable without coupling them to the larger tabs and composite suites.

## How?

- Routes both custom-select test files to the Chromium project and renders them with `vitest-browser-react`.
- Replaces Ariakit click, keyboard, type, wait, and sleep helpers with per-test `userEvent.setup()` and retryable `page` locators.
- Removes the old extra-Enter typeahead workaround; native browser input selects the matching option directly.
- Replaces concurrent multi-select clicks with sequential user interactions and observable selection assertions.
- Extends browser setup with the existing Vitest style-diff matcher and raw Snapshot Diff serializer. The existing snapshot passes unchanged.
- Declares `vitest-browser-react` directly in `@wordpress/components` and updates the lockfile.

Eleven Components `@ariakit/test` consumer files remain for bounded follow-up PRs.

## Testing Instructions

1. Run the focused browser suites:
   `npm run test:unit:vitest -- --project browser packages/components/src/custom-select-control/test/index.tsx packages/components/src/custom-select-control-v2/test/index.tsx`
2. Run the complete Browser Mode project:
   `npm run test:unit:vitest -- --project browser`
3. Validate routing, type/dependency conventions, and metadata:
   `npm run --workspace @wordpress/unit-tests test:unit:routing`
   `npm run --workspace @wordpress/unit-tests test:unit:conventions`
   `npm run lint:pkg-json -- packages/components/package.json`
   `npm run lint:lockfile`
4. Run the complete Vitest suite:
   `npm run test:unit:vitest`

Verified locally:

- Focused custom-select suites: 2 files and 69 tests passed in Chromium.
- Complete Browser Mode project: 9 files and 165 tests passed.
- Complete suite: 998 passed and 2 skipped files; 34,720 passed and 8 skipped tests.
- Residual Jest partition: 3 suites, 33 tests, 0 snapshots.
- Routing: 996 baseline tests owned exactly once; 1,000 Vitest tests and 3 Jest tests, with 164 tracked renames and 7 additions.
- Convention graph: 1,000 Vitest tests, 1,017 ESM graph files, 102 workspace dependencies, and 402 TypeScript tests.
- Strict JavaScript lint, package metadata, lockfile, and diff checks passed.
- The existing style-diff snapshot passed unchanged; no snapshot file was regenerated.

### Testing Instructions for Keyboard

Not applicable; this changes test infrastructure only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to convert the interaction helpers, investigate real-browser visibility and sequencing failures, add retryable assertions and dependency ownership, and run the verification commands. The resulting diff and unchanged snapshot were reviewed directly.