### PR TITLE
Storybook: move smoke-test deps into the storybook workspace

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -49,14 +49,8 @@ jobs:
                   NODE_ENV: test
               run: npm run storybook:e2e:build
 
-            - name: Install test-runner and Playwright dependencies
-              run: |
-                  npm install --no-save @storybook/test-runner@0.24.2
-                  npx playwright install --with-deps
+            - name: Install Playwright browsers
+              run: npm run --workspace @wordpress/storybook test:smoke:setup
 
             - name: Serve Storybook and run tests
-              run: |
-                  npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-                  "npx http-server ./storybook/build --port 50240 --silent" \
-                  "npx wait-on tcp:127.0.0.1:50240 && \
-                  npx test-storybook --url http://localhost:50240 --config-dir ./storybook"
+              run: npm run --workspace @wordpress/storybook test:smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@wordpress/release-tools": "file:./tools/release",
 				"@wordpress/scripts": "file:./packages/scripts",
 				"@wordpress/stylelint-tools": "file:./tools/stylelint",
-				"concurrently": "^3.5.0",
+				"concurrently": "^9.2.1",
 				"cross-env": "^7.0.3",
 				"husky": "^7.0.0",
 				"lerna": "^9.0.7",
@@ -4803,6 +4803,58 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
+		},
+		"node_modules/@jest/create-cache-key-function": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.4.1.tgz",
+			"integrity": "sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/@sinclair/typebox": {
+			"version": "0.34.52",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+			"integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@jest/diff-sequences": {
 			"version": "30.0.1",
@@ -13801,6 +13853,141 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/@storybook/test-runner": {
+			"version": "0.24.4",
+			"resolved": "https://registry.npmjs.org/@storybook/test-runner/-/test-runner-0.24.4.tgz",
+			"integrity": "sha512-xm04bba5N7QyHHc+wD4xmPZx0vKK/PIpmTFypy445HrWOj0nFK4pYg5dE6H4ppqMt7qZAnb5GfHTvBwJtywJ4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.22.5",
+				"@babel/generator": "^7.22.5",
+				"@babel/template": "^7.22.5",
+				"@babel/types": "^7.22.5",
+				"@jest/types": "^30.0.1",
+				"@swc/core": "^1.5.22",
+				"@swc/jest": "^0.2.38",
+				"expect-playwright": "^0.8.0",
+				"jest": "^30.0.4",
+				"jest-circus": "^30.0.4",
+				"jest-environment-node": "^30.0.4",
+				"jest-junit": "^16.0.0",
+				"jest-process-manager": "^0.4.0",
+				"jest-runner": "^30.0.4",
+				"jest-serializer-html": "^7.1.0",
+				"jest-watch-typeahead": "^3.0.1",
+				"nyc": "^15.1.0",
+				"playwright": "^1.14.0",
+				"playwright-core": ">=1.2.0",
+				"rimraf": "^3.0.2",
+				"uuid": "^8.3.2"
+			},
+			"bin": {
+				"test-storybook": "dist/test-storybook.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"storybook": "^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0"
+			}
+		},
+		"node_modules/@storybook/test-runner/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@storybook/test-runner/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@storybook/test-runner/node_modules/@sinclair/typebox": {
+			"version": "0.34.52",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+			"integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@storybook/test-runner/node_modules/jest-junit": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+			"integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"mkdirp": "^1.0.4",
+				"strip-ansi": "^6.0.1",
+				"uuid": "^8.3.2",
+				"xml": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/@storybook/test-runner/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@storybook/test-runner/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@storybook/test-runner/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@stylistic/stylelint-plugin": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.3.tgz",
@@ -14195,6 +14382,286 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/@swc/core": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
+			"integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@swc/counter": "^0.1.3",
+				"@swc/types": "^0.1.27"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/swc"
+			},
+			"optionalDependencies": {
+				"@swc/core-darwin-arm64": "1.15.47",
+				"@swc/core-darwin-x64": "1.15.47",
+				"@swc/core-linux-arm-gnueabihf": "1.15.47",
+				"@swc/core-linux-arm64-gnu": "1.15.47",
+				"@swc/core-linux-arm64-musl": "1.15.47",
+				"@swc/core-linux-ppc64-gnu": "1.15.47",
+				"@swc/core-linux-s390x-gnu": "1.15.47",
+				"@swc/core-linux-x64-gnu": "1.15.47",
+				"@swc/core-linux-x64-musl": "1.15.47",
+				"@swc/core-win32-arm64-msvc": "1.15.47",
+				"@swc/core-win32-ia32-msvc": "1.15.47",
+				"@swc/core-win32-x64-msvc": "1.15.47"
+			},
+			"peerDependencies": {
+				"@swc/helpers": ">=0.5.17"
+			},
+			"peerDependenciesMeta": {
+				"@swc/helpers": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@swc/core-darwin-arm64": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
+			"integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-darwin-x64": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
+			"integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm-gnueabihf": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
+			"integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
+			"integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-musl": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
+			"integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-ppc64-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
+			"integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-s390x-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
+			"integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-gnu": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
+			"integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-musl": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
+			"integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-arm64-msvc": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
+			"integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-ia32-msvc": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
+			"integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-x64-msvc": {
+			"version": "1.15.47",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
+			"integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/counter": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@swc/jest": {
+			"version": "0.2.39",
+			"resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
+			"integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/create-cache-key-function": "^30.0.0",
+				"@swc/counter": "^0.1.3",
+				"jsonc-parser": "^3.2.0"
+			},
+			"engines": {
+				"npm": ">= 7.0.0"
+			},
+			"peerDependencies": {
+				"@swc/core": "*"
+			}
+		},
+		"node_modules/@swc/types": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+			"integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@swc/counter": "^0.1.3"
 			}
 		},
 		"node_modules/@szmarczak/http-timer": {
@@ -15378,6 +15845,16 @@
 			"dependencies": {
 				"@types/node": "*",
 				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/wait-on": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
+			"integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/yargs": {
@@ -18437,11 +18914,31 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/append-transform": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-require-extensions": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
+		},
+		"node_modules/archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -18804,6 +19301,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/async-each": {
 			"version": "1.0.6",
@@ -19722,6 +20226,19 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "5.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/basic-ftp": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
@@ -20477,6 +20994,35 @@
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/caching-transform": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+			"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasha": "^5.0.0",
+				"make-dir": "^3.0.0",
+				"package-hash": "^4.0.0",
+				"write-file-atomic": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/caching-transform/node_modules/write-file-atomic": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"node_modules/call-bind": {
@@ -21403,138 +21949,54 @@
 			}
 		},
 		"node_modules/concurrently": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz",
-			"integrity": "sha512-Z2iVM5+c0VxKmENTXrG/kp+MUhWEEH+wI5wV/L8CTFJDb/uae1zSVIkNM7o3W4Tdt42pv7RGsOICaskWy9bqSA==",
+			"version": "9.2.4",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+			"integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"chalk": "0.5.1",
-				"commander": "2.6.0",
-				"date-fns": "^1.23.0",
-				"lodash": "^4.5.1",
-				"rx": "2.3.24",
-				"spawn-command": "^0.0.2-1",
-				"supports-color": "^3.2.3",
-				"tree-kill": "^1.1.0"
+				"chalk": "4.1.2",
+				"rxjs": "7.8.2",
+				"shell-quote": "1.9.0",
+				"supports-color": "8.1.1",
+				"tree-kill": "1.2.2",
+				"yargs": "17.7.2"
 			},
 			"bin": {
-				"concurrent": "src/main.js",
-				"concurrently": "src/main.js"
+				"conc": "dist/bin/concurrently.js",
+				"concurrently": "dist/bin/concurrently.js"
 			},
 			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/concurrently/node_modules/ansi-regex": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-			"integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/concurrently/node_modules/ansi-styles": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-			"integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/concurrently/node_modules/chalk": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-			"integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^1.1.0",
