### PR TITLE
Post Author Biography: Fix horizontal overflow with long unbroken text

### DIFF
--- a/packages/block-library/src/post-author-biography/style.scss
+++ b/packages/block-library/src/post-author-biography/style.scss
@@ -2,5 +2,5 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	white-space: pre-wrap;
-	overflow-wrap: break-word;
+	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 }

--- a/packages/block-library/src/post-author-biography/style.scss
+++ b/packages/block-library/src/post-author-biography/style.scss
@@ -2,4 +2,5 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	white-space: pre-wrap;
+	overflow-wrap: break-word;
 }


### PR DESCRIPTION
## What?

Closes #70849 

Fixes horizontal overflow in the Post Author Biography block when the author's biography contains a long string of text with no spaces.

## Why?

The `.wp-block-post-author-biography` selector sets `white-space: pre-wrap`, which only wraps text at natural break points (spaces). If a biography contains one long unbroken run of characters, there's nowhere to wrap, so the text overflows the block horizontally and forces a scrollbar.

## How?

Added `overflow-wrap: break-word;` to `.wp-block-post-author-biography`, so long unbroken text breaks within the block instead of overflowing it.

## Testing Instructions

1. Edit a user's biography (Users → your profile → Biographical Info) to a long string with no spaces, e.g. `Thisisaverylongstringofwordswithoutanyspacesorbreaksitjustkeepsgoingandgoingandwillcausehorizontalscrollingissuesbecausetherearenowordbreak` (repeat until it's clearly wider than the content area).
2. Create or edit a post authored by that user, insert a Post Author Biography block, and publish it.
3. View the post on the front end and confirm the biography text wraps within the block and no horizontal scrollbar appears.

## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1470" height="835" alt="Screenshot 2026-07-31 at 4 30 29 PM" src="https://github.com/user-attachments/assets/1849407b-0a8e-4b5c-b2c6-a84849198c08" />|<img width="1470" height="837" alt="Screenshot 2026-07-31 at 4 31 03 PM" src="https://github.com/user-attachments/assets/e830ea89-97e6-43b8-9154-f9afbee37b88" />|

## Use of AI Tools

None