### PR TITLE
Docs: Use `gutenberg` instead of `Gutenberg` in package name

### DIFF
--- a/lib/compat/plugin/style-state-aliases.php
+++ b/lib/compat/plugin/style-state-aliases.php
@@ -2,7 +2,7 @@
 /**
  * Plugin-specific style state alias back compatibility.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 /**

--- a/lib/compat/wordpress-7.1/icons.php
+++ b/lib/compat/wordpress-7.1/icons.php
@@ -2,7 +2,7 @@
 /**
  * Icons API functions.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! function_exists( 'wp_register_icon_collection' ) ) {

--- a/lib/experimental/font-face/bc-layer/class-gutenberg-fonts-api-bc-layer.php
+++ b/lib/experimental/font-face/bc-layer/class-gutenberg-fonts-api-bc-layer.php
@@ -5,7 +5,7 @@
  * BACKPORT NOTE: Do not backport this file to Core.
  * This file is now part of the API's Backwards-Compatibility (BC) layer.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage Fonts API
  * @since      15.7.0
  */

--- a/lib/experimental/font-face/bc-layer/class-wp-webfonts.php
+++ b/lib/experimental/font-face/bc-layer/class-wp-webfonts.php
@@ -7,7 +7,7 @@
  * using the previous API, it exists to prevent breakages, giving
  * developers time to upgrade their code.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage Fonts API's BC Layer
  * @since      X.X.X
  */

--- a/lib/experimental/interactivity-api/class-gutenberg-interactivity-api-full-page-navigation.php
+++ b/lib/experimental/interactivity-api/class-gutenberg-interactivity-api-full-page-navigation.php
@@ -2,7 +2,7 @@
 /**
  * Interactivity API: Experimental full-page client-side navigation.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage Interactivity API
  */
 

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests server side rendering of core/navigation-link
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage block-library
  */
 

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests server side rendering of core/navigation-submenu
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage block-library
  */
 

--- a/phpunit/class-wp-icon-collections-registry-test.php
+++ b/phpunit/class-wp-icon-collections-registry-test.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_Icon_Collections_Registry functionality.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Test_Icon_Collections_Registry extends WP_UnitTestCase {
 

--- a/phpunit/class-wp-icons-registry-gutenberg-test.php
+++ b/phpunit/class-wp-icons-registry-gutenberg-test.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_Icons_Registry_Gutenberg::register functionality.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Test_Icons_Registry_Gutenberg extends WP_UnitTestCase {
 

--- a/phpunit/class-wp-rest-icon-controller-test.php
+++ b/phpunit/class-wp-rest-icon-controller-test.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_REST_Icons_Controller functionality.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Test_REST_Icons_Controller extends WP_Test_REST_TestCase {
 	protected static $admin_id;

--- a/phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
+++ b/phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_Test_REST_Comments_Controller_Gutenberg functionality.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Test_REST_Comments_Controller_Gutenberg extends WP_Test_REST_TestCase {
 	protected static $admin_id;

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the Style Engine CSS declarations class.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage style-engine
  */
 

--- a/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rule-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the Style Engine CSS Rule class.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage style-engine
  */
 

--- a/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the Style Engine CSS Rules Store class.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage style-engine
  */
 

--- a/phpunit/style-engine/class-wp-style-engine-processor-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-processor-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the Style Engine Processor class.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage style-engine
  */
 

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the Style Engine global functions that interact with the WP_Style_Engine class.
  *
- * @package    Gutenberg
+ * @package    gutenberg
  * @subpackage style-engine
  */
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Used `gutenberg` instead of `Gutenberg` in package tags for consistency.

<!-- In a few words, what is the PR actually doing? -->

## Why?  How?
Used `gutenberg` instead of `Gutenberg` in package tags for consistency in below files.

Updated package name in below files: 

- lib/experimental/font-face/bc-layer/class-wp-webfonts.php
- lib/experimental/font-face/bc-layer/class-gutenberg-fonts-api-bc-layer.php
- lib/experimental/interactivity-api/class-gutenberg-interactivity-api-full-page-navigation.php
- lib/compat/plugin/style-state-aliases.php
- lib/compat/wordpress-7.1/icons.php
- phpunit/class-wp-icon-collections-registry-test.php
- phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
- phpunit/style-engine/class-wp-style-engine-css-rules-store-test.php
- phpunit/style-engine/class-wp-style-engine-css-rule-test.php
- phpunit/style-engine/class-wp-style-engine-processor-test.php
- phpunit/style-engine/style-engine-test.php
- phpunit/experimental/class-wp-rest-comments-controller-gutenberg-test.php
- phpunit/class-wp-rest-icon-controller-test.php
- phpunit/blocks/class-block-library-navigation-link-test.php
- phpunit/blocks/render-block-navigation-submenu-test.php
- phpunit/class-wp-icons-registry-gutenberg-test.php

## Testing Instructions

- No functional changes were made.

## Use of AI Tools
- With the help of Claude, identified the relevant files and reviewed them manually.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->