### PR TITLE
RTC: Prepare shared containers from the block attribute schema

### DIFF
--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -24,6 +24,14 @@ export function addMetaAttribute( blockTypeSettings ) {
 		...blockTypeSettings.attributes,
 		[ META_ATTRIBUTE_NAME ]: {
 			type: 'object',
+			/*
+			 * Declares the collection keys so real-time collaboration can share
+			 * one container per key instead of losing a concurrent first write.
+			 * See https://github.com/WordPress/gutenberg/issues/74751.
+			 */
+			query: {
+				noteId: { type: 'array' },
+			},
 		},
 	};
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -235,10 +235,117 @@ export function deserializeBlockAttributes( blocks: Block[] ): Block[] {
 		return {
 			...rest,
 			name,
-			attributes: newAttributes,
+			attributes: withoutEmptyDeclaredContainers( name, newAttributes ),
 			innerBlocks: deserializeBlockAttributes( innerBlocks ?? [] ),
 		};
 	} );
+}
+
+/**
+ * Remove the empty declared containers the document materializes (see
+ * createEmptyYContainer). Editor blocks omit those keys, so they are stripped
+ * whenever blocks are read back out of the document.
+ *
+ * @param blockName  The block type name.
+ * @param attributes The block attributes, as plain values from toJSON().
+ * @return The attributes without empty declared containers.
+ */
+function withoutEmptyDeclaredContainers(
+	blockName: string,
+	attributes: BlockAttributes
+): BlockAttributes {
+	let newAttributes: BlockAttributes | undefined;
+
+	for ( const [ attributeName, schema ] of getBlockAttributeSchemas(
+		blockName
+	) ) {
+		const value = attributes?.[ attributeName ];
+
+		if ( ! schema.query || value === undefined ) {
+			continue;
+		}
+
+		const stripped = withoutEmptyDeclaredValues( schema, value );
+
+		if ( stripped === value ) {
+			continue;
+		}
+
+		newAttributes = newAttributes ?? { ...attributes };
+
+		if ( stripped === undefined ) {
+			delete newAttributes[ attributeName ];
+		} else {
+			newAttributes[ attributeName ] = stripped;
+		}
+	}
+
+	return newAttributes ?? attributes;
+}
+
+/**
+ * Recursively strip a value's empty declared containers, returning undefined
+ * once nothing is left.
+ *
+ * @param schema The attribute type definition for this value.
+ * @param value  The value, as plain values from toJSON().
+ * @return The stripped value, undefined when empty, or `value` when unchanged.
+ */
+function withoutEmptyDeclaredValues(
+	schema: BlockAttributeSchema,
+	value: unknown
+): unknown {
+	if ( schema.type === 'array' ) {
+		return Array.isArray( value ) && value.length === 0 ? undefined : value;
+	}
+
+	if ( schema.type !== 'object' || ! schema.query || ! isRecord( value ) ) {
+		return value;
+	}
+
+	let newValue: Record< string, unknown > | undefined;
+
+	for ( const [ key, subSchema ] of Object.entries( schema.query ) ) {
+		if ( ! Object.hasOwn( value, key ) ) {
+			continue;
+		}
+
+		const stripped = withoutEmptyDeclaredValues( subSchema, value[ key ] );
+
+		if ( stripped === value[ key ] ) {
+			continue;
+		}
+
+		newValue = newValue ?? { ...value };
+
+		if ( stripped === undefined ) {
+			delete newValue[ key ];
+		} else {
+			newValue[ key ] = stripped;
+		}
+	}
+
+	const result = newValue ?? value;
+
+	return Object.keys( result ).length === 0 ? undefined : result;
+}
+
+/**
+ * Recursively remove the empty declared containers from blocks extracted from
+ * the CRDT document.
+ *
+ * @param blocks Blocks as extracted from the CRDT document via toJSON().
+ * @return The blocks without empty declared containers.
+ */
+export function stripEmptyDeclaredContainers( blocks: Block[] ): Block[] {
+	return blocks.map( ( block: Block ) => ( {
+		...block,
+		attributes: withoutEmptyDeclaredContainers(
+			block.name,
+			block.attributes
+		),
+		innerBlocks: stripEmptyDeclaredContainers( block.innerBlocks ?? [] ),
+	} ) );
 }
 
 /**
@@ -255,8 +362,18 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 		clientId: null,
 	};
 	const res = fastDeepEqual(
-		Object.assign( {}, gblock, overwrites ),
-		Object.assign( {}, yblockAsJson, overwrites )
+		Object.assign( {}, gblock, overwrites, {
+			attributes: withoutEmptyDeclaredContainers(
+				gblock.name,
+				gblock.attributes
+			),
+		} ),
+		Object.assign( {}, yblockAsJson, overwrites, {
+			attributes: withoutEmptyDeclaredContainers(
+				yblockAsJson.name,
+				yblockAsJson.attributes as unknown as BlockAttributes
+			),
+		} )
 	);
 	const inners = gblock.innerBlocks || [];
 	const yinners = yblock.get( 'innerBlocks' );
@@ -273,7 +390,7 @@ function createNewYAttributeMap(
 	blockName: string,
 	attributes: BlockAttributes
 ): YBlockAttributes {
-	return new Y.Map(
+	const yMap = new Y.Map(
 		Object.entries( attributes ).map(
 			( [ attributeName, attributeValue ] ) => {
 				return [
@@ -287,6 +404,24 @@ function createNewYAttributeMap(
 			}
 		)
 	);
+
+	// Materialize declared containers the block omits, so they are created
+	// with the block instead of by whoever writes the attribute first.
+	for ( const [ attributeName, schema ] of getBlockAttributeSchemas(
+		blockName
+	) ) {
+		if ( ! schema.query || Object.hasOwn( attributes, attributeName ) ) {
+			continue;
+		}
+
+		const container = createEmptyYContainer( schema );
+
+		if ( container ) {
+			yMap.set( attributeName, container );
+		}
+	}
+
+	return yMap;
 }
 
 function createNewYAttributeValue(
@@ -335,11 +470,86 @@ function createYValueFromSchema(
 		return yArray;
 	}
 
+	// Arrays of primitives are stored as Y.Array too, so that concurrent
+	// insertions are preserved. Arrays of objects without a query schema have
+	// no described structure to merge, so they stay plain values.
+	if (
+		schema.type === 'array' &&
+		Array.isArray( value ) &&
+		value.every( ( item ) => item === null || typeof item !== 'object' )
+	) {
+		const yArray = new Y.Array< unknown >();
+
+		if ( value.length > 0 ) {
+			yArray.insert( 0, value );
+		}
+
+		return yArray;
+	}
+
 	if ( schema.type === 'object' && schema.query && isRecord( value ) ) {
 		return createYMapFromQuery( schema.query, value );
 	}
 
 	return value;
+}
+
+/**
+ * Create the empty shared container a schema describes.
+ *
+ * Containers are materialized for every block up front: Yjs keeps concurrent
+ * insertions into a shared container, but resolves concurrent creation of the
+ * container itself as last-writer-wins, discarding one peer's contents.
+ *
+ * @param schema The attribute type definition.
+ * @return The empty container, or undefined when the schema describes none.
+ */
+function createEmptyYContainer(
+	schema: BlockAttributeSchema | undefined
+): Y.Array< unknown > | Y.Map< unknown > | undefined {
+	if ( schema?.type === 'array' ) {
+		return new Y.Array< unknown >();
+	}
+
+	if ( schema?.type === 'object' && schema.query ) {
+		return createYMapFromQuery( schema.query, undefined );
+	}
+
+	return undefined;
+}
+
+/**
+ * Empty a container in place. Re-creating it would reintroduce the creation
+ * race that materializing it avoids, so containers are only ever cleared.
+ *
+ * @param container      The Y.js container to empty.
+ * @param schema         The attribute type definition for the container.
+ * @param cursorPosition The local cursor position for rich-text delta merges.
+ * @param cursorScope    The selected block attribute scope for rich-text cursor hints.
+ */
+function clearYContainer(
+	container: unknown,
+	schema: BlockAttributeSchema | undefined,
+	cursorPosition: MergeCursorPosition,
+	cursorScope: RichTextCursorScope
+): void {
+	if ( container instanceof Y.Array ) {
+		if ( container.length > 0 ) {
+			container.delete( 0, container.length );
+		}
+		return;
+	}
+
+	if ( container instanceof Y.Map && schema?.query ) {
+		// Clears every key, preserving the declared nested containers.
+		mergeYMapValues(
+			container,
+			{},
+			schema.query,
+			cursorPosition,
+			cursorScope
+		);
+	}
 }
 
 /**
@@ -364,16 +574,28 @@ function createYMapFromQuery(
 	query: Record< string, BlockAttributeSchema >,
 	obj: unknown
 ): Y.Map< unknown > {
-	if ( ! isRecord( obj ) ) {
-		return new Y.Map();
-	}
+	const record = isRecord( obj ) ? obj : {};
 
-	const entries: [ string, unknown ][] = Object.entries( obj ).map(
+	const entries: [ string, unknown ][] = Object.entries( record ).map(
 		( [ key, val ] ): [ string, unknown ] => {
 			const subSchema = query[ key ];
 			return [ key, createYValueFromSchema( subSchema, val ) ];
 		}
 	);
+
+	// Materialize declared containers the value omits, so they are created
+	// with the block instead of by whoever writes the key first.
+	for ( const [ key, subSchema ] of Object.entries( query ) ) {
+		if ( Object.hasOwn( record, key ) ) {
+			continue;
+		}
+
+		const container = createEmptyYContainer( subSchema );
+
+		if ( container ) {
+			entries.push( [ key, container ] );
+		}
+	}
 
 	return new Y.Map( entries );
 }
@@ -570,12 +792,36 @@ export function mergeCrdtBlocks(
 
 						// Delete any attributes that are no longer present.
 						localAttributes.forEach(
-							( _attrValue: unknown, attrName: string ) => {
+							( attrValue: unknown, attrName: string ) => {
 								if (
 									! incomingBlockPropertyValue.hasOwnProperty(
 										attrName
 									)
 								) {
+									const schema = getBlockAttributeSchema(
+										incomingYBlock.name,
+										attrName
+									);
+
+									// Declared containers are emptied, never
+									// deleted, so they stay shared across peers.
+									if (
+										attrValue instanceof Y.AbstractType &&
+										createEmptyYContainer( schema )
+									) {
+										clearYContainer(
+											attrValue,
+											schema,
+											attributeCursor,
+											{
+												attributeKey: attrName,
+												clientId:
+													incomingYBlock.clientId,
+											}
+										);
+										return;
+									}
+
 									localAttributes.delete( attrName );
 								}
 							}
@@ -854,6 +1100,12 @@ function mergeYValue(
 	) {
 		mergeYArray( currentVal, newVal, schema, cursorPosition, cursorScope );
 	} else if (
+		schema?.type === 'array' &&
+		Array.isArray( newVal ) &&
+		currentVal instanceof Y.Array
+	) {
+		mergeYPlainArray( currentVal, newVal );
+	} else if (
 		schema?.type === 'object' &&
 		schema.query &&
 		isRecord( newVal ) &&
@@ -866,6 +1118,13 @@ function mergeYValue(
 			cursorPosition,
 			cursorScope
 		);
+	} else if (
+		currentVal instanceof Y.AbstractType &&
+		createEmptyYContainer( schema )
+	) {
+		// The incoming value cannot fill the declared container: it is absent
+		// or no longer the declared shape. Empty it rather than replace it.
+		clearYContainer( currentVal, schema, cursorPosition, cursorScope );
 	} else {
 		const newYValue = createYValueFromSchema( schema, newVal );
 
@@ -875,6 +1134,59 @@ function mergeYValue(
 		if ( newYValue !== newVal || ! fastDeepEqual( currentVal, newVal ) ) {
 			yMap.set( key, newYValue );
 		}
+	}
+}
+
+/**
+ * Merge an incoming plain array into an existing Y.Array of plain values.
+ *
+ * Uses the same left-right sweep diff as mergeYArray, comparing values
+ * directly. Keeping the Y.Array itself is the point: concurrent insertions are
+ * both preserved, whereas replacing it wholesale would discard one.
+ *
+ * @param yArray   The existing Y.Array to update.
+ * @param newValue The new plain array to merge into the Y.Array.
+ */
+function mergeYPlainArray( yArray: Y.Array< unknown >, newValue: unknown[] ) {
+	const numOfCommonEntries = Math.min( newValue.length, yArray.length );
+
+	let left = 0;
+	let right = 0;
+
+	// Skip equal elements from left.
+	for (
+		;
+		left < numOfCommonEntries &&
+		fastDeepEqual( newValue[ left ], yArray.get( left ) );
+		left++
+	) {
+		/* nop */
+	}
+
+	// Skip equal elements from right.
+	for (
+		;
+		right < numOfCommonEntries - left &&
+		fastDeepEqual(
+			newValue[ newValue.length - right - 1 ],
+			yArray.get( yArray.length - right - 1 )
+		);
+		right++
+	) {
+		/* nop */
+	}
+
+	// Replace the changed middle section. Only that range is touched, so an
+	// element another peer concurrently inserted outside it is left alone.
+	const numOfStaleEntries = yArray.length - left - right;
+	const numOfNewEntries = newValue.length - left - right;
+
+	if ( numOfStaleEntries > 0 ) {
+		yArray.delete( left, numOfStaleEntries );
+	}
+
+	if ( numOfNewEntries > 0 ) {
+		yArray.insert( left, newValue.slice( left, left + numOfNewEntries ) );
 	}
 }
 
