### PR TITLE
Ignore node_modules in schema integration test globs

### DIFF
--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -12,7 +12,7 @@ import blockSchema from '../../schemas/json/block.json';
 describe( 'block.json schema', () => {
 	const jsonFiles = glob.sync(
 		[ 'packages/*/src/**/block.json', '{lib,phpunit,test}/**/block.json' ],
-		{ onlyFiles: true }
+		{ onlyFiles: true, ignore: [ '**/node_modules/**' ] }
 	);
 	const invalidFiles = glob.sync(
 		[ 'test/integration/fixtures/block-schemas/*.json' ],

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -12,7 +12,7 @@ import themeSchema from '../../schemas/json/theme.json';
 describe( 'theme.json schema', () => {
 	const jsonFiles = glob.sync(
 		[ 'packages/*/src/**/theme.json', '{lib,phpunit,test}/**/theme.json' ],
-		{ onlyFiles: true }
+		{ onlyFiles: true, ignore: [ '**/node_modules/**' ] }
 	);
 	const invalidFiles = glob.sync(
 		[ 'test/integration/fixtures/schemas/*.json' ],


### PR DESCRIPTION
## What?

Extracted from #75814.

Excludes `node_modules` from the glob patterns in the `block.json` and `theme.json` schema integration tests.

## Why?

The globs (`packages/*/src/**/block.json`, `{lib,phpunit,test}/**/block.json`, and the `theme.json` equivalents) can match files inside nested `node_modules` directories. This happens with npm's `linked`/isolated install strategies (see #75814), but can also happen in hoisted mode whenever npm creates a nested `node_modules` due to conflicting dependency versions. When that happens, the tests either get stuck traversing huge directory trees in CI or validate third-party files they shouldn't.

## How?

Adds `ignore: [ '**/node_modules/**' ]` to the `fast-glob` options in both tests.

## Testing Instructions

1. Run `npm run test:unit -- test/integration/blocks-schema.test.js test/integration/theme-schema.test.js`.
2. Tests should pass, matching only repository-owned `block.json`/`theme.json` files.

## Use of AI Tools

This PR was authored with the assistance of Claude Code; the change was reviewed and is owned by the author.
