### PR TITLE
Core Data: add missing @wordpress/base-styles dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49574,6 +49574,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
+				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/blocks": "file:../blocks",
 				"@wordpress/components": "file:../components",

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
+-   Add missing `@wordpress/base-styles` dependency ([#81012](https://github.com/WordPress/gutenberg/pull/81012)).
 
 ## 7.51.0 (2026-07-14)
 

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -49,6 +49,7 @@
 	],
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",


### PR DESCRIPTION
## What?

Follow up to #80485. Adds the missing `@wordpress/base-styles` dependency to `@wordpress/core-data`.

## Why?

#80485 moved `entities-saved-states/style.scss` into `core-data`, which uses `@wordpress/base-styles`, but the dependency was never declared in the package's `package.json`. See https://github.com/WordPress/gutenberg/pull/80485#discussion_r3643714828.

The missing dependency was caught in #75814, which uses isolated dependencies.

## How?

Declares `@wordpress/base-styles` in `dependencies`, matching how other style-shipping packages (`block-editor`, `editor`, `components`) declare it.

## Testing Instructions

1. Run `npm install` and `npm run build`.
2. Verify the build succeeds and `packages/core-data/src/components/entities-saved-states/style.scss` compiles.

## Use of AI Tools

Authored with the help of Claude Code, reviewed by the PR author.
