### PR TITLE
Editor: Use the recommended Tabs component in the settings sidebar

### DIFF
--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -1,11 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { Tabs } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -14,9 +13,7 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { sidebars } from './constants';
 
-const { Tabs } = unlock( componentsPrivateApis );
-
-const SidebarHeader = ( _, ref ) => {
+function SidebarHeader() {
 	const { postTypeLabel, isRevisionsMode } = useSelect( ( select ) => {
 		const { getPostTypeLabel } = select( editorStore );
 		const { isRevisionsMode: _isRevisionsMode } = unlock(
@@ -39,24 +36,14 @@ const SidebarHeader = ( _, ref ) => {
 	}
 
 	return (
-		<Tabs.TabList ref={ ref }>
-			<Tabs.Tab
-				tabId={ sidebars.document }
-				// Used for focus management in the SettingsSidebar component.
-				data-tab-id={ sidebars.document }
-			>
-				{ documentLabel }
-			</Tabs.Tab>
-			<Tabs.Tab
-				tabId={ sidebars.block }
-				// Used for focus management in the SettingsSidebar component.
-				data-tab-id={ sidebars.block }
-			>
+		<Tabs.List activateOnFocus={ false }>
+			<Tabs.Tab value={ sidebars.document }>{ documentLabel }</Tabs.Tab>
+			<Tabs.Tab value={ sidebars.block }>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
 				{ __( 'Block' ) }
 			</Tabs.Tab>
-		</Tabs.TabList>
+		</Tabs.List>
 	);
-};
+}
 
-export default forwardRef( SidebarHeader );
+export default SidebarHeader;

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -6,12 +6,12 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { isRTL, __, _x } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as interfaceStore } from '@wordpress/interface';
+import { Tabs } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,8 +34,6 @@ import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-const { Tabs } = unlock( componentsPrivateApis );
-
 const SIDEBAR_ACTIVE_BY_DEFAULT = true;
 
 const SidebarContent = ( {
@@ -44,37 +42,9 @@ const SidebarContent = ( {
 	onActionPerformed,
 	extraPanels,
 } ) => {
-	const tabListRef = useRef( null );
 	const isRevisionsMode = useSelect( ( select ) => {
 		return unlock( select( editorStore ) ).isRevisionsMode();
 	} );
-
-	// This effect addresses a race condition caused by tabbing from the last
-	// block in the editor into the settings sidebar. Without this effect, the
-	// selected tab and browser focus can become separated in an unexpected way
-	// (e.g the "block" tab is focused, but the "post" tab is selected).
-	useEffect( () => {
-		const tabsElements = Array.from(
-			tabListRef.current?.querySelectorAll( '[role="tab"]' ) || []
-		);
-		const selectedTabElement = tabsElements.find(
-			// We are purposefully using a custom `data-tab-id` attribute here
-			// because we don't want rely on any assumptions about `Tabs`
-			// component internals.
-			( element ) => element.getAttribute( 'data-tab-id' ) === tabName
-		);
-		const activeElement = selectedTabElement?.ownerDocument.activeElement;
-		const tabsHasFocus = tabsElements.some( ( element ) => {
-			return activeElement && activeElement.id === element.id;
-		} );
-		if (
-			tabsHasFocus &&
-			selectedTabElement &&
-			selectedTabElement.id !== activeElement?.id
-		) {
-			selectedTabElement?.focus();
-		}
-	}, [ tabName ] );
 
 	let tabContent;
 	if ( isRevisionsMode ) {
@@ -106,7 +76,7 @@ const SidebarContent = ( {
 	return (
 		<PluginSidebar
 			identifier={ tabName }
-			header={ <SidebarHeader ref={ tabListRef } /> }
+			header={ <SidebarHeader /> }
 			closeLabel={ __( 'Close Settings' ) }
 			// This classname is added so we can apply a corrective negative
 			// margin to the panel.
@@ -121,13 +91,13 @@ const SidebarContent = ( {
 			icon={ isRTL() ? drawerLeft : drawerRight }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
-			<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
+			<Tabs.Panel value={ sidebars.document } tabIndex={ -1 }>
 				{ tabContent }
-			</Tabs.TabPanel>
-			<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
+			</Tabs.Panel>
+			<Tabs.Panel value={ sidebars.block } tabIndex={ -1 }>
 				<BlockInspector />
 				{ isRevisionsMode && <RevisionBlockDiffPanel /> }
-			</Tabs.TabPanel>
+			</Tabs.Panel>
 		</PluginSidebar>
 	);
 };
@@ -170,10 +140,14 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 	);
 
 	return (
-		<Tabs
-			selectedTabId={ tabName }
-			onSelect={ onTabSelect }
-			selectOnMove={ false }
+		// `PluginSidebar` takes the tab list and the panels as separate props,
+		// so this is the lowest place that can hold both. They portal into the
+		// sidebar slot, leaving this div empty; `Tabs` only needs to be their
+		// ancestor in the React tree, not in the DOM.
+		<Tabs.Root
+			className="editor-sidebar__tabs"
+			value={ tabName }
+			onValueChange={ onTabSelect }
 		>
 			<SidebarContent
 				tabName={ tabName }
@@ -181,7 +155,7 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
 			/>
-		</Tabs>
+		</Tabs.Root>
 	);
 };
 

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -15,6 +15,11 @@
 	}
 }
 
+// The `Tabs` root's children all render into the sidebar's slot.
+.editor-sidebar__tabs {
+	display: contents;
+}
+
 .editor-post-summary .components-v-stack:empty {
 	display: none;
 }

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -103,6 +103,37 @@ test.describe( 'Sidebar', () => {
 		await expect( activeTab ).toBeFocused();
 	} );
 
+	test( 'should focus the selected tab when tabbing into the sidebar', async ( {
+		editor,
+		page,
+	} ) => {
+		for ( const content of [ '0', '1' ] ) {
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			await page.keyboard.type( content );
+		}
+
+		const activeTab = page
+			.getByRole( 'region', {
+				name: 'Editor settings',
+			} )
+			.getByRole( 'tab', { selected: true } );
+
+		// A selected block puts the sidebar on the "Block" tab.
+		await page.keyboard.press( 'Escape' );
+		await page.keyboard.press( 'Tab' );
+		await expect( activeTab ).toHaveText( 'Block' );
+		await expect( activeTab ).toBeFocused();
+
+		// Moving to the title clears the block selection, which switches the
+		// sidebar back to the "Post" tab.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.click();
+		await page.keyboard.press( 'Tab' );
+		await expect( activeTab ).toHaveText( 'Post' );
+		await expect( activeTab ).toBeFocused();
+	} );
+
 	test( 'should be possible to programmatically remove Document Settings panels', async ( {
 		page,
 	} ) => {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1387,16 +1387,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/sidebar/header.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/sidebar/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/sidebar/post-revision-summary.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What?

PR migrates the post editor settings sidebar from the private `Tabs` in `@wordpress/components` to `Tabs` from `@wordpress/ui`. Also drops the focus-sync effect that kept the focused and selected tabs together, along with the `data-tab-id` attributes and the ref plumbing that existed only to serve them.

Builds on #81005 (ComplementaryArea fills rendered through a portal), which is what lets a single `Tabs.Root` reach both the tab list and the panels.

## Why?

`Tabs` from `@wordpress/ui` is the recommended component per the `use-recommended-components` ESLint rule, and the sidebar carried a suppression entry for it.

The focus-sync effect was added in #58041 to fix a race when tabbing off the last block: focus moved to the active **Block** tab, then `interfaceStore` noticed focus had left the blocks and switched selection to **Post**, leaving one tab focused and the other selected. That race is no longer reachable. The post title and blocks are a single contenteditable writing flow, so there are no per-block tab stops to leave, and Tab exits straight to the sidebar. The navigation it depended on was removed in #65204, which also deleted the guard test #58041 had updated.

Base UI covers the invariant on its own: `Tabs.Tab` syncs the composite's highlighted item to the active tab, and only the highlighted item carries `tabindex="0"`, so tabbing in lands on the selected tab by construction.

## How?

API mapping:

| Before | After |
| --- | --- |
| `<Tabs selectedTabId onSelect>` | `<Tabs.Root value onValueChange>` |
| `Tabs.TabList` / `Tabs.TabPanel` | `Tabs.List` / `Tabs.Panel` |
| `tabId="..."` | `value="..."` |
| `selectOnMove={ false }` on the root | `activateOnFocus={ false }` on the list |
| `focusable={ false }` on the panel | `tabIndex={ -1 }` |

The old root rendered no DOM, but `Tabs.Root` renders a `div`. Every child portals into the sidebar slot, so it is left with nothing to lay out and gets `display: contents`.

Adds an e2e test asserting the focused tab is the selected tab for both ways into the tab list, and removes the two now-unused `use-recommended-components` suppressions.

## Testing Instructions

1. Open a post. Toggle the settings sidebar and switch between the Post and Block tabs.
2. Arrow between the two tabs and confirm selection does not follow focus;
   Enter or Space selects the focused tab.
3. Select a block, press Tab into the sidebar, and confirm the Block tab is focused and selected. Click the title, press Tab, and confirm the same for the Post tab.
4. Check panel scrolling and the sticky panel header.
5. Enter and leave revision mode.


## Use of AI Tools

Assisted by Claude
