### PR TITLE
Upgrade Playwright to v1.62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"widgets/*"
 			],
 			"devDependencies": {
-				"@playwright/test": "^1.61.1",
+				"@playwright/test": "^1.62.1",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
@@ -12080,18 +12080,18 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+			"integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.61.1"
+				"playwright": "1.62.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -39867,33 +39867,33 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.61.1"
+				"playwright-core": "1.62.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/plur": {
@@ -51714,7 +51714,7 @@
 				"@jest/test-result": "^30.4.1",
 				"@octokit/types": "^6.34.0",
 				"@octokit/webhooks-types": "^5.8.0",
-				"@playwright/test": "^1.61.1",
+				"@playwright/test": "^1.62.1",
 				"jest-message-util": "^30.4.1"
 			},
 			"devDependencies": {
@@ -53548,7 +53548,7 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@flakiness/playwright": "^1.14.0",
-				"@playwright/test": "^1.61.1",
+				"@playwright/test": "^1.62.1",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
@@ -53610,7 +53610,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@playwright/test": "^1.61.1",
+				"@playwright/test": "^1.62.1",
 				"@types/node": "^20.19.39",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
@@ -53623,7 +53623,7 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@emotion/babel-plugin": "^11.13.5",
-				"@playwright/test": "^1.61.1",
+				"@playwright/test": "^1.62.1",
 				"@storybook/react-vite": "^10.4.3",
 				"@types/node": "^20.19.39",
 				"@wordpress/element": "file:../../packages/element",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"IS_GUTENBERG_PLUGIN": true
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.61.1",
+		"@playwright/test": "^1.62.1",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.1",
 		"@typescript/native": "npm:typescript@^7.0.2",

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -38,7 +38,7 @@
 		"@jest/test-result": "^30.4.1",
 		"@octokit/types": "^6.34.0",
 		"@octokit/webhooks-types": "^5.8.0",
-		"@playwright/test": "^1.61.1",
+		"@playwright/test": "^1.62.1",
 		"jest-message-util": "^30.4.1"
 	},
 	"devDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@flakiness/playwright": "^1.14.0",
-		"@playwright/test": "^1.61.1",
+		"@playwright/test": "^1.62.1",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.61.1",
+		"@playwright/test": "^1.62.1",
 		"@types/node": "^20.19.39",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",

--- a/test/storybook-playwright/package.json
+++ b/test/storybook-playwright/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@emotion/babel-plugin": "^11.13.5",
-		"@playwright/test": "^1.61.1",
+		"@playwright/test": "^1.62.1",
 		"@storybook/react-vite": "^10.4.3",
 		"@types/node": "^20.19.39",
 		"@wordpress/element": "file:../../packages/element",


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.62.

## What's new?
https://playwright.dev/docs/release-notes#version-162

## Testing Instructions

- Run any e2e test locally; the command should download new browsers and run the test successfully.
- CI checks are green.
