### PR TITLE
Fix ESLint errors for 'navigateRegionsProps' spread

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -104,7 +104,6 @@ function Layout() {
 			{ canvas === 'view' && <SaveKeyboardShortcut /> }
 			<div
 				{ ...navigateRegionsProps }
-				ref={ navigateRegionsProps.ref }
 				className={ clsx(
 					'edit-site-layout',
 					navigateRegionsProps.className,

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -36,11 +36,7 @@ function Layout( { blockEditorSettings } ) {
 
 	return (
 		<ErrorBoundary>
-			<div
-				className={ navigateRegionsProps.className }
-				{ ...navigateRegionsProps }
-				ref={ navigateRegionsProps.ref }
-			>
+			<div { ...navigateRegionsProps }>
 				<WidgetAreasBlockEditorProvider
 					blockEditorSettings={ blockEditorSettings }
 				>

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1154,11 +1154,6 @@
 			"count": 2
 		}
 	},
-	"packages/edit-site/src/components/layout/index.js": {
-		"react-hooks/refs": {
-			"count": 3
-		}
-	},
 	"packages/edit-site/src/components/page-templates/fields.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1212,11 +1207,6 @@
 	"packages/edit-site/src/components/site-editor-routes/notfound.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		}
-	},
-	"packages/edit-widgets/src/components/layout/index.js": {
-		"react-hooks/refs": {
-			"count": 3
 		}
 	},
 	"packages/edit-widgets/src/components/sidebar/index.js": {


### PR DESCRIPTION
## What?
Related #77940.

PR fixes suppressed ESLint errors caused by `navigateRegionsProps` spread.

## Testing Instructions
CI checks are passing.

## Use of AI Tools

None.
