### PR TITLE
Performance Tests: Ignore the locally generated artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 yarn.lock
 /artifacts
 /test/e2e/artifacts
+/test/performance/artifacts
 /test/e2e/flakiness-report
 /perf-envs
 /composer.lock


### PR DESCRIPTION
## What?

PR adds `/test/performance/artifacts` to `.gitignore`.

## Why?

`wp-scripts`' Playwright config defaults `WP_ARTIFACTS_PATH` to `path.join( process.cwd(), 'artifacts' )`, and `npm run test:performance` runs in the `@wordpress/performance-tests` workspace — so every local perf run writes results JSON, traces, `test-results/`, and a cached admin storage state into `test/performance/artifacts/`. `.gitignore` already covers `/artifacts` and `/test/e2e/artifacts`, but not this one, so the directory shows up as untracked after each run.

CI is unaffected: the performance workflow sets `WP_ARTIFACTS_PATH` to `$GITHUB_WORKSPACE/artifacts`, which the existing `/artifacts` rule already covers.

## Testing Instructions

* Run `npm run test:performance -- post-editor.spec.js`
* Run `git status`, the `test/performance/artifacts/` should no longer appear.