### PR TITLE
Test: Establish Vitest migration foundation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,6 +24,28 @@ concurrency:
 permissions: {}
 
 jobs:
+    unit-js-routing:
+        name: JavaScript test routing
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+              with:
+                  node-version: '20'
+
+            - name: Validate JavaScript test routing
+              run: npm run test:unit:routing
+
     unit-js:
         name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,6 +48,7 @@ jobs:
 
             - name: Build package TypeScript declarations
               run: |
+                  npx lerna run build
                   npm run --workspace @wordpress/build-scripts generate-worker-placeholders
                   npx tsc --build
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,6 +46,9 @@ jobs:
             - name: Validate JavaScript test routing
               run: npm run test:unit:routing
 
+            - name: Validate Vitest conventions and TypeScript test graph
+              run: npm run test:unit:conventions
+
     unit-js:
         name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -50,7 +50,7 @@ jobs:
               run: |
                   npx lerna run build
                   npm run --workspace @wordpress/build-scripts generate-worker-placeholders
-                  npx tsc --build
+                  npx tsc --build --noCheck
 
             - name: Validate Vitest conventions and TypeScript test graph
               run: npm run test:unit:conventions
@@ -105,7 +105,8 @@ jobs:
                     --ci \
                     --maxWorkers="$(nproc)" \
                     --shard="$SHARD" \
-                    --cacheDirectory="$HOME/.jest-cache"
+                    --cacheDirectory="$HOME/.jest-cache" \
+                    --passWithNoTests
 
             - name: Run the migrated Vitest partition
               env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -47,7 +47,9 @@ jobs:
               run: npm run test:unit:routing
 
             - name: Build package TypeScript declarations
-              run: npx tsc --build
+              run: |
+                  npm run --workspace @wordpress/build-scripts generate-worker-placeholders
+                  npx tsc --build
 
             - name: Validate Vitest conventions and TypeScript test graph
               run: npm run test:unit:conventions

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,6 +46,9 @@ jobs:
             - name: Validate JavaScript test routing
               run: npm run test:unit:routing
 
+            - name: Build package TypeScript declarations
+              run: npx tsc --build
+
             - name: Validate Vitest conventions and TypeScript test graph
               run: npm run test:unit:conventions
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -84,7 +84,7 @@ jobs:
               # build tasks, however. These must be run.
               run: npx lerna run build
 
-            - name: Running the tests
+            - name: Run the remaining Jest partition
               env:
                   SHARD: ${{ matrix.shard }}
                   # Record the Node.js major as a custom flakiness environment
@@ -97,6 +97,17 @@ jobs:
                     --maxWorkers="$(nproc)" \
                     --shard="$SHARD" \
                     --cacheDirectory="$HOME/.jest-cache"
+
+            - name: Run the migrated Vitest partition
+              env:
+                  SHARD: ${{ matrix.shard }}
+                  # Preserve the same Flakiness.io environment identity used
+                  # by the Jest partition.
+                  FK_ENV_NODEJS: ${{ matrix.node }}
+              run: |
+                  npm run test:unit:vitest -- \
+                    --shard="$SHARD" \
+                    --passWithNoTests
 
     unit-js-date:
         name: JavaScript Date Tests (Node.js ${{ matrix.node }})

--- a/package-lock.json
+++ b/package-lock.json
@@ -55776,7 +55776,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@babel/core": "^7.29.7",
+				"@babel/core": "^7.25.7",
 				"@babel/traverse": "^7.25.7",
 				"@emotion/jest": "^11.14.2",
 				"@emotion/styled": "^11.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55777,6 +55777,7 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@babel/core": "^7.29.7",
+				"@babel/traverse": "^7.25.7",
 				"@emotion/jest": "^11.14.2",
 				"@emotion/styled": "^11.14.1",
 				"@flakiness/jest": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48790,6 +48790,57 @@
 				}
 			}
 		},
+		"node_modules/vite-plugin-commonjs": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/vite-plugin-commonjs/-/vite-plugin-commonjs-0.10.4.tgz",
+			"integrity": "sha512-eWQuvQKCcx0QYB5e5xfxBNjQKyrjEWZIR9UOkOV6JAgxVhtbZvCOF+FNC2ZijBJ3U3Px04ZMMyyMyFBVWIJ5+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.12.1",
+				"magic-string": "^0.30.11",
+				"vite-plugin-dynamic-import": "^1.6.0"
+			}
+		},
+		"node_modules/vite-plugin-commonjs/node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/vite-plugin-dynamic-import": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-dynamic-import/-/vite-plugin-dynamic-import-1.6.0.tgz",
+			"integrity": "sha512-TM0sz70wfzTIo9YCxVFwS8OA9lNREsh+0vMHGSkWDTZ7bgd1Yjs5RV8EgB634l/91IsXJReg0xtmuQqP0mf+rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.12.1",
+				"es-module-lexer": "^1.5.4",
+				"fast-glob": "^3.3.2",
+				"magic-string": "^0.30.11"
+			}
+		},
+		"node_modules/vite-plugin-dynamic-import/node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/vite/node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -55725,6 +55776,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@babel/core": "^7.29.7",
 				"@emotion/jest": "^11.14.2",
 				"@flakiness/jest": "^1.3.1",
 				"@flakiness/vitest": "^1.9.0",
@@ -55732,8 +55784,11 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
+				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
 				"@wordpress/scripts": "file:../../packages/scripts",
+				"@wordpress/video-conversion": "file:../../packages/video-conversion",
+				"@wordpress/vips": "file:../../packages/vips",
 				"babel-jest": "^30.4.1",
 				"babel-plugin-transform-import-meta": "^2.3.3",
 				"client-zip": "^2.4.5",
@@ -55748,7 +55803,9 @@
 				"resize-observer-polyfill": "^1.5.1",
 				"snapshot-diff": "^0.10.0",
 				"timezone-mock": "^1.3.6",
-				"vitest": "^4.1.10"
+				"vite-plugin-commonjs": "^0.10.4",
+				"vitest": "^4.1.10",
+				"yargs": "^17.7.2"
 			}
 		},
 		"test/unit/node_modules/@jest/schemas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3461,6 +3461,16 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/@flakiness/vitest": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@flakiness/vitest/-/vitest-1.9.0.tgz",
+			"integrity": "sha512-13HkpcFJh03+PsFPT1+8u4XjohY9YTLGz4v1rjtuPtVZ6FgRs+eUJrKFF8GpNa3Xlr5DwgjgxunVhI1vqyoR4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/@floating-ui/core": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -13620,6 +13630,13 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@storybook/addon-a11y": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.5.tgz",
@@ -16865,6 +16882,53 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/@vitest/pretty-format": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -16876,6 +16940,126 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/runner/node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@vitest/spy": {
@@ -25832,6 +26016,16 @@
 			"deprecated": "⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/exponential-backoff": {
 			"version": "3.1.3",
@@ -39342,6 +39536,20 @@
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
 			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
 		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/octokit": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
@@ -40978,6 +41186,13 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pathval": {
 			"version": "2.0.0",
@@ -44784,6 +44999,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -45504,6 +45726,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/stackframe": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -45546,6 +45775,13 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
@@ -47095,6 +47331,13 @@
 			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
 			"license": "MIT"
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinyexec": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -48575,6 +48818,199 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest/node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vitest/node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest/node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/vm-browserify": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -49713,6 +50149,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/wide-align": {
@@ -52415,6 +52868,9 @@
 			"name": "@wordpress/html-entities",
 			"version": "4.51.0",
 			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^4.1.10"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -55271,6 +55727,7 @@
 			"devDependencies": {
 				"@emotion/jest": "^11.14.2",
 				"@flakiness/jest": "^1.3.1",
+				"@flakiness/vitest": "^1.9.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -55287,9 +55744,11 @@
 				"jest-junit": "^17.0.0",
 				"jest-message-util": "^30.4.1",
 				"jest-watch-typeahead": "^3.0.1",
+				"jsdom": "^26.1.0",
 				"resize-observer-polyfill": "^1.5.1",
 				"snapshot-diff": "^0.10.0",
-				"timezone-mock": "^1.3.6"
+				"timezone-mock": "^1.3.6",
+				"vitest": "^4.1.10"
 			}
 		},
 		"test/unit/node_modules/@jest/schemas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55807,7 +55807,7 @@
 				"timezone-mock": "^1.3.6",
 				"vite-plugin-commonjs": "^0.10.4",
 				"vitest": "^4.1.10",
-				"yargs": "^17.7.2"
+				"yargs": "^17.3.0"
 			}
 		},
 		"test/unit/node_modules/@jest/schemas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55778,6 +55778,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.29.7",
 				"@emotion/jest": "^11.14.2",
+				"@emotion/styled": "^11.14.1",
 				"@flakiness/jest": "^1.3.1",
 				"@flakiness/vitest": "^1.9.0",
 				"@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
 		"test:php": "npm-run-all lint:php test:unit:php",
 		"test:php:watch": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script test:watch",
 		"test:unit": "npm run --workspace @wordpress/unit-tests test:unit --",
+		"test:unit:routing": "npm run --workspace @wordpress/unit-tests test:unit:routing",
 		"test:unit:date": "bash ./bin/unit-test-date.sh",
 		"test:unit:debug": "npm run --workspace @wordpress/unit-tests test:unit:debug --",
 		"test:unit:profile": "npm run --workspace @wordpress/unit-tests test:unit:profile --",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
 		"test:php": "npm-run-all lint:php test:unit:php",
 		"test:php:watch": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script test:watch",
 		"test:unit": "npm run --workspace @wordpress/unit-tests test:unit --",
+		"test:unit:vitest": "npm run --workspace @wordpress/unit-tests test:unit:vitest --",
 		"test:unit:routing": "npm run --workspace @wordpress/unit-tests test:unit:routing",
 		"test:unit:date": "bash ./bin/unit-test-date.sh",
 		"test:unit:debug": "npm run --workspace @wordpress/unit-tests test:unit:debug --",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
 		"test:php": "npm-run-all lint:php test:unit:php",
 		"test:php:watch": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script test:watch",
 		"test:unit": "npm run --workspace @wordpress/unit-tests test:unit --",
+		"test:unit:conventions": "npm run --workspace @wordpress/unit-tests test:unit:conventions",
 		"test:unit:vitest": "npm run --workspace @wordpress/unit-tests test:unit:vitest --",
 		"test:unit:routing": "npm run --workspace @wordpress/unit-tests test:unit:routing",
 		"test:unit:date": "bash ./bin/unit-test-date.sh",

