### PR TITLE
Test: Add Vitest migration routing guardrails

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,6 +24,28 @@ concurrency:
 permissions: {}
 
 jobs:
+    unit-js-routing:
+        name: JavaScript test routing
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+              with:
+                  node-version: '20'
+
+            - name: Validate JavaScript test routing
+              run: npm run test:unit:routing
+
     unit-js:
         name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
         runs-on: 'ubuntu-24.04'

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
 		"test:php": "npm-run-all lint:php test:unit:php",
 		"test:php:watch": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' cli composer run-script test:watch",
 		"test:unit": "npm run --workspace @wordpress/unit-tests test:unit --",
+		"test:unit:routing": "npm run --workspace @wordpress/unit-tests test:unit:routing",
 		"test:unit:date": "bash ./bin/unit-test-date.sh",
 		"test:unit:debug": "npm run --workspace @wordpress/unit-tests test:unit:debug --",
 		"test:unit:profile": "npm run --workspace @wordpress/unit-tests test:unit:profile --",

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -4,21 +4,20 @@ The migration manifest in `test-migration.json` keeps every JavaScript unit and
 integration test assigned to exactly one runner while the repository moves from
 Jest to Vitest.
 
-The baseline count and hash were captured from executable Jest discovery with
-`jest --listTests`, then reconciled with the repository's static test-file
-patterns. Do not update the baseline when moving tests between runners.
+The routing validator derives the current test inventory from both runners and
+the repository's static test-file patterns. It does not depend on a fixed test
+count, so unrelated test additions and removals do not require migration
+metadata updates.
 
 When changing test ownership:
 
 -   Add individual tests to `vitest.files`, or use `vitest.directories` when an
     entire directory can move as one independently revertible unit.
--   Add tests created during the migration to the matching `added.jest` or
-    `added.vitest` list.
--   Add removed baseline tests to `retired` only when their removal is intentional
-    and explained in the pull request.
+-   New Jest tests require no migration metadata; runner discovery picks them up
+    automatically.
 -   Run `npm run test:unit:routing` together with both active runner partitions.
 
-The routing validator fails when a baseline test is missing, owned by both
-runners, or retired without removing its file. It also rejects invalid manifest
-entries, untracked new tests, static/executable discovery mismatches, and
-orphaned snapshots.
+The routing validator fails when a test is missing, owned by both runners, or
+not assigned to the expected Vitest migration entry. It also rejects invalid
+manifest entries, static/executable discovery mismatches, and orphaned
+snapshots.

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -19,5 +19,4 @@ When changing test ownership:
 
 The routing validator fails when a test is missing, owned by both runners, or
 not assigned to the expected Vitest migration entry. It also rejects invalid
-manifest entries, static/executable discovery mismatches, and orphaned
-snapshots.
+manifest entries and static/executable discovery mismatches.

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -1,0 +1,24 @@
+# Vitest migration routing
+
+The migration manifest in `test-migration.json` keeps every JavaScript unit and
+integration test assigned to exactly one runner while the repository moves from
+Jest to Vitest.
+
+The baseline count and hash were captured from executable Jest discovery with
+`jest --listTests`, then reconciled with the repository's static test-file
+patterns. Do not update the baseline when moving tests between runners.
+
+When changing test ownership:
+
+-   Add individual tests to `vitest.files`, or use `vitest.directories` when an
+    entire directory can move as one independently revertible unit.
+-   Add tests created during the migration to the matching `added.jest` or
+    `added.vitest` list.
+-   Add removed baseline tests to `retired` only when their removal is intentional
+    and explained in the pull request.
+-   Run `npm run test:unit:routing` together with both active runner partitions.
+
+The routing validator fails when a baseline test is missing, owned by both
+runners, or retired without removing its file. It also rejects invalid manifest
+entries, untracked new tests, static/executable discovery mismatches, and
+orphaned snapshots.

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -49,6 +49,7 @@
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
 		"test:unit:profile": "wp-scripts --cpu-prof test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
 		"test:unit:watch": "npm run test:unit -- --watch",
