### PR TITLE
Icons: keep `fill` and `stroke` on the sanitized `<svg>` root

### DIFF
--- a/lib/class-wp-icons-registry-gutenberg.php
+++ b/lib/class-wp-icons-registry-gutenberg.php
@@ -230,6 +230,44 @@ class WP_Icons_Registry_Gutenberg extends WP_Icons_Registry {
 	}
 
 	/**
+	 * Modified to keep `fill` and `stroke` on the root element, so icon
+	 * content inherits the surrounding color via `currentColor`.
+	 *
+	 * @param string $icon_content The icon SVG content to sanitize.
+	 * @return string The sanitized icon SVG content.
+	 */
+	protected function sanitize_icon_content( $icon_content ) {
+		$allowed_tags = array(
+			'svg'     => array(
+				'class'       => true,
+				'fill'        => true,
+				'stroke'      => true,
+				'xmlns'       => true,
+				'width'       => true,
+				'height'      => true,
+				'viewbox'     => true,
+				'aria-hidden' => true,
+				'role'        => true,
+				'focusable'   => true,
+			),
+			'path'    => array(
+				'fill'      => true,
+				'fill-rule' => true,
+				'd'         => true,
+				'transform' => true,
+			),
+			'polygon' => array(
+				'fill'      => true,
+				'fill-rule' => true,
+				'points'    => true,
+				'transform' => true,
+				'focusable' => true,
+			),
+		);
+		return wp_kses( $icon_content, $allowed_tags );
+	}
+
+	/**
 	 * Modified to also search in icon labels
 	 */
 	public function get_registered_icons( $search = '' ) {

--- a/lib/compat/wordpress-7.0/class-wp-icons-registry.php
+++ b/lib/compat/wordpress-7.0/class-wp-icons-registry.php
@@ -183,6 +183,8 @@ if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 			$allowed_tags = array(
 				'svg'     => array(
 					'class'       => true,
+					'fill'        => true,
+					'stroke'      => true,
 					'xmlns'       => true,
 					'width'       => true,
 					'height'      => true,

--- a/phpunit/class-wp-icons-registry-gutenberg-test.php
+++ b/phpunit/class-wp-icons-registry-gutenberg-test.php
@@ -319,6 +319,24 @@ class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Should keep the root `fill` and `stroke` attributes so sanitized
+	 * content still inherits the surrounding color via `currentColor`.
+	 */
+	public function test_register_icon_keeps_root_color_attributes() {
+		$this->register(
+			'test-collection/current-color',
+			array(
+				'label'   => 'Current Color',
+				'content' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor"><path d="M12 3v18" /></svg>',
+			)
+		);
+
+		$icon = $this->registry->get_registered_icon( 'test-collection/current-color' );
+		$this->assertStringContainsString( 'fill="currentColor"', $icon['content'] );
+		$this->assertStringContainsString( 'stroke="currentColor"', $icon['content'] );
+	}
+
+	/**
 	 * Provides icon files that cannot yield valid content.
 	 *
 	 * @return array<string, array{0: string|null, 1: string}> Data sets of [ $contents, $extension ].


### PR DESCRIPTION
## What

`sanitize_icon_content()` strips `fill` and `stroke` from the root `<svg>`, so registered icon content loses `fill="currentColor"` and stops inheriting the surrounding color. Every icon in `packages/icons` declares it on the root.

This allows both attributes: an override in `WP_Icons_Registry_Gutenberg`, which is what runs with the plugin active, and the same change in the 7.0 compat copy. Core's copy needs the same two attributes when the iteration syncs.

Gap discussed in [#75715 (comment)](https://github.com/WordPress/gutenberg/issues/75715#issuecomment-5140783098), surfaced with screenshots in [this review thread](https://github.com/WordPress/gutenberg/pull/80969#discussion_r3688317678).

## Why

Sanitized icons fall back to the default black fill: near-invisible against dark schemes, unresponsive to `currentColor`, and every consumer has to re-add the attribute client-side.

## How

- `WP_Icons_Registry_Gutenberg`
Overrides `sanitize_icon_content()` with `fill` and `stroke` allowed on the `svg` root.

- Compat
Mirrors the allow-list change in `lib/compat/wordpress-7.0/class-wp-icons-registry.php`.

- Tests
`test_register_icon_keeps_root_color_attributes` asserts both attributes survive registration.

## Testing

1. With the plugin active, check a core icon keeps its fill:

```bash
wp eval 'echo wp_get_icon( "core/calendar" );'
```

The root `<svg>` carries `fill="currentColor"`.

2. `GET /wp/v2/icons/core/calendar`: `content` carries the attribute as well.

3. Run the registry tests:

```bash
phpunit --filter Icons_Registry_Gutenberg
```

## Follow-ups

- [ ] Apply the same allow-list change to Core's `WP_Icons_Registry` with the 7.1 sync ([Core-64847](https://core.trac.wordpress.org/ticket/64847)).