--- a/packages/abilities/src/store/tests/reducer.test.ts
+++ b/packages/abilities/src/store/tests/reducer.test.ts
@@ -23,16 +23,20 @@ describe( 'Store Reducer', () => {
 					name: 'test/ability',
 					label: 'Test Ability',
 					description: 'Test ability',
+					category: 'test-category',
 					callback: () => Promise.resolve( {} ),
 				};
 
 				const action = {
 					type: REGISTER_ABILITY,
 					ability,
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: defaultState },
+					{
+						abilitiesByName: defaultState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -49,6 +53,7 @@ describe( 'Store Reducer', () => {
 					name: 'test/ability',
 					label: 'Test Ability',
 					description: 'Test ability',
+					category: 'test-category',
 					callback: () => Promise.resolve( {} ),
 					// Extra properties that should be filtered out
 					_links: { self: { href: '/test' } },
@@ -58,10 +63,13 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY,
 					ability,
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: defaultState },
+					{
+						abilitiesByName: defaultState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 				const registeredAbility =
@@ -84,6 +92,7 @@ describe( 'Store Reducer', () => {
 						name: 'test/ability',
 						label: 'Old Label',
 						description: 'Old description',
+						category: 'test-category',
 					},
 				};
 
@@ -91,16 +100,20 @@ describe( 'Store Reducer', () => {
 					name: 'test/ability',
 					label: 'New Label',
 					description: 'New description',
+					category: 'test-category',
 					input_schema: { type: 'string' },
 				};
 
 				const action = {
 					type: REGISTER_ABILITY,
 					ability,
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: initialState },
+					{
+						abilitiesByName: initialState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -123,21 +136,26 @@ describe( 'Store Reducer', () => {
 						name: 'test/ability1',
 						label: 'Test Ability 1',
 						description: 'First test ability',
+						category: 'test-category',
 					},
 					'test/ability2': {
 						name: 'test/ability2',
 						label: 'Test Ability 2',
 						description: 'Second test ability',
+						category: 'test-category',
 					},
 				};
 
 				const action = {
 					type: UNREGISTER_ABILITY,
 					name: 'test/ability1',
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: initialState },
+					{
+						abilitiesByName: initialState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -157,16 +175,20 @@ describe( 'Store Reducer', () => {
 						name: 'test/ability',
 						label: 'Test Ability',
 						description: 'Test ability',
+						category: 'test-category',
 					},
 				};
 
 				const action = {
 					type: UNREGISTER_ABILITY,
 					name: 'test/non-existent',
-				};
+				} as const;
 
 				const state = reducer(
-					{ abilitiesByName: initialState },
+					{
+						abilitiesByName: initialState,
+						categoriesBySlug: {},
+					},
 					action
 				);
 
@@ -180,8 +202,13 @@ describe( 'Store Reducer', () => {
 				};
 
 				const state = reducer(
-					{ abilitiesByName: defaultState },
-					action
+					{
+						abilitiesByName: defaultState,
+						categoriesBySlug: {},
+					},
+					// Intentionally bypass the static contract to cover the
+					// reducer's defensive handling of invalid runtime input.
+					action as never
 				);
 
 				expect( state.abilitiesByName ).toEqual( defaultState );
@@ -203,7 +230,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
@@ -229,7 +256,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
@@ -255,7 +282,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
@@ -298,7 +325,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: REGISTER_ABILITY_CATEGORY,
 					category,
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
@@ -324,7 +351,9 @@ describe( 'Store Reducer', () => {
 
 				const state = reducer(
 					{ categoriesBySlug: defaultState, abilitiesByName: {} },
-					action
+					// Intentionally bypass the static contract to cover the
+					// reducer's defensive handling of invalid runtime input.
+					action as never
 				);
 
 				expect( state.categoriesBySlug ).toEqual( defaultState );
@@ -349,7 +378,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: UNREGISTER_ABILITY_CATEGORY,
 					slug: 'category1',
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
@@ -374,7 +403,7 @@ describe( 'Store Reducer', () => {
 				const action = {
 					type: UNREGISTER_ABILITY_CATEGORY,
 					slug: 'non-existent',
-				};
+				} as const;
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
@@ -400,7 +429,9 @@ describe( 'Store Reducer', () => {
 
 				const state = reducer(
 					{ categoriesBySlug: initialState, abilitiesByName: {} },
-					action
+					// Intentionally bypass the static contract to cover the
+					// reducer's defensive handling of invalid runtime input.
+					action as never
 				);
 
 				expect( state.categoriesBySlug ).toEqual( initialState );

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -42,6 +42,9 @@
 	},
 	"wpScript": true,
 	"types": "build-types",
+	"devDependencies": {
+		"vitest": "^4.1.10"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/html-entities/src/test/entities.ts
+++ b/packages/html-entities/src/test/entities.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
  * Internal dependencies
  */
 import { decodeEntities } from '..';

--- a/packages/is-shallow-equal/test/index.ts
+++ b/packages/is-shallow-equal/test/index.ts
@@ -149,7 +149,7 @@ describe( 'isShallowEqual', () => {
 	} );
 
 	it( 'returns true on arrays that are a copy of each other', () => {
-		const a = [];
+		const a: unknown[] = [];
 		const b = a;
 
 		expect( isShallowEqual( a, b ) ).toBe( true );

--- a/packages/widget-dashboard/src/test/commands.test.tsx
+++ b/packages/widget-dashboard/src/test/commands.test.tsx
@@ -25,13 +25,24 @@ const layout: DashboardWidget[] = [
 	{ uuid: 'a', type: 'core/test', placement: { width: 1, height: 1 } },
 ];
 
+interface CommandsSelectors {
+	getContext: () => string;
+	getCommands: ( contextual: boolean ) => Array< { name: string } >;
+}
+
 function CommandsProbe( { names }: { names: string[] } ) {
 	const context = useSelect(
-		( select ) => select( commandsStore ).getContext(),
+		( select ) =>
+			(
+				select( commandsStore ) as unknown as CommandsSelectors
+			 ).getContext(),
 		[]
 	);
 	const contextualCommands = useSelect(
-		( select ) => select( commandsStore ).getCommands( true ),
+		( select ) =>
+			(
+				select( commandsStore ) as unknown as CommandsSelectors
+			 ).getCommands( true ),
 		[]
 	);
 

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -4,21 +4,20 @@ The migration manifest in `test-migration.json` keeps every JavaScript unit and
 integration test assigned to exactly one runner while the repository moves from
 Jest to Vitest.
 
-The baseline count and hash were captured from executable Jest discovery with
-`jest --listTests`, then reconciled with the repository's static test-file
-patterns. Do not update the baseline when moving tests between runners.
+The routing validator derives the current test inventory from both runners and
+the repository's static test-file patterns. It does not depend on a fixed test
+count, so unrelated test additions and removals do not require migration
+metadata updates.
 
 When changing test ownership:
 
 -   Add individual tests to `vitest.files`, or use `vitest.directories` when an
     entire directory can move as one independently revertible unit.
--   Add tests created during the migration to the matching `added.jest` or
-    `added.vitest` list.
--   Add removed baseline tests to `retired` only when their removal is intentional
-    and explained in the pull request.
+-   New Jest tests require no migration metadata; runner discovery picks them up
+    automatically.
 -   Run `npm run test:unit:routing` together with both active runner partitions.
 
-The routing validator fails when a baseline test is missing, owned by both
-runners, or retired without removing its file. It also rejects invalid manifest
-entries, untracked new tests, static/executable discovery mismatches, and
-orphaned snapshots.
+The routing validator fails when a test is missing, owned by both runners, or
+not assigned to the expected Vitest migration entry. It also rejects invalid
+manifest entries, static/executable discovery mismatches, and orphaned
+snapshots.

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -1,0 +1,24 @@
+# Vitest migration routing
+
+The migration manifest in `test-migration.json` keeps every JavaScript unit and
+integration test assigned to exactly one runner while the repository moves from
+Jest to Vitest.
+
+The baseline count and hash were captured from executable Jest discovery with
+`jest --listTests`, then reconciled with the repository's static test-file
+patterns. Do not update the baseline when moving tests between runners.
+
+When changing test ownership:
+
+-   Add individual tests to `vitest.files`, or use `vitest.directories` when an
+    entire directory can move as one independently revertible unit.
+-   Add tests created during the migration to the matching `added.jest` or
+    `added.vitest` list.
+-   Add removed baseline tests to `retired` only when their removal is intentional
+    and explained in the pull request.
+-   Run `npm run test:unit:routing` together with both active runner partitions.
+
+The routing validator fails when a baseline test is missing, owned by both
+runners, or retired without removing its file. It also rejects invalid manifest
+entries, untracked new tests, static/executable discovery mismatches, and
+orphaned snapshots.

--- a/test/unit/config/__snapshots__/emotion-serializer.vitest.test.jsx.snap
+++ b/test/unit/config/__snapshots__/emotion-serializer.vitest.test.jsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Emotion snapshot serializer > preserves stable labels for empty styled components 1`] = `
+<div
+  class="css-19mgf5f-EmptyBox emotion-0"
+>
+  Content
+</div>
+`;

--- a/test/unit/config/console.vitest.js
+++ b/test/unit/config/console.vitest.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { afterEach, beforeAll, beforeEach, expect, vi } from 'vitest';
+
+const supportedMatchers = {
+	error: 'toHaveErrored',
+	info: 'toHaveInformed',
+	log: 'toHaveLogged',
+	warn: 'toHaveWarned',
+};
+
+function createErrorMessage( state, spyInfo ) {
+	const { spy, pass, calls, matcherName, methodName, expected } = spyInfo;
+	const hint = pass ? `.not${ matcherName }` : matcherName;
+	const message = pass
+		? `Expected mock function not to be called but it was called with:\n${ calls.map(
+				state.utils.printReceived
+		  ) }`
+		: `Expected mock function to be called${
+				expected
+					? ` with:\n${ state.utils.printExpected( expected ) }\n`
+					: '.'
+		  }\nbut it was called with:\n${ calls.map(
+				state.utils.printReceived
+		  ) }`;
+
+	return () =>
+		`${ state.utils.matcherHint( hint, spy.getMockName() ) }` +
+		'\n\n' +
+		message +
+		'\n\n' +
+		`console.${ methodName }() should not be used unless explicitly expected\n` +
+		'See https://www.npmjs.com/package/@wordpress/vitest-console for details.';
+}
+
+function createSpyInfo( state, spy, matcherName, methodName, expected ) {
+	const calls = spy.mock.calls;
+	const pass = expected
+		? JSON.stringify( calls ).includes( JSON.stringify( expected ) )
+		: calls.length > 0;
+
+	return {
+		pass,
+		message: createErrorMessage( state, {
+			spy,
+			pass,
+			calls,
+			matcherName,
+			methodName,
+			expected,
+		} ),
+	};
+}
+
+expect.extend(
+	Object.entries( supportedMatchers ).reduce(
+		( result, [ methodName, matcherName ] ) => {
+			const matcherNameWith = `${ matcherName }With`;
+
+			return {
+				...result,
+				[ matcherName ]( received ) {
+					const spy = received[ methodName ];
+					const spyInfo = createSpyInfo(
+						this,
+						spy,
+						`.${ matcherName }`,
+						methodName
+					);
+					spy.assertionsNumber += 1;
+					return spyInfo;
+				},
+				[ matcherNameWith ]( received, ...expected ) {
+					const spy = received[ methodName ];
+					const spyInfo = createSpyInfo(
+						this,
+						spy,
+						`.${ matcherNameWith }`,
+						methodName,
+						expected
+					);
+					spy.assertionsNumber += 1;
+					return spyInfo;
+				},
+			};
+		},
+		{}
+	)
+);
+
+vi.spyOn( console, 'groupCollapsed' ).mockImplementation( () => undefined );
+vi.spyOn( console, 'groupEnd' ).mockImplementation( () => undefined );
+
+function setConsoleMethodSpy( [ methodName, matcherName ] ) {
+	const spy = vi
+		.spyOn( console, methodName )
+		.mockName( `console.${ methodName }` );
+
+	function resetSpy() {
+		spy.mockReset();
+		spy.mockImplementation( () => undefined );
+		spy.assertionsNumber = 0;
+	}
+
+	function assertExpectedCalls() {
+		if ( spy.assertionsNumber === 0 && spy.mock.calls.length > 0 ) {
+			expect( console ).not[ matcherName ]();
+		}
+	}
+
+	beforeAll( resetSpy );
+	beforeEach( () => {
+		assertExpectedCalls();
+		resetSpy();
+	} );
+	afterEach( assertExpectedCalls );
+}
+
+Object.entries( supportedMatchers ).forEach( setConsoleMethodSpy );

--- a/test/unit/config/console.vitest.test.js
+++ b/test/unit/config/console.vitest.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, test } from 'vitest';
+
+describe( 'Vitest console matchers', () => {
+	describe.each( [
+		[ 'error', 'toHaveErrored' ],
+		[ 'info', 'toHaveInformed' ],
+		[ 'log', 'toHaveLogged' ],
+		[ 'warn', 'toHaveWarned' ],
+	] )( 'console.%s', ( methodName, matcherName ) => {
+		const matcherNameWith = `${ matcherName }With`;
+		const message = `This is ${ methodName }!`;
+
+		test( `${ matcherName } accepts an expected console call`, () => {
+			console[ methodName ]( message );
+			expect( console )[ matcherName ]();
+		} );
+
+		test( `${ matcherName } rejects a missing console call`, () => {
+			expect( console ).not[ matcherName ]();
+			expect( () => expect( console )[ matcherName ]() ).toThrow(
+				'Expected mock function to be called.'
+			);
+		} );
+
+		test( `${ matcherNameWith } accepts matching arguments`, () => {
+			console[ methodName ]( message );
+			expect( console )[ matcherNameWith ]( message );
+		} );
+
+		test( `${ matcherNameWith } rejects non-matching arguments`, () => {
+			console[ methodName ]( 'Unknown message.' );
+			console[ methodName ]( message, 'Unknown param.' );
+
+			expect( console ).not[ matcherNameWith ]( message );
+			expect( () =>
+				expect( console )[ matcherNameWith ]( message )
+			).toThrow(
+				/Expected mock function to be called with:.*but it was called with:.*Unknown param./s
+			);
+		} );
+
+		test( 'tracks matcher assertions for lifecycle validation', () => {
+			const spy = console[ methodName ];
+
+			expect( spy.assertionsNumber ).toBe( 0 );
+			console[ methodName ]( message );
+			expect( console )[ matcherName ]();
+			expect( spy.assertionsNumber ).toBe( 1 );
+			expect( console )[ matcherNameWith ]( message );
+			expect( spy.assertionsNumber ).toBe( 2 );
+		} );
+	} );
+
+	it( 'does not treat collapsed console groups as log calls', () => {
+		console.groupCollapsed( 'Details' );
+		console.groupEnd();
+
+		expect( console ).not.toHaveLogged();
+	} );
+} );
+
+/* eslint-enable no-console */

--- a/test/unit/config/emotion-serializer.vitest.js
+++ b/test/unit/config/emotion-serializer.vitest.js
@@ -1,0 +1,42 @@
+function isEmptyEmotionClass( className ) {
+	const matchingRules = [];
+	const classSelector = `.${ className }`;
+
+	const collectMatchingRules = ( rules ) => {
+		Array.from( rules ).forEach( ( rule ) => {
+			if ( rule.cssRules ) {
+				collectMatchingRules( rule.cssRules );
+			}
+
+			if ( rule.selectorText?.includes( classSelector ) ) {
+				matchingRules.push( rule );
+			}
+		} );
+	};
+
+	Array.from( document.querySelectorAll( 'style[data-emotion]' ) ).forEach(
+		( element ) => collectMatchingRules( element.sheet?.cssRules ?? [] )
+	);
+
+	return (
+		matchingRules.length > 0 &&
+		matchingRules.every( ( rule ) => rule.style?.length === 0 )
+	);
+}
+
+export function createClassNameReplacer() {
+	let preservedClassNames = 0;
+
+	return ( className, index ) => {
+		if ( index === 0 ) {
+			preservedClassNames = 0;
+		}
+
+		if ( isEmptyEmotionClass( className ) ) {
+			preservedClassNames++;
+			return className;
+		}
+
+		return `emotion-${ index - preservedClassNames }`;
+	};
+}

--- a/test/unit/config/emotion-serializer.vitest.test.jsx
+++ b/test/unit/config/emotion-serializer.vitest.test.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe( 'Emotion snapshot serializer', () => {
+	it( 'preserves the established class and CSS snapshot format', () => {
+		const Box = styled.div`
+			color: red;
+		`;
+		const { container } = render( <Box>Content</Box> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- The serializer input is the rendered root node.
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			.emotion-0 {
+			  color: red;
+			}
+
+			<div
+			  class="emotion-0 emotion-1"
+			>
+			  Content
+			</div>
+		` );
+	} );
+
+	it( 'preserves stable labels for empty styled components', () => {
+		const EmptyBox = styled.div``;
+		const { container } = render( <EmptyBox>Content</EmptyBox> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- The serializer input is the rendered root node.
+		expect( container.firstChild ).toMatchSnapshot();
+	} );
+} );

--- a/test/unit/config/fixtures/module.wasm
+++ b/test/unit/config/fixtures/module.wasm
@@ -1,0 +1,1 @@
+This fixture must be replaced by the Vitest WASM alias before it is loaded.

--- a/test/unit/config/fixtures/setup.module.scss
+++ b/test/unit/config/fixtures/setup.module.scss
@@ -1,0 +1,1 @@
+// The Vitest CSS proxy replaces this module during tests.

--- a/test/unit/config/global-mocks.vitest.js
+++ b/test/unit/config/global-mocks.vitest.js
@@ -1,0 +1,162 @@
+/**
+ * Node dependencies
+ */
+import { Blob as BlobPolyfill, File as FilePolyfill } from 'node:buffer';
+import { TextDecoder, TextEncoder } from 'node:util';
+
+/**
+ * External dependencies
+ */
+import ResizeObserver from 'resize-observer-polyfill';
+import timezoneMock from 'timezone-mock';
+import { vi } from 'vitest';
+
+const OriginalDate = globalThis.Date;
+timezoneMock.options( {
+	fallbackFn: ( parameter ) => {
+		if ( parameter instanceof OriginalDate ) {
+			return new timezoneMock._Date( parameter.valueOf() );
+		}
+
+		throw new Error(
+			`Unhandled type passed to MockDate constructor: ${ typeof parameter }`
+		);
+	},
+} );
+
+if ( typeof globalThis.structuredClone === 'undefined' ) {
+	globalThis.structuredClone = ( value ) =>
+		JSON.parse( JSON.stringify( value ) );
+}
+
+vi.mock( '@wordpress/compose', async () => ( {
+	...( await vi.importActual( '@wordpress/compose' ) ),
+	useViewportMatch: vi.fn(),
+} ) );
+
+vi.mock( '@wordpress/block-editor/src/hooks/list-view', () => ( {
+	LIST_VIEW_SUPPORT_KEY: 'listView',
+	hasListViewSupport: vi.fn( () => false ),
+	ListViewPanel: vi.fn( () => null ),
+	default: {
+		edit: vi.fn( () => null ),
+		hasSupport: vi.fn( () => false ),
+		attributeKeys: [],
+	},
+} ) );
+
+vi.mock( 'client-zip', () => ( {
+	downloadZip: vi.fn(),
+} ) );
+
+globalThis.ResizeObserver = ResizeObserver;
+
+class FakeDOMRectList extends Array {
+	item( index ) {
+		return this[ index ] ?? null;
+	}
+}
+
+function hasAssociatedLayoutBox( element ) {
+	if ( ! element.isConnected ) {
+		return false;
+	}
+
+	let current = element;
+	while ( current ) {
+		if ( current.hidden || current.style?.display === 'none' ) {
+			return false;
+		}
+
+		if ( current === element && current.style?.display === 'contents' ) {
+			return false;
+		}
+
+		current = current.parentElement;
+	}
+
+	return true;
+}
+
+if ( typeof window !== 'undefined' ) {
+	window.wp = window.wp || {};
+	window.wp.oldEditor = {};
+
+	if ( ! globalThis.HTMLElement.prototype.getAnimations ) {
+		globalThis.HTMLElement.prototype.getAnimations = () => [];
+	}
+
+	if ( ! globalThis.CSS ) {
+		globalThis.CSS = {};
+	}
+	if ( ! globalThis.CSS.supports ) {
+		globalThis.CSS.supports = vi.fn( () => false );
+	}
+
+	if ( ! window.DOMRect ) {
+		window.DOMRect = class DOMRect {};
+	}
+
+	globalThis.Element.prototype.scrollIntoView = vi.fn();
+	globalThis.Element.prototype.getClientRects = function () {
+		const rects = [];
+		if ( hasAssociatedLayoutBox( this ) ) {
+			rects.push( {
+				bottom: 1,
+				height: 1,
+				left: 0,
+				right: 1,
+				top: 0,
+				width: 1,
+				x: 0,
+				y: 0,
+			} );
+		}
+
+		return new FakeDOMRectList( ...rects );
+	};
+}
+
+if ( ! globalThis.TextDecoder ) {
+	globalThis.TextDecoder = TextDecoder;
+}
+if ( ! globalThis.TextEncoder ) {
+	globalThis.TextEncoder = TextEncoder;
+}
+
+globalThis.Blob = BlobPolyfill;
+globalThis.File = FilePolyfill;
+
+vi.mock( '@testing-library/user-event', async () => {
+	if ( typeof globalThis.window === 'undefined' ) {
+		return {};
+	}
+
+	const actual = await vi.importActual( '@testing-library/user-event' );
+	const patchedUserEvent = {
+		...actual.userEvent,
+		setup( ...args ) {
+			const user = actual.userEvent.setup( ...args );
+			const { focus, blur } = globalThis.HTMLElement.prototype;
+			Object.defineProperties( globalThis.HTMLElement.prototype, {
+				focus: {
+					configurable: true,
+					value: focus,
+					writable: true,
+				},
+				blur: {
+					configurable: true,
+					value: blur,
+					writable: true,
+				},
+			} );
+			return user;
+		},
+	};
+
+	return {
+		...actual,
+		userEvent: patchedUserEvent,
+		default: patchedUserEvent,
+	};
+} );

--- a/test/unit/config/matchers/test/__snapshots__/to-match-diff-snapshot.vitest.test.js.snap
+++ b/test/unit/config/matchers/test/__snapshots__/to-match-diff-snapshot.vitest.test.js.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`snapshotDiff > captures matching stylesheet declarations > style colors 1`] = `
+Snapshot Diff:
+- Received styles
++ Base styles
+
+  Array [
+    Object {
+-     "color": "red",
++     "color": "blue",
+    },
+  ]
+`;
+
+exports[`snapshotDiff > formats the established uncolored object diff > object visibility 1`] = `
+Snapshot Diff:
+- First value
++ Second value
+
+  Object {
+-   "visible": false,
++   "visible": true,
+  }
+`;
+
+exports[`snapshotDiff > supports custom annotations > custom annotations 1`] = `
+Snapshot Diff:
+- Received styles
++ Base styles
+
+  Array [
+-   "old",
++   "new",
+  ]
+`;

--- a/test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js
+++ b/test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from 'vitest';
+
+describe( 'snapshotDiff', () => {
+	it( 'formats the established uncolored object diff', () => {
+		expect( { visible: false } ).toMatchDiffSnapshot(
+			{ visible: true },
+			{},
+			'object visibility'
+		);
+	} );
+
+	it( 'supports custom annotations', () => {
+		expect( [ 'old' ] ).toMatchDiffSnapshot(
+			[ 'new' ],
+			{
+				aAnnotation: 'Received styles',
+				bAnnotation: 'Base styles',
+			},
+			'custom annotations'
+		);
+	} );
+
+	it( 'captures matching stylesheet declarations', () => {
+		const style = document.createElement( 'style' );
+		style.textContent = '.received { color: red; } .base { color: blue; }';
+		const received = document.createElement( 'div' );
+		const base = document.createElement( 'div' );
+		received.className = 'received';
+		base.className = 'base';
+		document.head.append( style );
+		document.body.append( received, base );
+
+		expect( received ).toMatchStyleDiffSnapshot( base, 'style colors' );
+
+		style.remove();
+		received.remove();
+		base.remove();
+	} );
+
+	it( 'recognizes positioned popovers', () => {
+		const popover = document.createElement( 'div' );
+		const child = document.createElement( 'span' );
+		popover.className = 'components-popover is-positioned';
+		popover.append( child );
+
+		expect( child ).toBePositionedPopover();
+	} );
+} );

--- a/test/unit/config/matchers/to-be-positioned-popover.vitest.js
+++ b/test/unit/config/matchers/to-be-positioned-popover.vitest.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'vitest';
+
+function toBePositionedPopover( element ) {
+	const popover = element?.closest( '.components-popover' );
+	const isPopoverPositioned = popover?.classList.contains( 'is-positioned' );
+	const pass = !! isPopoverPositioned;
+
+	return {
+		pass,
+		message: () => {
+			const is = pass ? 'is' : 'is not';
+			return ! popover
+				? `Received element ${ is } a popover element or its descendant.`
+				: `Received element ${ is } positioned`;
+		},
+	};
+}
+
+expect.extend( { toBePositionedPopover } );

--- a/test/unit/config/matchers/to-match-diff-snapshot.vitest.js
+++ b/test/unit/config/matchers/to-match-diff-snapshot.vitest.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { expect, Snapshots } from 'vitest';
+
+const identity = ( value ) => value;
+
+export function snapshotDiff( valueA, valueB, options = {}, utils ) {
+	const difference = utils.diff( valueA, valueB, {
+		aAnnotation: 'First value',
+		aColor: identity,
+		bAnnotation: 'Second value',
+		bColor: identity,
+		changeColor: identity,
+		commonColor: identity,
+		contextLines: -1,
+		expand: false,
+		patchColor: identity,
+		printBasicPrototype: true,
+		...options,
+	} );
+
+	return `Snapshot Diff:\n${
+		difference ?? 'Compared values have no visual difference.'
+	}`;
+}
+
+function toMatchDiffSnapshot(
+	received,
+	expected,
+	options = {},
+	testName = ''
+) {
+	return Snapshots.toMatchSnapshot.call(
+		this,
+		snapshotDiff( received, expected, options, this.utils ),
+		testName
+	);
+}
+
+expect.extend( { toMatchDiffSnapshot } );

--- a/test/unit/config/matchers/to-match-style-diff-snapshot.vitest.js
+++ b/test/unit/config/matchers/to-match-style-diff-snapshot.vitest.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { expect, Snapshots } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import { snapshotDiff } from './to-match-diff-snapshot.vitest';
+
+const getStyleSheets = () =>
+	Array.from( document.getElementsByTagName( 'style' ) );
+
+const getStyleRulesForElement = ( element, styleSheets ) => {
+	return styleSheets.reduce( ( matchingRules, styleSheet ) => {
+		const found = [];
+
+		try {
+			Array.from( styleSheet.sheet.cssRules ).forEach( ( rule ) => {
+				if ( element?.matches( rule.selectorText ) ) {
+					found.push( rule.style );
+				}
+			} );
+		} catch {}
+
+		return [ ...matchingRules, ...found ];
+	}, [] );
+};
+
+const cleanStyleRule = ( rule ) => {
+	const size = Array.from( Array( rule.length ).keys() );
+	return size.reduce( ( result, index ) => {
+		const key = rule[ index ];
+		return { ...result, [ key ]: rule[ key ] };
+	}, {} );
+};
+
+function toMatchStyleDiffSnapshot( received, expected, testName = '' ) {
+	const styleSheets = getStyleSheets();
+	const receivedStyles = getStyleRulesForElement( received, styleSheets ).map(
+		cleanStyleRule
+	);
+	const expectedStyles = getStyleRulesForElement( expected, styleSheets ).map(
+		cleanStyleRule
+	);
+	const difference = snapshotDiff(
+		receivedStyles,
+		expectedStyles,
+		{
+			aAnnotation: 'Received styles',
+			bAnnotation: 'Base styles',
+		},
+		this.utils
+	);
+
+	return Snapshots.toMatchSnapshot.call( this, difference, testName );
+}
+
+expect.extend( { toMatchStyleDiffSnapshot } );

--- a/test/unit/config/setup-globals.vitest.js
+++ b/test/unit/config/setup-globals.vitest.js
@@ -1,0 +1,45 @@
+// Run all tests with development tools enabled.
+// eslint-disable-next-line @wordpress/wp-global-usage
+globalThis.SCRIPT_DEBUG = true;
+
+if ( typeof globalThis.window !== 'undefined' ) {
+	globalThis.window.tinyMCEPreInit = {
+		baseURL: 'about:blank',
+	};
+
+	globalThis.window.setImmediate = function ( callback ) {
+		return setTimeout( callback, 0 );
+	};
+
+	globalThis.window.requestIdleCallback = function requestIdleCallback(
+		callback
+	) {
+		const start = Date.now();
+
+		return setTimeout(
+			() =>
+				callback( {
+					didTimeout: false,
+					timeRemaining: () =>
+						Math.max( 0, 50 - ( Date.now() - start ) ),
+				} ),
+			0
+		);
+	};
+
+	globalThis.window.cancelIdleCallback = function cancelIdleCallback(
+		handle
+	) {
+		return clearTimeout( handle );
+	};
+
+	globalThis.window.matchMedia = () => ( {
+		matches: false,
+		addListener: () => {},
+		addEventListener: () => {},
+		removeListener: () => {},
+		removeEventListener: () => {},
+	} );
+
+	globalThis.window.userSettings = { uid: 1 };
+}

--- a/test/unit/config/setup.vitest.test.jsx
+++ b/test/unit/config/setup.vitest.test.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { decodeEntities } from '@wordpress/html-entities';
+import { convertGifToVideo } from '@wordpress/video-conversion/worker';
+import { vipsResizeImage } from '@wordpress/vips/worker';
+
+/**
+ * Internal dependencies
+ */
+import styles from './fixtures/setup.module.scss';
+import * as wasmModule from './fixtures/module.wasm';
+
+describe( 'Vitest repository setup', () => {
+	it( 'preserves aliases, DOM globals, CSS modules, and worker stubs', () => {
+		render( <div className={ styles.primaryAction }>Setup content</div> );
+
+		expect( screen.getByText( 'Setup content' ) ).toHaveClass(
+			'style-primary-action'
+		);
+		expect( decodeEntities( '&amp;' ) ).toBe( '&' );
+		// eslint-disable-next-line @wordpress/wp-global-usage -- This compatibility test verifies the test-only global.
+		expect( globalThis.SCRIPT_DEBUG ).toBe( true );
+		expect( window.tinyMCEPreInit.baseURL ).toBe( 'about:blank' );
+		expect( globalThis.CSS.supports( 'selector(:focus-visible)' ) ).toBe(
+			false
+		);
+		expect(
+			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches
+		).toBe( true );
+		expect( vi.isMockFunction( convertGifToVideo ) ).toBe( true );
+		expect( vi.isMockFunction( vipsResizeImage ) ).toBe( true );
+		expect( Object.keys( wasmModule ) ).toEqual( [] );
+	} );
+
+	it( 'cleans up Testing Library renders between tests', () => {
+		expect( screen.queryByText( 'Setup content' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/test/unit/config/style-mock.vitest.js
+++ b/test/unit/config/style-mock.vitest.js
@@ -1,0 +1,23 @@
+function toKebabCase( value ) {
+	return value
+		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
+		.replace( /([A-Z])([A-Z][a-z])/g, '$1-$2' )
+		.replace( /[^a-zA-Z0-9]+/g, '-' )
+		.replace( /^-|-$/g, '' )
+		.toLowerCase();
+}
+
+const styles = new Proxy(
+	{},
+	{
+		get( target, property ) {
+			if ( typeof property === 'string' && property !== '__esModule' ) {
+				return `style-${ toKebabCase( property ) }`;
+			}
+
+			return Reflect.get( target, property );
+		},
+	}
+);
+
+export default styles;

--- a/test/unit/config/testing-library.vitest.js
+++ b/test/unit/config/testing-library.vitest.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/vitest';
+// eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach( cleanup );

--- a/test/unit/config/testing-library.vitest.js
+++ b/test/unit/config/testing-library.vitest.js
@@ -1,9 +1,34 @@
 /**
  * External dependencies
  */
+import { createSerializer as createEmotionSerializer } from '@emotion/jest';
 import '@testing-library/jest-dom/vitest';
 // eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, expect } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import './matchers/to-match-diff-snapshot.vitest';
+import './matchers/to-match-style-diff-snapshot.vitest';
+import './matchers/to-be-positioned-popover.vitest';
+import { createClassNameReplacer } from './emotion-serializer.vitest';
 
 afterEach( cleanup );
+
+expect.addSnapshotSerializer(
+	createEmotionSerializer( {
+		classNameReplacer: createClassNameReplacer(),
+	} )
+);
+expect.addSnapshotSerializer( {
+	test( value ) {
+		return (
+			typeof value === 'string' && value.startsWith( 'Snapshot Diff:\n' )
+		);
+	},
+	serialize( value ) {
+		return value;
+	},
+} );

--- a/test/unit/config/video-conversion-worker-code-stub.vitest.js
+++ b/test/unit/config/video-conversion-worker-code-stub.vitest.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { vi } from 'vitest';
+
+export const convertGifToVideo = vi.fn();
+export const cancelGifToVideoOperations = vi.fn();
+export const terminateVideoConversionWorker = vi.fn();

--- a/test/unit/config/vips-worker-code-stub.vitest.js
+++ b/test/unit/config/vips-worker-code-stub.vitest.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { vi } from 'vitest';
+
+export const vipsConvertImageFormat = vi.fn();
+export const vipsCompressImage = vi.fn();
+export const vipsHasTransparency = vi.fn();
+export const vipsResizeImage = vi.fn();
+export const vipsRotateImage = vi.fn();
+export const vipsCancelOperations = vi.fn();
+export const terminateVipsWorker = vi.fn();

--- a/test/unit/config/yargs.vitest.js
+++ b/test/unit/config/yargs.vitest.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
+
+// Match the CommonJS `yargs` entry point, which is initialized with argv.
+export default yargs( hideBin( process.argv ) );

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -13,7 +13,7 @@ const testMigration = require( './test-migration.json' );
 const escapeRegExp = ( value ) =>
 	value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 const vitestTestPathIgnorePatterns = [
-	...testMigration.vitest.files.map(
+	...[ ...testMigration.vitest.files, ...testMigration.added.vitest ].map(
 		( testPath ) => `<rootDir>/${ escapeRegExp( testPath ) }$`
 	),
 	...testMigration.vitest.directories.map(

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -13,7 +13,7 @@ const testMigration = require( './test-migration.json' );
 const escapeRegExp = ( value ) =>
 	value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 const vitestTestPathIgnorePatterns = [
-	...[ ...testMigration.vitest.files, ...testMigration.added.vitest ].map(
+	...testMigration.vitest.files.map(
 		( testPath ) => `<rootDir>/${ escapeRegExp( testPath ) }$`
 	),
 	...testMigration.vitest.directories.map(

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -8,6 +8,18 @@ const glob = require( 'glob' ).sync;
  * Path to root project directory.
  */
 const ROOT_DIR = path.resolve( __dirname, '../..' );
+const testMigration = require( './test-migration.json' );
+
+const escapeRegExp = ( value ) =>
+	value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+const vitestTestPathIgnorePatterns = [
+	...testMigration.vitest.files.map(
+		( testPath ) => `<rootDir>/${ escapeRegExp( testPath ) }$`
+	),
+	...testMigration.vitest.directories.map(
+		( directoryPath ) => `<rootDir>/${ escapeRegExp( directoryPath ) }/`
+	),
+];
 
 // Ensure Babel config resolution works from the repo root,
 // even when Jest runs from the workspace directory.
@@ -106,6 +118,7 @@ module.exports = {
 		'<rootDir>/.*/build-module/',
 		'<rootDir>/.*/build-types/',
 		'<rootDir>/.+\\.d\\.ts$',
+		...vitestTestPathIgnorePatterns,
 	],
 	resolver: '<rootDir>/test/unit/scripts/resolver.js',
 	transform: {

--- a/test/unit/mocks/match-media.vitest.js
+++ b/test/unit/mocks/match-media.vitest.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { afterAll, beforeAll, vi } from 'vitest';
+
+if ( typeof window !== 'undefined' ) {
+	const originalMatchMedia = window.matchMedia;
+	const mockedMatchMedia = vi.fn( ( query ) => {
+		if ( /prefers-reduced-motion/.test( query ) ) {
+			return {
+				...originalMatchMedia( query ),
+				matches: true,
+			};
+		}
+
+		return originalMatchMedia( query );
+	} );
+
+	beforeAll( () => {
+		window.matchMedia = vi.fn( mockedMatchMedia );
+	} );
+
+	afterAll( () => {
+		window.matchMedia = originalMatchMedia;
+	} );
+}

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -49,6 +49,7 @@
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
 		"test:unit:profile": "wp-scripts --cpu-prof test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
 		"test:unit:watch": "npm run test:unit -- --watch",
-		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config jest.config.js"
+		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
+		"test:unit:routing": "node scripts/validate-test-routing.mjs"
 	}
 }

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -22,6 +22,7 @@
 	"devDependencies": {
 		"@emotion/jest": "^11.14.2",
 		"@flakiness/jest": "^1.3.1",
+		"@flakiness/vitest": "^1.9.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
@@ -38,15 +39,18 @@
 		"jest-junit": "^17.0.0",
 		"jest-message-util": "^30.4.1",
 		"jest-watch-typeahead": "^3.0.1",
+		"jsdom": "^26.1.0",
 		"resize-observer-polyfill": "^1.5.1",
 		"snapshot-diff": "^0.10.0",
-		"timezone-mock": "^1.3.6"
+		"timezone-mock": "^1.3.6",
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"
 	},
 	"scripts": {
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
+		"test:unit:vitest": "vitest run --config vitest.config.mjs",
 		"test:unit:profile": "wp-scripts --cpu-prof test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
 		"test:unit:watch": "npm run test:unit -- --watch",
 		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config jest.config.js",

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.29.7",
+		"@babel/core": "^7.25.7",
 		"@babel/traverse": "^7.25.7",
 		"@emotion/jest": "^11.14.2",
 		"@emotion/styled": "^11.14.1",

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -21,6 +21,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.29.7",
+		"@babel/traverse": "^7.25.7",
 		"@emotion/jest": "^11.14.2",
 		"@emotion/styled": "^11.14.1",
 		"@flakiness/jest": "^1.3.1",
@@ -57,6 +58,7 @@
 	},
 	"scripts": {
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
+		"test:unit:conventions": "node scripts/validate-vitest-conventions.mjs",
 		"test:unit:vitest": "vitest run --config vitest.config.mjs",
 		"test:unit:profile": "wp-scripts --cpu-prof test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
 		"test:unit:watch": "npm run test:unit -- --watch",

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -51,7 +51,7 @@
 		"timezone-mock": "^1.3.6",
 		"vite-plugin-commonjs": "^0.10.4",
 		"vitest": "^4.1.10",
-		"yargs": "^17.7.2"
+		"yargs": "^17.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -20,6 +20,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.29.7",
 		"@emotion/jest": "^11.14.2",
 		"@flakiness/jest": "^1.3.1",
 		"@flakiness/vitest": "^1.9.0",
@@ -27,8 +28,11 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@wordpress/babel-preset-default": "file:../../packages/babel-preset-default",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/jest-preset-default": "file:../../packages/jest-preset-default",
 		"@wordpress/scripts": "file:../../packages/scripts",
+		"@wordpress/video-conversion": "file:../../packages/video-conversion",
+		"@wordpress/vips": "file:../../packages/vips",
 		"babel-jest": "^30.4.1",
 		"babel-plugin-transform-import-meta": "^2.3.3",
 		"client-zip": "^2.4.5",
@@ -43,7 +47,9 @@
 		"resize-observer-polyfill": "^1.5.1",
 		"snapshot-diff": "^0.10.0",
 		"timezone-mock": "^1.3.6",
-		"vitest": "^4.1.10"
+		"vite-plugin-commonjs": "^0.10.4",
+		"vitest": "^4.1.10",
+		"yargs": "^17.7.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -22,6 +22,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.29.7",
 		"@emotion/jest": "^11.14.2",
+		"@emotion/styled": "^11.14.1",
 		"@flakiness/jest": "^1.3.1",
 		"@flakiness/vitest": "^1.9.0",
 		"@testing-library/jest-dom": "^6.9.1",

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -1,7 +1,6 @@
 /**
  * Node dependencies
  */
-import { createHash } from 'node:crypto';
 import path from 'node:path';
 
 /**
@@ -59,16 +58,6 @@ export function getVitestTests( rootDir, manifest ) {
 	);
 
 	return [
-		...new Set( [
-			...manifest.vitest.files,
-			...directoryTests,
-			...manifest.added.vitest,
-		] ),
+		...new Set( [ ...manifest.vitest.files, ...directoryTests ] ),
 	].sort();
-}
-
-export function hashTestFiles( testFiles ) {
-	return createHash( 'sha256' )
-		.update( [ ...testFiles ].sort().join( '\n' ) )
-		.digest( 'hex' );
 }

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -1,0 +1,74 @@
+/**
+ * Node dependencies
+ */
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+/**
+ * External dependencies
+ */
+import globPackage from 'glob';
+
+const { sync: glob } = globPackage;
+
+export const TEST_PATTERNS = [
+	'**/__tests__/**/*.[jt]s?(x)',
+	'**/test/*.[jt]s?(x)',
+	'**/?(*.)test.[jt]s?(x)',
+];
+
+export const TEST_IGNORES = [
+	'**/.git/**',
+	'**/node_modules/**',
+	'packages/e2e-tests/**',
+	'packages/e2e-test-utils-playwright/src/test.ts',
+	'**/build/**',
+	'**/build-module/**',
+	'**/build-types/**',
+	'**/*.d.ts',
+	'vendor/**',
+];
+
+function normalizeTestPath( testPath ) {
+	return testPath.split( path.sep ).join( '/' );
+}
+
+export function discoverTestFiles( rootDir ) {
+	return [
+		...new Set(
+			TEST_PATTERNS.flatMap( ( pattern ) =>
+				glob( pattern, {
+					absolute: false,
+					cwd: rootDir,
+					ignore: TEST_IGNORES,
+					nodir: true,
+				} )
+			).map( normalizeTestPath )
+		),
+	].sort();
+}
+
+export function getVitestTests( rootDir, manifest ) {
+	const discoveredTests = discoverTestFiles( rootDir );
+	const directoryTests = discoveredTests.filter( ( testPath ) =>
+		manifest.vitest.directories.some(
+			( directoryPath ) =>
+				testPath === directoryPath ||
+				testPath.startsWith( `${ directoryPath }/` )
+		)
+	);
+
+	return [
+		...new Set( [
+			...manifest.vitest.files,
+			...directoryTests,
+			...manifest.added.vitest,
+		] ),
+	].sort();
+}
+
+export function hashTestFiles( testFiles ) {
+	return createHash( 'sha256' )
+		.update( [ ...testFiles ].sort().join( '\n' ) )
+		.digest( 'hex' );
+}

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -16,11 +16,7 @@ import globPackage from 'glob';
 /**
  * Internal dependencies
  */
-import {
-	discoverTestFiles,
-	getVitestTests,
-	hashTestFiles,
-} from './discover-test-files.mjs';
+import { discoverTestFiles, getVitestTests } from './discover-test-files.mjs';
 
 const require = createRequire( import.meta.url );
 const ROOT_DIR = path.resolve(
@@ -97,6 +93,13 @@ function assertUniquePaths( label, testPaths ) {
 	}
 }
 
+function isWithinDirectory( testPath, directoryPath ) {
+	return (
+		testPath === directoryPath ||
+		testPath.startsWith( `${ directoryPath }/` )
+	);
+}
+
 const jestTests = listTests( 'jest', [
 	'--config',
 	JEST_CONFIG,
@@ -111,28 +114,30 @@ const vitestTests = existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) )
 	  ] )
 	: new Set();
 
-const addedJestTests = manifest.added.jest;
-const addedVitestTests = manifest.added.vitest;
-const addedTests = [ ...addedJestTests, ...addedVitestTests ];
-const retiredTests = manifest.retired;
 const migratedTestFiles = manifest.vitest.files;
 const migratedDirectories = manifest.vitest.directories;
 
-assertUniquePaths( 'added.jest', addedJestTests );
-assertUniquePaths( 'added.vitest', addedVitestTests );
-assertUniquePaths( 'retired', retiredTests );
 assertUniquePaths( 'vitest.files', migratedTestFiles );
 assertUniquePaths( 'vitest.directories', migratedDirectories );
 
-const duplicateManifestEntries = addedTests.filter(
-	( testPath, index ) =>
-		addedTests.indexOf( testPath ) !== index ||
-		retiredTests.includes( testPath )
-);
+const overlappingManifestEntries = [
+	...migratedTestFiles.filter( ( testPath ) =>
+		migratedDirectories.some( ( directoryPath ) =>
+			isWithinDirectory( testPath, directoryPath )
+		)
+	),
+	...migratedDirectories.filter( ( directoryPath, index ) =>
+		migratedDirectories.some(
+			( otherDirectoryPath, otherIndex ) =>
+				otherIndex !== index &&
+				isWithinDirectory( directoryPath, otherDirectoryPath )
+		)
+	),
+];
 assert.deepEqual(
-	duplicateManifestEntries,
+	overlappingManifestEntries,
 	[],
-	`Migration manifest entries must be disjoint:\n${ duplicateManifestEntries.join(
+	`Vitest migration manifest entries must be disjoint:\n${ overlappingManifestEntries.join(
 		'\n'
 	) }`
 );
@@ -150,50 +155,6 @@ assert.deepEqual(
 	invalidMigratedEntries,
 	[],
 	`Migrated files or directories do not exist:\n${ invalidMigratedEntries.join(
-		'\n'
-	) }`
-);
-
-const invalidAddedTests = addedTests.filter(
-	( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
-);
-assert.deepEqual(
-	invalidAddedTests,
-	[],
-	`Added tests do not exist:\n${ invalidAddedTests.join( '\n' ) }`
-);
-
-const activeRetiredTests = retiredTests.filter(
-	( testPath ) =>
-		existsSync( path.join( ROOT_DIR, testPath ) ) ||
-		jestTests.has( testPath ) ||
-		vitestTests.has( testPath )
-);
-assert.deepEqual(
-	activeRetiredTests,
-	[],
-	`Retired tests still exist or are discoverable:\n${ activeRetiredTests.join(
-		'\n'
-	) }`
-);
-
-const missingAddedJestTests = addedJestTests.filter(
-	( testPath ) => ! jestTests.has( testPath )
-);
-const missingAddedVitestTests = addedVitestTests.filter(
-	( testPath ) => ! vitestTests.has( testPath )
-);
-assert.deepEqual(
-	missingAddedJestTests,
-	[],
-	`Added Jest tests are not discoverable by Jest:\n${ missingAddedJestTests.join(
-		'\n'
-	) }`
-);
-assert.deepEqual(
-	missingAddedVitestTests,
-	[],
-	`Added Vitest tests are not discoverable by Vitest:\n${ missingAddedVitestTests.join(
 		'\n'
 	) }`
 );
@@ -216,37 +177,14 @@ assert.deepEqual(
 	`Vitest discovery does not match the migration manifest.`
 );
 
-const accountedBaseline = [
-	...new Set( [
-		...[ ...jestTests ].filter(
-			( testPath ) => ! addedJestTests.includes( testPath )
-		),
-		...[ ...vitestTests ].filter(
-			( testPath ) => ! addedVitestTests.includes( testPath )
-		),
-		...retiredTests,
-	] ),
-].sort();
-
-assert.equal(
-	accountedBaseline.length,
-	manifest.baseline.count,
-	'The number of accounted baseline tests changed.'
-);
-assert.equal(
-	hashTestFiles( accountedBaseline ),
-	manifest.baseline.sha256,
-	'The accounted baseline test file list changed.'
-);
-
 const staticInventory = discoverTestFiles( ROOT_DIR );
-const expectedStaticInventory = [ ...accountedBaseline, ...addedTests ]
-	.filter( ( testPath ) => ! retiredTests.includes( testPath ) )
-	.sort();
+const runnerInventory = [
+	...new Set( [ ...jestTests, ...vitestTests ] ),
+].sort();
 assert.deepEqual(
+	runnerInventory,
 	staticInventory,
-	expectedStaticInventory,
-	'Static test discovery does not match the executable runner inventory.'
+	'Executable runner inventory does not match static test discovery.'
 );
 
 const { sync: glob } = globPackage;
@@ -270,5 +208,5 @@ assert.deepEqual(
 );
 
 console.log(
-	`Validated exactly one runner for ${ manifest.baseline.count } baseline tests: ${ jestTests.size } Jest, ${ vitestTests.size } Vitest, ${ retiredTests.length } retired, and ${ addedTests.length } added.`
+	`Validated exactly one runner for ${ staticInventory.length } tests: ${ jestTests.size } Jest and ${ vitestTests.size } Vitest.`
 );

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -1,0 +1,274 @@
+/**
+ * Node dependencies
+ */
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * External dependencies
+ */
+import globPackage from 'glob';
+
+/**
+ * Internal dependencies
+ */
+import {
+	discoverTestFiles,
+	getVitestTests,
+	hashTestFiles,
+} from './discover-test-files.mjs';
+
+const require = createRequire( import.meta.url );
+const ROOT_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../../..'
+);
+const JEST_CONFIG = 'test/unit/jest.config.js';
+const VITEST_CONFIG = 'test/unit/vitest.config.mjs';
+const manifest = JSON.parse(
+	readFileSync(
+		path.join( ROOT_DIR, 'test/unit/test-migration.json' ),
+		'utf8'
+	)
+);
+
+function normalizeTestPath( testPath ) {
+	return path
+		.relative( ROOT_DIR, path.resolve( ROOT_DIR, testPath ) )
+		.split( path.sep )
+		.join( '/' );
+}
+
+function resolvePackageBin( packageName ) {
+	const packageJsonPath = require.resolve( `${ packageName }/package.json` );
+	const packageJson = JSON.parse( readFileSync( packageJsonPath, 'utf8' ) );
+	const binPath =
+		typeof packageJson.bin === 'string'
+			? packageJson.bin
+			: packageJson.bin[ packageName ];
+
+	return path.resolve( path.dirname( packageJsonPath ), binPath );
+}
+
+function listTests( packageName, args ) {
+	const result = spawnSync(
+		process.execPath,
+		[ resolvePackageBin( packageName ), ...args ],
+		{
+			cwd: ROOT_DIR,
+			encoding: 'utf8',
+			env: process.env,
+			maxBuffer: 20 * 1024 * 1024,
+		}
+	);
+
+	if ( result.status !== 0 ) {
+		process.stderr.write( result.stdout );
+		process.stderr.write( result.stderr );
+		process.exit( result.status ?? 1 );
+	}
+
+	return new Set(
+		result.stdout
+			.trim()
+			.split( /\r?\n/ )
+			.filter( Boolean )
+			.map( normalizeTestPath )
+	);
+}
+
+function assertUniquePaths( label, testPaths ) {
+	assert.equal(
+		new Set( testPaths ).size,
+		testPaths.length,
+		`${ label } contains duplicate paths.`
+	);
+
+	for ( const testPath of testPaths ) {
+		assert.equal(
+			testPath,
+			normalizeTestPath( testPath ),
+			`${ label } contains a non-normalized path: ${ testPath }`
+		);
+	}
+}
+
+const jestTests = listTests( 'jest', [
+	'--config',
+	JEST_CONFIG,
+	'--listTests',
+] );
+const vitestTests = existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) )
+	? listTests( 'vitest', [
+			'list',
+			'--config',
+			VITEST_CONFIG,
+			'--filesOnly',
+	  ] )
+	: new Set();
+
+const addedJestTests = manifest.added.jest;
+const addedVitestTests = manifest.added.vitest;
+const addedTests = [ ...addedJestTests, ...addedVitestTests ];
+const retiredTests = manifest.retired;
+const migratedTestFiles = manifest.vitest.files;
+const migratedDirectories = manifest.vitest.directories;
+
+assertUniquePaths( 'added.jest', addedJestTests );
+assertUniquePaths( 'added.vitest', addedVitestTests );
+assertUniquePaths( 'retired', retiredTests );
+assertUniquePaths( 'vitest.files', migratedTestFiles );
+assertUniquePaths( 'vitest.directories', migratedDirectories );
+
+const duplicateManifestEntries = addedTests.filter(
+	( testPath, index ) =>
+		addedTests.indexOf( testPath ) !== index ||
+		retiredTests.includes( testPath )
+);
+assert.deepEqual(
+	duplicateManifestEntries,
+	[],
+	`Migration manifest entries must be disjoint:\n${ duplicateManifestEntries.join(
+		'\n'
+	) }`
+);
+
+const invalidMigratedEntries = [
+	...migratedTestFiles.filter(
+		( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
+	),
+	...migratedDirectories.filter(
+		( directoryPath ) =>
+			! existsSync( path.join( ROOT_DIR, directoryPath ) )
+	),
+];
+assert.deepEqual(
+	invalidMigratedEntries,
+	[],
+	`Migrated files or directories do not exist:\n${ invalidMigratedEntries.join(
+		'\n'
+	) }`
+);
+
+const invalidAddedTests = addedTests.filter(
+	( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
+);
+assert.deepEqual(
+	invalidAddedTests,
+	[],
+	`Added tests do not exist:\n${ invalidAddedTests.join( '\n' ) }`
+);
+
+const activeRetiredTests = retiredTests.filter(
+	( testPath ) =>
+		existsSync( path.join( ROOT_DIR, testPath ) ) ||
+		jestTests.has( testPath ) ||
+		vitestTests.has( testPath )
+);
+assert.deepEqual(
+	activeRetiredTests,
+	[],
+	`Retired tests still exist or are discoverable:\n${ activeRetiredTests.join(
+		'\n'
+	) }`
+);
+
+const missingAddedJestTests = addedJestTests.filter(
+	( testPath ) => ! jestTests.has( testPath )
+);
+const missingAddedVitestTests = addedVitestTests.filter(
+	( testPath ) => ! vitestTests.has( testPath )
+);
+assert.deepEqual(
+	missingAddedJestTests,
+	[],
+	`Added Jest tests are not discoverable by Jest:\n${ missingAddedJestTests.join(
+		'\n'
+	) }`
+);
+assert.deepEqual(
+	missingAddedVitestTests,
+	[],
+	`Added Vitest tests are not discoverable by Vitest:\n${ missingAddedVitestTests.join(
+		'\n'
+	) }`
+);
+
+const overlappingTests = [ ...jestTests ].filter( ( testPath ) =>
+	vitestTests.has( testPath )
+);
+assert.deepEqual(
+	overlappingTests,
+	[],
+	`Tests are owned by both Jest and Vitest:\n${ overlappingTests.join(
+		'\n'
+	) }`
+);
+
+const expectedVitestTests = getVitestTests( ROOT_DIR, manifest );
+assert.deepEqual(
+	[ ...vitestTests ].sort(),
+	expectedVitestTests,
+	`Vitest discovery does not match the migration manifest.`
+);
+
+const accountedBaseline = [
+	...new Set( [
+		...[ ...jestTests ].filter(
+			( testPath ) => ! addedJestTests.includes( testPath )
+		),
+		...[ ...vitestTests ].filter(
+			( testPath ) => ! addedVitestTests.includes( testPath )
+		),
+		...retiredTests,
+	] ),
+].sort();
+
+assert.equal(
+	accountedBaseline.length,
+	manifest.baseline.count,
+	'The number of accounted baseline tests changed.'
+);
+assert.equal(
+	hashTestFiles( accountedBaseline ),
+	manifest.baseline.sha256,
+	'The accounted baseline test file list changed.'
+);
+
+const staticInventory = discoverTestFiles( ROOT_DIR );
+const expectedStaticInventory = [ ...accountedBaseline, ...addedTests ]
+	.filter( ( testPath ) => ! retiredTests.includes( testPath ) )
+	.sort();
+assert.deepEqual(
+	staticInventory,
+	expectedStaticInventory,
+	'Static test discovery does not match the executable runner inventory.'
+);
+
+const { sync: glob } = globPackage;
+const orphanedSnapshots = glob( '**/__snapshots__/*.snap', {
+	cwd: ROOT_DIR,
+	ignore: [ '**/node_modules/**', '**/vendor/**' ],
+	nodir: true,
+} ).filter( ( snapshotPath ) => {
+	const testPath = path.join(
+		path.dirname( path.dirname( snapshotPath ) ),
+		path.basename( snapshotPath, '.snap' )
+	);
+	return ! existsSync( path.join( ROOT_DIR, testPath ) );
+} );
+assert.deepEqual(
+	orphanedSnapshots,
+	[],
+	`Snapshots without a matching test file:\n${ orphanedSnapshots.join(
+		'\n'
+	) }`
+);
+
+console.log(
+	`Validated exactly one runner for ${ manifest.baseline.count } baseline tests: ${ jestTests.size } Jest, ${ vitestTests.size } Vitest, ${ retiredTests.length } retired, and ${ addedTests.length } added.`
+);

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -1,0 +1,305 @@
+/**
+ * External dependencies
+ */
+import { parseSync } from '@babel/core';
+import traverseModule from '@babel/traverse';
+import globPackage from 'glob';
+
+/**
+ * Node dependencies
+ */
+import { execFileSync } from 'node:child_process';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Internal dependencies
+ */
+import { getVitestTests } from './discover-test-files.mjs';
+
+const traverse = traverseModule.default ?? traverseModule;
+const { sync: glob } = globPackage;
+const ROOT_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../../..'
+);
+const migration = JSON.parse(
+	readFileSync(
+		path.join( ROOT_DIR, 'test/unit/test-migration.json' ),
+		'utf8'
+	)
+);
+const vitestTests = getVitestTests( ROOT_DIR, migration );
+const vitestInfrastructure = [
+	'test/unit/vitest.config.mjs',
+	...glob( 'test/unit/config/**/*.vitest.{js,mjs,ts,tsx}', {
+		cwd: ROOT_DIR,
+		nodir: true,
+	} ),
+	...glob( 'test/unit/scripts/*.mjs', {
+		cwd: ROOT_DIR,
+		nodir: true,
+	} ),
+];
+const files = [
+	...new Set( [ ...vitestTests, ...vitestInfrastructure ] ),
+].sort();
+const vitestApiNames = new Set( [
+	'afterAll',
+	'afterEach',
+	'assert',
+	'beforeAll',
+	'beforeEach',
+	'describe',
+	'expect',
+	'it',
+	'onTestFailed',
+	'onTestFinished',
+	'suite',
+	'test',
+	'vi',
+] );
+const violations = [];
+
+function isCommonJsExport( node ) {
+	if ( node?.type !== 'MemberExpression' ) {
+		return false;
+	}
+
+	if (
+		node.object?.type === 'Identifier' &&
+		node.object.name === 'exports'
+	) {
+		return true;
+	}
+
+	return (
+		node.object?.type === 'Identifier' &&
+		node.object.name === 'module' &&
+		node.property?.type === 'Identifier' &&
+		node.property.name === 'exports'
+	);
+}
+
+function isDynamicImport( node ) {
+	return (
+		node?.type === 'ImportExpression' ||
+		( node?.type === 'CallExpression' && node.callee?.type === 'Import' )
+	);
+}
+
+function findWorkspacePackage( file ) {
+	let directory = path.dirname( path.join( ROOT_DIR, file ) );
+
+	while ( directory.startsWith( ROOT_DIR ) ) {
+		const packagePath = path.join( directory, 'package.json' );
+		if ( existsSync( packagePath ) ) {
+			return packagePath;
+		}
+		if ( directory === ROOT_DIR ) {
+			break;
+		}
+		directory = path.dirname( directory );
+	}
+
+	return null;
+}
+
+for ( const file of files ) {
+	const filename = path.join( ROOT_DIR, file );
+	const source = readFileSync( filename, 'utf8' );
+	const plugins = [
+		'decorators-legacy',
+		'importAttributes',
+		'jsx',
+		'topLevelAwait',
+	];
+
+	if ( /\.[cm]?tsx?$/.test( file ) ) {
+		plugins.push( 'typescript' );
+	}
+
+	const ast = parseSync( source, {
+		ast: true,
+		babelrc: false,
+		code: false,
+		configFile: false,
+		filename,
+		parserOpts: {
+			plugins,
+			sourceType: 'module',
+		},
+	} );
+
+	traverse( ast, {
+		AssignmentExpression( astPath ) {
+			if ( isCommonJsExport( astPath.node.left ) ) {
+				violations.push(
+					`${ file }:${ astPath.node.loc.start.line } CommonJS export`
+				);
+			}
+		},
+		CallExpression( astPath ) {
+			const { node } = astPath;
+
+			if (
+				node.callee?.type === 'Identifier' &&
+				node.callee.name === 'require' &&
+				! astPath.scope.hasBinding( 'require' )
+			) {
+				violations.push(
+					`${ file }:${ node.loc.start.line } unbound require()`
+				);
+			}
+
+			if (
+				/\.tsx?$/.test( file ) &&
+				node.callee?.type === 'MemberExpression' &&
+				node.callee.object?.type === 'Identifier' &&
+				node.callee.object.name === 'vi' &&
+				node.callee.property?.type === 'Identifier' &&
+				node.callee.property.name === 'mock' &&
+				! isDynamicImport( node.arguments[ 0 ] )
+			) {
+				violations.push(
+					`${ file }:${ node.loc.start.line } TypeScript vi.mock() must use vi.mock(import(...))`
+				);
+			}
+		},
+		ReferencedIdentifier( astPath ) {
+			const { name } = astPath.node;
+			if (
+				vitestTests.includes( file ) &&
+				vitestApiNames.has( name ) &&
+				! astPath.scope.hasBinding( name )
+			) {
+				violations.push(
+					`${ file }:${ astPath.node.loc.start.line } unbound Vitest API: ${ name }`
+				);
+			}
+		},
+	} );
+
+	if (
+		vitestTests.includes( file ) &&
+		/(?:from\s+|import\s*)[('"]vitest\/globals/.test( source )
+	) {
+		violations.push( `${ file }: vitest/globals is not allowed` );
+	}
+}
+
+const vitestVersions = new Map();
+for ( const file of vitestTests ) {
+	const source = readFileSync( path.join( ROOT_DIR, file ), 'utf8' );
+	if ( ! /(?:from\s+|import\s*)[('"]vitest[)'"]/.test( source ) ) {
+		violations.push( `${ file }: no explicit import from vitest` );
+		continue;
+	}
+
+	const packagePath = findWorkspacePackage( file );
+	if ( ! packagePath ) {
+		violations.push( `${ file }: no owning package.json` );
+		continue;
+	}
+
+	const packageJson = JSON.parse( readFileSync( packagePath, 'utf8' ) );
+	const version = packageJson.devDependencies?.vitest;
+	const relativePackagePath = path.relative( ROOT_DIR, packagePath );
+	if ( ! version ) {
+		violations.push(
+			`${ file }: ${ relativePackagePath } must declare devDependencies.vitest`
+		);
+		continue;
+	}
+
+	vitestVersions.set( relativePackagePath, version );
+}
+
+const distinctVersions = new Set( vitestVersions.values() );
+if ( distinctVersions.size > 1 ) {
+	violations.push(
+		`Vitest dependency versions must match:\n${ [
+			...vitestVersions.entries(),
+		]
+			.map(
+				( [ packagePath, version ] ) => `${ packagePath }: ${ version }`
+			)
+			.join( '\n' ) }`
+	);
+}
+
+if ( violations.length ) {
+	throw new Error(
+		`Vitest convention violations:\n${ violations.join( '\n' ) }`
+	);
+}
+
+const typescriptTests = vitestTests.filter( ( file ) =>
+	/\.tsx?$/.test( file )
+);
+if ( typescriptTests.length ) {
+	const temporaryDirectory = mkdtempSync(
+		path.join( os.tmpdir(), 'gutenberg-vitest-typecheck-' )
+	);
+	const configPath = path.join( temporaryDirectory, 'tsconfig.json' );
+	const compatibilityTypesPath = path.join(
+		temporaryDirectory,
+		'compatibility.d.ts'
+	);
+	const typecheckConfig = {
+		extends: path.join( ROOT_DIR, 'tsconfig.base.json' ),
+		compilerOptions: {
+			allowJs: true,
+			checkJs: false,
+			composite: false,
+			declaration: true,
+			declarationMap: false,
+			emitDeclarationOnly: false,
+			noEmit: true,
+			rootDir: ROOT_DIR,
+			typeRoots: [
+				path.join( ROOT_DIR, 'typings' ),
+				path.join( ROOT_DIR, 'node_modules/@types' ),
+			],
+			types: [ 'gutenberg-env', 'node', 'style-imports' ],
+		},
+		files: [
+			compatibilityTypesPath,
+			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
+			...typescriptTests.map( ( file ) => path.join( ROOT_DIR, file ) ),
+		],
+	};
+
+	try {
+		// @wordpress/commands is a JavaScript package without published types.
+		// Keep this exception explicit until that package gains declarations.
+		writeFileSync(
+			compatibilityTypesPath,
+			"declare module '@wordpress/commands';"
+		);
+		writeFileSync( configPath, JSON.stringify( typecheckConfig ) );
+		execFileSync(
+			path.join(
+				ROOT_DIR,
+				'node_modules/.bin',
+				process.platform === 'win32' ? 'tsc.cmd' : 'tsc'
+			),
+			[ '--project', configPath, '--pretty', 'false' ],
+			{ cwd: ROOT_DIR, stdio: 'inherit' }
+		);
+	} finally {
+		rmSync( temporaryDirectory, { force: true, recursive: true } );
+	}
+}
+
+console.log(
+	`Validated ${ vitestTests.length } Vitest tests, ${ files.length } ESM graph files, ${ vitestVersions.size } workspace dependencies, and ${ typescriptTests.length } TypeScript tests.`
+);

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -16,6 +16,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,6 +28,7 @@ import { getVitestTests } from './discover-test-files.mjs';
 
 const traverse = traverseModule.default ?? traverseModule;
 const { sync: glob } = globPackage;
+const require = createRequire( import.meta.url );
 const ROOT_DIR = path.resolve(
 	path.dirname( fileURLToPath( import.meta.url ) ),
 	'../../..'
@@ -68,6 +70,17 @@ const vitestApiNames = new Set( [
 	'vi',
 ] );
 const violations = [];
+
+function resolvePackageBin( packageName ) {
+	const packageJsonPath = require.resolve( `${ packageName }/package.json` );
+	const packageJson = JSON.parse( readFileSync( packageJsonPath, 'utf8' ) );
+	const binPath =
+		typeof packageJson.bin === 'string'
+			? packageJson.bin
+			: Object.values( packageJson.bin )[ 0 ];
+
+	return path.resolve( path.dirname( packageJsonPath ), binPath );
+}
 
 function isCommonJsExport( node ) {
 	if ( node?.type !== 'MemberExpression' ) {
@@ -287,11 +300,7 @@ if ( typescriptTests.length ) {
 		);
 		writeFileSync( configPath, JSON.stringify( typecheckConfig ) );
 		execFileSync(
-			path.join(
-				ROOT_DIR,
-				'node_modules/.bin',
-				process.platform === 'win32' ? 'tsc.cmd' : 'tsc'
-			),
+			resolvePackageBin( 'typescript' ),
 			[ '--project', configPath, '--pretty', 'false' ],
 			{ cwd: ROOT_DIR, stdio: 'inherit' }
 		);

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -10,6 +10,9 @@
 	"retired": [],
 	"added": {
 		"jest": [],
-		"vitest": [ "test/unit/config/setup.vitest.test.jsx" ]
+		"vitest": [
+			"test/unit/config/console.vitest.test.js",
+			"test/unit/config/setup.vitest.test.jsx"
+		]
 	}
 }

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -1,0 +1,15 @@
+{
+	"baseline": {
+		"count": 996,
+		"sha256": "72316673c4f35ec4d55ec15ba4dbf3435dd2f57b3b54dc5258d9c75b340ad243"
+	},
+	"vitest": {
+		"files": [],
+		"directories": []
+	},
+	"retired": [],
+	"added": {
+		"jest": [],
+		"vitest": []
+	}
+}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -10,6 +10,6 @@
 	"retired": [],
 	"added": {
 		"jest": [],
-		"vitest": []
+		"vitest": [ "test/unit/config/setup.vitest.test.jsx" ]
 	}
 }

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -4,7 +4,7 @@
 		"sha256": "72316673c4f35ec4d55ec15ba4dbf3435dd2f57b3b54dc5258d9c75b340ad243"
 	},
 	"vitest": {
-		"files": [],
+		"files": [ "packages/html-entities/src/test/entities.ts" ],
 		"directories": []
 	},
 	"retired": [],

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -9,7 +9,10 @@
 	},
 	"retired": [],
 	"added": {
-		"jest": [],
+		"jest": [
+			"packages/ui/src/form/primitives/searchable-chip-select/test/index.test.tsx",
+			"tools/agents/test/setup-skills.test.js"
+		],
 		"vitest": [
 			"test/unit/config/console.vitest.test.js",
 			"test/unit/config/emotion-serializer.vitest.test.jsx",

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -1,23 +1,12 @@
 {
-	"baseline": {
-		"count": 996,
-		"sha256": "72316673c4f35ec4d55ec15ba4dbf3435dd2f57b3b54dc5258d9c75b340ad243"
-	},
 	"vitest": {
-		"files": [ "packages/html-entities/src/test/entities.ts" ],
-		"directories": []
-	},
-	"retired": [],
-	"added": {
-		"jest": [
-			"packages/ui/src/form/primitives/searchable-chip-select/test/index.test.tsx",
-			"tools/agents/test/setup-skills.test.js"
-		],
-		"vitest": [
+		"files": [
+			"packages/html-entities/src/test/entities.ts",
 			"test/unit/config/console.vitest.test.js",
 			"test/unit/config/emotion-serializer.vitest.test.jsx",
 			"test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js",
 			"test/unit/config/setup.vitest.test.jsx"
-		]
+		],
+		"directories": []
 	}
 }

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -12,6 +12,8 @@
 		"jest": [],
 		"vitest": [
 			"test/unit/config/console.vitest.test.js",
+			"test/unit/config/emotion-serializer.vitest.test.jsx",
+			"test/unit/config/matchers/test/to-match-diff-snapshot.vitest.test.js",
 			"test/unit/config/setup.vitest.test.jsx"
 		]
 	}

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -8,6 +8,9 @@ import { fileURLToPath } from 'node:url';
 /**
  * External dependencies
  */
+import { transformAsync } from '@babel/core';
+import globPackage from 'glob';
+import commonjs from 'vite-plugin-commonjs';
 import { defineConfig } from 'vitest/config';
 
 /**
@@ -26,13 +29,144 @@ const testMigration = JSON.parse(
 	)
 );
 const vitestTests = getVitestTests( ROOT_DIR, testMigration );
+const { sync: glob } = globPackage;
 
 // Preserve Jest's repository-root configuration discovery and default timezone.
 process.chdir( ROOT_DIR );
 process.env.TZ = 'UTC';
 
+const transpiledPackageNames = glob(
+	path.join( ROOT_DIR, 'packages/*/src/index.{js,ts,tsx}' )
+).map( ( fileName ) => {
+	const relative = path.relative( ROOT_DIR, fileName );
+	return relative.split( path.sep )[ 1 ];
+} );
+
+function wordpressBabelTransform() {
+	return {
+		name: 'wordpress-babel-transform',
+		enforce: 'pre',
+		async transform( source, id ) {
+			const filename = id.split( '?', 1 )[ 0 ];
+
+			if (
+				! filename.startsWith( `${ ROOT_DIR }${ path.sep }` ) ||
+				filename.includes( `${ path.sep }node_modules${ path.sep }` ) ||
+				! /\.m?[jt]sx?$/.test( filename )
+			) {
+				return;
+			}
+
+			const result = await transformAsync( source, {
+				caller: {
+					name: 'vite',
+					supportsDynamicImport: true,
+					supportsExportNamespaceFrom: true,
+					supportsStaticESM: true,
+					supportsTopLevelAwait: true,
+				},
+				envName: 'test',
+				filename,
+				root: ROOT_DIR,
+				sourceMaps: true,
+			} );
+
+			if ( ! result?.code ) {
+				return;
+			}
+
+			return {
+				code: result.code,
+				map: result.map,
+			};
+		},
+	};
+}
+
 export default defineConfig( {
 	root: ROOT_DIR,
+	plugins: [
+		wordpressBabelTransform(),
+		commonjs( {
+			filter: ( id ) =>
+				[
+					`${ ROOT_DIR }/packages/block-serialization-spec-parser/parser.js`,
+					`${ ROOT_DIR }/packages/env/lib/`,
+					`${ ROOT_DIR }/packages/project-management-automation/lib/`,
+					`${ ROOT_DIR }/packages/scripts/utils/`,
+					`${ ROOT_DIR }/tools/release/commands/changelog.js`,
+				].some( ( directory ) => id.startsWith( directory ) ) &&
+				! id.endsWith( '/packages/scripts/utils/license.js' ),
+		} ),
+	],
+	resolve: {
+		alias: [
+			{
+				find: /^.*\.(?:css|scss)$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/style-mock.vitest.js'
+				),
+			},
+			{
+				find: /^yargs$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/yargs.vitest.js'
+				),
+			},
+			{
+				find: '@wordpress/vips/worker',
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/vips-worker-code-stub.vitest.js'
+				),
+			},
+			{
+				find: '@wordpress/video-conversion/worker',
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/video-conversion-worker-code-stub.vitest.js'
+				),
+			},
+			{
+				find: /^@wordpress\/([^/]+)\/src\/(.+)$/,
+				replacement: path.join( ROOT_DIR, 'packages/$1/src/$2' ),
+			},
+			{
+				find: new RegExp(
+					`^@wordpress/(${ transpiledPackageNames.join( '|' ) })$`
+				),
+				replacement: path.join( ROOT_DIR, 'packages/$1/src' ),
+			},
+			{
+				find: '@wordpress/theme/design-tokens.js',
+				replacement: path.join(
+					ROOT_DIR,
+					'packages/theme/prebuilt/js/design-tokens.mjs'
+				),
+			},
+			{
+				find: /^@wordpress\/block-library\/build-module\/(.*)\.mjs$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'packages/block-library/src/$1.js'
+				),
+			},
+			{
+				find: /.+\.wasm$/,
+				replacement: path.join(
+					ROOT_DIR,
+					'test/unit/config/wasm-stub.js'
+				),
+			},
+		],
+	},
+	server: {
+		deps: {
+			external: [ /^@babel\// ],
+		},
+	},
 	test: {
 		environment: 'jsdom',
 		environmentOptions: {
@@ -63,6 +197,13 @@ export default defineConfig( {
 			hooks: 'list',
 			setupFiles: 'list',
 		},
+		setupFiles: [
+			path.join( ROOT_DIR, 'test/unit/config/setup-globals.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/global-mocks.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/gutenberg-env.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/mocks/match-media.vitest.js' ),
+		],
 		snapshotFormat: {
 			escapeString: false,
 			printBasicPrototype: false,

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -1,0 +1,71 @@
+/**
+ * Node dependencies
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * External dependencies
+ */
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Internal dependencies
+ */
+import { getVitestTests } from './scripts/discover-test-files.mjs';
+
+const ROOT_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../..'
+);
+const testMigration = JSON.parse(
+	readFileSync(
+		path.join( ROOT_DIR, 'test/unit/test-migration.json' ),
+		'utf8'
+	)
+);
+const vitestTests = getVitestTests( ROOT_DIR, testMigration );
+
+// Preserve Jest's repository-root configuration discovery and default timezone.
+process.chdir( ROOT_DIR );
+process.env.TZ = 'UTC';
+
+export default defineConfig( {
+	root: ROOT_DIR,
+	test: {
+		environment: 'jsdom',
+		environmentOptions: {
+			jsdom: {
+				url: 'http://localhost/',
+			},
+		},
+		globals: false,
+		include: vitestTests,
+		includeTaskLocation: true,
+		passWithNoTests: false,
+		reporters:
+			process.env.CI &&
+			process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
+				? [
+						'default',
+						'github-actions',
+						[
+							'@flakiness/vitest',
+							{
+								duplicates: 'rename',
+								flakinessProject: 'WordPress/gutenberg',
+							},
+						],
+				  ]
+				: [ 'default' ],
+		sequence: {
+			hooks: 'list',
+			setupFiles: 'list',
+		},
+		snapshotFormat: {
+			escapeString: false,
+			printBasicPrototype: false,
+		},
+	},
+} );

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -30,6 +30,23 @@ const testMigration = JSON.parse(
 );
 const vitestTests = getVitestTests( ROOT_DIR, testMigration );
 const { sync: glob } = globPackage;
+const reporters = [ 'default' ];
+
+if ( process.env.GITHUB_ACTIONS === 'true' ) {
+	reporters.push( 'github-actions' );
+}
+if (
+	process.env.CI &&
+	process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
+) {
+	reporters.push( [
+		'@flakiness/vitest',
+		{
+			duplicates: 'rename',
+			flakinessProject: 'WordPress/gutenberg',
+		},
+	] );
+}
 
 // Preserve Jest's repository-root configuration discovery and default timezone.
 process.chdir( ROOT_DIR );
@@ -178,21 +195,7 @@ export default defineConfig( {
 		include: vitestTests,
 		includeTaskLocation: true,
 		passWithNoTests: false,
-		reporters:
-			process.env.CI &&
-			process.env.GITHUB_REPOSITORY === 'WordPress/gutenberg'
-				? [
-						'default',
-						'github-actions',
-						[
-							'@flakiness/vitest',
-							{
-								duplicates: 'rename',
-								flakinessProject: 'WordPress/gutenberg',
-							},
-						],
-				  ]
-				: [ 'default' ],
+		reporters,
 		sequence: {
 			hooks: 'list',
 			setupFiles: 'list',
@@ -201,6 +204,7 @@ export default defineConfig( {
 			path.join( ROOT_DIR, 'test/unit/config/setup-globals.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/config/global-mocks.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/config/gutenberg-env.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/console.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
 			path.join( ROOT_DIR, 'test/unit/mocks/match-media.vitest.js' ),
 		],


### PR DESCRIPTION
Part of #80855.

## What?

**TL;DR — foundation changes:** add executable migration boundaries, the private Vitest configuration, environment mocks, console/snapshot parity, and CI guardrails while Jest remains the default runner.

## Why?

The repository needs behavior and ownership checks before changing runners. This PR makes every migration step measurable and independently testable.

## How?

- Derive the active test inventory at runtime and enforce exactly one runner per discovered test.
- Add a private ESM Vitest configuration with package aliases, worker/WASM stubs, CSS handling, and shared setup.
- Port Gutenberg's console checks, custom matchers, snapshot-diff behavior, and Emotion serialization.
- Preserve source locations, GitHub annotations, sharding, and Flakiness.io reporting.
- Enforce canonical Vitest imports, dependencies, types, and test-graph conventions.

## Testing Instructions

1. Run `npm run test:unit:routing`.
2. Run `npm run test:unit:conventions`.
3. Run `npm run test:unit:vitest -- test/unit/config`.

### Testing Instructions for Keyboard

Not applicable; this PR does not change user interfaces.

## Use of AI Tools

Codex assisted with implementation and verification. The resulting changes and test output were reviewed by the author.