### PR TITLE
Perf Tests: Merge selection event windows instead of summing durations

### DIFF
--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `Metrics.getSelectionEventDurations()`: Also collect `pointerup` and `selectionchange` durations, and omit event types that did not fire. Selecting a block within an editing host no longer fires `focus`/`focusin`, which made the metric report zero.
+-   `Metrics.getSelectionEventDurations()`: Also collect `pointerup` and `selectionchange` durations, and omit event types that did not fire. Selecting a block within an editing host no longer fires `focus`/`focusin`, which made the metric report zero. Dispatches that nest inside another dispatch now contribute only the time not already covered by it, so summing the returned durations no longer counts the nested work twice.
 
 ## 1.51.0 (2026-07-14)
 

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -24,6 +24,7 @@ type EventType =
 interface TraceEvent {
 	cat: string;
 	name: string;
+	ts: number;
 	dur?: number;
 	args: {
 		data?: {
@@ -31,6 +32,13 @@ interface TraceEvent {
 		};
 	};
 }
+
+// A traced `EventDispatch`, once filtered down to the events that carry both a
+// duration and an event type.
+type EventDispatch = TraceEvent & {
+	dur: number;
+	args: { data: { type: EventType } };
+};
 
 interface Trace {
 	traceEvents: TraceEvent[];
@@ -306,16 +314,43 @@ export class Metrics {
 	 * types that did not fire are left out: callers sum the durations, and an
 	 * empty list sums to `undefined`, which would poison the total.
 	 *
-	 * @return Durations of the traced `focus`, `focusin`, `pointerup`, and
-	 * `selectionchange` events that fired.
+	 * The dispatches also nest — a click that moves focus into the editing
+	 * host dispatches `focus`/`focusin` inside the `pointerup` dispatch — so
+	 * each dispatch is clipped to the time not already covered by an earlier
+	 * one. Summing then measures the wall clock instead of counting the
+	 * nested work once per enclosing dispatch.
+	 *
+	 * @return Non-overlapping durations of the traced `focus`, `focusin`,
+	 * `pointerup`, and `selectionchange` dispatches that fired, grouped by
+	 * event type.
 	 */
 	getSelectionEventDurations() {
-		return [
-			this.getEventDurations( 'focus' ),
-			this.getEventDurations( 'focusin' ),
-			this.getEventDurations( 'pointerup' ),
-			this.getEventDurations( 'selectionchange' ),
-		].filter( ( durations ) => durations.length );
+		const eventTypes: EventType[] = [
+			'focus',
+			'focusin',
+			'pointerup',
+			'selectionchange',
+		];
+		const durations = new Map< EventType, number[] >(
+			eventTypes.map( ( type ): [ EventType, number[] ] => [ type, [] ] )
+		);
+		const dispatches = this.getEventDispatches( eventTypes ).sort(
+			( a, b ) => a.ts - b.ts
+		);
+
+		let coveredUntil = -Infinity;
+		for ( const item of dispatches ) {
+			const end = item.ts + item.dur;
+			const from = Math.max( item.ts, coveredUntil );
+			coveredUntil = Math.max( coveredUntil, end );
+			durations
+				.get( item.args.data.type )!
+				.push( Math.max( 0, end - from ) / 1000 );
+		}
+
+		return [ ...durations.values() ].filter(
+			( eventDurations ) => eventDurations.length
+		);
 	}
 
 	/**
@@ -340,21 +375,30 @@ export class Metrics {
 	 * @return Durations of all events of a given type.
 	 */
 	getEventDurations( eventType: EventType ) {
+		return this.getEventDispatches( [ eventType ] ).map(
+			( item ) => item.dur / 1000
+		);
+	}
+
+	/**
+	 * @param eventTypes Types of event to filter.
+	 * @return The `EventDispatch` trace events of the given types.
+	 */
+	private getEventDispatches( eventTypes: EventType[] ) {
 		if ( this.trace.traceEvents.length === 0 ) {
 			throw new Error(
 				'No trace events found. Did you forget to call stopTracing()?'
 			);
 		}
 
-		return this.trace.traceEvents
-			.filter(
-				( item: TraceEvent ): boolean =>
-					item.cat === 'devtools.timeline' &&
-					item.name === 'EventDispatch' &&
-					item?.args?.data?.type === eventType &&
-					!! item.dur
-			)
-			.map( ( item ) => ( item.dur ? item.dur / 1000 : 0 ) );
+		return this.trace.traceEvents.filter(
+			( item: TraceEvent ): item is EventDispatch =>
+				item.cat === 'devtools.timeline' &&
+				item.name === 'EventDispatch' &&
+				!! item.dur &&
+				!! item.args?.data &&
+				eventTypes.includes( item.args.data.type )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## What?

Makes `Metrics.getSelectionEventDurations()` return non-overlapping durations, so the `focus` metric in the post editor perf spec measures wall clock instead of counting nested work more than once.

## Why?

Follow-up to #80524, which added `pointerup` and `selectionchange` to the metric. Those dispatches nest: a click that moves focus into the editing host dispatches `focus`/`focusin` inside the `pointerup` dispatch. The call site sums the per-type durations, so the enclosed time was counted once per enclosing dispatch, inflating the reported number by however much of the work happened inside another dispatch.

## How?

`getSelectionEventDurations()` now sweeps the matching `EventDispatch` trace events in start order and clips each one to the time not already covered by an earlier dispatch, so the durations sum to the union of the dispatch windows. Public API is unchanged: same method name, same `number[][]` shape grouped by event type, same "omit types that did not fire" behavior. The perf spec is untouched.

Supporting cleanup: the shared filter moved into a private `getEventDispatches()` that narrows via a type predicate, dropping a `dur as number` assertion and a dead `item.dur ? ' … : 0` branch from `getEventDurations()`.

## Testing Instructions

1. `npm run test:performance -- post-editor` against a built plugin.
2. The `focus` metric should still be non-zero and stable across runs, but lower than on trunk. The difference is the previously double-counted nested time. Other metrics are unaffected.

## Use of AI Tools

Assisted by Claude