### PR TITLE
Fix/responsive state text rotation

### DIFF
--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -329,6 +329,65 @@ function gutenberg_get_block_state_element_selectors( $root_selector ) {
 }
 
 /**
+ * Returns whether a writing mode and text alignment are the combination that
+ * block stylesheets flip upside down.
+ *
+ * Blocks that support vertical text are rotated half a turn when the text is
+ * aligned to the end of its inline axis, so that it reads bottom to top rather
+ * than top to bottom. See the `rotate` rules in the paragraph, heading, and post
+ * navigation link stylesheets.
+ *
+ * @param string|null $writing_mode Writing mode value, e.g. `vertical-rl`.
+ * @param string|null $text_align   Text alignment value, e.g. `right`.
+ * @return bool Whether the two values together flip the block.
+ */
+function gutenberg_is_text_orientation_flipped( $writing_mode, $text_align ) {
+	return ( 'vertical-rl' === $writing_mode && 'right' === $text_align )
+		|| ( 'vertical-lr' === $writing_mode && 'left' === $text_align );
+}
+
+/**
+ * Returns the `rotate` value a state needs so vertical text is not left facing
+ * the wrong way at a breakpoint.
+ *
+ * The stylesheet rules that flip vertical text match the block's
+ * `has-text-align-*` class and its inline `style` attribute. Both of those come
+ * from the default state and stay in the markup at every breakpoint, so a state
+ * that changes the writing mode or the text alignment cannot turn the flip off,
+ * or on, through the cascade. The state has to say so with its own declaration.
+ *
+ * @param array $base_typography  Typography styles from the block's default state.
+ * @param array $state_typography Typography styles the state applies on top.
+ * @return string|null `180deg` or `none`, or null when the state does not change
+ *                     whether the block is flipped.
+ */
+function gutenberg_get_state_text_orientation_rotation( $base_typography, $state_typography ) {
+	if (
+		! array_key_exists( 'writingMode', $state_typography ) &&
+		! array_key_exists( 'textAlign', $state_typography )
+	) {
+		return null;
+	}
+
+	$base_is_flipped = gutenberg_is_text_orientation_flipped(
+		$base_typography['writingMode'] ?? null,
+		$base_typography['textAlign'] ?? null
+	);
+
+	// Values the state does not set keep applying from the default state.
+	$state_is_flipped = gutenberg_is_text_orientation_flipped(
+		$state_typography['writingMode'] ?? $base_typography['writingMode'] ?? null,
+		$state_typography['textAlign'] ?? $base_typography['textAlign'] ?? null
+	);
+
+	if ( $base_is_flipped === $state_is_flipped ) {
+		return null;
+	}
+
+	return $state_is_flipped ? '180deg' : 'none';
+}
+
+/**
  * Adds a compiled state style rule to a rule list.
  *
  * @param array       $css_rules   Style rules.
@@ -336,8 +395,11 @@ function gutenberg_get_block_state_element_selectors( $root_selector ) {
  * @param string|null $selector    Block, feature, or element selector.
  * @param array       $style       Style object.
  * @param string|null $rules_group Optional CSS grouping rule, e.g. a media query.
+ * @param array|null  $base_style  Optional style object for the block's default
+ *                                 state, used to work out whether the state
+ *                                 changes the text orientation rotation.
  */
