### PR TITLE
DataViews: Stack field label and value in small grid preview size

### DIFF
--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -59,6 +59,7 @@
 .dataviews-view-grid-infinite-scroll {
 
 	.dataviews-view-grid__card {
+		container-type: inline-size;
 		height: 100%;
 		justify-content: flex-start;
 		position: relative;
@@ -177,6 +178,15 @@
 
 			&:not(:has(.dataviews-view-grid__field-value:not(:empty))) {
 				display: none;
+			}
+
+			@container (max-width: 200px) {
+				flex-direction: column;
+
+				.dataviews-view-grid__field-name,
+				.dataviews-view-grid__field-value {
+					width: 100%;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71853 

This PR modifies the DataViews Grid layout so that field labels and values stack vertically when the card is rendered at small preview size.

## Why?
Currently, the DataViews grid layout enforces a strict `35%` (label) and `65%` (value) width split. While this works well for larger cards, in smaller preview sizes it leads to severe text truncation and overflow, making the information unreadable. Stacking them provides much more room for long field values and improves overall readability.

## How?
This utilizes CSS Container Queries to handle the responsive layout natively:
1. Added `container-type: inline-size;` to the `.dataviews-view-grid__card` wrapper.
2. Added a `@container (max-width: 200px)` query to `.dataviews-view-grid__field` that changes the `flex-direction` to `column` and overrides the inline widths of the label and value to `100%`.

## Testing Instructions
1. Navigate to DataViews.
2. Ensure the view layout is set to Grid.
3. Open the Options menu and adjust the Grid preview size to a small size.
4. Observe the fields inside the grid cards.
5. Verify that the field label and value now stack vertically and take up 100% of the width, rather than truncating side-by-side.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="2936" height="1428" alt="image" src="https://github.com/user-attachments/assets/b1d6ec82-45a5-407f-95eb-84e406fc43c3" />|<img width="2912" height="1392" alt="image" src="https://github.com/user-attachments/assets/a8250b35-e6f4-4d61-bc17-544d1699e402" />|
