### PR TITLE
Writing flow: fix triple click selecting into the next block by detecting the edge touch

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Writing flow: Move the end of a triple click selection back to the last text position before the boundary the browser overshoots to, instead of only correcting a next sibling reported at an offset of 0, so triple clicking a paragraph followed by a separator or a container block no longer starts a multi selection ([#81022](https://github.com/WordPress/gutenberg/pull/81022)).
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,13 +17,13 @@
 
 ### Bug Fixes
 
--   Writing flow: Move the end of a triple click selection back to the last text position before the boundary the browser overshoots to, instead of only correcting a next sibling reported at an offset of 0, so triple clicking a paragraph followed by a separator or a container block no longer starts a multi selection ([#81022](https://github.com/WordPress/gutenberg/pull/81022)).
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `RichText`: Skip the block input transforms in fields that are not passed an `onReplace` ([#80978](https://github.com/WordPress/gutenberg/pull/80978)).
 -   `RichText`: Ignore pasted files, which carry no text to paste inline ([#81010](https://github.com/WordPress/gutenberg/pull/81010)).
+-   Writing flow: Move the end of a triple click selection back to the last text position before the boundary the browser overshoots to, instead of only correcting a next sibling reported at an offset of 0, so triple clicking a paragraph followed by a separator or a container block no longer starts a multi selection ([#81022](https://github.com/WordPress/gutenberg/pull/81022)).
 
 ## 16.0.0 (2026-07-14)
 

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -62,36 +62,66 @@ function extractSelectionEndNode( selection, isTripleClick ) {
 		focusOffset === focusNode.childNodes.length
 			? focusNode
 			: focusNode.childNodes[ focusOffset ];
+
+	if ( ! isTripleClick ) {
+		return endNode;
+	}
+
+	// A triple click extends the forward selection to the start edge of the
+	// following block, which would trigger multi selection even though no
+	// content of that block is selected. When the selection ends at the mere
+	// edge of another block, end it at the last text position of the block
+	// it starts in instead. Keyboard selections that legitimately extend to
+	// the same boundary must not be corrected, hence the triple click gate.
 	const range = selection.getRangeAt( 0 );
-	const clientId = getBlockClientId( selection.anchorNode );
 
-	// A triple click extends the forward selection past the block, which would
-	// trigger multi selection. Move the end back to the last text position
-	// before it, but only within the block the selection starts in, so a drag
-	// across blocks is left alone. The focus is the range end for a forward
-	// selection; node positions can't tell, as the focus may be an ancestor of
-	// the anchor.
-	if (
-		range.endContainer === focusNode &&
-		range.endOffset === focusOffset &&
-		isTripleClick &&
-		clientId &&
-		getBlockClientId( endNode ) !== clientId
-	) {
-		const { ownerDocument } = focusNode;
-		const walker = ownerDocument.createTreeWalker(
-			ownerDocument.body,
-			ownerDocument.defaultView.NodeFilter.SHOW_TEXT
+	// The focus is the range end for a forward selection; node positions
+	// cannot tell, as the focus may be an ancestor of the anchor.
+	if ( range.endContainer !== focusNode || range.endOffset !== focusOffset ) {
+		return endNode;
+	}
+
+	const { ownerDocument } = focusNode;
+	const startBlockClientId = getBlockClientId( selection.anchorNode );
+	const endBlockClientId = getBlockClientId( endNode );
+
+	if ( ! startBlockClientId || endBlockClientId === startBlockClientId ) {
+		return endNode;
+	}
+
+	// Whether the selection merely touches the edge of the end block: none
+	// of its content lies before the selection end.
+	if ( endBlockClientId ) {
+		const endBlockRange = ownerDocument.createRange();
+		endBlockRange.selectNodeContents(
+			ownerDocument.getElementById( `block-${ endBlockClientId }` )
 		);
-		walker.currentNode = endNode;
-		const previousTextNode = walker.previousNode();
 
-		if ( getBlockClientId( previousTextNode ) === clientId ) {
-			return previousTextNode;
+		// Compares the end of the selection with the start of the end
+		// block's content.
+		if (
+			range.compareBoundaryPoints( range.START_TO_END, endBlockRange ) > 0
+		) {
+			return endNode;
 		}
 	}
 
-	return endNode;
+	// End the selection at the last text position within the block it
+	// starts in.
+	const startBlockElement = ownerDocument.getElementById(
+		`block-${ startBlockClientId }`
+	);
+	const walker = ownerDocument.createTreeWalker(
+		startBlockElement,
+		ownerDocument.defaultView.NodeFilter.SHOW_TEXT
+	);
+	let lastTextNode;
+
+	while ( walker.nextNode() ) {
+		lastTextNode = walker.currentNode;
+	}
+
+	return lastTextNode ?? endNode;
 }
 
 function findDepth( a, b ) {

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -7,7 +7,6 @@ import {
 	create,
 	privateApis as richTextPrivateApis,
 } from '@wordpress/rich-text';
-import { isSelectionForward } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -63,22 +62,35 @@ function extractSelectionEndNode( selection, isTripleClick ) {
 		return focusNode;
 	}
 
-	// A triple click selects the paragraph, but the browser extends the
-	// forward selection into the next element at an offset of 0. This may
-	// trigger multi selection even though the selection does not visually end
-	// in the next block. Keyboard selections that legitimately extend to the
-	// same boundary (e.g. Shift+ArrowDown into a focusable block, where the
-	// browser reports the boundary at the element instead of its first text
-	// position) must not be corrected, so only do this for triple clicks.
+	const endNode = focusNode.childNodes[ focusOffset ];
+	const range = selection.getRangeAt( 0 );
+
+	// A triple click extends the forward selection past the block, which would
+	// trigger multi selection. Move the end back to the last text position
+	// before it, but only within the block the selection starts in, so a drag
+	// across blocks is left alone. The focus is the range end for a forward
+	// selection; node positions can't tell, as the focus may be an ancestor of
+	// the anchor.
 	if (
-		focusOffset === 0 &&
-		isSelectionForward( selection ) &&
+		range.endContainer === focusNode &&
+		range.endOffset === focusOffset &&
 		isTripleClick
 	) {
-		return focusNode.previousSibling ?? focusNode.parentElement;
+		const { ownerDocument } = focusNode;
+		const walker = ownerDocument.createTreeWalker(
+			ownerDocument.body,
+			ownerDocument.defaultView.NodeFilter.SHOW_TEXT
+		);
+		walker.currentNode = endNode;
+		const previousTextNode = walker.previousNode();
+		const clientId = getBlockClientId( selection.anchorNode );
+
+		if ( clientId && getBlockClientId( previousTextNode ) === clientId ) {
+			return previousTextNode;
+		}
 	}
 
-	return focusNode.childNodes[ focusOffset ];
+	return endNode;
 }
 
 function findDepth( a, b ) {

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -58,12 +58,12 @@ function extractSelectionEndNode( selection, isTripleClick ) {
 		return focusNode;
 	}
 
-	if ( focusOffset === focusNode.childNodes.length ) {
-		return focusNode;
-	}
-
-	const endNode = focusNode.childNodes[ focusOffset ];
+	const endNode =
+		focusOffset === focusNode.childNodes.length
+			? focusNode
+			: focusNode.childNodes[ focusOffset ];
 	const range = selection.getRangeAt( 0 );
+	const clientId = getBlockClientId( selection.anchorNode );
 
 	// A triple click extends the forward selection past the block, which would
 	// trigger multi selection. Move the end back to the last text position
@@ -74,7 +74,9 @@ function extractSelectionEndNode( selection, isTripleClick ) {
 	if (
 		range.endContainer === focusNode &&
 		range.endOffset === focusOffset &&
-		isTripleClick
+		isTripleClick &&
+		clientId &&
+		getBlockClientId( endNode ) !== clientId
 	) {
 		const { ownerDocument } = focusNode;
 		const walker = ownerDocument.createTreeWalker(
@@ -83,9 +85,8 @@ function extractSelectionEndNode( selection, isTripleClick ) {
 		);
 		walker.currentNode = endNode;
 		const previousTextNode = walker.previousNode();
-		const clientId = getBlockClientId( selection.anchorNode );
 
-		if ( clientId && getBlockClientId( previousTextNode ) === clientId ) {
+		if ( getBlockClientId( previousTextNode ) === clientId ) {
 			return previousTextNode;
 		}
 	}

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -995,6 +995,98 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			} );
 	} );
 
+	test( 'should select a single paragraph on triple click before a non text block', async ( {
+		page,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'One two three' },
+		} );
+		await editor.insertBlock( { name: 'core/separator' } );
+
+		// Move the caret into the paragraph so its block toolbar repositions
+		// above it and stops overlapping the text.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Triple click selects the paragraph. The browser extends the forward
+		// selection to the separator instead of into it at offset 0; that
+		// overshoot must not collapse the selection or extend it into the
+		// separator.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click( { clickCount: 3 } );
+
+		// Only the paragraph is selected, not a multi-block selection reaching
+		// into the separator.
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
+
+		// The whole paragraph is selected (not collapsed), so typing replaces
+		// its content.
+		await page.keyboard.type( 'a' );
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [
+				{ name: 'core/paragraph', attributes: { content: 'a' } },
+				{ name: 'core/separator' },
+			] );
+	} );
+
+	test( 'should select a single paragraph on triple click before a container block', async ( {
+		page,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'One two three' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [
+				{ name: 'core/paragraph', attributes: { content: 'Inner' } },
+			],
+		} );
+
+		// Move the caret into the first paragraph so its block toolbar
+		// repositions above it and stops overlapping the text.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Triple click selects the paragraph. The browser extends the forward
+		// selection into the group, where the boundary has no preceding
+		// sibling; that overshoot must not collapse the selection or extend it
+		// into the group.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first()
+			.click( { clickCount: 3 } );
+
+		// Only the first paragraph is selected, not a multi-block selection
+		// reaching into the group.
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
+
+		// The whole paragraph is selected (not collapsed), so typing replaces
+		// its content.
+		await page.keyboard.type( 'a' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'a' } },
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Inner' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should gradually multi-select', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1087,6 +1087,63 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should select a single paragraph on triple click inside a container block', async ( {
+		page,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		// The group needs two paragraphs: a container holding a single
+		// paragraph does not host an editable root.
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Inner one' },
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Inner two' },
+				},
+			],
+		} );
+		await editor.insertBlock( { name: 'core/separator' } );
+
+		// Move the caret into the last paragraph of the group so its block
+		// toolbar repositions above it and stops overlapping the text.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Triple click selects the paragraph. The browser extends the forward
+		// selection past the group, to the separator after it; that overshoot
+		// must not select the group as a whole.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.last()
+			.click( { clickCount: 3 } );
+
+		// Only the paragraph is selected, not the group containing it.
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
+
+		// The whole paragraph is selected (not collapsed), so typing replaces
+		// its content.
+		await page.keyboard.type( 'a' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Inner one' },
+					},
+					{ name: 'core/paragraph', attributes: { content: 'a' } },
+				],
+			},
+			{ name: 'core/separator' },
+		] );
+	} );
+
 	test( 'should gradually multi-select', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1035,6 +1035,46 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			] );
 	} );
 
