### PR TITLE
Fix/rtc non synced entity undo 80722

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52566,6 +52566,7 @@
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/hooks": "file:../hooks",
+				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/undo-manager": "file:../undo-manager",
 				"diff": "^8.0.3",

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Preserve undo and redo history for non-synced entities while real-time collaboration is active ([#80722](https://github.com/WordPress/gutenberg/issues/80722)).
+
 ### Internal
 
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -27,7 +27,12 @@ const EMPTY_OBJECT = {};
  */
 export function getUndoManager( state: State ) {
 	// undoManager is undefined until the first sync-enabled entity is loaded.
-	return getSyncManager()?.undoManager ?? state.undoManager;
+	const syncUndoManager = getSyncManager()?.undoManager;
+	if ( syncUndoManager ) {
+		syncUndoManager.setFallbackUndoManager( state.undoManager );
+		return syncUndoManager;
+	}
+	return state.undoManager;
 }
 
 /**

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -24,7 +24,6 @@ import {
 	isNumericID,
 	getUserPermissionCacheKey,
 } from './utils';
-import { getSyncManager } from './sync';
 import type * as ET from './entity-types';
 import logEntityDeprecation from './utils/log-entity-deprecation';
 
@@ -1153,9 +1152,6 @@ export function getRedoEdit( state: State ): Optional< any > {
  * @return Whether there is a previous edit or not.
  */
 export function hasUndo( state: State ): boolean {
-	if ( getSyncManager()?.undoManager ) {
-		return state.syncUndoManagerState.hasUndo;
-	}
 	return getUndoManager( state ).hasUndo();
 }
 
@@ -1168,9 +1164,6 @@ export function hasUndo( state: State ): boolean {
  * @return Whether there is a next edit or not.
  */
 export function hasRedo( state: State ): boolean {
-	if ( getSyncManager()?.undoManager ) {
-		return state.syncUndoManagerState.hasRedo;
-	}
 	return getUndoManager( state ).hasRedo();
 }
 

--- a/packages/core-data/src/test/private-selectors.js
+++ b/packages/core-data/src/test/private-selectors.js
@@ -19,6 +19,7 @@ describe( 'getUndoManager', () => {
 			hasRedo: jest.fn(),
 			hasUndo: jest.fn(),
 			redo: jest.fn(),
+			setFallbackUndoManager: jest.fn(),
 			undo: jest.fn(),
 		};
 		const fallbackUndoManager = {
@@ -41,6 +42,9 @@ describe( 'getUndoManager', () => {
 		};
 
 		expect( getUndoManager( state ) ).toBe( syncUndoManager );
+		expect( syncUndoManager.setFallbackUndoManager ).toHaveBeenCalledWith(
+			fallbackUndoManager
+		);
 	} );
 
 	it( 'returns the default undo manager when there is no sync undo manager', () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -38,24 +38,26 @@ describe( 'hasUndo/hasRedo', () => {
 		getSyncManager.mockReset();
 	} );
 
-	it( 'reads undo availability from core-data state when a sync undo manager is available', () => {
+	it( 'reads undo availability from the sync undo manager', () => {
 		const undoManager = {
-			hasUndo: jest.fn( () => false ),
-			hasRedo: jest.fn( () => false ),
+			hasUndo: jest.fn( () => true ),
+			hasRedo: jest.fn( () => true ),
+			setFallbackUndoManager: jest.fn(),
 		};
 		getSyncManager.mockReturnValue( { undoManager } );
 
-		const state = deepFreeze( {
+		const state = {
+			undoManager: {},
 			syncUndoManagerState: {
-				hasRedo: true,
-				hasUndo: true,
+				hasRedo: false,
+				hasUndo: false,
 			},
-		} );
+		};
 
 		expect( hasUndo( state ) ).toBe( true );
 		expect( hasRedo( state ) ).toBe( true );
-		expect( undoManager.hasUndo ).not.toHaveBeenCalled();
-		expect( undoManager.hasRedo ).not.toHaveBeenCalled();
+		expect( undoManager.hasUndo ).toHaveBeenCalled();
+		expect( undoManager.hasRedo ).toHaveBeenCalled();
 	} );
 
 	it( 'falls back to the default undo manager when no sync undo manager is available', () => {

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Preserve undo and redo history for non-synced entities while real-time collaboration is active ([#80722](https://github.com/WordPress/gutenberg/issues/80722)).
+
 ## 1.51.0 (2026-07-14)
 
 ## 1.50.0 (2026-07-01)

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -119,9 +119,10 @@ Awareness provides ephemeral presence information (cursor positions, user identi
 
 ## Undo / redo
 
-The `SyncUndoManager` (`src/undo-manager.ts`) replaces the default WordPress undo manager when synced entities are in use. It wraps Yjs's built-in undo functionality.
+The `SyncUndoManager` (`src/undo-manager.ts`) coordinates undo history when synced entities are in use. It combines Yjs's built-in undo functionality with the default WordPress undo manager.
 
 -   **Lazy creation**: The undo manager is created when the first entity is loaded. If no entities are synced, the default WordPress undo manager is used.
 -   **Automatic tracking**: Unlike the default undo manager, which explicitly records each edit, the `SyncUndoManager` relies on Yjs to track changes to observed `Y.Map` instances. Only changes with the local editor origin are tracked.
+-   **Fallback tracking**: Changes to entities that are not in the Yjs scope are delegated to the default WordPress undo manager.
+-   **Global ordering**: A source stack records whether each undo level belongs to Yjs or the fallback manager so interleaved edits are undone and redone chronologically.
 -   **Capture grouping**: Changes within 500ms of each other are grouped into a single undo step, preventing mid-word undo breaks.
--   **Limitation**: Once created, the `SyncUndoManager` only tracks synced entities. Edits to non-synced entities are not included in the undo stack.

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -45,6 +45,7 @@
 	"dependencies": {
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/undo-manager": "file:../undo-manager",
 		"diff": "^8.0.3",

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -87,33 +87,10 @@ export function createSyncManager( debug = false ): SyncManager {
 	const entityStates: Map< EntityID, EntityState > = new Map();
 
 	/**
-	 * A "sync-aware" undo manager for all synced entities. It is lazily created
-	 * when the first entity is loaded.
-	 *
-	 * IMPORTANT: In Gutenberg, the undo manager is effectively global and manages
-	 * undo/redo state for all entities. If the default WPUndoManager is used,
-	 * changes to entities are recorded in the `editEntityRecord` action:
-	 *
-	 * https://github.com/WordPress/gutenberg/blob/b63451e26e3c91b6bb291a2f9994722e3850417e/packages/core-data/src/actions.js#L428-L442
-	 *
-	 * In contrast, the `SyncUndoManager` only manages undo/redo for entities that
-	 * **are being synced by this sync manager**. The `addRecord` method is still
-	 * called in the code linked above, but it is a no-op. Yjs automatically tracks
-	 * changes to entities via the associated CRDT doc:
-	 *
-	 * https://github.com/WordPress/gutenberg/blob/b63451e26e3c91b6bb291a2f9994722e3850417e/packages/sync/src/undo-manager.ts#L42-L48
-	 *
-	 * This means that if at least one entity is being synced, then undo/redo
-	 * operations will be **restricted to synced entities only.**
-	 *
-	 * We could improve the `SyncUndoManager` to also track non-synced entities by
-	 * delegating to a secondary `WPUndoManager`, but this would add complexity
-	 * since we would need to maintain two separate undo/redo stacks and ensure
-	 * that they retain ordering and integrity.
-	 *
-	 * However, we also anticipate that most entities being edited in Gutenberg
-	 * will be synced entities (e.g. posts, pages, templates, template parts,
-	 * etc.), so this limitation may be temporary.
+	 * A global, sync-aware undo manager. It is lazily created when the first
+	 * entity is loaded. Synced records use Yjs history, while non-synced records
+	 * use the default WordPress undo manager. The coordinator preserves ordering
+	 * between both histories.
 	 */
 	let undoManager: SyncUndoManager | undefined;
 
@@ -267,7 +244,7 @@ export function createSyncManager( debug = false ): SyncManager {
 		}
 
 		const { addUndoMeta, onUndoStackChange, restoreUndoMeta } = handlers;
-		undoManager.addToScope( recordMap, {
+		undoManager.addToScope( recordMap, objectType, objectId, {
 			addUndoMeta,
 			restoreUndoMeta,
 			onUndoStackChange,

--- a/packages/sync/src/test/undo-manager.test.ts
+++ b/packages/sync/src/test/undo-manager.test.ts
@@ -5,6 +5,14 @@ import * as Y from 'yjs';
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 /**
+ * WordPress dependencies
+ */
+import {
+	createUndoManager as createWPUndoManager,
+	type HistoryRecord,
+} from '@wordpress/undo-manager';
+
+/**
  * Internal dependencies
  */
 import { LOCAL_EDITOR_ORIGIN } from '../config';
@@ -17,12 +25,13 @@ describe( 'SyncUndoManager', () => {
 		docs.splice( 0 ).forEach( ( doc ) => doc.destroy() );
 	} );
 
-	function createScopedMap() {
+	function createScopedMap( objectId = String( docs.length + 1 ) ) {
 		const doc = new Y.Doc();
 		docs.push( doc );
 		return {
 			doc,
 			map: doc.getMap( 'record' ),
+			objectId,
 			handlers: {
 				addUndoMeta: jest.fn(),
 				onUndoStackChange: jest.fn(),
@@ -31,13 +40,55 @@ describe( 'SyncUndoManager', () => {
 		};
 	}
 
+	function createRecord(
+		id: string | Record< string, unknown >,
+		from: unknown,
+		to: unknown
+	): HistoryRecord< any > {
+		return [ { id, changes: { title: { from, to } } } ];
+	}
+
+	function addScopedMap(
+		undoManager: ReturnType< typeof createUndoManager >,
+		scope: ReturnType< typeof createScopedMap >
+	) {
+		undoManager.addToScope(
+			scope.map,
+			'postType/post',
+			scope.objectId,
+			scope.handlers
+		);
+	}
+
+	function addSyncRecord(
+		undoManager: ReturnType< typeof createUndoManager >,
+		scope: ReturnType< typeof createScopedMap >,
+		value: string
+	) {
+		const previousValue = scope.map.get( 'title' );
+		scope.doc.transact( () => {
+			scope.map.set( 'title', value );
+		}, LOCAL_EDITOR_ORIGIN );
+		undoManager.addRecord(
+			createRecord(
+				{
+					kind: 'postType',
+					name: 'post',
+					recordId: scope.objectId,
+				},
+				previousValue,
+				value
+			)
+		);
+	}
+
 	it( 'notifies scoped handlers when the Yjs undo stack changes', () => {
 		const undoManager = createUndoManager();
 		const first = createScopedMap();
 		const second = createScopedMap();
 
-		undoManager.addToScope( first.map, first.handlers );
-		undoManager.addToScope( second.map, second.handlers );
+		addScopedMap( undoManager, first );
+		addScopedMap( undoManager, second );
 
 		first.doc.transact( () => {
 			first.map.set( 'title', 'First changed' );
@@ -66,8 +117,8 @@ describe( 'SyncUndoManager', () => {
 		const first = createScopedMap();
 		const second = createScopedMap();
 
-		undoManager.addToScope( first.map, first.handlers );
-		undoManager.addToScope( second.map, second.handlers );
+		addScopedMap( undoManager, first );
+		addScopedMap( undoManager, second );
 
 		first.doc.transact( () => {
 			first.map.set( 'title', 'First changed' );
@@ -124,5 +175,104 @@ describe( 'SyncUndoManager', () => {
 		expect( second.handlers.addUndoMeta ).toHaveBeenCalledTimes( 3 );
 		expect( first.handlers.restoreUndoMeta ).not.toHaveBeenCalled();
 		expect( second.handlers.restoreUndoMeta ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'uses the fallback history for non-synced entity records', () => {
+		const undoManager = createUndoManager();
+		const record = createRecord(
+			{ kind: 'root', name: 'note', recordId: '1' },
+			'Before',
+			'After'
+		);
+
+		undoManager.addRecord( record );
+
+		expect( undoManager.hasUndo() ).toBe( true );
+		expect( undoManager.undo() ).toEqual( record );
+		expect( undoManager.hasRedo() ).toBe( true );
+		expect( undoManager.redo() ).toEqual( record );
+	} );
+
+	it( 'retains fallback history created before syncing starts', () => {
+		const fallbackUndoManager = createWPUndoManager();
+		const record = createRecord(
+			{ kind: 'root', name: 'note', recordId: '1' },
+			'Before',
+			'After'
+		);
+		fallbackUndoManager.addRecord( record );
+
+		const undoManager = createUndoManager();
+		undoManager.setFallbackUndoManager( fallbackUndoManager );
+
+		expect( undoManager.hasUndo() ).toBe( true );
+		expect( undoManager.undo() ).toEqual( record );
+	} );
+
+	it( 'orders existing fallback history with new synced history', () => {
+		const fallbackUndoManager = createWPUndoManager();
+		const fallbackRecord = createRecord(
+			{ kind: 'root', name: 'note', recordId: '1' },
+			'Before',
+			'After'
+		);
+		fallbackUndoManager.addRecord( fallbackRecord );
+
+		const undoManager = createUndoManager();
+		const synced = createScopedMap();
+		undoManager.setFallbackUndoManager( fallbackUndoManager );
+		addScopedMap( undoManager, synced );
+		addSyncRecord( undoManager, synced, 'Synced' );
+
+		expect( undoManager.undo() ).toEqual( [] );
+		expect( undoManager.undo() ).toEqual( fallbackRecord );
+		expect( undoManager.redo() ).toEqual( fallbackRecord );
+		expect( synced.map.get( 'title' ) ).toBeUndefined();
+		expect( undoManager.redo() ).toEqual( [] );
+		expect( synced.map.get( 'title' ) ).toBe( 'Synced' );
+	} );
+
+	it( 'preserves chronology between synced and non-synced records', () => {
+		const undoManager = createUndoManager();
+		const synced = createScopedMap();
+		const fallbackRecord = createRecord(
+			{ kind: 'root', name: 'note', recordId: '1' },
+			'Before',
+			'After'
+		);
+		addScopedMap( undoManager, synced );
+
+		addSyncRecord( undoManager, synced, 'Synced' );
+		undoManager.addRecord( fallbackRecord );
+
+		expect( undoManager.undo() ).toEqual( fallbackRecord );
+		expect( synced.map.get( 'title' ) ).toBe( 'Synced' );
+		expect( undoManager.undo() ).toEqual( [] );
+		expect( synced.map.get( 'title' ) ).toBeUndefined();
+
+		expect( undoManager.redo() ).toEqual( [] );
+		expect( synced.map.get( 'title' ) ).toBe( 'Synced' );
+		expect( undoManager.redo() ).toEqual( fallbackRecord );
+	} );
+
+	it( 'starts a new synced undo level after a fallback record', () => {
+		const undoManager = createUndoManager();
+		const synced = createScopedMap();
+		const fallbackRecord = createRecord(
+			{ kind: 'root', name: 'note', recordId: '1' },
+			'Before',
+			'After'
+		);
+		addScopedMap( undoManager, synced );
+
+		addSyncRecord( undoManager, synced, 'First' );
+		undoManager.addRecord( fallbackRecord );
+		addSyncRecord( undoManager, synced, 'Second' );
+
+		expect( undoManager.undo() ).toEqual( [] );
+		expect( synced.map.get( 'title' ) ).toBe( 'First' );
+		expect( undoManager.undo() ).toEqual( fallbackRecord );
+		expect( undoManager.undo() ).toEqual( [] );
+		expect( synced.map.get( 'title' ) ).toBeUndefined();
 	} );
 } );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -198,13 +198,16 @@ export interface SyncManager {
 	) => void;
 }
 
-export interface SyncUndoManager extends WPUndoManager< ObjectData > {
+export interface SyncUndoManager extends WPUndoManager {
 	addToScope: (
 		ymap: Y.Map< any >,
+		objectType: ObjectType,
+		objectId: ObjectID,
 		handlers: Pick<
 			RecordHandlers,
 			'addUndoMeta' | 'restoreUndoMeta' | 'onUndoStackChange'
 		>
 	) => void;
+	setFallbackUndoManager: ( undoManager: WPUndoManager< any > ) => void;
 	stopCapturing: () => void;
 }

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -6,7 +6,12 @@ import type * as Y from 'yjs';
 /**
  * WordPress dependencies
  */
-import type { HistoryRecord } from '@wordpress/undo-manager';
+import { isShallowEqual } from '@wordpress/is-shallow-equal';
+import {
+	createUndoManager as createWPUndoManager,
+	type HistoryRecord,
+	type UndoManager as WPUndoManager,
+} from '@wordpress/undo-manager';
 
 /**
  * Internal dependencies
@@ -14,7 +19,6 @@ import type { HistoryRecord } from '@wordpress/undo-manager';
 import { LOCAL_EDITOR_ORIGIN } from './config';
 import { YMultiDocUndoManager } from './y-utilities/y-multidoc-undomanager';
 import type {
-	ObjectData,
 	RecordHandlers,
 	SyncUndoManager,
 	SyncUndoStackState,
@@ -33,6 +37,21 @@ interface StackItemEvent {
 	ydoc: Y.Doc;
 }
 
+type UndoSource = { type: 'sync'; ydoc: Y.Doc } | { type: 'fallback' };
+
+const getEntityKey = ( objectType: string, objectId: string ): string =>
+	`${ objectType }:${ objectId }`;
+
+const isRecordEmpty = ( record?: HistoryRecord< any > ): boolean =>
+	! record?.some( ( { changes } ) =>
+		Object.values( changes ).some(
+			( { from, to } ) =>
+				typeof from !== 'function' &&
+				typeof to !== 'function' &&
+				! isShallowEqual( from, to )
+		)
+	);
+
 /**
  * Implementation of the WordPress UndoManager interface using YMultiDocUndoManager
  * internally. This allows undo/redo operations to be transacted against multiple
@@ -41,6 +60,13 @@ interface StackItemEvent {
  */
 export function createUndoManager(): SyncUndoManager {
 	const undoMetaHandlers = new Map< Y.Doc, UndoMetaHandlers >();
+	const syncedEntities = new Map< string, Y.Doc >();
+	let fallbackUndoManager: WPUndoManager< any > = createWPUndoManager();
+	let undoSources: UndoSource[] = [];
+	let redoSources: UndoSource[] = [];
+	let reservedSyncSources: Y.Doc[] = [];
+	let unclaimedSyncSources: Y.Doc[] = [];
+	let isApplyingHistory = false;
 	const yUndoManager = new YMultiDocUndoManager( [], {
 		// Throttle undo/redo captures after 500ms of inactivity.
 		// 500 was selected from subjective local UX testing, shorter timeouts
@@ -52,9 +78,16 @@ export function createUndoManager(): SyncUndoManager {
 	} );
 
 	const getUndoStackState = (): SyncUndoStackState => ( {
-		hasRedo: yUndoManager.canRedo(),
-		hasUndo: yUndoManager.canUndo(),
+		hasRedo: redoSources.length > 0 || fallbackUndoManager.hasRedo(),
+		hasUndo: undoSources.length > 0 || fallbackUndoManager.hasUndo(),
 	} );
+
+	const notifyAllUndoStackChanges = (): void => {
+		const state = getUndoStackState();
+		undoMetaHandlers.forEach( ( handlers ) => {
+			handlers.onUndoStackChange?.( state );
+		} );
+	};
 
 	const notifyUndoStackChange = ( ydoc: Y.Doc ): void => {
 		undoMetaHandlers
@@ -69,6 +102,16 @@ export function createUndoManager(): SyncUndoManager {
 		}
 
 		handlers.addUndoMeta( event.ydoc, event.stackItem.meta );
+		if ( event.type === 'undo' && ! isApplyingHistory ) {
+			const reservationIndex = reservedSyncSources.indexOf( event.ydoc );
+			if ( reservationIndex === -1 ) {
+				undoSources.push( { type: 'sync', ydoc: event.ydoc } );
+				redoSources = [];
+				unclaimedSyncSources.push( event.ydoc );
+			} else {
+				reservedSyncSources.splice( reservationIndex, 1 );
+			}
+		}
 		notifyUndoStackChange( event.ydoc );
 	} );
 
@@ -87,10 +130,40 @@ export function createUndoManager(): SyncUndoManager {
 	} );
 
 	yUndoManager.on( 'stack-cleared', () => {
-		undoMetaHandlers.forEach( ( handlers ) => {
-			handlers.onUndoStackChange?.( getUndoStackState() );
-		} );
+		notifyAllUndoStackChanges();
 	} );
+
+	const getRecordSource = ( record: HistoryRecord< any > ): UndoSource => {
+		let sourceDoc: Y.Doc | undefined;
+		for ( const { id } of record ) {
+			if ( typeof id === 'string' ) {
+				return { type: 'fallback' };
+			}
+			const { kind, name, recordId } = id;
+			if (
+				typeof kind !== 'string' ||
+				typeof name !== 'string' ||
+				( typeof recordId !== 'string' && typeof recordId !== 'number' )
+			) {
+				return { type: 'fallback' };
+			}
+			const ydoc = syncedEntities.get(
+				getEntityKey( `${ kind }/${ name }`, String( recordId ) )
+			);
+			if ( ! ydoc || ( sourceDoc && sourceDoc !== ydoc ) ) {
+				return { type: 'fallback' };
+			}
+			sourceDoc = ydoc;
+		}
+		return sourceDoc
+			? { type: 'sync', ydoc: sourceDoc }
+			: { type: 'fallback' };
+	};
+
+	const sourcesMatch = ( first: UndoSource, second: UndoSource ): boolean =>
+		first.type === second.type &&
+		( first.type === 'fallback' ||
+			( second.type === 'sync' && first.ydoc === second.ydoc ) );
 
 	return {
 		/**
@@ -98,27 +171,72 @@ export function createUndoManager(): SyncUndoManager {
 		 * Since Yjs automatically tracks changes, this method translates the WordPress
 		 * HistoryRecord format into Yjs operations.
 		 *
-		 * @param _record   A record of changes to record.
-		 * @param _isStaged Whether to immediately create an undo point or not.
+		 * @param record   A record of changes to record.
+		 * @param isStaged Whether to immediately create an undo point or not.
 		 */
-		addRecord(
-			_record?: HistoryRecord< ObjectData >,
-			_isStaged = false // eslint-disable-line @typescript-eslint/no-unused-vars
-		): void {
-			// This is a no-op for Yjs since it automatically tracks changes.
-			// If needed, we could implement custom logic to handle specific records.
+		addRecord( record?: HistoryRecord< any >, isStaged = false ): void {
+			if ( ! record ) {
+				fallbackUndoManager.addRecord();
+				yUndoManager.stopCapturing();
+				return;
+			}
+			if ( isRecordEmpty( record ) ) {
+				return;
+			}
+
+			const source = getRecordSource( record );
+			const previousSource = undoSources.at( -1 );
+			const continuesPreviousSource =
+				isStaged &&
+				previousSource !== undefined &&
+				sourcesMatch( previousSource, source );
+
+			// A new edit invalidates redo history regardless of which backend
+			// recorded the undone changes.
+			redoSources = [];
+			if ( source.type === 'sync' ) {
+				fallbackUndoManager.addRecord();
+				const unclaimedIndex = unclaimedSyncSources.lastIndexOf(
+					source.ydoc
+				);
+				if ( unclaimedIndex !== -1 ) {
+					unclaimedSyncSources.splice( unclaimedIndex, 1 );
+				} else if ( ! continuesPreviousSource ) {
+					yUndoManager.stopCapturing();
+					undoSources.push( source );
+					reservedSyncSources.push( source.ydoc );
+				}
+			} else {
+				yUndoManager.clear( false, true );
+				yUndoManager.stopCapturing();
+				fallbackUndoManager.addRecord(
+					record,
+					continuesPreviousSource ? isStaged : false
+				);
+				if ( ! continuesPreviousSource ) {
+					undoSources.push( source );
+				}
+			}
+			notifyAllUndoStackChanges();
 		},
 
 		/**
 		 * Add a Yjs map to the scope of the undo manager.
 		 *
 		 * @param {Y.Map< any >} ymap                       The Yjs map to add to the scope.
+		 * @param {string}       objectType                 The entity object type.
+		 * @param {string}       objectId                   The entity object ID.
 		 * @param                handlers                   Handlers for the scoped document.
 		 * @param                handlers.addUndoMeta       Handler to add metadata to undo items.
 		 * @param                handlers.onUndoStackChange Handler for undo stack changes.
 		 * @param                handlers.restoreUndoMeta   Handler to restore metadata from undo items.
 		 */
-		addToScope( ymap: Y.Map< any >, handlers: UndoMetaHandlers ): void {
+		addToScope(
+			ymap: Y.Map< any >,
+			objectType: string,
+			objectId: string,
+			handlers: UndoMetaHandlers
+		): void {
 			if ( ymap.doc === null ) {
 				// Necessary for a type check, but this shouldn't happen.
 				return;
@@ -126,9 +244,32 @@ export function createUndoManager(): SyncUndoManager {
 
 			const ydoc = ymap.doc;
 			yUndoManager.addToScope( ymap );
+			syncedEntities.set( getEntityKey( objectType, objectId ), ydoc );
 
 			if ( ! undoMetaHandlers.has( ydoc ) ) {
-				ydoc.on( 'destroy', () => undoMetaHandlers.delete( ydoc ) );
+				ydoc.on( 'destroy', () => {
+					undoMetaHandlers.delete( ydoc );
+					for ( const [ key, doc ] of syncedEntities ) {
+						if ( doc === ydoc ) {
+							syncedEntities.delete( key );
+						}
+					}
+					undoSources = undoSources.filter(
+						( source ) =>
+							source.type === 'fallback' || source.ydoc !== ydoc
+					);
+					redoSources = redoSources.filter(
+						( source ) =>
+							source.type === 'fallback' || source.ydoc !== ydoc
+					);
+					reservedSyncSources = reservedSyncSources.filter(
+						( doc ) => doc !== ydoc
+					);
+					unclaimedSyncSources = unclaimedSyncSources.filter(
+						( doc ) => doc !== ydoc
+					);
+					notifyAllUndoStackChanges();
+				} );
 			}
 			undoMetaHandlers.set( ydoc, handlers );
 		},
@@ -137,32 +278,62 @@ export function createUndoManager(): SyncUndoManager {
 		 * Undo the last recorded changes.
 		 *
 		 */
-		undo(): HistoryRecord< ObjectData > | undefined {
-			if ( ! yUndoManager.canUndo() ) {
-				return;
+		undo(): HistoryRecord< any > | undefined {
+			const source = undoSources.pop();
+			if ( ! source ) {
+				const record = fallbackUndoManager.undo();
+				if ( record ) {
+					redoSources.push( { type: 'fallback' } );
+				}
+				notifyAllUndoStackChanges();
+				return record;
 			}
-
-			// Perform the undo operation
-			yUndoManager.undo();
-
-			// Intentionally return an empty array, because the SyncProvider will update
-			// the entity record based on the Yjs document changes.
+			redoSources.push( source );
+			if ( source.type === 'fallback' ) {
+				const record = fallbackUndoManager.undo();
+				notifyAllUndoStackChanges();
+				return record;
+			}
+			const unclaimedIndex = unclaimedSyncSources.lastIndexOf(
+				source.ydoc
+			);
+			if ( unclaimedIndex !== -1 ) {
+				unclaimedSyncSources.splice( unclaimedIndex, 1 );
+			}
+			isApplyingHistory = true;
+			try {
+				yUndoManager.undo();
+			} finally {
+				isApplyingHistory = false;
+			}
 			return [];
 		},
 
 		/**
 		 * Redo the last undone changes.
 		 */
-		redo(): HistoryRecord< ObjectData > | undefined {
-			if ( ! yUndoManager.canRedo() ) {
-				return;
+		redo(): HistoryRecord< any > | undefined {
+			const source = redoSources.pop();
+			if ( ! source ) {
+				const record = fallbackUndoManager.redo();
+				if ( record ) {
+					undoSources.push( { type: 'fallback' } );
+				}
+				notifyAllUndoStackChanges();
+				return record;
 			}
-
-			// Perform the redo operation
-			yUndoManager.redo();
-
-			// Intentionally return an empty array, because the SyncProvider will update
-			// the entity record based on the Yjs document changes.
+			undoSources.push( source );
+			if ( source.type === 'fallback' ) {
+				const record = fallbackUndoManager.redo();
+				notifyAllUndoStackChanges();
+				return record;
+			}
+			isApplyingHistory = true;
+			try {
+				yUndoManager.redo();
+			} finally {
+				isApplyingHistory = false;
+			}
 			return [];
 		},
 
@@ -172,7 +343,7 @@ export function createUndoManager(): SyncUndoManager {
 		 * @return {boolean} Whether there are changes to undo.
 		 */
 		hasUndo(): boolean {
-			return yUndoManager.canUndo();
+			return getUndoStackState().hasUndo;
 		},
 
 		/**
@@ -181,7 +352,11 @@ export function createUndoManager(): SyncUndoManager {
 		 * @return {boolean} Whether there are changes to redo.
 		 */
 		hasRedo(): boolean {
-			return yUndoManager.canRedo();
+			return getUndoStackState().hasRedo;
+		},
+
+		setFallbackUndoManager( undoManager: WPUndoManager< any > ): void {
+			fallbackUndoManager = undoManager;
 		},
 
 		/**


### PR DESCRIPTION
## What?

Closes 80722

Preserves undo/redo for non-synced entities while RTC is active.

## Why?

RTC replaced the default undo manager globally, causing edits to non-synced entities to be excluded from undo history.

## How?

Combines Yjs and core-data undo histories while preserving chronological ordering between synced and non-synced edits.

## Testing Instructions

1. Enable RTC and open a synced post.
2. Edit a non-synced custom entity.
3. Confirm `hasUndo()` is true.
4. Undo and redo the edit.
5. Interleave post and custom-entity edits and confirm they undo chronologically.

### Testing Instructions for Keyboard

Use the editor’s keyboard shortcuts to undo and redo the changes.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to assist with investigation, implementation, tests, and documentation. The changes were reviewed and validated by the contributor.