-				"escape-string-regexp": "^1.0.0",
-				"has-ansi": "^0.1.0",
-				"strip-ansi": "^0.3.0",
-				"supports-color": "^0.2.0"
+				"node": ">=18"
 			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-			"integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
-			"dev": true,
-			"bin": {
-				"supports-color": "cli.js"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/concurrently/node_modules/commander": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-			"integrity": "sha512-PhbTMT+ilDXZKqH8xbvuUY2ZEQNef0Q7DKxgoEKb4ccytsdvVVJmYqR0sGbi96nxU6oGrwEIQnclpK2NBZuQlg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6.x"
-			}
-		},
-		"node_modules/concurrently/node_modules/date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-			"dev": true
-		},
-		"node_modules/concurrently/node_modules/has-ansi": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-			"integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^0.2.0"
-			},
-			"bin": {
-				"has-ansi": "cli.js"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": {
+				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
 			}
 		},
 		"node_modules/concurrently/node_modules/has-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/concurrently/node_modules/strip-ansi": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-			"integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^0.2.1"
-			},
-			"bin": {
-				"strip-ansi": "cli.js"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/concurrently/node_modules/supports-color": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-			"integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"has-flag": "^1.0.0"
+				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=0.8.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/configstore": {
@@ -22412,6 +22874,16 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
 		},