+	test( 'should select a single paragraph on triple click before a placeholder block', async ( {
+		page,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'One two three' },
+		} );
+		await editor.insertBlock( { name: 'core/image' } );
+
+		// Move the caret into the paragraph so its block toolbar repositions
+		// above it and stops overlapping the text.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Triple click selects the paragraph. The browser extends the forward
+		// selection into an empty element of the placeholder, where the offset
+		// is both 0 and the number of child nodes; that overshoot must not
+		// collapse the selection or extend it into the image.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click( { clickCount: 3 } );
+
+		// Only the paragraph is selected, not a multi-block selection reaching
+		// into the image.
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
+
+		// The whole paragraph is selected (not collapsed), so typing replaces
+		// its content.
+		await page.keyboard.type( 'a' );
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [
+				{ name: 'core/paragraph', attributes: { content: 'a' } },
+				{ name: 'core/image' },
+			] );
+	} );
+
 	test( 'should select a single paragraph on triple click before a container block', async ( {
 		page,
 		editor,


### PR DESCRIPTION
## What?

Alternative to #81022 that keeps its tests. Triple clicking a paragraph no longer starts a multi selection with the block below it, or selects the parent container when the paragraph is the last block inside one.

## Why?

Same as #81022: Chromium extends a triple click's selection to the edge of the next block under an `editableRoot`, and the existing correction in `extractSelectionEndNode` only recognises one of the DOM positions the browser reports that edge at.

## How?

Instead of matching the DOM shape of the overshoot, detect the condition that defines it:

1. **Detect the mere edge touch.** Compare the selection end with the start of the end block's content (`compareBoundaryPoints`). When no content of that block lies within the selection, the selection merely touches its edge, so it should not count as selecting into it. A selection that does contain any of the next block's content is always left alone, no matter which DOM position it is reported at.
2. **End the selection in the clicked block.** The end moves to the last text position of the block the selection starts in. The tree walker is scoped to that block's element, so the correction cannot depend on what happens to sit between blocks in the DOM.

The `isTripleClick` gate stays. A keyboard selection can produce the exact same geometry with the opposite intent: extending towards a separator ends at its edge with zero content of it selected, because an edge touch is the only selection state that can ever include a text-free block.

## Testing Instructions

See #81022; its four new tests are included unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQNdFF1FUU9JXfNGZev2na
