### PR TITLE
Global Styles: Prevent editor crash when a preset is missing a slug

### DIFF
--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   Wrap block-level preset class selectors in `:where()` so they keep the same `0-1-0` specificity as root-level presets, preventing block-level palettes (e.g. via the `wp_theme_json_data_theme` filter) from overriding responsive state styles ([#80580](https://github.com/WordPress/gutenberg/issues/80580)).
+-   Skip presets that are missing a `slug` when generating custom properties and preset classes, instead of throwing a `TypeError` that crashes the editor ([#80480](https://github.com/WordPress/gutenberg/issues/80480)).
 
 ### New Features
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -258,6 +258,11 @@ function getPresetsClasses(
 				if ( presetByOrigin[ origin ] ) {
 					presetByOrigin[ origin ].forEach(
 						( { slug }: { slug: string } ) => {
+							// A preset without a slug can't produce a usable
+							// class name or custom property, so skip it.
+							if ( typeof slug !== 'string' ) {
+								return;
+							}
 							classes!.forEach(
 								( {
 									classSuffix,
@@ -1469,6 +1474,11 @@ function getPresetVarDeclarations(
 			continue;
 		}
 		for ( const value of presetByOrigin[ origin ] ) {
+			// A preset without a slug can't produce a usable custom property
+			// name, so skip it.
+			if ( typeof value?.slug !== 'string' ) {
+				continue;
+			}
 			const slug = kebabCase( value.slug );
 			if ( valueKey && ! valueFunc ) {
 				declarations.push(

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -393,6 +393,35 @@ describe( 'global styles renderer', () => {
 				':root{--wp--preset--color--white: white;--wp--preset--color--black: black;--wp--preset--color--white-2-black: value;--wp--custom--white-2-black: value;--wp--custom--font-primary: value;--wp--custom--line-height--body: 1.7;--wp--custom--line-height--heading: 1.3;}h1,h2,h3,h4,h5,h6{--wp--preset--font-size--small: 12px;--wp--preset--font-size--medium: 23px;}'
 			);
 		} );
+
+		it( 'should skip presets that are missing a slug', () => {
+			// A font family declaring only `fontFace`, with no `fontFamily`,
+			// `name` or `slug`. See https://github.com/WordPress/gutenberg/issues/80480.
+			const tree = {
+				settings: {
+					typography: {
+						fontFamilies: {
+							theme: [
+								{
+									fontFace: [
+										{
+											fontFamily: 'Poppins',
+											fontStyle: 'normal',
+											fontWeight: '100',
+											src: [
+												'file:./assets/fonts/poppins/poppins-100-normal.woff2',
+											],
+										},
+									],
+								},
+							],
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			expect( generateCustomProperties( tree, {} ) ).toEqual( '' );
+		} );
 	} );
 
 	describe( 'transformToStyles', () => {
@@ -539,6 +568,49 @@ describe( 'global styles renderer', () => {
 			expect( transformToStyles( tree, blockSelectors ) ).toEqual(
 				':where(body) {margin: 0;}.is-layout-flow > .alignleft { float: left; margin-inline-start: 0; margin-inline-end: 2em; }.is-layout-flow > .alignright { float: right; margin-inline-start: 2em; margin-inline-end: 0; }.is-layout-flow > .aligncenter { margin-left: auto !important; margin-right: auto !important; }.is-layout-constrained > .alignleft { float: left; margin-inline-start: 0; margin-inline-end: 2em; }.is-layout-constrained > .alignright { float: right; margin-inline-start: 2em; margin-inline-end: 0; }.is-layout-constrained > .aligncenter { margin-left: auto !important; margin-right: auto !important; }.is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)) { max-width: var(--wp--style--global--content-size); margin-left: auto !important; margin-right: auto !important; }.is-layout-constrained > .alignwide { max-width: var(--wp--style--global--wide-size); }body .is-layout-flex { display:flex; }.is-layout-flex { flex-wrap: wrap; align-items: center; }.is-layout-flex > :is(*, div) { margin: 0; }body .is-layout-grid { display:grid; }.is-layout-grid > :is(*, div) { margin: 0; }body{background-color: red;margin: 10px;padding: 10px;}a:where(:not(.wp-element-button)){color: blue;}:root :where(a:where(:not(.wp-element-button)):hover){color: orange;}:root :where(a:where(:not(.wp-element-button)):focus){color: orange;}h1{font-size: 42px;}:root :where(.wp-block-group){margin-top: 10px;margin-right: 20px;margin-bottom: 30px;margin-left: 40px;padding-top: 11px;padding-right: 22px;padding-bottom: 33px;padding-left: 44px;}:root :where(h1,h2,h3,h4,h5,h6){color: orange;}:root :where(h1 a:where(:not(.wp-element-button)),h2 a:where(:not(.wp-element-button)),h3 a:where(:not(.wp-element-button)),h4 a:where(:not(.wp-element-button)),h5 a:where(:not(.wp-element-button)),h6 a:where(:not(.wp-element-button))){color: hotpink;}:root :where(h1 a:where(:not(.wp-element-button)):hover,h2 a:where(:not(.wp-element-button)):hover,h3 a:where(:not(.wp-element-button)):hover,h4 a:where(:not(.wp-element-button)):hover,h5 a:where(:not(.wp-element-button)):hover,h6 a:where(:not(.wp-element-button)):hover){color: red;}:root :where(h1 a:where(:not(.wp-element-button)):focus,h2 a:where(:not(.wp-element-button)):focus,h3 a:where(:not(.wp-element-button)):focus,h4 a:where(:not(.wp-element-button)):focus,h5 a:where(:not(.wp-element-button)):focus,h6 a:where(:not(.wp-element-button)):focus){color: red;}:root :where(.wp-block-image img, .wp-block-image .wp-crop-area){border-radius: 9999px;}:root :where(.wp-block-image){color: red;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.has-white-color{color: var(--wp--preset--color--white) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}:where(h1,h2,h3,h4,h5,h6).has-blue-color{color: var(--wp--preset--color--blue) !important;}:where(h1,h2,h3,h4,h5,h6).has-blue-background-color{background-color: var(--wp--preset--color--blue) !important;}:where(h1,h2,h3,h4,h5,h6).has-blue-border-color{border-color: var(--wp--preset--color--blue) !important;}'
 			);
+		} );
+
+		it( 'should skip preset classes for presets that are missing a slug', () => {
+			// A font family declaring only `fontFace`, with no `fontFamily`,
+			// `name` or `slug`. See https://github.com/WordPress/gutenberg/issues/80480.
+			const tree = {
+				settings: {
+					typography: {
+						fontFamilies: {
+							theme: [
+								{
+									fontFace: [
+										{
+											fontFamily: 'Poppins',
+											fontStyle: 'normal',
+											fontWeight: '100',
+											src: [
+												'file:./assets/fonts/poppins/poppins-100-normal.woff2',
+											],
+										},
+									],
+								},
+							],
+						},
+					},
+				},
+			} as unknown as GlobalStylesConfig;
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				{},
+				false,
+				false,
+				true,
+				true,
+				{
+					...minimalStyleOptions,
+					blockStyles: false,
+					presets: true,
+				}
+			);
+
+			expect( result ).toEqual( '' );
 		} );
 
 		it( 'should handle feature selectors', () => {


### PR DESCRIPTION
## What?
Closes #80480

Skips global styles presets that have no `slug` instead of crashing the editor.

## Why?
`kebabCase( undefined )` throws `TypeError: Cannot read properties of undefined (reading 'replace')` during render, taking down the React tree.

## How?
Guards the two preset loops in `packages/global-styles-engine/src/core/render.tsx` that pass a preset `slug` to `kebabCase`:

- `getPresetVarDeclarations` 
- `getPresetsClasses` 

A preset without a slug can't produce a valid custom property name or class name, so it's skipped. Valid presets are unaffected. Adds a regression test for each path.

## Testing Instructions
1. Add a typeset to a block theme's `styles/` directory with a font family that has only a `fontFace` array:

```json
{
	"$schema": "https://schemas.wp.org/wp/7.0/theme.json",
	"version": 3,
	"title": "Poppins",
	"slug": "poppins",
	"settings": {
		"typography": {
			"fontFamilies": [
				{
					"fontFace": [
						{
							"fontFamily": "Poppins",
							"fontStyle": "normal",
							"fontWeight": "100",
							"src": [ "file:./assets/fonts/poppins/poppins-100-normal.woff2" ]
						}
					]
				}
			]
		}
	}
}
```

2. Open Site Editor → Styles → Typography and switch to the typeset.
3. Expected: the editor no longer crashes. On `trunk` it white-screens with the `TypeError` above.

Unit tests: `npm run test:unit packages/global-styles-engine/src/test/render.test.ts`


## Screenshots or screencast
N/A — the fix removes a crash; see the screencast on #80480 for the broken behaviour.

## Use of AI Tools
Claude