-		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config jest.config.js"
+		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
+		"test:unit:routing": "node scripts/validate-test-routing.mjs"
 	}
 }

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -1,7 +1,6 @@
 /**
  * Node dependencies
  */
-import { createHash } from 'node:crypto';
 import path from 'node:path';
 
 /**
@@ -59,16 +58,6 @@ export function getVitestTests( rootDir, manifest ) {
 	);
 
 	return [
-		...new Set( [
-			...manifest.vitest.files,
-			...directoryTests,
-			...manifest.added.vitest,
-		] ),
+		...new Set( [ ...manifest.vitest.files, ...directoryTests ] ),
 	].sort();
-}
-
-export function hashTestFiles( testFiles ) {
-	return createHash( 'sha256' )
-		.update( [ ...testFiles ].sort().join( '\n' ) )
-		.digest( 'hex' );
 }

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -1,0 +1,74 @@
+/**
+ * Node dependencies
+ */
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+/**
+ * External dependencies
+ */
+import globPackage from 'glob';
+
+const { sync: glob } = globPackage;
+
+export const TEST_PATTERNS = [
+	'**/__tests__/**/*.[jt]s?(x)',
+	'**/test/*.[jt]s?(x)',
+	'**/?(*.)test.[jt]s?(x)',
+];
+
+export const TEST_IGNORES = [
+	'**/.git/**',
+	'**/node_modules/**',
+	'packages/e2e-tests/**',
+	'packages/e2e-test-utils-playwright/src/test.ts',
+	'**/build/**',
+	'**/build-module/**',
+	'**/build-types/**',
+	'**/*.d.ts',
+	'vendor/**',
+];
+
+function normalizeTestPath( testPath ) {
+	return testPath.split( path.sep ).join( '/' );
+}
+
+export function discoverTestFiles( rootDir ) {
+	return [
+		...new Set(
+			TEST_PATTERNS.flatMap( ( pattern ) =>
+				glob( pattern, {
+					absolute: false,
+					cwd: rootDir,
+					ignore: TEST_IGNORES,
+					nodir: true,
+				} )
+			).map( normalizeTestPath )
+		),
+	].sort();
+}
+
+export function getVitestTests( rootDir, manifest ) {
+	const discoveredTests = discoverTestFiles( rootDir );
+	const directoryTests = discoveredTests.filter( ( testPath ) =>
+		manifest.vitest.directories.some(
+			( directoryPath ) =>
+				testPath === directoryPath ||
+				testPath.startsWith( `${ directoryPath }/` )
+		)
+	);
+
+	return [
+		...new Set( [
+			...manifest.vitest.files,
+			...directoryTests,
+			...manifest.added.vitest,
+		] ),
+	].sort();
+}
+
+export function hashTestFiles( testFiles ) {
+	return createHash( 'sha256' )
+		.update( [ ...testFiles ].sort().join( '\n' ) )
+		.digest( 'hex' );
+}

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -39,6 +39,7 @@ export function discoverTestFiles( rootDir ) {
 				glob( pattern, {
 					absolute: false,
 					cwd: rootDir,
+					dot: true,
 					ignore: TEST_IGNORES,
 					nodir: true,
 				} )
@@ -47,8 +48,7 @@ export function discoverTestFiles( rootDir ) {
 	].sort();
 }
 
