### PR TITLE
Editor: Initialize category selector with site default for new posts

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -15,11 +15,12 @@
  *
  * Note: The settings that are WP version specific should be handled inside the `compat` directory.
  *
- * @param array $settings Existing block editor settings.
+ * @param array                   $settings       Existing block editor settings.
+ * @param WP_Block_Editor_Context $editor_context The current block editor context.
  *
  * @return array New block editor settings.
  */
-function gutenberg_get_block_editor_settings( $settings ) {
+function gutenberg_get_block_editor_settings( $settings, $editor_context = null ) {
 	$global_styles = array();
 	$presets       = array(
 		array(
@@ -121,6 +122,18 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	$settings['canEditCSS'] = current_user_can( 'edit_css' );
 
+	if ( isset( $editor_context->post ) && $editor_context->post instanceof WP_Post ) {
+		$post_type = $editor_context->post->post_type;
+
+		if ( is_object_in_taxonomy( $post_type, 'category' ) ) {
+			$post_type_object = get_post_type_object( $post_type );
+
+			if ( $post_type_object && current_user_can( $post_type_object->cap->create_posts ) ) {
+				$settings['defaultCategory'] = (int) get_option( 'default_category' );
+			}
+		}
+	}
+
 	return $settings;
 }
-add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0 );
+add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0, 2 );

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -113,6 +113,36 @@ export function findTerm( terms, parent, name ) {
 }
 
 /**
+ * Returns selected term IDs with a default-category fallback.
+ *
+ * @param {Object}   args                 Selection arguments.
+ * @param {number[]} args.terms           Selected term IDs from post attributes.
+ * @param {string}   args.slug            Taxonomy slug.
+ * @param {boolean}  args.isNewPost       Whether the post is new.
+ * @param {number}   args.defaultCategory Default category ID from editor settings.
+ *
+ * @return {number[]} Selected term IDs.
+ */
+export function getSelectedTermIds( {
+	terms,
+	slug,
+	isNewPost,
+	defaultCategory,
+} ) {
+	if (
+		slug !== 'category' ||
+		! isNewPost ||
+		terms.length > 0 ||
+		! Number.isInteger( defaultCategory ) ||
+		defaultCategory <= 0
+	) {
+		return terms;
+	}
+
+	return [ defaultCategory ];
+}
+
+/**
  * Get filter matcher function.
  *
  * @param {string} filterValue Filter value.
@@ -177,18 +207,29 @@ export function HierarchicalTermSelector( { slug } ) {
 	const {
 		hasCreateAction,
 		hasAssignAction,
-		terms,
+		selectedTerms,
 		loading,
 		availableTerms,
 		taxonomy,
 	} = useSelect(
 		( select ) => {
-			const { getCurrentPost, getEditedPostAttribute } =
-				select( editorStore );
+			const {
+				getCurrentPost,
+				getEditedPostAttribute,
+				getEditorSettings,
+				isEditedPostNew,
+			} = select( editorStore );
 			const { getEntityRecord, getEntityRecords, isResolving } =
 				select( coreStore );
 			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
 			const post = getCurrentPost();
+			const postTerms = _taxonomy
+				? getEditedPostAttribute( _taxonomy.rest_base ) || EMPTY_ARRAY
+				: EMPTY_ARRAY;
+			const defaultCategory = parseInt(
+				getEditorSettings()?.defaultCategory,
+				10
+			);
 
 			return {
 				hasCreateAction: _taxonomy
@@ -201,9 +242,12 @@ export function HierarchicalTermSelector( { slug } ) {
 							'wp:action-assign-' + _taxonomy.rest_base
 					  ]
 					: false,
-				terms: _taxonomy
-					? getEditedPostAttribute( _taxonomy.rest_base )
-					: EMPTY_ARRAY,
+				selectedTerms: getSelectedTermIds( {
+					terms: postTerms,
+					slug,
+					isNewPost: isEditedPostNew(),
+					defaultCategory,
+				} ),
 				loading: isResolving( 'getEntityRecords', [
 					'taxonomy',
 					slug,
@@ -222,10 +266,10 @@ export function HierarchicalTermSelector( { slug } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 
 	const availableTermsTree = useMemo(
-		() => sortBySelected( buildTermsTree( availableTerms ), terms ),
+		() => sortBySelected( buildTermsTree( availableTerms ), selectedTerms ),
 		// Remove `terms` from the dependency list to avoid reordering every time
 		// checking or unchecking a term.
-		[ availableTerms ]
+		[ availableTerms, selectedTerms ]
 	);
 
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -261,10 +305,10 @@ export function HierarchicalTermSelector( { slug } ) {
 	 * @param {number} termId
 	 */
 	const onChange = ( termId ) => {
-		const hasTerm = terms.includes( termId );
+		const hasTerm = selectedTerms.includes( termId );
 		const newTerms = hasTerm
-			? terms.filter( ( id ) => id !== termId )
-			: [ ...terms, termId ];
+			? selectedTerms.filter( ( id ) => id !== termId )
+			: [ ...selectedTerms, termId ];
 		onUpdateTerms( newTerms );
 	};
 
@@ -295,8 +339,10 @@ export function HierarchicalTermSelector( { slug } ) {
 		const existingTerm = findTerm( availableTerms, formParent, formName );
 		if ( existingTerm ) {
 			// If the term we are adding exists but is not selected select it.
-			if ( ! terms.some( ( term ) => term === existingTerm.id ) ) {
-				onUpdateTerms( [ ...terms, existingTerm.id ] );
+			if (
+				! selectedTerms.some( ( term ) => term === existingTerm.id )
+			) {
+				onUpdateTerms( [ ...selectedTerms, existingTerm.id ] );
 			}
 
 			setFormName( '' );
@@ -328,7 +374,7 @@ export function HierarchicalTermSelector( { slug } ) {
 		setAdding( false );
 		setFormName( '' );
 		setFormParent( '' );
-		onUpdateTerms( [ ...terms, newTerm.id ] );
+		onUpdateTerms( [ ...selectedTerms, newTerm.id ] );
 	};
 
 	const setFilter = ( value ) => {
@@ -367,7 +413,7 @@ export function HierarchicalTermSelector( { slug } ) {
 					className="editor-post-taxonomies__hierarchical-terms-choice"
 				>
 					<CheckboxControl
-						checked={ terms.indexOf( term.id ) !== -1 }
+						checked={ selectedTerms.indexOf( term.id ) !== -1 }
 						onChange={ () => {
 							const termId = parseInt( term.id, 10 );
 							onChange( termId );

--- a/packages/editor/src/components/post-taxonomies/test/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/test/hierarchical-term-selector.js
@@ -5,6 +5,7 @@ import {
 	sortBySelected,
 	getFilterMatcher,
 	findTerm,
+	getSelectedTermIds,
 } from '../hierarchical-term-selector';
 
 describe( 'sortBySelected', () => {
@@ -161,5 +162,51 @@ describe( 'getFilterMatcher', () => {
 		};
 		const matcher = getFilterMatcher( 'parent' );
 		expect( matcher( input ) ).toEqual( output );
+	} );
+} );
+
+describe( 'getSelectedTermIds', () => {
+	test( 'returns default category for new posts with no selected categories', () => {
+		expect(
+			getSelectedTermIds( {
+				terms: [],
+				slug: 'category',
+				isNewPost: true,
+				defaultCategory: 1,
+			} )
+		).toEqual( [ 1 ] );
+	} );
+
+	test( 'does not apply default category for existing posts', () => {
+		expect(
+			getSelectedTermIds( {
+				terms: [],
+				slug: 'category',
+				isNewPost: false,
+				defaultCategory: 1,
+			} )
+		).toEqual( [] );
+	} );
+
+	test( 'does not override existing selected categories', () => {
+		expect(
+			getSelectedTermIds( {
+				terms: [ 3 ],
+				slug: 'category',
+				isNewPost: true,
+				defaultCategory: 1,
+			} )
+		).toEqual( [ 3 ] );
+	} );
+
+	test( 'does not apply default category to non-category taxonomies', () => {
+		expect(
+			getSelectedTermIds( {
+				terms: [],
+				slug: 'post_tag',
+				isNewPost: true,
+				defaultCategory: 1,
+			} )
+		).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #32651 

Ensure the post category selector reflects the site’s default post category for new posts when no category has been selected yet.

## Why?
In the block editor, a new post can show no category selected even though WordPress has a default post category configured.
This differs from classic WordPress behavior and can confuse users, especially when they expect the default category to be preselected.

## How?

Exposed only the default category to the editor bootstrap settings (without exposing the full /wp/v2/settings endpoint).
Updated HierarchicalTermSelector only when all of the following are true:
- The taxonomy is category.
- The post is new.
- No categories are currently selected.
- A valid default category value is available.


## Testing Instructions

1. In WP Admin, go to Settings > Writing and set a known Default Post Category (for example, “Uncategorized” or another category).
2. Open the post editor and create a new post (auto-draft/new post flow).
3. Open the Categories panel.
4. Confirm the default category is preselected.
5. Select a different category and confirm your explicit selection is respected.
6. Reload/edit an existing post and confirm this change does not force-apply a default category.
7. Confirm non-category taxonomies (e.g., tags) are unaffected.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|New post can show no category selected even when a default category is configured | New post shows the configured default category selected when no category has been selected yet (category2 is set as default category )|
|<img width="1860" height="1174" alt="image" src="https://github.com/user-attachments/assets/345dab35-cc3f-4556-bbd7-2814b854e0b7" />|<img width="305" height="154" alt="image" src="https://github.com/user-attachments/assets/460608d0-cdd1-434f-861b-c2bda96e2b8a" />|

## Use of AI Tools
Used GitHub Copilot (GPT-5.3-Codex) for implementation assistance and drafting.
All generated code/text was reviewed and validated by me before submission.