+		"node_modules/corser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+			"integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/cosmiconfig": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -22862,6 +23334,20 @@
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
+		"node_modules/cwd": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
+			"integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-pkg": "^0.1.2",
+				"fs-exists-sync": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/cyclist": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.2.tgz",
@@ -23187,6 +23673,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/default-require-extensions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+			"integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -23422,6 +23924,16 @@
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
 			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
 			"license": "MIT"
+		},
+		"node_modules/diffable-html": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-4.1.0.tgz",
+			"integrity": "sha512-++kyNek+YBLH8cLXS+iTj/Hiy2s5qkRJEJ8kgu/WHbFrVY2vz9xPFUT+fii2zGF0m1CaojDlQJjkfrCt7YWM1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"htmlparser2": "^3.9.2"
+			}
 		},
 		"node_modules/diffie-hellman": {
 			"version": "5.0.3",
@@ -24113,6 +24625,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.2",
@@ -25200,6 +25719,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/exit-x": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -25260,6 +25788,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/expand-tilde": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"os-homedir": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -25276,6 +25817,14 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
+		},
+		"node_modules/expect-playwright": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.8.0.tgz",
+			"integrity": "sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==",
+			"deprecated": "⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/exponential-backoff": {
 			"version": "3.1.3",
@@ -25915,10 +26464,62 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/find-file-up": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+			"integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fs-exists-sync": "^0.1.0",
+				"resolve-dir": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/find-parent-dir": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
 			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ="
+		},
+		"node_modules/find-pkg": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+			"integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-file-up": "^0.1.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/find-process": {
+			"version": "1.4.11",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.11.tgz",
+			"integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "~4.1.2",
+				"commander": "^12.1.0",
+				"loglevel": "^1.9.2"
+			},
+			"bin": {
+				"find-process": "bin/find-process.js"
+			}
+		},
+		"node_modules/find-process/node_modules/commander": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/find-root": {
 			"version": "1.1.0",
@@ -26125,12 +26726,43 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"node_modules/fromentries": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/fs-exists-sync": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/fs-ext": {
 			"version": "2.1.1",
@@ -26323,6 +26955,16 @@
 			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/get-pkg-repo": {
@@ -26999,6 +27641,33 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"node_modules/hasha": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+			"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/hasha/node_modules/type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/hashery": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
@@ -27021,6 +27690,16 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
 			}
 		},
 		"node_modules/header-case": {
@@ -27062,6 +27741,19 @@
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
 			"dependencies": {
 				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parse-passwd": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/hookified": {
@@ -27214,6 +27906,105 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/htmlparser2": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/dom-serializer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/dom-serializer/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/htmlparser2/node_modules/domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/domutils": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/htmlparser2/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -27329,6 +28120,74 @@
 				"@types/express": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/http-server": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+			"integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"basic-auth": "^2.0.1",
+				"chalk": "^4.1.2",
+				"corser": "^2.0.1",
+				"he": "^1.2.0",
+				"html-encoding-sniffer": "^3.0.0",
+				"http-proxy": "^1.18.1",
+				"mime": "^1.6.0",
+				"minimist": "^1.2.6",
+				"opener": "^1.5.1",
+				"portfinder": "^1.0.28",
+				"secure-compare": "3.0.1",
+				"union": "~0.5.0",
+				"url-join": "^4.0.1"
+			},
+			"bin": {
+				"http-server": "bin/http-server"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/http-server/node_modules/html-encoding-sniffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/http-server/node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/http-server/node_modules/whatwg-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/http2-wrapper": {
@@ -28531,6 +29390,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/istanbul-lib-hook": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"append-transform": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/istanbul-lib-instrument": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
@@ -28554,6 +29426,65 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/istanbul-lib-processinfo": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+			"integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"archy": "^1.0.0",
+				"cross-spawn": "^7.0.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"p-map": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-processinfo/node_modules/p-map": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/istanbul-lib-report": {
@@ -30636,6 +31567,46 @@
 				}
 			}
 		},
