### PR TITLE
View config: lowercase dynamic filter names

### DIFF
--- a/backport-changelog/7.1/12809.md
+++ b/backport-changelog/7.1/12809.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12809
+
+* https://github.com/WordPress/gutenberg/pull/81068

--- a/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
+++ b/docs/how-to-guides/curating-the-editor-experience/filters-and-hooks.md
@@ -83,16 +83,16 @@ The filter receives an instance of the `WP_Theme_JSON_Data class` with the data 
 
 ## Server-side view configuration filter
 
-DataViews-powered screens (such as the Pages list and its Quick Edit form) take their configuration from the server. A dynamic filter, `get_entity_view_config_{$kind}_{$name}`, lets you customize that configuration for a specific entity, where the dynamic portions are the entity kind (e.g. `postType`) and name (e.g. `page`).
+DataViews-powered screens (such as the Pages list and its Quick Edit form) take their configuration from the server. A dynamic filter, `get_entity_view_config_{$kind}_{$name}`, lets you customize that configuration for a specific entity, where the dynamic portions are the entity kind (e.g. `postType`) and name (e.g. `page`), lowercased — so the `postType`/`page` entity maps to the `get_entity_view_config_posttype_page` filter.
 
 Right now, the filter is in use by the following Site Editor screens:
 
 | Page | Filter name |
 | --- | --- |
-| Pages | `get_entity_view_config_postType_page` |
-| Templates | `get_entity_view_config_postType_wp_template` |
-| Parts | `get_entity_view_config_postType_wp_template_part` |
-| Patterns | `get_entity_view_config_postType_wp_block` |
+| Pages | `get_entity_view_config_posttype_page` |
+| Templates | `get_entity_view_config_posttype_wp_template` |
+| Parts | `get_entity_view_config_posttype_wp_template_part` |
+| Patterns | `get_entity_view_config_posttype_wp_block` |
 
 There are four aspects to configure for each entity (and screen):
 
@@ -111,7 +111,7 @@ function example_filter_page_view_config( $data ) {
 
 	return $data;
 }
-add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
+add_filter( 'get_entity_view_config_posttype_page', 'example_filter_page_view_config' );
 ```
 
 ### Update entries with `merge`
@@ -142,7 +142,7 @@ function example_filter_page_view_config( $data ) {
 
 	return $data;
 }
-add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
+add_filter( 'get_entity_view_config_posttype_page', 'example_filter_page_view_config' );
 ```
 
 ### Remove entries with `remove`
@@ -168,7 +168,7 @@ function example_page_view_config_remove( $data ) {
 
 	return $data;
 }
-add_filter( 'get_entity_view_config_postType_page', 'example_page_view_config_remove' );
+add_filter( 'get_entity_view_config_posttype_page', 'example_page_view_config_remove' );
 ```
 
 ### Update entries with `replace`
@@ -191,7 +191,7 @@ function example_filter_page_view_config( $data ) {
 
 	return $data;
 }
-add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
+add_filter( 'get_entity_view_config_posttype_page', 'example_filter_page_view_config' );
 ```
 
 However, this code uses `replace` to substitute the list of visible fields with just `date`, and the Quick Edit form's entire field list with `date` and `my_custom_field`:
@@ -210,7 +210,7 @@ function example_filter_page_view_config( $data ) {
 
 	return $data;
 }
