### PR TITLE
Allow organization or repository variable to dictate the Actions runner

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     e2e-playwright:
         name: Playwright - ${{ matrix.part }}
-        runs-on: ${{ vars.PHPUNIT_RUNNER || 'ubuntu-24.04' }}
+        runs-on: ${{ vars.RUNNER_GROUP || 'ubuntu-24.04' }}
         permissions:
             contents: read
             id-token: write
@@ -78,7 +78,7 @@ jobs:
 
     e2e-playwright-rtc-websocket:
         name: Playwright - RTC WebSocket
-        runs-on: ${{ vars.PHPUNIT_RUNNER || 'ubuntu-24.04' }}
+        runs-on: ${{ vars.RUNNER_GROUP || 'ubuntu-24.04' }}
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     e2e-playwright:
         name: Playwright - ${{ matrix.part }}
-        runs-on: ${{ vars.RUNNER_GROUP || 'ubuntu-24.04' }}
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
             id-token: write
@@ -78,7 +78,7 @@ jobs:
 
     e2e-playwright-rtc-websocket:
         name: Playwright - RTC WebSocket
-        runs-on: ${{ vars.RUNNER_GROUP || 'ubuntu-24.04' }}
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     e2e-playwright:
         name: Playwright - ${{ matrix.part }}
-        runs-on: 'ubuntu-24.04'
+        runs-on: ${{ vars.PHPUNIT_RUNNER || 'ubuntu-24.04' }}
         permissions:
             contents: read
             id-token: write
@@ -78,7 +78,7 @@ jobs:
 
     e2e-playwright-rtc-websocket:
         name: Playwright - RTC WebSocket
-        runs-on: 'ubuntu-24.04'
+        runs-on: ${{ vars.PHPUNIT_RUNNER || 'ubuntu-24.04' }}
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,7 +31,7 @@ jobs:
     performance:
         timeout-minutes: 60
         name: Run performance tests
-        runs-on: ${{ vars.RUNNER_GROUP || 'ubuntu-24.04' }}
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,7 +31,7 @@ jobs:
     performance:
         timeout-minutes: 60
         name: Run performance tests
-        runs-on: 'ubuntu-24.04'
+        runs-on: ${{ vars.RUNNER_GROUP || 'ubuntu-24.04' }}
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}


### PR DESCRIPTION
## What?
This updates the performance and E2E GitHub Actions workflows to be directed by an organization or repository variable to use a specific runner or configured group of runners, while still defaulting to the default.

When a maintainer sets `RUNNER_GROUP` to a runner label, the configured jobs will run on that runner instead without editing the workflow.

See also Core-65749.

<!-- In a few words, what is the PR actually doing? -->

## Why?
This is useful for directing longer-running jobs to a dedicated runner during high-load contribution periods, such as Contributor Days or deadlines within a release window.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
None.