+		"node_modules/jest-process-manager": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/jest-process-manager/-/jest-process-manager-0.4.0.tgz",
+			"integrity": "sha512-80Y6snDyb0p8GG83pDxGI/kQzwVTkCxc7ep5FPe/F6JYdvRDhwr6RzRmPSP7SEwuLhxo80lBS/NqOdUIbHIfhw==",
+			"deprecated": "⚠️ The 'jest-process-manager' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/wait-on": "^5.2.0",
+				"chalk": "^4.1.0",
+				"cwd": "^0.10.0",
+				"exit": "^0.1.2",
+				"find-process": "^1.4.4",
+				"prompts": "^2.4.1",
+				"signal-exit": "^3.0.3",
+				"spawnd": "^5.0.0",
+				"tree-kill": "^1.2.2",
+				"wait-on": "^7.0.0"
+			}
+		},
+		"node_modules/jest-process-manager/node_modules/wait-on": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+			"integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"axios": "^1.6.1",
+				"joi": "^17.11.0",
+				"lodash": "^4.17.21",
+				"minimist": "^1.2.8",
+				"rxjs": "^7.8.1"
+			},
+			"bin": {
+				"wait-on": "bin/wait-on"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/jest-regex-util": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -32083,6 +33054,16 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-serializer-html": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-7.1.0.tgz",
+			"integrity": "sha512-xYL2qC7kmoYHJo8MYqJkzrl/Fdlx+fat4U1AqYg+kafqwcKPiMkOcjWHPKhueuNEgr+uemhGc+jqXYiwCyRyLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"diffable-html": "^4.1.0"
+			}
+		},
 		"node_modules/jest-snapshot": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
@@ -32931,6 +33912,16 @@
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.11"
+			}
+		},
+		"node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/klona": {
@@ -34659,6 +35650,13 @@
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
 			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
 		},
+		"node_modules/lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -34916,6 +35914,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/loglevel": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			},
+			"funding": {
+				"type": "tidelift",
+				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
 		"node_modules/longest-streak": {
@@ -36663,6 +37675,19 @@
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
 			"dev": true
 		},
+		"node_modules/node-preload": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+			"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"process-on-spawn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.50",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -37855,6 +38880,276 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/nyc": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"caching-transform": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"decamelize": "^1.2.0",
+				"find-cache-dir": "^3.2.0",
+				"find-up": "^4.1.0",
+				"foreground-child": "^2.0.0",
+				"get-package-type": "^0.1.0",
+				"glob": "^7.1.6",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-hook": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-processinfo": "^2.0.2",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"make-dir": "^3.0.0",
+				"node-preload": "^0.2.1",
+				"p-map": "^3.0.0",
+				"process-on-spawn": "^1.0.0",
+				"resolve-from": "^5.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^2.0.0",
+				"test-exclude": "^6.0.0",
+				"yargs": "^15.0.2"
+			},
+			"bin": {
+				"nyc": "bin/nyc.js"
+			},
+			"engines": {
+				"node": ">=8.9"
+			}
+		},
+		"node_modules/nyc/node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/nyc/node_modules/find-cache-dir": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"commondir": "^1.0.1",
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+			}
+		},
+		"node_modules/nyc/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/foreground-child": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/nyc/node_modules/istanbul-lib-instrument": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/core": "^7.7.5",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.0.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/istanbul-lib-source-maps": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nyc/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/nyc/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/p-map": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/nyc/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/nyc/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/nyc/node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nyc/node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -38459,6 +39754,16 @@
 			"integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
 			"dev": true
 		},
+		"node_modules/os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/os-name": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -38746,6 +40051,22 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/package-hash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"graceful-fs": "^4.1.15",
+				"hasha": "^5.0.0",
+				"lodash.flattendeep": "^4.4.0",
+				"release-zalgo": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -39328,6 +40649,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/parse-path": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
@@ -39908,6 +41239,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/portfinder": {
+			"version": "1.0.38",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+			"integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async": "^3.2.6",
+				"debug": "^4.3.6"
+			},
+			"engines": {
+				"node": ">= 10.12"
 			}
 		},
 		"node_modules/posix-character-classes": {
@@ -40647,6 +41992,19 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
+		"node_modules/process-on-spawn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+			"integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fromentries": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/proggy": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/proggy/-/proggy-3.0.0.tgz",
@@ -40703,6 +42061,20 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/promzard": {
@@ -41651,6 +43023,19 @@
 				"regjsparser": "bin/parser"
 			}
 		},
