### PR TITLE
Update Terrazzo packages to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14729,9 +14729,9 @@
 			}
 		},
 		"node_modules/@terrazzo/json-schema-tools": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@terrazzo/json-schema-tools/-/json-schema-tools-0.2.1.tgz",
-			"integrity": "sha512-hJPz/huIuYCbXmTV6TU9PNl8BeFFoSQVXfB2oHf7fiY1rymrfMfoFJAQ0IErVoisuBR0DdYquTlQkY/cnz+vEQ==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@terrazzo/json-schema-tools/-/json-schema-tools-0.2.2.tgz",
+			"integrity": "sha512-4g+n4yG5XfqSJRMiH8wz+mTGibDavrGkxQ3s0gOrUsvYBHe9HU/j0ElW0PMYtR54+dcW8Tt9qpFSE7BfZcInmA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -14745,16 +14745,16 @@
 			}
 		},
 		"node_modules/@terrazzo/parser": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.4.0.tgz",
-			"integrity": "sha512-9lTsqAp13nOARSWPFN+55A09OaSU2UfMh3K1x4XlbpTvUGnUtb1rnUg+3t8+5VwTGWVtDA5cUhZfpNESQpxucA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.5.0.tgz",
+			"integrity": "sha512-u8q7KDWJPXvcm3jOiTEBs1xCqNT8ZFu5QCN08YXeRhbekGe78JF+16c65p9y4t29Z6fN2fakc4bMCvGALlgIaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/json-schema-tools": "^0.2.1",
+				"@terrazzo/json-schema-tools": "^0.2.2",
 				"@terrazzo/token-tools": "^2.4.0",
-				"@terrazzo/token-types": "^2.4.0",
+				"@terrazzo/token-types": "^2.5.0",
 				"@types/babel__code-frame": "^7.27.0",
 				"colorjs.io": "^0.6.1",
 				"fast-deep-equal": "^3.1.3",
@@ -14783,28 +14783,28 @@
 			}
 		},
 		"node_modules/@terrazzo/plugin-css": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.4.0.tgz",
-			"integrity": "sha512-mGyrW15w3vqGaO5f/jjntQoAlPNjlnbMWt70UxZkN4ITsFBaxTsWrrm6zuKibkbNuYFX5HcZSUiwf5f7Gd1Vsg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.5.0.tgz",
+			"integrity": "sha512-Bbrd7+kjyZp1TANzcXLWI/5/3j2eEBW0NBJFkhDoHdc7uh1vSXg+ev3VMFq/ycrS9AkqFZ9NvcjDFc/ypoNPeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@terrazzo/token-tools": "^2.4.0"
 			},
 			"peerDependencies": {
-				"@terrazzo/cli": "^2.4.0",
-				"@terrazzo/parser": "^2.4.0"
+				"@terrazzo/cli": "^2.5.0",
+				"@terrazzo/parser": "^2.5.0"
 			}
 		},
 		"node_modules/@terrazzo/token-tools": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.4.0.tgz",
-			"integrity": "sha512-nO0VFZrhsgX3IVsTxVxHiQS4qZK8rFSR7rMh39jJ81xfIlNELYEmE251vgzdly6JHUFk8m8k4EI5L74ekcoxvQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.5.0.tgz",
+			"integrity": "sha512-CREnj4kmbskWugkNCA8SYFcjJmlNpXci2ft9U8GjLOdi5eNkWGjDSW5U3oxn+BQkm0mNjWrWBloyg/L6vzFnWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/token-types": "^2.4.0",
+				"@terrazzo/token-types": "^2.5.0",
 				"colorjs.io": "^0.6.1",
 				"wildcard-match": "^5.1.4"
 			}
@@ -14821,9 +14821,9 @@
 			}
 		},
 		"node_modules/@terrazzo/token-types": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.4.0.tgz",
-			"integrity": "sha512-VE1hhpGCGw57pfflLzC6Xjn/akag526lM6gAf3SNVjEL6AUvGRevjyWG3mgX8I9O5UzbMOH/Gn3RVp63SdE+NA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.5.0.tgz",
+			"integrity": "sha512-KJIG2a20UbG1+fCCuh9TvmyJ5NjHrZ8byFAEiNNJ8FZZ1Ut0DTo4V2vJY1i62bEYRm1kkLd+PkRM7KjsU1JgxQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -54970,9 +54970,9 @@
 			},
 			"devDependencies": {
 				"@storybook/react-vite": "^10.4.3",
-				"@terrazzo/parser": "^2.4.0",
-				"@terrazzo/plugin-css": "^2.4.0",
-				"@terrazzo/token-tools": "^2.4.0",
+				"@terrazzo/parser": "^2.5.0",
+				"@terrazzo/plugin-css": "^2.5.0",
+				"@terrazzo/token-tools": "^2.5.0",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14806,9 +14806,9 @@
 			}
 		},
 		"node_modules/@terrazzo/json-schema-tools": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@terrazzo/json-schema-tools/-/json-schema-tools-0.2.1.tgz",
-			"integrity": "sha512-hJPz/huIuYCbXmTV6TU9PNl8BeFFoSQVXfB2oHf7fiY1rymrfMfoFJAQ0IErVoisuBR0DdYquTlQkY/cnz+vEQ==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@terrazzo/json-schema-tools/-/json-schema-tools-0.2.2.tgz",
+			"integrity": "sha512-4g+n4yG5XfqSJRMiH8wz+mTGibDavrGkxQ3s0gOrUsvYBHe9HU/j0ElW0PMYtR54+dcW8Tt9qpFSE7BfZcInmA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -14822,16 +14822,16 @@
 			}
 		},
 		"node_modules/@terrazzo/parser": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.4.0.tgz",
-			"integrity": "sha512-9lTsqAp13nOARSWPFN+55A09OaSU2UfMh3K1x4XlbpTvUGnUtb1rnUg+3t8+5VwTGWVtDA5cUhZfpNESQpxucA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.5.0.tgz",
+			"integrity": "sha512-u8q7KDWJPXvcm3jOiTEBs1xCqNT8ZFu5QCN08YXeRhbekGe78JF+16c65p9y4t29Z6fN2fakc4bMCvGALlgIaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/json-schema-tools": "^0.2.1",
+				"@terrazzo/json-schema-tools": "^0.2.2",
 				"@terrazzo/token-tools": "^2.4.0",
-				"@terrazzo/token-types": "^2.4.0",
+				"@terrazzo/token-types": "^2.5.0",
 				"@types/babel__code-frame": "^7.27.0",
 				"colorjs.io": "^0.6.1",
 				"fast-deep-equal": "^3.1.3",
@@ -14860,28 +14860,28 @@
 			}
 		},
 		"node_modules/@terrazzo/plugin-css": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.4.0.tgz",
