### PR TITLE
Global Styles: Add theme.json support for <pre> element

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -110,6 +110,7 @@ Settings related to colors.
 | heading | Allow users to set heading colors in a block. | `boolean` | `true` |
 | button | Allow users to set button colors in a block. | `boolean` | `true` |
 | caption | Allow users to set caption colors in a block. | `boolean` | `true` |
+| pre | Allow users to set preformatted text colors in a block. | `boolean` | `true` |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -843,6 +843,7 @@ class WP_Theme_JSON_Gutenberg {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption'   => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'      => 'cite',
+		'pre'       => 'pre',
 		'select'    => 'select',
 		'textInput' => 'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=text],[type=tel],[type=url])',
 	);

--- a/packages/blocks/src/api/constants.ts
+++ b/packages/blocks/src/api/constants.ts
@@ -307,6 +307,7 @@ export const __EXPERIMENTAL_ELEMENTS: Record< string, string > = {
 	caption:
 		'.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 	cite: 'cite',
+	pre: 'pre',
 	select: 'select',
 	textInput:
 		'textarea, input:where([type=email],[type=number],[type=password],[type=search],[type=tel],[type=text],[type=url])',

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -264,6 +264,11 @@
 							"description": "Allow users to set caption colors in a block.",
 							"type": "boolean",
 							"default": true
+						},
+						"pre": {
+							"description": "Allow users to set preformatted text colors in a block.",
+							"type": "boolean",
+							"default": true
 						}
 					},
 					"additionalProperties": false
@@ -2278,6 +2283,29 @@
 					]
 				},
 				"cite": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
+									}
+								]
+							}
+						}
+					]
+				},
+				"pre": {
 					"allOf": [
 						{
 							"$ref": "#/definitions/stylesProperties"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71585

This PR adds support for styling `<pre>` elements globally via `theme.json` by registering `pre` as a valid element under `styles.elements`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, when a `<pre>` element without a Core block class (such as one generated inside a Classic block or from legacy content) contains a string of text wider than the viewport, it forces the *entire page* to have a horizontal scrollbar. However, this fix can be used for _other purpose_ too.

By adding `<pre>` to the supported `theme.json` elements, theme authors can now globally apply properties like `overflow-x: auto;`, colors, typography, and spacing to all `<pre>` tags, resolving the overflow issue natively without requiring custom CSS stylesheets.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added `'pre' => 'pre'` to the element selectors in `lib/class-wp-theme-json-gutenberg.php` and `packages/blocks/src/api/constants.js`. Allowed styling the element in the schemas.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the `theme.json` file of your active block theme and add the following configuration:
```json
"styles": {
    "elements": {
	    "pre": {
		    "color": {
			    "background": "black",
			    "text": "green"
		    },
		    "css": "overflow-x: auto;",
		    "spacing": {
			    "padding": {
				    "top": "25px",
				    "right": "25px",
				    "bottom": "25px",
				    "left": "25px"
			    }
		    }
	    }
    }
}
```
2. Create a new post in the Site Editor.
3. Add a block that uses `<pre>`
4. Verify the `<pre>` block has the custom background, text color, and padding applied.

## Screenshot
<img width="2940" height="1422" alt="image" src="https://github.com/user-attachments/assets/acc2b600-ee44-4f94-b608-d6cbdcb16330" />
