### PR TITLE
Editor: Migrate settings sidebar to Tabs from @wordpress/ui

### DIFF
--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { Tabs } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -12,8 +12,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { sidebars } from './constants';
-
-const { Tabs } = unlock( componentsPrivateApis );
 
 export default function SidebarHeader() {
 	const { postTypeLabel, isRevisionsMode } = useSelect( ( select ) => {
@@ -38,12 +36,12 @@ export default function SidebarHeader() {
 	}
 
 	return (
-		<Tabs.TabList>
-			<Tabs.Tab tabId={ sidebars.document }>{ documentLabel }</Tabs.Tab>
-			<Tabs.Tab tabId={ sidebars.block }>
+		<Tabs.List activateOnFocus={ false }>
+			<Tabs.Tab value={ sidebars.document }>{ documentLabel }</Tabs.Tab>
+			<Tabs.Tab value={ sidebars.block }>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
 				{ __( 'Block' ) }
 			</Tabs.Tab>
-		</Tabs.TabList>
+		</Tabs.List>
 	);
 }

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -6,7 +6,6 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
 import { isRTL, __, _x } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -36,16 +35,44 @@ import { store as editorStore } from '../../store';
 
 const SIDEBAR_ACTIVE_BY_DEFAULT = true;
 
-const SidebarContent = ( {
-	tabName,
-	keyboardShortcut,
-	onTabSelect,
-	onActionPerformed,
-	extraPanels,
-} ) => {
-	const isRevisionsMode = useSelect( ( select ) => {
-		return unlock( select( editorStore ) ).isRevisionsMode();
-	} );
+function Sidebar( { extraPanels, onActionPerformed } ) {
+	useAutoSwitchEditorSidebars();
+
+	const { tabName, keyboardShortcut, isRevisionsMode } = useSelect(
+		( select ) => {
+			const shortcut = select(
+				keyboardShortcutsStore
+			).getShortcutRepresentation( 'core/editor/toggle-sidebar' );
+
+			const sidebar =
+				select( interfaceStore ).getActiveComplementaryArea( 'core' );
+			const _isEditorSidebarOpened = [
+				sidebars.block,
+				sidebars.document,
+			].includes( sidebar );
+			let _tabName = sidebar;
+			if ( ! _isEditorSidebarOpened ) {
+				_tabName = select( blockEditorStore ).getBlockSelectionStart()
+					? sidebars.block
+					: sidebars.document;
+			}
+
+			return {
+				tabName: _tabName,
+				keyboardShortcut: shortcut,
+				isRevisionsMode: unlock(
+					select( editorStore )
+				).isRevisionsMode(),
+			};
+		},
+		[]
+	);
+
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+
+	function onTabSelect( newSelectedTabId ) {
+		enableComplementaryArea( 'core', newSelectedTabId );
+	}
 
 	let tabContent;
 	if ( isRevisionsMode ) {
@@ -103,54 +130,6 @@ const SidebarContent = ( {
 			</Tabs.Panel>
 		</PluginSidebar>
 	);
-};
-
-const Sidebar = ( { extraPanels, onActionPerformed } ) => {
-	useAutoSwitchEditorSidebars();
-	const { tabName, keyboardShortcut } = useSelect( ( select ) => {
-		const shortcut = select(
-			keyboardShortcutsStore
-		).getShortcutRepresentation( 'core/editor/toggle-sidebar' );
-
-		const sidebar =
-			select( interfaceStore ).getActiveComplementaryArea( 'core' );
-		const _isEditorSidebarOpened = [
-			sidebars.block,
-			sidebars.document,
-		].includes( sidebar );
-		let _tabName = sidebar;
-		if ( ! _isEditorSidebarOpened ) {
-			_tabName = !! select( blockEditorStore ).getBlockSelectionStart()
-				? sidebars.block
-				: sidebars.document;
-		}
-
-		return {
-			tabName: _tabName,
-			keyboardShortcut: shortcut,
-		};
-	}, [] );
-
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
-
-	const onTabSelect = useCallback(
-		( newSelectedTabId ) => {
-			if ( !! newSelectedTabId ) {
-				enableComplementaryArea( 'core', newSelectedTabId );
-			}
-		},
-		[ enableComplementaryArea ]
-	);
-
-	return (
-		<SidebarContent
-			tabName={ tabName }
-			keyboardShortcut={ keyboardShortcut }
-			onTabSelect={ onTabSelect }
-			onActionPerformed={ onActionPerformed }
-			extraPanels={ extraPanels }
-		/>
-	);
-};
+}
 
 export default Sidebar;

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -6,12 +6,12 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useContext } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { isRTL, __, _x } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as interfaceStore } from '@wordpress/interface';
+import { Tabs } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,20 +34,15 @@ import { sidebars } from './constants';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-const { Tabs } = unlock( componentsPrivateApis );
-
 const SIDEBAR_ACTIVE_BY_DEFAULT = true;
 
 const SidebarContent = ( {
 	tabName,
 	keyboardShortcut,
+	onTabSelect,
 	onActionPerformed,
 	extraPanels,
 } ) => {
-	// Because `PluginSidebar` renders a `ComplementaryArea`, we
-	// need to forward the `Tabs` context so it can be passed through the
-	// underlying slot/fill.
-	const tabsContextValue = useContext( Tabs.Context );
 	const isRevisionsMode = useSelect( ( select ) => {
 		return unlock( select( editorStore ) ).isRevisionsMode();
 	} );
@@ -82,15 +77,8 @@ const SidebarContent = ( {
 	return (
 		<PluginSidebar
 			identifier={ tabName }
-			header={
-				<Tabs.Context.Provider value={ tabsContextValue }>
-					<SidebarHeader />
-				</Tabs.Context.Provider>
-			}
+			header={ <SidebarHeader /> }
 			closeLabel={ __( 'Close Settings' ) }
-			// This classname is added so we can apply a corrective negative
-			// margin to the panel.
-			// see https://github.com/WordPress/gutenberg/pull/55360#pullrequestreview-1737671049
 			className="editor-sidebar__panel"
 			headerClassName="editor-sidebar__panel-tabs"
 			title={
@@ -100,16 +88,19 @@ const SidebarContent = ( {
 			toggleShortcut={ keyboardShortcut }
 			icon={ isRTL() ? drawerLeft : drawerRight }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
+			// Makes `Tabs.Root` the container, so the tab list passed as
+			// `header` and the panels below share a subtree across the fill.
+			render={
+				<Tabs.Root value={ tabName } onValueChange={ onTabSelect } />
+			}
 		>
-			<Tabs.Context.Provider value={ tabsContextValue }>
-				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
-					{ tabContent }
-				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
-					<BlockInspector />
-					{ isRevisionsMode && <RevisionBlockDiffPanel /> }
-				</Tabs.TabPanel>
-			</Tabs.Context.Provider>
+			<Tabs.Panel value={ sidebars.document } tabIndex={ -1 }>
+				{ tabContent }
+			</Tabs.Panel>
+			<Tabs.Panel value={ sidebars.block } tabIndex={ -1 }>
+				<BlockInspector />
+				{ isRevisionsMode && <RevisionBlockDiffPanel /> }
+			</Tabs.Panel>
 		</PluginSidebar>
 	);
 };
@@ -152,18 +143,13 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 	);
 
 	return (
-		<Tabs
-			selectedTabId={ tabName }
-			onSelect={ onTabSelect }
-			selectOnMove={ false }
-		>
-			<SidebarContent
-				tabName={ tabName }
-				keyboardShortcut={ keyboardShortcut }
-				onActionPerformed={ onActionPerformed }
-				extraPanels={ extraPanels }
-			/>
-		</Tabs>
+		<SidebarContent
+			tabName={ tabName }
+			keyboardShortcut={ keyboardShortcut }
+			onTabSelect={ onTabSelect }
+			onActionPerformed={ onActionPerformed }
+			extraPanels={ extraPanels }
+		/>
 	);
 };
 

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `ComplementaryArea`: Add a `render` prop to replace the default container element, following the `@wordpress/ui` convention ([#81054](https://github.com/WordPress/gutenberg/pull/81054)).
+
 ### Bug Fixes
 
 -   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `ComplementaryArea`: Add a `render` prop to replace the default container element, following the `@wordpress/ui` convention ([#81054](https://github.com/WordPress/gutenberg/pull/81054)).
+-   `ComplementaryArea`: Add a `render` prop to replace the default container element with a given React element ([#81054](https://github.com/WordPress/gutenberg/pull/81054)).
 
 ### Bug Fixes
 

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -17,7 +17,13 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { check, starEmpty, starFilled } from '@wordpress/icons';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import {
+	cloneElement,
+	isValidElement,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { store as viewportStore } from '@wordpress/viewport';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -49,6 +55,33 @@ const variants = {
 	mobileOpen: { width: '100vw' },
 };
 
+/**
+ * Renders the complementary area container, replacing the default `div` with
+ * the element (or element factory) given via the `render` prop.
+ *
+ * `className` and `style` are composed rather than overwritten, since the
+ * container is also the scroll container for the sidebar.
+ *
+ * @param {Function|Object} [render] Replacement element, or a function
+ *                                   returning one.
+ * @param {Object}          props    Props for the container.
+ */
+function renderContainer( render, props ) {
+	if ( typeof render === 'function' ) {
+		return render( props );
+	}
+
+	if ( isValidElement( render ) ) {
+		return cloneElement( render, {
+			...props,
+			className: clsx( render.props.className, props.className ),
+			style: { ...render.props.style, ...props.style },
+		} );
+	}
+
+	return <div { ...props } />;
+}
+
 function ComplementaryAreaFill( {
 	activeArea,
 	isActive,
@@ -56,6 +89,7 @@ function ComplementaryAreaFill( {
 	children,
 	className,
 	id,
+	render,
 } ) {
 	const disableMotion = useReducedMotion();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
@@ -94,17 +128,16 @@ function ComplementaryAreaFill( {
 						transition={ transition }
 						className="interface-complementary-area__fill"
 					>
-						<div
-							id={ id }
-							className={ className }
-							style={ {
+						{ renderContainer( render, {
+							id,
+							className,
+							style: {
 								width: isMobileViewport
 									? '100vw'
 									: SIDEBAR_WIDTH,
-							} }
-						>
-							{ children }
-						</div>
+							},
+							children,
+						} ) }
 					</motion.div>
 				) }
 			</AnimatePresence>
@@ -177,6 +210,7 @@ function ComplementaryArea( {
 	icon: iconProp,
 	isPinnable = true,
 	panelClassName,
+	render,
 	scope,
 	name,
 	title,
@@ -302,6 +336,7 @@ function ComplementaryArea( {
 				className={ clsx( 'interface-complementary-area', className ) }
 				scope={ scope }
 				id={ identifier.replace( '/', ':' ) }
+				render={ render }
 			>
 				<ComplementaryAreaHeader
 					className={ headerClassName }

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -57,20 +57,15 @@ const variants = {
 
 /**
  * Renders the complementary area container, replacing the default `div` with
- * the element (or element factory) given via the `render` prop.
+ * the element given via the `render` prop.
  *
  * `className` and `style` are composed rather than overwritten, since the
  * container is also the scroll container for the sidebar.
  *
- * @param {Function|Object} [render] Replacement element, or a function
- *                                   returning one.
- * @param {Object}          props    Props for the container.
+ * @param {Object} [render] Replacement element.
+ * @param {Object} props    Props for the container.
  */
 function renderContainer( render, props ) {
-	if ( typeof render === 'function' ) {
-		return render( props );
-	}
-
 	if ( isValidElement( render ) ) {
 		return cloneElement( render, {
 			...props,

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1377,16 +1377,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/sidebar/header.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/sidebar/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/sidebar/post-revision-summary.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What?
This is an alternative to #81006.

PR migrates the editor settings sidebar from the private `Tabs` in `@wordpress/components` to `Tabs` from `@wordpress/ui`. Adds a `render` prop to `ComplementaryArea` to make that possible. `edit-widgets` stays on the private `Tabs` for a follow-up.  The experimental media editor can also simplify its tabs rendering logic - #73771.

## Why?

This is not a drop-in swap. The sidebar passes its tab list through `PluginSidebar`'s `header` prop and its panels as children, and `ComplementaryArea` renders those at two separate points inside its `Fill`. Because `ComplementaryAreaSlot` is a non-bubbling `Slot`, the fill's children reconcile in the Slot's React tree rather than the Fill's, so the two halves of the tabs end up in different trees. The old code worked around this by reading `Tabs.Context` and re-providing it on both sides of the boundary. `@wordpress/ui` `Tabs` is built on Base UI, which does not expose an equivalent context, and splitting into two roots would break the aria linkage and trip the Tab/Panel count validation.

## How?

`ComplementaryArea` gains a `render` prop following the `@wordpress/ui` and Base UI convention, which replaces the container element inside `ComplementaryAreaFill`. `className` and `style` compose rather than overwrite, since that element is also the sidebar's scroll container. The sidebar then passes `render={ <Tabs.Root /> }` so the container itself is the tabs root, and the list and panels share one subtree. No portal, no context forwarding, and no extra DOM node.

`ComplementaryAreaSlot` is deliberately left non-bubbling. Switching it to `bubblesVirtually` nests a second React portal container inside the editor root, which double-dispatches events to ancestor handlers and breaks region navigation.

## Testing Instructions

Open the post editor and confirm the Document and Block tabs switch correctly by clicking, using the keyboard, and selecting a block. Confirm the panel header stays sticky while scrolling the sidebar, and that plugin sidebars registered via `PluginSidebar` still render.

```
npm run test:e2e -- \
  test/e2e/specs/editor/various/sidebar.spec.js \
  test/e2e/specs/site-editor/settings-sidebar.spec.js \
  test/e2e/specs/editor/plugins/plugins-api.spec.js \
  test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
```

## Use of AI Tools

Assisted by Claude
