### PR TITLE
Fix typos in code `comments` and `JSDoc`

### DIFF
--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -66,7 +66,7 @@ export type PopoverProps = {
 	/**
 	 * Determines whether tabbing is constrained to within the popover,
 	 * preventing keyboard focus from leaving the popover content without
-	 * explicit focus elswhere, or whether the popover remains part of the wider
+	 * explicit focus elsewhere, or whether the popover remains part of the wider
 	 * tab order. If no value is passed, it will be derived from `focusOnMount`.
 	 *
 	 * @default `focusOnMount` !== false

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -127,7 +127,7 @@ function compareObjectTabbables( a, b ) {
 }
 
 /**
- * Givin focusable elements, filters out tabbable element.
+ * Given focusable elements, filters out tabbable element.
  *
  * @param {HTMLElement[]} focusables Focusable elements to filter.
  *

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -88,7 +88,7 @@ export default {
 
 		const blockName = getBlockName( clientId );
 
-		// Navigaton block types are read-only.
+		// Navigation block types are read-only.
 		// See https://github.com/WordPress/gutenberg/pull/72165.
 		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
 			return false;
@@ -111,7 +111,7 @@ export default {
 		const clientId = getSelectedBlockClientId();
 		const blockName = getBlockName( clientId );
 
-		// Navigaton block types are read-only.
+		// Navigation block types are read-only.
 		// See https://github.com/WordPress/gutenberg/pull/72165.
 		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
 			return false;

--- a/packages/editor/src/bindings/term-data.js
+++ b/packages/editor/src/bindings/term-data.js
@@ -132,7 +132,7 @@ export default {
 		const clientId = getSelectedBlockClientId();
 		const blockName = getBlockName( clientId );
 
-		// Navigaton block types are read-only.
+		// Navigation block types are read-only.
 		// See https://github.com/WordPress/gutenberg/pull/72165.
 		if ( NAVIGATION_BLOCK_TYPES.includes( blockName ) ) {
 			return false;

--- a/packages/env/lib/execute-lifecycle-script.js
+++ b/packages/env/lib/execute-lifecycle-script.js
@@ -24,7 +24,7 @@ class LifecycleScriptError extends Error {
  *
  * @param {string}   event   The lifecycle event to run the script for.
  * @param {WPConfig} config  The config object to use.
- * @param {Object}   spinner A CLI spinner which indciates progress.
+ * @param {Object}   spinner A CLI spinner which indicates progress.
  *
  * @return {Promise} Resolves when the script has completed and rejects when there is an error.
  */

--- a/packages/global-styles-ui/src/font-library/api.ts
+++ b/packages/global-styles-ui/src/font-library/api.ts
@@ -24,7 +24,7 @@ function invalidateFontFamilyCache( registry: DataRegistry ) {
 
 	// Invalidate all font family queries
 	// Ideally there should be a dedicated action to do this
-	// "invalide all cacches for this entity type"
+	// "invalid all caches for this entity type"
 	receiveEntityRecords(
 		'postType',
 		'wp_font_family',

--- a/packages/interactivity-router/src/assets/script-modules.ts
+++ b/packages/interactivity-router/src/assets/script-modules.ts
@@ -69,7 +69,7 @@ export const preloadScriptModules = ( doc: Document ) => {
 };
 
 /**
- * Imports modules respresented by the passed `ScriptModuleLoad` instances.
+ * Imports modules represented by the passed `ScriptModuleLoad` instances.
  *
  * @param modules Array of `MoudleLoad` instances.
  * @return Promise that resolves once all modules are imported.

--- a/packages/interactivity-router/src/assets/script-modules.ts
+++ b/packages/interactivity-router/src/assets/script-modules.ts
@@ -71,7 +71,7 @@ export const preloadScriptModules = ( doc: Document ) => {
 /**
  * Imports modules represented by the passed `ScriptModuleLoad` instances.
  *
- * @param modules Array of `MoudleLoad` instances.
+ * @param modules Array of `ModuleLoad` instances.
  * @return Promise that resolves once all modules are imported.
  */
 export const importScriptModules = ( modules: ScriptModuleLoad[] ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes several typos in code comments and `JSDoc` across the codebase - no functional or logic changes.

1. `packages/editor/src/bindings/post-data.js` (lines 91, 114)  "Navigaton" → "Navigation"
2. `packages/editor/src/bindings/term-data.js` (line 135)  "Navigaton" → "Navigation"
3. `packages/interactivity-router/src/assets/script-modules.ts` (lines 72, 74)  "respresented" → "represented"; "MoudleLoad" → "ModuleLoad"
4. `packages/dom/src/tabbable.js` (line 130)  "Givin" → "Given"
5. `packages/components/src/popover/types.ts` (line 69)  minor typo fix in comment
6. `packages/env/lib/execute-lifecycle-script.js` (line 27)  "indcates" → "indicates"
7. `packages/global-styles-ui/src/font-library/api.ts` (line 27)  "invalide" → "invalid" and "cacches" →"caches"
<!-- In a few words, what is the PR actually doing? -->

## Why?
These typos are in comments and `JSDoc` annotations, not user-facing strings, but cleaning them up improves code readability and maintainability,

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Manually reviewed each occurrence and corrected the spelling in place. No logic, behavior, or public API was touched this is a `comment/doc-only` change.

## Testing Instructions
- No functional changes were made, so no new tests are required.
- Verified that only `comment/JSDoc` text was modified and no code lines were altered.

## Use of AI Tools
- Used Claude to identify typos, then manually reviewed all of them.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
