### PR TITLE
Storybook: Fix missing block styles in BlockCanvas playground stories

### DIFF
--- a/storybook/stories/playground/box/index.jsx
+++ b/storybook/stories/playground/box/index.jsx
@@ -12,8 +12,10 @@ import {
 /**
  * Internal dependencies
  */
-import { editorStyles } from '../editor-styles';
+import { editorStyles, blockLibraryContentStyles } from '../editor-styles';
 import './style.css';
+
+const contentStyles = [ ...blockLibraryContentStyles, ...editorStyles ];
 
 export default function EditorBox() {
 	const [ blocks, updateBlocks ] = useState( [] );
@@ -37,7 +39,7 @@ export default function EditorBox() {
 				} }
 			>
 				<BlockToolbar hideDragHandle />
-				<BlockCanvas height="500px" styles={ editorStyles } />
+				<BlockCanvas height="500px" styles={ contentStyles } />
 			</BlockEditorProvider>
 		</div>
 	);

--- a/storybook/stories/playground/editor-styles.js
+++ b/storybook/stories/playground/editor-styles.js
@@ -1,3 +1,21 @@
+// Base styles for the content rendered within the BlockCanvas iframe.
+// Reason: Styles are contained in the BlockCanvas iframe.
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
+import componentsStyles from '@wordpress/components/build-style/style.css?raw';
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
+import blockEditorContentStyles from '@wordpress/block-editor/build-style/content.css?raw';
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
+import blockLibraryStyles from '@wordpress/block-library/build-style/style.css?raw';
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
+import blockLibraryEditorStyles from '@wordpress/block-library/build-style/editor.css?raw';
+
+export const blockLibraryContentStyles = [
+	{ css: componentsStyles },
+	{ css: blockEditorContentStyles },
+	{ css: blockLibraryStyles },
+	{ css: blockLibraryEditorStyles },
+];
+
 export const editorStyles = [
 	{
 		css: `

--- a/storybook/stories/playground/fullpage/index.jsx
+++ b/storybook/stories/playground/fullpage/index.jsx
@@ -16,7 +16,9 @@ import '@wordpress/format-library';
 // Reason: Styles are injected dynamically.
 // eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
 import styles from './style.lazy.scss?inline';
-import { editorStyles } from '../editor-styles';
+import { editorStyles, blockLibraryContentStyles } from '../editor-styles';
+
+const contentStyles = [ ...blockLibraryContentStyles, ...editorStyles ];
 
 export default function EditorFullPage() {
 	const [ blocks, updateBlocks ] = useState( [] );
@@ -50,7 +52,7 @@ export default function EditorFullPage() {
 					<BlockInspector />
 				</div>
 				<div className="playground__content">
-					<BlockCanvas height="100%" styles={ editorStyles } />
+					<BlockCanvas height="100%" styles={ contentStyles } />
 				</div>
 			</BlockEditorProvider>
 		</div>

--- a/storybook/stories/playground/with-undo-redo/index.jsx
+++ b/storybook/stories/playground/with-undo-redo/index.jsx
@@ -15,8 +15,10 @@ import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { editorStyles } from '../editor-styles';
+import { editorStyles, blockLibraryContentStyles } from '../editor-styles';
 import './style.css';
+
+const contentStyles = [ ...blockLibraryContentStyles, ...editorStyles ];
 
 export default function EditorWithUndoRedo() {
 	const { value, setValue, hasUndo, hasRedo, undo, redo } =
@@ -64,7 +66,7 @@ export default function EditorWithUndoRedo() {
 					/>
 					<BlockToolbar hideDragHandle />
 				</div>
-				<BlockCanvas height="100%" styles={ editorStyles } />
+				<BlockCanvas height="100%" styles={ contentStyles } />
 			</BlockEditorProvider>
 		</div>
 	);


### PR DESCRIPTION
## What?
Closes #68092

Fixes missing/broken block styles (e.g. Image and Button blocks rendering unstyled) in the `BlockCanvas` iframe used by the Playground → Block Editor stories: **Box**, **Default**, and **Undo Redo**.

## Why?
`BlockCanvas` renders block content inside an isolated iframe that does not inherit any CSS from the parent Storybook document. These three stories were only passing a small custom stylesheet (`editorStyles`) into `BlockCanvas`'s `styles` prop with none of the actual block-presentational CSS. As a result, blocks like Image and Buttons rendered with unstyled placeholders, buttons, and layout inside the canvas.

## How?
Added a `blockLibraryContentStyles` export to `storybook/stories/playground/editor-styles.js` containing the four stylesheets needed for the canvas to render blocks correctly:
- `@wordpress/components/build-style/style.css`
- `@wordpress/block-editor/build-style/content.css`
- `@wordpress/block-library/build-style/style.css`
- `@wordpress/block-library/build-style/editor.css`

Each affected story (`box`, `fullpage`, `with-undo-redo`) now spreads `blockLibraryContentStyles` together with its existing `editorStyles` into the `styles` prop passed to `BlockCanvas`, instead of duplicating the raw CSS imports in each file.

## Testing Instructions
1. `npm run storybook:dev`
2. Go to **Playground → Block Editor → Box** (or **Default** / **Undo Redo**)
3. Add an Image block to the canvas
4. Before this PR: the Image placeholder renders as unstyled plain text/box. After this PR: it renders with the proper bordered placeholder, icon, and styled "Insert from URL" button.
5. Repeat for a Buttons block to confirm button styling also renders correctly.

## Screenshots or screencast 

| | Before | After |
|----------|--------|-------|
| Default | <img width="1470" alt="Before Default" src="https://github.com/user-attachments/assets/811e0bb5-a35b-425b-8f27-6ac3dbff0df3" /> | <img width="1469" alt="After Default" src="https://github.com/user-attachments/assets/84e89ee1-8f34-447c-8854-17fcaf80d137" /> |
| Box | <img width="1469" alt="Before Box" src="https://github.com/user-attachments/assets/dfe7e6d3-f464-4618-9d1a-a4c333ea38a7" /> | <img width="1470" alt="After Box" src="https://github.com/user-attachments/assets/a75eef71-5f51-4d4e-a595-54d5c2a72441" /> |
| Undo / Redo | <img width="1470" alt="Before Undo Redo" src="https://github.com/user-attachments/assets/0be125b0-4e1f-48b0-9bf3-1d4058355fc5" /> | <img width="1470" alt="After Undo Redo" src="https://github.com/user-attachments/assets/a6ddc08c-cf6e-4617-a9d2-f8cf85351643" /> |

## Use of AI Tools
This PR was developed with the assistance of Claude Code.
