### PR TITLE
RichText: fix paste handler crash when pasting files

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -21,7 +21,8 @@
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
--   `RichText`: Skip the block input transforms in fields that are not passed an `onReplace`.
+-   `RichText`: Skip the block input transforms in fields that are not passed an `onReplace` ([#80978](https://github.com/WordPress/gutenberg/pull/80978)).
+-   `RichText`: Ignore pasted files, which carry no text to paste inline ([#81010](https://github.com/WordPress/gutenberg/pull/81010)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/paste-handler.js
@@ -55,9 +55,22 @@ export default ( props ) => ( element ) => {
 			return;
 		}
 
-		const { plainText, html } = getPasteEventData( event );
+		const pasteData = getPasteEventData( event );
+
+		// Some browsers don't support `clipboardData` and paste plain text on
+		// their own, so the event has to be left alone for them.
+		if ( ! pasteData ) {
+			return;
+		}
 
 		event.preventDefault();
+
+		const { plainText, html, files } = pasteData;
+
+		// Rich text can only paste text; files are placed by the writing flow.
+		if ( files.length ) {
+			return;
+		}
 
 		// Allows us to ask for this information when we get a report.
 		// `pasteHandler` also logs this, but we're not using `pasteHandler` in


### PR DESCRIPTION
Fixes a crash in `RichText` paste handler when files are pasted.

Steps to reproduce:
1. Create a `core/pullquote` block and focus the `value` rich text field
2. Try to paste a file into the field. For example, "Copy" a file in Finder, and in the focused field, select "Paste" from the right-click context menu.

The Pullquote block cannot accept a file paste: the `value` field can only accept a text, and unlike Paragraph or Heading, it doesn't support `splitting`. The `useWritingFlow`/`useClipboardHandler` doesn't do the paste, and the event falls through to the `RichText` default handler, which crashes because there is no text (`plainText`/`html`) in the event.

<img width="579" height="49" alt="Screenshot 2026-07-31 at 10 28 10" src="https://github.com/user-attachments/assets/24224d99-29e1-4cc9-8e3f-0b4fc19473dd" />

This PR fixes the crash by adding a guard.
