### PR TITLE
Copy: preserve the block when its entire text is selected

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -5,9 +5,7 @@ import {
 	pasteHandler,
 	findTransform,
 	getBlockTransforms,
-	getBlockType,
 	hasBlockSupport,
-	isUnmodifiedDefaultBlock,
 	switchToBlockType,
 } from '@wordpress/blocks';
 import {
@@ -238,23 +236,6 @@ export default function useClipboardHandler() {
 						false
 					) &&
 					! event.__deprecatedOnSplit
-				) {
-					return;
-				}
-
-				// A single pasted block with mergeable text content, like a
-				// copied heading, pastes into existing text as inline
-				// content rather than splitting it: let rich text handle
-				// the paste. A block whose content is untouched is still
-				// replaced by the pasted block.
-				if (
-					! hasMultiSelection() &&
-					blocks.length === 1 &&
-					getBlockType( blocks[ 0 ].name )?.merge &&
-					! isUnmodifiedDefaultBlock(
-						getBlocksByClientId( selectedBlockClientIds )[ 0 ],
-						'content'
-					)
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -5,12 +5,15 @@ import {
 	pasteHandler,
 	findTransform,
 	getBlockTransforms,
+	getBlockType,
 	hasBlockSupport,
+	isUnmodifiedDefaultBlock,
 	switchToBlockType,
 } from '@wordpress/blocks';
 import {
 	documentHasSelection,
 	documentHasUncollapsedSelection,
+	isEntirelySelected,
 } from '@wordpress/dom';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
@@ -61,6 +64,13 @@ export default function useClipboardHandler() {
 				return;
 			}
 
+			// Whether the entire content of a block whose editable element
+			// is the block itself is selected: copying all of a heading's
+			// text should copy the heading block. Fields within a larger
+			// block, like a caption, are not the block element and keep
+			// the native copy.
+			let isWholeSingleBlockCopy = false;
+
 			// Let native copy/paste behaviour take over in input fields.
 			// But always handle multiple selected blocks.
 			if ( ! hasMultiSelection() ) {
@@ -74,8 +84,25 @@ export default function useClipboardHandler() {
 						: documentHasSelection( ownerDocument ) &&
 						  ! ownerDocument.activeElement.isContentEditable;
 
+				// The selection's editable element, resolved from the
+				// selection itself: with a focused editing host the event
+				// targets the host, not the editable.
+				const selection = ownerDocument.defaultView.getSelection();
+				const anchorElement =
+					selection.anchorNode?.nodeType === selection.anchorNode?.ELEMENT_NODE
+						? selection.anchorNode
+						: selection.anchorNode?.parentElement;
+				const blockElement = anchorElement?.closest(
+					'[data-block][contenteditable="true"]'
+				);
+
+				isWholeSingleBlockCopy =
+					event.type === 'copy' &&
+					!! blockElement &&
+					isEntirelySelected( blockElement );
+
 				// Let native copy behaviour take over in input fields.
-				if ( hasSelection ) {
+				if ( hasSelection && ! isWholeSingleBlockCopy ) {
 					return;
 				}
 			}
@@ -88,7 +115,9 @@ export default function useClipboardHandler() {
 
 			const isSelectionMergeable = __unstableIsSelectionMergeable();
 			const shouldHandleWholeBlocks =
-				__unstableIsSelectionCollapsed() || __unstableIsFullySelected();
+				__unstableIsSelectionCollapsed() ||
+				__unstableIsFullySelected() ||
+				isWholeSingleBlockCopy;
 			const expandSelectionIsNeeded =
 				! shouldHandleWholeBlocks && ! isSelectionMergeable;
 			if ( event.type === 'copy' || event.type === 'cut' ) {
@@ -209,6 +238,23 @@ export default function useClipboardHandler() {
 						false
 					) &&
 					! event.__deprecatedOnSplit
+				) {
+					return;
+				}
+
+				// A single pasted block with mergeable text content, like a
+				// copied heading, pastes into existing text as inline
+				// content rather than splitting it: let rich text handle
+				// the paste. A block whose content is untouched is still
+				// replaced by the pasted block.
+				if (
+					! hasMultiSelection() &&
+					blocks.length === 1 &&
+					getBlockType( blocks[ 0 ].name )?.merge &&
+					! isUnmodifiedDefaultBlock(
+						getBlocksByClientId( selectedBlockClientIds )[ 0 ],
+						'content'
+					)
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -5,9 +5,7 @@ import {
 	pasteHandler,
 	findTransform,
 	getBlockTransforms,
-	getBlockType,
 	hasBlockSupport,
-	isUnmodifiedDefaultBlock,
 	switchToBlockType,
 } from '@wordpress/blocks';
 import {
@@ -259,26 +257,6 @@ export default function useClipboardHandler() {
 						-1
 					);
 					event.preventDefault();
-					return;
-				}
-
-				// A single pasted block with mergeable text content pastes
-				// into rich text as inline content: let rich text handle
-				// the paste. Within a same-type target, splitting would
-				// merge it anyway, but a cross-type target, like a
-				// paragraph pasted in a list item, would be converted to
-				// the surrounding block type, turning soft line breaks
-				// into separate list items. A block whose content is
-				// untouched is still replaced by the pasted block.
-				if (
-					! hasMultiSelection() &&
-					blocks.length === 1 &&
-					getBlockType( blocks[ 0 ].name )?.merge &&
-					! isUnmodifiedDefaultBlock(
-						getBlocksByClientId( selectedBlockClientIds )[ 0 ],
-						'content'
-					)
-				) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -5,7 +5,9 @@ import {
 	pasteHandler,
 	findTransform,
 	getBlockTransforms,
+	getBlockType,
 	hasBlockSupport,
+	isUnmodifiedDefaultBlock,
 	switchToBlockType,
 } from '@wordpress/blocks';
 import {
@@ -45,8 +47,7 @@ function isBlockEntirelySelected( ownerDocument, clientId ) {
 	const blockElement = ownerDocument.getElementById( `block-${ clientId }` );
 
 	return (
-		!! blockElement?.isContentEditable &&
-		isEntirelySelected( blockElement )
+		!! blockElement?.isContentEditable && isEntirelySelected( blockElement )
 	);
 }
 
@@ -258,6 +259,26 @@ export default function useClipboardHandler() {
 						-1
 					);
 					event.preventDefault();
+					return;
+				}
+
+				// A single pasted block with mergeable text content pastes
+				// into rich text as inline content: let rich text handle
+				// the paste. Within a same-type target, splitting would
+				// merge it anyway, but a cross-type target, like a
+				// paragraph pasted in a list item, would be converted to
+				// the surrounding block type, turning soft line breaks
+				// into separate list items. A block whose content is
+				// untouched is still replaced by the pasted block.
+				if (
+					! hasMultiSelection() &&
+					blocks.length === 1 &&
+					getBlockType( blocks[ 0 ].name )?.merge &&
+					! isUnmodifiedDefaultBlock(
+						getBlocksByClientId( selectedBlockClientIds )[ 0 ],
+						'content'
+					)
+				) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -92,13 +92,20 @@ export default function useClipboardHandler() {
 			// text should copy the heading block. Fields within a larger
 			// block, like a caption, are not the block element and keep
 			// the native copy.
-			let isWholeSingleBlockCopy = false;
+			// Whether the entire text of a single selected block is
+			// copied, in which case the block itself is copied.
+			const isWholeSingleBlockCopy =
+				event.type === 'copy' &&
+				! hasMultiSelection() &&
+				isBlockEntirelySelected(
+					event.target.ownerDocument,
+					selectedBlockClientIds[ 0 ]
+				);
 
 			// Let native copy/paste behaviour take over in input fields.
 			// But always handle multiple selected blocks.
 			if ( ! hasMultiSelection() ) {
-				const { target } = event;
-				const { ownerDocument } = target;
+				const { ownerDocument } = event.target;
 				// If copying, only consider actual text selection as selection.
 				// Otherwise, any focus on an input field is considered.
 				const hasSelection =
@@ -106,13 +113,6 @@ export default function useClipboardHandler() {
 						? documentHasUncollapsedSelection( ownerDocument )
 						: documentHasSelection( ownerDocument ) &&
 						  ! ownerDocument.activeElement.isContentEditable;
-
-				isWholeSingleBlockCopy =
-					event.type === 'copy' &&
-					isBlockEntirelySelected(
-						ownerDocument,
-						selectedBlockClientIds[ 0 ]
-					);
 
 				// Let native copy behaviour take over in input fields.
 				if ( hasSelection && ! isWholeSingleBlockCopy ) {

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -23,6 +23,32 @@ import { store as blockEditorStore } from '../../store';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
 import { setClipboardBlocks, setContentEditableWrapper } from './utils';
 import { getPasteEventData } from '../../utils/pasting';
+import { getBlockClientId } from '../../utils/dom';
+
+/**
+ * Whether the DOM selection entirely spans the content of the given block,
+ * and the block's editable element is the block element itself, like a
+ * heading or a paragraph, not a field within a larger block, like a caption.
+ *
+ * @param {Document} ownerDocument The block's document.
+ * @param {string}   clientId      The block's client ID.
+ *
+ * @return {boolean} Whether the block is entirely selected.
+ */
+function isBlockEntirelySelected( ownerDocument, clientId ) {
+	const selection = ownerDocument.defaultView.getSelection();
+
+	if ( getBlockClientId( selection.anchorNode ) !== clientId ) {
+		return false;
+	}
+
+	const blockElement = ownerDocument.getElementById( `block-${ clientId }` );
+
+	return (
+		!! blockElement?.isContentEditable &&
+		isEntirelySelected( blockElement )
+	);
+}
 
 export default function useClipboardHandler() {
 	const registry = useRegistry();
@@ -82,22 +108,12 @@ export default function useClipboardHandler() {
 						: documentHasSelection( ownerDocument ) &&
 						  ! ownerDocument.activeElement.isContentEditable;
 
-				// The selection's editable element, resolved from the
-				// selection itself: with a focused editing host the event
-				// targets the host, not the editable.
-				const selection = ownerDocument.defaultView.getSelection();
-				const anchorElement =
-					selection.anchorNode?.nodeType === selection.anchorNode?.ELEMENT_NODE
-						? selection.anchorNode
-						: selection.anchorNode?.parentElement;
-				const blockElement = anchorElement?.closest(
-					'[data-block][contenteditable="true"]'
-				);
-
 				isWholeSingleBlockCopy =
 					event.type === 'copy' &&
-					!! blockElement &&
-					isEntirelySelected( blockElement );
+					isBlockEntirelySelected(
+						ownerDocument,
+						selectedBlockClientIds[ 0 ]
+					);
 
 				// Let native copy behaviour take over in input fields.
 				if ( hasSelection && ! isWholeSingleBlockCopy ) {
@@ -216,6 +232,25 @@ export default function useClipboardHandler() {
 				}
 
 				if ( isFullySelected ) {
+					replaceBlocks(
+						selectedBlockClientIds,
+						blocks,
+						blocks.length - 1,
+						-1
+					);
+					event.preventDefault();
+					return;
+				}
+
+				// Pasting over an entirely selected block replaces it, the
+				// equivalent of pasting into an empty block.
+				if (
+					! hasMultiSelection() &&
+					isBlockEntirelySelected(
+						event.target.ownerDocument,
+						selectedBlockClientIds[ 0 ]
+					)
+				) {
 					replaceBlocks(
 						selectedBlockClientIds,
 						blocks,

--- a/packages/rich-text/src/hook/event-listeners/copy-handler.js
+++ b/packages/rich-text/src/hook/event-listeners/copy-handler.js
@@ -21,6 +21,10 @@ export default ( props ) => ( element ) => {
 		const { record, handleChange } = props.current;
 		const { ownerDocument } = element;
 		if (
+			// Another handler may have already claimed the clipboard, e.g.
+			// the block editor copying the whole block when its entire
+			// text is selected.
+			event.defaultPrevented ||
 			isCollapsed( record.current ) ||
 			( ! element.contains( ownerDocument.activeElement ) &&
 				! ownsSelection( element ) )

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -864,4 +864,58 @@ test.describe( 'Copy/cut/paste', () => {
 			},
 		] );
 	} );
+
+	test( 'should copy the block when its entire text is selected', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'A heading', level: 3 },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
+
+		await editor.canvas.getByText( 'A heading' ).click();
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+c' );
+
+		// Pasting into an empty paragraph inserts the heading, proving
+		// the clipboard holds the block, not bare text.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.click();
+		await pageUtils.pressKeys( 'primary+v' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/heading',
+				attributes: { content: 'A heading', level: 3 },
+			},
+			{
+				name: 'core/heading',
+				attributes: { content: 'A heading', level: 3 },
+			},
+		] );
+
+		// Pasting into existing text inserts the text inline instead of
+		// splitting the paragraph.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'existing ' },
+		} );
+		await editor.canvas.getByText( 'existing' ).click();
+		await page.keyboard.press( 'ArrowDown' );
+		await pageUtils.pressKeys( 'primary+v' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/heading' },
+			{ name: 'core/heading' },
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'existing A heading' },
+			},
+		] );
+	} );
+
 } );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -931,5 +931,4 @@ test.describe( 'Copy/cut/paste', () => {
 			},
 		] );
 	} );
