### PR TITLE
Build: Replace abandoned esbuild-plugin-babel with an inline plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24690,15 +24690,6 @@
 				"esbuild": "*"
 			}
 		},
-		"node_modules/esbuild-plugin-babel": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/esbuild-plugin-babel/-/esbuild-plugin-babel-0.2.3.tgz",
-			"integrity": "sha512-hGLL31n+GvBhkHUpPCt1sU4ynzOH7I1IUkKhera66jigi4mHFPL6dfJo44L6/1rfcZudXx+wGdf9VOifzDPqYQ==",
-			"license": "ISC",
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
 		"node_modules/esbuild-sass-plugin": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.3.1.tgz",
@@ -54632,6 +54623,7 @@
 			"version": "0.19.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@babel/core": "^7.25.7",
 				"@emotion/babel-plugin": "^11.13.5",
 				"@wordpress/style-runtime": "file:../style-runtime",
 				"autoprefixer": "^10.4.21",
@@ -54640,7 +54632,6 @@
 				"chokidar": "^4.0.0",
 				"cssnano": "^6.0.1",
 				"esbuild": "^0.27.2",
-				"esbuild-plugin-babel": "^0.2.3",
 				"esbuild-sass-plugin": "^3.3.1",
 				"fast-glob": "^3.2.7",
 				"moment-timezone": "^0.5.40",

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -16,6 +16,10 @@
 -   Sync the page template `/?_fields=` preload path with the `_fields` list in `@wordpress/core-data` so the preload is consumed instead of the page issuing a duplicate request ([#80648](https://github.com/WordPress/gutenberg/pull/80648)).
 -   Scope the generated page template's critical styles to `body.js` so the no-JS notice stays visible ([#80628](https://github.com/WordPress/gutenberg/pull/80628)).
 
+### Internal
+
+-   Replace the abandoned `esbuild-plugin-babel` dependency with an equivalent inline esbuild plugin backed by a direct `@babel/core` dependency ([#81033](https://github.com/WordPress/gutenberg/pull/81033)).
+
 ## 0.19.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/wp-build/lib/babel-plugin.mjs
+++ b/packages/wp-build/lib/babel-plugin.mjs
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { loadOptions, transformAsync } from '@babel/core';
+
+/**
+ * Create an esbuild plugin that transforms matching files with Babel.
+ *
+ * Minimal inline replacement for the abandoned `esbuild-plugin-babel`
+ * package. Babel's regular config resolution still applies, so project-level
+ * config files are merged with the passed config.
+ *
+ * @param {Object}                                 options          Plugin options.
+ * @param {RegExp}                                 options.filter   Filter for files to transform.
+ * @param {import('@babel/core').TransformOptions} [options.config] Babel options merged with resolved config.
+ * @return {import('esbuild').Plugin} esbuild plugin.
+ */
+export function createBabelPlugin( { filter, config = {} } ) {
+	return {
+		name: 'babel',
+		setup( build ) {
+			build.onLoad( { filter }, async ( args ) => {
+				const contents = await readFile( args.path, 'utf8' );
+				/**
+				 * @type {import('@babel/core').TransformOptions | null}
+				 */
+				const babelOptions = loadOptions( {
+					...config,
+					filename: args.path,
+					caller: {
+						/*
+						 * Keep the replaced plugin's caller name so external
+						 * Babel configs keyed on it still match.
+						 */
+						name: 'esbuild-plugin-babel',
+						supportsStaticESM: true,
+					},
+				} );
+
+				if ( ! babelOptions ) {
+					return { contents };
+				}
+
+				if ( babelOptions.sourceMaps ) {
+					babelOptions.sourceFileName = path.relative(
+						process.cwd(),
+						args.path
+					);
+				}
+
+				const result = await transformAsync( contents, babelOptions );
+
+				if ( typeof result?.code !== 'string' ) {
+					throw new Error(
+						`Babel produced no code for ${ args.path }.`
+					);
+				}
+
+				return { contents: result.code };
+			} );
+		},
+	};
+}

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -18,7 +18,6 @@ import postcssModules from 'postcss-modules';
 import autoprefixer from 'autoprefixer';
 import rtlcss from 'rtlcss';
 import cssnano from 'cssnano';
-import babel from 'esbuild-plugin-babel';
 import { camelCase } from 'change-case';
 import { NodePackageImporter } from 'sass-embedded';
 
@@ -56,6 +55,7 @@ import {
 	renderTemplateToString,
 } from './php-generator.mjs';
 import { getPackageInfo, getPackageInfoFromFile } from './package-utils.mjs';
+import { createBabelPlugin } from './babel-plugin.mjs';
 import { createWordpressExternalsPlugin } from './wordpress-externals-plugin.mjs';
 import {
 	getAllRoutes,
@@ -1373,7 +1373,7 @@ async function transpilePackage( packageName ) {
 	// Check if this is the components package that needs emotion babel plugin.
 	// Ideally we should remove this exception and move away from emotion.
 	const needsEmotionPlugin = packageName === 'components';
-	const emotionPlugin = babel( {
+	const emotionPlugin = createBabelPlugin( {
 		filter: /\.[jt]sx?$/,
 		config: {
 			plugins: [ styleRuntimeRequire.resolve( '@emotion/babel-plugin' ) ],

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -35,6 +35,7 @@
 		"wp-build": "./lib/build.mjs"
 	},
 	"dependencies": {
+		"@babel/core": "^7.25.7",
 		"@emotion/babel-plugin": "^11.13.5",
 		"@wordpress/style-runtime": "file:../style-runtime",
 		"autoprefixer": "^10.4.21",
@@ -43,7 +44,6 @@
 		"chokidar": "^4.0.0",
 		"cssnano": "^6.0.1",
 		"esbuild": "^0.27.2",
-		"esbuild-plugin-babel": "^0.2.3",
 		"esbuild-sass-plugin": "^3.3.1",
 		"fast-glob": "^3.2.7",
 		"moment-timezone": "^0.5.40",


### PR DESCRIPTION
## What?

Removes the `esbuild-plugin-babel` dependency from `@wordpress/build` and replaces it with an equivalent inline esbuild plugin (`lib/babel-plugin.mjs`) backed by a direct `@babel/core` dependency.

## Why?

- `esbuild-plugin-babel` is abandoned: its last release (0.2.3) was published in May 2022 and the project has seen no activity since.
- It is a blocker for the Babel v8 upgrade: it declares a `@babel/core: ^7.0.0` peer dependency, so installs against Babel 8 fail dependency resolution, and with the package unmaintained no fix can be expected. Its `import babel from '@babel/core'` default-import usage is also incompatible with Babel 8's ESM-only exports.
- The whole package is a ~40-line `onLoad` hook; owning those lines directly removes the dead dependency and puts the `@babel/core` requirement under our control for the v8 upgrade.

## How?

- Adds `lib/babel-plugin.mjs` with `createBabelPlugin()`, a faithful port of `esbuild-plugin-babel`'s behavior: same Babel config resolution via `loadOptions()` (project-level config files still merge in), same `sourceMaps`/`sourceFileName` handling, and the same `caller.name` (`esbuild-plugin-babel`) so any external Babel config keyed on it keeps matching.
- `build.mjs` uses `createBabelPlugin()` for the Emotion transform of the `components` package, unchanged otherwise.
- `package.json`: drops `esbuild-plugin-babel`, adds a direct `@babel/core: ^7.25.7` dependency — the range every other workspace declares (enforced by `lint:deps`).
- The only intentional delta: if Babel returns no code for a file, the plugin now throws a descriptive error instead of passing `null` contents to esbuild.

## Testing Instructions

1. `npm install`
2. `NODE_ENV=production node packages/wp-build/lib/build.mjs`
3. The build completes and `packages/components/build`/`build-module` output is byte-identical to trunk (verified locally with `diff -r` against a trunk baseline build).
4. `npm run test:unit -- packages/wp-build` passes.