-			"integrity": "sha512-mGyrW15w3vqGaO5f/jjntQoAlPNjlnbMWt70UxZkN4ITsFBaxTsWrrm6zuKibkbNuYFX5HcZSUiwf5f7Gd1Vsg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.5.0.tgz",
+			"integrity": "sha512-Bbrd7+kjyZp1TANzcXLWI/5/3j2eEBW0NBJFkhDoHdc7uh1vSXg+ev3VMFq/ycrS9AkqFZ9NvcjDFc/ypoNPeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@terrazzo/token-tools": "^2.4.0"
 			},
 			"peerDependencies": {
-				"@terrazzo/cli": "^2.4.0",
-				"@terrazzo/parser": "^2.4.0"
+				"@terrazzo/cli": "^2.5.0",
+				"@terrazzo/parser": "^2.5.0"
 			}
 		},
 		"node_modules/@terrazzo/token-tools": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.4.0.tgz",
-			"integrity": "sha512-nO0VFZrhsgX3IVsTxVxHiQS4qZK8rFSR7rMh39jJ81xfIlNELYEmE251vgzdly6JHUFk8m8k4EI5L74ekcoxvQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.5.0.tgz",
+			"integrity": "sha512-CREnj4kmbskWugkNCA8SYFcjJmlNpXci2ft9U8GjLOdi5eNkWGjDSW5U3oxn+BQkm0mNjWrWBloyg/L6vzFnWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/token-types": "^2.4.0",
+				"@terrazzo/token-types": "^2.5.0",
 				"colorjs.io": "^0.6.1",
 				"wildcard-match": "^5.1.4"
 			}
@@ -14898,9 +14898,9 @@
 			}
 		},
 		"node_modules/@terrazzo/token-types": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.4.0.tgz",
