### PR TITLE
List View: Pass only minimal required data to sub-tree branches

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -70,7 +70,7 @@ function CopyMenuItem( {
 }
 
 export function BlockSettingsDropdown( {
-	block,
+	clientId,
 	clientIds,
 	children,
 	__experimentalSelectBlock,

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -19,7 +19,8 @@ import { unlock } from '../../lock-unlock';
 
 export const Appender = forwardRef(
 	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
-		const { insertedBlock, setInsertedBlock } = useListViewContext();
+		const { insertedBlockClientId, setInsertedBlockClientId } =
+			useListViewContext();
 
 		const instanceId = useInstanceId( Appender );
 		const { directInsert, hideInserter } = useSelect(
@@ -46,7 +47,7 @@ export const Appender = forwardRef(
 		} );
 
 		const insertedBlockTitle = useBlockDisplayTitle( {
-			clientId: insertedBlock?.clientId,
+			clientId: insertedBlockClientId,
 			context: 'list-view',
 		} );
 
@@ -92,7 +93,9 @@ export const Appender = forwardRef(
 					toggleProps={ { 'aria-describedby': descriptionId } }
 					onSelectOrClose={ ( maybeInsertedBlock ) => {
 						if ( maybeInsertedBlock?.clientId ) {
-							setInsertedBlock( maybeInsertedBlock );
+							setInsertedBlockClientId(
+								maybeInsertedBlock.clientId
+							);
 						}
 					} }
 				/>

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -27,8 +27,11 @@ const ListViewBlockContents = forwardRef(
 		ref
 	) => {
 		const { clientId } = block;
-		const { AdditionalBlockContent, insertedBlock, setInsertedBlock } =
-			useListViewContext();
+		const {
+			AdditionalBlockContent,
+			insertedBlockClientId,
+			setInsertedBlockClientId,
+		} = useListViewContext();
 
 		// Only include all selected blocks if the currently clicked on block
 		// is one of the selected blocks. This ensures that if a user attempts
@@ -43,8 +46,8 @@ const ListViewBlockContents = forwardRef(
 				{ AdditionalBlockContent && (
 					<AdditionalBlockContent
 						block={ block }
-						insertedBlock={ insertedBlock }
-						setInsertedBlock={ setInsertedBlock }
+						insertedBlockClientId={ insertedBlockClientId }
+						setInsertedBlockClientId={ setInsertedBlockClientId }
 					/>
 				) }
 				<BlockDraggable

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -15,7 +15,7 @@ const ListViewBlockContents = forwardRef(
 		{
 			onClick,
 			onToggleExpanded,
-			block,
+			clientId,
 			isSelected,
 			position,
 			siblingBlockCount,
@@ -26,7 +26,6 @@ const ListViewBlockContents = forwardRef(
 		},
 		ref
 	) => {
-		const { clientId } = block;
 		const {
 			AdditionalBlockContent,
 			insertedBlockClientId,
@@ -41,11 +40,15 @@ const ListViewBlockContents = forwardRef(
 			? selectedClientIds
 			: [ clientId ];
 
+		// The additional content is only relevant to the row of the block that
+		// was just inserted, so the other rows skip mounting it entirely.
+		const showAdditionalBlockContent =
+			!! AdditionalBlockContent && insertedBlockClientId === clientId;
+
 		return (
 			<>
-				{ AdditionalBlockContent && (
+				{ showAdditionalBlockContent && (
 					<AdditionalBlockContent
-						block={ block }
 						insertedBlockClientId={ insertedBlockClientId }
 						setInsertedBlockClientId={ setInsertedBlockClientId }
 					/>
@@ -59,7 +62,7 @@ const ListViewBlockContents = forwardRef(
 						<ListViewBlockSelectButton
 							ref={ ref }
 							className="block-editor-list-view-block-contents"
-							block={ block }
+							clientId={ clientId }
 							onClick={ onClick }
 							onToggleExpanded={ onToggleExpanded }
 							isSelected={ isSelected }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -33,7 +33,7 @@ const { Badge: WCBadge } = unlock( componentsPrivateApis );
 function ListViewBlockSelectButton(
 	{
 		className,
-		block: { clientId },
+		clientId,
 		onClick,
 		onContextMenu,
 		onMouseDown,

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -175,7 +175,7 @@ function ListViewBlock( {
 		BlockSettingsMenu,
 		listViewInstanceId,
 		expandedState,
-		setInsertedBlock,
+		setInsertedBlockClientId,
 		treeGridElementRef,
 		rootClientId,
 	} = useListViewContext();
@@ -742,7 +742,9 @@ function ListViewBlock( {
 							disableOpenOnArrowDown
 							expand={ expand }
 							expandedState={ expandedState }
-							setInsertedBlock={ setInsertedBlock }
+							setInsertedBlockClientId={
+								setInsertedBlockClientId
+							}
 							__experimentalSelectBlock={
 								updateFocusAndSelection
 							}

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -54,7 +54,7 @@ import usePasteStyles from '../use-paste-styles';
 import { getBlockVisibilityLabel } from '../block-visibility';
 
 function ListViewBlock( {
-	block: { clientId },
+	clientId,
 	displacement,
 	isAfterDraggedBlocks,
 	isDragged,
@@ -120,12 +120,11 @@ function ListViewBlock( {
 	const { getGroupingBlockName } = useSelect( blocksStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-
 	const pasteStyles = usePasteStyles();
 
 	const {
-		block,
 		blockName,
+		blockVisibility,
 		blockEditingMode,
 		allowRightClickOverrides,
 		editedSection,
@@ -134,8 +133,8 @@ function ListViewBlock( {
 	} = useSelect(
 		( select ) => {
 			const {
-				getBlock,
 				getBlockName,
+				getBlockAttributes,
 				getBlockEditingMode: getBlockEditingModeForClientId,
 				getSettings,
 				getEditedContentOnlySection,
@@ -143,8 +142,9 @@ function ListViewBlock( {
 			const settings = getSettings();
 
 			return {
-				block: getBlock( clientId ),
 				blockName: getBlockName( clientId ),
+				blockVisibility:
+					getBlockAttributes( clientId )?.metadata?.blockVisibility,
 				blockEditingMode: getBlockEditingModeForClientId( clientId ),
 				allowRightClickOverrides: settings.allowRightClickOverrides,
 				editedSection: getEditedContentOnlySection(),
@@ -543,7 +543,7 @@ function ListViewBlock( {
 	// When switching between rendering modes (such as template preview and content only),
 	// it is possible for a block to temporarily be unavailable. In this case, we should not
 	// render the leaf, to avoid errors further down the tree.
-	if ( ! block ) {
+	if ( ! blockName ) {
 		return null;
 	}
 
@@ -560,7 +560,7 @@ function ListViewBlock( {
 
 	// Determine label based on where block is hidden (not when/current viewport)
 	const blockVisibilityDescription = getBlockVisibilityLabel(
-		block?.attributes?.metadata?.blockVisibility,
+		blockVisibility,
 		viewportSettings
 	);
 
@@ -650,7 +650,7 @@ function ListViewBlock( {
 				{ ( { ref, tabIndex, onFocus } ) => (
 					<div className="block-editor-list-view-block__contents-container">
 						<ListViewBlockContents
-							block={ block }
+							clientId={ clientId }
 							onClick={ selectEditorBlock }
 							onContextMenu={
 								isDisabled ? undefined : onContextMenu
@@ -724,8 +724,8 @@ function ListViewBlock( {
 				>
 					{ ( { ref, tabIndex, onFocus } ) => (
 						<BlockSettingsMenu
+							clientId={ clientId }
 							clientIds={ dropdownClientIds }
-							block={ block }
 							icon={ moreVertical }
 							label={ __( 'Options' ) }
 							popoverProps={ {

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -222,7 +222,7 @@ function ListViewBranch( props ) {
 			<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 				{ showBlock && (
 					<ListViewBlock
-						block={ block }
+						clientId={ clientId }
 						selectBlock={ selectBlock }
 						isSelected={ isSelected }
 						isBranchSelected={ isSelectedBranch }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -134,7 +134,8 @@ function ListViewComponent(
 
 	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
 
-	const [ insertedBlock, setInsertedBlock ] = useState( null );
+	const [ insertedBlockClientId, setInsertedBlockClientId ] =
+		useState( null );
 
 	const { setSelectedTreeId } = useListViewExpandSelectedItem( {
 		firstSelectedBlockClientId: selectedClientIds[ 0 ],
@@ -296,8 +297,8 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			AdditionalBlockContent,
-			insertedBlock,
-			setInsertedBlock,
+			insertedBlockClientId,
+			setInsertedBlockClientId,
 			treeGridElementRef: elementRef,
 			rootClientId,
 		} ),
@@ -314,8 +315,8 @@ function ListViewComponent(
 			BlockSettingsMenu,
 			instanceId,
 			AdditionalBlockContent,
-			insertedBlock,
-			setInsertedBlock,
+			insertedBlockClientId,
+			setInsertedBlockClientId,
 			rootClientId,
 		]
 	);

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -37,7 +37,7 @@ function AddSubmenuItem( {
 	onClose,
 	expandedState,
 	expand,
-	setInsertedBlock,
+	setInsertedBlockClientId,
 } ) {
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
@@ -90,7 +90,7 @@ function AddSubmenuItem( {
 				// This call sets the local List View state for the "last inserted block".
 				// This is required for the Nav Block to determine whether or not to display
 				// the Link UI for this new block.
-				setInsertedBlock( newLink );
+				setInsertedBlockClientId( newLink.clientId );
 
 				if ( ! expandedState[ block.clientId ] ) {
 					expand( block.clientId );
@@ -201,7 +201,9 @@ export default function LeafMoreMenu( props ) {
 							onClose={ onClose }
 							expandedState={ props.expandedState }
 							expand={ props.expand }
-							setInsertedBlock={ props.setInsertedBlock }
+							setInsertedBlockClientId={
+								props.setInsertedBlockClientId
+							}
 						/>
 						{ canDuplicate && (
 							<MenuItem

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -33,7 +33,7 @@ const BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU = [
 ];
 
 function AddSubmenuItem( {
-	block,
+	clientId,
 	onClose,
 	expandedState,
 	expand,
@@ -42,9 +42,15 @@ function AddSubmenuItem( {
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
 
-	const clientId = block.clientId;
+	// The menu contents only mount while the dropdown is open, so reading the
+	// whole block here doesn't subscribe every List View row to the block tree.
+	const block = useSelect(
+		( select ) => select( blockEditorStore ).getBlock( clientId ),
+		[ clientId ]
+	);
+
 	const isDisabled = ! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes(
-		block.name
+		block?.name
 	);
 	return (
 		<MenuItem
@@ -92,8 +98,8 @@ function AddSubmenuItem( {
 				// the Link UI for this new block.
 				setInsertedBlockClientId( newLink.clientId );
 
-				if ( ! expandedState[ block.clientId ] ) {
-					expand( block.clientId );
+				if ( ! expandedState[ clientId ] ) {
+					expand( clientId );
 				}
 				onClose();
 			} }
@@ -104,8 +110,7 @@ function AddSubmenuItem( {
 }
 
 export default function LeafMoreMenu( props ) {
-	const { block } = props;
-	const { clientId } = block;
+	const { clientId } = props;
 
 	const {
 		moveBlocksDown,
@@ -127,6 +132,7 @@ export default function LeafMoreMenu( props ) {
 			( select ) => {
 				const {
 					getBlockRootClientId,
+					getBlockName,
 					canInsertBlockType,
 					getDirectInsertBlock,
 					getBlockIndex,
@@ -135,6 +141,7 @@ export default function LeafMoreMenu( props ) {
 				const { getDefaultBlockName } = select( blocksStore );
 
 				const _rootClientId = getBlockRootClientId( clientId );
+				const blockName = getBlockName( clientId );
 				const canInsertDefaultBlock = canInsertBlockType(
 					getDefaultBlockName(),
 					_rootClientId
@@ -146,20 +153,20 @@ export default function LeafMoreMenu( props ) {
 				return {
 					rootClientId: _rootClientId,
 					canDuplicate:
-						!! block &&
-						hasBlockSupport( block.name, 'multiple', true ) &&
-						canInsertBlockType( block.name, _rootClientId ),
+						!! blockName &&
+						hasBlockSupport( blockName, 'multiple', true ) &&
+						canInsertBlockType( blockName, _rootClientId ),
 					canInsertBlock:
 						( canInsertDefaultBlock || !! directInsertBlock ) &&
-						!! block &&
-						canInsertBlockType( block.name, _rootClientId ),
+						!! blockName &&
+						canInsertBlockType( blockName, _rootClientId ),
 					isFirst: getBlockIndex( clientId ) === 0,
 					isLast:
 						getBlockIndex( clientId ) ===
 						getBlockCount( _rootClientId ) - 1,
 				};
 			},
-			[ clientId, block ]
+			[ clientId ]
 		);
 
 	return (
@@ -197,7 +204,7 @@ export default function LeafMoreMenu( props ) {
 							{ __( 'Move down' ) }
 						</MenuItem>
 						<AddSubmenuItem
-							block={ block }
+							clientId={ clientId }
 							onClose={ onClose }
 							expandedState={ props.expandedState }
 							expand={ props.expand }

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -35,23 +35,15 @@ const BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU = [
 function AddSubmenuItem( {
 	clientId,
 	onClose,
+	isDisabled,
 	expandedState,
 	expand,
 	setInsertedBlockClientId,
 } ) {
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
 		useDispatch( blockEditorStore );
+	const { getBlock } = useSelect( blockEditorStore );
 
-	// The menu contents only mount while the dropdown is open, so reading the
-	// whole block here doesn't subscribe every List View row to the block tree.
-	const block = useSelect(
-		( select ) => select( blockEditorStore ).getBlock( clientId ),
-		[ clientId ]
-	);
-
-	const isDisabled = ! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes(
-		block?.name
-	);
 	return (
 		<MenuItem
 			icon={ addSubmenu }
@@ -62,6 +54,7 @@ function AddSubmenuItem( {
 					DEFAULT_BLOCK.name,
 					DEFAULT_BLOCK.attributes
 				);
+				const block = getBlock( clientId );
 
 				if ( block.name === 'core/navigation-submenu' ) {
 					insertBlock(
@@ -127,47 +120,57 @@ export default function LeafMoreMenu( props ) {
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 
-	const { rootClientId, canDuplicate, canInsertBlock, isFirst, isLast } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlockRootClientId,
-					getBlockName,
-					canInsertBlockType,
-					getDirectInsertBlock,
-					getBlockIndex,
-					getBlockCount,
-				} = select( blockEditorStore );
-				const { getDefaultBlockName } = select( blocksStore );
+	const {
+		blockName,
+		rootClientId,
+		canDuplicate,
+		canInsertBlock,
+		isFirst,
+		isLast,
+	} = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlockName,
+				canInsertBlockType,
+				getDirectInsertBlock,
+				getBlockIndex,
+				getBlockCount,
+			} = select( blockEditorStore );
+			const { getDefaultBlockName } = select( blocksStore );
 
-				const _rootClientId = getBlockRootClientId( clientId );
-				const blockName = getBlockName( clientId );
-				const canInsertDefaultBlock = canInsertBlockType(
-					getDefaultBlockName(),
-					_rootClientId
-				);
-				const directInsertBlock = _rootClientId
-					? getDirectInsertBlock( _rootClientId )
-					: null;
+			const _rootClientId = getBlockRootClientId( clientId );
+			const _blockName = getBlockName( clientId );
+			const canInsertDefaultBlock = canInsertBlockType(
+				getDefaultBlockName(),
+				_rootClientId
+			);
+			const directInsertBlock = _rootClientId
+				? getDirectInsertBlock( _rootClientId )
+				: null;
 
-				return {
-					rootClientId: _rootClientId,
-					canDuplicate:
-						!! blockName &&
-						hasBlockSupport( blockName, 'multiple', true ) &&
-						canInsertBlockType( blockName, _rootClientId ),
-					canInsertBlock:
-						( canInsertDefaultBlock || !! directInsertBlock ) &&
-						!! blockName &&
-						canInsertBlockType( blockName, _rootClientId ),
-					isFirst: getBlockIndex( clientId ) === 0,
-					isLast:
-						getBlockIndex( clientId ) ===
-						getBlockCount( _rootClientId ) - 1,
-				};
-			},
-			[ clientId ]
-		);
+			return {
+				blockName: _blockName,
+				rootClientId: _rootClientId,
+				canDuplicate:
+					!! _blockName &&
+					hasBlockSupport( _blockName, 'multiple', true ) &&
+					canInsertBlockType( _blockName, _rootClientId ),
+				canInsertBlock:
+					( canInsertDefaultBlock || !! directInsertBlock ) &&
+					!! _blockName &&
+					canInsertBlockType( _blockName, _rootClientId ),
+				isFirst: getBlockIndex( clientId ) === 0,
+				isLast:
+					getBlockIndex( clientId ) ===
+					getBlockCount( _rootClientId ) - 1,
+			};
+		},
+		[ clientId ]
+	);
+
+	const isSubmenuDisabled =
+		! BLOCKS_THAT_CAN_BE_CONVERTED_TO_SUBMENU.includes( blockName );
 
 	return (
 		<DropdownMenu
@@ -206,6 +209,7 @@ export default function LeafMoreMenu( props ) {
 						<AddSubmenuItem
 							clientId={ clientId }
 							onClose={ onClose }
+							isDisabled={ isSubmenuDisabled }
 							expandedState={ props.expandedState }
 							expand={ props.expand }
 							setInsertedBlockClientId={

--- a/packages/block-library/src/navigation/edit/navigation-link-ui.js
+++ b/packages/block-library/src/navigation/edit/navigation-link-ui.js
@@ -19,7 +19,6 @@ const BLOCKS_WITH_LINK_UI_SUPPORT = [
 ];
 
 export function NavigationLinkUI( {
-	block,
 	insertedBlockClientId,
 	setInsertedBlockClientId,
 } ) {
@@ -41,10 +40,8 @@ export function NavigationLinkUI( {
 		[ insertedBlockClientId ]
 	);
 
-	const supportsLinkControls =
+	const showLinkControls =
 		BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName );
-	const blockWasJustInserted = insertedBlockClientId === block.clientId;
-	const showLinkControls = supportsLinkControls && blockWasJustInserted;
 
 	// Get binding utilities for the inserted block
 	const { createBinding, clearBinding } = useEntityBinding( {

--- a/packages/block-library/src/navigation/edit/navigation-link-ui.js
+++ b/packages/block-library/src/navigation/edit/navigation-link-ui.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,20 +18,38 @@ const BLOCKS_WITH_LINK_UI_SUPPORT = [
 	'core/navigation-submenu',
 ];
 
-export function NavigationLinkUI( { block, insertedBlock, setInsertedBlock } ) {
+export function NavigationLinkUI( {
+	block,
+	insertedBlockClientId,
+	setInsertedBlockClientId,
+} ) {
 	const { updateBlockAttributes, removeBlock } =
 		useDispatch( blockEditorStore );
 
-	const supportsLinkControls = BLOCKS_WITH_LINK_UI_SUPPORT?.includes(
-		insertedBlock?.name
+	const { insertedBlockName, insertedBlockAttributes } = useSelect(
+		( select ) => {
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
+
+			return {
+				insertedBlockName: getBlockName( insertedBlockClientId ),
+				insertedBlockAttributes: getBlockAttributes(
+					insertedBlockClientId
+				),
+			};
+		},
+		[ insertedBlockClientId ]
 	);
-	const blockWasJustInserted = insertedBlock?.clientId === block.clientId;
+
+	const supportsLinkControls =
+		BLOCKS_WITH_LINK_UI_SUPPORT?.includes( insertedBlockName );
+	const blockWasJustInserted = insertedBlockClientId === block.clientId;
 	const showLinkControls = supportsLinkControls && blockWasJustInserted;
 
 	// Get binding utilities for the inserted block
 	const { createBinding, clearBinding } = useEntityBinding( {
-		clientId: insertedBlock?.clientId,
-		attributes: insertedBlock?.attributes || {},
+		clientId: insertedBlockClientId,
+		attributes: insertedBlockAttributes || {},
 	} );
 
 	if ( ! showLinkControls ) {
@@ -51,12 +69,12 @@ export function NavigationLinkUI( { block, insertedBlock, setInsertedBlock } ) {
 
 		// Follows the exact same pattern as Navigation Link block's onClose handler
 		// If there is no URL then remove the auto-inserted block to avoid empty blocks
-		if ( ! insertedBlock?.attributes?.url && insertedBlock?.clientId ) {
+		if ( ! insertedBlockAttributes?.url && insertedBlockClientId ) {
 			// Remove the block entirely to avoid poor UX
 			// This matches the Navigation Link block's behavior
-			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+			removeBlock( insertedBlockClientId, shouldAutoSelectBlock );
 		}
-		setInsertedBlock( null );
+		setInsertedBlockClientId( null );
 	};
 
 	const setInsertedBlockAttributes =
@@ -75,16 +93,16 @@ export function NavigationLinkUI( { block, insertedBlock, setInsertedBlock } ) {
 
 		// If we have an existing inserted block and a new block is being set,
 		// remove the original block to avoid duplicates
-		if ( insertedBlock?.clientId && newBlock ) {
-			removeBlock( insertedBlock.clientId, shouldAutoSelectBlock );
+		if ( insertedBlockClientId && newBlock ) {
+			removeBlock( insertedBlockClientId, shouldAutoSelectBlock );
 		}
-		setInsertedBlock( newBlock );
+		setInsertedBlockClientId( newBlock?.clientId ?? null );
 	};
 
 	return (
 		<LinkUI
-			clientId={ insertedBlock?.clientId }
-			link={ insertedBlock?.attributes }
+			clientId={ insertedBlockClientId }
+			link={ insertedBlockAttributes }
 			onBlockInsert={ handleSetInsertedBlock }
 			onClose={ () => {
 				// Use cleanup function
@@ -95,8 +113,8 @@ export function NavigationLinkUI( { block, insertedBlock, setInsertedBlock } ) {
 				const { isEntityLink, attributes: updatedAttributes } =
 					updateAttributes(
 						updatedValue,
-						setInsertedBlockAttributes( insertedBlock?.clientId ),
-						insertedBlock?.attributes
+						setInsertedBlockAttributes( insertedBlockClientId ),
+						insertedBlockAttributes
 					);
 
 				// Handle URL binding based on the final computed state
@@ -108,7 +126,7 @@ export function NavigationLinkUI( { block, insertedBlock, setInsertedBlock } ) {
 					clearBinding();
 				}
 
-				setInsertedBlock( null );
+				setInsertedBlockClientId( null );
 			} }
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -25,8 +25,7 @@ const { useHistory, useLocation } = unlock( routerPrivateApis );
 export default function LeafMoreMenu( props ) {
 	const history = useHistory();
 	const { path } = useLocation();
-	const { block } = props;
-	const { clientId } = block;
+	const { clientId } = props;
 	const { moveBlocksDown, moveBlocksUp, removeBlocks } =
 		useDispatch( blockEditorStore );
 
@@ -42,39 +41,40 @@ export default function LeafMoreMenu( props ) {
 		BlockTitle( { clientId, maximumLength: 25 } )
 	);
 
-	const rootClientId = useSelect(
+	const { rootClientId, blockName, attributes } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
+			const { getBlockRootClientId, getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
 
-			return getBlockRootClientId( clientId );
+			return {
+				rootClientId: getBlockRootClientId( clientId ),
+				blockName: getBlockName( clientId ),
+				attributes: getBlockAttributes( clientId ),
+			};
 		},
 		[ clientId ]
 	);
 
-	const onGoToPage = useCallback(
-		( selectedBlock ) => {
-			const { attributes, name } = selectedBlock;
-			if (
-				attributes.kind === 'post-type' &&
-				attributes.id &&
-				attributes.type &&
-				history
-			) {
-				history.navigate(
-					`/${ attributes.type }/${ attributes.id }?canvas=edit`,
-					{
-						state: { backPath: path },
-					}
-				);
-			}
-			if ( name === 'core/page-list-item' && attributes.id && history ) {
-				history.navigate( `/page/${ attributes.id }?canvas=edit`, {
+	const onGoToPage = useCallback( () => {
+		if (
+			attributes.kind === 'post-type' &&
+			attributes.id &&
+			attributes.type &&
+			history
+		) {
+			history.navigate(
+				`/${ attributes.type }/${ attributes.id }?canvas=edit`,
+				{
 					state: { backPath: path },
-				} );
-			}
-		},
-		[ path, history ]
-	);
+				}
+			);
+		}
+		if ( blockName === 'core/page-list-item' && attributes.id && history ) {
+			history.navigate( `/page/${ attributes.id }?canvas=edit`, {
+				state: { backPath: path },
+			} );
+		}
+	}, [ path, history, attributes, blockName ] );
 
 	return (
 		<DropdownMenu
@@ -106,17 +106,16 @@ export default function LeafMoreMenu( props ) {
 						>
 							{ __( 'Move down' ) }
 						</MenuItem>
-						{ block.attributes?.type === 'page' &&
-							block.attributes?.id && (
-								<MenuItem
-									onClick={ () => {
-										onGoToPage( block );
-										onClose();
-									} }
-								>
-									{ goToLabel }
-								</MenuItem>
-							) }
+						{ attributes?.type === 'page' && attributes?.id && (
+							<MenuItem
+								onClick={ () => {
+									onGoToPage();
+									onClose();
+								} }
+							>
+								{ goToLabel }
+							</MenuItem>
+						) }
 					</MenuGroup>
 					<MenuGroup>
 						<MenuItem


### PR DESCRIPTION
## What?
PR updates the data passed to sub-tree components and lets them derive values as needed, rather than passing the whole block.

### What has changed:

* `insertedBlock` -> `insertedBlockClientId`.
* `branch.js` passes `clientId` instead of the tree node, so `memo( ListViewBlock )` compares a string rather than an object rebuilt on every tree invalidation.
* `AdditionalBlockContent` renders only for the row matching `insertedBlockClientId`, so `NavigationLinkUI` can drop `block`. Previously, every row mounted it and ran its `useSelect` + `useEntityBinding` before bailing on `! showLinkControls`. Affecting only Navigation List Views.

## Why?
A minor perf and code quality improvement. The `clientId` strings don't change often, reducing accidental re-renders.

## Testing Instructions
Most of these are covered by e2e tests, but here are a couple of paths for smoke testing.

* Type in a nested block with List View open; rows should still update correctly.
* Navigation block inspector List View: Move up/down, Add submenu link, Duplicate, Add before/after, Remove. Confirm each acts on the row you opened the menu on.
* Same checks in the Site Editor's Navigation sidebar, plus "Go to <page>" on a page link.
* Multi-select blocks in the main List View, open Options, and Delete; all selected blocks should go.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
