### PR TITLE
Global Styles: explore the inheritance cascade in the style panels' options menu

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -39,10 +39,7 @@ import { getResolvedValue } from '@wordpress/global-styles-engine';
  * Internal dependencies
  */
 import { hasBackgroundImageValue } from '../global-styles/background-panel';
-import {
-	InheritanceResetButton,
-	isGlobalStylesInheritanceEnabled,
-} from '../global-styles/inheritance';
+import { isGlobalStylesInheritanceEnabled } from '../global-styles/inheritance';
 import { setImmutably } from '../../utils/object';
 import MediaReplaceFlow from '../media-replace-flow';
 import { store as blockEditorStore } from '../../store';
@@ -197,7 +194,6 @@ function BackgroundControlsPanel( {
 	onToggle: onToggleCallback = noop,
 	hasImageValue,
 	onReset,
-	hasLocalOverride,
 	containerRef,
 } ) {
 	if ( ! hasImageValue ) {
@@ -230,38 +226,24 @@ function BackgroundControlsPanel( {
 							as="button"
 							onToggleCallback={ onToggleCallback }
 						/>
-						{ onReset &&
-							( hasLocalOverride ? (
-								<InheritanceResetButton
-									className="block-editor-global-styles-background-panel__reset"
-									onResetToInherited={ () => {
-										onReset();
-										// Close the dropdown if open.
-										if ( isOpen ) {
-											onToggle();
-										}
-										// Focus the toggle button.
-										focusToggleButton( containerRef );
-									} }
-								/>
-							) : (
-								<Button
-									__next40pxDefaultSize
-									label={ __( 'Reset' ) }
-									className="block-editor-global-styles-background-panel__reset"
-									size="small"
-									icon={ resetIcon }
-									onClick={ () => {
-										onReset();
-										// Close the dropdown if open.
-										if ( isOpen ) {
-											onToggle();
-										}
-										// Focus the toggle button.
-										focusToggleButton( containerRef );
-									} }
-								/>
-							) ) }
+						{ onReset && (
+							<Button
+								__next40pxDefaultSize
+								label={ __( 'Reset' ) }
+								className="block-editor-global-styles-background-panel__reset"
+								size="small"
+								icon={ resetIcon }
+								onClick={ () => {
+									onReset();
+									// Close the dropdown if open.
+									if ( isOpen ) {
+										onToggle();
+									}
+									// Focus the toggle button.
+									focusToggleButton( containerRef );
+								} }
+							/>
+						) }
 					</>
 				);
 			} }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -23,6 +22,7 @@ import {
 	InheritanceToolsPanelItem,
 	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
+import { InheritanceToolsPanel } from './inheritance/panel-menu';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,
@@ -142,7 +142,7 @@ export function BackgroundToolsPanel( {
 	};
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
@@ -155,7 +155,7 @@ export function BackgroundToolsPanel( {
 			<div className="background-block-support-panel__inner-wrapper">
 				{ children }
 			</div>
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }
 
@@ -366,6 +366,7 @@ export default function BackgroundImagePanel( {
 					showLocalOverrideActionsInLabel={ false }
 					hasValue={ () => hasBackgroundImageValue( value ) }
 					label={ __( 'Image' ) }
+					stylePaths={ [ 'background.backgroundImage' ] }
 					onDeselect={ resetBackground }
 					isShownByDefault={ defaultControls.backgroundImage }
 					panelId={ panelId }
@@ -386,6 +387,7 @@ export default function BackgroundImagePanel( {
 			{ showBackgroundColorControl && (
 				<ColorGradientDropdownItem
 					label={ __( 'Color' ) }
+					stylePaths={ [ 'color.background' ] }
 					hasValue={ () => hasBackgroundColorValue( value ) }
 					resetValue={ resetBackgroundColor }
 					isShownByDefault={ defaultControls.backgroundColor }
@@ -433,6 +435,7 @@ export default function BackgroundImagePanel( {
 			{ showBackgroundGradientControl && (
 				<ColorGradientDropdownItem
 					label={ __( 'Gradient' ) }
+					stylePaths={ [ 'color.gradient' ] }
 					hasValue={ () => hasBackgroundGradientValue( value ) }
 					resetValue={ resetGradient }
 					isShownByDefault={ defaultControls.gradient }
@@ -478,6 +481,7 @@ export default function BackgroundImagePanel( {
 			{ showLegacyColorGradientControl && (
 				<ColorGradientDropdownItem
 					label={ __( 'Gradient' ) }
+					stylePaths={ [ 'color.gradient' ] }
 					hasValue={ () => hasLegacyColorGradientValue( value ) }
 					resetValue={ resetLegacyColorGradient }
 					isShownByDefault={ defaultControls.gradient }

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -5,7 +5,6 @@ import {
 	BorderBoxControl,
 	__experimentalHasSplitBorders as hasSplitBorders,
 	__experimentalIsDefinedBorder as isDefinedBorder,
-	__experimentalToolsPanel as ToolsPanel,
 	BaseControl,
 } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
@@ -26,6 +25,7 @@ import {
 	InheritanceToolsPanelItem,
 	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
+import { InheritanceToolsPanel } from './inheritance/panel-menu';
 
 export function useHasBorderPanel( settings ) {
 	const controls = Object.values( useHasBorderPanelControls( settings ) );
@@ -80,14 +80,14 @@ function BorderToolsPanel( {
 	};
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			label={ label }
 			resetAll={ resetAll }
 			panelId={ panelId }
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }
 
@@ -399,6 +399,11 @@ export default function BorderPanel( {
 					) }
 					hasValue={ () => isDefinedBorder( value?.border ) }
 					label={ __( 'Border' ) }
+					stylePaths={ [
+						'border.color',
+						'border.style',
+						'border.width',
+					] }
 					onDeselect={ () => resetBorder() }
 					isShownByDefault={ showBorderByDefault }
 					panelId={ panelId }
@@ -446,6 +451,7 @@ export default function BorderPanel( {
 					) }
 					hasValue={ hasBorderRadius }
 					label={ __( 'Radius' ) }
+					stylePaths={ [ 'border.radius' ] }
 					hasInlineEndToggle
 					onDeselect={ () => setBorderRadius( undefined ) }
 					isShownByDefault={ defaultControls.radius }
@@ -467,6 +473,7 @@ export default function BorderPanel( {
 						hasShadow() && inheritedShadow !== undefined
 					) }
 					label={ __( 'Shadow' ) }
+					stylePaths={ [ 'shadow' ] }
 					hasValue={ hasShadow }
 					onDeselect={ resetShadow }
 					isShownByDefault={ defaultControls.shadow }

--- a/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
+++ b/packages/block-editor/src/components/global-styles/color-gradient-dropdown-item.js
@@ -28,7 +28,6 @@ import ColorGradientControl from '../colors-gradients/control';
 import { unlock } from '../../lock-unlock';
 import {
 	getInheritanceProps,
-	InheritanceResetButton,
 	InheritanceToolsPanelItem,
 	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
@@ -214,6 +213,7 @@ export default function ColorGradientDropdownItem( {
 	className = 'block-editor-tools-panel-color-gradient-settings__item',
 	isPlaceholder = false,
 	hasInheritedValue = false,
+	stylePaths,
 	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
 	const colorGradientDropdownButtonRef = useRef( undefined );
@@ -229,6 +229,7 @@ export default function ColorGradientDropdownItem( {
 	return (
 		<InheritanceToolsPanelItem
 			{ ...inheritanceProps }
+			stylePaths={ stylePaths }
 			showLocalOverrideActionsInLabel={ false }
 			hasValue={ hasValue }
 			label={ label }
@@ -261,34 +262,22 @@ export default function ColorGradientDropdownItem( {
 									label={ label }
 								/>
 							</Button>
-							{ hasValue() &&
-								( hasLocalOverride ? (
-									<InheritanceResetButton
-										className="block-editor-panel-color-gradient-settings__reset"
-										onResetToInherited={ () => {
-											resetValue();
-											if ( isOpen ) {
-												onToggle();
-											}
-											colorGradientDropdownButtonRef.current?.focus();
-										} }
-									/>
-								) : (
-									<Button
-										__next40pxDefaultSize
-										label={ __( 'Reset' ) }
-										className="block-editor-panel-color-gradient-settings__reset"
-										size="small"
-										icon={ resetIcon }
-										onClick={ () => {
-											resetValue();
-											if ( isOpen ) {
-												onToggle();
-											}
-											colorGradientDropdownButtonRef.current?.focus();
-										} }
-									/>
-								) ) }
+							{ hasValue() && (
+								<Button
+									__next40pxDefaultSize
+									label={ __( 'Reset' ) }
+									className="block-editor-panel-color-gradient-settings__reset"
+									size="small"
+									icon={ resetIcon }
+									onClick={ () => {
+										resetValue();
+										if ( isOpen ) {
+											onToggle();
+										}
+										colorGradientDropdownButtonRef.current?.focus();
+									} }
+								/>
+							) }
 							{ contrastWarning && (
 								// An icon-only warning that stays visible while a
 								// contrast warning is in effect. It is not a menu;

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getCSSValueFromRawStyle } from '@wordpress/style-engine';
@@ -22,6 +21,7 @@ import {
 	encodeColorValueWithPalette,
 } from '../../utils/color-values';
 import { isGlobalStylesInheritanceEnabled } from './inheritance';
+import { InheritanceToolsPanel } from './inheritance/panel-menu';
 
 // Despite the "ColorPanel" name, this gates only the element-level color
 // controls (link, heading, button, caption, h1–h6) — surfaced as the
@@ -113,7 +113,7 @@ export function ColorToolsPanel( {
 	};
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			label={ label || __( 'Elements' ) }
 			resetAll={ resetAll }
 			panelId={ panelId }
@@ -127,7 +127,7 @@ export function ColorToolsPanel( {
 			<div className="color-block-support-panel__inner-wrapper">
 				{ children }
 			</div>
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }
 
@@ -302,6 +302,7 @@ export default function ColorPanel( {
 		showLinkPanel && {
 			key: 'link',
 			label: __( 'Link' ),
+			stylePaths: [ 'elements.link.color.text' ],
 			hasValue: hasLink,
 			resetValue: resetLink,
 			isShownByDefault: defaultControls.link,
@@ -462,6 +463,11 @@ export default function ColorPanel( {
 		items.push( {
 			key: name,
 			label: elementLabel,
+			stylePaths: [
+				`elements.${ name }.color.text`,
+				`elements.${ name }.color.background`,
+				`elements.${ name }.color.gradient`,
+			],
 			hasValue: hasElement,
 			resetValue: resetElement,
 			isShownByDefault: defaultControls[ name ],

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -7,7 +7,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	__experimentalToolsPanel as ToolsPanel,
 	BoxControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
@@ -38,6 +37,7 @@ import {
 	InheritanceToolsPanelItem,
 	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
+import { InheritanceToolsPanel } from './inheritance/panel-menu';
 
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
@@ -321,14 +321,14 @@ function DimensionsToolsPanel( {
 	};
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			label={ __( 'Dimensions' ) }
 			resetAll={ resetAll }
 			panelId={ panelId }
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }
 
@@ -766,6 +766,7 @@ export default function DimensionsPanel( {
 							inheritedContentSizeValue !== undefined
 					) }
 					label={ __( 'Content width' ) }
+					stylePaths={ [ 'layout.contentSize' ] }
 					hasValue={ hasUserSetContentSizeValue }
 					onDeselect={ resetContentSizeValue }
 					isShownByDefault={
@@ -812,6 +813,7 @@ export default function DimensionsPanel( {
 							inheritedWideSizeValue !== undefined
 					) }
 					label={ __( 'Wide width' ) }
+					stylePaths={ [ 'layout.wideSize' ] }
 					hasValue={ hasUserSetWideSizeValue }
 					onDeselect={ resetWideSizeValue }
 					isShownByDefault={
@@ -851,6 +853,7 @@ export default function DimensionsPanel( {
 				<InheritanceToolsPanelItem
 					hasValue={ hasPaddingValue }
 					label={ __( 'Padding' ) }
+					stylePaths={ [ 'spacing.padding' ] }
 					hasInlineEndToggle={ hasSpacingToggle(
 						paddingSides,
 						showSpacingPresetsControl
@@ -905,6 +908,7 @@ export default function DimensionsPanel( {
 				<InheritanceToolsPanelItem
 					hasValue={ hasMarginValue }
 					label={ __( 'Margin' ) }
+					stylePaths={ [ 'spacing.margin' ] }
 					hasInlineEndToggle={ hasSpacingToggle(
 						marginSides,
 						showSpacingPresetsControl
@@ -968,6 +972,7 @@ export default function DimensionsPanel( {
 				<InheritanceToolsPanelItem
 					hasValue={ hasGapValue }
 					label={ __( 'Block spacing' ) }
+					stylePaths={ [ 'spacing.blockGap' ] }
 					hasInlineEndToggle={ isAxialGap }
 					onDeselect={ resetGapValue }
 					isShownByDefault={
@@ -1049,6 +1054,7 @@ export default function DimensionsPanel( {
 					) }
 					hasValue={ hasMinHeightValue }
 					label={ __( 'Minimum height' ) }
+					stylePaths={ [ 'dimensions.minHeight' ] }
 					onDeselect={ resetMinHeightValue }
 					isShownByDefault={
 						defaultControls.minHeight ?? DEFAULT_CONTROLS.minHeight
@@ -1084,6 +1090,7 @@ export default function DimensionsPanel( {
 					) }
 					hasValue={ hasMinWidthValue }
 					label={ __( 'Minimum width' ) }
+					stylePaths={ [ 'dimensions.minWidth' ] }
 					onDeselect={ resetMinWidthValue }
 					isShownByDefault={
 						defaultControls.minWidth ?? DEFAULT_CONTROLS.minWidth
@@ -1117,6 +1124,7 @@ export default function DimensionsPanel( {
 					) }
 					hasValue={ hasHeightValue }
 					label={ __( 'Height' ) }
+					stylePaths={ [ 'dimensions.height' ] }
 					onDeselect={ resetHeightValue }
 					isShownByDefault={
 						defaultControls.height ?? DEFAULT_CONTROLS.height
@@ -1144,6 +1152,7 @@ export default function DimensionsPanel( {
 					) }
 					hasValue={ hasWidthValue }
 					label={ __( 'Width' ) }
+					stylePaths={ [ 'dimensions.width' ] }
 					onDeselect={ resetWidthValue }
 					isShownByDefault={
 						defaultControls.width ?? DEFAULT_CONTROLS.width

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	__experimentalToolsPanel as ToolsPanel,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/use-recommended-components
 	__experimentalZStack as ZStack, // eslint-disable-line @wordpress/use-recommended-components
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
@@ -33,9 +32,9 @@ import { setImmutably } from '../../utils/object';
 import {
 	getInheritanceProps,
 	InheritanceToolsPanelItem,
-	InheritanceResetButton,
 	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
+import { InheritanceToolsPanel } from './inheritance/panel-menu';
 
 const EMPTY_ARRAY = [];
 function useMultiOriginColorPresets(
@@ -85,14 +84,14 @@ function FiltersToolsPanel( {
 	};
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			label={ _x( 'Filters', 'Name for applying graphical effects' ) }
 			resetAll={ resetAll }
 			panelId={ panelId }
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }
 
@@ -130,7 +129,7 @@ const LabeledColorIndicator = ( { indicator, label } ) => (
 
 const renderToggle = ( duotone, resetConfig ) =>
 	function Toggle( { onToggle, isOpen } ) {
-		const { hasLocalValue, hasLocalOverride, onReset } = resetConfig;
+		const { hasLocalValue, onReset } = resetConfig;
 		const duotoneButtonRef = useRef( undefined );
 
 		const toggleProps = {
@@ -160,21 +159,15 @@ const renderToggle = ( duotone, resetConfig ) =>
 						label={ __( 'Duotone' ) }
 					/>
 				</Button>
-				{ hasLocalValue &&
-					( hasLocalOverride ? (
-						<InheritanceResetButton
-							className="block-editor-panel-duotone-settings__reset"
-							onResetToInherited={ handleReset }
-						/>
-					) : (
-						<Button
-							size="small"
-							icon={ resetIcon }
-							label={ __( 'Reset' ) }
-							className="block-editor-panel-duotone-settings__reset"
-							onClick={ handleReset }
-						/>
-					) ) }
+				{ hasLocalValue && (
+					<Button
+						size="small"
+						icon={ resetIcon }
+						label={ __( 'Reset' ) }
+						className="block-editor-panel-duotone-settings__reset"
+						onClick={ handleReset }
+					/>
+				) }
 			</>
 		);
 	};
@@ -272,6 +265,7 @@ export default function FiltersPanel( {
 							inheritedDuotone !== undefined
 					) }
 					label={ __( 'Duotone' ) }
+					stylePaths={ [ 'filter.duotone' ] }
 					hasValue={ hasDuotone }
 					onDeselect={ resetDuotone }
 					isShownByDefault={ defaultControls.duotone }

--- a/packages/block-editor/src/components/global-styles/inheritance/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/index.js
@@ -6,31 +6,14 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Icon as WCIcon,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
-import { reset as resetIcon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
 
 /**
- * Whether the inspector surfaces inherited Global Styles values.
- *
- * Behind the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment,
- * so the treatment is off unless someone opts in on the Experiments screen.
- * With it off, the panels show locally-set values alone.
- *
- * Evaluated per call rather than once at module scope, so tests can toggle
- * the experiment and so a later move to a store-backed setting only has to
- * change this one place. Always returns a boolean: callers pass the result
- * down as a prop, and `undefined` would trigger a receiving component's own
- * default parameter.
- *
- * @return {boolean} Whether the inherited-value treatment is enabled.
+ * Internal dependencies
  */
-export const isGlobalStylesInheritanceEnabled = () =>
-	!! window.__experimentalGlobalStylesInheritanceUI;
+import { useInheritanceMenuItem } from './panel-menu';
+
+export { isGlobalStylesInheritanceEnabled } from './is-enabled';
 
 /**
  * Returns props to spread onto a wrapping `<InheritanceToolsPanelItem>`
@@ -41,8 +24,8 @@ export const isGlobalStylesInheritanceEnabled = () =>
  * label text receives the inherited-from-Global-Styles treatment
  * (dotted underline). No dot is shown.
  *
- * When `hasLocalOverride` is true, a small reset dot is rendered as a
- * sibling of the control exposing a "Reset to inherited value" action.
+ * When `hasLocalOverride` is true, the class marking the override is returned;
+ * the override itself is reported in the panel's options menu.
  *
  * The two states are mutually exclusive at the source. If both are passed,
  * only the local-override class is returned.
@@ -83,59 +66,6 @@ export function getInheritanceProps(
 }
 
 /**
- * Renders the small always-visible reset button shown next to a control
- * that holds a local override of an inherited Global Styles value. Used by
- * `<InheritanceToolsPanelItem>` and the color/gradient controls.
- *
- * At rest the button shows a blue dot signalling the local override. On
- * hover/focus the dot morphs into the `reset` (dash) icon and the button
- * exposes a "Reset to inherited value" tooltip. Activating it clears the
- * override so the control falls back to its inherited value — the same
- * action the `ToolsPanel` menu performs via `onDeselect`.
- *
- * @param {Object}   props
- * @param {Function} props.onResetToInherited Reset handler.
- * @param {string}   [props.className]        Optional className for the button.
- *
- * @return {Element} The reset button.
- */
-export function InheritanceResetButton( { onResetToInherited, className } ) {
-	return (
-		// Intentionally small (14×14) circular control; exempt from the
-		// 40px default-size enforcement rule.
-		// eslint-disable-next-line @wordpress/components-no-missing-40px-size-prop
-		<Button
-			__next40pxDefaultSize={ false }
-			label={ __( 'Reset to inherited value' ) }
-			// The button has children (the dot + reset icon), so the tooltip
-			// is not shown automatically; opt in explicitly.
-			showTooltip
-			className={ clsx(
-				'has-local-override-from-global-styles__reset',
-				className
-			) }
-			onClick={ ( event ) => {
-				// Prevent the click from reaching any wrapping
-				// `<label htmlFor>` association, which would otherwise
-				// focus/activate the inner control.
-				event.preventDefault();
-				event.stopPropagation();
-				onResetToInherited?.();
-			} }
-		>
-			<span
-				aria-hidden="true"
-				className="has-local-override-from-global-styles__dot"
-			/>
-			<WCIcon
-				className="has-local-override-from-global-styles__reset-icon"
-				icon={ resetIcon }
-			/>
-		</Button>
-	);
-}
-
-/**
  * A `ToolsPanelItem` that reflects whether its control's value is inherited
  * from Global Styles or locally overridden. The two states are mutually
  * exclusive.
@@ -143,13 +73,13 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
  * - Inherited: the control label receives the inherited-from-Global-Styles
  *   treatment (dotted underline) via the `is-inherited-from-global-styles`
  *   class applied through `getInheritanceProps`. No dot is shown.
- * - Local override: a reset dot is rendered as a plain sibling of the control
- *   at the item's inline-end — never nested in the label — exposing the same
- *   one-click reset the `ToolsPanel` options menu performs via `onDeselect`.
+ * - Local override: nothing is rendered in the row. The override is reported in
+ *   the panel's options menu instead, which the item registers itself with
+ *   here, under the `Reset` that already puts the value back.
  *
- * Controls that render their own reset control next to a custom toggle (color,
- * background image) pass `showLocalOverrideActionsInLabel={ false }` so the
- * item does not render a second reset dot.
+ * `showLocalOverrideActionsInLabel` and `hasInlineEndToggle` positioned the
+ * per-control reset dot this placement replaces. They are still accepted so the
+ * panels that pass them keep working, but no longer do anything.
  *
  * @param {Object}                    props
  * @param {?string}                   props.className                         Item className.
@@ -157,8 +87,9 @@ export function InheritanceResetButton( { onResetToInherited, className } ) {
  * @param {boolean}                   props.hasLocalOverride                  Local override is set.
  * @param {import('react').ReactNode} props.label                             Control label.
  * @param {?Function}                 props.onDeselect                        Reset handler.
- * @param {boolean}                   [props.showLocalOverrideActionsInLabel] Render the reset dot here (default true).
- * @param {boolean}                   [props.hasInlineEndToggle]              The control renders a 24x24 toggle (linked/unlink, units switch) at its inline-end; offset the reset dot to sit just to its inline-start (default false).
+ * @param {boolean}                   [props.showLocalOverrideActionsInLabel] Inert; see above.
+ * @param {boolean}                   [props.hasInlineEndToggle]              Inert; see above.
+ * @param {?string[]}                 [props.stylePaths]                      Dot-paths the control writes (e.g. `[ 'typography.fontSize' ]`), used to resolve the cascade shown in the panel's options menu.
  * @param {import('react').ReactNode} props.children                          The control.
  *
  * @return {Element} The panel item.
@@ -173,13 +104,18 @@ export function InheritanceToolsPanelItem( {
 	hasLocalOverride,
 	label,
 	onDeselect,
-	showLocalOverrideActionsInLabel = true,
-	hasInlineEndToggle = false,
+	// Destructured (and unused) so they do not leak onto the underlying
+	// `ToolsPanelItem`. Both only ever positioned the reset dot.
+	showLocalOverrideActionsInLabel,
+	hasInlineEndToggle,
+	stylePaths,
 	children,
 	...rest
 } ) {
-	const showResetAffordance =
-		hasLocalOverride && showLocalOverrideActionsInLabel;
+	// `label` doubles as the key `ToolsPanel` builds its menu items from, so the
+	// cascade lands under this control's own row in the panel's options menu —
+	// beside the `Reset` that already puts the value back.
+	useInheritanceMenuItem( label, hasLocalOverride, stylePaths );
 
 	return (
 		<ToolsPanelItem
@@ -189,16 +125,6 @@ export function InheritanceToolsPanelItem( {
 			{ ...rest }
 		>
 			{ children }
-			{ showResetAffordance && (
-				<div
-					className={ clsx( 'global-styles-inheritance-affordance', {
-						'global-styles-inheritance-affordance--offset-toggle':
-							hasInlineEndToggle,
-					} ) }
-				>
-					<InheritanceResetButton onResetToInherited={ onDeselect } />
-				</div>
-			) }
 		</ToolsPanelItem>
 	);
 }

--- a/packages/block-editor/src/components/global-styles/inheritance/is-enabled.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/is-enabled.js
@@ -1,0 +1,20 @@
+/**
+ * Whether the inspector surfaces inherited Global Styles values.
+ *
+ * Behind the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so
+ * the treatment is off unless someone opts in on the Experiments screen. With
+ * it off, the panels show locally-set values alone.
+ *
+ * Evaluated per call rather than once at module scope, so tests can toggle the
+ * experiment and so a later move to a store-backed setting only has to change
+ * this one place. Always returns a boolean: callers pass the result down as a
+ * prop, and `undefined` would trigger a receiving component's own default
+ * parameter.
+ *
+ * Lives in its own module rather than in `./index` because `./panel-menu` needs
+ * it too, and `./index` imports `./panel-menu`.
+ *
+ * @return {boolean} Whether the inherited-value treatment is enabled.
+ */
+export const isGlobalStylesInheritanceEnabled = () =>
+	!! window.__experimentalGlobalStylesInheritanceUI;

--- a/packages/block-editor/src/components/global-styles/inheritance/panel-menu.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/panel-menu.js
@@ -1,0 +1,289 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+import { VisuallyHidden } from '@wordpress/ui';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useReducer,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useControlCascade } from '../style-origins/use-cascade';
+import { isGlobalStylesInheritanceEnabled } from './is-enabled';
+
+/**
+ * Panel-level home for Global Styles inheritance.
+ *
+ * The alternative explored here is the per-control indicator: a marker sitting
+ * in the control's own row. That placement has to find room in rows that vary a
+ * lot — labelled inputs, `ItemGroup` rows whose whole surface is a flyout
+ * toggle, controls that already occupy their inline-end with a units switch or
+ * a link/unlink button — and it has to stay reachable by tap on mobile, where
+ * hover-revealed affordances do not exist. It also only ever had room for one
+ * bit of information: that the value was overridden, not what it overrode.
+ *
+ * This module puts the answer in the options ("ellipsis") menu that every style
+ * panel already has, under the control it belongs to. That menu already lists
+ * every control by name, and already offers each one a `Reset` — which for a
+ * control holding a local value over an inherited one is exactly the "put it
+ * back" action. So nothing new is added to it: the cascade slots in underneath
+ * the row that already exists, and the existing reset does the work.
+ *
+ * Nothing at rest, deliberately. No indicator on the control rows, none on the
+ * panel's menu toggle. The trade is discoverability — nothing announces that a
+ * block is overriding anything, and you find out by opening the menu. That is
+ * the point rather than an omission: every attempt at an at-rest marker had to
+ * answer "where does it go on a row that is entirely a flyout toggle, and how
+ * is it tapped on mobile", and a placement with no marker does not have to.
+ */
+
+/**
+ * Exported so `BlockSupportSlotContainer` can forward it across the
+ * `bubblesVirtually` slot boundary, where the block inspector's panel items
+ * render in a different React tree from the panel that collects them. The
+ * `ToolsPanelContext` is forwarded there for the same reason.
+ */
+export const InheritanceMenuContext = createContext( undefined );
+
+// Stable identity so a panel with nothing overridden never produces a new state
+// object and re-renders for nothing.
+const EMPTY_CASCADES = {};
+
+function cascadesReducer( state, action ) {
+	switch ( action.type ) {
+		case 'SET': {
+			const existing = state[ action.label ];
+			if ( existing && existing.token !== action.token ) {
+				// Another item already owns this label. Can happen while the
+				// inspector swaps between blocks exposing the same control.
+				return state;
+			}
+			return {
+				...state,
+				[ action.label ]: {
+					token: action.token,
+					cascade: action.cascade,
+				},
+			};
+		}
+		case 'UNSET': {
+			// Matched on the token as well as the label: when the inspector
+			// switches between blocks that expose the same control, the
+			// outgoing item's cleanup can run after the incoming item has
+			// registered, and an unqualified removal would drop the new entry.
+			if ( state[ action.label ]?.token !== action.token ) {
+				return state;
+			}
+			const next = { ...state };
+			delete next[ action.label ];
+			return next;
+		}
+		default:
+			return state;
+	}
+}
+
+/**
+ * Collects, for one style panel, the cascade behind each control that holds a
+ * local value shadowing an inherited one, keyed by the control's label — the
+ * same key `ToolsPanel` builds its own menu items from.
+ *
+ * @param {Object}                    props
+ * @param {import('react').ReactNode} props.children
+ *
+ * @return {Element} The provider.
+ */
+export function InheritanceMenuProvider( { children } ) {
+	const [ cascades, dispatch ] = useReducer(
+		cascadesReducer,
+		EMPTY_CASCADES
+	);
+
+	const setCascade = useCallback( ( label, token, cascade ) => {
+		dispatch( { type: 'SET', label, token, cascade } );
+	}, [] );
+
+	const unsetCascade = useCallback( ( label, token ) => {
+		dispatch( { type: 'UNSET', label, token } );
+	}, [] );
+
+	const value = useMemo(
+		() => ( { cascades, setCascade, unsetCascade } ),
+		[ cascades, setCascade, unsetCascade ]
+	);
+
+	return (
+		<InheritanceMenuContext.Provider value={ value }>
+			{ children }
+		</InheritanceMenuContext.Provider>
+	);
+}
+
+/**
+ * Publishes a control's cascade to its panel's options menu. A no-op outside an
+ * `InheritanceMenuProvider`, so controls can call it unconditionally.
+ *
+ * @param {?string}   label            The control's label, which is also the key
+ *                                     `ToolsPanel` uses for its menu items.
+ * @param {boolean}   hasLocalOverride Whether the control holds a local value
+ *                                     shadowing an inherited one.
+ * @param {?string[]} [stylePaths]     Dot-paths the control writes, used to look
+ *                                     up the cascade behind it.
+ */
+export function useInheritanceMenuItem( label, hasLocalOverride, stylePaths ) {
+	const context = useContext( InheritanceMenuContext );
+	const setCascade = context?.setCascade;
+	const unsetCascade = context?.unsetCascade;
+
+	// Identifies this control instance for the lifetime of the component, so a
+	// departing item cannot clear an entry a newly-mounted item has just made
+	// under the same label.
+	const token = useMemo( () => ( {} ), [] );
+
+	// Only resolved while the control actually overrides something: an
+	// inheriting control has nothing to describe, and this is the one
+	// non-trivial computation on the path.
+	const cascade = useControlCascade(
+		hasLocalOverride && context ? stylePaths : undefined
+	);
+	// Dispatching on a value signature rather than array identity keeps a
+	// keystroke that leaves the cascade unchanged from re-rendering the panel.
+	const cascadeSignature = JSON.stringify( cascade );
+
+	useEffect( () => {
+		// `ToolsPanel` keys its own menu items by label, so a non-string label
+		// has no menu row for the cascade to sit under.
+		if ( ! setCascade || typeof label !== 'string' || ! label ) {
+			return undefined;
+		}
+		// Parsed back from the signature rather than closing over `cascade`, so
+		// this effect depends only on the value identity and not on the array's
+		// reference, which is new on every render.
+		const parsed = JSON.parse( cascadeSignature );
+		if ( ! parsed.length ) {
+			unsetCascade( label, token );
+			return undefined;
+		}
+		setCascade( label, token, parsed );
+		return () => unsetCascade( label, token );
+	}, [ setCascade, unsetCascade, label, token, cascadeSignature ] );
+}
+
+/**
+ * The cascade behind one control: the value in effect, then each layer it
+ * covers, with the origin that set it.
+ *
+ * @param {Object}   props
+ * @param {Object[]} props.cascade Cascade groups from `useControlCascade`.
+ *
+ * @return {Element} The rows.
+ */
+function ControlCascade( { cascade } ) {
+	// A control writing several paths (Appearance sets both font style and
+	// weight) needs the property named per group, or two stacks read as one.
+	const showProperty = cascade.length > 1;
+	return (
+		<div className="block-editor-global-styles-inheritance-menu">
+			{ cascade.map( ( group ) => (
+				<div key={ group.path }>
+					{ showProperty && (
+						<div className="block-editor-global-styles-inheritance-menu__property">
+							{ group.property }
+						</div>
+					) }
+					{ group.entries.map( ( entry, index ) => (
+						<div
+							key={ `${ entry.label }-${ index }` }
+							className={
+								entry.isWinner
+									? 'block-editor-global-styles-inheritance-menu__layer is-in-effect'
+									: 'block-editor-global-styles-inheritance-menu__layer'
+							}
+						>
+							<span className="block-editor-global-styles-inheritance-menu__origin">
+								{ entry.label }
+							</span>
+							<span className="block-editor-global-styles-inheritance-menu__value">
+								{ entry.value }
+							</span>
+							{ /*
+							 * Which layer wins is conveyed visually by the
+							 * strikethrough alone. The description is read as
+							 * one run of text, so without this a screen reader
+							 * hears four values and no way to tell which one
+							 * applies.
+							 */ }
+							<VisuallyHidden>
+								{ entry.isWinner
+									? /* translators: Follows a style value, marking it as the one currently applied. */
+									  __( 'in effect.' )
+									: /* translators: Follows a style value, marking it as covered by a higher layer. */
+									  __( 'overridden.' ) }
+							</VisuallyHidden>
+						</div>
+					) ) }
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+/**
+ * Reads the collected cascades and hands the panel a per-menu-item renderer.
+ *
+ * Split from `InheritanceToolsPanel` because the state lives in the provider
+ * that component renders, which its own render cannot read.
+ *
+ * @param {Object} props Props for the underlying `ToolsPanel`.
+ *
+ * @return {Element} The panel.
+ */
+function InheritanceToolsPanelInner( props ) {
+	const cascades = useContext( InheritanceMenuContext )?.cascades;
+
+	const renderDescription = useCallback(
+		( label ) => {
+			const cascade = cascades?.[ label ]?.cascade;
+			return cascade?.length ? (
+				<ControlCascade cascade={ cascade } />
+			) : null;
+		},
+		[ cascades ]
+	);
+
+	return (
+		<ToolsPanel
+			{ ...props }
+			__experimentalMenuItemDescription={ renderDescription }
+		/>
+	);
+}
+
+/**
+ * Drop-in replacement for `ToolsPanel` in the style panels. With the
+ * `gutenberg-global-styles-inheritance-ui` experiment off it is the plain
+ * `ToolsPanel`; with it on, each control's menu row gains the cascade behind
+ * its value. The panel itself is untouched either way.
+ *
+ * @param {Object} props Props for the underlying `ToolsPanel`.
+ *
+ * @return {Element} The panel.
+ */
+export function InheritanceToolsPanel( props ) {
+	if ( ! isGlobalStylesInheritanceEnabled() ) {
+		return <ToolsPanel { ...props } />;
+	}
+	return (
+		<InheritanceMenuProvider>
+			<InheritanceToolsPanelInner { ...props } />
+		</InheritanceMenuProvider>
+	);
+}

--- a/packages/block-editor/src/components/global-styles/inheritance/style.scss
+++ b/packages/block-editor/src/components/global-styles/inheritance/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
 
 // Inherited Global Styles values — visual treatment for inspector control
 // labels.
@@ -6,8 +7,9 @@
 // `.is-inherited-from-global-styles` marks controls displaying inherited
 // values: the label gets a dotted underline.
 // `.has-local-override-from-global-styles` marks controls that locally override
-// inherited values: a blue reset dot is rendered as a sibling at the item's
-// inline-end. The states are mutually exclusive.
+// inherited values. It paints nothing — the override is reported in the panel's
+// options menu — but is kept as the hook tests and future treatments key off.
+// The states are mutually exclusive.
 .is-inherited-from-global-styles {
 	// `.components-base-control__label` covers most controls (ToggleGroup,
 	// selects, the visible `<span>` label some controls render). Controls
@@ -32,153 +34,58 @@
 	}
 }
 
-// Local-override reset dot — a sibling of the control positioned at the item's
-// inline-end.
-.has-local-override-from-global-styles {
-	position: relative;
+// Panel-menu placement (`gutenberg-global-styles-inheritance-ui`).
+//
+// Nothing at rest: no indicator on the control rows and none on the panel's
+// options toggle. The cascade appears only inside the open options menu, under
+// the menu row for the control it belongs to.
+.block-editor-global-styles-inheritance-menu {
+	color: $gray-700;
 }
 
-.global-styles-inheritance-affordance {
-	position: absolute;
-	inset-block-start: 0;
-	inset-inline-end: 0;
-	z-index: 1;
+// Shown only when one control writes several properties (Appearance sets both
+// font style and weight), so the two stacks under it do not read as one.
+.block-editor-global-styles-inheritance-menu__property {
+	margin-top: $grid-unit-05;
+	font-style: italic;
+}
+
+// Origin on the left, value on the right. The value column is allowed to grow
+// and the origin to shrink: origins are known short strings, whereas a value
+// can be a preset slug or a `clamp()` range.
+.block-editor-global-styles-inheritance-menu__layer {
 	display: flex;
-	align-items: center;
-	justify-content: center;
-	pointer-events: none;
+	justify-content: space-between;
+	// Wide enough that a struck-through origin never runs into a struck-through
+	// value: with both ruled, a small gap reads as one continuous line.
+	gap: $grid-unit-20;
+	// The rows were flush against each other, which made the whole stack read
+	// as one clump sitting apart from its control rather than as lines
+	// belonging to it.
+	padding-block: 2px;
 
-	// Match the label line height so the shorter (14px) reset dot centers on
-	// the 16px label rather than pinning to its top.
-	height: $grid-unit-20;
+	// Everything under the winning layer is covered by it. Struck through
+	// rather than dimmed, so "not in effect" survives being read at a glance
+	// and does not rely on colour alone.
+	//
+	// Deliberately no `opacity` on top of the muted colour: at 11px it drove
+	// these rows to 2.67:1 against the menu, well under the 4.5:1 that WCAG
+	// 1.4.3 requires at this size. `$gray-700` alone clears it at 4.6:1, and
+	// the strikethrough is what carries the meaning anyway.
+	text-decoration: line-through;
 
-	// Controls that render a 24px toggle at the item's inline-end (linked/
-	// unlink, units switch): shift the dot one toggle width plus an 8px gap
-	// toward the inline-start so it sits just to the left of that toggle and
-	// the two never overlap.
-	&--offset-toggle {
-		inset-inline-end: calc(24px + 8px);
-	}
-
-	.has-local-override-from-global-styles__reset {
-		pointer-events: auto;
-		// The affordance wrapper handles placement; drop the inline margin the
-		// shared rule adds for the in-label (color/background) context.
-		margin-inline-start: 0 !important;
-	}
-}
-
-// Local-override reset button. At rest it shows the blue dot signalling a local
-// override; on hover/focus the dot is swapped for the `reset` (dash) icon and a
-// "Reset to inherited value" tooltip.
-.has-local-override-from-global-styles__reset {
-	display: inline-flex !important;
-	align-items: center;
-	justify-content: center;
-	vertical-align: middle;
-	position: relative;
-	margin-inline-start: 6px;
-
-	// Override the default IconButton chrome so the trigger appears as a
-	// tight inline circle that never shifts the sibling label text.
-	min-width: 14px !important;
-	width: 14px !important;
-	height: 14px !important;
-	padding: 0 !important;
-	border-radius: 50% !important;
-	background: transparent !important;
-	box-shadow: none !important;
-	overflow: hidden;
-
-	// `<Button>` does not preserve text-transform overrides from its parent
-	// label. Belt-and-braces: ensure the trigger never inherits an uppercase
-	// transform from a label that happens to use one.
-	text-transform: none;
-	letter-spacing: normal;
-
-	// Some `<label>` rules style descendant text/buttons (legacy
-	// pre-existing CSS). Reset to the design-system pointer token.
-	cursor: var(--wpds-cursor-control);
-
-	&:hover,
-	&:focus {
-		background: transparent !important;
-
-		.has-local-override-from-global-styles__dot {
-			display: none;
-		}
-
-		.has-local-override-from-global-styles__reset-icon {
-			display: block;
-		}
-	}
-
-	&:focus-visible {
-		// Inset focus ring so it doesn't push other text around.
-		outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
-		outline-offset: 1px;
-	}
-
-	// Color/gradient control context: the button is positioned by
-	// `block-editor-panel-color-gradient-settings__reset` (absolute,
-	// hover-revealed) as a sibling of the toggle. The shared rule above sets
-	// `position: relative`; re-assert `position: absolute` here (this compound
-	// selector wins on specificity) to sit in the reset slot.
-	&.block-editor-panel-color-gradient-settings__reset {
-		position: absolute;
-		justify-content: center;
-		top: 50%;
-		transform: translateY(-50%);
-		margin-block: 0;
-		margin-inline-start: 0;
-		opacity: 1;
-	}
-
-	// Shadow control context: the blue-dot override reset reuses the shadow
-	// remove-button slot, which is absolutely positioned and hover-revealed
-	// (`opacity: 0`). The override dot must stay visible, so re-assert
-	// placement and force `opacity: 1` (this compound selector wins on
-	// specificity).
-	&.block-editor-global-styles__shadow-editor__remove-button {
-		position: absolute;
-		justify-content: center;
-		inset-inline-end: 8px;
-		top: 50%;
-		transform: translateY(-50%);
-		margin-block: 0;
-		margin-inline-start: 0;
-		opacity: 1;
-	}
-
-	// Reuses the hover-revealed remove-button slot; keep the override dot
-	// placed and always visible.
-	&.block-editor-panel-duotone-settings__reset {
-		position: absolute;
-		justify-content: center;
-		inset-inline-end: 8px;
-		top: 50%;
-		transform: translateY(-50%);
-		margin-block: 0;
-		margin-inline-start: 0;
-		opacity: 1;
+	&.is-in-effect {
+		color: $gray-900;
+		text-decoration: none;
 	}
 }
 
-.has-local-override-from-global-styles__dot {
-	display: block;
-	width: 8px;
-	height: 8px;
-	background-color: var(--wp-admin-theme-color, #007cba);
-	border-radius: 50%;
+.block-editor-global-styles-inheritance-menu__origin {
+	flex-shrink: 1;
+	min-width: 0;
 }
 
-// The dash icon revealed on hover/focus, centered over the dot's slot and
-// clipped to the circular button bounds so the box size stays stable.
-.has-local-override-from-global-styles__reset-icon {
-	display: none;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	color: var(--wp-admin-theme-color, #007cba);
+.block-editor-global-styles-inheritance-menu__value {
+	flex-shrink: 0;
+	font-family: monospace;
 }

--- a/packages/block-editor/src/components/global-styles/inheritance/test/index.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import { click } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -12,41 +11,7 @@ import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import {
-	getInheritanceProps,
-	InheritanceResetButton,
-	InheritanceToolsPanelItem,
-} from '../';
-
-describe( 'InheritanceResetButton', () => {
-	test( 'renders an always-visible reset button labelled for the inherited value', () => {
-		render( <InheritanceResetButton onResetToInherited={ () => {} } /> );
-		expect(
-			screen.getByRole( 'button', {
-				name: 'Reset to inherited value',
-			} )
-		).toBeVisible();
-	} );
-
-	test( 'invokes the reset handler when activated', async () => {
-		const onResetToInherited = jest.fn();
-		render(
-			<InheritanceResetButton onResetToInherited={ onResetToInherited } />
-		);
-		await click(
-			screen.getByRole( 'button', { name: 'Reset to inherited value' } )
-		);
-		expect( onResetToInherited ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	test( 'does not expose a menu or a push-to-Global-Styles action', () => {
-		render( <InheritanceResetButton onResetToInherited={ () => {} } /> );
-		expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
-		expect(
-			screen.queryByRole( 'menuitem', { name: /Make default/ } )
-		).not.toBeInTheDocument();
-	} );
-} );
+import { getInheritanceProps, InheritanceToolsPanelItem } from '../';
 
 describe( 'getInheritanceProps', () => {
 	test( 'returns explicit false state when neither flag is set', () => {
@@ -185,97 +150,5 @@ describe( 'InheritanceToolsPanelItem inherited state', () => {
 				name: 'Reset to inherited value',
 			} )
 		).not.toBeInTheDocument();
-	} );
-} );
-
-describe( 'InheritanceToolsPanelItem local-override reset dot', () => {
-	function renderItem( props ) {
-		return render(
-			<ToolsPanel label="Panel" panelId="panel">
-				<InheritanceToolsPanelItem
-					label="Line height"
-					panelId="panel"
-					isShownByDefault
-					hasValue={ () => false }
-					{ ...props }
-				>
-					<div className="components-base-control__label">
-						Line height
-					</div>
-				</InheritanceToolsPanelItem>
-			</ToolsPanel>
-		);
-	}
-
-	test( 'renders the reset dot as a sibling of the control, not inside the label', () => {
-		renderItem( {
-			hasLocalOverride: true,
-			onDeselect: () => {},
-		} );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		expect( resetButton ).toBeVisible();
-
-		// The reset dot is a plain sibling; it must never be nested inside
-		// the label (which would create an interactive-in-label a11y issue).
-		expect(
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.components-base-control__label' )
-		).toBeNull();
-	} );
-
-	test( 'does not render the item reset dot when showLocalOverrideActionsInLabel is false', () => {
-		// Color/background render their own reset control next to a custom
-		// toggle, so the item must not render a second one.
-		renderItem( {
-			hasLocalOverride: true,
-			showLocalOverrideActionsInLabel: false,
-			onDeselect: () => {},
-		} );
-		expect(
-			screen.queryByRole( 'button', {
-				name: 'Reset to inherited value',
-			} )
-		).not.toBeInTheDocument();
-	} );
-
-	test( 'the reset dot invokes the deselect handler', async () => {
-		const onDeselect = jest.fn();
-		renderItem( { hasLocalOverride: true, onDeselect } );
-		await click(
-			screen.getByRole( 'button', { name: 'Reset to inherited value' } )
-		);
-		expect( onDeselect ).toHaveBeenCalled();
-	} );
-
-	test( 'does not offset the reset dot by default', () => {
-		renderItem( { hasLocalOverride: true, onDeselect: () => {} } );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		const affordance =
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.global-styles-inheritance-affordance' );
-		expect( affordance ).not.toHaveClass(
-			'global-styles-inheritance-affordance--offset-toggle'
-		);
-	} );
-
-	test( 'offsets the reset dot when the control has an inline-end toggle', () => {
-		renderItem( {
-			hasLocalOverride: true,
-			hasInlineEndToggle: true,
-			onDeselect: () => {},
-		} );
-		const resetButton = screen.getByRole( 'button', {
-			name: 'Reset to inherited value',
-		} );
-		const affordance =
-			// eslint-disable-next-line testing-library/no-node-access
-			resetButton.closest( '.global-styles-inheritance-affordance' );
-		expect( affordance ).toHaveClass(
-			'global-styles-inheritance-affordance--offset-toggle'
-		);
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/inheritance/test/panel-menu.js
+++ b/packages/block-editor/src/components/global-styles/inheritance/test/panel-menu.js
@@ -1,0 +1,205 @@
+/**
+ * External dependencies
+ */
+import { render, screen, within } from '@testing-library/react';
+import { click } from '@ariakit/test';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { InheritanceToolsPanelItem } from '../';
+import {
+	InheritanceMenuProvider,
+	InheritanceToolsPanel,
+	useInheritanceMenuItem,
+} from '../panel-menu';
+
+jest.mock( '../../style-origins/use-cascade', () => ( {
+	// Returns a fixed cascade for whichever paths a control declares, so these
+	// tests cover the menu wiring rather than cascade resolution — that is
+	// exercised against the engine in `global-styles-engine`.
+	useControlCascade: ( stylePaths ) =>
+		stylePaths?.length
+			? stylePaths.map( ( path ) => ( {
+					path,
+					property: path.split( '.' ).pop(),
+					entries: [
+						{
+							label: 'This block',
+							value: '2rem',
+							isWinner: true,
+						},
+						{
+							label: 'Site-wide',
+							value: '1rem',
+							isWinner: false,
+						},
+					],
+			  } ) )
+			: [],
+} ) );
+
+/**
+ * A panel holding a `Size` and a `Line height` control, each of which can hold
+ * a local value on top of an inherited one.
+ *
+ * @param {Object} props
+ * @param {Object} props.initial Initial local values, keyed by control label.
+ */
+function TestPanel( { initial } ) {
+	const [ values, setValues ] = useState( initial );
+
+	const item = ( label, stylePaths ) => (
+		<InheritanceToolsPanelItem
+			key={ label }
+			label={ label }
+			stylePaths={ stylePaths }
+			hasValue={ () => values[ label ] !== undefined }
+			hasLocalOverride={ values[ label ] !== undefined }
+			isInherited={ values[ label ] === undefined }
+			onDeselect={ () =>
+				setValues( { ...values, [ label ]: undefined } )
+			}
+			isShownByDefault
+			panelId="test-panel"
+		>
+			<span>{ label }</span>
+		</InheritanceToolsPanelItem>
+	);
+
+	return (
+		<InheritanceToolsPanel
+			label="Typography"
+			panelId="test-panel"
+			resetAll={ () => setValues( {} ) }
+		>
+			{ item( 'Size', [ 'typography.fontSize' ] ) }
+			{ item( 'Line height', [ 'typography.lineHeight' ] ) }
+		</InheritanceToolsPanel>
+	);
+}
+
+const openPanelMenu = async () =>
+	click( screen.getByRole( 'button', { name: 'Typography options' } ) );
+
+describe( 'Global Styles inheritance in the panel options menu', () => {
+	beforeEach( () => {
+		window.__experimentalGlobalStylesInheritanceUI = true;
+	} );
+
+	afterEach( () => {
+		delete window.__experimentalGlobalStylesInheritanceUI;
+	} );
+
+	test( 'leaves the control rows free of any override indicator', () => {
+		render( <TestPanel initial={ { Size: '2rem' } } /> );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Reset to inherited value' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a panel that overrides identically to one that does not', () => {
+		// Nothing at rest, including on the panel's own options toggle: with
+		// the menu closed, an overriding panel is indistinguishable from a
+		// panel with nothing set.
+		const toggleMarkup = ( container ) =>
+			within( container ).getByRole( 'button', {
+				name: 'Typography options',
+			} ).outerHTML;
+
+		const { container, unmount } = render(
+			<TestPanel initial={ { Size: '2rem' } } />
+		);
+		const overridingMarkup = toggleMarkup( container );
+		unmount();
+
+		const { container: inheritingContainer } = render(
+			<TestPanel initial={ {} } />
+		);
+
+		expect( overridingMarkup ).toBe( toggleMarkup( inheritingContainer ) );
+	} );
+
+	test( 'shows the cascade under the overriding control, and only that one', async () => {
+		render( <TestPanel initial={ { Size: '2rem' } } /> );
+		await openPanelMenu();
+
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Reset Size' } )
+		).toHaveAccessibleDescription( /This block.*2rem.*Site-wide.*1rem/s );
+
+		// The inheriting control's row carries no cascade at all.
+		expect(
+			screen.getByRole( 'menuitemcheckbox', { name: 'Line height' } )
+		).not.toHaveAccessibleDescription();
+	} );
+
+	test( 'keeps the cascade out of the menu row itself', async () => {
+		render( <TestPanel initial={ { Size: '2rem' } } /> );
+		await openPanelMenu();
+
+		// Referenced as the item's description rather than nested inside it:
+		// nested content would land in the accessible *name*, making every
+		// overriding control impossible to query by its own label. It also
+		// keeps `role="menu"` holding only menu items.
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Reset Size' } )
+		).toHaveAccessibleName( 'Reset Size' );
+	} );
+
+	test( "the control's own Reset is what puts the value back", async () => {
+		render( <TestPanel initial={ { Size: '2rem' } } /> );
+		await openPanelMenu();
+		await click( screen.getByRole( 'menuitem', { name: 'Reset Size' } ) );
+
+		await openPanelMenu();
+		expect(
+			screen.queryByRole( 'menuitem', { name: 'Reset Size' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'adds no separate restore action of its own', async () => {
+		render( <TestPanel initial={ { Size: '2rem' } } /> );
+		await openPanelMenu();
+
+		expect(
+			screen.queryByRole( 'menuitem', {
+				name: 'Restore inherited styles',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'adds nothing to the menu when the experiment is off', async () => {
+		delete window.__experimentalGlobalStylesInheritanceUI;
+		render( <TestPanel initial={ { Size: '2rem' } } /> );
+		await openPanelMenu();
+
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Reset Size' } )
+		).not.toHaveAccessibleDescription();
+	} );
+
+	test( 'is inert outside a provider', () => {
+		const Probe = () => {
+			useInheritanceMenuItem( 'Size', true, [ 'typography.fontSize' ] );
+			return <span>probe</span>;
+		};
+		expect( () => render( <Probe /> ) ).not.toThrow();
+	} );
+
+	test( 'exposes the provider for slot-boundary forwarding', () => {
+		expect( () =>
+			render(
+				<InheritanceMenuProvider>
+					<span>child</span>
+				</InheritanceMenuProvider>
+			)
+		).not.toThrow();
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/inherited-value-context.js
@@ -237,7 +237,7 @@ function useVariationAndElements( blockName, className ) {
  * @param {?string} blockName       Selected block name (e.g. `core/heading`).
  * @param {?string} className       Block `className` used to detect an applied variation.
  * @param {?Object} [selectedState] Selected block style state (`{ viewport, pseudo }`), or null for the default state.
- * @return {{ value: Object, sources: Object }} Merged panel-scoped payload and source map.
+ * @return {{ value: Object, sources: Object, cascade: Object }} Merged panel-scoped payload, winning-source map, and full per-path cascade.
  */
 export function useResolvedStyle( blockName, className, selectedState = null ) {
 	const { variationName, headingLevel } = useVariationAndElements(
@@ -252,7 +252,7 @@ export function useResolvedStyle( blockName, className, selectedState = null ) {
 			return NO_RESOLVED_STYLE;
 		}
 		if ( ! blockName ) {
-			return { value: {}, sources: {} };
+			return { value: {}, sources: {}, cascade: {} };
 		}
 		return resolveStyle( globalStyles, {
 			blockName,

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -25,7 +25,6 @@ import { Tooltip } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { InheritanceResetButton } from './inheritance';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -165,7 +164,7 @@ export function ShadowPopover( {
 }
 
 function renderShadowToggle( shadow, onShadowChange, resetConfig ) {
-	const { hasLocalValue, hasLocalOverride, onReset } = resetConfig;
+	const { hasLocalValue, onReset } = resetConfig;
 	return function ShadowToggle( { onToggle, isOpen } ) {
 		const shadowButtonRef = useRef( undefined );
 
@@ -200,22 +199,16 @@ function renderShadowToggle( shadow, onShadowChange, resetConfig ) {
 						<FlexItem>{ __( 'Drop shadow' ) }</FlexItem>
 					</HStack>
 				</Button>
-				{ hasLocalValue &&
-					( hasLocalOverride ? (
-						<InheritanceResetButton
-							className="block-editor-global-styles__shadow-editor__remove-button"
-							onResetToInherited={ handleReset }
-						/>
-					) : (
-						<Button
-							__next40pxDefaultSize
-							size="small"
-							icon={ reset }
-							label={ __( 'Remove' ) }
-							className="block-editor-global-styles__shadow-editor__remove-button"
-							onClick={ handleReset }
-						/>
-					) ) }
+				{ hasLocalValue && (
+					<Button
+						__next40pxDefaultSize
+						size="small"
+						icon={ reset }
+						label={ __( 'Remove' ) }
+						className="block-editor-global-styles__shadow-editor__remove-button"
+						onClick={ handleReset }
+					/>
+				) }
 			</>
 		);
 	};

--- a/packages/block-editor/src/components/global-styles/style-origins/helpers.js
+++ b/packages/block-editor/src/components/global-styles/style-origins/helpers.js
@@ -1,0 +1,426 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Shared helpers for presenting the Global Styles cascade. Used by the origin
+ * popover opened from a control's override indicator and by the inline origin
+ * trace shown inside color popovers, so both describe an origin the same way.
+ */
+
+// Object-valued leaves that are a single atomic definition and must not be
+// descended into when flattening. Mirrors `ATOMIC_OBJECT_KEYS` in the engine.
+const ATOMIC_OBJECT_KEYS = new Set( [ 'backgroundImage' ] );
+
+/**
+ * Flattens a style tree into `{ 'dot.path': value }`, stopping at primitives,
+ * arrays, and atomic object leaves.
+ *
+ * @param {?Object} tree   Style tree.
+ * @param {string}  prefix Accumulated dot-path prefix.
+ * @param {Object}  out    Accumulator.
+ * @return {Object} Flat map of dot-path to leaf value.
+ */
+export function flattenStyleTree( tree, prefix = '', out = {} ) {
+	if ( ! tree || typeof tree !== 'object' || Array.isArray( tree ) ) {
+		return out;
+	}
+	for ( const key of Object.keys( tree ) ) {
+		const value = tree[ key ];
+		const path = prefix ? `${ prefix }.${ key }` : key;
+		if (
+			value !== null &&
+			typeof value === 'object' &&
+			! Array.isArray( value ) &&
+			! ATOMIC_OBJECT_KEYS.has( key )
+		) {
+			flattenStyleTree( value, path, out );
+		} else if (
+			path !== 'css' &&
+			value !== undefined &&
+			value !== '' &&
+			value !== null
+		) {
+			out[ path ] = value;
+		}
+	}
+	return out;
+}
+
+/**
+ * Splits a CSS length into its number and unit, or returns `null` when the
+ * value is not a plain length (a `calc()`, a keyword, a custom property).
+ *
+ * @param {string} value CSS value.
+ * @return {?{number: number, unit: string}} Parsed length.
+ */
+function parseLength( value ) {
+	const match = String( value )
+		.trim()
+		.match( /^(-?\d*\.?\d+)([a-z%]*)$/i );
+	return match
+		? { number: parseFloat( match[ 1 ] ), unit: match[ 2 ] }
+		: null;
+}
+
+/**
+ * Splits a CSS argument list on top-level commas, leaving nested calls intact.
+ *
+ * @param {string} args Argument list, without the surrounding parentheses.
+ * @return {string[]} Arguments.
+ */
+function splitCssArguments( args ) {
+	const parts = [];
+	let depth = 0;
+	let buffer = '';
+	for ( const character of args ) {
+		if ( character === '(' ) {
+			depth += 1;
+		} else if ( character === ')' ) {
+			depth -= 1;
+		} else if ( character === ',' && depth === 0 ) {
+			parts.push( buffer.trim() );
+			buffer = '';
+			continue;
+		}
+		buffer += character;
+	}
+	parts.push( buffer.trim() );
+	return parts;
+}
+
+/**
+ * Renders a leaf value compactly enough for a single sidebar row.
+ *
+ * @param {*}       value               Leaf value.
+ * @param {?Object} [presetValueBySlug] Map of `<kind>|<slug>` to the value that
+ *                                      preset resolves to, e.g. a colour's hex.
+ *                                      Preset references fall back to their slug
+ *                                      when the map has no entry.
+ * @return {string} Display string.
+ */
+export function formatValue( value, presetValueBySlug ) {
+	if ( value === undefined || value === null || value === '' ) {
+		return '—';
+	}
+	if ( typeof value === 'string' || typeof value === 'number' ) {
+		// Preset references are long and mostly boilerplate. A slug names the
+		// preset but not what it paints, so where the resolved value is known
+		// (colours) it is shown instead, and the slug is the fallback. Both the
+		// CSS custom property form and the `var:preset|…` attribute form appear
+		// here.
+		const cssVar = String( value ).match(
+			/^var\(\s*--wp--preset--([a-z-]+)--([a-z0-9-]+)\s*\)$/i
+		);
+		if ( cssVar ) {
+			return (
+				presetValueBySlug?.[ `${ cssVar[ 1 ] }|${ cssVar[ 2 ] }` ] ??
+				cssVar[ 2 ]
+			);
+		}
+		const presetRef = String( value ).match(
+			/^var:preset\|([a-z-]+)\|([a-z0-9-]+)$/i
+		);
+		if ( presetRef ) {
+			return (
+				presetValueBySlug?.[
+					`${ presetRef[ 1 ] }|${ presetRef[ 2 ] }`
+				] ?? presetRef[ 2 ]
+			);
+		}
+
+		// Fluid typography emits `clamp( min, preferred, max )`, which runs to
+		// 50-odd characters and dominates the row. The preferred term is a
+		// viewport formula nobody reads; the useful part is the range it moves
+		// between, so show that.
+		const clamped = String( value ).match( /^clamp\((.*)\)$/is );
+		if ( clamped ) {
+			const args = splitCssArguments( clamped[ 1 ] );
+			if ( args.length === 3 ) {
+				const min = parseLength( args[ 0 ] );
+				const max = parseLength( args[ 2 ] );
+				// Both ends in the same unit is the usual case, and naming the
+				// unit twice is what pushed the row past the column. State it
+				// once, at the end, the way a range normally reads.
+				if ( min && max && min.unit === max.unit && min.unit ) {
+					return `${ min.number } – ${ max.number }${ min.unit }`;
+				}
+				return `${ args[ 0 ] } – ${ args[ 2 ] }`;
+			}
+		}
+
+		return String( value );
+	}
+	if ( Array.isArray( value ) ) {
+		return value.join( ', ' );
+	}
+	if ( typeof value === 'object' ) {
+		if ( value.url ) {
+			return value.title || value.url.split( '/' ).pop();
+		}
+		return JSON.stringify( value );
+	}
+	return String( value );
+}
+
+/**
+ * Composes the human label for a cascade layer. The engine deliberately emits
+ * structural metadata rather than a pre-built string, so the breadcrumb is
+ * assembled (and translated) here, where the block registry is available.
+ *
+ * @param {Object}  entry           Cascade entry.
+ * @param {?string} entry.layer     Layer identifier.
+ * @param {?string} entry.element   Root element name, for element layers.
+ * @param {?string} entry.variation Variation slug, for variation layers.
+ * @param {string}  blockTitle      Registered title of the selected block.
+ * @param {Object}  variationLabels Map of variation slug to registered label.
+ * @return {string} Breadcrumb label.
+ */
+export function getLayerLabel(
+	{ layer, element, variation },
+	blockTitle,
+	variationLabels
+) {
+	switch ( layer ) {
+		case 'local':
+			/*
+			 * Every layer here applies to this block; what separates them is
+			 * how far each one reaches. So the labels name scope, and reading
+			 * the column downward narrows it: "Site-wide" → "All Paragraph
+			 * blocks" → "Subtitle style" → "This block".
+			 *
+			 * Deliberately not "From block settings" or similar. That names
+			 * where the value is stored rather than how far it reaches, which
+			 * is a different question from the one every other row answers —
+			 * and it is the longest label in the column that gets squeezed by
+			 * the value beside it.
+			 *
+			 * "This" carries the contrast against "All %s blocks" on its own,
+			 * so no emphasiser is needed in front of it.
+			 */
+			return __( 'This block' );
+		case 'localCss':
+			return __( 'Custom CSS' );
+		case 'root':
+			/*
+			 * Deliberately not "Root", which describes the data structure
+			 * rather than anything the user recognises.
+			 *
+			 * This layer is the site's top-level Styles: everything set
+			 * without picking a block. It cannot currently be split into "the
+			 * theme's defaults" versus "what you changed" — the editor merges
+			 * those before the block editor receives them — so the wording has
+			 * to stay true for both.
+			 */
+			return __( 'Site-wide' );
+		case 'element':
+			return sprintf(
+				/* translators: %s: Element name, e.g. "Button". */
+				__( '%s element' ),
+				element
+					? element.charAt( 0 ).toUpperCase() + element.slice( 1 )
+					: __( 'Unknown' )
+			);
+		case 'block':
+			return sprintf(
+				/* translators: %s: Block title, e.g. "Group". */
+				__( 'All %s blocks' ),
+				blockTitle
+			);
+		case 'blockVariation':
+			return sprintf(
+				/* translators: %s: Block style variation name, e.g. "Subtitle". */
+				__( '%s style' ),
+				variationLabels[ variation ] ?? variation
+			);
+		default:
+			return layer;
+	}
+}
+
+/**
+ * Builds the per-path cascade rows, folding the block's own local styles in as
+ * the highest layer. The engine resolves the Global Styles layers only; a local
+ * override lives in block attributes and is layered on here.
+ *
+ * @param {Object}  cascade     Per-path cascade from the engine.
+ * @param {Object}  localStyles The block's own `style` attribute.
+ * @param {?string} customCss   The block's `style.css` attribute.
+ * @return {Object} Map of dot-path to ordered cascade entries.
+ */
+export function withLocalOverrides( cascade, localStyles, customCss ) {
+	const local = flattenStyleTree( localStyles );
+	// Custom CSS is emitted after the block's own styles and usually carries
+	// `!important`, so it sits at the top of the cascade.
+	const customDeclarations = getCustomCssDeclarations( customCss );
+	const paths = new Set( [
+		...Object.keys( cascade ),
+		...Object.keys( local ),
+		...Object.keys( customDeclarations ),
+	] );
+	const result = {};
+	for ( const path of paths ) {
+		const inherited = ( cascade[ path ] ?? [] ).map( ( entry ) => ( {
+			...entry,
+		} ) );
+		if ( Object.hasOwn( local, path ) ) {
+			for ( const entry of inherited ) {
+				entry.isWinner = false;
+			}
+			inherited.push( {
+				layer: 'local',
+				value: local[ path ],
+				isWinner: true,
+			} );
+		}
+		if ( Object.hasOwn( customDeclarations, path ) ) {
+			for ( const entry of inherited ) {
+				entry.isWinner = false;
+			}
+			inherited.push( {
+				layer: 'localCss',
+				value: customDeclarations[ path ],
+				isWinner: true,
+			} );
+		}
+		if ( inherited.length > 0 ) {
+			result[ path ] = inherited;
+		}
+	}
+	return result;
+}
+
+/**
+ * Folds a block's preset attributes into its `style` tree.
+ *
+ * Preset selections are not stored under `style`: choosing a palette colour
+ * saves `textColor: 'primary'`, a preset size saves `fontSize: 'large'`, and so
+ * on. Reading `attributes.style` alone therefore misses them, and a locally set
+ * value looks inherited. This mirrors the per-hook `attributesToStyle` helpers
+ * (see `hooks/typography.js`) so origin reporting agrees with the controls.
+ *
+ * @param {?Object} attributes Block attributes.
+ * @return {Object} Style tree including preset-derived values.
+ */
+export function attributesToStyleTree( attributes ) {
+	if ( ! attributes ) {
+		return {};
+	}
+	const {
+		style,
+		fontFamily,
+		fontSize,
+		textColor,
+		backgroundColor,
+		gradient,
+	} = attributes;
+	const typography = {
+		...style?.typography,
+		...( fontFamily
+			? { fontFamily: `var:preset|font-family|${ fontFamily }` }
+			: {} ),
+		...( fontSize
+			? { fontSize: `var:preset|font-size|${ fontSize }` }
+			: {} ),
+	};
+	const color = {
+		...style?.color,
+		...( textColor ? { text: `var:preset|color|${ textColor }` } : {} ),
+		...( backgroundColor
+			? { background: `var:preset|color|${ backgroundColor }` }
+			: {} ),
+		...( gradient
+			? { gradient: `var:preset|gradient|${ gradient }` }
+			: {} ),
+	};
+	return {
+		...style,
+		...( Object.keys( typography ).length ? { typography } : {} ),
+		...( Object.keys( color ).length ? { color } : {} ),
+	};
+}
+
+// CSS properties a block's own custom CSS can declare that map onto a style
+// path the cascade already tracks. Only these can be attributed; anything else
+// in custom CSS is left to the computed-value check to flag generically.
+const STYLE_PATH_BY_CSS_PROPERTY = {
+	'font-size': 'typography.fontSize',
+	'font-weight': 'typography.fontWeight',
+	'font-style': 'typography.fontStyle',
+	'font-family': 'typography.fontFamily',
+	'line-height': 'typography.lineHeight',
+	'letter-spacing': 'typography.letterSpacing',
+	'text-transform': 'typography.textTransform',
+	'text-decoration': 'typography.textDecoration',
+	'text-align': 'typography.textAlign',
+	color: 'color.text',
+	'background-color': 'color.background',
+	'border-radius': 'border.radius',
+	'border-width': 'border.width',
+	'border-style': 'border.style',
+	'border-color': 'border.color',
+	padding: 'spacing.padding',
+	margin: 'spacing.margin',
+};
+
+/**
+ * Reads the top-level declarations out of a block's custom CSS.
+ *
+ * Block custom CSS may nest selectors (`&:hover { … }`); those target something
+ * other than the block's own resting state, so only declarations at the top
+ * level are attributed. `!important` is stripped from the reported value — it
+ * explains *why* the declaration wins, not what it sets.
+ *
+ * @param {?string} css The block's `style.css` attribute.
+ * @return {Object} Map of style dot-path to declared value.
+ */
+export function getCustomCssDeclarations( css ) {
+	const declarations = {};
+	if ( typeof css !== 'string' || ! css.trim() ) {
+		return declarations;
+	}
+
+	const add = ( chunk ) => {
+		const separator = chunk.indexOf( ':' );
+		if ( separator === -1 ) {
+			return;
+		}
+		const property = chunk.slice( 0, separator ).trim().toLowerCase();
+		const value = chunk
+			.slice( separator + 1 )
+			.replace( /!important\s*$/i, '' )
+			.trim();
+		const path = STYLE_PATH_BY_CSS_PROPERTY[ property ];
+		if ( path && value ) {
+			declarations[ path ] = value;
+		}
+	};
+
+	let depth = 0;
+	let buffer = '';
+	for ( const character of css ) {
+		if ( character === '{' ) {
+			depth += 1;
+			buffer = '';
+			continue;
+		}
+		if ( character === '}' ) {
+			depth = Math.max( 0, depth - 1 );
+			buffer = '';
+			continue;
+		}
+		if ( depth > 0 ) {
+			continue;
+		}
+		if ( character === ';' ) {
+			add( buffer );
+			buffer = '';
+			continue;
+		}
+		buffer += character;
+	}
+	add( buffer );
+
+	return declarations;
+}

--- a/packages/block-editor/src/components/global-styles/style-origins/use-cascade.js
+++ b/packages/block-editor/src/components/global-styles/style-origins/use-cascade.js
@@ -1,0 +1,157 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../../store';
+import { useResolvedStyle } from '../inherited-value-context';
+import { useBlockEditContext } from '../../block-edit/context';
+import {
+	attributesToStyleTree,
+	formatValue,
+	getLayerLabel,
+	withLocalOverrides,
+} from './helpers';
+
+const EMPTY_ARRAY = [];
+
+/**
+ * Resolves the cascade behind one control — the ordered list of layers that set
+ * the style paths it writes to, each with its value and a human label.
+ *
+ * Runs on the panel *item* side rather than in the panel itself. The block
+ * inspector renders its panels outside the selected block's edit context, so
+ * only the items (which are slot fills rendered in the block's tree) can see
+ * which block they belong to.
+ *
+ * @param {?string[]} stylePaths Dot-paths the control writes, e.g.
+ *                               `[ 'typography.fontSize' ]`. A control may
+ *                               write several — Appearance sets both
+ *                               `fontStyle` and `fontWeight`.
+ *
+ * @return {Array<{path: string, property: string, entries: Array<{label: string, value: string, isWinner: boolean}>}>}
+ *         One group per path that has a cascade, ordered high to low
+ *         precedence within each group.
+ */
+export function useControlCascade( stylePaths ) {
+	const { clientId, name: blockName } = useBlockEditContext();
+
+	const attributes = useSelect(
+		( select ) =>
+			clientId
+				? select( blockEditorStore ).getBlockAttributes( clientId )
+				: null,
+		[ clientId ]
+	);
+
+	const blockTitle = useSelect(
+		( select ) =>
+			blockName
+				? select( blocksStore ).getBlockType( blockName )?.title ??
+				  blockName
+				: '',
+		[ blockName ]
+	);
+
+	// Returns the store's own array so the subscription stays cold; the label
+	// map is derived below rather than built inside the mapper, which would
+	// hand back a fresh object on every store change.
+	const blockStyles = useSelect(
+		( select ) =>
+			blockName
+				? select( blocksStore ).getBlockStyles( blockName ) ??
+				  EMPTY_ARRAY
+				: EMPTY_ARRAY,
+		[ blockName ]
+	);
+
+	const variationLabels = useMemo( () => {
+		const labels = {};
+		for ( const style of blockStyles ) {
+			labels[ style.name ] = style.label ?? style.name;
+		}
+		return labels;
+	}, [ blockStyles ] );
+
+	const localStyles = useMemo(
+		() => attributesToStyleTree( attributes ),
+		[ attributes ]
+	);
+
+	// A colour preset's slug names the preset but not what it paints, and the
+	// point of the row is the value in effect. Resolved here so the pure
+	// `formatValue` stays free of any settings lookup.
+	//
+	// Read straight off the resolved features tree rather than through
+	// `useSettings`, whose block-scoped lookup returns nothing for these paths
+	// in this position.
+	const colorPalettes = useSelect( ( select ) => {
+		const features =
+			select( blockEditorStore ).getSettings().__experimentalFeatures;
+		return features?.color?.palette;
+	}, [] );
+	const presetValueBySlug = useMemo( () => {
+		const map = {};
+		for ( const origin of [ 'default', 'theme', 'custom' ] ) {
+			for ( const { slug, color } of colorPalettes?.[ origin ] ??
+				EMPTY_ARRAY ) {
+				if ( slug && color ) {
+					map[ `color|${ slug }` ] = color;
+				}
+			}
+		}
+		return map;
+	}, [ colorPalettes ] );
+
+	const { cascade } = useResolvedStyle(
+		blockName,
+		attributes?.className ?? ''
+	);
+
+	return useMemo( () => {
+		if ( ! blockName || ! stylePaths?.length ) {
+			return EMPTY_ARRAY;
+		}
+		const byPath = withLocalOverrides(
+			cascade ?? {},
+			localStyles,
+			attributes?.style?.css
+		);
+		const groups = [];
+		for ( const path of stylePaths ) {
+			const entries = byPath[ path ];
+			// A path only earns a row once something below the winner set it
+			// too — otherwise there is no inherited value to describe, and
+			// nothing for a restore to fall back to.
+			if ( ! entries || entries.length < 2 ) {
+				continue;
+			}
+			groups.push( {
+				path,
+				property: path.split( '.' ).pop(),
+				// Highest precedence first: the value in effect leads, and the
+				// layers under it read as what it is covering.
+				entries: [ ...entries ].reverse().map( ( entry ) => ( {
+					label: getLayerLabel( entry, blockTitle, variationLabels ),
+					value: formatValue( entry.value, presetValueBySlug ),
+					isWinner: !! entry.isWinner,
+				} ) ),
+			} );
+		}
+		return groups.length ? groups : EMPTY_ARRAY;
+	}, [
+		blockName,
+		stylePaths,
+		cascade,
+		localStyles,
+		attributes,
+		blockTitle,
+		variationLabels,
+		presetValueBySlug,
+	] );
+}

--- a/packages/block-editor/src/components/global-styles/test/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/background-panel.js
@@ -252,7 +252,7 @@ describe( 'BackgroundPanel — inherited Global Styles label treatment', () => {
 
 			expect(
 				screen.getAllByRole( 'button', {
-					name: /reset to inherited value/i,
+					name: /^reset$/i,
 				} ).length
 			).toBeGreaterThanOrEqual( 1 );
 		} );
@@ -316,7 +316,7 @@ describe( 'BackgroundPanel — inherited Global Styles label treatment', () => {
 
 			expect(
 				screen.getByRole( 'button', {
-					name: /reset to inherited value/i,
+					name: /^reset$/i,
 				} )
 			).toBeInTheDocument();
 		} );

--- a/packages/block-editor/src/components/global-styles/test/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.js
@@ -125,10 +125,11 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 			expect( radiusInput ).toHaveValue( 12 );
 			expect( radiusInput ).not.toHaveAttribute( 'placeholder' );
 			expect(
-				screen.getByRole( 'button', {
-					name: /reset to inherited value/i,
-				} )
-			).toBeInTheDocument();
+				// eslint-disable-next-line testing-library/no-node-access
+				document.querySelector(
+					'.has-local-override-from-global-styles'
+				)
+			).not.toBeNull();
 		} );
 
 		it( 'does not invoke onChange on mount when only an inherited radius is present (display-without-commit)', () => {
@@ -241,12 +242,14 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 				/>
 			);
 
-			// The local override surfaces the accessible reset affordance.
+			// Nothing is rendered in the row for a local override; the class
+			// hook is the per-row signal.
 			expect(
-				screen.getAllByRole( 'button', {
-					name: /reset to inherited value/i,
-				} ).length
-			).toBeGreaterThanOrEqual( 1 );
+				// eslint-disable-next-line testing-library/no-node-access
+				document.querySelector(
+					'.has-local-override-from-global-styles'
+				)
+			).not.toBeNull();
 		} );
 
 		it( 'does not bake the inherited radius into the local override when only color/style/width are customised (regression)', async () => {
@@ -337,9 +340,7 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 			);
 
 			expect(
-				screen.getByRole( 'button', {
-					name: /reset to inherited value/i,
-				} )
+				screen.getByRole( 'button', { name: /^remove$/i } )
 			).toBeInTheDocument();
 		} );
 
@@ -384,32 +385,6 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 				screen.queryByRole( 'button', {
 					name: /reset to inherited value/i,
 				} )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'renders the blue-dot InheritanceResetButton for a local override', () => {
-			const inheritedValue = { shadow: 'var:preset|shadow|soft' };
-			const value = { shadow: 'var:preset|shadow|hard' };
-
-			render(
-				<BorderPanel
-					value={ value }
-					inheritedValue={ inheritedValue }
-					settings={ settingsAll }
-					onChange={ () => {} }
-					panelId="test-panel"
-				/>
-			);
-
-			// The local override renders the blue-dot reset (mirroring the
-			// color/gradient controls), not the plain remove button.
-			expect(
-				screen.getByRole( 'button', {
-					name: /reset to inherited value/i,
-				} )
-			).toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'button', { name: /^remove$/i } )
 			).not.toBeInTheDocument();
 		} );
 

--- a/packages/block-editor/src/components/global-styles/test/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/color-panel.js
@@ -287,7 +287,7 @@ describe( 'ColorPanel — inherited Global Styles label treatment', () => {
 
 			expect(
 				screen.getAllByRole( 'button', {
-					name: /reset to inherited value/i,
+					name: /^reset$/i,
 				} ).length
 			).toBeGreaterThanOrEqual( 1 );
 		} );

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -142,14 +142,15 @@ function renderPanel( props ) {
 	);
 }
 
-// A local override surfaces the accessible reset-to-inherited affordance, so
-// assert on that rather than the label's CSS class hook.
+// With nothing rendered in the row at rest, the per-row signal for an override
+// is the class hook the SCSS keys off. The actionable part — the cascade and
+// its reset — lives in the panel's options menu, covered in
+// `inheritance/test/panel-menu.js`.
 function expectLocalOverride() {
 	expect(
-		screen.getByRole( 'button', {
-			name: /reset to inherited value/i,
-		} )
-	).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access
+		document.querySelector( '.has-local-override-from-global-styles' )
+	).not.toBeNull();
 }
 
 // Asserts the placeholder treatment for a control. A control can inherit a

--- a/packages/block-editor/src/components/global-styles/test/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/filters-panel.js
@@ -77,7 +77,7 @@ describe( 'FiltersPanel — visual treatment and display-without-commit', () => 
 
 		expect(
 			screen.getByRole( 'button', {
-				name: /reset to inherited value/i,
+				name: /^reset$/i,
 			} )
 		).toBeInTheDocument();
 	} );

--- a/packages/block-editor/src/components/global-styles/test/inherited-value-context.js
+++ b/packages/block-editor/src/components/global-styles/test/inherited-value-context.js
@@ -254,7 +254,7 @@ describe( 'useResolvedStyle hook', () => {
 		mockStores( { typography: { fontSize: '16px' } } );
 		render( <Probe /> );
 		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent(
-			'{"value":{},"sources":{}}'
+			'{"value":{},"sources":{},"cascade":{}}'
 		);
 	} );
 
@@ -262,7 +262,7 @@ describe( 'useResolvedStyle hook', () => {
 		mockStores( null );
 		render( <Probe blockName="core/heading" /> );
 		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent(
-			'{"value":{},"sources":{}}'
+			'{"value":{},"sources":{},"cascade":{}}'
 		);
 	} );
 

--- a/packages/block-editor/src/components/global-styles/test/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-panel.js
@@ -655,12 +655,14 @@ describe( 'TypographyPanel — inheritedValue round-trip', () => {
 		expect( columnsInput ).toHaveValue( 0 );
 		expect( columnsInput ).not.toHaveAttribute( 'placeholder' );
 
-		// Both zero values are local overrides, so each control surfaces the
-		// accessible reset-to-inherited affordance.
+		// Both zero values are local overrides. Nothing is rendered in the
+		// rows for that; the class hook is the per-row signal and the cascade
+		// itself lives in the panel's options menu.
 		expect(
-			screen.getAllByRole( 'button', {
-				name: /reset to inherited value/i,
-			} )
+			// eslint-disable-next-line testing-library/no-node-access
+			document.querySelectorAll(
+				'.has-local-override-from-global-styles'
+			)
 		).toHaveLength( 2 );
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -4,7 +4,6 @@
 import {
 	FontSizePicker,
 	__experimentalNumberControl as NumberControl,
-	__experimentalToolsPanel as ToolsPanel,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	Notice,
 	ToggleControl,
@@ -43,6 +42,7 @@ import {
 	InheritanceToolsPanelItem,
 	isGlobalStylesInheritanceEnabled,
 } from './inheritance';
+import { InheritanceToolsPanel } from './inheritance/panel-menu';
 
 const MIN_TEXT_COLUMNS = 1;
 const MAX_TEXT_COLUMNS = 6;
@@ -196,7 +196,7 @@ export function TypographyToolsPanel( {
 	};
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			label={ __( 'Typography' ) }
 			resetAll={ resetAll }
 			panelId={ panelId }
@@ -204,7 +204,7 @@ export function TypographyToolsPanel( {
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }
 
@@ -815,6 +815,7 @@ export default function TypographyPanel( {
 			{ hasTextColorEnabled && (
 				<ColorGradientDropdownItem
 					label={ __( 'Color' ) }
+					stylePaths={ [ 'color.text' ] }
 					hasValue={ hasTextColorValue }
 					resetValue={ resetTextColor }
 					isShownByDefault={ defaultControls.textColor }
@@ -861,6 +862,7 @@ export default function TypographyPanel( {
 						hasFontFamily() && inheritedFontFamily !== undefined
 					) }
 					label={ __( 'Font' ) }
+					stylePaths={ [ 'typography.fontFamily' ] }
 					hasValue={ hasFontFamily }
 					onDeselect={ resetFontFamily }
 					isShownByDefault={ defaultControls.fontFamily }
@@ -880,6 +882,7 @@ export default function TypographyPanel( {
 						hasFontSize() && rawInheritedFontSize !== undefined
 					) }
 					label={ __( 'Size' ) }
+					stylePaths={ [ 'typography.fontSize' ] }
 					hasValue={ hasFontSize }
 					hasInlineEndToggle
 					onDeselect={ resetFontSize }
@@ -906,6 +909,10 @@ export default function TypographyPanel( {
 								inheritedFontWeight !== undefined )
 					) }
 					label={ appearanceControlLabel }
+					stylePaths={ [
+						'typography.fontStyle',
+						'typography.fontWeight',
+					] }
 					hasValue={ hasFontAppearance }
 					onDeselect={ resetFontAppearance }
 					isShownByDefault={ defaultControls.fontAppearance }
@@ -931,6 +938,7 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Line height' ) }
+					stylePaths={ [ 'typography.lineHeight' ] }
 					hasValue={ hasLineHeight }
 					onDeselect={ resetLineHeight }
 					isShownByDefault={ defaultControls.lineHeight }
@@ -964,6 +972,7 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Letter spacing' ) }
+					stylePaths={ [ 'typography.letterSpacing' ] }
 					hasValue={ hasLetterSpacing }
 					onDeselect={ resetLetterSpacing }
 					isShownByDefault={ defaultControls.letterSpacing }
@@ -997,6 +1006,7 @@ export default function TypographyPanel( {
 						hasTextIndent() && inheritedTextIndent !== undefined
 					) }
 					label={ __( 'Line indent' ) }
+					stylePaths={ [ 'typography.textIndent' ] }
 					hasValue={ hasTextIndent }
 					onDeselect={ resetTextIndent }
 					isShownByDefault={ defaultControls.textIndent }
@@ -1038,6 +1048,7 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Columns' ) }
+					stylePaths={ [ 'typography.textColumns' ] }
 					hasValue={ hasTextColumns }
 					onDeselect={ resetTextColumns }
 					isShownByDefault={ defaultControls.textColumns }
@@ -1068,6 +1079,7 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Decoration' ) }
+					stylePaths={ [ 'typography.textDecoration' ] }
 					hasValue={ hasTextDecoration }
 					onDeselect={ resetTextDecoration }
 					isShownByDefault={ defaultControls.textDecoration }
@@ -1088,6 +1100,7 @@ export default function TypographyPanel( {
 						'single-column'
 					) }
 					label={ __( 'Orientation' ) }
+					stylePaths={ [ 'typography.writingMode' ] }
 					hasValue={ hasWritingMode }
 					onDeselect={ resetWritingMode }
 					isShownByDefault={ defaultControls.writingMode }
@@ -1107,6 +1120,7 @@ export default function TypographyPanel( {
 							inheritedTextTransform !== undefined
 					) }
 					label={ __( 'Letter case' ) }
+					stylePaths={ [ 'typography.textTransform' ] }
 					hasValue={ hasTextTransform }
 					onDeselect={ resetTextTransform }
 					isShownByDefault={ defaultControls.textTransform }
@@ -1127,6 +1141,7 @@ export default function TypographyPanel( {
 						hasTextAlign() && inheritedTextAlign !== undefined
 					) }
 					label={ __( 'Text alignment' ) }
+					stylePaths={ [ 'typography.textAlign' ] }
 					hasValue={ hasTextAlign }
 					onDeselect={ resetTextAlign }
 					isShownByDefault={ defaultControls.textAlign }

--- a/packages/block-editor/src/components/inspector-controls/block-support-slot-container.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-slot-container.js
@@ -4,6 +4,11 @@
 import { __experimentalToolsPanelContext as ToolsPanelContext } from '@wordpress/components';
 import { useContext, useMemo } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { InheritanceMenuContext } from '../global-styles/inheritance/panel-menu';
+
 export default function BlockSupportSlotContainer( {
 	Slot,
 	fillProps,
@@ -11,15 +16,23 @@ export default function BlockSupportSlotContainer( {
 } ) {
 	// Add the toolspanel context provider and value to existing fill props
 	const toolsPanelContext = useContext( ToolsPanelContext );
+	// Fills render in their own React tree, so the panel's inheritance registry
+	// has to be forwarded the same way the `ToolsPanel` context is, or panel
+	// items never reach the panel collecting them.
+	const inheritanceMenuContext = useContext( InheritanceMenuContext );
 	const computedFillProps = useMemo(
 		() => ( {
 			...( fillProps ?? {} ),
 			forwardedContext: [
 				...( fillProps?.forwardedContext ?? [] ),
 				[ ToolsPanelContext.Provider, { value: toolsPanelContext } ],
+				[
+					InheritanceMenuContext.Provider,
+					{ value: inheritanceMenuContext },
+				],
 			],
 		} ),
-		[ toolsPanelContext, fillProps ]
+		[ toolsPanelContext, inheritanceMenuContext, fillProps ]
 	);
 
 	return (

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
@@ -11,6 +10,7 @@ import { useCallback } from '@wordpress/element';
 import { store as blockEditorStore } from '../../store';
 import { cleanEmptyObject } from '../../hooks/utils';
 import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
+import { InheritanceToolsPanel } from '../global-styles/inheritance/panel-menu';
 
 export default function BlockSupportToolsPanel( { children, group, label } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -70,7 +70,7 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 	);
 
 	return (
-		<ToolsPanel
+		<InheritanceToolsPanel
 			className={ `${ group }-block-support-panel` }
 			label={ label }
 			resetAll={ resetAll }
@@ -83,6 +83,6 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }
-		</ToolsPanel>
+		</InheritanceToolsPanel>
 	);
 }

--- a/packages/components/src/tools-panel/style.module.scss
+++ b/packages/components/src/tools-panel/style.module.scss
@@ -115,3 +115,88 @@
 		opacity: 0.3;
 	}
 }
+
+// Consumer-supplied description sitting beneath a menu item. Indented to the
+// item's label so it reads as belonging to that row rather than to the group,
+// and `aria-hidden` — the item's `aria-describedby` is what carries it to
+// assistive technology.
+// No negative offset pulling it toward the item: the item is a full-height
+// button carrying a focus ring, and any overlap puts that ring through the
+// first line of the description.
+// An item carrying a description is bracketed by a rule above and below, so the
+// pair reads as one unit rather than as a row followed by loose text.
+//
+// Drawn as a pseudo-element rather than a border because the rule has to reach
+// the dropdown edges, while the item's own background and focus ring must keep
+// their normal inset width — a negative margin on the item itself would drag
+// both out with it.
+.menu-item-described {
+	position: relative;
+
+	// The rule sits in a gap rather than against the item, so the focus ring of
+	// whatever is above it has room to draw without the two colliding.
+	margin-top: $grid-unit-20;
+
+	&::before {
+		content: "";
+		position: absolute;
+		inset-block-start: -#{$grid-unit-10};
+		inset-inline: -$grid-unit-10;
+		border-top: $border-width solid $gray-400;
+	}
+
+	// First in its group, the group's own label is already the top boundary and
+	// a rule directly beneath it reads as a stray line.
+	&:first-child {
+		margin-top: 0;
+
+		&::before {
+			content: none;
+		}
+	}
+}
+
+// Where two described items sit back to back, the first one's closing rule is
+// already the second one's opening rule.
+.menu-item-description + .menu-item-described {
+	margin-top: 0;
+
+	&::before {
+		content: none;
+	}
+}
+
+.menu-item-description {
+	// The item above is a full-height button whose focus ring is drawn 1.5px
+	// wide at a 1.5px offset, so it paints 3px outside its box. This is the
+	// tightest step on the grid that still clears it — any less and a focused
+	// control's ring cuts through the first line of its own description.
+	padding-block: $grid-unit-05 $grid-unit-15;
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: 1.5;
+
+	// Closes the described item off from the next one with the same rule that
+	// sits above `Reset all` — which inside a dropdown is `$gray-400`, not the
+	// `$gray-900` the bare `MenuGroup` uses (see `dropdown/style.scss`).
+	border-bottom: $border-width solid $gray-400;
+
+	// That rule spans the dropdown edge to edge, because it belongs to the
+	// `MenuGroup` itself. This sits one level deeper, inside the group's
+	// content box, so it has to give back the group's own inline padding to
+	// reach the same width — then take it again as padding, plus the menu
+	// item's, before any indent.
+	margin-inline: -$grid-unit-10;
+
+	// One step further in than the labels above, so the description reads as
+	// hanging off its own item rather than as a sibling row. The end side stays
+	// level with the item's own padding, keeping values right-aligned with the
+	// `Reset` beside the label.
+	padding-inline-start: $grid-unit-30;
+	padding-inline-end: $grid-unit-20;
+
+	// Unless it is the last thing in the group, where the following group's own
+	// top border would double it up.
+	&:last-child {
+		border-bottom: none;
+	}
+}

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import type { ForwardedRef } from 'react';
+import clsx from 'clsx';
 
 /**
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
+import { Fragment } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { check, moreVertical, plus } from '@wordpress/icons';
 import { __, _x, sprintf } from '@wordpress/i18n';
 
@@ -27,14 +30,53 @@ import type {
 	ToolsPanelHeaderProps,
 } from '../types';
 
+// Renders a menu item's description, when the consumer supplies one, as an
+// `aria-hidden` sibling referenced by the item's `aria-describedby`. Keeping it
+// out of the menu's role structure avoids putting non-menuitem children inside
+// `role="menu"`, while `aria-describedby` still surfaces it to assistive
+// technology as that item's description.
+const createDescriptionRenderer = (
+	menuItemDescription: ToolsPanelControlsGroupProps[ 'menuItemDescription' ],
+	descriptionIdPrefix: string | undefined
+) =>
+	function renderDescription( label: string ) {
+		const description = menuItemDescription?.( label );
+		if ( ! description || ! descriptionIdPrefix ) {
+			return { descriptionId: undefined, descriptionNode: null };
+		}
+		const descriptionId = `${ descriptionIdPrefix }-${ label.replace(
+			/\W+/g,
+			'-'
+		) }`;
+		return {
+			descriptionId,
+			descriptionNode: (
+				<div
+					id={ descriptionId }
+					aria-hidden="true"
+					className={ styles[ 'menu-item-description' ] }
+				>
+					{ description }
+				</div>
+			),
+		};
+	};
+
 const DefaultControlsGroup = ( {
 	itemClassName,
 	items,
 	toggleItem,
+	menuItemDescription,
+	descriptionIdPrefix,
 }: ToolsPanelControlsGroupProps ) => {
 	if ( ! items.length ) {
 		return null;
 	}
+
+	const renderDescription = createDescriptionRenderer(
+		menuItemDescription,
+		descriptionIdPrefix
+	);
 
 	const resetSuffix = (
 		<span aria-hidden className={ styles[ 'reset-label' ] }>
@@ -45,46 +87,60 @@ const DefaultControlsGroup = ( {
 	return (
 		<>
 			{ items.map( ( [ label, hasValue ] ) => {
+				const { descriptionId, descriptionNode } =
+					renderDescription( label );
 				if ( hasValue ) {
 					return (
-						<MenuItem
-							key={ label }
-							className={ itemClassName }
-							role="menuitem"
-							label={ sprintf(
-								// translators: %s: The name of the control being reset e.g. "Padding".
-								__( 'Reset %s' ),
-								label
-							) }
-							onClick={ () => {
-								toggleItem( label );
-								speak(
-									sprintf(
-										// translators: %s: The name of the control being reset e.g. "Padding".
-										__( '%s reset to default' ),
-										label
-									),
-									'assertive'
-								);
-							} }
-							suffix={ resetSuffix }
-						>
-							{ label }
-						</MenuItem>
+						<Fragment key={ label }>
+							<MenuItem
+								className={ clsx( itemClassName, {
+									[ styles[ 'menu-item-described' ] ]:
+										!! descriptionId,
+								} ) }
+								role="menuitem"
+								aria-describedby={ descriptionId }
+								label={ sprintf(
+									// translators: %s: The name of the control being reset e.g. "Padding".
+									__( 'Reset %s' ),
+									label
+								) }
+								onClick={ () => {
+									toggleItem( label );
+									speak(
+										sprintf(
+											// translators: %s: The name of the control being reset e.g. "Padding".
+											__( '%s reset to default' ),
+											label
+										),
+										'assertive'
+									);
+								} }
+								suffix={ resetSuffix }
+							>
+								{ label }
+							</MenuItem>
+							{ descriptionNode }
+						</Fragment>
 					);
 				}
 
 				return (
-					<MenuItem
-						key={ label }
-						icon={ check }
-						className={ itemClassName }
-						role="menuitemcheckbox"
-						isSelected
-						aria-disabled
-					>
-						{ label }
-					</MenuItem>
+					<Fragment key={ label }>
+						<MenuItem
+							icon={ check }
+							className={ clsx( itemClassName, {
+								[ styles[ 'menu-item-described' ] ]:
+									!! descriptionId,
+							} ) }
+							role="menuitemcheckbox"
+							aria-describedby={ descriptionId }
+							isSelected
+							aria-disabled
+						>
+							{ label }
+						</MenuItem>
+						{ descriptionNode }
+					</Fragment>
 				);
 			} ) }
 		</>
@@ -94,14 +150,23 @@ const DefaultControlsGroup = ( {
 const OptionalControlsGroup = ( {
 	items,
 	toggleItem,
+	menuItemDescription,
+	descriptionIdPrefix,
 }: ToolsPanelControlsGroupProps ) => {
 	if ( ! items.length ) {
 		return null;
 	}
 
+	const renderDescription = createDescriptionRenderer(
+		menuItemDescription,
+		descriptionIdPrefix
+	);
+
 	return (
 		<>
 			{ items.map( ( [ label, isSelected ] ) => {
+				const { descriptionId, descriptionNode } =
+					renderDescription( label );
 				const itemLabel = isSelected
 					? sprintf(
 							// translators: %s: The name of the control being hidden and reset e.g. "Padding".
@@ -115,37 +180,46 @@ const OptionalControlsGroup = ( {
 					  );
 
 				return (
-					<MenuItem
-						key={ label }
-						icon={ isSelected ? check : null }
-						isSelected={ isSelected }
-						label={ itemLabel }
-						onClick={ () => {
-							if ( isSelected ) {
-								speak(
-									sprintf(
-										// translators: %s: The name of the control being reset e.g. "Padding".
-										__( '%s hidden and reset to default' ),
-										label
-									),
-									'assertive'
-								);
-							} else {
-								speak(
-									sprintf(
-										// translators: %s: The name of the control being reset e.g. "Padding".
-										__( '%s is now visible' ),
-										label
-									),
-									'assertive'
-								);
-							}
-							toggleItem( label );
-						} }
-						role="menuitemcheckbox"
-					>
-						{ label }
-					</MenuItem>
+					<Fragment key={ label }>
+						<MenuItem
+							className={ clsx( {
+								[ styles[ 'menu-item-described' ] ]:
+									!! descriptionId,
+							} ) }
+							icon={ isSelected ? check : null }
+							isSelected={ isSelected }
+							aria-describedby={ descriptionId }
+							label={ itemLabel }
+							onClick={ () => {
+								if ( isSelected ) {
+									speak(
+										sprintf(
+											// translators: %s: The name of the control being reset e.g. "Padding".
+											__(
+												'%s hidden and reset to default'
+											),
+											label
+										),
+										'assertive'
+									);
+								} else {
+									speak(
+										sprintf(
+											// translators: %s: The name of the control being reset e.g. "Padding".
+											__( '%s is now visible' ),
+											label
+										),
+										'assertive'
+									);
+								}
+								toggleItem( label );
+							} }
+							role="menuitemcheckbox"
+						>
+							{ label }
+						</MenuItem>
+						{ descriptionNode }
+					</Fragment>
 				);
 			} ) }
 		</>
@@ -168,8 +242,14 @@ const ToolsPanelHeader = (
 		resetAll,
 		toggleItem,
 		dropdownMenuProps,
+		__experimentalMenuItemDescription,
 		...headerProps
 	} = useToolsPanelHeader( props );
+
+	const instanceId = useInstanceId(
+		ToolsPanelHeader,
+		'tools-panel-item-description'
+	);
 
 	if ( ! labelText ) {
 		return null;
@@ -216,10 +296,18 @@ const ToolsPanelHeader = (
 									itemClassName={
 										defaultControlsItemClassName
 									}
+									menuItemDescription={
+										__experimentalMenuItemDescription
+									}
+									descriptionIdPrefix={ instanceId }
 								/>
 								<OptionalControlsGroup
 									items={ optionalItems }
 									toggleItem={ toggleItem }
+									menuItemDescription={
+										__experimentalMenuItemDescription
+									}
+									descriptionIdPrefix={ instanceId }
 								/>
 							</MenuGroup>
 							<MenuGroup>

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -29,6 +29,7 @@ const UnconnectedToolsPanel = (
 		toggleItem,
 		headingLevel,
 		dropdownMenuProps,
+		__experimentalMenuItemDescription,
 		...toolsPanelProps
 	} = useToolsPanel( props );
 
@@ -49,6 +50,9 @@ const UnconnectedToolsPanel = (
 					toggleItem={ toggleItem }
 					headingLevel={ headingLevel }
 					dropdownMenuProps={ dropdownMenuProps }
+					__experimentalMenuItemDescription={
+						__experimentalMenuItemDescription
+					}
 				/>
 				{ children }
 			</ToolsPanelContext.Provider>

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -65,6 +65,19 @@ export type ToolsPanelProps = {
 	 */
 	shouldRenderPlaceholderItems?: boolean;
 	/**
+	 * Experimental prop supplying extra descriptive content to render beneath an
+	 * individual menu item in the panel's options dropdown, given that item's
+	 * label. Return `null` for items with nothing to add.
+	 *
+	 * The content is rendered `aria-hidden` and referenced by the menu item's
+	 * `aria-describedby`, so it stays out of the menu's role structure while
+	 * still reaching assistive technology as that item's description.
+	 *
+	 * Called within the panel's own React tree, so it can read context provided
+	 * around the `ToolsPanel`.
+	 */
+	__experimentalMenuItemDescription?: ( label: string ) => ReactNode;
+	/**
 	 * Experimental prop allowing for a custom CSS class to be applied to the
 	 * first visible `ToolsPanelItem` within the `ToolsPanel`.
 	 */
@@ -107,6 +120,11 @@ export type ToolsPanelHeaderProps = {
 	 * `onSelect` or `onDeselect` callbacks as appropriate.
 	 */
 	toggleItem: ( label: string ) => void;
+	/**
+	 * Supplies extra descriptive content rendered beneath an individual menu
+	 * item, given that item's label.
+	 */
+	__experimentalMenuItemDescription?: ( label: string ) => ReactNode;
 };
 
 export type ToolsPanelItem = {
@@ -199,6 +217,15 @@ export type ToolsPanelControlsGroupProps = {
 	itemClassName?: string;
 	items: [ string, boolean ][];
 	toggleItem: ( label: string ) => void;
+	/**
+	 * Returns descriptive content to render beneath the item with this label.
+	 */
+	menuItemDescription?: ( label: string ) => ReactNode;
+	/**
+	 * Prefix for the generated `id` linking an item to its description. Unique
+	 * per panel, so several panels can be open without colliding.
+	 */
+	descriptionIdPrefix?: string;
 };
 
 export type ToolsPanelMenuItemsConfig = {

--- a/packages/global-styles-engine/src/resolve-style.ts
+++ b/packages/global-styles-engine/src/resolve-style.ts
@@ -15,11 +15,30 @@ interface SelectedState {
 
 interface SourceDescriptor {
 	layer: string;
+	// Structural metadata describing *which* root/element/block/variation the
+	// layer refers to. Deliberately not a pre-built human string: the engine is
+	// framework- and i18n-agnostic, so the UI composes the label (and looks up
+	// the block's registered title) from these fields.
+	blockName?: string | null;
+	element?: string | null;
+	variation?: string | null;
+}
+
+// One layer's contribution to a single leaf path. `cascade[ pathKey ]` holds
+// these ordered low-to-high precedence, so the last entry is the winner and the
+// preceding ones are the values it overrode.
+interface CascadeEntry extends SourceDescriptor {
+	value: unknown;
+	isWinner: boolean;
 }
 
 interface ResolvedStyle {
 	value: StyleTree;
 	sources: Record< string, SourceDescriptor >;
+	// Full per-path cascade. `sources` keeps only the winning layer; this keeps
+	// the layers it beat, which is what an origin/cascade view needs in order to
+	// explain *why* a value is what it is.
+	cascade: Record< string, CascadeEntry[] >;
 }
 
 // Query describing which slice of `globalStyles` to resolve. Kept separate from
@@ -77,6 +96,7 @@ const TREE_STRUCTURAL_KEYS = new Set( [ 'blocks', 'variations', 'css' ] );
 const EMPTY_INHERITANCE: ResolvedStyle = Object.freeze( {
 	value: {},
 	sources: {},
+	cascade: {},
 } );
 
 // Source descriptors per inheritance layer. `layer` identifies which layer
@@ -88,12 +108,15 @@ const SOURCE_DESCRIPTORS: Record< string, SourceDescriptor > = {
 	blockVariation: { layer: 'blockVariation' },
 };
 
-function createSourceDescriptor( type: string ): SourceDescriptor | null {
+function createSourceDescriptor(
+	type: string,
+	metadata?: Omit< SourceDescriptor, 'layer' >
+): SourceDescriptor | null {
 	const descriptor = SOURCE_DESCRIPTORS[ type ];
 	if ( ! descriptor ) {
 		return null;
 	}
-	return { ...descriptor };
+	return { ...descriptor, ...metadata };
 }
 
 interface Contribution {
@@ -208,6 +231,7 @@ const ATOMIC_OBJECT_KEYS = new Set( [ 'backgroundImage' ] );
  * @param sourceMetadata
  * @param sources
  * @param path
+ * @param cascade
  * @return The mutated `target`.
  */
 function deepMergeDroppingEmpties(
@@ -216,7 +240,8 @@ function deepMergeDroppingEmpties(
 	globalStyles: StyleTree,
 	sourceMetadata?: SourceDescriptor,
 	sources?: Record< string, SourceDescriptor >,
-	path: string[] = []
+	path: string[] = [],
+	cascade?: Record< string, CascadeEntry[] >
 ): StyleTree {
 	if ( ! source || typeof source !== 'object' || Array.isArray( source ) ) {
 		return target;
@@ -263,7 +288,8 @@ function deepMergeDroppingEmpties(
 				globalStyles,
 				sourceMetadata,
 				sources,
-				nextPath
+				nextPath,
+				cascade
 			);
 		} else {
 			target[ key ] =
@@ -274,8 +300,21 @@ function deepMergeDroppingEmpties(
 					? { ...sourceValue }
 					: sourceValue;
 			if ( sourceMetadata && sources ) {
-				sources[ getPathKey( nextPath ) ] =
-					getSourceForPath( sourceMetadata );
+				const pathKey = getPathKey( nextPath );
+				sources[ pathKey ] = getSourceForPath( sourceMetadata );
+				if ( cascade ) {
+					// A later layer writing the same leaf demotes whatever came
+					// before it; only the final write stays the winner.
+					const entries = ( cascade[ pathKey ] ??= [] );
+					for ( const entry of entries ) {
+						entry.isWinner = false;
+					}
+					entries.push( {
+						...getSourceForPath( sourceMetadata ),
+						value: target[ key ],
+						isWinner: true,
+					} );
+				}
 			}
 		}
 	}
@@ -352,7 +391,8 @@ function deleteAtPath( target: StyleTree, pathSegments: string[] ) {
 // not actually reach the block. See `NON_CASCADING_ROOT_PREFIXES`.
 function dropNonCascadingRootLeaves(
 	value: StyleTree,
-	sources: Record< string, SourceDescriptor >
+	sources: Record< string, SourceDescriptor >,
+	cascade?: Record< string, CascadeEntry[] >
 ) {
 	for ( const pathKey of Object.keys( sources ) ) {
 		if (
@@ -362,6 +402,30 @@ function dropNonCascadingRootLeaves(
 			deleteAtPath( value, pathKey.split( '.' ) );
 			delete sources[ pathKey ];
 		}
+	}
+	if ( ! cascade ) {
+		return;
+	}
+	// A root contribution at a non-cascading path never reaches the block, so it
+	// must not appear as an overridden layer either — even when some higher
+	// layer won the path and kept it out of the `sources` sweep above.
+	for ( const pathKey of Object.keys( cascade ) ) {
+		if ( ! isNonCascadingRootPath( pathKey ) ) {
+			continue;
+		}
+		const kept = cascade[ pathKey ].filter(
+			( entry ) => entry.layer !== 'root'
+		);
+		if ( kept.length === 0 ) {
+			delete cascade[ pathKey ];
+			continue;
+		}
+		// Removing the winner (root won and was dropped) promotes the highest
+		// remaining layer, keeping exactly one winner per path.
+		if ( ! kept.some( ( entry ) => entry.isWinner ) ) {
+			kept[ kept.length - 1 ].isWinner = true;
+		}
+		cascade[ pathKey ] = kept;
 	}
 }
 
@@ -433,8 +497,14 @@ function computeResolvedStyle(
 	// block's own styles. `elements` is ordered low to high precedence, so a
 	// level-specific `h2` correctly wins over the generic `heading`.
 	const elementLayers = ( elements ?? [] )
-		.map( ( elementName ) => styles.elements?.[ elementName ] ?? null )
-		.filter( ( layer ): layer is StyleTree => !! layer );
+		.map( ( elementName ) => ( {
+			element: elementName,
+			layer: styles.elements?.[ elementName ] ?? null,
+		} ) )
+		.filter(
+			( entry ): entry is { element: string; layer: StyleTree } =>
+				!! entry.layer
+		);
 	// Resolve the active block style variation's styles (with `{ ref }`
 	// values resolved) against the Global Styles tree.
 	const variation = variationName
@@ -451,22 +521,25 @@ function computeResolvedStyle(
 			pickLayerRootContribution( root ),
 			createSourceDescriptor( 'root' )
 		),
-		...elementLayers.map( ( layer ) =>
+		...elementLayers.map( ( { element, layer } ) =>
 			createContribution(
 				pickLayerRootContribution( layer ),
-				createSourceDescriptor( 'element' )
+				createSourceDescriptor( 'element', { blockName, element } )
 			)
 		),
 		block
 			? createContribution(
 					pickLayerRootContribution( block ),
-					createSourceDescriptor( 'block' )
+					createSourceDescriptor( 'block', { blockName } )
 			  )
 			: null,
 		variation
 			? createContribution(
 					pickLayerRootContribution( variation ),
-					createSourceDescriptor( 'blockVariation' )
+					createSourceDescriptor( 'blockVariation', {
+						blockName,
+						variation: variationName,
+					} )
 			  )
 			: null,
 	];
@@ -484,12 +557,15 @@ function computeResolvedStyle(
 				),
 				createSourceDescriptor( 'root' )
 			),
-			...elementLayers.map( ( layer ) =>
+			...elementLayers.map( ( { element, layer } ) =>
 				createContribution(
 					pickLayerRootContribution(
 						getStateSlice( layer, selectedState )
 					),
-					createSourceDescriptor( 'element' )
+					createSourceDescriptor( 'element', {
+						blockName,
+						element,
+					} )
 				)
 			),
 			block
@@ -497,7 +573,7 @@ function computeResolvedStyle(
 						pickLayerRootContribution(
 							getStateSlice( block, selectedState )
 						),
-						createSourceDescriptor( 'block' )
+						createSourceDescriptor( 'block', { blockName } )
 				  )
 				: null,
 			variation
@@ -505,7 +581,10 @@ function computeResolvedStyle(
 						pickLayerRootContribution(
 							getStateSlice( variation, selectedState )
 						),
-						createSourceDescriptor( 'blockVariation' )
+						createSourceDescriptor( 'blockVariation', {
+							blockName,
+							variation: variationName,
+						} )
 				  )
 				: null
 		);
@@ -520,6 +599,7 @@ function computeResolvedStyle(
 	}
 
 	const sources: Record< string, SourceDescriptor > = {};
+	const cascade: Record< string, CascadeEntry[] > = {};
 	const value = filteredContributions.reduce(
 		( mergedValue, contribution ) =>
 			deepMergeDroppingEmpties(
@@ -527,22 +607,24 @@ function computeResolvedStyle(
 				contribution.styles,
 				globalStyles as StyleTree,
 				contribution.source,
-				sources
+				sources,
+				[],
+				cascade
 			),
 		{} as StyleTree
 	);
 
 	// Root-level non-cascading values do not reach the block; drop them from
-	// value and sources together. Then resolve theme-file image pointers so
-	// consumers receive fully-resolved values.
-	dropNonCascadingRootLeaves( value, sources );
+	// value, sources, and cascade together. Then resolve theme-file image
+	// pointers so consumers receive fully-resolved values.
+	dropNonCascadingRootLeaves( value, sources, cascade );
 	resolveThemeFileBackgroundImage(
 		value,
 		globalStyles as StyleTree,
 		( globalStyles._links as Record< string, any > ) ?? null
 	);
 
-	return { value, sources };
+	return { value, sources, cascade };
 }
 
 const NO_LINKS = {};

--- a/packages/global-styles-engine/src/test/resolve-style.test.ts
+++ b/packages/global-styles-engine/src/test/resolve-style.test.ts
@@ -899,3 +899,106 @@ describe( 'resolveStyle – non-cascading root drop', () => {
 		);
 	} );
 } );
+
+describe( 'resolveStyle – per-path cascade', () => {
+	// Root and block both set fontSize; block wins. Root alone sets fontFamily.
+	const gs = {
+		styles: {
+			typography: { fontSize: '16px', fontFamily: 'Inter' },
+			blocks: {
+				'core/paragraph': {
+					typography: { fontSize: '18px' },
+				},
+			},
+		},
+	};
+
+	test( 'records every contributing layer, ordered low to high', () => {
+		const { cascade } = resolveStyle( gs, {
+			blockName: 'core/paragraph',
+		} );
+		expect(
+			cascade[ 'typography.fontSize' ].map( ( entry ) => [
+				entry.layer,
+				entry.value,
+			] )
+		).toEqual( [
+			[ 'root', '16px' ],
+			[ 'block', '18px' ],
+		] );
+	} );
+
+	test( 'marks exactly one winner, the highest-precedence layer', () => {
+		const { cascade, sources } = resolveStyle( gs, {
+			blockName: 'core/paragraph',
+		} );
+		const entries = cascade[ 'typography.fontSize' ];
+		expect( entries.filter( ( entry ) => entry.isWinner ) ).toHaveLength(
+			1
+		);
+		const winner = entries.find( ( entry ) => entry.isWinner );
+		// The cascade's winner must agree with the existing source map.
+		expect( winner.layer ).toBe( sources[ 'typography.fontSize' ].layer );
+		expect( winner.value ).toBe( '18px' );
+	} );
+
+	test( 'an uncontested leaf is a single winning entry', () => {
+		const { cascade } = resolveStyle( gs, {
+			blockName: 'core/paragraph',
+		} );
+		expect( cascade[ 'typography.fontFamily' ] ).toEqual( [
+			{ layer: 'root', value: 'Inter', isWinner: true },
+		] );
+	} );
+
+	test( 'carries structural metadata for composing an origin label', () => {
+		const withVariation = {
+			styles: {
+				blocks: {
+					'core/group': {
+						typography: { fontSize: '16px' },
+						variations: {
+							subtitle: { typography: { fontSize: '20px' } },
+						},
+					},
+				},
+			},
+		};
+		const { cascade } = resolveStyle( withVariation, {
+			blockName: 'core/group',
+			variationName: 'subtitle',
+		} );
+		const entries = cascade[ 'typography.fontSize' ];
+		expect( entries.at( -1 ) ).toMatchObject( {
+			layer: 'blockVariation',
+			blockName: 'core/group',
+			variation: 'subtitle',
+			value: '20px',
+			isWinner: true,
+		} );
+	} );
+
+	test( 'omits root layers at non-cascading paths, which never reach the block', () => {
+		const nonCascading = {
+			styles: {
+				spacing: { padding: { top: '10px' } },
+				blocks: {
+					'core/group': { spacing: { padding: { top: '30px' } } },
+				},
+			},
+		};
+		const { cascade } = resolveStyle( nonCascading, {
+			blockName: 'core/group',
+		} );
+		// Root padding paints the root element only, so it must not appear as
+		// a layer the block's own padding overrode.
+		expect( cascade[ 'spacing.padding.top' ] ).toEqual( [
+			{
+				layer: 'block',
+				blockName: 'core/group',
+				value: '30px',
+				isWinner: true,
+			},
+		] );
+	} );
+} );


### PR DESCRIPTION
## Important note

**This is an exploration, opened as a draft to keep the conversation going.** It is not proposed for merge as-is — see [Known gaps](#known-gaps), one of which is architectural and one of which is a deliberate behaviour change. It builds on #80649, #80993 and @jasmussen's [comment](https://github.com/WordPress/gutenberg/pull/80993#issuecomment-5140052431). Take it over, cherry-pick from it, or close it.

## What?

@jasmussen, on #80993:

> one of the primary challenges with the previous implementations was where to put this indicator so that it could be accessible on mobile with a tap as well: given the mix of controls with labels and ItemGroup controls with flyouts, that was the primary challenge. Some of the concepts discussed late in the thread suggest moving away from that dot indicator and more towards an element that can live inside the ellipsis dropdown for style control panels: there could be something there too.

This is that, and it **replaces** the per-control dot rather than sitting alongside it. Nothing is rendered at rest — not on the control rows, not on the panel's options toggle. Inherited values simply read as values. Open a style panel's options menu and each control that overrides an inherited value shows its cascade under its own row, beside the `Reset` that already puts the value back:

```
TYPOGRAPHY
  Color                          RESET
     This block               #503AA8
     S̶i̶t̶e̶-̶w̶i̶d̶e̶                #̶2̶E̶2̶A̶2̶4̶
  ─────────────────────────────────────
  Size                           RESET
     Custom CSS                   3rem
     T̶h̶i̶s̶ ̶b̶l̶o̶c̶k̶                   5̶2̶p̶x̶
     S̶u̶b̶t̶i̶t̶l̶e̶ ̶s̶t̶y̶l̶e̶      1̶.̶5̶ ̶–̶ ̶1̶.̶7̶5̶r̶e̶m̶
     S̶i̶t̶e̶-̶w̶i̶d̶e̶              1̶.̶1̶8̶7̶5̶r̶e̶m̶
  ─────────────────────────────────────
  Font
  Appearance
```

https://github.com/user-attachments/assets/5a770f4e-3fd7-4066-9a22-3651f403ef75

Uses the existing `gutenberg-global-styles-inheritance-ui` experiment — no new flag, and no PHP changes at all. To compare against the per-control dot, compare against `trunk`.

## Why this shape

**No new action.** The menu already lists every control and already offers each one a `Reset` — which for a control holding a local value over an inherited one *is* the "put it back" action. So nothing is added to the menu; the cascade slots in under the row that already exists. An earlier revision had a bulk `Restore inherited styles` and it became redundant the moment the rows moved under their controls, taking a staged-restore queue with it.

**Values, not a marker.** A one-bit indicator can say *overridden* but not what was overridden, what the value would fall back to, or where that comes from — the questions that send people to the browser inspector. A menu row has space for all three; a control row does not. That is the argument for this placement, more than the mobile one.

**Nothing at rest is a deliberate trade.** @jasmussen: *"I'd personally also be fine with—to start—landing with nothing but the actual inheritance shown as values: no indicators at all."* The cost is discoverability: nothing announces that a block overrides anything, and you find out by opening the menu. Every at-rest marker so far has had to answer "where does it go on a row that is entirely a flyout toggle, and how is it tapped on mobile" — a placement with no marker doesn't have to.

## How?

**Engine.** `resolveStyle` keeps the full per-path cascade (`cascade: Record<path, CascadeEntry[]>`) instead of collapsing to the winning layer. `sources` is unchanged. Layers carry structural metadata rather than pre-built strings, so the UI composes and translates the labels. **Ported unchanged from #80993 — this is its second consumer, and an argument for landing it as its own PR.**

**Labels name scope, so reading down narrows it:** Site-wide → All Paragraph blocks → Subtitle style → This block → Custom CSS. Deliberately not "From block settings" and friends: that names where a value is stored rather than how far it reaches, a different question from the one every other row answers.

**Values are shortened to fit a menu row.** Colour presets resolve to their hex — a slug names the preset but not what it paints. Fluid typography's `clamp()` collapses to `1.5 – 1.75rem` rather than a 50-character viewport formula.

**Paths.** `InheritanceToolsPanelItem` takes a `stylePaths` prop (Appearance passes two, element colours three), wired at all 26 call sites.

**Cascade resolves on the item side.** The block inspector renders panels *outside* the selected block's edit context, so only the items — slot fills in the block's tree — know which block they belong to. They publish into a registry the panel reads, forwarded across the `bubblesVirtually` boundary the way `ToolsPanelContext` already is. Only computed while a control actually overrides something, and propagated on a value signature rather than array identity, so typing doesn't re-render the panel.

## What this removes

Because the placement replaces rather than supplements, `InheritanceResetButton` and its styles are deleted, and the four controls that swapped their ordinary reset for the dot — colour/gradient, shadow, duotone, background image — get that reset back unconditionally. That incidentally resolves @t-hamano's point on #80649 that colour controls lost their reset in order to gain an indicator.

`has-local-override-from-global-styles` is kept as a class hook but now paints nothing — it is where a future at-rest treatment would attach.

## Accessibility

Audited in the browser, not assumed:

- The cascade is an `aria-hidden` sibling referenced by the item's `aria-describedby`. `role="menu"` keeps only menu items as children, and the accessible **name** stays `Reset Size` — nesting would have folded the cascade into the name and made every overriding control unqueryable by its own label.
- Each row carries visually-hidden state: *"Custom CSS 3rem in effect. This block 52px overridden…"*. Without it the distinction was strikethrough-only, and a screen reader heard four values with no way to tell which applied.
- Covered layers measure **4.61:1**, in-effect **16.67:1**. An earlier `opacity: 0.7` put these at 2.67:1 and was removed; the strikethrough carries the meaning and is not a colour-only encoding.
- Tap targets: menu rows 226×32–34, panel toggle 24×24 — both meet WCAG 2.2 SC 2.5.8. The whole row is the target, not the `RESET` text.
- Arrow-key navigation skips the description; nothing focusable inside it.

## Testing instructions

1. Enable **Global Styles inheritance in the block inspector** on Gutenberg → Experiments.
2. Add a Paragraph, apply the **Subtitle** block style, set a font size and a text colour.
3. Open the Typography panel's ⋮ menu — each overriding control shows its cascade.
4. `Reset` on a row returns it to the next layer down, not to the bottom of the stack.
5. Compare against `trunk` for the per-control dot this replaces.

## Known gaps

- **This needs a `ToolsPanel` API change, and #80652 says not to make one.** That issue states abstractions should stay local to Global Styles and that higher-level form component APIs should not gain support for this pattern while the design is unsettled. This adds `__experimentalMenuItemDescription` to `ToolsPanel` in `@wordpress/components` — a shared component used by every block's inspector. I could not find a way to do it locally: the menu is generated from ToolsPanel's internal item registry, `dropdownMenuProps` cannot reach its children, and the header is not replaceable. **That cost is itself a finding**: the per-control indicator lives in the control row, which Global Styles already owns; this menu belongs to ToolsPanel. If this direction is pursued it needs either a sanctioned extension point or a local reconstruction of the panel header.
- **It removes a visible part of #80649's merged work.** 16 tests asserting the dot were rewritten to assert the new behaviour. If the dot should stay, this needs rethinking rather than rebasing.
- **Custom-CSS-only overrides are covered; theme/plugin stylesheet overrides are not.** The computed-style check from #80993 was deliberately left out — it had known false positives.
- **The en-dash in `1.5 – 1.75rem` is swallowed by the strikethrough** on losing layers.
- **The mobile rendering path is unverified.** Tap target *sizes* are viewport-independent and were measured, but below 782px `useToolsPanelDropdownMenuProps` drops its popover placement and the menu positions differently. Needs a real device pass — which matters, since mobile reachability is this exploration's premise.
- **No `CHANGELOG.md` entries**, deliberately.

## AI disclosure

- **AI assistance:** Yes
- **Tool(s) used:** Claude Code (Opus 5)
- **What AI generated:** the implementation, tests, and this description.
- **What was human-reviewed:** direction, UX decisions, and behaviour were driven and reviewed interactively against a running editor throughout. Several defects were found only by that review — the panel the block inspector actually uses was not the one first wired, React context did not cross the `bubblesVirtually` slot boundary, a separator overlapped a focused item's ring, and the contrast failure above. Treat the code as exploratory.
