### PR TITLE
Declare missing prettier and stylelint workspace dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53175,7 +53175,8 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/node": "^20.19.39",
-				"@types/prettier": "^2.4.4"
+				"@types/prettier": "^2.4.4",
+				"prettier": "npm:wp-prettier@^3.0.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -55588,6 +55589,7 @@
 			"dependencies": {
 				"@wordpress/stylelint-config": "file:../../packages/stylelint-config",
 				"@wordpress/theme": "file:../../packages/theme",
+				"stylelint": "^16.26.1",
 				"stylelint-plugin-logical-css": "^1.2.3"
 			}
 		},

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -34,7 +34,8 @@
 	"types": "build-types",
 	"devDependencies": {
 		"@types/node": "^20.19.39",
-		"@types/prettier": "^2.4.4"
+		"@types/prettier": "^2.4.4",
+		"prettier": "npm:wp-prettier@^3.0.3"
 	},
 	"peerDependencies": {
 		"prettier": ">=3"

--- a/tools/stylelint/package.json
+++ b/tools/stylelint/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@wordpress/stylelint-config": "file:../../packages/stylelint-config",
 		"@wordpress/theme": "file:../../packages/theme",
+		"stylelint": "^16.26.1",
 		"stylelint-plugin-logical-css": "^1.2.3"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## What?

Declares two missing workspace dependencies so packages no longer rely on hoisting from the root:

- `packages/prettier-config`: add `prettier` (`npm:wp-prettier@^3.0.3`) as a devDependency.
- `tools/stylelint`: add `stylelint` as a dependency.

## Why?

- The `prettier-config` unit tests resolve `prettier` from within the package (`require.resolve( 'prettier' )`), but the package never declared it — it's only a peer dependency there.
- `@wordpress/stylelint-config`, a dependency of `tools/stylelint`, declares `stylelint` as a peer dependency, so the consuming workspace must provide it directly.

Both currently work only because the dependencies happen to be hoisted to the root `node_modules`; declaring them explicitly makes the workspaces correct under isolated/linked install strategies.

## How?

Adds the missing entries to the respective `package.json` files and updates the lockfile.

## Testing Instructions

1. `npm install`
2. `npm run test:unit -- packages/prettier-config` — tests pass.
3. `npm run lint:css` — stylelint still runs.

## Use of AI Tools

Written with the help of Claude Code, reviewed and tested by the author.
