### PR TITLE
List View: Only subscribe to the block subtree for rows that can show images

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -63,8 +63,7 @@ const IMAGE_GETTERS = {
 };
 
 function getImagesFromBlock( block, isExpanded ) {
-	const getImages = IMAGE_GETTERS[ block.name ];
-	const images = !! getImages ? getImages( block ) : undefined;
+	const images = block ? IMAGE_GETTERS[ block.name ]( block ) : undefined;
 
 	if ( ! images ) {
 		return [];
@@ -92,7 +91,11 @@ function getImagesFromBlock( block, isExpanded ) {
 export default function useListViewImages( { clientId, isExpanded } ) {
 	const { block } = useSelect(
 		( select ) => {
-			return { block: select( blockEditorStore ).getBlock( clientId ) };
+			const { getBlockName, getBlock } = select( blockEditorStore );
+			// Reading the block subscribes to its whole subtree, so only
+			// do it for blocks that can show an image.
+			const hasImages = !! IMAGE_GETTERS[ getBlockName( clientId ) ];
+			return { block: hasImages ? getBlock( clientId ) : undefined };
 		},
 		[ clientId ]
 	);


### PR DESCRIPTION
## What?
Gate the `getBlock` call in `useListViewImages` on the block being one of the four types that can render a preview image (`core/image`, `core/cover`, `core/media-text`, `core/gallery`).

Avoids unwanted re-renders by this hook when no images can be displayed for a block.

## Testing Instructions
1. Open a post or page.
2. Add image and gallery blocks and select media.
3. Confirm that image previews are correctly displayed in the List View.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