+		"node_modules/release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-error": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/remark": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
@@ -41767,6 +43152,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/requireindex": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -41836,6 +43228,60 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-dir/node_modules/global-modules": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"global-prefix": "^0.1.4",
+				"is-windows": "^0.2.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-dir/node_modules/global-prefix": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"homedir-polyfill": "^1.0.0",
+				"ini": "^1.3.4",
+				"is-windows": "^0.2.0",
+				"which": "^1.2.12"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-dir/node_modules/is-windows": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-file-extension": {
@@ -42222,12 +43668,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
 			"integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw=="
-		},
-		"node_modules/rx": {
-			"version": "2.3.24",
-			"resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
-			"integrity": "sha512-Ue4ZB7Dzbn2I9sIj8ws536nOP2S53uypyCkCz9q0vlYD5Kn6/pu4dE+wt2ZfFzd9m73hiYKnnCb1OyKqc+MRkg==",
-			"dev": true
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.2",
@@ -42877,6 +44317,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/secure-compare": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+			"integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -43067,6 +44514,13 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -43408,6 +44862,13 @@
 			"engines": {
 				"node": ">= 10"
 			}
+		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -43773,11 +45234,83 @@
 			"deprecated": "See https://github.com/lydell/source-map-url#deprecated",
 			"dev": true
 		},
-		"node_modules/spawn-command": {
-			"version": "0.0.2-1",
-			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
-			"dev": true
+		"node_modules/spawn-wrap": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+			"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"make-dir": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/spawn-wrap/node_modules/foreground-child": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/spawn-wrap/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/spawn-wrap/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/spawnd": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-5.0.0.tgz",
+			"integrity": "sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"exit": "^0.1.2",
+				"signal-exit": "^3.0.3",
+				"tree-kill": "^1.2.2",
+				"wait-port": "^0.2.9"
+			}
 		},
 		"node_modules/spdx-correct": {
 			"version": "3.0.0",
@@ -46297,6 +47830,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/union": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+			"integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+			"dev": true,
+			"dependencies": {
+				"qs": "^6.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -46628,6 +48173,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/url-loader": {
 			"version": "4.1.1",
@@ -47052,6 +48604,59 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/wait-port": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.14.tgz",
+			"integrity": "sha512-kIzjWcr6ykl7WFbZd0TMae8xovwqcqbx6FM9l+7agOgUByhzdjfzZBPK2CPufldTOMxbUivss//Sh9MFawmPRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^2.4.2",
+				"commander": "^3.0.2",
+				"debug": "^4.1.1"
+			},
+			"bin": {
+				"wait-port": "bin/wait-port.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wait-port/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/wait-port/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/wait-port/node_modules/commander": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+			"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/walk-up-path": {
 			"version": "4.0.0",
@@ -48074,6 +49679,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.19",
@@ -53506,6 +55118,7 @@
 				"@storybook/addon-docs": "^10.4.3",
 				"@storybook/icons": "^2.0.1",
 				"@storybook/react-vite": "^10.4.3",
+				"@storybook/test-runner": "^0.24.2",
 				"@types/react": "^18.3.27",
 				"@vitejs/plugin-react": "^5.1.2",
 				"@wordpress/admin-ui": "file:../packages/admin-ui",
@@ -53533,6 +55146,9 @@
 				"@wordpress/theme": "file:../packages/theme",
 				"@wordpress/ui": "file:../packages/ui",
 				"clsx": "^2.1.1",
+				"concurrently": "^9.2.1",
+				"http-server": "^14.1.1",
+				"playwright": "^1.62.1",
 				"react": "^18.3.1",
 				"react-docgen-typescript": "^2.4.0",
 				"react-dom": "^18.3.1",
@@ -53540,7 +55156,8 @@
 				"storybook-addon-tag-badges": "^3.0.4",
 				"terser": "^5.37.0",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
-				"vite": "^7.3.2"
+				"vite": "^7.3.2",
+				"wait-on": "^8.0.1"
 			}
 		},
 		"test/e2e": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"@wordpress/release-tools": "file:./tools/release",
 		"@wordpress/scripts": "file:./packages/scripts",
 		"@wordpress/stylelint-tools": "file:./tools/stylelint",
-		"concurrently": "^3.5.0",
+		"concurrently": "^9.2.1",
 		"cross-env": "^7.0.3",
 		"husky": "^7.0.0",
 		"lerna": "^9.0.7",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -32,6 +32,7 @@
 		"@storybook/addon-docs": "^10.4.3",
 		"@storybook/icons": "^2.0.1",
 		"@storybook/react-vite": "^10.4.3",
+		"@storybook/test-runner": "^0.24.2",
 		"@types/react": "^18.3.27",
 		"@vitejs/plugin-react": "^5.1.2",
 		"@wordpress/admin-ui": "file:../packages/admin-ui",
@@ -59,6 +60,9 @@
 		"@wordpress/theme": "file:../packages/theme",
 		"@wordpress/ui": "file:../packages/ui",
 		"clsx": "^2.1.1",
+		"concurrently": "^9.2.1",
+		"http-server": "^14.1.1",
+		"playwright": "^1.62.1",
 		"react": "^18.3.1",
 		"react-docgen-typescript": "^2.4.0",
 		"react-dom": "^18.3.1",
@@ -66,13 +70,16 @@
 		"storybook-addon-tag-badges": "^3.0.4",
 		"terser": "^5.37.0",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
-		"vite": "^7.3.2"
+		"vite": "^7.3.2",
+		"wait-on": "^8.0.1"
 	},
 	"publishConfig": {
 		"access": "public"
 	},
 	"scripts": {
 		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c . -o ./build && node ./scripts/inject-legacy-docgen.mjs ./build/manifests/components.json",
-		"storybook:dev": "storybook dev -c . -p 50240"
+		"storybook:dev": "storybook dev -c . -p 50240",
+		"test:smoke": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"http-server ./build --port 50240 --silent\" \"wait-on tcp:127.0.0.1:50240 && test-storybook --url http://localhost:50240 --config-dir .\"",
+		"test:smoke:setup": "playwright install --with-deps"
 	}
 }


