### PR TITLE
Fix e2e tests that break when shard rebalancing changes their neighbors

### DIFF
--- a/test/e2e/specs/editor/various/font-appearance-control.spec.js
+++ b/test/e2e/specs/editor/various/font-appearance-control.spec.js
@@ -4,8 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Font Appearance Control dropdown menu', () => {
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.createNewPost();
+		// The tests read the block inspector, and the sidebar's visibility is
+		// a persisted user preference, so a preceding test that closed it
+		// would otherwise leave these tests without an inspector.
+		await editor.openDocumentSettingsSidebar();
 	} );
 
 	test( 'should apply available font weight and styles from active font family', async ( {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -301,7 +301,10 @@ class InserterUtils {
 	}
 
 	getBlockLibraryTab( name ) {
-		return this.page.getByRole( 'tab', { name } );
+		// `exact` needed so 'Patterns' cannot also match the 'My patterns'
+		// tab, which renders whenever the site has user patterns (for
+		// example ones left behind by an earlier spec in the same run).
+		return this.page.getByRole( 'tab', { name, exact: true } );
 	}
 
 	async expectActiveTab( name ) {


### PR DESCRIPTION
Trunk's e2e suite has been red since [#80314](https://github.com/WordPress/gutenberg/pull/80314) landed, but not because that PR broke the editor: it added new e2e tests, and shard balancing is duration-based, so the suite's shards recomposed and two latent order-dependent specs started failing deterministically. This PR hardens both. The failing tests moved with each subsequent reshuffle — `font-appearance-control.spec.js` on Playwright shard 5 in the [first](https://github.com/WordPress/gutenberg/actions/runs/30825519615) [two](https://github.com/WordPress/gutenberg/actions/runs/30827874018) red runs, `site-editor-inserter.spec.js` on shard 7 [after #79934 added more tests](https://github.com/WordPress/gutenberg/actions/runs/30835196962) — which is the signature of order dependence rather than a product regression.

**Font appearance control**: the two tests read the block inspector but never open it, relying on the sidebar's default-visible state. Sidebar visibility is a persisted user preference: preferences are reset once per CI run in the global setup, then shared by every test in the shard, with writes flushed on a debounce. Any earlier test that leaves the sidebar hidden therefore starves these tests of an inspector, and the failure screenshots show exactly that: the `Typography options` click timing out with the sidebar closed. With a seeded `isComplementaryAreaVisible: false` preference the failure reproduces on trunk before #80314 too, and both development and production builds pass with a clean profile — the editor itself is fine. Fix: call `editor.openDocumentSettingsSidebar()` in `beforeEach`, like sibling specs do (a no-op when the sidebar is already open).

**Site editor inserter**: the `InserterUtils` tab locator used `getByRole`'s default substring matching, so `'Patterns'` also matches the `My patterns` pattern-category tab, which renders inside the Patterns panel whenever the site has user patterns — for example ones left behind by an earlier spec in the same run (`deleteAllBlocks()` also only runs once, in the global setup). The zoomed-out inserter opens straight to the Patterns tab, so `expectActiveTab( 'Patterns' )` dies on a strict mode violation: with a user pattern present, the substring locator resolves to both tabs while the exact locator resolves to the one selected top-level tab. Fix: match tab names exactly.

## Testing Instructions

1. `npm run test:e2e -- test/e2e/specs/editor/various/font-appearance-control.spec.js test/e2e/specs/site-editor/site-editor-inserter.spec.js` passes.
2. Font appearance, poisoned state: seed the closed sidebar an earlier test can leave behind — `wp user meta update admin wp_persisted_preferences --format=json '{"core":{"isComplementaryAreaVisible":false},"_modified":"2026-08-03T00:00:00.000Z"}'` — then drive the spec's steps manually (insert a paragraph, click `Typography options`): without this change the button never renders; with it the sidebar is opened explicitly. (Running the suite re-resets preferences in global setup, which is why mid-run state must be simulated.)
3. Inserter, poisoned state: create a user pattern (any reusable block), enter Zoom Out in the site editor and open the inserter: `getByRole( 'tab', { name: 'Patterns' } )` now resolves to two tabs (`Patterns`, `My patterns`) which is the CI strict mode violation, while the exact-match locator used by this change resolves to the single selected tab.

AI usage disclosure: investigation and fixes drafted with AI assistance and reviewed by me.