### PR TITLE
DOM: treat a caret at a soft line wrap as an ambiguous position in Firefox

### DIFF
--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -100,7 +100,11 @@ export default function getRectangleFromRange( range ) {
 		range.startOffset > 0 &&
 		range.startOffset < /** @type {Text} */ ( startContainer ).length
 	) {
-		const measure = ( start, end ) => {
+		assertIsDefined( ownerDocument, 'ownerDocument' );
+		const measure = (
+			/** @type {number} */ start,
+			/** @type {number} */ end
+		) => {
 			const charRange = ownerDocument.createRange();
 			charRange.setStart( startContainer, start );
 			charRange.setEnd( startContainer, end );

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -88,6 +88,32 @@ export default function getRectangleFromRange( range ) {
 		return null;
 	}
 
+	// A collapsed range at a soft line wrap is equally ambiguous: the same
+	// position ends one line and starts the next. Some browsers (Gecko)
+	// return a single rectangle for it, on the upper line, regardless of
+	// where the caret is. Detect the boundary by measuring the characters
+	// around the position: when they sit on different lines, there is no
+	// way to know which line the caret is on, so don't return anything.
+	if (
+		rects.length === 1 &&
+		startContainer.nodeType === startContainer.TEXT_NODE &&
+		range.startOffset > 0 &&
+		range.startOffset < /** @type {Text} */ ( startContainer ).length
+	) {
+		const measure = ( start, end ) => {
+			const charRange = ownerDocument.createRange();
+			charRange.setStart( startContainer, start );
+			charRange.setEnd( startContainer, end );
+			return charRange.getBoundingClientRect();
+		};
+		const before = measure( range.startOffset - 1, range.startOffset );
+		const after = measure( range.startOffset, range.startOffset + 1 );
+
+		if ( before.bottom <= after.top ) {
+			return null;
+		}
+	}
+
 	let rect = rects[ 0 ];
 
 	// If the collapsed range starts (and therefore ends) at an element node,

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -91,6 +91,32 @@ export default function getRectangleFromRange( range ) {
 		return null;
 	}
 
+	// A collapsed range at a soft line wrap is equally ambiguous: the same
+	// position ends one line and starts the next. Some browsers (Gecko)
+	// return a single rectangle for it, on the upper line, regardless of
+	// where the caret is. Detect the boundary by measuring the characters
+	// around the position: when they sit on different lines, there is no
+	// way to know which line the caret is on, so don't return anything.
+	if (
+		rects.length === 1 &&
+		startContainer.nodeType === startContainer.TEXT_NODE &&
+		range.startOffset > 0 &&
+		range.startOffset < /** @type {Text} */ ( startContainer ).length
+	) {
+		const measure = ( start, end ) => {
+			const charRange = ownerDocument.createRange();
+			charRange.setStart( startContainer, start );
+			charRange.setEnd( startContainer, end );
+			return charRange.getBoundingClientRect();
+		};
+		const before = measure( range.startOffset - 1, range.startOffset );
+		const after = measure( range.startOffset, range.startOffset + 1 );
+
+		if ( before.bottom <= after.top ) {
+			return null;
+		}
+	}
+
 	let rect = rects[ 0 ];
 
 	// If the collapsed range starts (and therefore ends) at an element node,

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1080,7 +1080,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 <!-- /wp:paragraph -->` );
 	} );
 
-	test( 'should move to the start of the first line on ArrowUp (-firefox)', async ( {
+	test( 'should move to the start of the first line on ArrowUp', async ( {
 		page,
 		editor,
 	} ) => {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1074,7 +1074,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 <!-- /wp:paragraph -->` );
 	} );
 
-	test( 'should move to the start of the first line on ArrowUp (-firefox)', async ( {
+	test( 'should move to the start of the first line on ArrowUp', async ( {
 		page,
 		editor,
 	} ) => {


### PR DESCRIPTION
## What?
Fixes #34215. In Firefox, ArrowUp from the start of a wrapped line no longer jumps out of the block.

## Why?
A caret at a soft line wrap is one position with two places on screen: the end of one line and the start of the next. Which one the caret occupies (its affinity) is internal to the browser's selection engine and not exposed through the Range API. Chromium returns both candidate rectangles for such a range, and `getRectangleFromRange` already maps that to `null`: `isEdge` then declines and native caret movement, which does know the affinity, handles the key. That guard was added for this same bug in Chromium (#42423). Gecko, however, returns a single rectangle, always the upper line's ([bug 1014738](https://bugzilla.mozilla.org/show_bug.cgi?id=1014738)), so the guard never fires and `isVerticalEdge` concludes the caret is on the first line.

## How?
Detect the ambiguity Gecko hides: for a single-rectangle collapsed range inside a text node, measure the characters on either side of the position; when they sit on different lines the position is a wrap boundary, and the function returns `null` like the multi-rectangle case. No browser sniffing; Chromium never reaches the new code since its two rectangles exit at the existing guard.

The previously skipped first-line ArrowUp test runs on Firefox again and covers the fix; it fails on trunk.

Alternative to #76954 and #71205. Resolving the ambiguity toward either line breaks the opposite gesture, since the two readings of the boundary belong to different lines; deferring to the browser is the only side that cannot be wrong about where the caret is.

## Testing Instructions
1. In Firefox, add a paragraph long enough to wrap, after another block.
2. Place the caret at the start of the second line and press ArrowUp.
3. The caret moves to the first line of the same block; previously it jumped to the block above.

## Use of AI Tools
Written with Claude Code, reviewed and tested by me.