-add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
+add_filter( 'get_entity_view_config_posttype_page', 'example_filter_page_view_config' );
 ```
 
 ### Set entries with `set`
@@ -242,7 +242,7 @@ function example_filter_page_view_config( $data ) {
 
 	return $data;
 }
-add_filter( 'get_entity_view_config_postType_page', 'example_filter_page_view_config' );
+add_filter( 'get_entity_view_config_posttype_page', 'example_filter_page_view_config' );
 ```
 
 ## Client-side (Editor) filters

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -121,7 +121,7 @@ class Gutenberg_View_Config_Data {
 	 *
 	 * Exposes the container through the dynamic
 	 * `get_entity_view_config_{$kind}_{$name}` filter (with the dynamic portions
-	 * lowercased, so that core and third parties can provide the configuration for a specific entity,
+	 * lowercased), so that core and third parties can provide the configuration for a specific entity,
 	 * then reconciles the filtered container back into a plain configuration array,
 	 * limited to the documented configuration keys.
 	 *

--- a/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-view-config-data.php
@@ -120,9 +120,9 @@ class Gutenberg_View_Config_Data {
 	 * Applies the entity view configuration filter and returns the result.
 	 *
 	 * Exposes the container through the dynamic
-	 * `get_entity_view_config_{$kind}_{$name}` filter so that core and third
-	 * parties can provide the configuration for a specific entity, then
-	 * reconciles the filtered container back into a plain configuration array,
+	 * `get_entity_view_config_{$kind}_{$name}` filter (with the dynamic portions
+	 * lowercased, so that core and third parties can provide the configuration for a specific entity,
+	 * then reconciles the filtered container back into a plain configuration array,
 	 * limited to the documented configuration keys.
 	 *
 	 * @since 7.1.0
@@ -136,7 +136,9 @@ class Gutenberg_View_Config_Data {
 		 * Filters the view configuration for a given entity.
 		 *
 		 * The dynamic portions of the hook name, `$kind` and `$name`, refer to the
-		 * entity kind (e.g. `postType`) and the entity name (e.g. `page`).
+		 * entity kind (e.g. `postType`) and the entity name (e.g. `page`),
+		 * lowercased — so the `postType`/`page` entity maps to the
+		 * `get_entity_view_config_posttype_page` hook.
 		 *
 		 * Callbacks receive a Gutenberg_View_Config_Data object and change the
 		 * configuration through its methods. Each write method takes the schema
@@ -180,7 +182,7 @@ class Gutenberg_View_Config_Data {
 		 * }
 		 */
 		apply_filters(
-			"get_entity_view_config_{$kind}_{$name}",
+			gutenberg_get_entity_view_config_hook_name( $kind, $name ),
 			$this,
 			array(
 				'kind' => $kind,

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -4,10 +4,29 @@
  *
  * Builds the default view configuration for an entity and exposes it through
  * the dynamic `get_entity_view_config_{$kind}_{$name}` filter so core and third
- * parties can provide the configuration for a specific entity.
+ * parties can provide the configuration for a specific entity. The dynamic
+ * portions of the hook name are lowercased, e.g.
+ * `get_entity_view_config_posttype_page` for the `page` post type.
  *
  * @package gutenberg
  */
+
+/**
+ * Builds the name of the dynamic filter that provides the view configuration
+ * for an entity.
+ *
+ * The entity kind and name are embedded in the hook name lowercased, so the
+ * hook follows the WordPress convention of lowercase hook names regardless of
+ * how the entity identifiers are spelled: the `postType`/`page` entity maps to
+ * the `get_entity_view_config_posttype_page` hook.
+ *
+ * @param string $kind The entity kind (e.g. `postType`).
+ * @param string $name The entity name (e.g. `page`).
+ * @return string The filter name.
+ */
+function gutenberg_get_entity_view_config_hook_name( $kind, $name ) {
+	return strtolower( "get_entity_view_config_{$kind}_{$name}" );
+}
 
 /**
  * Builds the default `form` configuration for post types that don't provide their own.
@@ -24,7 +43,7 @@
  *
  * @return array The default form configuration.
  */
-function _gutenberg_get_default_post_type_form() {
+function _gutenberg_get_default_posttype_form() {
 	return array(
 		'layout' => array( 'type' => 'panel' ),
 		'fields' => array(
@@ -94,8 +113,10 @@ function _gutenberg_get_default_post_type_form() {
  * Returns the view configuration for the given entity.
  *
  * Builds the default configuration shared by all entities and then exposes it
- * through the dynamic `get_entity_view_config_{$kind}_{$name}` filter so that core
- * and third parties can provide the configuration for a specific entity.
+ * through the dynamic `get_entity_view_config_{$kind}_{$name}` filter — with the
+ * dynamic portions lowercased, see gutenberg_get_entity_view_config_hook_name()
+ * — so that core and third parties can provide the configuration for a
+ * specific entity.
  *
  * @param string $kind The entity kind (e.g. `postType`).
  * @param string $name The entity name (e.g. `page`).
@@ -143,7 +164,7 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
 		'default_view'    => $default_view,
 		'default_layouts' => $default_layouts,
 		'view_list'       => $view_list,
-		'form'            => 'postType' === $kind ? _gutenberg_get_default_post_type_form() : array(),
+		'form'            => 'postType' === $kind ? _gutenberg_get_default_posttype_form() : array(),
 	);
 
 	$data = new Gutenberg_View_Config_Data( $config );
@@ -157,7 +178,7 @@ function gutenberg_get_entity_view_config( $kind, $name ) {
  * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
  * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_page( $data ) {
+function _gutenberg_get_entity_view_config_posttype_page( $data ) {
 	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
@@ -295,7 +316,7 @@ function _gutenberg_get_entity_view_config_post_type_page( $data ) {
  * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
  * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
+function _gutenberg_get_entity_view_config_posttype_wp_block( $data ) {
 	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
@@ -411,7 +432,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_block( $data ) {
  * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
  * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
+function _gutenberg_get_entity_view_config_posttype_wp_template_part( $data ) {
 	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
@@ -511,7 +532,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_template_part( $data ) {
  * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
  * @return Gutenberg_View_Config_Data The updated view configuration container.
  */
-function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
+function _gutenberg_get_entity_view_config_posttype_wp_template( $data ) {
 	$default_view = array(
 		'type'             => 'grid',
 		'perPage'          => 20,
@@ -723,7 +744,7 @@ function _gutenberg_get_entity_view_config_post_type_wp_template( $data ) {
  * Registers the Gutenberg entity view configuration filters, overriding any
  * defaults that WordPress core may have already registered.
  *
- * Core registers its own `_wp_get_entity_view_config_post_type_*` callbacks on
+ * Core registers its own `_wp_get_entity_view_config_posttype_*` callbacks on
  * the shared `get_entity_view_config_{$kind}_{$name}` hooks. The Gutenberg
  * plugin always ships the newest configuration, so it removes the core defaults
  * and installs its own `_gutenberg_*` callbacks instead.
@@ -740,9 +761,9 @@ function gutenberg_register_entity_view_config_filters() {
 	$post_types = array( 'page', 'post', 'wp_block', 'wp_template_part', 'wp_template' );
 
 	foreach ( $post_types as $post_type ) {
-		$hook        = "get_entity_view_config_postType_{$post_type}";
-		$wp_callback = "_wp_get_entity_view_config_post_type_{$post_type}";
-		$gb_callback = "_gutenberg_get_entity_view_config_post_type_{$post_type}";
+		$hook        = gutenberg_get_entity_view_config_hook_name( 'postType', $post_type );
+		$wp_callback = "_wp_get_entity_view_config_posttype_{$post_type}";
+		$gb_callback = "_gutenberg_get_entity_view_config_posttype_{$post_type}";
 
 		// has_filter() returns the priority the callback was registered at.
 		$wp_priority = has_filter( $hook, $wp_callback );

--- a/packages/e2e-tests/plugins/view-config-extensibility.php
+++ b/packages/e2e-tests/plugins/view-config-extensibility.php
@@ -105,6 +105,6 @@ function gutenberg_test_customize_page_view_config( $data ) {
 	return $data;
 }
 add_filter(
-	'get_entity_view_config_postType_page',
+	'get_entity_view_config_posttype_page',
 	'gutenberg_test_customize_page_view_config'
 );

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -66,7 +66,7 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	 * Tears down each test.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'get_entity_view_config_postType_unregistered_cpt' );
+		remove_all_filters( 'get_entity_view_config_posttype_unregistered_cpt' );
 		remove_all_filters( 'get_entity_view_config_custom_kind_custom_name' );
 		parent::tear_down();
 	}
@@ -142,6 +142,28 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 				'name' => 'custom_name',
 			),
 			$received_entity
+		);
+	}
+
+	/**
+	 * The dynamic filter name lowercases the entity kind and name.
+	 */
+	public function test_filter_hook_name_is_lowercased() {
+		$called = false;
+		add_filter(
+			'get_entity_view_config_posttype_unregistered_cpt',
+			function ( $data ) use ( &$called ) {
+				$called = true;
+				return $data;
+			}
+		);
+
+		gutenberg_get_entity_view_config( 'postType', 'Unregistered_CPT' );
+
+		$this->assertTrue( $called );
+		$this->assertSame(
+			'get_entity_view_config_posttype_unregistered_cpt',
+			gutenberg_get_entity_view_config_hook_name( 'postType', 'Unregistered_CPT' )
 		);
 	}
 


### PR DESCRIPTION
Backport at https://github.com/WordPress/wordpress-develop/pull/12809

## What?

Lowercases the dynamic filter names for view config.

## Why?

Lowercase names match PHP practices, [feedback](https://make.wordpress.org/core/2026/07/31/filtering-site-editor-screens-in-wordpress-7-1/#comment-49084).

## How?

Make the dynamic filter hook name lowercase.

## Testing Instructions

Load the Site Editor screens (Pages, Templates, Patterns&Parts) and verify they still work as before.