### PR TITLE
Block Editor: Add filter for context-aware styles

### DIFF
--- a/packages/block-editor/src/components/block-styles/test/use-styles-for-block.js
+++ b/packages/block-editor/src/components/block-styles/test/use-styles-for-block.js
@@ -1,0 +1,267 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeAllFilters } from '@wordpress/hooks';
+import { useSelect, useDispatch, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useStylesForBlocks from '../use-styles-for-block';
+
+jest.mock( '../../../store', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	store: 'core/blocks',
+	getBlockType: jest.fn(),
+	cloneBlock: jest.fn(),
+	getBlockFromExample: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+	select: jest.fn(),
+} ) );
+
+describe( 'useStylesForBlocks', () => {
+	beforeEach( () => {
+		useDispatch.mockImplementation( () => ( {
+			updateBlockAttributes: jest.fn(),
+		} ) );
+
+		useSelect.mockImplementation( () => ( {
+			styles: [
+				{ name: 'default', label: 'Default', isDefault: true },
+				{ name: 'outline', label: 'Outline' },
+			],
+			block: { name: 'core/button' },
+			blockName: 'core/button',
+			blockType: {},
+			className: '',
+		} ) );
+
+		select.mockImplementation( ( storeName ) => {
+			if ( storeName === 'core/block-editor' ) {
+				return {
+					getBlockAttributes: ( id ) =>
+						id === 'test-id'
+							? { className: 'is-style-card-variation' }
+							: {},
+					getBlockParentsByBlockName: ( id, name ) =>
+						name === 'core/cover' ? [ 'parent-id' ] : [],
+				};
+			}
+			if ( storeName === 'core/editor' ) {
+				return {
+					getCurrentPostType: () => 'page',
+				};
+			}
+			if ( storeName === 'core' ) {
+				return {
+					canUser: () => false,
+				};
+			}
+			return {};
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		removeAllFilters( 'blockEditor.useStylesForBlock' );
+	} );
+
+	it( 'returns styles unmodified by default', () => {
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+		expect( result.current.stylesToRender ).toHaveLength( 2 );
+	} );
+
+	it( 'filters styles based on block attributes', () => {
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/filter-by-attribute',
+			( styles, blockName, clientId ) => {
+				const attributes =
+					select( 'core/block-editor' ).getBlockAttributes(
+						clientId
+					);
+				if (
+					attributes?.className?.includes( 'is-style-card-variation' )
+				) {
+					return styles.filter(
+						( style ) => style.name !== 'outline'
+					);
+				}
+				return styles;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 1 );
+		expect( result.current.stylesToRender[ 0 ].name ).toBe( 'default' );
+	} );
+
+	it( 'filters styles based on parent/ancestor blocks', () => {
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/filter-by-parent',
+			( styles, blockName, clientId ) => {
+				const coverParents = select(
+					'core/block-editor'
+				).getBlockParentsByBlockName( clientId, 'core/cover' );
+				if ( coverParents.length > 0 ) {
+					return styles.filter(
+						( style ) => style.name !== 'outline'
+					);
+				}
+				return styles;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 1 );
+		expect( result.current.stylesToRender[ 0 ].name ).toBe( 'default' );
+	} );
+
+	it( 'filters styles based on editor context', () => {
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/filter-by-post-type',
+			( styles ) => {
+				const postType = select( 'core/editor' ).getCurrentPostType();
+				if ( postType === 'page' ) {
+					return styles.filter(
+						( style ) => style.name !== 'outline'
+					);
+				}
+				return styles;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 1 );
+	} );
+
+	it( 'can modify existing styles or append new ones', () => {
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/modify-styles',
+			( styles ) => {
+				const modifiedStyles = styles.map( ( style ) => {
+					if ( style.name === 'default' ) {
+						return { ...style, label: 'Super Default' };
+					}
+					return style;
+				} );
+
+				modifiedStyles.push( {
+					name: 'injected',
+					label: 'Injected Style',
+				} );
+				return modifiedStyles;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 3 );
+		expect( result.current.stylesToRender[ 0 ].label ).toBe(
+			'Super Default'
+		);
+		expect( result.current.stylesToRender[ 2 ].name ).toBe( 'injected' );
+	} );
+
+	it( 'can disable the styles panel completely by returning an empty array', () => {
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/disable-all-styles',
+			() => []
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 0 );
+	} );
+
+	it( 'filters styles based on user permissions', () => {
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/filter-by-permission',
+			( styles ) => {
+				const canPublish = select( 'core' ).canUser(
+					'create',
+					'posts'
+				);
+				if ( ! canPublish ) {
+					return styles.filter(
+						( style ) => style.name !== 'outline'
+					);
+				}
+				return styles;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 1 );
+		expect( result.current.stylesToRender[ 0 ].name ).toBe( 'default' );
+	} );
+
+	it( 'filters styles based on custom global states (e.g. dark mode)', () => {
+		select.mockImplementationOnce( ( storeName ) => {
+			if ( storeName === 'my-custom-plugin' ) {
+				return { isDarkModeActive: () => true };
+			}
+			return {};
+		} );
+
+		addFilter(
+			'blockEditor.useStylesForBlock',
+			'test/filter-by-dark-mode',
+			( styles ) => {
+				const isDarkMode =
+					select( 'my-custom-plugin' ).isDarkModeActive();
+				if ( isDarkMode ) {
+					return [
+						...styles,
+						{ name: 'dark-outline', label: 'Dark Outline' },
+					];
+				}
+				return styles;
+			}
+		);
+
+		const { result } = renderHook( () =>
+			useStylesForBlocks( { clientId: 'test-id', onSwitch: jest.fn() } )
+		);
+
+		expect( result.current.stylesToRender ).toHaveLength( 3 );
+		expect( result.current.stylesToRender[ 2 ].name ).toBe(
+			'dark-outline'
+		);
+	} );
+} );

--- a/packages/block-editor/src/components/block-styles/use-styles-for-block.js
+++ b/packages/block-editor/src/components/block-styles/use-styles-for-block.js
@@ -9,6 +9,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -65,16 +66,36 @@ export default function useStylesForBlocks( { clientId, onSwitch } ) {
 
 		return {
 			block: ! blockType?.example ? block : null,
+			blockName: block.name,
 			blockType,
 			styles: getBlockStyles( block.name ),
 			className: block.attributes.className || '',
 		};
 	};
-	const { styles, block, blockType, className } = useSelect( selector, [
-		clientId,
-	] );
+	const { styles, block, blockName, blockType, className } = useSelect(
+		selector,
+		[ clientId ]
+	);
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const stylesToRender = getRenderedStyles( styles );
+
+	/**
+	 * Filters the available styles for a block to render in the UI.
+	 *
+	 * @param {Array}  styles    The array of styles available for the block.
+	 * @param {string} blockName The name of the block (e.g., 'core/button').
+	 * @param {string} clientId  The client ID of the block.
+	 */
+	const filteredStyles = useMemo(
+		() =>
+			applyFilters(
+				'blockEditor.useStylesForBlock',
+				styles,
+				blockName,
+				clientId
+			),
+		[ styles, blockName, clientId ]
+	);
+	const stylesToRender = getRenderedStyles( filteredStyles );
 	const activeStyle = getActiveStyle( stylesToRender, className );
 	const genericPreviewBlock = useGenericPreviewBlock( block, blockType );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71592

This PR introduces a new JavaScript filter, `blockEditor.useStylesForBlock`, which allows developers to dynamically intercept and modify the list of block styles available in the editor's Styles panel as per the context of the block. 

## Why?
Currently, when a block style is registered via `registerBlockStyle`, it appears globally for all instances of that block. Issue #71592 highlighted the critical need for "Context Aware Block Styles." 

Developers need the ability to show or hide specific styles based on context, such as:
- A style that should only be visible if the block is inside a specific parent (e.g., a specific Button style only allowed inside a Cover block).
- A style that should only be visible for a specific block variation (e.g., checking the block's attributes/className).
- Disabling styles inherited from a parent block for a specific variation.
- Filtering styles based on user permissions or custom post types.

## How?
1. Added `applyFilters( 'blockEditor.useStylesForBlock', styles, blockName, clientId )` inside `packages/block-editor/src/components/block-styles/use-styles-for-block.js`.
2. Added a comprehensive Jest test suite (`test/use-styles-for-block.js`) that proves the filter can successfully handle attribute-based filtering (variations), ancestor-based filtering, editor context checks, and capability checks.

## Testing Instructions
### Test 1: Context-Aware Styles (Parent Blocks)
1. Open a post or page in the Block Editor.
2. Open your browser's Developer Tools Console and paste this snippet:
```javascript
// Register a global style
wp.blocks.registerBlockStyle( 'core/button', { name: 'neon', label: 'Neon (Cover Only)' } );

// Filter it so it only appears inside a Cover block
wp.hooks.addFilter( 'blockEditor.useStylesForBlock', 'testing/context-style', ( styles, blockName, clientId ) => {
    if ( blockName !== 'core/button' || ! styles ) return styles;
    const isInsideCover = wp.data.select( 'core/block-editor' ).getBlockParentsByBlockName( clientId, 'core/cover' ).length > 0;
    return isInsideCover ? styles : styles.filter( s => s.name !== 'neon' );
} );
```
3. Insert a standard Button block on the page. Look at the Styles panel, the "Neon" style should not be there.
4. Insert a Cover block, and add a Button inside it. Select that nested Button, the "Neon" style should now appear.

### Test 2: Variation-Aware Styles (Attributes)

1. Refresh the editor to clear the previous test.
2. In the Developer Tools Console, paste this snippet:
```javascript
// Register a global style
wp.blocks.registerBlockStyle( 'core/group', { name: 'magical-card', label: 'Magical Card' } );

// Filter it so it only appears if the group has a specific class (simulating a variation)
wp.hooks.addFilter( 'blockEditor.useStylesForBlock', 'testing/variation-style', ( styles, blockName, clientId ) => {
    if ( blockName !== 'core/group' || ! styles ) return styles;
    const attrs = wp.data.select( 'core/block-editor' ).getBlockAttributes( clientId );
    const isCard = attrs?.className?.includes( 'is-style-card-variation' );
    return isCard ? styles : styles.filter( s => s.name !== 'magical-card' );
} );
```
3. Insert a Group block. Check the Styles panel, the "Magical Card" style should not be there.
4. Scroll down to the Advanced section in the right sidebar, and in the "Additional CSS class(es)" field, type: `is-style-card-variation`.
5. Check the Styles panel again, the "Magical Card" style will instantly appear.