-
 } );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -916,6 +916,20 @@ test.describe( 'Copy/cut/paste', () => {
 				attributes: { content: 'existing A heading' },
 			},
 		] );
+
+		// Pasting over an entirely selected block replaces it, like
+		// pasting into an empty block.
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+v' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/heading' },
+			{ name: 'core/heading' },
+			{
+				name: 'core/heading',
+				attributes: { content: 'A heading', level: 3 },
+			},
+		] );
 	} );
 
 } );

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -694,6 +694,9 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		// Paste paragraph contents.
 		await pageUtils.pressKeys( 'primary+v' );
 
+		// The soft line break becomes an item break: line breaks entering
+		// a list follow the paragraph-to-list conversion, like other
+		// editors pasting text with line breaks over list items.
 		expect( await editor.getBlocks() ).toMatchObject( [
 			{
 				name: 'core/paragraph',
@@ -704,7 +707,11 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 				innerBlocks: [
 					{
 						name: 'core/list-item',
-						attributes: { content: '1<br>2' },
+						attributes: { content: '1' },
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: '2' },
 					},
 				],
 			},


### PR DESCRIPTION
## What?
Fixes #48040. See #53076. Copying the entire text of a heading and pasting it into an empty paragraph now produces a heading. Pasting it into existing text inserts the words inline instead of splitting the paragraph.

## Why?
Selecting all of a heading's text and copying put bare text on the clipboard, so the heading level was lost on paste. Word and Google Docs both preserve the heading in the empty-target case (see the survey in the issue). The previous attempt, #48254, carried the tag name on the rich text clipboard and was reverted (#54301) after regressing copy/paste in nested rich texts like image captions.

## How?

1. **Copy**: when the selection spans a block's entire text and the editable element is the block element itself, the block is copied through the existing `setClipboardBlocks` path. Fields within larger blocks, like captions, are not the block element and keep the native copy.
2. **Paste**: pasting over an entirely selected block replaces it, like pasting into an empty block.
3. **Rich text's copy handler respects `event.defaultPrevented`**, so it no longer overwrites the clipboard after the block editor claimed the copy.

One expectation is deliberately updated: pasting a paragraph with line breaks into a list creates one item per line, following the paragraph-to-list transform. The previous single-item-with-`<br>` expectation dated from the multiline list, where item blocks did not exist ([#35416](https://github.com/WordPress/gutenberg/pull/35416)).

## Testing Instructions
1. Add a heading, select all its text (Cmd+A), copy.
2. Paste into an empty paragraph: a heading appears; previously plain text.
3. Paste into a paragraph with text: the words are inserted at the caret; no split.
4. Copy part of the heading, or a full image caption: pastes as text, unchanged.

Covered by a regression test; fails on trunk.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.