@@ -911,6 +1223,23 @@ function mergeYMapValues(
 	// Delete properties absent from the incoming object.
 	for ( const key of yMap.keys() ) {
 		if ( ! Object.hasOwn( newObj, key ) ) {
+			const currentVal = yMap.get( key );
+
+			// Declared containers are emptied, never deleted, so they stay
+			// shared across peers.
+			if (
+				currentVal instanceof Y.AbstractType &&
+				createEmptyYContainer( query[ key ] )
+			) {
+				clearYContainer(
+					currentVal,
+					query[ key ],
+					cursorPosition,
+					cursorScope
+				);
+				continue;
+			}
+
 			yMap.delete( key );
 		}
 	}
@@ -1025,6 +1354,18 @@ function getBlockAttributeSchema(
 	blockName: string,
 	attributeName: string
 ): BlockAttributeSchema | undefined {
+	return getBlockAttributeSchemas( blockName ).get( attributeName );
+}
+
+/**
+ * Get the attribute type definitions for every attribute of a block type.
+ *
+ * @param blockName The name of the block, e.g. 'core/paragraph'.
+ * @return The type definitions, keyed by attribute name.
+ */
+function getBlockAttributeSchemas(
+	blockName: string
+): Map< string, BlockAttributeSchema > {
 	if ( ! cachedBlockAttributeSchemas ) {
 		// Parse the attributes for all blocks once.
 		cachedBlockAttributeSchemas = new Map();
@@ -1044,7 +1385,7 @@ function getBlockAttributeSchema(
 		}
 	}
 
-	return cachedBlockAttributeSchemas.get( blockName )?.get( attributeName );
+	return cachedBlockAttributeSchemas.get( blockName ) ?? new Map();
 }
 
 /**
@@ -1070,7 +1411,7 @@ function isExpectedAttributeType(
 		return typeof attributeValue === 'string';
 	}
 
-	if ( schema?.type === 'array' && schema.query ) {
+	if ( schema?.type === 'array' ) {
 		return attributeValue instanceof Y.Array;
 	}
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -30,6 +30,7 @@ import {
 	mergeCrdtBlocks,
 	type MergeCursorPosition,
 	mergeRichTextUpdate,
+	stripEmptyDeclaredContainers,
 	type YBlock,
 	type YBlocks,
 } from './crdt-blocks';
@@ -415,11 +416,14 @@ export function getPostChangesFromCRDTDoc(
 						ydoc.meta?.get( CRDT_DOC_META_PERSISTENCE_KEY ) &&
 						editedRecord.content
 					) {
-						const blocksJson = ymap.get( 'blocks' )?.toJSON() ?? [];
+						const blocksJson = stripEmptyDeclaredContainers(
+							ymap.get( 'blocks' )?.toJSON() ?? []
+						);
 
 						return (
-							__unstableSerializeAndClean( blocksJson ).trim() !==
-							getRawValue( editedRecord.content )
+							__unstableSerializeAndClean(
+								blocksJson as WPBlock[]
+							).trim() !== getRawValue( editedRecord.content )
 						);
 					}
 

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -29,7 +29,13 @@ jest.mock( '@wordpress/blocks', () => ( {
 	getBlockTypes: () => [
 		{
 			name: 'core/paragraph',
-			attributes: { content: { type: 'rich-text' } },
+			attributes: {
+				content: { type: 'rich-text' },
+				metadata: {
+					type: 'object',
+					query: { noteId: { type: 'array' } },
+				},
+			},
 		},
 		{
 			name: 'core/image',
@@ -111,6 +117,7 @@ import { RichTextData } from '@wordpress/rich-text';
  * Internal dependencies
  */
 import {
+	deserializeBlockAttributes,
 	mergeCrdtBlocks,
 	mergeRichTextUpdate,
 	type Block,
@@ -3107,6 +3114,222 @@ describe( 'crdt-blocks', () => {
 
 				expect( yText.toString() ).toBe( 'a𝄞xb' );
 			} );
+		} );
+	} );
+
+	describe( 'block metadata attribute merging', () => {
+		// The `metadata` attribute is injected for every block type as a
+		// plain `{ type: 'object' }` attribute with no query schema (see
+		// block-editor/src/hooks/metadata.js). Its `noteId` key stores the
+		// note threads attached to a block, so concurrent writes from two
+		// peers must merge instead of last-writer-wins.
+		// See https://github.com/WordPress/gutenberg/issues/74751.
+
+		function makeNoteBlock( metadata?: Record< string, unknown > ): Block {
+			return {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Note target block',
+					...( metadata ? { metadata } : {} ),
+				},
+				innerBlocks: [],
+				clientId: 'block-1',
+			};
+		}
+
+		function getDeserializedMetadata( blocks: YBlocks ) {
+			const [ block ] = deserializeBlockAttributes(
+				blocks.toJSON() as Block[]
+			);
+			return block.attributes.metadata as
+				| Record< string, unknown >
+				| undefined;
+		}
+
+		it( 'preserves both notes when two users add a note to the same block concurrently', () => {
+			// Set up doc1 (User A) with a block that has no notes.
+			mergeCrdtBlocks( yblocks, [ makeNoteBlock() ], null );
+
+			// Set up doc2 (User B) by syncing initial state.
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			// User A adds note 101 (concurrently with B, before syncing).
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 101 ] } ) ],
+				null
+			);
+
+			// User B adds note 102 (concurrently with A, before syncing).
+			mergeCrdtBlocks(
+				yblocks2,
+				[ makeNoteBlock( { noteId: [ 102 ] } ) ],
+				null
+			);
+
+			// Sync: apply each other's changes.
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+			Y.applyUpdate( doc, Y.encodeStateAsUpdate( doc2 ) );
+
+			// Both docs should have both notes attached to the block.
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				const metadata = getDeserializedMetadata( checkBlocks );
+				const noteIds = ( metadata?.noteId as number[] ) ?? [];
+				expect( [ ...noteIds ].sort() ).toEqual( [ 101, 102 ] );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'preserves a concurrent note addition and a custom block name', () => {
+			mergeCrdtBlocks( yblocks, [ makeNoteBlock() ], null );
+
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			// User A adds a note.
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 101 ] } ) ],
+				null
+			);
+
+			// User B renames the block (metadata.name) concurrently.
+			mergeCrdtBlocks(
+				yblocks2,
+				[ makeNoteBlock( { name: 'Custom name' } ) ],
+				null
+			);
+
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+			Y.applyUpdate( doc, Y.encodeStateAsUpdate( doc2 ) );
+
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				const metadata = getDeserializedMetadata( checkBlocks );
+				expect( metadata?.noteId ).toEqual( [ 101 ] );
+				expect( metadata?.name ).toBe( 'Custom name' );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'propagates note removal to other peers', () => {
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 101, 102 ] } ) ],
+				null
+			);
+
+			const doc2 = new Y.Doc();
+			const yblocks2 = doc2.getArray< YBlock >();
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			// User A removes note 101.
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 102 ] } ) ],
+				null
+			);
+
+			Y.applyUpdate( doc2, Y.encodeStateAsUpdate( doc ) );
+
+			for ( const checkBlocks of [ yblocks, yblocks2 ] ) {
+				const metadata = getDeserializedMetadata( checkBlocks );
+				expect( metadata?.noteId ).toEqual( [ 102 ] );
+			}
+
+			doc2.destroy();
+		} );
+
+		it( 'removes the metadata attribute when the incoming block has none', () => {
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 101 ] } ) ],
+				null
+			);
+
+			// The last note was removed: the incoming block carries no
+			// metadata attribute at all.
+			mergeCrdtBlocks( yblocks, [ makeNoteBlock() ], null );
+
+			expect( getDeserializedMetadata( yblocks ) ).toBeUndefined();
+		} );
+
+		it( 'does not expose empty metadata containers on blocks without metadata', () => {
+			mergeCrdtBlocks( yblocks, [ makeNoteBlock() ], null );
+
+			expect( getDeserializedMetadata( yblocks ) ).toBeUndefined();
+		} );
+
+		it( 'round-trips metadata values through the CRDT document', () => {
+			mergeCrdtBlocks(
+				yblocks,
+				[
+					makeNoteBlock( {
+						noteId: [ 101 ],
+						name: 'Custom name',
+					} ),
+				],
+				null
+			);
+
+			expect( getDeserializedMetadata( yblocks ) ).toEqual( {
+				noteId: [ 101 ],
+				name: 'Custom name',
+			} );
+		} );
+
+		it( 'upgrades plain-value metadata from older documents on merge', () => {
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 7 ] } ) ],
+				null
+			);
+
+			// Simulate an older document where metadata was stored as a
+			// plain value.
+			doc.transact( () => {
+				const attributes = yblocks
+					.get( 0 )
+					.get( 'attributes' ) as YBlockAttributes;
+				attributes.set( 'metadata', { noteId: [ 7 ] } );
+			} );
+
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 7, 8 ] } ) ],
+				null
+			);
+
+			expect( getDeserializedMetadata( yblocks )?.noteId ).toEqual( [
+				7, 8,
+			] );
+		} );
+
+		it( 'does not generate document updates when re-merging unchanged blocks', () => {
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 101 ] } ) ],
+				null
+			);
+
+			let updates = 0;
+			doc.on( 'update', () => {
+				updates++;
+			} );
+
+			// A fresh, deep-equal copy: the serializable-blocks cache is
+			// keyed by array identity, so this exercises a full re-merge.
+			mergeCrdtBlocks(
+				yblocks,
+				[ makeNoteBlock( { noteId: [ 101 ] } ) ],
+				null
+			);
+
+			expect( updates ).toBe( 0 );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-concurrent-notes.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-concurrent-notes.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * External dependencies
+ */
+import type { Page, Route } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+
+/**
+ * Regression test for https://github.com/WordPress/gutenberg/issues/74751.
+ *
+ * When two collaborators attached a note to the same block at the same
+ * moment, the block `metadata` attribute was merged last-writer-wins in the
+ * CRDT document and one peer's note id was discarded. That note then
+ * appeared as attached to a deleted block ("Original block deleted") for its
+ * author and was invisible to everyone else.
+ *
+ * The test forces true concurrency by holding all wp-sync requests on both
+ * pages while each user adds a note, then releasing them so the concurrent
+ * updates merge. It lives in `http-only/` because pausing replication via
+ * request interception only works with the HTTP polling provider.
+ */
+test.describe( 'Collaboration - concurrent notes on the same block', () => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+	} );
+
+	test( 'notes added by two users at the same moment both survive', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Concurrent Notes Test',
+			status: 'draft',
+			content:
+				'<!-- wp:paragraph --><p>Shared note target</p><!-- /wp:paragraph -->',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openCollaborativeSession( post.id );
+
+		const { page2, editor2 } = collaborationUtils;
+
+		// Both users select the same paragraph block.
+		for ( const [ pg, ed ] of [
+			[ page, editor ],
+			[ page2, editor2 ],
+		] as const ) {
+			await ed.canvas
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.filter( { hasText: 'Shared note target' } )
+				.click();
+			await expect(
+				pg.getByRole( 'toolbar', { name: 'Block tools' } )
+			).toBeVisible();
+		}
+
+		// Pause replication: hold every wp-sync request on both pages so
+		// neither user's changes reach the other until both notes exist.
+		const heldRoutes: Route[] = [];
+		const holdSync = async ( route: Route ) => {
+			heldRoutes.push( route );
+		};
+		const isSyncRequest = ( url: URL ) => url.href.includes( 'wp-sync' );
+		await page.route( isSyncRequest, holdSync );
+		await page2.route( isSyncRequest, holdSync );
+
+		// User A adds a note to the block.
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		await page
+			.getByRole( 'textbox', { name: 'New note', exact: true } )
+			.fill( 'Concurrent note from User A' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Add note', exact: true } )
+			.click();
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', {
+					name: 'Note: Concurrent note from User A',
+				} )
+		).toBeVisible();
+
+		// User B adds a note to the same block, unaware of User A's note.
+		await editor2.clickBlockOptionsMenuItem( 'Add note' );
+		await page2
+			.getByRole( 'textbox', { name: 'New note', exact: true } )
+			.fill( 'Concurrent note from User B' );
+		await page2
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Add note', exact: true } )
+			.click();
+		await expect(
+			page2
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', {
+					name: 'Note: Concurrent note from User B',
+				} )
+		).toBeVisible();
+
+		// Resume replication and release the held requests.
+		await page.unroute( isSyncRequest, holdSync );
+		await page2.unroute( isSyncRequest, holdSync );
+		for ( const route of heldRoutes ) {
+			// A held request may have been aborted in the meantime.
+			await route.continue().catch( () => {} );
+		}
+
+		// Let the concurrent updates converge on both pages.
+		await collaborationUtils.waitForSyncCycle( page );
+		await collaborationUtils.waitForSyncCycle( page2 );
+
+		// The block should reference both notes on both pages.
+		const getFirstBlockNoteIds = ( pg: Page ) =>
+			pg.evaluate( () => {
+				const blocks = (
+					window as unknown as {
+						wp: {
+							data: {
+								select: ( store: string ) => {
+									getBlocks: () => Array< {
+										attributes?: {
+											metadata?: {
+												noteId?: number[];
+											};
+										};
+									} >;
+								};
+							};
+						};
+					}
+				 ).wp.data
+					.select( 'core/block-editor' )
+					.getBlocks();
+				return blocks[ 0 ]?.attributes?.metadata?.noteId ?? [];
+			} );
+
+		for ( const pg of [ page, page2 ] ) {
+			await expect
+				.poll( () => getFirstBlockNoteIds( pg ), {
+					timeout: 15000,
+				} )
+				.toHaveLength( 2 );
+		}
+
+		// Both note threads are visible to both users, and neither note is
+		// orphaned ("Original block deleted").
+		for ( const pg of [ page, page2 ] ) {
+			const toggleButton = pg
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'All notes', exact: true } );
+			await expect( toggleButton ).toBeVisible( { timeout: 10000 } );
+			if (
+				( await toggleButton.getAttribute( 'aria-expanded' ) ) ===
+				'false'
+			) {
+				await toggleButton.click();
+			}
+
+			const allNotes = pg.getByRole( 'tree', { name: 'All notes' } );
+			await expect(
+				allNotes.getByRole( 'treeitem', {
+					name: 'Note: Concurrent note from User A',
+				} )
+			).toBeVisible( { timeout: 10000 } );
+			await expect(
+				allNotes.getByRole( 'treeitem', {
+					name: 'Note: Concurrent note from User B',
+				} )
+			).toBeVisible( { timeout: 10000 } );
+			await expect(
+				pg
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByText( 'Original block deleted' )
+			).toBeHidden();
+		}
+	} );
+} );