-function gutenberg_add_block_state_style_rule( &$css_rules, $state, $selector, $style, $rules_group = null ) {
+function gutenberg_add_block_state_style_rule( &$css_rules, $state, $selector, $style, $rules_group = null, $base_style = null ) {
 	if ( empty( $style ) || ! is_array( $style ) ) {
 		return;
 	}
@@ -352,6 +414,18 @@ function gutenberg_add_block_state_style_rule( &$css_rules, $state, $selector, $
 	// Base text alignment is class-based, so state styles need a declaration.
 	if ( is_string( $text_align ) && '' !== trim( $text_align ) ) {
 		$declarations['text-align'] = $text_align;
+	}
+
+	// The base rotation comes from stylesheet rules that match markup, which a
+	// breakpoint cannot change, so state styles need a declaration for that too.
+	if ( is_array( $base_style ) ) {
+		$rotation = gutenberg_get_state_text_orientation_rotation(
+			$base_style['typography'] ?? array(),
+			$style['typography'] ?? array()
+		);
+		if ( null !== $rotation ) {
+			$declarations['rotate'] = $rotation;
+		}
 	}
 
 	if ( empty( $declarations ) ) {
@@ -374,9 +448,12 @@ function gutenberg_add_block_state_style_rule( &$css_rules, $state, $selector, $
  * @param array         $state_styles Map of state to style array.
  * @param WP_Block_Type $block_type   Block type.
  * @param string|null   $rules_group  Optional CSS grouping rule, e.g. a media query.
+ * @param array|null    $base_style   Optional style object for the block's default
+ *                                    state, used to work out whether a state
+ *                                    changes the text orientation rotation.
  * @return array[] State style rules.
  */
-function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rules_group = null ) {
+function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rules_group = null, $base_style = null ) {
 	$css_rules       = array();
 	$block_selectors = isset( $block_type->selectors ) && is_array( $block_type->selectors )
 		? $block_type->selectors
@@ -393,7 +470,8 @@ function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rul
 				$state,
 				$group['selector'],
 				$group['style'],
-				$rules_group
+				$rules_group,
+				$base_style
 			);
 		}
 	}
@@ -553,12 +631,19 @@ function gutenberg_render_block_states_support( $block_content, $block ) {
 		);
 
 		if ( ! empty( $root_state_style ) ) {
+			/*
+			 * The default state's styles are passed alongside so the rule can carry
+			 * a `rotate` declaration when the breakpoint changes whether vertical
+			 * text should be flipped. Pseudo states are not given the same
+			 * treatment because no block that flips vertical text supports one.
+			 */
 			$css_rules = array_merge(
 				$css_rules,
 				gutenberg_get_block_state_style_rules(
 					array( '' => $root_state_style ),
 					$block_type,
-					$media_query
+					$media_query,
+					$style
 				)
 			);
 		}

--- a/lib/compat/wordpress-7.1/kses.php
+++ b/lib/compat/wordpress-7.1/kses.php
@@ -99,6 +99,33 @@ function gutenberg_add_svg_to_safe_style_css( array $attr ): array {
 add_filter( 'safe_style_css', 'gutenberg_add_svg_to_safe_style_css' );
 
 /**
+ * Adds the `rotate` property to the list of safe CSS properties.
+ *
+ * Block stylesheets flip vertical text upside down with `rotate` when the text is
+ * aligned to the end of its inline axis. Those rules match the block's class and
+ * inline `style` attribute, neither of which changes at a breakpoint, so the state
+ * block support has to emit `rotate` as a declaration to turn the flip off (or on)
+ * for a viewport. {@see safecss_filter_attr()} allows the `transform` shorthand but
+ * none of the individual transform properties, so without this the declaration is
+ * stripped from the frontend stylesheet while still working in the editor.
+ *
+ * @param string[] $attr Array of allowed CSS attributes.
+ * @return string[] Modified array of allowed CSS attributes.
+ */
+function gutenberg_add_rotate_to_safe_style_css( $attr ) {
+	if ( ! is_array( $attr ) ) {
+		return $attr;
+	}
+
+	if ( ! in_array( 'rotate', $attr, true ) ) {
+		$attr[] = 'rotate';
+	}
+
+	return $attr;
+}
+add_filter( 'safe_style_css', 'gutenberg_add_rotate_to_safe_style_css' );
+
+/**
  * Allow gradient background-image values, including gradients combined with a
  * url() image, in inline styles.
  *

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `RichText`: Skip the block input transforms in fields that are not passed an `onReplace`.
+-   Viewport style states that change a block's writing mode or text alignment now emit a `rotate` declaration, so the stylesheet rule that flips vertical text upside down is turned off, or on, at that breakpoint. Previously the rule kept applying from the default state, because it matches the block's `has-text-align-*` class and inline `style` attribute and neither of those changes at a breakpoint.
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -232,6 +232,81 @@ function getStateTextAlignCSS( stateStyles, selector ) {
 }
 
 /**
+ * Returns whether a writing mode and text alignment are the combination that
+ * block stylesheets flip upside down.
+ *
+ * Blocks that support vertical text are rotated half a turn when the text is
+ * aligned to the end of its inline axis, so that it reads bottom to top rather
+ * than top to bottom. See the `rotate` rules in the paragraph, heading, and post
+ * navigation link stylesheets.
+ *
+ * @param {string} [writingMode] Writing mode value, e.g. `vertical-rl`.
+ * @param {string} [textAlign]   Text alignment value, e.g. `right`.
+ * @return {boolean} Whether the two values together flip the block.
+ */
+function isTextOrientationFlipped( writingMode, textAlign ) {
+	return (
+		( writingMode === 'vertical-rl' && textAlign === 'right' ) ||
+		( writingMode === 'vertical-lr' && textAlign === 'left' )
+	);
+}
+
+/**
+ * Returns CSS that keeps vertical text from facing the wrong way in a block
+ * instance state style object.
+ *
+ * The stylesheet rules that flip vertical text match the block's
+ * `has-text-align-*` class and its inline `style` attribute. Both of those come
+ * from the default state and stay in the markup at every breakpoint, so a state
+ * that changes the writing mode or the text alignment cannot turn the flip off,
+ * or on, through the cascade. The state needs its own declaration.
+ *
+ * @param {Object} baseStyle   Style object for the block's default state.
+ * @param {Object} stateStyles State style object.
+ * @param {string} selector    CSS selector for the generated style.
+ * @return {string|undefined} CSS string with the rotation declaration, or
+ *                            undefined when the state does not change whether
+ *                            the block is flipped.
+ */
+function getStateTextOrientationRotationCSS(
+	baseStyle,
+	stateStyles,
+	selector
+) {
+	const baseTypography = baseStyle?.typography;
+	const stateTypography = stateStyles?.typography;
+
+	if (
+		stateTypography?.writingMode === undefined &&
+		stateTypography?.textAlign === undefined
+	) {
+		return undefined;
+	}
+
+	const baseIsFlipped = isTextOrientationFlipped(
+		baseTypography?.writingMode,
+		baseTypography?.textAlign
+	);
+
+	// Values the state does not set keep applying from the default state.
+	const stateIsFlipped = isTextOrientationFlipped(
+		stateTypography?.writingMode ?? baseTypography?.writingMode,
+		stateTypography?.textAlign ?? baseTypography?.textAlign
+	);
+
+	if ( baseIsFlipped === stateIsFlipped ) {
+		return undefined;
+	}
+
+	const declaration = `rotate: ${
+		stateIsFlipped ? '180deg' : 'none'
+	} !important`;
+	return selector
+		? `${ selector } { ${ declaration }; }`
+		: `${ declaration };`;
+}
+
+/**
  * Generates CSS for a block instance state style object.
  *
  * State declarations need to win over preset utility classes, but fallback
@@ -240,9 +315,12 @@ function getStateTextAlignCSS( stateStyles, selector ) {
  *
  * @param {Object} stateStyles State style object.
  * @param {string} selector    CSS selector for the generated style.
+ * @param {Object} [baseStyle] Style object for the block's default state, used to
+ *                             work out whether the state changes the text
+ *                             orientation rotation.
  * @return {string} Generated stylesheet.
  */
-export function getStateStylesCSS( stateStyles, selector ) {
+export function getStateStylesCSS( stateStyles, selector, baseStyle ) {
 	const fallbackDimensionStyles =
 		getStateFallbackDimensionStyles( stateStyles );
 	const stylesWithDimensionFallbacks = fallbackDimensionStyles
@@ -255,12 +333,23 @@ export function getStateStylesCSS( stateStyles, selector ) {
 		? compileCSS( fallbackBorderStyles, { selector } )
 		: undefined;
 	const textAlignCSS = getStateTextAlignCSS( stateStyles, selector );
+	const rotationCSS = getStateTextOrientationRotationCSS(
+		baseStyle,
+		stateStyles,
+		selector
+	);
 	const backgroundResetCSS = getStateBackgroundResetCSS(
 		stateStyles,
 		selector
 	);
 
-	return [ importantCSS, textAlignCSS, fallbackCSS, backgroundResetCSS ]
+	return [
+		importantCSS,
+		textAlignCSS,
+		rotationCSS,
+		fallbackCSS,
+		backgroundResetCSS,
+	]
 		.filter( Boolean )
 		.join( '\n' );
 }
@@ -364,12 +453,13 @@ function getStateStyleGroups( stateStyles, name ) {
  * @return {string|undefined} Generated stylesheet.
  */
 export function getBlockStateStylesCSS( stateStyles, options ) {
-	const { name, baseSelector, state = '' } = options;
+	const { name, baseSelector, state = '', baseStyle } = options;
 	const rules = getStateStyleGroups( stateStyles, name )
 		.map( ( { selector: blockSelector, style } ) =>
 			getStateStylesCSS(
 				style,
-				buildScopedBlockSelector( baseSelector, blockSelector, state )
+				buildScopedBlockSelector( baseSelector, blockSelector, state ),
+				baseStyle
 			)
 		)
 		.filter( Boolean );
@@ -467,11 +557,18 @@ export function getResponsiveStateCSSRules(
 			}
 
 			const viewportCSSRules = [];
+			/*
+			 * The default state's styles are passed alongside so the rule can carry
+			 * a `rotate` declaration when the breakpoint changes whether vertical
+			 * text should be flipped. Pseudo states are not given the same
+			 * treatment because no block that flips vertical text supports one.
+			 */
 			const rootCSS = getBlockStateStylesCSS(
 				getRootStateStyles( viewportStyles, nestedStateKeys ),
 				{
 					name,
 					baseSelector,
+					baseStyle: style,
 				}
 			);
 			if ( rootCSS ) {

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -443,6 +443,63 @@ describe( 'getResponsiveStateCSSRules', () => {
 		] );
 	} );
 
+	it( 'cancels the vertical text rotation when a viewport changes the writing mode', () => {
+		expect(
+			getResponsiveStateCSSRules(
+				{
+					typography: {
+						textAlign: 'right',
+						writingMode: 'vertical-rl',
+					},
+					'@mobile': {
+						typography: { writingMode: 'horizontal-tb' },
+					},
+				},
+				'core/paragraph',
+				'.wp-elements-1'
+			)
+		).toEqual( [
+			'@media (width <= 480px){.wp-elements-1 { writing-mode: horizontal-tb !important; }\n.wp-elements-1 { rotate: none !important; }}',
+		] );
+	} );
+
+	it( 'applies the vertical text rotation when a viewport introduces the flipped combination', () => {
+		expect(
+			getResponsiveStateCSSRules(
+				{
+					typography: { textAlign: 'right' },
+					'@mobile': {
+						typography: { writingMode: 'vertical-rl' },
+					},
+				},
+				'core/paragraph',
+				'.wp-elements-1'
+			)
+		).toEqual( [
+			'@media (width <= 480px){.wp-elements-1 { writing-mode: vertical-rl !important; }\n.wp-elements-1 { rotate: 180deg !important; }}',
+		] );
+	} );
+
+	it( 'omits the rotation when a viewport does not change whether text is flipped', () => {
+		expect(
+			getResponsiveStateCSSRules(
+				{
+					typography: {
+						textAlign: 'right',
+						writingMode: 'vertical-rl',
+					},
+					'@mobile': {
+						typography: { textAlign: 'right' },
+					},
+				},
+				'core/paragraph',
+				'.wp-elements-1'
+			)
+		).toEqual( [
+			'@media (width <= 480px){.wp-elements-1 { text-align: right !important; }}',
+		] );
+	} );
+
 	it( 'routes viewport styles through feature selectors', () => {
 		expect(
 			getResponsiveStateCSSRules(

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -934,6 +934,146 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests that a responsive writing mode switches off the stylesheet rule that
+	 * flips vertical text upside down.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_writing_mode_cancels_text_orientation_rotation() {
+		$this->ensure_block_registered( 'core/paragraph' );
+
+		$block_content = '<p class="wp-block-paragraph has-text-align-right" style="writing-mode:vertical-rl">Hello</p>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'textAlign'   => 'right',
+						'writingMode' => 'vertical-rl',
+					),
+					'@mobile'    => array(
+						'typography' => array(
+							'writingMode' => 'horizontal-tb',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $matches[0] . '{writing-mode:horizontal-tb !important;rotate:none !important;}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a responsive writing mode switches on the rotation when the
+	 * breakpoint values are the combination the stylesheet rule flips, but the
+	 * default state's values are not.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_writing_mode_adds_text_orientation_rotation() {
+		$this->ensure_block_registered( 'core/paragraph' );
+
+		$block_content = '<p class="wp-block-paragraph has-text-align-right">Hello</p>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'textAlign' => 'right',
+					),
+					'@mobile'    => array(
+						'typography' => array(
+							'writingMode' => 'vertical-rl',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (width <= 480px){.' . $matches[0] . '{writing-mode:vertical-rl !important;rotate:180deg !important;}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that no rotation is emitted when the breakpoint does not change
+	 * whether the block is flipped.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_state_omits_rotation_when_orientation_is_unchanged() {
+		$this->ensure_block_registered( 'core/paragraph' );
+
+		$block_content = '<p class="wp-block-paragraph has-text-align-right" style="writing-mode:vertical-rl">Hello</p>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'textAlign'   => 'right',
+						'writingMode' => 'vertical-rl',
+					),
+					'@mobile'    => array(
+						'typography' => array(
+							'textAlign' => 'right',
+						),
+					),
+				),
+			),
+		);
+
+		gutenberg_render_block_states_support( $block_content, $block );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringNotContainsString( 'rotate:', $actual_stylesheet );
+	}
+
+	/**
+	 * Tests that no rotation is emitted when the breakpoint changes neither the
+	 * writing mode nor the text alignment.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_state_omits_rotation_when_typography_orientation_untouched() {
+		$this->ensure_block_registered( 'core/paragraph' );
+
+		$block_content = '<p class="wp-block-paragraph has-text-align-right" style="writing-mode:vertical-rl">Hello</p>';
+		$block         = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'textAlign'   => 'right',
+						'writingMode' => 'vertical-rl',
+					),
+					'@mobile'    => array(
+						'color' => array(
+							'text' => '#ff0000',
+						),
+					),
+				),
+			),
+		);
+
+		gutenberg_render_block_states_support( $block_content, $block );
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringNotContainsString( 'rotate:', $actual_stylesheet );
+	}
+
 	public function test_legacy_responsive_root_state_generates_media_query_scoped_css() {
 		$this->ensure_block_registered( 'core/paragraph' );
 


### PR DESCRIPTION
> [!TIP]
> This is a throw away PR to test something for https://github.com/WordPress/gutenberg/issues/80944

## Testing Instructions

Requires a viewport narrower than 480px — resize the browser or use the device toolbar in devtools. Responsive editing is on by default, no experiment needed.

### 1. Stale rotation is cancelled (the reported bug)

Add a paragraph via the code editor (`⌥⌘M` / `Ctrl+Alt+M`), publish, and view the post:

```
<!-- wp:paragraph {"style":{"typography":{"writingMode":"vertical-rl","textAlign":"right"},"@mobile":{"typography":{"writingMode":"horizontal-tb"}}}} -->
<p class="has-text-align-right" style="writing-mode:vertical-rl">vertical</p>
<!-- /wp:paragraph -->
```

- Wide: vertical text, reading bottom to top. Unchanged from trunk.
- Below 480px: horizontal text reading normally, left to right.
- **On trunk:** horizontal text, upside down.

Note there is no `textAlign` in the `@mobile` object. The alignment was never the cause; the writing mode alone reproduces it.

### 2. Rotation is applied when a breakpoint introduces the combination

```
<!-- wp:paragraph {"style":{"typography":{"textAlign":"right"},"@mobile":{"typography":{"writingMode":"vertical-rl"}}}} -->
<p class="has-text-align-right">vertical on mobile</p>
<!-- /wp:paragraph -->
```

- Wide: ordinary right-aligned horizontal text.
- Below 480px: vertical text reading bottom to top, matching what you get when
  the same combination is set on desktop.
- **On trunk:** vertical text reading top to bottom. The breakpoint silently
  behaves differently from the default state for identical values.

### 3. Nothing is emitted when the orientation does not change

```
<!-- wp:paragraph {"style":{"typography":{"writingMode":"vertical-rl","textAlign":"right"},"@mobile":{"color":{"text":"#ff0000"}}}} -->
<p class="has-text-align-right" style="writing-mode:vertical-rl">vertical</p>
<!-- /wp:paragraph -->
```

Text stays rotated at every width, and the generated rule contains only the colour. No stray `rotate` declaration on blocks that do not need one.

### 4. Editor UI path

1. Add a paragraph and type some text.
2. Typography panel, Orientation, Vertical. Toolbar, align right. The text flips.    That is the intended feature.
3. Preview dropdown, turn on Responsive editing, switch to Mobile.
4. Typography panel, Orientation, Horizontal.
5. Canvas shows horizontal, right-reading text. On trunk it is upside down.

### Checking the CSS directly

Inspect the paragraph and find the `@media (width <= 480px)` rule on its `.wp-states-…` class:

```css
/* this branch */
@media (width <= 480px){.wp-states-17cad9b9{writing-mode:horizontal-tb !important;rotate:none !important;}}

/* trunk */
@media (width <= 480px){.wp-states-5d7e40b0{writing-mode:horizontal-tb !important;}}
```
