### PR TITLE
Tests: Replace page-level selectors with locators in e2e specs

### DIFF
--- a/test/e2e/specs/admin/workflow-palette.spec.js
+++ b/test/e2e/specs/admin/workflow-palette.spec.js
@@ -63,6 +63,6 @@ test.describe( 'Workflow palette', () => {
 		const requestCountAfterFirstOpen = abilityRequests.length;
 		await page.keyboard.press( 'ControlOrMeta+j' );
 		await expect( palette ).toBeVisible();
-		expect( abilityRequests.length ).toBe( requestCountAfterFirstOpen );
+		expect( abilityRequests ).toHaveLength( requestCountAfterFirstOpen );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -52,9 +52,10 @@ test.describe( 'Avatar', () => {
 		);
 
 		await expect( blockInspectorControls ).toBeVisible();
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
 
 		const userInput = page.locator(
 			'role=region[name="Editor settings"i] >> role=combobox[name="User"i]'

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -281,7 +281,7 @@ test.describe( 'Buttons', () => {
 			} )
 			.getByRole( 'button', { name: 'Color', exact: true } )
 			.click();
-		await page.click( 'role=option[name="Cyan bluish gray"i]' );
+		await page.getByRole( 'option', { name: 'Cyan bluish gray' } ).click();
 		await editorSettings
 			.locator( '.components-tools-panel' )
 			.filter( {
@@ -289,7 +289,7 @@ test.describe( 'Buttons', () => {
 			} )
 			.getByRole( 'button', { name: 'Color', exact: true } )
 			.click();
-		await page.click( 'role=option[name="Vivid red"i]' );
+		await page.getByRole( 'option', { name: 'Vivid red' } ).click();
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
@@ -320,8 +320,12 @@ test.describe( 'Buttons', () => {
 		// Match by substring: when the control has a value (e.g. an inherited
 		// color), the button's accessible name gains a "The currently selected
 		// color is…" suffix, so an exact-name match no longer works.
-		await page.click( 'role=button[name=/Custom color picker/i]' );
-		await page.fill( 'role=textbox[name="Hex color"i]', 'ff0000' );
+		await page
+			.getByRole( 'button', { name: /Custom color picker/i } )
+			.click();
+		await page
+			.getByRole( 'textbox', { name: 'Hex color' } )
+			.fill( 'ff0000' );
 
 		await editorSettings
 			.locator( '.components-tools-panel' )
@@ -330,8 +334,12 @@ test.describe( 'Buttons', () => {
 			} )
 			.getByRole( 'button', { name: 'Color', exact: true } )
 			.click();
-		await page.click( 'role=button[name=/Custom color picker/i]' );
-		await page.fill( 'role=textbox[name="Hex color"i]', '00ff00' );
+		await page
+			.getByRole( 'button', { name: /Custom color picker/i } )
+			.click();
+		await page
+			.getByRole( 'textbox', { name: 'Hex color' } )
+			.fill( '00ff00' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
@@ -356,7 +364,9 @@ test.describe( 'Buttons', () => {
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'button', { name: 'Gradient', exact: true } )
 			.click();
-		await page.click( 'role=option[name="Gradient: Purple to yellow"i]' );
+		await page
+			.getByRole( 'option', { name: 'Gradient: Purple to yellow' } )
+			.click();
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();
@@ -381,15 +391,23 @@ test.describe( 'Buttons', () => {
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'button', { name: 'Gradient', exact: true } )
 			.click();
-		await page.click(
-			'role=button[name=/^Gradient control point at position 0% with color code/]'
-		);
-		await page.fill( 'role=textbox[name="Hex color"i]', 'ff0000' );
+		await page
+			.getByRole( 'button', {
+				name: /^Gradient control point at position 0% with color code/,
+			} )
+			.click();
+		await page
+			.getByRole( 'textbox', { name: 'Hex color' } )
+			.fill( 'ff0000' );
 		await page.keyboard.press( 'Escape' );
-		await page.click(
-			'role=button[name=/^Gradient control point at position 100% with color code/]'
-		);
-		await page.fill( 'role=textbox[name="Hex color"i]', '00ff00' );
+		await page
+			.getByRole( 'button', {
+				name: /^Gradient control point at position 100% with color code/,
+			} )
+			.click();
+		await page
+			.getByRole( 'textbox', { name: 'Hex color' } )
+			.fill( '00ff00' );
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -62,9 +62,9 @@ test.describe( 'Columns', () => {
 			)
 		);
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name="Lock"i]' );
+		await page.getByRole( 'menuitem', { name: 'Lock' } ).click();
 		await page.locator( 'role=checkbox[name="Lock removal"i]' ).check();
-		await page.click( 'role=button[name="Apply"i]' );
+		await page.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// Select columns block
 		await editor.selectBlocks(
@@ -80,7 +80,7 @@ test.describe( 'Columns', () => {
 		await expect( columnsChangeInput ).toHaveAttribute( 'min', '3' );
 
 		// Changing the number of columns should take into account locked columns
-		await page.fill( 'role=spinbutton[name="Columns"i]', '1' );
+		await page.getByRole( 'spinbutton', { name: 'Columns' } ).fill( '1' );
 		await pageUtils.pressKeys( 'Tab' );
 		await expect( columnsChangeInput ).toHaveValue( '3' );
 	} );

--- a/test/e2e/specs/editor/blocks/comments.spec.js
+++ b/test/e2e/specs/editor/blocks/comments.spec.js
@@ -86,7 +86,7 @@ test.describe( 'Comments', () => {
 			page.locator( 'role=link[name="Newer Comments"i]' )
 		).toBeHidden();
 
-		await page.click( 'role=link[name="Older Comments"i]' );
+		await page.getByRole( 'link', { name: 'Older Comments' } ).click();
 
 		// We check that there are a previous and a next link.
 		await expect(
@@ -96,7 +96,7 @@ test.describe( 'Comments', () => {
 			page.locator( 'role=link[name="Newer Comments"i]' )
 		).toBeVisible();
 
-		await page.click( 'role=link[name="Older Comments"i]' );
+		await page.getByRole( 'link', { name: 'Older Comments' } ).click();
 
 		// We check that there is only have a next link
 		await expect(
@@ -356,10 +356,12 @@ class CommentsBlockUtils {
 	 */
 	async setOption( setting, value ) {
 		await this.admin.visitAdminPage( 'options.php', '' );
-		const previousValue = await this.page.inputValue( `#${ setting }` );
+		const previousValue = await this.page
+			.locator( `#${ setting }` )
+			.inputValue();
 
-		await this.page.fill( `#${ setting }`, value );
-		await this.page.click( '#Update' );
+		await this.page.locator( `#${ setting }` ).fill( value );
+		await this.page.locator( '#Update' ).click();
 
 		return previousValue;
 	}

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -149,6 +149,7 @@ test.describe( 'Details', () => {
 			)
 			.toBe( true );
 	} );
+
 	test( 'should select the parent when clicking its summary from an inner paragraph', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -238,10 +238,11 @@ test.describe( 'Fit Text', () => {
 			await editor.openDocumentSettingsSidebar();
 
 			// Set a custom font size
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
-			);
-			await page.click( 'role=spinbutton[name="Font size"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Set custom size' } )
+				.click();
+			await page.getByRole( 'spinbutton', { name: 'Font size' } ).click();
 			await page.keyboard.type( '24' );
 
 			// fitText should be cleared

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -68,15 +68,17 @@ test.describe( 'Gallery', () => {
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->` );
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Undo' } )
+			.click();
 
 		await expect.poll( editor.getEditedPostContent ).toBe( '' );
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Redo"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Redo' } )
+			.click();
 
 		await expect
 			.poll( editor.getEditedPostContent )

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -19,11 +19,12 @@ test.describe( 'Group', () => {
 
 		await inserterButton.click();
 
-		await page.type( 'role=searchbox[name="Search"i]', 'Group' );
+		await page.getByRole( 'searchbox', { name: 'Search' } ).type( 'Group' );
 
-		await page.click(
-			'role=listbox[name="Blocks"i] >> role=option[name="Group"i]'
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Group' } )
+			.click();
 
 		// Select the default, selected Group layout from the variation picker.
 		await editor.canvas
@@ -69,9 +70,10 @@ test.describe( 'Group', () => {
 			)
 			.click();
 		await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
-		await page.click(
-			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Paragraph' } )
+			.click();
 		await page.keyboard.type( 'Group Block with a Paragraph' );
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -197,7 +197,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( innerElement ).toBeVisible();
 
 			// Test: submenu closes on click outside submenu
-			await page.click( 'body' );
+			await page.locator( 'body' ).click();
 			await expect( innerElement ).toBeHidden();
 
 			// Test: nested submenu opens on click
@@ -212,7 +212,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( secondLevelElement ).toBeVisible();
 
 			// Test: nested submenus close on click outside submenu
-			await page.click( 'body' );
+			await page.locator( 'body' ).click();
 			await expect( firstLevelElement ).toBeHidden();
 			await expect( secondLevelElement ).toBeHidden();
 
@@ -350,7 +350,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( secondLevelElement ).toBeHidden();
 
 			// Close the menu via click on the body
-			await page.click( 'body' );
+			await page.locator( 'body' ).click();
 			await expect( firstLevelElement ).toBeHidden();
 
 			// Test: nested submenu closes on ESC key and focuses parent menu item:
@@ -445,7 +445,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( secondLevelElement ).toBeHidden();
 
 			// Close menu via click on the body
-			await page.click( 'body' );
+			await page.locator( 'body' ).click();
 			await expect( firstLevelElement ).toBeHidden();
 			await expect( secondLevelElement ).toBeHidden();
 		} );
@@ -503,7 +503,7 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await expect( innerElement ).toBeVisible();
 
 			// page-list submenu closes on click outside
-			await page.click( 'body' );
+			await page.locator( 'body' ).click();
 			await expect( innerElement ).toBeHidden();
 
 			// page-list submenu opens on enter keypress

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1088,10 +1088,10 @@ test.describe( 'Navigation block', () => {
 			await admin.visitAdminPage( 'options-permalink.php' );
 
 			// Select the Post name permalink structure (/%postname%/)
-			await page.click( '#permalink-input-post-name' );
+			await page.locator( '#permalink-input-post-name' ).click();
 
 			// Click Save Changes
-			await page.click( '#submit' );
+			await page.locator( '#submit' ).click();
 
 			// Wait for settings to be saved
 			await page.waitForSelector( '.notice-success' );
@@ -1129,10 +1129,10 @@ test.describe( 'Navigation block', () => {
 			await admin.visitAdminPage( 'options-permalink.php' );
 
 			// Select Plain permalinks
-			await page.click( '#permalink-input-plain' );
+			await page.locator( '#permalink-input-plain' ).click();
 
 			// Click Save Changes
-			await page.click( '#submit' );
+			await page.locator( '#submit' ).click();
 
 			// Wait for settings to be saved
 			await page.waitForSelector( '.notice-success' );

--- a/test/e2e/specs/editor/blocks/table.spec.js
+++ b/test/e2e/specs/editor/blocks/table.spec.js
@@ -101,9 +101,10 @@ test.describe( 'Table', () => {
 			.click();
 
 		// Expect the header and footer switches to be present now that the table has been created.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
 		await expect( headerSwitch ).toBeVisible();
 		await expect( footerSwitch ).toBeVisible();
 
@@ -156,9 +157,10 @@ test.describe( 'Table', () => {
 			.click();
 
 		// Toggle on the switches and add some content.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
 		await page.locator( 'role=checkbox[name="Header section"i]' ).check();
 		await page.locator( 'role=checkbox[name="Footer section"i]' ).check();
 		await editor.canvas
@@ -167,7 +169,9 @@ test.describe( 'Table', () => {
 
 		// Add a column.
 		await editor.clickBlockToolbarButton( 'Edit table' );
-		await page.click( 'role=menuitem[name="Insert column after"i]' );
+		await page
+			.getByRole( 'menuitem', { name: 'Insert column after' } )
+			.click();
 
 		// Expect the table to have 3 columns across the header, body and footer.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
@@ -178,7 +182,7 @@ test.describe( 'Table', () => {
 
 		// Delete a column.
 		await editor.clickBlockToolbarButton( 'Edit table' );
-		await page.click( 'role=menuitem[name="Delete column"i]' );
+		await page.getByRole( 'menuitem', { name: 'Delete column' } ).click();
 
 		// Expect the table to have 2 columns across the header, body and footer.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
@@ -209,19 +213,25 @@ test.describe( 'Table', () => {
 		await cells.nth( 1 ).click();
 		await page.keyboard.type( 'To the left' );
 		await editor.clickBlockToolbarButton( 'Align column content' );
-		await page.click( 'role=menuitemradio[name="Align column left"i]' );
+		await page
+			.getByRole( 'menuitemradio', { name: 'Align column left' } )
+			.click();
 
 		// Click the next cell and add some text. Align center.
 		await cells.nth( 2 ).click();
 		await page.keyboard.type( 'Centered' );
 		await editor.clickBlockToolbarButton( 'Align column content' );
-		await page.click( 'role=menuitemradio[name="Align column center"i]' );
+		await page
+			.getByRole( 'menuitemradio', { name: 'Align column center' } )
+			.click();
 
 		// Tab to the next cell and add some text. Align right.
 		await cells.nth( 3 ).click();
 		await page.keyboard.type( 'Right aligned' );
 		await editor.clickBlockToolbarButton( 'Align column content' );
-		await page.click( 'role=menuitemradio[name="Align column right"i]' );
+		await page
+			.getByRole( 'menuitemradio', { name: 'Align column right' } )
+			.click();
 
 		// Expect the post to have the correct alignment classes inside the table.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
@@ -241,9 +251,10 @@ test.describe( 'Table', () => {
 			.click();
 
 		// Enable fixed width as it exacerbates the amount of empty space around the RichText.
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
 		await page
 			.locator( 'role=checkbox[name="Fixed width table cells"i]' )
 			.check();

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -26,9 +26,10 @@ test.describe( 'Using Hooks API', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
 		await expect(
 			page.locator( 'role=button[name="Reset Block"i]' )
 		).toBeVisible();
@@ -48,10 +49,11 @@ test.describe( 'Using Hooks API', () => {
 			'role=document[name="Block: Paragraph"i]'
 		);
 		await expect( paragraphBlock ).toHaveText( 'First paragraph' );
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
-		await page.click( 'role=button[name="Reset Block"i]' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
+		await page.getByRole( 'button', { name: 'Reset Block' } ).click();
 		expect( await editor.getEditedPostContent() ).toEqual( '' );
 	} );
 } );

--- a/test/e2e/specs/editor/plugins/image-size.spec.js
+++ b/test/e2e/specs/editor/plugins/image-size.spec.js
@@ -42,9 +42,11 @@ test.describe( 'changing image size', () => {
 		// Select the new size updated with the plugin.
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'tab', { name: 'Settings' } ).click();
-		await page.selectOption( 'role=combobox[name="Resolution"i]', {
-			label: 'Custom Size One',
-		} );
+		await page
+			.getByRole( 'combobox', { name: 'Resolution' } )
+			.selectOption( {
+				label: 'Custom Size One',
+			} );
 
 		// Verify that the custom size was applied to the image.
 		await expect(

--- a/test/e2e/specs/editor/plugins/register-block-type-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/register-block-type-hooks.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Register block type hooks', () => {
 	} );
 
 	test( 'has a custom category for Paragraph block', async ( { page } ) => {
-		await page.click( 'role=button[name="Block Inserter"i]' );
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		expect(
 			page.locator(

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -102,7 +102,9 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'access+h' );
 
 		// Click a non-focusable element before the first tabbable within the modal.
-		await page.click( 'role=heading[name="Keyboard shortcuts"i]' );
+		await page
+			.getByRole( 'heading', { name: 'Keyboard shortcuts' } )
+			.click();
 
 		await pageUtils.pressKeys( 'shift+Tab' );
 
@@ -132,14 +134,16 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		// this behavior.
 
 		// Open the top bar Options menu.
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
 
 		// Open the Preferences modal.
-		await page.click(
-			'role=menu[name="Options"i] >> role=menuitem[name="Preferences"i]'
-		);
+		await page
+			.getByRole( 'menu', { name: 'Options' } )
+			.getByRole( 'menuitem', { name: 'Preferences' } )
+			.click();
 
 		const preferencesModal = page.locator(
 			'role=dialog[name="Preferences"i]'
@@ -213,10 +217,9 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		// that doesn't exist. The content only shows 'No blocks found' and it's
 		// not scrollable any longer. Check it's not focusable.
 		await clickAndFocusTab( blocksTab );
-		await page.type(
-			'role=searchbox[name="Search for a block"i]',
-			'qwerty'
-		);
+		await page
+			.getByRole( 'searchbox', { name: 'Search for a block' } )
+			.type( 'qwerty' );
 		await clickAndFocusTab( blocksTab );
 		await pageUtils.pressKeys( 'Shift+Tab' );
 		await expect( closeButton ).toBeFocused();

--- a/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
+++ b/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
@@ -29,8 +29,8 @@ test.describe( 'adding inline tokens', () => {
 		await page.keyboard.type( 'a ' );
 
 		await editor.showBlockToolbar();
-		await page.click( 'role=button[name="More"i]' );
-		await page.click( 'role=menuitem[name="Inline image"i]' );
+		await page.getByRole( 'button', { name: 'More' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Inline image' } ).click();
 
 		const testImagePath = './assets/10x10_e2e_test_image_z9T8jK.png';
 		const fileName = randomUUID();
@@ -41,7 +41,9 @@ test.describe( 'adding inline tokens', () => {
 			.setInputFiles( tmpFileName );
 
 		// Insert the uploaded image.
-		await page.click( 'role=button[name="Select"i]' );
+		await page
+			.getByRole( 'button', { name: 'Select', exact: true } )
+			.click();
 
 		// Check the content.
 		const contentRegex = new RegExp(
@@ -60,9 +62,11 @@ test.describe( 'adding inline tokens', () => {
 		await expect(
 			page.locator( 'role=spinbutton[name="Width"i]' )
 		).toBeFocused();
-		await page.fill( 'role=spinbutton[name="Width"i]', '20' );
-		await page.fill( 'role=textbox[name="Alternative text"i]', 'Alt' );
-		await page.click( 'role=button[name="Apply"i]' );
+		await page.getByRole( 'spinbutton', { name: 'Width' } ).fill( '20' );
+		await page
+			.getByRole( 'textbox', { name: 'Alternative text' } )
+			.fill( 'Alt' );
+		await page.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// Check the content.
 		const contentRegex2 = new RegExp(

--- a/test/e2e/specs/editor/various/adding-patterns.spec.js
+++ b/test/e2e/specs/editor/various/adding-patterns.spec.js
@@ -12,10 +12,10 @@ test.describe( 'adding patterns', () => {
 		await page.getByLabel( 'Block Inserter' ).click();
 
 		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			'Standard'
-		);
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Standard' );
 
 		await page.getByRole( 'option', { name: 'Standard' } ).click();
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -16,8 +16,12 @@ test.describe( 'Block Locking', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-		await page.click( 'role=checkbox[name="Lock removal"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock removal', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		await expect(
 			page.locator( 'role=menuitem[name="Delete"]' )
@@ -35,8 +39,12 @@ test.describe( 'Block Locking', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-		await page.click( 'role=checkbox[name="Lock movement"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock movement', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		// Hide options.
 		await editor.clickBlockToolbarButton( 'Options' );
@@ -58,8 +66,12 @@ test.describe( 'Block Locking', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-		await page.click( 'role=checkbox[name="Lock all"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock all', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		expect( await editor.getEditedPostContent() )
 			.toBe( `<!-- wp:paragraph {"lock":{"move":true,"remove":true}} -->
@@ -75,12 +87,20 @@ test.describe( 'Block Locking', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-		await page.click( 'role=checkbox[name="Lock all"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock all', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		await editor.clickBlockToolbarButton( 'Unlock' );
-		await page.click( 'role=checkbox[name="Lock all"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock all', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		await expect(
 			page
@@ -123,8 +143,12 @@ test.describe( 'Block Locking', () => {
 		await paragraph.click();
 
 		await editor.clickBlockToolbarButton( 'Unlock' );
-		await page.click( 'role=checkbox[name="Lock all"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock all', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		await expect(
 			page

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -107,8 +107,12 @@ test.describe( 'Block Switcher', () => {
 		await expect( button ).toBeEnabled();
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
-		await page.click( 'role=checkbox[name="Lock removal"]' );
-		await page.click( 'role=button[name="Apply"]' );
+		await page
+			.getByRole( 'checkbox', { name: 'Lock removal', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
 
 		// Verify the block switcher isn't enabled.
 		await expect( button ).toBeDisabled();

--- a/test/e2e/specs/editor/various/duplicating-blocks.spec.js
+++ b/test/e2e/specs/editor/various/duplicating-blocks.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Duplicating blocks', () => {
 
 		// Test: Duplicate using the block settings menu.
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name=/Duplicate/i]' );
+		await page.getByRole( 'menuitem', { name: /Duplicate/i } ).click();
 
 		expect( await editor.getEditedPostContent() ).toBe(
 			`<!-- wp:paragraph -->

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -28,10 +28,11 @@ test.describe( 'Font Size Picker', () => {
 				.locator( 'role=button[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "small"' );
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
-			);
-			await page.click( 'role=spinbutton[name="Font size"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Set custom size' } )
+				.click();
+			await page.getByRole( 'spinbutton', { name: 'Font size' } ).click();
 
 			await page.keyboard.type( '23' );
 
@@ -51,10 +52,11 @@ test.describe( 'Font Size Picker', () => {
 				.locator( 'role=button[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph reset - custom size' );
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
-			);
-			await page.click( 'role=spinbutton[name="Font size"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Set custom size' } )
+				.click();
+			await page.getByRole( 'spinbutton', { name: 'Font size' } ).click();
 			await page.keyboard.type( '23' );
 
 			await expect.poll( editor.getEditedPostContent )
@@ -143,9 +145,10 @@ test.describe( 'Font Size Picker', () => {
 				.locator( 'role=button[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "large"' );
-			await page.click(
-				'role=group[name="Font size"i] >> role=combobox[name="Font size"i]'
-			);
+			await page
+				.getByRole( 'group', { name: 'Font size' } )
+				.getByRole( 'combobox', { name: 'Font size' } )
+				.click();
 			await pageUtils.pressKeys( 'ArrowDown', { times: 4 } );
 			await page.keyboard.press( 'Enter' );
 
@@ -167,9 +170,10 @@ test.describe( 'Font Size Picker', () => {
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
 			);
-			await page.click(
-				'role=group[name="Font size"i] >> role=combobox[name="Font size"i]'
-			);
+			await page
+				.getByRole( 'group', { name: 'Font size' } )
+				.getByRole( 'combobox', { name: 'Font size' } )
+				.click();
 			await pageUtils.pressKeys( 'ArrowDown', { times: 3 } );
 			await page.keyboard.press( 'Enter' );
 
@@ -178,8 +182,10 @@ test.describe( 'Font Size Picker', () => {
 <p class="has-medium-font-size">Paragraph with font size reset using tools panel menu</p>
 <!-- /wp:paragraph -->` );
 
-			await page.click( 'role=button[name="Typography options"i]' );
-			await page.click( 'role=menuitem[name="Reset Size"i]' );
+			await page
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Reset Size' } ).click();
 			await page.keyboard.press( 'Escape' ); // Close the menu
 
 			await expect.poll( editor.getEditedPostContent )
@@ -200,9 +206,10 @@ test.describe( 'Font Size Picker', () => {
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'
 			);
-			await page.click(
-				'role=group[name="Font size"i] >> role=combobox[name="Font size"i]'
-			);
+			await page
+				.getByRole( 'group', { name: 'Font size' } )
+				.getByRole( 'combobox', { name: 'Font size' } )
+				.click();
 			await pageUtils.pressKeys( 'ArrowDown', { times: 2 } );
 			await page.keyboard.press( 'Enter' );
 
@@ -211,10 +218,11 @@ test.describe( 'Font Size Picker', () => {
 <p class="has-small-font-size">Paragraph with font size reset using input field</p>
 <!-- /wp:paragraph -->` );
 
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
-			);
-			await page.click( 'role=spinbutton[name="Font size"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Set custom size' } )
+				.click();
+			await page.getByRole( 'spinbutton', { name: 'Font size' } ).click();
 			await pageUtils.pressKeys( 'primary+A' );
 			await page.keyboard.press( 'Backspace' );
 
@@ -235,9 +243,10 @@ test.describe( 'Font Size Picker', () => {
 				.locator( 'role=button[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "large"' );
-			await page.click(
-				'role=radiogroup[name="Font size"i] >> role=radio[name="Large"i]'
-			);
+			await page
+				.getByRole( 'radiogroup', { name: 'Font size' } )
+				.getByRole( 'radio', { name: 'Large', exact: true } )
+				.click();
 
 			await expect.poll( editor.getEditedPostContent )
 				.toBe( `<!-- wp:paragraph {"fontSize":"large"} -->
@@ -256,17 +265,20 @@ test.describe( 'Font Size Picker', () => {
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
 			);
-			await page.click(
-				'role=radiogroup[name="Font size"i] >> role=radio[name="Small"i]'
-			);
+			await page
+				.getByRole( 'radiogroup', { name: 'Font size' } )
+				.getByRole( 'radio', { name: 'Small' } )
+				.click();
 
 			await expect.poll( editor.getEditedPostContent )
 				.toBe( `<!-- wp:paragraph {"fontSize":"small"} -->
 <p class="has-small-font-size">Paragraph with font size reset using tools panel menu</p>
 <!-- /wp:paragraph -->` );
 
-			await page.click( 'role=button[name="Typography options"i]' );
-			await page.click( 'role=menuitem[name="Reset Size"i]' );
+			await page
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Reset Size' } ).click();
 			await page.keyboard.press( 'Escape' ); // Close the menu
 
 			await expect.poll( editor.getEditedPostContent )
@@ -287,19 +299,21 @@ test.describe( 'Font Size Picker', () => {
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'
 			);
-			await page.click(
-				'role=radiogroup[name="Font size"i] >> role=radio[name="Small"i]'
-			);
+			await page
+				.getByRole( 'radiogroup', { name: 'Font size' } )
+				.getByRole( 'radio', { name: 'Small' } )
+				.click();
 
 			await expect.poll( editor.getEditedPostContent )
 				.toBe( `<!-- wp:paragraph {"fontSize":"small"} -->
 <p class="has-small-font-size">Paragraph with font size reset using input field</p>
 <!-- /wp:paragraph -->` );
 
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
-			);
-			await page.click( 'role=spinbutton[name="Font size"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Set custom size' } )
+				.click();
+			await page.getByRole( 'spinbutton', { name: 'Font size' } ).click();
 			await pageUtils.pressKeys( 'primary+A' );
 			await page.keyboard.press( 'Backspace' );
 

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -6,7 +6,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 async function getFootnotes( page, withoutSave = false ) {
 	// Save post so we can check meta.
 	if ( ! withoutSave ) {
-		await page.click( 'button:text("Save draft")' );
+		await page.getByRole( 'button', { name: 'Save draft' } ).click();
 	}
 	await page.waitForSelector( 'button:text("Saved")' );
 	const footnotes = await page.evaluate( () => {

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -103,18 +103,20 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
+			.click();
 
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			'Heading'
-		);
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Heading' );
 
-		await page.hover(
-			'role=listbox[name="Blocks"i] >> role=option[name="Heading"i]'
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Heading', exact: true } )
+			.hover();
 		const paragraphBoundingBox = await paragraphBlock.boundingBox();
 
 		await expect( insertingBlocksUtils.indicator ).toBeVisible();
@@ -174,18 +176,20 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
+			.click();
 
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			'Heading'
-		);
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Heading' );
 
-		await page.hover(
-			'role=listbox[name="Blocks"i] >> role=option[name="Heading"i]'
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Heading', exact: true } )
+			.hover();
 		const paragraphBoundingBox = await paragraphBlock.boundingBox();
 
 		await page.mouse.down();
@@ -239,20 +243,22 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
+			.click();
 
 		const PATTERN_NAME = 'Standard';
 
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			PATTERN_NAME
-		);
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( PATTERN_NAME );
 
-		await page.hover(
-			`role=listbox[name="Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Patterns' } )
+			.getByRole( 'option', { name: PATTERN_NAME } )
+			.hover();
 
 		// FIXME: I think we should show the indicator when hovering on patterns as well?
 		// @see https://github.com/WordPress/gutenberg/issues/45183
@@ -337,16 +343,18 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'ArrowUp' );
 
 		// Insert a synced pattern.
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
-		);
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			PATTERN_NAME
-		);
-		await page.hover(
-			`role=listbox[name="Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( PATTERN_NAME );
+		await page
+			.getByRole( 'listbox', { name: 'Patterns' } )
+			.getByRole( 'option', { name: PATTERN_NAME } )
+			.hover();
 
 		const paragraphBoundingBox = await paragraphBlock.boundingBox();
 
@@ -409,20 +417,22 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'[data-type="core/paragraph"] >> text=Dummy text'
 		);
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
+			.click();
 
 		const PATTERN_NAME = 'Standard';
 
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			PATTERN_NAME
-		);
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( PATTERN_NAME );
 
-		await page.hover(
-			`role=listbox[name="Patterns"i] >> role=option[name="${ PATTERN_NAME }"i]`
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Patterns' } )
+			.getByRole( 'option', { name: PATTERN_NAME } )
+			.hover();
 
 		const paragraphBoundingBox = await paragraphBlock.boundingBox();
 

--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Keep styles on block transforms', () => {
 			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Heading 2' } )
 			.click();
-		await page.click( 'role=menuitem[name="Paragraph"i]' );
+		await page.getByRole( 'menuitem', { name: 'Paragraph' } ).click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -64,9 +64,11 @@ test.describe( 'Keep styles on block transforms', () => {
 		await page.keyboard.type( 'Line 3 to be made large' );
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
-		await page.click( 'role=radio[name="Large"i]' );
-		await page.click( 'role=button[name="Multiple blocks selected"i]' );
-		await page.click( 'role=menuitem[name="Heading"i]' );
+		await page.getByRole( 'radio', { name: 'Large', exact: true } ).click();
+		await page
+			.getByRole( 'button', { name: 'Multiple blocks selected' } )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'Heading' } ).click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
@@ -93,10 +95,10 @@ test.describe( 'Keep styles on block transforms', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Line 1 to be made large' );
-		await page.click( 'role=radio[name="Large"i]' );
+		await page.getByRole( 'radio', { name: 'Large', exact: true } ).click();
 		await editor.showBlockToolbar();
-		await page.click( 'role=button[name="Paragraph"i]' );
-		await page.click( 'role=menuitem[name="Group"i]' );
+		await page.getByRole( 'button', { name: 'Paragraph' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Group' } ).click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/manage-reusable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/manage-reusable-blocks.spec.js
@@ -12,14 +12,18 @@ test.describe( 'Managing reusable blocks', () => {
 		const originalEntries = await page.locator( '.hentry' ).count();
 
 		// Import Reusable block.
-		await page.click( 'role=button[name="Import from JSON"i]' );
+		await page.getByRole( 'button', { name: 'Import from JSON' } ).click();
 
 		// Select the file to upload.
 		const testReusableBlockFile = './assets/greeting-reusable-block.json';
-		await page.setInputFiles( 'input[type="file"]', testReusableBlockFile );
+		await page
+			.locator( 'input[type="file"]' )
+			.setInputFiles( testReusableBlockFile );
 
 		// Submit the form.
-		await page.click( 'role=button[name="Import"i]' );
+		await page
+			.getByRole( 'button', { name: 'Import', exact: true } )
+			.click();
 
 		// Wait for the success notice.
 		await expect(

--- a/test/e2e/specs/editor/various/parsing-patterns.spec.js
+++ b/test/e2e/specs/editor/various/parsing-patterns.spec.js
@@ -43,10 +43,10 @@ test.describe( 'Parsing patterns', () => {
 			editor.canvas.locator( 'role=document[name="Block: Button"i]' )
 		);
 
-		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
-			'whitespace'
-		);
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'whitespace' );
 		await page
 			.locator( 'role=option[name="Pattern with top-level whitespace"i]' )
 			.click();

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -67,7 +67,7 @@ test.describe( 'Post Editor Template mode', () => {
 		);
 
 		// Save changes.
-		await page.click( 'role=button[name="Back"i]' );
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Save', exact: true } )
@@ -264,7 +264,9 @@ class PostEditorTemplateMode {
 	}
 
 	async saveTemplateWithoutPublishing() {
-		await this.page.click( 'role=button[name="Back"i]' );
+		await this.page
+			.getByRole( 'button', { name: 'Back', exact: true } )
+			.click();
 		await this.page
 			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Save', exact: true } )

--- a/test/e2e/specs/editor/various/post-title.spec.js
+++ b/test/e2e/specs/editor/various/post-title.spec.js
@@ -184,7 +184,7 @@ test.describe( 'Post title', () => {
 				} )
 			).toBeVisible();
 
-			const pageTitleField = page.getByRole( 'textbox', {
+			const titleField = page.getByRole( 'textbox', {
 				name: 'Add title',
 			} );
 
@@ -195,11 +195,11 @@ test.describe( 'Post title', () => {
 			} );
 
 			// focus on the title field
-			await pageTitleField.focus();
+			await titleField.focus();
 
 			await pageUtils.pressKeys( 'primary+v' );
 
-			await expect( pageTitleField ).toHaveText(
+			await expect( titleField ).toHaveText(
 				'I am <em>emphasis</em> I am <strong>bold</strong> I am <a href="#">anchor</a>'
 			);
 		} );

--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -47,10 +47,15 @@ test.describe( 'Post visibility', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		// Set a publish date for the next month.
-		await page.click( 'role=button[name="Change date: Immediately"i]' );
+		await page
+			.getByRole( 'button', { name: 'Change date: Immediately' } )
+			.click();
 
-		await page.click( 'role=button[name="View next month"i]' );
-		await page.click( 'role=application[name="Calendar"] >> text=15' );
+		await page.getByRole( 'button', { name: 'View next month' } ).click();
+		await page
+			.getByRole( 'application', { name: 'Calendar', exact: true } )
+			.getByText( '15' )
+			.click();
 		await page
 			.locator( '.block-editor-publish-date-time-picker' )
 			.getByRole( 'button', {

--- a/test/e2e/specs/editor/various/pref-modal.spec.js
+++ b/test/e2e/specs/editor/various/pref-modal.spec.js
@@ -12,10 +12,11 @@ test.describe( 'Preferences modal', () => {
 		test( 'Enable pre-publish checks is visible on desktop', async ( {
 			page,
 		} ) => {
-			await page.click(
-				'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
-			);
-			await page.click( 'role=menuitem[name="Preferences"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Options' } )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Preferences' } ).click();
 
 			const prePublishToggle = page.locator(
 				'role=checkbox[name="Enable pre-publish checks"i]'
@@ -31,10 +32,11 @@ test.describe( 'Preferences modal', () => {
 		} ) => {
 			await page.setViewportSize( { width: 500, height: 800 } );
 
-			await page.click(
-				'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
-			);
-			await page.click( 'role=menuitem[name="Preferences"i]' );
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Options' } )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Preferences' } ).click();
 
 			const generalButton = page.locator(
 				'role=button[name="General"i]'

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -62,7 +62,7 @@ test.describe( 'Preview', () => {
 		await editor.publishPost();
 
 		// Close the panel.
-		await page.click( 'role=button[name="Close panel"i]' );
+		await page.getByRole( 'button', { name: 'Close panel' } ).click();
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
@@ -110,7 +110,7 @@ test.describe( 'Preview', () => {
 		await editorPage.keyboard.press( 'Tab' );
 
 		// Save the post as a draft.
-		await editorPage.click( 'role=button[name="Save draft"i]' );
+		await editorPage.getByRole( 'button', { name: 'Save draft' } ).click();
 		await editorPage.waitForSelector(
 			'role=button[name="Dismiss this notice"] >> text=Draft saved'
 		);
@@ -132,7 +132,7 @@ test.describe( 'Preview', () => {
 		await editorPage.keyboard.press( 'Tab' );
 
 		// Save draft and open the preview page right after.
-		await editorPage.click( 'role=button[name="Save draft"i]' );
+		await editorPage.getByRole( 'button', { name: 'Save draft' } ).click();
 		await editorPage.waitForSelector(
 			'role=button[name="Dismiss this notice"] >> text=Draft saved'
 		);
@@ -163,7 +163,7 @@ test.describe( 'Preview', () => {
 		await editor.publishPost();
 
 		// Close the panel.
-		await page.click( 'role=button[name="Close panel"i]' );
+		await page.getByRole( 'button', { name: 'Close panel' } ).click();
 
 		// Change the title and preview to trigger an autosave.
 		await editor.canvas
@@ -212,7 +212,7 @@ test.describe( 'Preview', () => {
 		await editor.publishPost();
 
 		// Close the panel.
-		await page.click( 'role=button[name="Close panel"i]' );
+		await page.getByRole( 'button', { name: 'Close panel' } ).click();
 
 		// Change the title and preview again.
 		await editor.canvas
@@ -303,7 +303,7 @@ test.describe( 'Preview with Custom Fields enabled', () => {
 		await editor.publishPost();
 
 		// Close the panel.
-		await page.click( 'role=button[name="Close panel"i]' );
+		await page.getByRole( 'button', { name: 'Close panel' } ).click();
 
 		// Open the preview page.
 		const previewPage = await editor.openPreviewPage();
@@ -357,7 +357,7 @@ test.describe( 'Preview with private custom post type', () => {
 		} );
 
 		// Open the view menu.
-		await page.click( 'role=button[name="View"i]' );
+		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 
 		await expect(
 			page.locator( 'role=menuitem[name="Preview in new tab"i]' )
@@ -379,7 +379,9 @@ class PreviewUtils {
 			await previewToggle.click();
 		}
 
-		await this.page.click( 'role=menuitem[name="Preview in new tab"i]' );
+		await this.page
+			.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+			.click();
 		// eslint-disable-next-line playwright/no-wait-for-navigation
 		return previewPage.waitForNavigation();
 	}
@@ -387,15 +389,19 @@ class PreviewUtils {
 	async toggleCustomFieldsOption( shouldBeChecked ) {
 		// Open preferences dialog.
 
-		await this.page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
-		);
-		await this.page.click( 'role=menuitem[name="Preferences"i]' );
+		await this.page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
+		await this.page
+			.getByRole( 'menuitem', { name: 'Preferences' } )
+			.click();
 
 		// Navigate to general section.
-		await this.page.click(
-			'role=dialog[name="Preferences"i] >> role=tab[name="General"i]'
-		);
+		await this.page
+			.getByRole( 'dialog', { name: 'Preferences' } )
+			.getByRole( 'tab', { name: 'General' } )
+			.click();
 
 		// Find custom fields checkbox.
 		const customFieldsCheckbox = this.page.locator(
@@ -420,8 +426,9 @@ class PreviewUtils {
 			return;
 		}
 
-		await this.page.click(
-			'role=dialog[name="Preferences"i] >> role=button[name="Close"i]'
-		);
+		await this.page
+			.getByRole( 'dialog', { name: 'Preferences' } )
+			.getByRole( 'button', { name: 'Close' } )
+			.click();
 	}
 }

--- a/test/e2e/specs/editor/various/style-variation.spec.js
+++ b/test/e2e/specs/editor/various/style-variation.spec.js
@@ -19,7 +19,7 @@ test.describe( 'adding blocks', () => {
 
 		await editor.clickBlockToolbarButton( 'Quote' );
 
-		await page.click( 'role=menuitem[name="Plain"i]' );
+		await page.getByRole( 'menuitem', { name: 'Plain' } ).click();
 
 		// Check the content
 		const content = await editor.getEditedPostContent();

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -62,7 +62,9 @@ test.describe( 'Toolbar roving tabindex', () => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'List' );
 		await ToolbarRovingTabindexUtils.focusBlockToolbar();
-		await page.click( `role=button[name="Select parent block: List"i]` );
+		await page
+			.getByRole( 'button', { name: 'Select parent block: List' } )
+			.click();
 		await ToolbarRovingTabindexUtils.wrapCurrentBlockWithGroup( 'List' );
 		await ToolbarRovingTabindexUtils.testGroupKeyboardNavigation(
 			'Block: List',
@@ -175,8 +177,12 @@ class ToolbarRovingTabindexUtils {
 	}
 
 	async wrapCurrentBlockWithGroup( currentBlockTitle ) {
-		await this.page.click( `role=button[name="${ currentBlockTitle }"i]` );
-		await this.page.click( `role=menuitem[name="Group"]` );
+		await this.page
+			.getByRole( 'button', { name: currentBlockTitle, exact: true } )
+			.click();
+		await this.page
+			.getByRole( 'menuitem', { name: 'Group', exact: true } )
+			.click();
 	}
 
 	async testGroupKeyboardNavigation(

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -475,7 +475,7 @@ test.describe( 'undo', () => {
 		await expect(
 			page.locator( 'role=button[name="Redo"]' )
 		).toBeEnabled();
-		await page.click( 'role=button[name="Redo"]' );
+		await page.getByRole( 'button', { name: 'Redo', exact: true } ).click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1422,9 +1422,10 @@ class WritingFlowUtils {
 		} );
 		await firstColumn.focus();
 		await firstColumn.getByRole( 'button', { name: 'Add block' } ).click();
-		await this.page.click(
-			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
-		);
+		await this.page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Paragraph' } )
+			.click();
 		await this.page.keyboard.type( '1st col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "1st" instead of "First" here.
 
 		await this.editor.canvas
@@ -1433,9 +1434,10 @@ class WritingFlowUtils {
 		await this.editor.canvas
 			.locator( 'role=button[name="Add block"i]' )
 			.click();
-		await this.page.click(
-			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
-		);
+		await this.page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Paragraph' } )
+			.click();
 		await this.page.keyboard.type( '2nd col' ); // If this text is too long, it may wrap to a new line and cause test failure. That's why we're using "2nd" instead of "Second" here.
 		await this.editor.showBlockToolbar();
 		await this.page.keyboard.press( 'Shift+Tab' ); // Move to toolbar to select parent

--- a/test/e2e/specs/interactivity/async-actions.spec.ts
+++ b/test/e2e/specs/interactivity/async-actions.spec.ts
@@ -8,9 +8,11 @@ test.describe( 'async actions', () => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/generator-scope' );
 	} );
+
 	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
 		await page.goto( utils.getLink( 'test/generator-scope' ) );
 	} );
+
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
 		await utils.deactivatePlugins();
 		await utils.deleteAllPosts();

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -8,9 +8,11 @@ test.describe( 'deferred store', () => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/deferred-store' );
 	} );
+
 	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
 		await page.goto( utils.getLink( 'test/deferred-store' ) );
 	} );
+
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
 		await utils.deactivatePlugins();
 		await utils.deleteAllPosts();

--- a/test/e2e/specs/interactivity/directive-on-document.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-document.spec.ts
@@ -65,6 +65,7 @@ test.describe( 'data-wp-on-document', () => {
 		await page.keyboard.press( 'ArrowDown' );
 		await expect( counter ).toHaveText( '2' );
 	} );
+
 	test( 'should work with multiple event handlers on the same event type', async ( {
 		page,
 	} ) => {

--- a/test/e2e/specs/interactivity/directive-on-window.spec.ts
+++ b/test/e2e/specs/interactivity/directive-on-window.spec.ts
@@ -65,6 +65,7 @@ test.describe( 'data-wp-on-window', () => {
 		await page.setViewportSize( { width: 200, height: 600 } );
 		await expect( counter ).toHaveText( '2' );
 	} );
+
 	test( 'should work with multiple event handlers on the same event type', async ( {
 		page,
 	} ) => {

--- a/test/e2e/specs/interactivity/directive-text.spec.ts
+++ b/test/e2e/specs/interactivity/directive-text.spec.ts
@@ -8,9 +8,11 @@ test.describe( 'data-wp-text', () => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/directive-text' );
 	} );
+
 	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
 		await page.goto( utils.getLink( 'test/directive-text' ) );
 	} );
+
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
 		await utils.deactivatePlugins();
 		await utils.deleteAllPosts();

--- a/test/e2e/specs/interactivity/tovdom-islands.spec.ts
+++ b/test/e2e/specs/interactivity/tovdom-islands.spec.ts
@@ -8,9 +8,11 @@ test.describe( 'toVdom - islands', () => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/tovdom-islands' );
 	} );
+
 	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
 		await page.goto( utils.getLink( 'test/tovdom-islands' ) );
 	} );
+
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
 		await utils.deactivatePlugins();
 		await utils.deleteAllPosts();

--- a/test/e2e/specs/interactivity/tovdom.spec.ts
+++ b/test/e2e/specs/interactivity/tovdom.spec.ts
@@ -8,9 +8,11 @@ test.describe( 'toVdom', () => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/tovdom' );
 	} );
+
 	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
 		await page.goto( utils.getLink( 'test/tovdom' ) );
 	} );
+
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
 		await utils.deactivatePlugins();
 		await utils.deleteAllPosts();

--- a/test/e2e/specs/interactivity/with-scope.spec.ts
+++ b/test/e2e/specs/interactivity/with-scope.spec.ts
@@ -8,9 +8,11 @@ test.describe( 'withScope', () => {
 		await utils.activatePlugins();
 		await utils.addPostWithBlock( 'test/with-scope' );
 	} );
+
 	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
 		await page.goto( utils.getLink( 'test/with-scope' ) );
 	} );
+
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
 		await utils.deactivatePlugins();
 		await utils.deleteAllPosts();

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -339,17 +339,19 @@ async function addPageContent( editor, page ) {
 		'role=button[name="Block Inserter"i]'
 	);
 	await inserterButton.click();
-	await page.type( 'role=searchbox[name="Search"i]', 'Group' );
-	await page.click(
-		'role=listbox[name="Blocks"i] >> role=option[name="Group"i]'
-	);
+	await page.getByRole( 'searchbox', { name: 'Search' } ).type( 'Group' );
+	await page
+		.getByRole( 'listbox', { name: 'Blocks' } )
+		.getByRole( 'option', { name: 'Group' } )
+		.click();
 	await editor.canvas
 		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
 		.click();
 	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
-	await page.click(
-		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
-	);
+	await page
+		.getByRole( 'listbox', { name: 'Blocks' } )
+		.getByRole( 'option', { name: 'Paragraph' } )
+		.click();
 	await page.keyboard.type( 'Parent Group Block with a Paragraph' );
 	await page.keyboard.press( 'Enter' );
 	await page.keyboard.type( '/group' );
@@ -361,9 +363,10 @@ async function addPageContent( editor, page ) {
 		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
 		.click();
 	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
-	await page.click(
-		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
-	);
+	await page
+		.getByRole( 'listbox', { name: 'Blocks' } )
+		.getByRole( 'option', { name: 'Paragraph' } )
+		.click();
 	await page.keyboard.type( 'Child Group Block with a Paragraph' );
 	await page.keyboard.press( 'Enter' );
 	await page.keyboard.type( '/group' );
@@ -375,9 +378,10 @@ async function addPageContent( editor, page ) {
 		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
 		.click();
 	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
-	await page.click(
-		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
-	);
+	await page
+		.getByRole( 'listbox', { name: 'Blocks' } )
+		.getByRole( 'option', { name: 'Paragraph' } )
+		.click();
 	await page.keyboard.type( 'Grandchild Group Block with a Paragraph' );
 	await page.getByRole( 'button', { name: 'Publish', exact: true } ).click();
 }

--- a/test/e2e/specs/site-editor/browser-history.spec.js
+++ b/test/e2e/specs/site-editor/browser-history.spec.js
@@ -18,7 +18,9 @@ test.describe( 'Site editor browser history', () => {
 		await expect( page ).toHaveURL( 'wp-admin/site-editor.php' );
 
 		// Navigate to a single template
-		await page.click( 'role=button[name="Templates"]' );
+		await page
+			.getByRole( 'button', { name: 'Templates', exact: true } )
+			.click();
 		await page
 			.locator( '.fields-field__title', { hasText: 'Index' } )
 			.click();

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -42,8 +42,10 @@ test.describe( 'Site editor url navigation', () => {
 		} );
 
 		await admin.visitSiteEditor();
-		await page.click( 'role=button[name="Templates"]' );
-		await page.click( 'role=button[name="Add Template"i]' );
+		await page
+			.getByRole( 'button', { name: 'Templates', exact: true } )
+			.click();
+		await page.getByRole( 'button', { name: 'Add Template' } ).click();
 		const singleItemPost = page.getByRole( 'button', {
 			name: 'Single item: Post',
 		} );
@@ -63,14 +65,17 @@ test.describe( 'Site editor url navigation', () => {
 		page,
 	} ) => {
 		await admin.visitSiteEditor();
-		await page.click( 'role=button[name="Patterns"i]' );
-		await page.click( 'role=button[name="add pattern"i]' );
+		await page.getByRole( 'button', { name: 'Patterns' } ).click();
+		await page.getByRole( 'button', { name: 'add pattern' } ).click();
 		await page
 			.getByRole( 'menu', { name: 'add pattern' } )
 			.getByRole( 'menuitem', { name: 'add template part' } )
 			.click();
 		// Fill in a name in the dialog that pops up.
-		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Demo' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'textbox', { name: 'Name' } )
+			.type( 'Demo' );
 		await page.keyboard.press( 'Enter' );
 		await expect( page ).toHaveURL(
 			'/wp-admin/site-editor.php?p=%2Fwp_template_part%2Femptytheme%2F%2Fdemo&canvas=edit'

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -56,7 +56,7 @@ test.describe( 'Style Book', () => {
 			} )
 		).toBeVisible();
 
-		await page.click( 'role=tab[name="Media"i]' );
+		await page.getByRole( 'tab', { name: 'Media' } ).click();
 
 		await expect(
 			styleBookIframe.getByRole( 'button', {
@@ -90,8 +90,12 @@ test.describe( 'Style Book', () => {
 	test( 'should allow to return Global Styles root when example is clicked', async ( {
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Blocks"]' );
-		await page.click( 'role=button[name="Heading"]' );
+		await page
+			.getByRole( 'button', { name: 'Blocks', exact: true } )
+			.click();
+		await page
+			.getByRole( 'button', { name: 'Heading', exact: true } )
+			.click();
 
 		await page
 			.frameLocator( '[name="style-book-canvas"]' )
@@ -100,8 +104,8 @@ test.describe( 'Style Book', () => {
 			} )
 			.click();
 
-		await page.click( 'role=button[name="Back"]' );
-		await page.click( 'role=button[name="Back"]' );
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
 
 		await expect(
 			page.locator( 'role=button[name="Blocks"]' )
@@ -154,7 +158,7 @@ test.describe( 'Style Book', () => {
 			'style book should be visible'
 		).toBeVisible();
 
-		await page.click( 'role=button[name="Back"]' );
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
 
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -77,9 +77,9 @@ test.describe( 'Global styles variations', () => {
 			canvas: 'edit',
 		} );
 		await siteEditorStyleVariations.browseStyles();
-		await page.click( 'role=button[name="pink"i]' );
-		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Background styles"i]' );
+		await page.getByRole( 'button', { name: 'pink' } ).click();
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Background styles' } ).click();
 
 		await expect(
 			page.locator(
@@ -87,9 +87,9 @@ test.describe( 'Global styles variations', () => {
 			)
 		).toHaveCSS( 'background', /rgb\(202, 105, 211\)/ );
 
-		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Typography"i]' );
-		await page.click( 'role=button[name="Text"i]' );
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Typography' } ).click();
+		await page.getByRole( 'button', { name: 'Text', exact: true } ).click();
 
 		await expect(
 			page.locator(
@@ -113,9 +113,9 @@ test.describe( 'Global styles variations', () => {
 			canvas: 'edit',
 		} );
 		await siteEditorStyleVariations.browseStyles();
-		await page.click( 'role=button[name="yellow"i]' );
-		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Background styles"i]' );
+		await page.getByRole( 'button', { name: 'yellow' } ).click();
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Background styles' } ).click();
 
 		await expect(
 			page.locator(
@@ -123,9 +123,9 @@ test.describe( 'Global styles variations', () => {
 			)
 		).toHaveCSS( 'background', /rgb\(255, 239, 11\)/ );
 
-		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Typography"i]' );
-		await page.click( 'role=button[name="Text"i]' );
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Typography' } ).click();
+		await page.getByRole( 'button', { name: 'Text', exact: true } ).click();
 
 		await expect(
 			page.locator(
@@ -149,10 +149,10 @@ test.describe( 'Global styles variations', () => {
 			canvas: 'edit',
 		} );
 		await siteEditorStyleVariations.browseStyles();
-		await page.click( 'role=button[name="pink"i]' );
-		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Colors"i]' );
-		await page.click( 'role=button[name="Edit palette"i]' );
+		await page.getByRole( 'button', { name: 'pink' } ).click();
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Colors' } ).click();
+		await page.getByRole( 'button', { name: 'Edit palette' } ).click();
 
 		await expect(
 			page.locator( 'role=option[name="Foreground"i]' )
@@ -179,7 +179,7 @@ test.describe( 'Global styles variations', () => {
 			canvas: 'edit',
 		} );
 		await siteEditorStyleVariations.browseStyles();
-		await page.click( 'role=button[name="yellow"i]' );
+		await page.getByRole( 'button', { name: 'yellow' } ).click();
 
 		const paragraph = editor.canvas.locator(
 			'text="My awesome paragraph"'
@@ -200,7 +200,9 @@ class SiteEditorStyleVariations {
 	}
 
 	async browseStyles() {
-		await this.page.click( 'role=button[name="Styles"i]' );
-		await this.page.click( 'role=button[name="Browse styles"i]' );
+		await this.page.getByRole( 'button', { name: 'Styles' } ).click();
+		await this.page
+			.getByRole( 'button', { name: 'Browse styles' } )
+			.click();
 	}
 }

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -37,7 +37,10 @@ test.describe( 'Template Part', () => {
 			.click();
 
 		// Fill in a name in the dialog that pops up.
-		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'New' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'textbox', { name: 'Name' } )
+			.type( 'New' );
 		await page.keyboard.press( 'Enter' );
 
 		// The template part should be visible with a block appender.
@@ -68,9 +71,10 @@ test.describe( 'Template Part', () => {
 		// Insert a new template block and choose an existing header pattern.
 		await editor.insertBlock( { name: 'core/template-part' } );
 		await editor.canvas.locator( 'role=button[name="Choose"i]' ).click();
-		await page.click(
-			'role=listbox[name="Patterns"i] >> role=option[name="header"i]'
-		);
+		await page
+			.getByRole( 'listbox', { name: 'Patterns' } )
+			.getByRole( 'option', { name: 'header' } )
+			.click();
 
 		// There are now two header template parts.
 		await expect( headerTemplateParts ).toHaveCount( 2 );
@@ -98,7 +102,10 @@ test.describe( 'Template Part', () => {
 
 		// Convert block to a template part.
 		await editor.clickBlockOptionsMenuItem( 'Create Template part' );
-		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Test' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'textbox', { name: 'Name' } )
+			.type( 'Test' );
 		await page.keyboard.press( 'Enter' );
 
 		await page.waitForSelector(
@@ -147,7 +154,10 @@ test.describe( 'Template Part', () => {
 
 		// Convert block to a template part.
 		await editor.clickBlockOptionsMenuItem( 'Create template part' );
-		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Test' );
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'textbox', { name: 'Name' } )
+			.type( 'Test' );
 		await page.keyboard.press( 'Enter' );
 
 		await page.waitForSelector(

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -57,9 +57,10 @@ test.describe( 'Template Revert', () => {
 			)
 			.isVisible();
 		if ( isTemplateTabVisible ) {
-			await page.click(
-				'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
-			);
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Template' } )
+				.click();
 		}
 
 		// The revert button isn't visible anymore.
@@ -136,9 +137,10 @@ test.describe( 'Template Revert', () => {
 		expect( contentAfterSave ).not.toEqual( contentBefore );
 
 		// Undo revert by clicking header button and check state again.
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Undo' } )
+			.click();
 		const contentAfterUndo =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 		expect( contentAfterUndo ).toEqual( contentBefore );
@@ -160,17 +162,19 @@ test.describe( 'Template Revert', () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 		await templateRevertUtils.revertTemplate();
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Undo' } )
+			.click();
 
 		const contentAfterUndo =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 		expect( contentAfterUndo ).not.toEqual( contentBefore );
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Redo"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Redo' } )
+			.click();
 
 		const contentAfterRedo =
 			await templateRevertUtils.getCurrentSiteEditorContent();
@@ -199,9 +203,10 @@ test.describe( 'Template Revert', () => {
 
 		await templateRevertUtils.revertTemplate();
 
-		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Undo' } )
+			.click();
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,
 		} );
@@ -227,14 +232,16 @@ class TemplateRevertUtils {
 			)
 			.isVisible();
 		if ( isTemplateTabVisible ) {
-			await this.page.click(
-				'role=region[name="Editor settings"i] >> role=tab[name="Template"i]'
-			);
+			await this.page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tab', { name: 'Template' } )
+				.click();
 		}
-		await this.page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Actions"i]'
-		);
-		await this.page.click( 'role=menuitem[name=/Reset/i]' );
+		await this.page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
+		await this.page.getByRole( 'menuitem', { name: /Reset/i } ).click();
 		await this.page.getByRole( 'button', { name: 'Reset' } ).click();
 		await this.page.waitForSelector(
 			'role=button[name="Dismiss this notice"i] >> text=/ reset./'

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -227,7 +227,7 @@ test.describe( 'Style Revisions', () => {
 			page.getByLabel( 'Global styles revisions list' )
 		).toBeVisible();
 
-		await page.click( 'role=button[name="Back"]' );
+		await page.getByRole( 'button', { name: 'Back', exact: true } ).click();
 
 		await expect(
 			page.getByLabel( 'Global styles revisions list' )

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -685,10 +685,7 @@ class WidgetsCustomizerPage {
 			.click();
 
 		await this.page
-			.getByRole( 'heading', {
-				name: new RegExp( widgetAreaName, 'i' ),
-				level: 3,
-			} )
+			.getByRole( 'heading', { name: widgetAreaName, level: 3 } )
 			.click();
 	}
 

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -74,9 +74,10 @@ test.describe( 'Widgets Customizer', () => {
 		).toBeVisible();
 
 		// Click on the inline appender.
-		await page.click(
-			'css=.editor-styles-wrapper >> role=button[name="Add block"i]'
-		);
+		await page
+			.locator( '.editor-styles-wrapper' )
+			.getByRole( 'button', { name: 'Add block' } )
+			.click();
 
 		const inlineInserterSearchBox = page.locator(
 			'role=searchbox[name="Search"i]'
@@ -86,7 +87,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		await page.keyboard.type( 'Search' );
 
-		await page.click( 'role=option[name="Search"i]' );
+		await page.getByRole( 'option', { name: 'Search' } ).click();
 
 		await page
 			.locator(
@@ -131,7 +132,7 @@ test.describe( 'Widgets Customizer', () => {
 		await widgetsCustomizerPage.visitCustomizerPage();
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
 
-		await page.focus( 'text=First Paragraph' );
+		await page.getByText( 'First Paragraph' ).focus();
 		await editor.clickBlockToolbarButton( 'Options' );
 
 		await showMoreSettingsButton.click();
@@ -202,7 +203,7 @@ test.describe( 'Widgets Customizer', () => {
 		await expect( inserterHeading ).toBeVisible();
 
 		// Open the Publish Settings.
-		await page.click( 'role=button[name="Publish Settings"i]' );
+		await page.getByRole( 'button', { name: 'Publish Settings' } ).click();
 
 		// Expect the Publish Settings outer section to be found.
 		const publishSettings = page.locator(
@@ -215,7 +216,9 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Focus the block and start typing to hide the block toolbar.
 		// Shouldn't be needed if we automatically hide the toolbar on blur.
-		await page.focus( 'role=document[name="Block: Paragraph"i]' );
+		await page
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.focus();
 		await page.keyboard.type( ' ' );
 
 		// Open the inserter outer section.
@@ -227,7 +230,10 @@ test.describe( 'Widgets Customizer', () => {
 		await expect( publishSettings ).toBeHidden();
 
 		// Back to the widget areas panel.
-		await page.click( 'role=button[name=/Back$/] >> visible=true' );
+		await page
+			.getByRole( 'button', { name: /Back$/ } )
+			.filter( { visible: true } )
+			.click();
 
 		// Expect the inserter outer section to be closed.
 		await expect( inserterHeading ).toBeHidden();
@@ -252,7 +258,10 @@ test.describe( 'Widgets Customizer', () => {
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
 
 		// Navigate back to the parent panel.
-		await page.click( 'role=button[name=/Back$/] >> visible=true' );
+		await page
+			.getByRole( 'button', { name: /Back$/ } )
+			.filter( { visible: true } )
+			.click();
 
 		const previewFrame = widgetsCustomizerPage.previewFrame;
 
@@ -320,9 +329,12 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Expect clicking on the section title should clear the selection.
 		{
-			await page.click(
-				'role=heading[name="Customizing ▸ Widgets Footer #1"i][level=3]'
-			);
+			await page
+				.getByRole( 'heading', {
+					name: 'Customizing ▸ Widgets Footer #1',
+					level: 3,
+				} )
+				.click();
 			await expect( blockToolbar ).toBeHidden();
 
 			await paragraphBlock.focus();
@@ -331,7 +343,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Expect clicking on the preview iframe should clear the selection.
 		{
-			await page.click( '#customize-preview' );
+			await page.locator( '#customize-preview' ).click();
 			await expect( blockToolbar ).toBeHidden();
 
 			await paragraphBlock.focus();
@@ -403,7 +415,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Testing removing the block.
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name=/Delete/]' );
+		await page.getByRole( 'menuitem', { name: /Delete/ } ).click();
 
 		// Add it back again using the variant.
 		const testWidgetBlock =
@@ -425,7 +437,9 @@ test.describe( 'Widgets Customizer', () => {
 		// Wait for publishing to finish.
 		await Promise.all( [
 			page.waitForResponse( '/wp-admin/admin-ajax.php' ),
-			page.click( 'role=button[name="Publish"i]' ),
+			page
+				.getByRole( 'button', { name: 'Publish', exact: true } )
+				.click(),
 		] );
 		await expect(
 			page.locator( 'role=button[name="Published"i]' )
@@ -486,17 +500,20 @@ test.describe( 'Widgets Customizer', () => {
 		await widgetsCustomizerPage.visitCustomizerPage();
 		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
 
-		await page.focus( 'text="First Paragraph"' );
+		await page.getByText( 'First Paragraph', { exact: true } ).focus();
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name="Group"i]' );
+		await page.getByRole( 'menuitem', { name: 'Group' } ).click();
 
 		// Refocus the paragraph block.
-		await page.focus(
-			'*role=document[name="Block: Paragraph"i] >> text="First Paragraph"'
-		);
+		await page
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( {
+				has: page.getByText( 'First Paragraph', { exact: true } ),
+			} )
+			.focus();
 		await editor.clickBlockToolbarButton( 'Move to widget area' );
 
-		await page.click( 'role=menuitemradio[name="Footer #2"i]' );
+		await page.getByRole( 'menuitemradio', { name: 'Footer #2' } ).click();
 
 		// Should switch to and expand Footer #2.
 		await expect(
@@ -544,7 +561,9 @@ test.describe( 'Widgets Customizer', () => {
 		// Click Publish
 		await Promise.all( [
 			page.waitForResponse( '/wp-admin/admin-ajax.php' ),
-			page.click( 'role=button[name="Publish"i]' ),
+			page
+				.getByRole( 'button', { name: 'Publish', exact: true } )
+				.click(),
 		] );
 		// Wait for publishing to finish.
 		await expect(
@@ -552,17 +571,25 @@ test.describe( 'Widgets Customizer', () => {
 		).toBeDisabled();
 
 		// Select the paragraph block
-		await page.focus( 'role=document[name="Block: Paragraph"i]' );
+		await page
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.focus();
 
 		// Click the three dots button, then click "Show More Settings".
 		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name="Show more settings"i]' );
+		await page
+			.getByRole( 'menuitem', { name: 'Show more settings' } )
+			.click();
 
 		// Change `drop cap` (Any change made in this section is sufficient; not required to be `drop cap`).
-		await page.click( 'role=button[name="Typography options"i]' );
-		await page.click( 'role=menuitemcheckbox[name="Show Drop cap"i]' );
+		await page
+			.getByRole( 'button', { name: 'Typography options' } )
+			.click();
+		await page
+			.getByRole( 'menuitemcheckbox', { name: 'Show Drop cap' } )
+			.click();
 
-		await page.click( 'role=checkbox[name="Drop cap"i]' );
+		await page.getByRole( 'checkbox', { name: 'Drop cap' } ).click();
 
 		// Now that we've made a change:
 		// (1) Publish button should be active
@@ -600,7 +627,9 @@ test.describe( 'Widgets Customizer', () => {
 		// Click Publish
 		await Promise.all( [
 			page.waitForResponse( '/wp-admin/admin-ajax.php' ),
-			page.click( 'role=button[name="Publish"i]' ),
+			page
+				.getByRole( 'button', { name: 'Publish', exact: true } )
+				.click(),
 		] );
 
 		// reload
@@ -651,20 +680,26 @@ class WidgetsCustomizerPage {
 	 * @param {string} widgetAreaName The Widget Area's name to expand on.
 	 */
 	async expandWidgetArea( widgetAreaName ) {
-		await this.page.click( 'role=heading[name=/Widgets/i][level=3]' );
+		await this.page
+			.getByRole( 'heading', { name: /Widgets/i, level: 3 } )
+			.click();
 
-		await this.page.click(
-			`role=heading[name=/${ widgetAreaName }/i][level=3]`
-		);
+		await this.page
+			.getByRole( 'heading', {
+				name: new RegExp( widgetAreaName, 'i' ),
+				level: 3,
+			} )
+			.click();
 	}
 
 	/**
 	 * @param {string} blockName The block to be added.
 	 */
 	async addBlock( blockName ) {
-		await this.page.click(
-			'role=toolbar[name="Document tools"i] >> role=button[name="Add block"i]'
-		);
+		await this.page
+			.getByRole( 'toolbar', { name: 'Document tools' } )
+			.getByRole( 'button', { name: 'Add block' } )
+			.click();
 
 		const searchBox = this.page.locator( 'role=searchbox[name="Search"i]' );
 
@@ -677,7 +712,9 @@ class WidgetsCustomizerPage {
 
 		await searchBox.type( blockName );
 
-		await this.page.click( `role=option[name="${ blockName }"]` );
+		await this.page
+			.getByRole( 'option', { name: blockName, exact: true } )
+			.click();
 
 		const addedBlock = this.page.locator(
 			'role=document >> css=.is-selected[data-block]'


### PR DESCRIPTION
## What?
PR bulk fixes `playwright/prefer-locator` ESLint warnings in `test/e2e/specs` by converting `page.click( 'role=…' )`-style calls to locator chains, preferring `getByRole`.

## Why?

These are leftovers from the pre-locator Playwright API. Locators auto-wait and retry; page-level selector methods don't.

## How?

Mechanical conversion, preserving matching semantics:

| Selector | Result |
| --- | --- |
| `role=button[name="X"i]` | `getByRole( 'button', { name: 'X' } )` |
| `role=button[name="X"]` (no `i`) | `getByRole( 'button', { name: 'X', exact: true } )` |
| `role=button[name=/X/i]` | `getByRole( 'button', { name: /X/i } )` |
| `role=heading[…][level=3]` | `getByRole( 'heading', { …, level: 3 } )` |
| `a >> b` | `.getByRole( … ).getByRole( … )` |
| `text=X` / `text="X"` | `getByText( 'X' )` / `getByText( 'X', { exact: true } )` |
| CSS selectors | `.locator( … )` |

## Testing Instructions
Tests-only change; relying on CI. `npm run lint:js -- test/e2e/specs` should report no `prefer-locator` warnings, down from 217, with all other rule counts unchanged.

## Use of AI Tools

Assisted By Claude
