### PR TITLE
Button: Suppress UA focus ring when focused and pressed

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Bug Fixes
 
+-   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).
 -   `Autocomplete`: Omit `aria-activedescendant` while no suggestion is highlighted, instead of returning `null` for it ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -17,6 +17,10 @@
 		box-shadow: none;
 	}
 
+	&:focus {
+		outline: none;
+	}
+
 	&:focus:not(:active) {
 		@include mixins.outset-ring__focus();
 	}

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
--   Focus utilities: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
+-   `Button`, `Link`, `Combobox`, `Select`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 
 ### Code Quality

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   Focus utilities: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 
 ### Code Quality

--- a/packages/ui/src/utils/css/focus.module.scss
+++ b/packages/ui/src/utils/css/focus.module.scss
@@ -5,12 +5,20 @@
 
 	@layer utilities {
 		.outset-ring--focus:focus,
-		.outset-ring--focus-except-active:focus:not(:active),
 		.outset-ring--focus-visible:focus-visible,
 		.outset-ring--focus-within:focus-within,
-		.outset-ring--focus-within-except-active:focus-within:not(:has(:active)),
 		.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
 		:focus-visible .outset-ring--focus-parent-visible {
+			@include mixins.focus-ring();
+		}
+
+		.outset-ring--focus-except-active:focus,
+		.outset-ring--focus-within-except-active:focus-within {
+			outline: none;
+		}
+
+		.outset-ring--focus-except-active:focus:not(:active),
+		.outset-ring--focus-within-except-active:focus-within:not(:has(:active)) {
 			@include mixins.focus-ring();
 		}
 	}


### PR DESCRIPTION
## What?

Suppresses the browser's default focus outline when a button is keyboard-focused and pressed (`:focus-visible:active`).

## Why?

`Button` and the `@wordpress/ui` `outset-ring--focus-except-active` utility only apply the custom focus ring on `:focus:not(:active)`. When the button is also `:active`, nothing overrides the browser outline, so a UA focus ring can appear alongside the pressed state styling.

## How?

- `Button`: reset `outline` on `:focus`, and keep applying the design-system ring on `:focus:not(:active)`.
- `@wordpress/ui` focus utilities: apply the same reset/ring split for `outset-ring--focus-except-active` and `outset-ring--focus-within-except-active`.

## Testing Instructions

1. Open Storybook (`npm run storybook:dev`) or the block editor.
2. **Tab** to a `Button` (or `@wordpress/ui` `Button`) so it shows the custom focus ring.
3. Press and hold Space, Enter, or the mouse button while focused.
4. Confirm the custom focus ring disappears while pressed, and that no browser default outline appears.
5. Release the key or mouse button and confirm the custom focus ring returns.

## Screenshots or screencast

### `:focus-visible:active`

| Before | After |
|--------|-------|
|<img width="270" height="232" alt="before" src="https://github.com/user-attachments/assets/aac13f1c-0171-4de8-a4b0-3f158b975ef2" />|<img width="270" height="232" alt="after" src="https://github.com/user-attachments/assets/28e65926-daec-421e-8ffb-7bc05c9c039e" />|