-			"integrity": "sha512-VE1hhpGCGw57pfflLzC6Xjn/akag526lM6gAf3SNVjEL6AUvGRevjyWG3mgX8I9O5UzbMOH/Gn3RVp63SdE+NA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.5.0.tgz",
+			"integrity": "sha512-KJIG2a20UbG1+fCCuh9TvmyJ5NjHrZ8byFAEiNNJ8FZZ1Ut0DTo4V2vJY1i62bEYRm1kkLd+PkRM7KjsU1JgxQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -54225,9 +54225,9 @@
 			},
 			"devDependencies": {
 				"@storybook/react-vite": "^10.4.3",
-				"@terrazzo/parser": "^2.4.0",
-				"@terrazzo/plugin-css": "^2.4.0",
-				"@terrazzo/token-tools": "^2.4.0",
+				"@terrazzo/parser": "^2.5.0",
+				"@terrazzo/plugin-css": "^2.5.0",
+				"@terrazzo/token-tools": "^2.5.0",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Internal
 
 -   Collapse the `tsconfig.src.json`/`tsconfig.bin.json`/`tsconfig.test.json` projects into the repository-standard split of `tsconfig.build.json` and a default dev `tsconfig.json`. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 
 ### Bug Fixes
 
@@ -31,7 +32,6 @@
 
 ### Internal
 
--   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 
 ### Code Quality

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0.
+-   Update Terrazzo packages to 2.5.0 ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Code Quality
 
+-   Update Terrazzo packages to 2.5.0.
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0 ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -31,11 +31,11 @@
 
 ### Internal
 
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Code Quality
 
+-   Update Terrazzo packages to 2.5.0.
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0.
+-   Update Terrazzo packages to 2.5.0 ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0 ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -16,11 +16,11 @@
 
 ### Internal
 
+-   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 
 ### Code Quality
 
--   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).
 -   Update `colorjs.io` to 0.7.1 ([#80762](https://github.com/WordPress/gutenberg/pull/80762)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Stop publishing `@wordpress/theme` source paths by moving publish-ready assets outside `src` and enforcing the package boundary ([#80213](https://github.com/WordPress/gutenberg/pull/80213)).

--- a/packages/theme/bin/build-design-tokens/index.ts
+++ b/packages/theme/bin/build-design-tokens/index.ts
@@ -12,23 +12,12 @@ const sources = await Promise.all(
 );
 
 const {
-	tokens: parsedTokens,
+	tokens,
 	sources: parsedSources,
 	resolver,
 } = await parse( sources, {
 	config,
-	skipLint: true,
 } );
-
-// Temporary workaround for Terrazzo bug where `alphabetize: false` leaves token
-// map keys in JSON Pointer form (e.g. `#/foo/bar`) while `aliasOf` references
-// remain dot-delimited (e.g. `foo.bar`), breaking alias lookups. Transforms the
-// map keys using the already-normalized `token.id`.
-//
-// See: https://github.com/terrazzoapp/terrazzo/issues/734
-const tokens = Object.fromEntries(
-	Object.values( parsedTokens ).map( ( token ) => [ token.id, token ] )
-);
 
 const { outputFiles } = await build( tokens, {
 	sources: parsedSources,

--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/index.ts
@@ -2,60 +2,6 @@ import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Plugin } from '@terrazzo/parser';
 
-type DTCGPrimitiveValue =
-	| string
-	| number
-	| boolean
-	| { value: number; unit: string }
-	| { r: number; g: number; b: number; a?: number };
-
-type DTCGValue = DTCGPrimitiveValue | Record< string, DTCGPrimitiveValue >;
-
-interface DTCGExtensions {
-	[ key: string ]: unknown;
-	mode?: Record< string, DTCGValue >;
-}
-
-/**
- * @see https://tr.designtokens.org/format/
- */
-interface DTCGToken {
-	$value: DTCGValue;
-	$type?: string;
-	$description?: string;
-	$extensions?: DTCGExtensions;
-}
-
-interface DTCGGroup {
-	$type?: string;
-	$description?: string;
-	$extensions?: DTCGExtensions;
-	[ key: string ]:
-		| DTCGToken
-		| DTCGGroup
-		| string
-		| DTCGExtensions
-		| undefined;
-}
-
-type DTCGDocument = Record< string, DTCGGroup >;
-
-interface ModeOverride {
-	path: string[];
-	$value: DTCGValue;
-	$type?: string;
-}
-
-/**
- * Type guard to check if a value is a DTCG token (has $value).
- *
- * @param value - The value to check.
- * @return True if the value is a DTCG token.
- */
-function isDTCGToken( value: DTCGToken | DTCGGroup ): value is DTCGToken {
-	return '$value' in value;
-}
-
 /**
  * Set a nested value in an object from a path array.
  *
@@ -66,7 +12,7 @@ function isDTCGToken( value: DTCGToken | DTCGGroup ): value is DTCGToken {
 function setNestedValue(
 	object: Record< string, unknown >,
 	pathParts: string[],
-	value: any
+	value: unknown
 ): void {
 	let current = object;
 
@@ -84,108 +30,85 @@ function setNestedValue(
 }
 
 /**
- * Recursively extracts mode overrides from a DTCG token tree.
- *
- * @param object      - The DTCG group to extract from.
- * @param currentPath - The current path in the token tree.
- * @param currentType - The $type inherited from parent groups.
- * @return A map of mode names to their token overrides.
- */
-function getModeOverrides(
-	object: DTCGGroup,
-	currentPath: string[] = [],
-	currentType?: string
-): Map< string, ModeOverride[] > {
-	const modeOverrides = new Map< string, ModeOverride[] >();
-
-	// Check if this group defines a $type that should be inherited by children
-	const groupType = object.$type ?? currentType;
-
-	for ( const [ key, value ] of Object.entries( object ) ) {
-		// Skip DTCG metadata keys
-		if ( key.startsWith( '$' ) ) {
-			continue;
-		}
-
-		const node = value as DTCGToken | DTCGGroup;
-
-		if ( isDTCGToken( node ) ) {
-			// Extract mode-specific values from extensions
-			const modes = node.$extensions?.mode;
-			if ( modes ) {
-				for ( const [ mode, modeValue ] of Object.entries( modes ) ) {
-					modeOverrides.set( mode, [
-						...( modeOverrides.get( mode ) ?? [] ),
-						{
-							path: [ ...currentPath, key ],
-							$value: modeValue,
-							$type: node.$type ?? groupType,
-						},
-					] );
-				}
-			}
-		} else {
-			// Recurse into nested groups, passing down the type
-			const nextPath = [ ...currentPath, key ];
-			const childOverrides = getModeOverrides(
-				node,
-				nextPath,
-				groupType
-			);
-
-			// Merge child results
-			for ( const [ mode, overrides ] of childOverrides ) {
-				modeOverrides.set( mode, [
-					...( modeOverrides.get( mode ) ?? [] ),
-					...overrides,
-				] );
-			}
-		}
-	}
-
-	return modeOverrides;
-}
-
-/**
  * Terrazzo plugin that generates mode-specific DTCG override files.
- *
- * For each mode found in tokens (via $extensions.mode), generates a separate
- * JSON file per source file containing tokens that have values for that mode.
  *
  * @return A Terrazzo plugin that generates mode-specific DTCG override files.
  */
 export default function pluginModeOverrides(): Plugin {
+	const sourceByToken = new Map< string, string >();
+
 	return {
 		name: '@wordpress/terrazzo-plugin-mode-overrides',
-		async build( { outputFile, sources } ) {
-			for ( const { filename, src } of sources ) {
-				if ( ! filename ) {
+		enforce: 'pre',
+		async transform( { tokens } ) {
+			sourceByToken.clear();
+			for ( const [ id, token ] of Object.entries( tokens ) ) {
+				const { filename } = token.source;
+
+				if ( filename ) {
+					sourceByToken.set( id, filename );
+				}
+			}
+		},
+		async build( { outputFile, resolver } ) {
+			const permutations = resolver.listPermutations?.();
+
+			if ( ! permutations ) {
+				throw new Error(
+					'Could not enumerate mode permutations from the Terrazzo resolver.'
+				);
+			}
+
+			const modifierNames = new Set(
+				permutations.flatMap( ( input ) => Object.keys( input ) )
+			);
+
+			if ( modifierNames.size !== 1 ) {
+				throw new Error(
+					`Expected one mode modifier, received ${ modifierNames.size }.`
+				);
+			}
+
+			const [ modeModifier ] = modifierNames;
+
+			for ( const input of permutations ) {
+				const mode = input[ modeModifier ];
+
+				if ( ! mode || mode === '.' ) {
 					continue;
 				}
 
-				// Parse the source JSON file
-				let document: DTCGDocument;
-				try {
-					document = JSON.parse( src ) as DTCGDocument;
-				} catch ( error ) {
-					throw new Error(
-						`Could not parse ${ filename }\n\n${ error }`
-					);
-				}
+				const modeTokens = resolver.apply( input, {
+					sets: [],
+					modifiers: [ modeModifier ],
+					resolveAliases: false,
+				} );
+				const outputs = new Map<
+					string,
+					{ filename: URL; document: Record< string, unknown > }
+				>();
 
-				// Extract mode overrides from this file
-				const fileOverrides = getModeOverrides( document );
+				for ( const [ id, token ] of Object.entries( modeTokens ) ) {
+					const sourceFilename = sourceByToken.get( id );
 
-				// Generate a DTCG file for each mode found in this source file
-				for ( const [ mode, overrides ] of fileOverrides ) {
-					const output: Record< string, unknown > = {};
-
-					for ( const override of overrides ) {
-						const { path, $value, $type } = override;
-						setNestedValue( output, path, { $type, $value } );
+					if ( ! sourceFilename ) {
+						throw new Error( `Could not find source for ${ id }.` );
 					}
 
-					// Output as {basename}.{mode}.json (e.g., dimension.compact.json)
+					const sourceUrl = new URL( sourceFilename );
+					const output = outputs.get( sourceUrl.href ) ?? {
+						filename: sourceUrl,
+						document: {},
+					};
+
+					setNestedValue( output.document, id.split( '.' ), {
+						$type: token.$type,
+						$value: token.$value,
+					} );
+					outputs.set( sourceUrl.href, output );
+				}
+
+				for ( const { filename, document } of outputs.values() ) {
 					const sourceDir = new URL( './', filename );
 					const outFileName = `${ basename(
 						filename.pathname,
@@ -195,9 +118,10 @@ export default function pluginModeOverrides(): Plugin {
 						`modes/${ outFileName }`,
 						sourceDir
 					);
+
 					outputFile(
 						fileURLToPath( outFileUrl ),
-						JSON.stringify( output, null, '\t' )
+						JSON.stringify( document, null, '\t' )
 					);
 				}
 			}

--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/test/index.test.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/test/index.test.ts
@@ -6,11 +6,13 @@ const cwd = new URL( 'file:///virtual/' );
 async function buildModeOverrides( {
 	sourceDocuments,
 	modeTokens,
+	resolvedModeTokens = modeTokens,
 	sourceByToken,
 	removeTokensBeforeBuild = false,
 }: {
 	sourceDocuments: Record< string, Record< string, unknown > >;
 	modeTokens: Record< string, Record< string, unknown > >;
+	resolvedModeTokens?: Record< string, Record< string, unknown > >;
 	sourceByToken: Record< string, string >;
 	removeTokensBeforeBuild?: boolean;
 } ) {
@@ -26,10 +28,25 @@ async function buildModeOverrides( {
 			{ source: { filename: new URL( filename, cwd ).href } },
 		] )
 	);
+	const modifierName = 'themeMode';
 	const resolver = {
-		listPermutations: () => [ { tzMode: '.' }, { tzMode: 'compact' } ],
-		apply: jest.fn( ( input: { tzMode: string } ) =>
-			input.tzMode === 'compact' ? modeTokens : {}
+		listPermutations: () => [
+			{ [ modifierName ]: '.' },
+			{ [ modifierName ]: 'compact' },
+		],
+		apply: jest.fn(
+			(
+				input: Record< string, string >,
+				options?: { resolveAliases?: boolean }
+			) => {
+				if ( input[ modifierName ] !== 'compact' ) {
+					return {};
+				}
+
+				return options?.resolveAliases === false
+					? modeTokens
+					: resolvedModeTokens;
+			}
 		),
 	};
 	const outputFiles = new Map< string, string >();
@@ -46,7 +63,7 @@ async function buildModeOverrides( {
 		tokens,
 		sources,
 		resolver,
-		outputFile: ( filename, contents ) => {
+		outputFile: ( filename: string, contents: string | Buffer ) => {
 			outputFiles.set( filename, contents.toString() );
 		},
 	} as never );
@@ -172,6 +189,12 @@ describe( 'pluginModeOverrides', () => {
 				'wpds-dimension.gap': {
 					$type: 'dimension',
 					$value: '{wpds-dimension.base}',
+				},
+			},
+			resolvedModeTokens: {
+				'wpds-dimension.gap': {
+					$type: 'dimension',
+					$value: { value: 8, unit: 'px' },
 				},
 			},
 			sourceByToken: {

--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/test/index.test.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/test/index.test.ts
@@ -4,24 +4,16 @@ import pluginModeOverrides from '../index';
 const cwd = new URL( 'file:///virtual/' );
 
 async function buildModeOverrides( {
-	sourceDocuments,
 	modeTokens,
 	resolvedModeTokens = modeTokens,
 	sourceByToken,
 	removeTokensBeforeBuild = false,
 }: {
-	sourceDocuments: Record< string, Record< string, unknown > >;
 	modeTokens: Record< string, Record< string, unknown > >;
 	resolvedModeTokens?: Record< string, Record< string, unknown > >;
 	sourceByToken: Record< string, string >;
 	removeTokensBeforeBuild?: boolean;
 } ) {
-	const sources = Object.entries( sourceDocuments ).map(
-		( [ filename, document ] ) => ( {
-			filename: new URL( filename, cwd ),
-			src: JSON.stringify( document ),
-		} )
-	);
 	const tokens = Object.fromEntries(
 		Object.entries( sourceByToken ).map( ( [ id, filename ] ) => [
 			id,
@@ -61,7 +53,6 @@ async function buildModeOverrides( {
 
 	await plugin.build?.( {
 		tokens,
-		sources,
 		resolver,
 		outputFile: ( filename: string, contents: string | Buffer ) => {
 			outputFiles.set( filename, contents.toString() );
@@ -74,39 +65,6 @@ async function buildModeOverrides( {
 describe( 'pluginModeOverrides', () => {
 	it( 'generates a mode override file for each source', async () => {
 		const outputFiles = await buildModeOverrides( {
-			sourceDocuments: {
-				'border.json': {
-					'wpds-border': {
-						$type: 'dimension',
-						radius: {
-							sm: {
-								$value: { value: 2, unit: 'px' },
-								$extensions: {
-									mode: {
-										compact: {
-											value: 1,
-											unit: 'px',
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				'dimension.json': {
-					'wpds-dimension': {
-						$type: 'dimension',
-						gap: {
-							$value: { value: 8, unit: 'px' },
-							$extensions: {
-								mode: {
-									compact: { value: 4, unit: 'px' },
-								},
-							},
-						},
-					},
-				},
-			},
 			modeTokens: {
 				'wpds-border.radius.sm': {
 					$type: 'dimension',
@@ -167,24 +125,6 @@ describe( 'pluginModeOverrides', () => {
 
 	it( 'preserves unresolved aliases in generated mode overrides', async () => {
 		const outputFiles = await buildModeOverrides( {
-			sourceDocuments: {
-				'dimension.json': {
-					'wpds-dimension': {
-						$type: 'dimension',
-						base: {
-							$value: { value: 8, unit: 'px' },
-						},
-						gap: {
-							$value: '{wpds-dimension.base}',
-							$extensions: {
-								mode: {
-									compact: '{wpds-dimension.base}',
-								},
-							},
-						},
-					},
-				},
-			},
 			modeTokens: {
 				'wpds-dimension.gap': {
 					$type: 'dimension',
@@ -210,21 +150,6 @@ describe( 'pluginModeOverrides', () => {
 
 	it( 'generates mode overrides after other transforms remove tokens', async () => {
 		const outputFiles = await buildModeOverrides( {
-			sourceDocuments: {
-				'dimension.json': {
-					'wpds-dimension': {
-						$type: 'dimension',
-						primitive: {
-							$value: { value: 8, unit: 'px' },
-							$extensions: {
-								mode: {
-									compact: { value: 4, unit: 'px' },
-								},
-							},
-						},
-					},
-				},
-			},
 			modeTokens: {
 				'wpds-dimension.primitive': {
 					$type: 'dimension',

--- a/packages/theme/bin/terrazzo-plugin-mode-overrides/test/index.test.ts
+++ b/packages/theme/bin/terrazzo-plugin-mode-overrides/test/index.test.ts
@@ -1,0 +1,223 @@
+import { fileURLToPath } from 'node:url';
+import pluginModeOverrides from '../index';
+
+const cwd = new URL( 'file:///virtual/' );
+
+async function buildModeOverrides( {
+	sourceDocuments,
+	modeTokens,
+	sourceByToken,
+	removeTokensBeforeBuild = false,
+}: {
+	sourceDocuments: Record< string, Record< string, unknown > >;
+	modeTokens: Record< string, Record< string, unknown > >;
+	sourceByToken: Record< string, string >;
+	removeTokensBeforeBuild?: boolean;
+} ) {
+	const sources = Object.entries( sourceDocuments ).map(
+		( [ filename, document ] ) => ( {
+			filename: new URL( filename, cwd ),
+			src: JSON.stringify( document ),
+		} )
+	);
+	const tokens = Object.fromEntries(
+		Object.entries( sourceByToken ).map( ( [ id, filename ] ) => [
+			id,
+			{ source: { filename: new URL( filename, cwd ).href } },
+		] )
+	);
+	const resolver = {
+		listPermutations: () => [ { tzMode: '.' }, { tzMode: 'compact' } ],
+		apply: jest.fn( ( input: { tzMode: string } ) =>
+			input.tzMode === 'compact' ? modeTokens : {}
+		),
+	};
+	const outputFiles = new Map< string, string >();
+	const plugin = pluginModeOverrides();
+
+	await plugin.transform?.( { tokens } as never );
+	if ( removeTokensBeforeBuild ) {
+		for ( const id of Object.keys( tokens ) ) {
+			delete tokens[ id ];
+		}
+	}
+
+	await plugin.build?.( {
+		tokens,
+		sources,
+		resolver,
+		outputFile: ( filename, contents ) => {
+			outputFiles.set( filename, contents.toString() );
+		},
+	} as never );
+
+	return outputFiles;
+}
+
+describe( 'pluginModeOverrides', () => {
+	it( 'generates a mode override file for each source', async () => {
+		const outputFiles = await buildModeOverrides( {
+			sourceDocuments: {
+				'border.json': {
+					'wpds-border': {
+						$type: 'dimension',
+						radius: {
+							sm: {
+								$value: { value: 2, unit: 'px' },
+								$extensions: {
+									mode: {
+										compact: {
+											value: 1,
+											unit: 'px',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				'dimension.json': {
+					'wpds-dimension': {
+						$type: 'dimension',
+						gap: {
+							$value: { value: 8, unit: 'px' },
+							$extensions: {
+								mode: {
+									compact: { value: 4, unit: 'px' },
+								},
+							},
+						},
+					},
+				},
+			},
+			modeTokens: {
+				'wpds-border.radius.sm': {
+					$type: 'dimension',
+					$value: { value: 1, unit: 'px' },
+				},
+				'wpds-dimension.gap': {
+					$type: 'dimension',
+					$value: { value: 4, unit: 'px' },
+				},
+			},
+			sourceByToken: {
+				'wpds-border.radius.sm': 'border.json',
+				'wpds-dimension.gap': 'dimension.json',
+			},
+		} );
+
+		expect( outputFiles ).toEqual(
+			new Map( [
+				[
+					fileURLToPath(
+						new URL( 'modes/border.compact.json', cwd )
+					),
+					JSON.stringify(
+						{
+							'wpds-border': {
+								radius: {
+									sm: {
+										$type: 'dimension',
+										$value: { value: 1, unit: 'px' },
+									},
+								},
+							},
+						},
+						null,
+						'\t'
+					),
+				],
+				[
+					fileURLToPath(
+						new URL( 'modes/dimension.compact.json', cwd )
+					),
+					JSON.stringify(
+						{
+							'wpds-dimension': {
+								gap: {
+									$type: 'dimension',
+									$value: { value: 4, unit: 'px' },
+								},
+							},
+						},
+						null,
+						'\t'
+					),
+				],
+			] )
+		);
+	} );
+
+	it( 'preserves unresolved aliases in generated mode overrides', async () => {
+		const outputFiles = await buildModeOverrides( {
+			sourceDocuments: {
+				'dimension.json': {
+					'wpds-dimension': {
+						$type: 'dimension',
+						base: {
+							$value: { value: 8, unit: 'px' },
+						},
+						gap: {
+							$value: '{wpds-dimension.base}',
+							$extensions: {
+								mode: {
+									compact: '{wpds-dimension.base}',
+								},
+							},
+						},
+					},
+				},
+			},
+			modeTokens: {
+				'wpds-dimension.gap': {
+					$type: 'dimension',
+					$value: '{wpds-dimension.base}',
+				},
+			},
+			sourceByToken: {
+				'wpds-dimension.gap': 'dimension.json',
+			},
+		} );
+		const output = outputFiles.get(
+			fileURLToPath( new URL( 'modes/dimension.compact.json', cwd ) )
+		);
+
+		expect( output ).toContain( '"$value": "{wpds-dimension.base}"' );
+	} );
+
+	it( 'generates mode overrides after other transforms remove tokens', async () => {
+		const outputFiles = await buildModeOverrides( {
+			sourceDocuments: {
+				'dimension.json': {
+					'wpds-dimension': {
+						$type: 'dimension',
+						primitive: {
+							$value: { value: 8, unit: 'px' },
+							$extensions: {
+								mode: {
+									compact: { value: 4, unit: 'px' },
+								},
+							},
+						},
+					},
+				},
+			},
+			modeTokens: {
+				'wpds-dimension.primitive': {
+					$type: 'dimension',
+					$value: { value: 4, unit: 'px' },
+				},
+			},
+			sourceByToken: {
+				'wpds-dimension.primitive': 'dimension.json',
+			},
+			removeTokensBeforeBuild: true,
+		} );
+
+		expect(
+			outputFiles.get(
+				fileURLToPath( new URL( 'modes/dimension.compact.json', cwd ) )
+			)
+		).toContain( '"value": 4' );
+	} );
+} );

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -88,9 +88,9 @@
 	},
 	"devDependencies": {
 		"@storybook/react-vite": "^10.4.3",
-		"@terrazzo/parser": "^2.4.0",
-		"@terrazzo/plugin-css": "^2.4.0",
-		"@terrazzo/token-tools": "^2.4.0",
+		"@terrazzo/parser": "^2.5.0",
+		"@terrazzo/plugin-css": "^2.5.0",
+		"@terrazzo/token-tools": "^2.5.0",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",

--- a/packages/theme/src/semantic-color-contrast-pairs.ts
+++ b/packages/theme/src/semantic-color-contrast-pairs.ts
@@ -1,0 +1,88 @@
+/**
+ * Semantic color token paths used together for normal text.
+ *
+ * Paths omit the shared `wpds-color` prefix so build configuration and runtime
+ * tests can adapt the same pairs to DTCG token IDs and CSS custom properties.
+ */
+export const SEMANTIC_COLOR_CONTRAST_PAIRS = [
+	{
+		background: 'background.surface.neutral',
+		foreground: 'foreground.content.neutral',
+	},
+	{
+		background: 'background.surface.neutral-strong',
+		foreground: 'foreground.content.neutral',
+	},
+	{
+		background: 'background.surface.neutral-weak',
+		foreground: 'foreground.content.neutral',
+	},
+	{
+		background: 'background.surface.neutral',
+		foreground: 'foreground.content.neutral-weak',
+	},
+	{
+		background: 'background.surface.info',
+		foreground: 'foreground.content.info',
+	},
+	{
+		background: 'background.surface.info-weak',
+		foreground: 'foreground.content.info-weak',
+	},
+	{
+		background: 'background.surface.success',
+		foreground: 'foreground.content.success',
+	},
+	{
+		background: 'background.surface.success-weak',
+		foreground: 'foreground.content.success-weak',
+	},
+	{
+		background: 'background.surface.warning',
+		foreground: 'foreground.content.warning',
+	},
+	{
+		background: 'background.surface.warning-weak',
+		foreground: 'foreground.content.warning-weak',
+	},
+	{
+		background: 'background.surface.caution',
+		foreground: 'foreground.content.caution',
+	},
+	{
+		background: 'background.surface.caution-weak',
+		foreground: 'foreground.content.caution-weak',
+	},
+	{
+		background: 'background.surface.error',
+		foreground: 'foreground.content.error',
+	},
+	{
+		background: 'background.surface.error-weak',
+		foreground: 'foreground.content.error-weak',
+	},
+	{
+		background: 'background.interactive.brand-strong',
+		foreground: 'foreground.interactive.brand-strong',
+	},
+	{
+		background: 'background.interactive.brand-strong-active',
+		foreground: 'foreground.interactive.brand-strong-active',
+	},
+	{
+		background: 'background.interactive.error-strong',
+		foreground: 'foreground.interactive.error-strong',
+	},
+	{
+		background: 'background.interactive.error-strong-active',
+		foreground: 'foreground.interactive.error-strong-active',
+	},
+	{
+		background: 'background.interactive.neutral-strong',
+		foreground: 'foreground.interactive.neutral-strong',
+	},
+	{
+		background: 'background.interactive.neutral-strong-active',
+		foreground: 'foreground.interactive.neutral-strong-active',
+	},
+] as const;

--- a/packages/theme/src/test/semantic-color-contrast.test.ts
+++ b/packages/theme/src/test/semantic-color-contrast.test.ts
@@ -1,7 +1,8 @@
 import { renderHook } from '@testing-library/react';
-import { getContrast } from '../color-ramps/lib/color-utils';
-import { useThemeProviderStyles } from '../use-theme-provider-styles';
 import { DEFAULT_SEED_COLORS } from '../color-ramps';
+import { getContrast } from '../color-ramps/lib/color-utils';
+import { SEMANTIC_COLOR_CONTRAST_PAIRS } from '../semantic-color-contrast-pairs';
+import { useThemeProviderStyles } from '../use-theme-provider-styles';
 
 const MINIMUM_TEXT_CONTRAST = 4.5;
 const CUSTOM_PRIMARY = '#0057b8';
@@ -28,88 +29,12 @@ const THEME_PROVIDER_STYLE_CASES = [
 	},
 ] as const;
 
-const CONTRAST_PAIRS = [
-	{
-		background: '--wpds-color-background-surface-neutral',
-		foreground: '--wpds-color-foreground-content-neutral',
-	},
-	{
-		background: '--wpds-color-background-surface-neutral-strong',
-		foreground: '--wpds-color-foreground-content-neutral',
-	},
-	{
-		background: '--wpds-color-background-surface-neutral-weak',
-		foreground: '--wpds-color-foreground-content-neutral',
-	},
-	{
-		background: '--wpds-color-background-surface-neutral',
-		foreground: '--wpds-color-foreground-content-neutral-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-info',
-		foreground: '--wpds-color-foreground-content-info',
-	},
-	{
-		background: '--wpds-color-background-surface-info-weak',
-		foreground: '--wpds-color-foreground-content-info-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-success',
-		foreground: '--wpds-color-foreground-content-success',
-	},
-	{
-		background: '--wpds-color-background-surface-success-weak',
-		foreground: '--wpds-color-foreground-content-success-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-warning',
-		foreground: '--wpds-color-foreground-content-warning',
-	},
-	{
-		background: '--wpds-color-background-surface-warning-weak',
-		foreground: '--wpds-color-foreground-content-warning-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-caution',
-		foreground: '--wpds-color-foreground-content-caution',
-	},
-	{
-		background: '--wpds-color-background-surface-caution-weak',
-		foreground: '--wpds-color-foreground-content-caution-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-error',
-		foreground: '--wpds-color-foreground-content-error',
-	},
-	{
-		background: '--wpds-color-background-surface-error-weak',
-		foreground: '--wpds-color-foreground-content-error-weak',
-	},
-	{
-		background: '--wpds-color-background-interactive-brand-strong',
-		foreground: '--wpds-color-foreground-interactive-brand-strong',
-	},
-	{
-		background: '--wpds-color-background-interactive-brand-strong-active',
-		foreground: '--wpds-color-foreground-interactive-brand-strong-active',
-	},
-	{
-		background: '--wpds-color-background-interactive-error-strong',
-		foreground: '--wpds-color-foreground-interactive-error-strong',
-	},
-	{
-		background: '--wpds-color-background-interactive-error-strong-active',
-		foreground: '--wpds-color-foreground-interactive-error-strong-active',
-	},
-	{
-		background: '--wpds-color-background-interactive-neutral-strong',
-		foreground: '--wpds-color-foreground-interactive-neutral-strong',
-	},
-	{
-		background: '--wpds-color-background-interactive-neutral-strong-active',
-		foreground: '--wpds-color-foreground-interactive-neutral-strong-active',
-	},
-] as const;
+const CONTRAST_PAIRS = SEMANTIC_COLOR_CONTRAST_PAIRS.map(
+	( { foreground, background } ) => ( {
+		foreground: `--wpds-color-${ foreground.replaceAll( '.', '-' ) }`,
+		background: `--wpds-color-${ background.replaceAll( '.', '-' ) }`,
+	} )
+);
 
 function readToken(
 	styles: Record< string, string | number | undefined >,

--- a/packages/theme/src/test/semantic-color-contrast.test.ts
+++ b/packages/theme/src/test/semantic-color-contrast.test.ts
@@ -1,115 +1,18 @@
 import { renderHook } from '@testing-library/react';
+import { SEMANTIC_COLOR_CONTRAST_PAIRS } from '../semantic-color-contrast-pairs';
 import { getContrast } from '../color-ramps/lib/color-utils';
 import { useThemeProviderStyles } from '../use-theme-provider-styles';
-import { DEFAULT_SEED_COLORS } from '../color-ramps';
 
 const MINIMUM_TEXT_CONTRAST = 4.5;
 const CUSTOM_PRIMARY = '#0057b8';
 const CUSTOM_BACKGROUND = '#f6f3ef';
 
-const THEME_PROVIDER_STYLE_CASES = [
-	{
-		name: 'default seed colors',
-		settings: {
-			color: {
-				primary: DEFAULT_SEED_COLORS.primary,
-				background: DEFAULT_SEED_COLORS.background,
-			},
-		},
-	},
-	{
-		name: 'custom seed colors',
-		settings: {
-			color: {
-				primary: CUSTOM_PRIMARY,
-				background: CUSTOM_BACKGROUND,
-			},
-		},
-	},
-] as const;
-
-const CONTRAST_PAIRS = [
-	{
-		background: '--wpds-color-background-surface-neutral',
-		foreground: '--wpds-color-foreground-content-neutral',
-	},
-	{
-		background: '--wpds-color-background-surface-neutral-strong',
-		foreground: '--wpds-color-foreground-content-neutral',
-	},
-	{
-		background: '--wpds-color-background-surface-neutral-weak',
-		foreground: '--wpds-color-foreground-content-neutral',
-	},
-	{
-		background: '--wpds-color-background-surface-neutral',
-		foreground: '--wpds-color-foreground-content-neutral-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-info',
-		foreground: '--wpds-color-foreground-content-info',
-	},
-	{
-		background: '--wpds-color-background-surface-info-weak',
-		foreground: '--wpds-color-foreground-content-info-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-success',
-		foreground: '--wpds-color-foreground-content-success',
-	},
-	{
-		background: '--wpds-color-background-surface-success-weak',
-		foreground: '--wpds-color-foreground-content-success-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-warning',
-		foreground: '--wpds-color-foreground-content-warning',
-	},
-	{
-		background: '--wpds-color-background-surface-warning-weak',
-		foreground: '--wpds-color-foreground-content-warning-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-caution',
-		foreground: '--wpds-color-foreground-content-caution',
-	},
-	{
-		background: '--wpds-color-background-surface-caution-weak',
-		foreground: '--wpds-color-foreground-content-caution-weak',
-	},
-	{
-		background: '--wpds-color-background-surface-error',
-		foreground: '--wpds-color-foreground-content-error',
-	},
-	{
-		background: '--wpds-color-background-surface-error-weak',
-		foreground: '--wpds-color-foreground-content-error-weak',
-	},
-	{
-		background: '--wpds-color-background-interactive-brand-strong',
-		foreground: '--wpds-color-foreground-interactive-brand-strong',
-	},
-	{
-		background: '--wpds-color-background-interactive-brand-strong-active',
-		foreground: '--wpds-color-foreground-interactive-brand-strong-active',
-	},
-	{
-		background: '--wpds-color-background-interactive-error-strong',
-		foreground: '--wpds-color-foreground-interactive-error-strong',
-	},
-	{
-		background: '--wpds-color-background-interactive-error-strong-active',
-		foreground: '--wpds-color-foreground-interactive-error-strong-active',
-	},
-	{
-		background: '--wpds-color-background-interactive-neutral-strong',
-		foreground: '--wpds-color-foreground-interactive-neutral-strong',
-	},
-	{
-		background: '--wpds-color-background-interactive-neutral-strong-active',
-		foreground: '--wpds-color-foreground-interactive-neutral-strong-active',
-	},
-] as const;
+const CONTRAST_PAIRS = SEMANTIC_COLOR_CONTRAST_PAIRS.map(
+	( { foreground, background } ) => ( {
+		foreground: `--wpds-color-${ foreground.replaceAll( '.', '-' ) }`,
+		background: `--wpds-color-${ background.replaceAll( '.', '-' ) }`,
+	} )
+);
 
 function readToken(
 	styles: Record< string, string | number | undefined >,
@@ -123,25 +26,27 @@ function readToken(
 }
 
 describe( 'semantic color contrast', () => {
-	it.each( THEME_PROVIDER_STYLE_CASES )(
-		'keeps critical foreground/background pairs above WCAG AA text contrast with $name',
-		( { settings } ) => {
-			const { result } = renderHook( () =>
-				useThemeProviderStyles( settings )
-			);
-			const styles = result.current.themeProviderStyles as Record<
-				string,
-				string | number | undefined
-			>;
+	it( 'keeps critical foreground/background pairs above WCAG AA text contrast with custom seed colors', () => {
+		const { result } = renderHook( () =>
+			useThemeProviderStyles( {
+				color: {
+					primary: CUSTOM_PRIMARY,
+					background: CUSTOM_BACKGROUND,
+				},
+			} )
+		);
+		const styles = result.current.themeProviderStyles as Record<
+			string,
+			string | number | undefined
+		>;
 
-			CONTRAST_PAIRS.forEach( ( { foreground, background } ) => {
-				const foregroundValue = readToken( styles, foreground );
-				const backgroundValue = readToken( styles, background );
+		CONTRAST_PAIRS.forEach( ( { foreground, background } ) => {
+			const foregroundValue = readToken( styles, foreground );
+			const backgroundValue = readToken( styles, background );
 
-				expect(
-					getContrast( foregroundValue, backgroundValue )
-				).toBeGreaterThanOrEqual( MINIMUM_TEXT_CONTRAST );
-			} );
-		}
-	);
+			expect(
+				getContrast( foregroundValue, backgroundValue )
+			).toBeGreaterThanOrEqual( MINIMUM_TEXT_CONTRAST );
+		} );
+	} );
 } );

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -266,49 +266,13 @@ const config: Config = {
 		} ),
 		pluginModeOverrides(),
 	],
-
-	// Linter rules current error when multiple entry files are used
-	// See https://github.com/terrazzoapp/terrazzo/issues/505
-	// lint: {
-	// 	rules: {
-	// 		'a11y/min-contrast': [
-	// 			'error',
-	// 			{
-	// 				level: 'AA',
-	// 				pairs: [
-	// 					// Standard BG / FG pairs
-	// 					...[
-	// 						'color.primitive.neutral.1',
-	// 						'color.primitive.neutral.2',
-	// 						'color.primitive.neutral.3',
-	// 						'color.primitive.primary.1',
-	// 						'color.primitive.primary.2',
-	// 						'color.primitive.primary.3',
-	// 					].flatMap( ( bgToken ) =>
-	// 						[
-	// 							'color.primitive.neutral.11',
-	// 							'color.primitive.neutral.12',
-	// 							'color.primitive.primary.11',
-	// 							'color.primitive.primary.12',
-	// 						].map( ( fgToken ) => ( {
-	// 							foreground: fgToken,
-	// 							background: bgToken,
-	// 						} ) )
-	// 					),
-	// 					// Action pairs (ie. using step 9 as background)
-	// 					{
-	// 						foreground: 'color.primitive.primary.contrast',
-	// 						background: 'color.primitive.primary.9',
-	// 					},
-	// 					{
-	// 						foreground: 'color.primitive.primary.1',
-	// 						background: 'color.primitive.primary.9',
-	// 					},
-	// 				],
-	// 			},
-	// 		],
-	// 	},
-	// },
+	lint: {
+		rules: {
+			// Primitive color names are generated outside this package and use
+			// camelCase names that do not match Terrazzo's kebab-case default.
+			'core/consistent-naming': [ 'off', {} ],
+		},
+	},
 };
 
 export default defineConfig( config, {

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -7,6 +7,7 @@ import pluginDsTokenDocs from './bin/terrazzo-plugin-ds-tokens-docs/index';
 import pluginDsTokenFallbacks from './bin/terrazzo-plugin-ds-token-fallbacks/index';
 import inlineAliasValues from './bin/terrazzo-plugin-inline-alias-values/index';
 import typescriptTypes from './bin/terrazzo-plugin-typescript-types/index';
+import { SEMANTIC_COLOR_CONTRAST_PAIRS } from './src/semantic-color-contrast-pairs';
 
 const config: Config = {
 	tokens: [
@@ -268,6 +269,18 @@ const config: Config = {
 	],
 	lint: {
 		rules: {
+			'a11y/min-contrast': [
+				'error',
+				{
+					level: 'AA',
+					pairs: SEMANTIC_COLOR_CONTRAST_PAIRS.map(
+						( { foreground, background } ) => ( {
+							foreground: `wpds-color.${ foreground }`,
+							background: `wpds-color.${ background }`,
+						} )
+					),
+				},
+			],
 			// Primitive color names are generated outside this package and use
 			// camelCase names that do not match Terrazzo's kebab-case default.
 			'core/consistent-naming': [ 'off', {} ],

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -7,6 +7,7 @@ import pluginDsTokenDocs from './bin/terrazzo-plugin-ds-tokens-docs/index';
 import pluginDsTokenFallbacks from './bin/terrazzo-plugin-ds-token-fallbacks/index';
 import inlineAliasValues from './bin/terrazzo-plugin-inline-alias-values/index';
 import typescriptTypes from './bin/terrazzo-plugin-typescript-types/index';
+import { SEMANTIC_COLOR_CONTRAST_PAIRS } from './src/semantic-color-contrast-pairs';
 
 const config: Config = {
 	tokens: [
@@ -271,6 +272,18 @@ const config: Config = {
 	],
 	lint: {
 		rules: {
+			'a11y/min-contrast': [
+				'error',
+				{
+					level: 'AA',
+					pairs: SEMANTIC_COLOR_CONTRAST_PAIRS.map(
+						( { foreground, background } ) => ( {
+							foreground: `wpds-color.${ foreground }`,
+							background: `wpds-color.${ background }`,
+						} )
+					),
+				},
+			],
 			// Primitive color names are generated outside this package and use
 			// camelCase names that do not match Terrazzo's kebab-case default.
 			'core/consistent-naming': [ 'off', {} ],

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -269,49 +269,13 @@ const config: Config = {
 		} ),
 		pluginModeOverrides(),
 	],
-
-	// Linter rules current error when multiple entry files are used
-	// See https://github.com/terrazzoapp/terrazzo/issues/505
-	// lint: {
-	// 	rules: {
-	// 		'a11y/min-contrast': [
-	// 			'error',
-	// 			{
-	// 				level: 'AA',
-	// 				pairs: [
-	// 					// Standard BG / FG pairs
-	// 					...[
-	// 						'color.primitive.neutral.1',
-	// 						'color.primitive.neutral.2',
-	// 						'color.primitive.neutral.3',
-	// 						'color.primitive.primary.1',
-	// 						'color.primitive.primary.2',
-	// 						'color.primitive.primary.3',
-	// 					].flatMap( ( bgToken ) =>
-	// 						[
-	// 							'color.primitive.neutral.11',
-	// 							'color.primitive.neutral.12',
-	// 							'color.primitive.primary.11',
-	// 							'color.primitive.primary.12',
-	// 						].map( ( fgToken ) => ( {
-	// 							foreground: fgToken,
-	// 							background: bgToken,
-	// 						} ) )
-	// 					),
-	// 					// Action pairs (ie. using step 9 as background)
-	// 					{
-	// 						foreground: 'color.primitive.primary.contrast',
-	// 						background: 'color.primitive.primary.9',
-	// 					},
-	// 					{
-	// 						foreground: 'color.primitive.primary.1',
-	// 						background: 'color.primitive.primary.9',
-	// 					},
-	// 				],
-	// 			},
-	// 		],
-	// 	},
-	// },
+	lint: {
+		rules: {
+			// Primitive color names are generated outside this package and use
+			// camelCase names that do not match Terrazzo's kebab-case default.
+			'core/consistent-naming': [ 'off', {} ],
+		},
+	},
 };
 
 export default defineConfig( config, {


### PR DESCRIPTION
Complete release span:

- `@terrazzo/parser`: [2.5.0](https://github.com/terrazzoapp/terrazzo/releases/tag/%40terrazzo%2Fparser%402.5.0)
- `@terrazzo/plugin-css`: [2.5.0](https://github.com/terrazzoapp/terrazzo/releases/tag/%40terrazzo%2Fplugin-css%402.5.0)
- `@terrazzo/token-tools`: [2.5.0 on npm](https://www.npmjs.com/package/@terrazzo/token-tools/v/2.5.0), whose shipped changelog identifies [#791](https://github.com/terrazzoapp/terrazzo/pull/791). Upstream did not create a matching Git tag or GitHub release; see the [effective source span](https://github.com/terrazzoapp/terrazzo/compare/%40terrazzo%2Ftoken-tools%402.4.0...2a7bb898033ffbf5d4d1c5a120aa60a78dfca7ed).

## What?

Updates the aligned Terrazzo group in `packages/theme` from the declared and resolved 2.4.0 versions to 2.5.0. It also uses the new partial-resolver API for mode overrides, removes an obsolete parser workaround, and restores token linting, including native WCAG AA checks for semantic color pairs.

## Why?

Terrazzo 2.5 keeps the parser, CSS plugin, and token tools aligned. Its resolver can now produce only the tokens declared by a mode while preserving aliases, and its repaired multi-file linting can validate the default Theme token graph during generation.

## Notable upstream changes

- **Parser 2.5 adds a `resolveAliases` option to `resolver.apply`.** The Theme mode plugin now requests only the active mode modifier with alias resolution disabled. This preserves alias expressions in mode override files while removing the custom DTCG traversal and second JSON parse. Characterization tests cover per-source output, unresolved aliases, and tokens removed by earlier transforms.
- **The parser now returns normalized token-map keys with `alphabetize: false`.** Upstream fixed [#734](https://github.com/terrazzoapp/terrazzo/issues/734) in [#735](https://github.com/terrazzoapp/terrazzo/pull/735). The obsolete Gutenberg remapping pass is removed; all 332 current Theme tokens already have map keys equal to `token.id`.
- **Multi-file linting no longer has the old [#505](https://github.com/terrazzoapp/terrazzo/issues/505) blocker.** Theme parsing now runs all 16 recommended value and structure rules. The generated camelCase primitive names intentionally disable only the separate `core/consistent-naming` warning. Terrazzo's native `a11y/min-contrast` rule additionally validates 20 current semantic foreground/background pairs at WCAG AA. The same pair list drives a focused Jest check for custom runtime seeds, which the static token build cannot observe. The old commented contrast list was removed because it referenced token IDs that no longer exist.
- **Plugin CSS 2.5 updates its peer requirements to parser and CLI 2.5.** Gutenberg updates the direct parser declaration in the same change. The repository does not install the optional CLI peer, and the existing `FORMAT_ID` imports continue to resolve.
- **Token Tools 2.5 upgrades its build to tsgo/TypeScript 7 and replaces bundled Rolldown output with per-module TypeScript output.** The shipped changelog records [#791](https://github.com/terrazzoapp/terrazzo/pull/791), and the effective source span also includes the compiler-output migration in [#782](https://github.com/terrazzoapp/terrazzo/pull/782). The public root, `/css`, and `/js` specifiers and the `makeCSSVar` signature remain available.
- **Token Tools also moves its internal lint and format tooling to Oxlint/Oxfmt.** Most changes in [#789](https://github.com/terrazzoapp/terrazzo/pull/789) are equivalent rewrites. Invalid input to `makeCSSVar` now throws `TypeError` instead of `Error`, but Gutenberg always passes a valid token ID string, so this does not affect its consumer.
- **The aligned release moves required lockfile helpers.** `@terrazzo/token-types` moves from 2.4.0 to 2.5.0 and `@terrazzo/json-schema-tools` moves from 0.2.1 to 0.2.2. These are build-time transitive changes only.

## How?

Updates the three direct development dependencies, regenerates the root lockfile, and records the maintenance change in the Theme changelog. The mode plugin captures source ownership before other transforms, then uses the Terrazzo resolver to generate each mode-specific DTCG file. A shared semantic contrast-pair contract feeds DTCG IDs to Terrazzo and CSS custom-property names to the custom-seed runtime test.

## Testing Instructions

This is a build-tool update with no intended runtime UI change.

1. Open Storybook at **Design System → Tokens → Typography**.
2. Inspect the heading, body, and code examples.
3. Confirm that the typography examples still render with their expected font families, sizes, weights, and line heights.

<details>
<summary>Automated verification</summary>

Theme token and default-ramp generation completed with token linting enabled, all 20 semantic contrast pairs passing, and no tracked generated-output changes. A controlled one-to-one color pair failed generation with the expected WCAG AA diagnostic, confirming native enforcement. All 14 Theme test suites passed: 138 tests and 8 snapshots. The full repository build, targeted JavaScript lint, dependency validation, lockfile validation, and published-dependency audit also passed.

</details>

### Testing Instructions for Keyboard

No interaction behavior changes. Use Tab to move through Storybook's navigation and content controls, and confirm the typography documentation remains reachable and readable.

## Screenshots or screencast

Not applicable; no visual change is intended.

## Use of AI Tools

Codex selected and implemented the aligned dependency update, reviewed the upstream releases and peer constraints, reconstructed the Token Tools release span from its published package and merged upstream changes, audited Theme's direct imports, added pre-refactor characterization tests, applied the Terrazzo resolver and lint improvements, replaced the obsolete contrast setup with native Terrazzo validation while retaining custom-seed runtime coverage, and ran the verification above.
