### PR TITLE
Editor: Remove sidebar tabs focus sync effect

### DIFF
--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -4,7 +4,6 @@
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -16,7 +15,7 @@ import { sidebars } from './constants';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-const SidebarHeader = ( _, ref ) => {
+export default function SidebarHeader() {
 	const { postTypeLabel, isRevisionsMode } = useSelect( ( select ) => {
 		const { getPostTypeLabel } = select( editorStore );
 		const { isRevisionsMode: _isRevisionsMode } = unlock(
@@ -39,24 +38,12 @@ const SidebarHeader = ( _, ref ) => {
 	}
 
 	return (
-		<Tabs.TabList ref={ ref }>
-			<Tabs.Tab
-				tabId={ sidebars.document }
-				// Used for focus management in the SettingsSidebar component.
-				data-tab-id={ sidebars.document }
-			>
-				{ documentLabel }
-			</Tabs.Tab>
-			<Tabs.Tab
-				tabId={ sidebars.block }
-				// Used for focus management in the SettingsSidebar component.
-				data-tab-id={ sidebars.block }
-			>
+		<Tabs.TabList>
+			<Tabs.Tab tabId={ sidebars.document }>{ documentLabel }</Tabs.Tab>
+			<Tabs.Tab tabId={ sidebars.block }>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
 				{ __( 'Block' ) }
 			</Tabs.Tab>
 		</Tabs.TabList>
 	);
-};
-
-export default forwardRef( SidebarHeader );
+}

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -6,7 +6,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useContext, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 import { isRTL, __, _x } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -44,7 +44,6 @@ const SidebarContent = ( {
 	onActionPerformed,
 	extraPanels,
 } ) => {
-	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
 	// need to forward the `Tabs` context so it can be passed through the
 	// underlying slot/fill.
@@ -52,33 +51,6 @@ const SidebarContent = ( {
 	const isRevisionsMode = useSelect( ( select ) => {
 		return unlock( select( editorStore ) ).isRevisionsMode();
 	} );
-
-	// This effect addresses a race condition caused by tabbing from the last
-	// block in the editor into the settings sidebar. Without this effect, the
-	// selected tab and browser focus can become separated in an unexpected way
-	// (e.g the "block" tab is focused, but the "post" tab is selected).
-	useEffect( () => {
-		const tabsElements = Array.from(
-			tabListRef.current?.querySelectorAll( '[role="tab"]' ) || []
-		);
-		const selectedTabElement = tabsElements.find(
-			// We are purposefully using a custom `data-tab-id` attribute here
-			// because we don't want rely on any assumptions about `Tabs`
-			// component internals.
-			( element ) => element.getAttribute( 'data-tab-id' ) === tabName
-		);
-		const activeElement = selectedTabElement?.ownerDocument.activeElement;
-		const tabsHasFocus = tabsElements.some( ( element ) => {
-			return activeElement && activeElement.id === element.id;
-		} );
-		if (
-			tabsHasFocus &&
-			selectedTabElement &&
-			selectedTabElement.id !== activeElement?.id
-		) {
-			selectedTabElement?.focus();
-		}
-	}, [ tabName ] );
 
 	let tabContent;
 	if ( isRevisionsMode ) {
@@ -112,7 +84,7 @@ const SidebarContent = ( {
 			identifier={ tabName }
 			header={
 				<Tabs.Context.Provider value={ tabsContextValue }>
-					<SidebarHeader ref={ tabListRef } />
+					<SidebarHeader />
 				</Tabs.Context.Provider>
 			}
 			closeLabel={ __( 'Close Settings' ) }

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -103,6 +103,37 @@ test.describe( 'Sidebar', () => {
 		await expect( activeTab ).toBeFocused();
 	} );
 
+	test( 'should focus the selected tab when tabbing into the sidebar', async ( {
+		editor,
+		page,
+	} ) => {
+		for ( const content of [ '0', '1' ] ) {
+			await editor.insertBlock( { name: 'core/paragraph' } );
+			await page.keyboard.type( content );
+		}
+
+		const activeTab = page
+			.getByRole( 'region', {
+				name: 'Editor settings',
+			} )
+			.getByRole( 'tab', { selected: true } );
+
+		// A selected block puts the sidebar on the "Block" tab.
+		await page.keyboard.press( 'Escape' );
+		await page.keyboard.press( 'Tab' );
+		await expect( activeTab ).toHaveText( 'Block' );
+		await expect( activeTab ).toBeFocused();
+
+		// Moving to the title clears the block selection, which switches the
+		// sidebar back to the "Post" tab.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.click();
+		await page.keyboard.press( 'Tab' );
+		await expect( activeTab ).toHaveText( 'Post' );
+		await expect( activeTab ).toBeFocused();
+	} );
+
 	test( 'should be possible to programmatically remove Document Settings panels', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## What?
Extracted from #81006.

PR removes the focus-sync effect that kept the focused and selected tabs together, along with the data-tab-id attributes and the ref plumbing that existed only to serve them.

## Why?

The focus-sync effect was added in #58041 to fix a race when tabbing off the last block: focus moved to the active **Block** tab, then `interfaceStore` noticed focus had left the blocks and switched selection to **Post**, leaving one tab focused and the other selected. That race is no longer reachable. The post title and blocks are a single contenteditable writing flow, so there are no per-block tab stops to leave, and Tab exits straight to the sidebar. The navigation it depended on was removed in #65204, which also deleted the guard test #58041 had updated.

## Testing Instructions

1. Open a post. Toggle the settings sidebar and switch between the Post and Block tabs.
2. Arrow between the two tabs and confirm selection does not follow focus; Enter or Space selects the focused tab.
3. Select a block, press Tab into the sidebar, and confirm the Block tab is focused and selected. Click the title, press Tab, and confirm the same for the Post tab.
4. Check panel scrolling and the sticky panel header.
5. Enter and leave revision mode.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