-export function getVitestTests( rootDir, manifest ) {
-	const discoveredTests = discoverTestFiles( rootDir );
+export function getVitestTests( discoveredTests, manifest ) {
 	const directoryTests = discoveredTests.filter( ( testPath ) =>
 		manifest.vitest.directories.some(
 			( directoryPath ) =>

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -16,11 +16,7 @@ import globPackage from 'glob';
 /**
  * Internal dependencies
  */
-import {
-	discoverTestFiles,
-	getVitestTests,
-	hashTestFiles,
-} from './discover-test-files.mjs';
+import { discoverTestFiles, getVitestTests } from './discover-test-files.mjs';
 
 const require = createRequire( import.meta.url );
 const ROOT_DIR = path.resolve(
@@ -97,6 +93,13 @@ function assertUniquePaths( label, testPaths ) {
 	}
 }
 
+function isWithinDirectory( testPath, directoryPath ) {
+	return (
+		testPath === directoryPath ||
+		testPath.startsWith( `${ directoryPath }/` )
+	);
+}
+
 const jestTests = listTests( 'jest', [
 	'--config',
 	JEST_CONFIG,
@@ -111,28 +114,30 @@ const vitestTests = existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) )
 	  ] )
 	: new Set();
 
-const addedJestTests = manifest.added.jest;
-const addedVitestTests = manifest.added.vitest;
-const addedTests = [ ...addedJestTests, ...addedVitestTests ];
-const retiredTests = manifest.retired;
 const migratedTestFiles = manifest.vitest.files;
 const migratedDirectories = manifest.vitest.directories;
 
-assertUniquePaths( 'added.jest', addedJestTests );
-assertUniquePaths( 'added.vitest', addedVitestTests );
-assertUniquePaths( 'retired', retiredTests );
 assertUniquePaths( 'vitest.files', migratedTestFiles );
 assertUniquePaths( 'vitest.directories', migratedDirectories );
 
-const duplicateManifestEntries = addedTests.filter(
-	( testPath, index ) =>
-		addedTests.indexOf( testPath ) !== index ||
-		retiredTests.includes( testPath )
-);
+const overlappingManifestEntries = [
+	...migratedTestFiles.filter( ( testPath ) =>
+		migratedDirectories.some( ( directoryPath ) =>
+			isWithinDirectory( testPath, directoryPath )
+		)
+	),
+	...migratedDirectories.filter( ( directoryPath, index ) =>
+		migratedDirectories.some(
+			( otherDirectoryPath, otherIndex ) =>
+				otherIndex !== index &&
+				isWithinDirectory( directoryPath, otherDirectoryPath )
+		)
+	),
+];
 assert.deepEqual(
-	duplicateManifestEntries,
+	overlappingManifestEntries,
 	[],
-	`Migration manifest entries must be disjoint:\n${ duplicateManifestEntries.join(
+	`Vitest migration manifest entries must be disjoint:\n${ overlappingManifestEntries.join(
 		'\n'
 	) }`
 );
@@ -150,50 +155,6 @@ assert.deepEqual(
 	invalidMigratedEntries,
 	[],
 	`Migrated files or directories do not exist:\n${ invalidMigratedEntries.join(
-		'\n'
-	) }`
-);
-
-const invalidAddedTests = addedTests.filter(
-	( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
-);
-assert.deepEqual(
-	invalidAddedTests,
-	[],
-	`Added tests do not exist:\n${ invalidAddedTests.join( '\n' ) }`
-);
-
-const activeRetiredTests = retiredTests.filter(
-	( testPath ) =>
-		existsSync( path.join( ROOT_DIR, testPath ) ) ||
-		jestTests.has( testPath ) ||
-		vitestTests.has( testPath )
-);
-assert.deepEqual(
-	activeRetiredTests,
-	[],
-	`Retired tests still exist or are discoverable:\n${ activeRetiredTests.join(
-		'\n'
-	) }`
-);
-
-const missingAddedJestTests = addedJestTests.filter(
-	( testPath ) => ! jestTests.has( testPath )
-);
-const missingAddedVitestTests = addedVitestTests.filter(
-	( testPath ) => ! vitestTests.has( testPath )
-);
-assert.deepEqual(
-	missingAddedJestTests,
-	[],
-	`Added Jest tests are not discoverable by Jest:\n${ missingAddedJestTests.join(
-		'\n'
-	) }`
-);
-assert.deepEqual(
-	missingAddedVitestTests,
-	[],
-	`Added Vitest tests are not discoverable by Vitest:\n${ missingAddedVitestTests.join(
 		'\n'
 	) }`
 );
@@ -216,37 +177,14 @@ assert.deepEqual(
 	`Vitest discovery does not match the migration manifest.`
 );
 
-const accountedBaseline = [
-	...new Set( [
-		...[ ...jestTests ].filter(
-			( testPath ) => ! addedJestTests.includes( testPath )
-		),
-		...[ ...vitestTests ].filter(
-			( testPath ) => ! addedVitestTests.includes( testPath )
-		),
-		...retiredTests,
-	] ),
-].sort();
-
-assert.equal(
-	accountedBaseline.length,
-	manifest.baseline.count,
-	'The number of accounted baseline tests changed.'
-);
-assert.equal(
-	hashTestFiles( accountedBaseline ),
-	manifest.baseline.sha256,
-	'The accounted baseline test file list changed.'
-);
-
 const staticInventory = discoverTestFiles( ROOT_DIR );
-const expectedStaticInventory = [ ...accountedBaseline, ...addedTests ]
-	.filter( ( testPath ) => ! retiredTests.includes( testPath ) )
-	.sort();
+const runnerInventory = [
+	...new Set( [ ...jestTests, ...vitestTests ] ),
+].sort();
 assert.deepEqual(
+	runnerInventory,
 	staticInventory,
-	expectedStaticInventory,
-	'Static test discovery does not match the executable runner inventory.'
+	'Executable runner inventory does not match static test discovery.'
 );
 
 const { sync: glob } = globPackage;
@@ -270,5 +208,5 @@ assert.deepEqual(
 );
 
 console.log(
-	`Validated exactly one runner for ${ manifest.baseline.count } baseline tests: ${ jestTests.size } Jest, ${ vitestTests.size } Vitest, ${ retiredTests.length } retired, and ${ addedTests.length } added.`
+	`Validated exactly one runner for ${ staticInventory.length } tests: ${ jestTests.size } Jest and ${ vitestTests.size } Vitest.`
 );

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -1,0 +1,274 @@
+/**
+ * Node dependencies
+ */
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * External dependencies
+ */
+import globPackage from 'glob';
+
+/**
+ * Internal dependencies
+ */
+import {
+	discoverTestFiles,
+	getVitestTests,
+	hashTestFiles,
+} from './discover-test-files.mjs';
+
+const require = createRequire( import.meta.url );
+const ROOT_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../../..'
+);
+const JEST_CONFIG = 'test/unit/jest.config.js';
+const VITEST_CONFIG = 'test/unit/vitest.config.mjs';
+const manifest = JSON.parse(
+	readFileSync(
+		path.join( ROOT_DIR, 'test/unit/test-migration.json' ),
+		'utf8'
+	)
+);
+
+function normalizeTestPath( testPath ) {
+	return path
+		.relative( ROOT_DIR, path.resolve( ROOT_DIR, testPath ) )
+		.split( path.sep )
+		.join( '/' );
+}
+
+function resolvePackageBin( packageName ) {
+	const packageJsonPath = require.resolve( `${ packageName }/package.json` );
+	const packageJson = JSON.parse( readFileSync( packageJsonPath, 'utf8' ) );
+	const binPath =
+		typeof packageJson.bin === 'string'
+			? packageJson.bin
+			: packageJson.bin[ packageName ];
+
+	return path.resolve( path.dirname( packageJsonPath ), binPath );
+}
+
+function listTests( packageName, args ) {
+	const result = spawnSync(
+		process.execPath,
+		[ resolvePackageBin( packageName ), ...args ],
+		{
+			cwd: ROOT_DIR,
+			encoding: 'utf8',
+			env: process.env,
+			maxBuffer: 20 * 1024 * 1024,
+		}
+	);
+
+	if ( result.status !== 0 ) {
+		process.stderr.write( result.stdout );
+		process.stderr.write( result.stderr );
+		process.exit( result.status ?? 1 );
+	}
+
+	return new Set(
+		result.stdout
+			.trim()
+			.split( /\r?\n/ )
+			.filter( Boolean )
+			.map( normalizeTestPath )
+	);
+}
+
+function assertUniquePaths( label, testPaths ) {
+	assert.equal(
+		new Set( testPaths ).size,
+		testPaths.length,
+		`${ label } contains duplicate paths.`
+	);
+
+	for ( const testPath of testPaths ) {
+		assert.equal(
+			testPath,
+			normalizeTestPath( testPath ),
+			`${ label } contains a non-normalized path: ${ testPath }`
+		);
+	}
+}
+
+const jestTests = listTests( 'jest', [
+	'--config',
+	JEST_CONFIG,
+	'--listTests',
+] );
+const vitestTests = existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) )
+	? listTests( 'vitest', [
+			'list',
+			'--config',
+			VITEST_CONFIG,
+			'--filesOnly',
+	  ] )
+	: new Set();
+
+const addedJestTests = manifest.added.jest;
+const addedVitestTests = manifest.added.vitest;
+const addedTests = [ ...addedJestTests, ...addedVitestTests ];
+const retiredTests = manifest.retired;
+const migratedTestFiles = manifest.vitest.files;
+const migratedDirectories = manifest.vitest.directories;
+
+assertUniquePaths( 'added.jest', addedJestTests );
+assertUniquePaths( 'added.vitest', addedVitestTests );
+assertUniquePaths( 'retired', retiredTests );
+assertUniquePaths( 'vitest.files', migratedTestFiles );
+assertUniquePaths( 'vitest.directories', migratedDirectories );
+
+const duplicateManifestEntries = addedTests.filter(
+	( testPath, index ) =>
+		addedTests.indexOf( testPath ) !== index ||
+		retiredTests.includes( testPath )
+);
+assert.deepEqual(
+	duplicateManifestEntries,
+	[],
+	`Migration manifest entries must be disjoint:\n${ duplicateManifestEntries.join(
+		'\n'
+	) }`
+);
+
+const invalidMigratedEntries = [
+	...migratedTestFiles.filter(
+		( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
+	),
+	...migratedDirectories.filter(
+		( directoryPath ) =>
+			! existsSync( path.join( ROOT_DIR, directoryPath ) )
+	),
+];
+assert.deepEqual(
+	invalidMigratedEntries,
+	[],
+	`Migrated files or directories do not exist:\n${ invalidMigratedEntries.join(
+		'\n'
+	) }`
+);
+
+const invalidAddedTests = addedTests.filter(
+	( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
+);
+assert.deepEqual(
+	invalidAddedTests,
+	[],
+	`Added tests do not exist:\n${ invalidAddedTests.join( '\n' ) }`
+);
+
+const activeRetiredTests = retiredTests.filter(
+	( testPath ) =>
+		existsSync( path.join( ROOT_DIR, testPath ) ) ||
+		jestTests.has( testPath ) ||
+		vitestTests.has( testPath )
+);
+assert.deepEqual(
+	activeRetiredTests,
+	[],
+	`Retired tests still exist or are discoverable:\n${ activeRetiredTests.join(
+		'\n'
+	) }`
+);
+
+const missingAddedJestTests = addedJestTests.filter(
+	( testPath ) => ! jestTests.has( testPath )
+);
+const missingAddedVitestTests = addedVitestTests.filter(
+	( testPath ) => ! vitestTests.has( testPath )
+);
+assert.deepEqual(
+	missingAddedJestTests,
+	[],
+	`Added Jest tests are not discoverable by Jest:\n${ missingAddedJestTests.join(
+		'\n'
+	) }`
+);
+assert.deepEqual(
+	missingAddedVitestTests,
+	[],
+	`Added Vitest tests are not discoverable by Vitest:\n${ missingAddedVitestTests.join(
+		'\n'
+	) }`
+);
+
+const overlappingTests = [ ...jestTests ].filter( ( testPath ) =>
+	vitestTests.has( testPath )
+);
+assert.deepEqual(
+	overlappingTests,
+	[],
+	`Tests are owned by both Jest and Vitest:\n${ overlappingTests.join(
+		'\n'
+	) }`
+);
+
+const expectedVitestTests = getVitestTests( ROOT_DIR, manifest );
+assert.deepEqual(
+	[ ...vitestTests ].sort(),
+	expectedVitestTests,
+	`Vitest discovery does not match the migration manifest.`
+);
+
+const accountedBaseline = [
+	...new Set( [
+		...[ ...jestTests ].filter(
+			( testPath ) => ! addedJestTests.includes( testPath )
+		),
+		...[ ...vitestTests ].filter(
+			( testPath ) => ! addedVitestTests.includes( testPath )
+		),
+		...retiredTests,
+	] ),
+].sort();
+
+assert.equal(
+	accountedBaseline.length,
+	manifest.baseline.count,
+	'The number of accounted baseline tests changed.'
+);
+assert.equal(
+	hashTestFiles( accountedBaseline ),
+	manifest.baseline.sha256,
+	'The accounted baseline test file list changed.'
+);
+
+const staticInventory = discoverTestFiles( ROOT_DIR );
+const expectedStaticInventory = [ ...accountedBaseline, ...addedTests ]
+	.filter( ( testPath ) => ! retiredTests.includes( testPath ) )
+	.sort();
+assert.deepEqual(
+	staticInventory,
+	expectedStaticInventory,
+	'Static test discovery does not match the executable runner inventory.'
+);
+
+const { sync: glob } = globPackage;
+const orphanedSnapshots = glob( '**/__snapshots__/*.snap', {
+	cwd: ROOT_DIR,
+	ignore: [ '**/node_modules/**', '**/vendor/**' ],
+	nodir: true,
+} ).filter( ( snapshotPath ) => {
+	const testPath = path.join(
+		path.dirname( path.dirname( snapshotPath ) ),
+		path.basename( snapshotPath, '.snap' )
+	);
+	return ! existsSync( path.join( ROOT_DIR, testPath ) );
+} );
+assert.deepEqual(
+	orphanedSnapshots,
+	[],
+	`Snapshots without a matching test file:\n${ orphanedSnapshots.join(
+		'\n'
+	) }`
+);
+
+console.log(
+	`Validated exactly one runner for ${ manifest.baseline.count } baseline tests: ${ jestTests.size } Jest, ${ vitestTests.size } Vitest, ${ retiredTests.length } retired, and ${ addedTests.length } added.`
+);

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -3,15 +3,10 @@
  */
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-
-/**
- * External dependencies
- */
-import globPackage from 'glob';
 
 /**
  * Internal dependencies
@@ -100,6 +95,21 @@ function isWithinDirectory( testPath, directoryPath ) {
 	);
 }
 
+function isValidManifestPath( testPath, expectedType ) {
+	const resolvedPath = path.resolve( ROOT_DIR, testPath );
+	const relativePath = path.relative( ROOT_DIR, resolvedPath );
+	const isWithinRoot =
+		relativePath !== '..' &&
+		! relativePath.startsWith( `..${ path.sep }` ) &&
+		! path.isAbsolute( relativePath );
+
+	return (
+		isWithinRoot &&
+		existsSync( resolvedPath ) &&
+		statSync( resolvedPath )[ expectedType ]()
+	);
+}
+
 const jestTests = listTests( 'jest', [
 	'--config',
 	JEST_CONFIG,
@@ -144,17 +154,17 @@ assert.deepEqual(
 
 const invalidMigratedEntries = [
 	...migratedTestFiles.filter(
-		( testPath ) => ! existsSync( path.join( ROOT_DIR, testPath ) )
+		( testPath ) => ! isValidManifestPath( testPath, 'isFile' )
 	),
 	...migratedDirectories.filter(
 		( directoryPath ) =>
-			! existsSync( path.join( ROOT_DIR, directoryPath ) )
+			! isValidManifestPath( directoryPath, 'isDirectory' )
 	),
 ];
 assert.deepEqual(
 	invalidMigratedEntries,
 	[],
-	`Migrated files or directories do not exist:\n${ invalidMigratedEntries.join(
+	`Migrated files or directories must exist inside the repository and match their declared type:\n${ invalidMigratedEntries.join(
 		'\n'
 	) }`
 );
@@ -185,26 +195,6 @@ assert.deepEqual(
 	runnerInventory,
 	staticInventory,
 	'Executable runner inventory does not match static test discovery.'
-);
-
-const { sync: glob } = globPackage;
-const orphanedSnapshots = glob( '**/__snapshots__/*.snap', {
-	cwd: ROOT_DIR,
-	ignore: [ '**/node_modules/**', '**/vendor/**' ],
-	nodir: true,
-} ).filter( ( snapshotPath ) => {
-	const testPath = path.join(
-		path.dirname( path.dirname( snapshotPath ) ),
-		path.basename( snapshotPath, '.snap' )
-	);
-	return ! existsSync( path.join( ROOT_DIR, testPath ) );
-} );
-assert.deepEqual(
-	orphanedSnapshots,
-	[],
-	`Snapshots without a matching test file:\n${ orphanedSnapshots.join(
-		'\n'
-	) }`
 );
 
 console.log(

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -57,9 +57,13 @@ function listTests( packageName, args ) {
 		}
 	);
 
+	if ( result.error ) {
+		throw result.error;
+	}
+
 	if ( result.status !== 0 ) {
-		process.stderr.write( result.stdout );
-		process.stderr.write( result.stderr );
+		process.stderr.write( result.stdout ?? '' );
+		process.stderr.write( result.stderr ?? '' );
 		process.exit( result.status ?? 1 );
 	}
 
@@ -123,6 +127,7 @@ const vitestTests = existsSync( path.join( ROOT_DIR, VITEST_CONFIG ) )
 			'--filesOnly',
 	  ] )
 	: new Set();
+const staticInventory = discoverTestFiles( ROOT_DIR );
 
 const migratedTestFiles = manifest.vitest.files;
 const migratedDirectories = manifest.vitest.directories;
@@ -169,6 +174,20 @@ assert.deepEqual(
 	) }`
 );
 
+const emptyMigratedDirectories = migratedDirectories.filter(
+	( directoryPath ) =>
+		! staticInventory.some( ( testPath ) =>
+			isWithinDirectory( testPath, directoryPath )
+		)
+);
+assert.deepEqual(
+	emptyMigratedDirectories,
+	[],
+	`Migrated directories must contain at least one test:\n${ emptyMigratedDirectories.join(
+		'\n'
+	) }`
+);
+
 const overlappingTests = [ ...jestTests ].filter( ( testPath ) =>
 	vitestTests.has( testPath )
 );
@@ -180,14 +199,13 @@ assert.deepEqual(
 	) }`
 );
 
