### PR TITLE
Block Editor: Refactor withFontSizes to a function component

### DIFF
--- a/packages/block-editor/src/components/font-sizes/test/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/test/with-font-sizes.js
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import withFontSizes from '../with-font-sizes';
+import { useSettings } from '../../use-settings';
+
+jest.mock( '../../use-settings', () => ( {
+	useSettings: jest.fn(),
+} ) );
+
+jest.mock( '../utils', () => ( {
+	getFontSize: ( fontSizes, fontSizeAttribute, customFontSizeAttribute ) => {
+		if ( fontSizeAttribute ) {
+			const fontSizeObject = fontSizes?.find(
+				( { slug } ) => slug === fontSizeAttribute
+			);
+			if ( fontSizeObject ) {
+				return fontSizeObject;
+			}
+		}
+		return { size: customFontSizeAttribute };
+	},
+	getFontSizeClass: ( fontSizeSlug ) =>
+		fontSizeSlug ? `has-${ fontSizeSlug }-font-size` : undefined,
+} ) );
+
+const FONT_SIZES = [
+	{ name: 'Small', slug: 'small', size: 12 },
+	{ name: 'Medium', slug: 'medium', size: 24 },
+];
+
+function FontSizeConsumer( { fontSize, setFontSize } ) {
+	return (
+		<>
+			<span data-testid="font-size-value">
+				{ JSON.stringify( fontSize ) }
+			</span>
+			<button type="button" onClick={ () => setFontSize( 24 ) }>
+				Set named size
+			</button>
+			<button type="button" onClick={ () => setFontSize( 18 ) }>
+				Set custom size
+			</button>
+		</>
+	);
+}
+
+const EnhancedFontSizeConsumer =
+	withFontSizes( 'fontSize' )( FontSizeConsumer );
+
+function getRenderedFontSize() {
+	return JSON.parse( screen.getByTestId( 'font-size-value' ).textContent );
+}
+
+describe( 'withFontSizes', () => {
+	beforeEach( () => {
+		useSettings.mockReturnValue( [ FONT_SIZES ] );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'derives named and custom font size values from attributes', () => {
+		const setAttributes = jest.fn();
+		const { rerender } = render(
+			<EnhancedFontSizeConsumer
+				attributes={ { fontSize: 'small' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+
+		expect( getRenderedFontSize() ).toEqual( {
+			name: 'Small',
+			slug: 'small',
+			size: 12,
+			class: 'has-small-font-size',
+		} );
+
+		rerender(
+			<EnhancedFontSizeConsumer
+				attributes={ { customFontSize: 18 } }
+				setAttributes={ setAttributes }
+			/>
+		);
+
+		expect( getRenderedFontSize() ).toEqual( { size: 18 } );
+	} );
+
+	it( 'maps a matching size back to its named font size attribute', () => {
+		const setAttributes = jest.fn();
+		render(
+			<EnhancedFontSizeConsumer
+				attributes={ {} }
+				setAttributes={ setAttributes }
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Set named size' } )
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			fontSize: 'medium',
+			customFontSize: undefined,
+		} );
+	} );
+
+	it( 'stores a non-matching size as a custom font size', () => {
+		const setAttributes = jest.fn();
+		render(
+			<EnhancedFontSizeConsumer
+				attributes={ {} }
+				setAttributes={ setAttributes }
+			/>
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Set custom size' } )
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			fontSize: undefined,
+			customFontSize: 18,
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
-import { Component } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -66,104 +66,14 @@ export default ( ...fontSizeNames ) => {
 				'withFontSizes'
 			),
 			( WrappedComponent ) => {
-				return class WithFontSizes extends Component {
-					constructor( props ) {
-						super( props );
+				return function WithFontSizes( props ) {
+					const { attributes, fontSizes, setAttributes } = props;
 
-						this.setters = this.createSetters();
-
-						this.state = {};
-					}
-
-					createSetters() {
-						return Object.entries( fontSizeAttributeNames ).reduce(
-							(
-								settersAccumulator,
-								[
-									fontSizeAttributeName,
-									customFontSizeAttributeName,
-								]
-							) => {
-								const upperFirstFontSizeAttributeName =
-									upperFirst( fontSizeAttributeName );
-								settersAccumulator[
-									`set${ upperFirstFontSizeAttributeName }`
-								] = this.createSetFontSize(
-									fontSizeAttributeName,
-									customFontSizeAttributeName
-								);
-								return settersAccumulator;
-							},
-							{}
-						);
-					}
-
-					createSetFontSize(
-						fontSizeAttributeName,
-						customFontSizeAttributeName
-					) {
-						return ( fontSizeValue ) => {
-							const fontSizeObject = this.props.fontSizes?.find(
-								( { size } ) => size === Number( fontSizeValue )
-							);
-							this.props.setAttributes( {
-								[ fontSizeAttributeName ]:
-									fontSizeObject && fontSizeObject.slug
-										? fontSizeObject.slug
-										: undefined,
-								[ customFontSizeAttributeName ]:
-									fontSizeObject && fontSizeObject.slug
-										? undefined
-										: fontSizeValue,
-							} );
-						};
-					}
-
-					static getDerivedStateFromProps(
-						{ attributes, fontSizes },
-						previousState
-					) {
-						const didAttributesChange = (
-							customFontSizeAttributeName,
-							fontSizeAttributeName
-						) => {
-							if ( previousState[ fontSizeAttributeName ] ) {
-								// If new font size is name compare with the previous slug.
-								if ( attributes[ fontSizeAttributeName ] ) {
-									return (
-										attributes[ fontSizeAttributeName ] !==
-										previousState[ fontSizeAttributeName ]
-											.slug
-									);
-								}
-								// If font size is not named, update when the font size value changes.
-								return (
-									previousState[ fontSizeAttributeName ]
-										.size !==
-									attributes[ customFontSizeAttributeName ]
-								);
-							}
-							// In this case we need to build the font size object.
-							return true;
-						};
-
-						if (
-							! Object.values( fontSizeAttributeNames ).some(
-								didAttributesChange
-							)
-						) {
-							return null;
-						}
-
-						const newState = Object.entries(
-							fontSizeAttributeNames
-						)
-							.filter( ( [ key, value ] ) =>
-								didAttributesChange( value, key )
-							)
-							.reduce(
+					const fontSizeValues = useMemo(
+						() =>
+							Object.entries( fontSizeAttributeNames ).reduce(
 								(
-									newStateAccumulator,
+									accumulator,
 									[
 										fontSizeAttributeName,
 										customFontSizeAttributeName,
@@ -178,37 +88,64 @@ export default ( ...fontSizeNames ) => {
 											customFontSizeAttributeName
 										]
 									);
-									newStateAccumulator[
-										fontSizeAttributeName
-									] = {
+									accumulator[ fontSizeAttributeName ] = {
 										...fontSizeObject,
 										class: getFontSizeClass(
 											fontSizeAttributeValue
 										),
 									};
-									return newStateAccumulator;
+									return accumulator;
 								},
 								{}
-							);
+							),
+						[ attributes, fontSizes ]
+					);
 
-						return {
-							...previousState,
-							...newState,
-						};
-					}
+					const setters = useMemo(
+						() =>
+							Object.entries( fontSizeAttributeNames ).reduce(
+								(
+									accumulator,
+									[
+										fontSizeAttributeName,
+										customFontSizeAttributeName,
+									]
+								) => {
+									const upperName = upperFirst(
+										fontSizeAttributeName
+									);
+									accumulator[ `set${ upperName }` ] = (
+										fontSizeValue
+									) => {
+										const fontSizeObject = fontSizes?.find(
+											( { size } ) =>
+												size === Number( fontSizeValue )
+										);
+										setAttributes( {
+											[ fontSizeAttributeName ]:
+												fontSizeObject?.slug ||
+												undefined,
+											[ customFontSizeAttributeName ]:
+												fontSizeObject?.slug
+													? undefined
+													: fontSizeValue,
+										} );
+									};
+									return accumulator;
+								},
+								{}
+							),
+						[ fontSizes, setAttributes ]
+					);
 
-					render() {
-						return (
-							<WrappedComponent
-								{ ...{
-									...this.props,
-									fontSizes: undefined,
-									...this.state,
-									...this.setters,
-								} }
-							/>
-						);
-					}
+					return (
+						<WrappedComponent
+							{ ...props }
+							fontSizes={ undefined }
+							{ ...fontSizeValues }
+							{ ...setters }
+						/>
+					);
 				};
 			},
 		] ),


### PR DESCRIPTION
## What?

Related to #22890.

Refactors the `withFontSizes` higher-order component from a React class component to a function component using hooks.

The existing HOC API is preserved, including derived font-size props and setter functions.

## Why?

Issue #22890 tracks React class components that should be converted to function components using hooks.

`withFontSizes` still relied on constructor-created setters, derived component state, `getDerivedStateFromProps`, and a class `render()` method even though its behavior can be derived directly from props.

This change removes that class lifecycle while preserving the existing font-size behavior.

## How?

- Replaces the `WithFontSizes` class with a named function component.
- Uses `useMemo` to derive font-size values from `attributes` and the available `fontSizes`.
- Uses `useMemo` to create the corresponding font-size setter functions.
- Preserves the wrapped-component prop contract.
- Adds focused characterization tests covering:
  - named font-size derivation;
  - custom font-size derivation;
  - mapping a matching size to a named font-size attribute;
  - storing a non-matching size as a custom font-size attribute.

The new characterization tests were first run successfully against the previous class implementation and then run unchanged against the function-component implementation.

## Testing Instructions

Run the focused font-size unit tests:

```sh
npm run test:unit -- \
    packages/block-editor/src/components/font-sizes/test/utils.js \
    packages/block-editor/src/components/font-sizes/test/fluid-utils.js \
    packages/block-editor/src/components/font-sizes/test/with-font-sizes.js \
    --runInBand
```

Expected result:

- 3 test suites pass.
- 16 tests pass.

Run targeted JavaScript linting:

```sh
npm run lint:js -- \
    packages/block-editor/src/components/font-sizes/with-font-sizes.js \
    packages/block-editor/src/components/font-sizes/test/with-font-sizes.js
```

The patch was also checked with:

```sh
git diff --check
```

### Testing Instructions for Keyboard

Not applicable. This refactor does not change user-facing UI or keyboard interaction.

## Screenshots or screencast

Not applicable. This is an internal implementation refactor with no intended visual changes.

## Use of AI Tools

I used ChatGPT as an AI-assisted engineering tool during investigation, implementation planning, test design, and review.

I personally reviewed the resulting source changes, ran the characterization tests against both the previous class implementation and the refactored function component, ran the surrounding regression tests and project linting, and verified the final diff before submission.