### PR TITLE
Background: Fix the legacy gradient UI where a gradient cannot be selected

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `RichText`: Skip the block input transforms in fields that are not passed an `onReplace` ([#80978](https://github.com/WordPress/gutenberg/pull/80978)).
 -   `RichText`: Ignore pasted files, which carry no text to paste inline ([#81010](https://github.com/WordPress/gutenberg/pull/81010)).
+-   Background block support: Fix gradients not being applied to a block when a theme opts out of `settings.background.gradient` in `theme.json`.
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -199,10 +199,9 @@ export function BackgroundImagePanel( {
 		selectedState
 	);
 
-	const backgroundGradientSupported = hasBackgroundSupport(
-		name,
-		'gradient'
-	);
+	const backgroundGradientSupported =
+		hasBackgroundSupport( name, 'gradient' ) &&
+		!! settings?.background?.gradient;
 
 	const colorSupport = getBlockSupport( name, 'color' );
 	const hasColorBackgroundSupport =

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -1,11 +1,24 @@
 /**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import {
 	setBackgroundStyleDefaults,
 	backgroundResetAllFilter,
+	BackgroundImagePanel,
 	BACKGROUND_BLOCK_DEFAULT_VALUES,
 } from '../background';
+import { BackgroundToolsPanel } from '../../components/global-styles/background-panel';
 
 describe( 'background', () => {
 	describe( 'backgroundResetAllFilter', () => {
@@ -114,6 +127,116 @@ describe( 'background', () => {
 		] )( 'should %s', ( message, styles, expected ) => {
 			const result = setBackgroundStyleDefaults( styles );
 			expect( result ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'BackgroundImagePanel gradient routing', () => {
+		const BLOCK_NAME = 'core/test-background-gradient';
+		const baseSettings = {
+			color: {
+				background: true,
+				gradients: {
+					theme: [
+						{
+							name: 'Vivid',
+							slug: 'vivid',
+							gradient:
+								'linear-gradient(135deg, rgb(6, 147, 227) 0%, rgb(155, 81, 224) 100%)',
+						},
+					],
+				},
+			},
+		};
+
+		beforeAll( () => {
+			registerBlockType( BLOCK_NAME, {
+				apiVersion: 3,
+				title: 'Test background gradient',
+				supports: {
+					background: {
+						gradient: true,
+						__experimentalDefaultControls: { gradient: true },
+					},
+					color: {
+						gradients: true,
+						__experimentalDefaultControls: { background: true },
+					},
+				},
+			} );
+		} );
+
+		afterAll( () => {
+			unregisterBlockType( BLOCK_NAME );
+		} );
+
+		it( 'stores the gradient in the background style when the setting is enabled', async () => {
+			const settings = {
+				...baseSettings,
+				background: { gradient: true },
+			};
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<BackgroundImagePanel
+					clientId="block-1"
+					name={ BLOCK_NAME }
+					setAttributes={ setAttributes }
+					settings={ settings }
+					asWrapper={ BackgroundToolsPanel }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: /Gradient/ } )
+			);
+			await user.click( await screen.findByRole( 'option' ) );
+
+			// The gradient is kept whole in the style, not extracted to the
+			// legacy attribute.
+			expect( setAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					style: {
+						background: {
+							gradient: 'var:preset|gradient|vivid',
+						},
+					},
+					gradient: undefined,
+				} )
+			);
+		} );
+
+		it( 'stores the gradient in the legacy attribute when the setting is disabled', async () => {
+			const settings = {
+				...baseSettings,
+				background: { gradient: false },
+			};
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<BackgroundImagePanel
+					clientId="block-1"
+					name={ BLOCK_NAME }
+					setAttributes={ setAttributes }
+					settings={ settings }
+					asWrapper={ BackgroundToolsPanel }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: /Gradient/ } )
+			);
+			await user.click( await screen.findByRole( 'option' ) );
+
+			// The panel writes to the legacy `color.gradient` when the theme
+			// opts out, and the slug leaves nothing inline in the style.
+			expect( setAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					style: undefined,
+					gradient: 'vivid',
+				} )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Follow up to #77279

When a theme opts out of the new gradient background in `theme.json`, the Background panel falls back to the legacy gradient UI. I noticed that selecting a preset there does nothing at all, so this PR fixes it.

https://github.com/user-attachments/assets/1a92e79d-5292-4245-9b9f-39ac55c1384c

## Why?

The Background panel and the block inspector hook that saves the value were deciding "which gradient is this?" by two different rules.

- The **panel** looks at the `settings.background.gradient` value resolved from `theme.json`. When a theme sets it to `false`, the panel [hides the new gradient control and renders the legacy one instead](https://github.com/WordPress/gutenberg/blob/d15606e7ceb37e4479250ce329e269e796192d52/packages/block-editor/src/components/global-styles/background-panel.js#L187-L206), which [writes to `style.color.gradient`](https://github.com/WordPress/gutenberg/blob/d15606e7ceb37e4479250ce329e269e796192d52/packages/block-editor/src/components/global-styles/background-panel.js#L300-L308).
- The **hook** looked only at whether the block declares the `background.gradient` block support. `core/group` declares it, so the hook always expected the value at `style.background.gradient`.

With the setting disabled, the panel wrote to one place and the hook read from another. Finding nothing, the hook saved an empty value, and the gradient never made it onto the block.

## How?

Make the hook use the same rule as the panel: the block support and the resolved `theme.json` setting.

## Testing Instructions

1. Add the `background.gradient` opt-out to your theme's `theme.json`:

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"background": {
			"gradient": false
		}
	}
}
```

2. Insert a Group block and open the Background panel in the inspector.
3. Open the Gradient control and pick a preset.
4. The gradient should be applied to the block, and it should persist after saving and reloading.

## Use of AI Tools

Claude Code was used to locate the cause, write the fix and author the unit tests. All changes were reviewed by me.