-const expectedVitestTests = getVitestTests( ROOT_DIR, manifest );
+const expectedVitestTests = getVitestTests( staticInventory, manifest );
 assert.deepEqual(
 	[ ...vitestTests ].sort(),
 	expectedVitestTests,
 	`Vitest discovery does not match the migration manifest.`
 );
 
-const staticInventory = discoverTestFiles( ROOT_DIR );
 const runnerInventory = [
 	...new Set( [ ...jestTests, ...vitestTests ] ),
 ].sort();

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -1,0 +1,15 @@
+{
+	"baseline": {
+		"count": 996,
+		"sha256": "72316673c4f35ec4d55ec15ba4dbf3435dd2f57b3b54dc5258d9c75b340ad243"
+	},
+	"vitest": {
+		"files": [],
+		"directories": []
+	},
+	"retired": [],
+	"added": {
+		"jest": [],
+		"vitest": []
+	}
+}

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -1,15 +1,6 @@
 {
-	"baseline": {
-		"count": 996,
-		"sha256": "72316673c4f35ec4d55ec15ba4dbf3435dd2f57b3b54dc5258d9c75b340ad243"
-	},
 	"vitest": {
 		"files": [],
 		"directories": []
-	},
-	"retired": [],
-	"added": {
-		"jest": [],
-		"vitest": []
 	}
 }


### PR DESCRIPTION
Part of #80855.

Next step: #81037

## What?

Adds an executable routing guardrail for the incremental Jest-to-Vitest migration.

## Why?

Each discovered test must be owned by exactly one active runner so migration steps cannot silently lose or duplicate coverage.

## How?

Adds static test discovery, a migration manifest, and a CI routing check that compares repository inventory with the active runner partition.

## Testing Instructions

1. Run `npm run test:unit:routing`.
2. Confirm it reports one owner for every discovered test.

### Testing Instructions for Keyboard

Not applicable; this change does not affect user interfaces.

## Use of AI Tools

Codex assisted with implementation and verification. The resulting changes and test output were reviewed by the author.
