### PR TITLE
Interface: Render ComplementaryArea fills through a portal

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useContext, useCallback } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
 import { isRTL, __ } from '@wordpress/i18n';
 import {
 	ComplementaryArea,
@@ -82,17 +82,13 @@ function SidebarContent( {
 		// block selection changes, not sidebar state changes.
 	}, [ hasSelectedNonAreaBlock, enableComplementaryArea ] );
 
-	const tabsContextValue = useContext( Tabs.Context );
-
 	return (
 		<ComplementaryArea
 			className="edit-widgets-sidebar"
 			header={
-				<Tabs.Context.Provider value={ tabsContextValue }>
-					<SidebarHeader
-						selectedWidgetAreaBlock={ selectedWidgetAreaBlock }
-					/>
-				</Tabs.Context.Provider>
+				<SidebarHeader
+					selectedWidgetAreaBlock={ selectedWidgetAreaBlock }
+				/>
 			}
 			headerClassName="edit-widgets-sidebar__panel-tabs"
 			/* translators: button label text should, if possible, be under 16 characters. */
@@ -103,32 +99,30 @@ function SidebarContent( {
 			icon={ isRTL() ? drawerLeft : drawerRight }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
-			<Tabs.Context.Provider value={ tabsContextValue }>
-				<Tabs.TabPanel
-					tabId={ WIDGET_AREAS_IDENTIFIER }
-					focusable={ false }
-				>
-					<WidgetAreas
-						selectedWidgetAreaId={
-							selectedWidgetAreaBlock?.attributes.id
-						}
-					/>
-				</Tabs.TabPanel>
-				<Tabs.TabPanel
-					tabId={ BLOCK_INSPECTOR_IDENTIFIER }
-					focusable={ false }
-				>
-					{ hasSelectedNonAreaBlock ? (
-						<BlockInspector />
-					) : (
-						// Pretend that Widget Areas are part of the UI by not
-						// showing the Block Inspector when one is selected.
-						<span className="block-editor-block-inspector__no-blocks">
-							{ __( 'No block selected.' ) }
-						</span>
-					) }
-				</Tabs.TabPanel>
-			</Tabs.Context.Provider>
+			<Tabs.TabPanel
+				tabId={ WIDGET_AREAS_IDENTIFIER }
+				focusable={ false }
+			>
+				<WidgetAreas
+					selectedWidgetAreaId={
+						selectedWidgetAreaBlock?.attributes.id
+					}
+				/>
+			</Tabs.TabPanel>
+			<Tabs.TabPanel
+				tabId={ BLOCK_INSPECTOR_IDENTIFIER }
+				focusable={ false }
+			>
+				{ hasSelectedNonAreaBlock ? (
+					<BlockInspector />
+				) : (
+					// Pretend that Widget Areas are part of the UI by not
+					// showing the Block Inspector when one is selected.
+					<span className="block-editor-block-inspector__no-blocks">
+						{ __( 'No block selected.' ) }
+					</span>
+				) }
+			</Tabs.TabPanel>
 		</ComplementaryArea>
 	);
 }

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -6,7 +6,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useContext, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { isRTL, __, _x } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -45,10 +45,6 @@ const SidebarContent = ( {
 	extraPanels,
 } ) => {
 	const tabListRef = useRef( null );
-	// Because `PluginSidebar` renders a `ComplementaryArea`, we
-	// need to forward the `Tabs` context so it can be passed through the
-	// underlying slot/fill.
-	const tabsContextValue = useContext( Tabs.Context );
 	const isRevisionsMode = useSelect( ( select ) => {
 		return unlock( select( editorStore ) ).isRevisionsMode();
 	} );
@@ -110,11 +106,7 @@ const SidebarContent = ( {
 	return (
 		<PluginSidebar
 			identifier={ tabName }
-			header={
-				<Tabs.Context.Provider value={ tabsContextValue }>
-					<SidebarHeader ref={ tabListRef } />
-				</Tabs.Context.Provider>
-			}
+			header={ <SidebarHeader ref={ tabListRef } /> }
 			closeLabel={ __( 'Close Settings' ) }
 			// This classname is added so we can apply a corrective negative
 			// margin to the panel.
@@ -129,15 +121,13 @@ const SidebarContent = ( {
 			icon={ isRTL() ? drawerLeft : drawerRight }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
-			<Tabs.Context.Provider value={ tabsContextValue }>
-				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					{ tabContent }
-				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
-					<BlockInspector />
-					{ isRevisionsMode && <RevisionBlockDiffPanel /> }
-				</Tabs.TabPanel>
-			</Tabs.Context.Provider>
+			<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
+				{ tabContent }
+			</Tabs.TabPanel>
+			<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
+				<BlockInspector />
+				{ isRevisionsMode && <RevisionBlockDiffPanel /> }
+			</Tabs.TabPanel>
 		</PluginSidebar>
 	);
 };

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `ComplementaryArea`: Render fills through a portal (`bubblesVirtually`), so they keep the React context of the `Fill` instead of inheriting the one at the `Slot`. Sidebar content no longer needs to forward context across the slot boundary by hand ([#81005](https://github.com/WordPress/gutenberg/pull/81005)).
+
 ### Internal
 
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -39,7 +39,15 @@ import { store as interfaceStore } from '../../store';
 const ANIMATION_DURATION = 0.3;
 
 function ComplementaryAreaSlot( { scope, ...props } ) {
-	return <Slot name={ `ComplementaryArea/${ scope }` } { ...props } />;
+	// Portaled, so fills keep the `Fill`'s React context, not the `Slot`'s.
+	return (
+		<Slot
+			name={ `ComplementaryArea/${ scope }` }
+			bubblesVirtually
+			className="interface-complementary-area-slot"
+			{ ...props }
+		/>
+	);
 }
 
 const SIDEBAR_WIDTH = 280;

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -73,6 +73,11 @@
 	}
 }
 
+// Portal target sitting between the sidebar region and the fill.
+.interface-complementary-area-slot {
+	height: 100%;
+}
+
 .interface-complementary-area__fill {
 	height: 100%;
 }


### PR DESCRIPTION
## What?

PR switches the `ComplementaryArea` slot to `bubblesVirtually`, so fills render through a portal and keep the React context of the `Fill` rather than inheriting the one at the `Slot`. Drops the hand-rolled `Tabs.Context` forwarding from the post editor and widgets editor sidebars.

## Why?

`ComplementaryArea` used a non-bubbling `Slot`, which re-renders Fills in the `Slot`'s tree and severs context. Both sidebars worked around it by reading `Tabs.Context` and re-providing it on either side of the boundary.

That workaround only exists because the current `Tabs` exposes its context; the recommended `Tabs` from `@wordpress/ui` (built on Base UI) does not, so the sidebars can't be migrated while the boundary still drops context.

## How?

- `ComplementaryAreaSlot` passes `bubblesVirtually` and an `interface-complementary-area-slot` class name.
- The portal target is a real `div` between the skeleton's sidebar region and the fill, so it gets `height: 100%` to keep the panel's scroll container and sticky header working.
- Removes `useContext( Tabs.Context )` and both `Tabs.Context.Provider` wrappers from the editor and edit-widgets sidebars.

## Testing Instructions

1. Post editor: toggle the settings sidebar, switch between the Post and Block tabs, confirm the open/close animation and panel scrolling are unchanged.
2. Open dropdowns and popovers inside the sidebar, including nested ones.
3. Switch directly between two open complementary areas (e.g., Settings and a plugin sidebar); the transition should not animate.
4. Enter and leave revision mode.
5. Repeat 1-2 on the widgets screen and in the media editor, checking the media editor at both the small and medium breakpoints.

## Use of AI Tools

Assisted by Claude.
