### PR TITLE
Notes: Display shortcut for form action buttons

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -9,7 +9,7 @@ import {
 import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
-import { isKeyboardEvent } from '@wordpress/keycodes';
+import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { privateApis as dataviewsPrivateApis } from '@wordpress/dataviews';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
@@ -123,7 +123,12 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 				gap="sm"
 				wrap="wrap"
 			>
-				<Button size="compact" variant="tertiary" onClick={ onCancel }>
+				<Button
+					size="compact"
+					variant="tertiary"
+					onClick={ onCancel }
+					shortcut="Escape"
+				>
 					<Truncate>{ __( 'Cancel' ) }</Truncate>
 				</Button>
 				<Button
@@ -132,6 +137,7 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 					variant="primary"
 					type="submit"
 					disabled={ isDisabled }
+					shortcut={ displayShortcut.primary( 'Enter' ) }
 				>
 					<Truncate>{ labels?.submit ?? __( 'Add note' ) }</Truncate>
 				</Button>


### PR DESCRIPTION
## What?
PR adds shortcut displays for Notes form action buttons, Escape to cancel, and <kbd>CMD</kbd>+<kbd>Enter</kbd> to submit.

## Testing Instructions
1. Open a post.
2. Start adding a note to a block.
3. Hover on the action buttons.
4. Confirm that proper shortcuts are displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="251" height="185" alt="CleanShot 2026-08-02 at 18 34 28" src="https://github.com/user-attachments/assets/0cf5c464-2780-42ef-8057-70e3bb266af1" />


## Use of AI Tools

None.