### PR DESCRIPTION
## What?

Closes #74751

Two people adding a note to the same block at the same moment no longer lose one of the notes.

Alternative approach to #79956, which fixes the same issue by teaching the collaboration layer about notes directly.

## Why?

When two collaborators add a note to the same paragraph at almost the same time, one note goes missing. Its author sees "Original block deleted" next to it, and the other person never sees it at all.

A block keeps a list of the notes attached to it. When both people write that list at the same time, the collaboration layer keeps only one of the two writes and discards the other. The discarded note is still there, but nothing connects it to the block any more.

## How?

The list is only fragile while it does not exist yet. Once a shared list is there, two people adding to it both succeed — it is two people *creating* the same list at the same time that goes wrong.

So instead of teaching the collaboration layer about notes, blocks now declare in advance that this list exists. The collaboration layer reads that declaration and prepares the list when the block itself is created, so nobody ever has to create it. It also empties such a list rather than removing it, so the problem cannot come back later.

These prepared-but-empty lists are hidden again when blocks are read back, so saved content, the editor state, and the "unsaved changes" indicator all behave exactly as before.

The collaboration code never mentions notes, so another `metadata` feature can get the same protection by adding one line to the declaration. As a side benefit, renaming a block and adding a note at the same time no longer conflict either.

## Testing Instructions

1. Enable real-time collaboration under Settings > Writing.
2. Open the same post as two different users in two browsers.
3. Throttle or briefly disconnect the network on both, add a note to the same block as each user at roughly the same moment, then restore the connection.
4. Both notes should be attached to the block for both users. Previously one showed "Original block deleted" for its author and was invisible to the other user.

### Testing Instructions for Keyboard

No user interface changes, so there is nothing keyboard-specific to test beyond the steps above.

## Screenshots or screencast

N/A — no visual changes.

## Use of AI Tools

Written with Claude Code (Claude Opus 5). The overall approach, the decision to declare the shape in the block attribute schema rather than special-case notes in the collaboration layer, and the final review of the code are mine.
