### PR TITLE
URL: Stop normalizePath throwing on a malformed percent sequence

### DIFF
--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `getQueryArgs`: Split each query argument on its first `=` only, so values containing `=` — base64 padding, JWTs, nested URLs — are no longer truncated, and ignore malformed pairs with no key instead of promoting the value to one ([#81066](https://github.com/WordPress/gutenberg/pull/81066)).
+-   `normalizePath` no longer throws a `URIError` when a query parameter contains a malformed percent sequence, such as `/wp/v2/posts?search=50%off`. It now uses `safeDecodeURIComponent`, matching the fix already applied to `getQueryArgs` in [#45561](https://github.com/WordPress/gutenberg/pull/45561) ([#81086](https://github.com/WordPress/gutenberg/pull/81086)).
 
 ## 4.53.0 (2026-08-12)
 

--- a/packages/url/src/normalize-path.ts
+++ b/packages/url/src/normalize-path.ts
@@ -1,3 +1,5 @@
+import { safeDecodeURIComponent } from './safe-decode-uri-component';
+
 /**
  * Given a path, returns a normalized path where equal query parameter values
  * will be treated as identical, regardless of order they appear in the original
@@ -25,7 +27,7 @@ export function normalizePath( path: string ): string {
 			// [ [ 'b, '1%2C2' ], [ 'c', '2' ], [ 'a', '5' ] ]
 			.map( ( entry ) => entry.split( '=' ) )
 			// [ [ 'b', '1,2' ], [ 'c', '2' ], [ 'a', '5' ] ]
-			.map( ( pair ) => pair.map( decodeURIComponent ) )
+			.map( ( pair ) => pair.map( safeDecodeURIComponent ) )
 			// [ [ 'a', '5' ], [ 'b, '1,2' ], [ 'c', '2' ] ]
 			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
 			// [ [ 'a', '5' ], [ 'b, '1%2C2' ], [ 'c', '2' ] ]

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1298,4 +1298,18 @@ describe( 'normalizePath', () => {
 		const ab = normalizePath( '/foo/bar?a%2Ca=5,5&a,b=1,1' );
 		expect( ab ).toBe( '/foo/bar?a%2Ca=5%2C5&a%2Cb=1%2C1' );
 	} );
+
+	it( 'should not blow up on malformed params', () => {
+		const path = '/foo/bar?baz=%E0%A4%A';
+
+		expect( () => normalizePath( path ) ).not.toThrow();
+		expect( normalizePath( path ) ).toBe( '/foo/bar?baz=%25E0%25A4%25A' );
+	} );
+
+	it( 'returns a stable path when a param is malformed', () => {
+		const ab = normalizePath( '/foo/bar?a=5&b=50%off' );
+		const ba = normalizePath( '/foo/bar?b=50%off&a=5' );
+
+		expect( ab ).toBe( ba );
+	} );
 } );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/81085

`normalizePath` throws a `URIError` when a query parameter contains a malformed percent sequence. This switches it to the package's own `safeDecodeURIComponent`.

## Why?

`normalizePath` decodes each parameter with bare `decodeURIComponent`, so a lone `%` in a value takes the whole call down:

```js
normalizePath( '/wp/v2/posts?search=50%off' );
// URIError: URI malformed
```

This is the same failure that was fixed for `getQueryArgs` in #45561, where the throw was breaking Calypso. That PR introduced `safeDecodeURIComponent` for exactly this, and `normalizePath` was not updated at the time.

It reaches past the function because the preloading middleware in `@wordpress/api-fetch` calls `normalizePath` on every key of the preloaded data and on `options.path` for every request that passes through it. One unencoded `%`, in a hand-written path or in a server-generated preload key, takes out the middleware instead of failing a single request, and it surfaces during normalization rather than as an API error.

## How?

One line plus the import, matching #45561: `decodeURIComponent` becomes `safeDecodeURIComponent`, which returns the component untouched when decoding fails.

Well-formed input is unaffected. Malformed input now normalizes instead of throwing, and the function stays order-stable, which is the property it exists to provide:

```js
normalizePath( '/foo/bar?a=5&b=50%off' ) === normalizePath( '/foo/bar?b=50%off&a=5' );
// true
```

## Testing Instructions

1. Open a post or page.
2. Open the console.
3. Run `wp.url.normalizePath( '/wp/v2/posts?search=50%off' )`.
4. On trunk it throws `URIError: URI malformed`. With this branch it returns `/wp/v2/posts?search=50%25off`.

Or run the package tests:

```
npm run test:unit -- packages/url
```

Two tests are added, one asserting it no longer throws and one asserting it stays order-stable when a parameter is malformed. `packages/api-fetch` also passes, since it is the consumer of this function.

## Testing Instructions for Keyboard

Not applicable, this is a package-level change with no UI.

## Screenshots or screencast

Not applicable.
