### PR TITLE
Navigation: Prefill a submenu with a Page List of the parent page's children

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery will keep its current images but stop updating automatically ([#80727](https://github.com/WordPress/gutenberg/pull/80727)).
 -   Page List: Rename the "Edit" action to "Detach", and confirm it in a dialog explaining that the list will keep its current pages but stop adding new ones automatically, matching the Gallery block ([#80847](https://github.com/WordPress/gutenberg/pull/80847)).
+-   Navigation Link: When adding a submenu to a link that points at a Page with child pages, prefill the submenu with a Page List showing that page's children, so the submenu stays up to date as child pages are added ([#42598](https://github.com/WordPress/gutenberg/issues/42598)).
 
 ### Bug Fixes
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -7,7 +7,8 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
@@ -162,6 +163,7 @@ export default function NavigationLinkEdit( {
 
 	const validateLinkStatus = useEnableLinkStatusValidation( clientId );
 	const { getBlocks } = useSelect( blockEditorStore );
+	const registry = useRegistry();
 
 	// URL binding logic
 	const { hasUrlBinding, isBoundEntityAvailable, entityRecord } =
@@ -185,13 +187,51 @@ export default function NavigationLinkEdit( {
 	);
 
 	/**
+	 * Builds a Page List block listing this link's child pages, or `null` when
+	 * the link doesn't point at a Page that has children.
+	 *
+	 * Submenus under a Page are commonly a manual copy of that page's
+	 * children, so a Page List is a better starting point than an empty link:
+	 * it keeps the submenu up to date as child pages are added.
+	 */
+	const getChildPageListBlock = useCallback( async () => {
+		const isPageLink =
+			type === 'page' && ( ! kind || kind === 'post-type' ) && !! id;
+
+		if ( ! isPageLink ) {
+			return null;
+		}
+
+		const childPages = await registry
+			.resolveSelect( coreStore )
+			.getEntityRecords( 'postType', 'page', {
+				parent: id,
+				per_page: 1,
+				_fields: [ 'id' ],
+			} )
+			.catch( () => null );
+
+		if ( ! childPages?.length ) {
+			return null;
+		}
+
+		return createBlock( 'core/page-list', { parentPageID: id } );
+	}, [ type, kind, id, registry ] );
+
+	/**
 	 * Transform to submenu block.
 	 */
-	const transformToSubmenu = useCallback( () => {
+	const transformToSubmenu = useCallback( async () => {
 		let innerBlocks = getBlocks( clientId );
 		if ( innerBlocks.length === 0 ) {
-			innerBlocks = [ createBlock( 'core/navigation-link' ) ];
-			selectBlock( innerBlocks[ 0 ].clientId );
+			const childPageList = await getChildPageListBlock();
+
+			if ( childPageList ) {
+				innerBlocks = [ childPageList ];
+			} else {
+				innerBlocks = [ createBlock( 'core/navigation-link' ) ];
+				selectBlock( innerBlocks[ 0 ].clientId );
+			}
 		}
 		const newSubmenu = createBlock(
 			'core/navigation-submenu',
@@ -199,7 +239,14 @@ export default function NavigationLinkEdit( {
 			innerBlocks
 		);
 		replaceBlock( clientId, newSubmenu );
-	}, [ getBlocks, clientId, selectBlock, replaceBlock, attributes ] );
+	}, [
+		getBlocks,
+		clientId,
+		getChildPageListBlock,
+		selectBlock,
+		replaceBlock,
+		attributes,
+	] );
 
 	// On mount, if this is a new link without a URL and it's selected,
 	// select the parent block (submenu or navigation) instead to keep the appender visible.

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -219,6 +219,129 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 		} );
 
+		test.describe( 'adding a submenu to a page link', () => {
+			test.afterEach( async ( { requestUtils } ) => {
+				await Promise.all( [
+					requestUtils.deleteAllPages(),
+					requestUtils.deleteAllMenus(),
+				] );
+			} );
+
+			async function addSubmenuToPageLink( {
+				admin,
+				editor,
+				page,
+				requestUtils,
+				parentPage,
+			} ) {
+				await requestUtils.createNavigationMenu( {
+					title: 'Test Menu',
+					content: `<!-- wp:navigation-link {"label":"${ parentPage.title.raw }","type":"page","id":${ parentPage.id },"kind":"post-type","url":"${ parentPage.link }"} /-->`,
+				} );
+
+				await admin.createNewPost();
+				await editor.insertBlock( { name: 'core/navigation' } );
+
+				await editor.canvas
+					.getByRole( 'document', {
+						name: 'Block: Page Link',
+					} )
+					.click();
+
+				await page
+					.getByRole( 'button', { name: 'Add submenu' } )
+					.click();
+			}
+
+			test( 'inserts a Page List of the page’s children', async ( {
+				admin,
+				page,
+				editor,
+				requestUtils,
+			} ) => {
+				const parentPage = await requestUtils.createPage( {
+					title: 'Projects',
+					status: 'publish',
+				} );
+				await requestUtils.createPage( {
+					title: 'Project One',
+					status: 'publish',
+					parent: parentPage.id,
+				} );
+				await requestUtils.createPage( {
+					title: 'Unrelated Page',
+					status: 'publish',
+				} );
+
+				await addSubmenuToPageLink( {
+					admin,
+					editor,
+					page,
+					requestUtils,
+					parentPage,
+				} );
+
+				const submenuBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Submenu',
+				} );
+				await expect( submenuBlock ).toBeVisible();
+
+				// The Page List is the submenu's only child and lists the
+				// parent page's children.
+				await expect(
+					submenuBlock.getByRole( 'document', {
+						name: 'Block: Page List',
+					} )
+				).toBeVisible();
+				const pageListBlock = submenuBlock.getByRole( 'document', {
+					name: 'Block: Page List',
+				} );
+				await expect(
+					pageListBlock.getByText( 'Project One' )
+				).toBeVisible();
+				// The list is scoped to the parent page, so unrelated top level
+				// pages are not included.
+				await expect(
+					pageListBlock.getByText( 'Unrelated Page' )
+				).toBeHidden();
+			} );
+
+			test( 'inserts an empty link when the page has no children', async ( {
+				admin,
+				page,
+				editor,
+				requestUtils,
+			} ) => {
+				const parentPage = await requestUtils.createPage( {
+					title: 'Contact',
+					status: 'publish',
+				} );
+
+				await addSubmenuToPageLink( {
+					admin,
+					editor,
+					page,
+					requestUtils,
+					parentPage,
+				} );
+
+				const submenuBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Submenu',
+				} );
+				await expect( submenuBlock ).toBeVisible();
+
+				// Falls back to the empty link, which opens the link UI.
+				await expect(
+					page.getByRole( 'combobox', { name: 'Search or type URL' } )
+				).toBeVisible();
+				await expect(
+					submenuBlock.getByRole( 'document', {
+						name: 'Block: Page List',
+					} )
+				).toBeHidden();
+			} );
+		} );
+
 		test( 'submenu converts to link automatically', async ( {
 			admin,
 			pageUtils,


### PR DESCRIPTION
## What?
Closes #42598

When you add a submenu to a Navigation item that links to a Page, the submenu is now prefilled with a Page List block scoped to that page's children (`parentPageID`), instead of an empty Navigation Link.

If the page has no child pages, nothing changes, the submenu still starts with an empty Navigation Link and opens the link UI.

## Why?
A very common Navigation pattern is manually created top level items, each with a submenu of that item's child pages:

```
Projects
├── Project One
├── Project Two
└── Project Three
```

Building that by hand means the site owner has to update the Navigation every time a child page is added. A Page List scoped to the parent page is dynamic, so it stays current on its own, but wiring it up manually (add submenu → delete the placeholder link → insert Page List → set its Parent) is a fair amount of overhead for what is a common pattern.

Since the Page List block already supports a `parentPageID` attribute (the dependency, #42599, has landed), we can just make it the default starting point for this case.

## Testing Instructions
1. Create a page named **Projects**, and publish a couple of pages with **Projects** set as their Parent (e.g. **Project One**, **Project Two**). Also publish an unrelated top level page (e.g. **Contact**).
2. In a post or template, insert a **Navigation** block.
3. Add a link to the **Projects** page.
4. Select that link and click **Add submenu** in the block toolbar.
5. The submenu is created containing a **Page List** block listing **Project One** and **Project Two**, and not **Contact**. Selecting the Page List and opening the sidebar shows **Parent** set to **Projects**.
6. Publish and view the front end, the submenu shows the child pages.
7. Add a new child page under **Projects** and reload the front end. It appears in the submenu without editing the Navigation.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/e76eb93a-2c5d-49cc-bdde-081255d8fa9d

## Use of AI Tools
This PR was authored with the assistance of Claude Opus.