### PR DESCRIPTION
## What?

Moves the Storybook smoke-test dependencies (`@storybook/test-runner`, `playwright`, `http-server`, `concurrently`, `wait-on`) into the `@wordpress/storybook` workspace so the `storybook-check` workflow no longer needs ad-hoc `npm install` or `npx` at CI time.

## Why?

Dependencies installed ad hoc at CI time (`npm install --no-save`, `npx`) are invisible to the tooling that governs the repo's dependency tree: they are not in `package-lock.json`, so they are not covered by security audits, Dependabot, syncpack version policies, or lockfile validation. They also offer no protection against supply-chain attacks — the workflow fetches whatever the registry serves at run time, without the lockfile's integrity pinning or the repo's `min-release-age` safeguard, and a compromised package would execute inside CI with access to its secrets. Declaring them in the workspace that owns the smoke test puts them under the same lockfile, audit, and update process as every other dependency.

As a bonus, this also fixes the workflow under `install-strategy=linked` (isolated dependencies - #75814), where `npx` no longer resolves hoisted binaries from the repo root: the workflow becomes a pair of plain `npm run --workspace` calls that work under both isolated and hoisted strategies.

**Recommendation:** for the reasons above, we should ideally ban installing dependencies from within CI workflows (`npm install <pkg>`, `npx <pkg>`, etc.) across the repo — every dependency a workflow needs should be declared in a workspace `package.json` and installed through the lockfile via the regular `npm ci` step. CC: @desrosj 

## How?

- Adds `@storybook/test-runner@0.24.2` (its `storybook` peer is already a devDependency of the workspace), `playwright`, `http-server`, `concurrently`, and `wait-on` to `storybook/package.json` devDependencies.
- Adds `test:smoke` (serve build + wait + `test-storybook`) and `test:smoke:setup` (Playwright browser install) scripts to the workspace.
- The workflow steps become `npm run --workspace @wordpress/storybook test:smoke:setup` and `… test:smoke` — `npm run` puts the workspace `node_modules/.bin` on `PATH`, so no `npx` is needed.

## Testing Instructions

1. Verify the "Storybook build and Smoke Tests" CI job passes.
2. Locally: `npm ci`, `npm run storybook:build`, then `npm run --workspace @wordpress/storybook test:smoke`.

Note: this change was also validated with isolated dependencies (`install-strategy=linked`) by temporarily basing it on #75814 — the smoke-test job passed there too ([run 1](https://github.com/WordPress/gutenberg/actions/runs/30625453734), [run 2](https://github.com/WordPress/gutenberg/actions/runs/30626526493)).

## Use of AI Tools

Authored with the assistance of Claude Code; reviewed and tested by the PR author.
