### PR TITLE
[WP 7.1] Background: Fix the legacy gradient UI where a gradient cannot be selected

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bug Fixes
 
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
+-   Background block support: Fix gradients not being applied to a block when a theme opts out of `settings.background.gradient` in `theme.json` ([#81056](https://github.com/WordPress/gutenberg/pull/81056)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -199,10 +199,9 @@ export function BackgroundImagePanel( {
 		selectedState
 	);
 
-	const backgroundGradientSupported = hasBackgroundSupport(
-		name,
-		'gradient'
-	);
+	const backgroundGradientSupported =
+		hasBackgroundSupport( name, 'gradient' ) &&
+		!! settings?.background?.gradient;
 
 	const colorSupport = getBlockSupport( name, 'color' );
 	const hasColorBackgroundSupport =

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -1,11 +1,24 @@
 /**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import {
 	setBackgroundStyleDefaults,
 	backgroundResetAllFilter,
+	BackgroundImagePanel,
 	BACKGROUND_BLOCK_DEFAULT_VALUES,
 } from '../background';
+import { BackgroundToolsPanel } from '../../components/global-styles/background-panel';
 
 describe( 'background', () => {
 	describe( 'backgroundResetAllFilter', () => {
@@ -114,6 +127,116 @@ describe( 'background', () => {
 		] )( 'should %s', ( message, styles, expected ) => {
 			const result = setBackgroundStyleDefaults( styles );
 			expect( result ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'BackgroundImagePanel gradient routing', () => {
+		const BLOCK_NAME = 'core/test-background-gradient';
+		const baseSettings = {
+			color: {
+				background: true,
+				gradients: {
+					theme: [
+						{
+							name: 'Vivid',
+							slug: 'vivid',
+							gradient:
+								'linear-gradient(135deg, rgb(6, 147, 227) 0%, rgb(155, 81, 224) 100%)',
+						},
+					],
+				},
+			},
+		};
+
+		beforeAll( () => {
+			registerBlockType( BLOCK_NAME, {
+				apiVersion: 3,
+				title: 'Test background gradient',
+				supports: {
+					background: {
+						gradient: true,
+						__experimentalDefaultControls: { gradient: true },
+					},
+					color: {
+						gradients: true,
+						__experimentalDefaultControls: { background: true },
+					},
+				},
+			} );
+		} );
+
+		afterAll( () => {
+			unregisterBlockType( BLOCK_NAME );
+		} );
+
+		it( 'stores the gradient in the background style when the setting is enabled', async () => {
+			const settings = {
+				...baseSettings,
+				background: { gradient: true },
+			};
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<BackgroundImagePanel
+					clientId="block-1"
+					name={ BLOCK_NAME }
+					setAttributes={ setAttributes }
+					settings={ settings }
+					asWrapper={ BackgroundToolsPanel }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: /Gradient/ } )
+			);
+			await user.click( await screen.findByRole( 'option' ) );
+
+			// The gradient is kept whole in the style, not extracted to the
+			// legacy attribute.
+			expect( setAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					style: {
+						background: {
+							gradient: 'var:preset|gradient|vivid',
+						},
+					},
+					gradient: undefined,
+				} )
+			);
+		} );
+
+		it( 'stores the gradient in the legacy attribute when the setting is disabled', async () => {
+			const settings = {
+				...baseSettings,
+				background: { gradient: false },
+			};
+			const user = userEvent.setup();
+			const setAttributes = jest.fn();
+
+			render(
+				<BackgroundImagePanel
+					clientId="block-1"
+					name={ BLOCK_NAME }
+					setAttributes={ setAttributes }
+					settings={ settings }
+					asWrapper={ BackgroundToolsPanel }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: /Gradient/ } )
+			);
+			await user.click( await screen.findByRole( 'option' ) );
+
+			// The panel writes to the legacy `color.gradient` when the theme
+			// opts out, and the slug leaves nothing inline in the style.
+			expect( setAttributes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					style: undefined,
+					gradient: 'vivid',
+				} )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
Merge patch for https://github.com/WordPress/gutenberg/pull/81056

## What

When a theme opts out of the new gradient background in theme.json, the Background panel falls back to the legacy gradient UI. I noticed that selecting a preset there does nothing at all, so this PR fixes it.

## Testing

See https://github.com/WordPress/gutenberg/pull/81056
