### PR TITLE
Media Editor: Render sidebar tabs via ComplementaryArea's render prop

### DIFF
--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -3,7 +3,6 @@
  */
 import {
 	Button,
-	Flex,
 	Spinner,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
@@ -176,11 +175,11 @@ function HeaderActions( {
 }: HeaderActionsProps ) {
 	const [ isShortcutsModalOpen, setIsShortcutsModalOpen ] = useState( false );
 	return (
-		<Flex
+		<Stack
 			className="media-editor__header-actions"
 			justify="flex-end"
-			expanded={ false }
-			gap={ 2 }
+			align="center"
+			gap="sm"
 		>
 			{ isImage && (
 				<Button
@@ -206,7 +205,7 @@ function HeaderActions( {
 					onClose={ () => setIsShortcutsModalOpen( false ) }
 				/>
 			) }
-		</Flex>
+		</Stack>
 	);
 }
 
@@ -248,10 +247,10 @@ function HistoryActions( {
 		endGesture();
 	};
 	return (
-		<Flex
+		<Stack
 			className="media-editor__history-actions"
-			expanded={ false }
-			gap={ 2 }
+			align="center"
+			gap="sm"
 		>
 			<Button
 				size="compact"
@@ -286,7 +285,7 @@ function HistoryActions( {
 				accessibleWhenDisabled
 				onClick={ handleRedo }
 			/>
-		</Flex>
+		</Stack>
 	);
 }
 
@@ -307,11 +306,11 @@ function FooterActions( {
 }: FooterActionsProps ) {
 	const saveDisabled = isSaving || ! hasMedia || ! hasChanges;
 	return (
-		<Flex
+		<Stack
 			className="media-editor__footer-actions"
 			justify="flex-end"
-			expanded={ false }
-			gap={ 2 }
+			align="center"
+			gap="sm"
 		>
 			<Button
 				__next40pxDefaultSize
@@ -332,7 +331,7 @@ function FooterActions( {
 			>
 				{ __( 'Save' ) }
 			</Button>
-		</Flex>
+		</Stack>
 	);
 }
 

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -593,60 +593,60 @@ function MediaEditorContent( {
 			onChange={ handleChange }
 			settings={ { fields } }
 		>
-			{ ! media ? (
-				<div className="media-editor">
+			<div className="media-editor">
+				{ ! media ? (
 					<div className="media-editor__loading">
 						<Spinner />
 					</div>
-				</div>
-			) : (
-				<div className="media-editor">
-					<MediaEditorSidebar
-						tabs={ tabs }
-						activeTabId={ activeTabId }
-						onTabChange={ setSelectedTabId }
-					/>
-					<InterfaceSkeleton
-						className="media-editor__skeleton"
-						labels={ {
-							body: isImage
-								? __( 'Image editor' )
-								: __( 'Media preview' ),
-							sidebar: __( 'Media details' ),
-						} }
-						content={
-							<div className="media-editor__content">
-								<div className="media-editor__canvas-area">
-									{ isImage ? (
-										<MediaEditorCanvas
-											focusOnMount
-											isPlacementActive={
-												isPlacementActive
-											}
-											onGestureStart={
-												handleCanvasGestureStart
-											}
-											onGestureEnd={
-												handleCanvasGestureEnd
-											}
-										/>
-									) : (
-										<MediaPreview />
+				) : (
+					<>
+						<MediaEditorSidebar
+							tabs={ tabs }
+							activeTabId={ activeTabId }
+							onTabChange={ setSelectedTabId }
+						/>
+						<InterfaceSkeleton
+							className="media-editor__skeleton"
+							labels={ {
+								body: isImage
+									? __( 'Image editor' )
+									: __( 'Media preview' ),
+								sidebar: __( 'Media details' ),
+							} }
+							content={
+								<div className="media-editor__content">
+									<div className="media-editor__canvas-area">
+										{ isImage ? (
+											<MediaEditorCanvas
+												focusOnMount
+												isPlacementActive={
+													isPlacementActive
+												}
+												onGestureStart={
+													handleCanvasGestureStart
+												}
+												onGestureEnd={
+													handleCanvasGestureEnd
+												}
+											/>
+										) : (
+											<MediaPreview />
+										) }
+									</div>
+									{ isImage && (
+										<div className="media-editor__canvas-toolbar">
+											{ ruler }
+										</div>
 									) }
 								</div>
-								{ isImage && (
-									<div className="media-editor__canvas-toolbar">
-										{ ruler }
-									</div>
-								) }
-							</div>
-						}
-						sidebar={
-							<ComplementaryArea.Slot scope="media-editor" />
-						}
-					/>
-				</div>
-			) }
+							}
+							sidebar={
+								<ComplementaryArea.Slot scope="media-editor" />
+							}
+						/>
+					</>
+				) }
+			</div>
 			<ConfirmDialog
 				isOpen={ isDiscardDialogOpen }
 				confirmButtonText={ __( 'Discard' ) }

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -110,11 +110,17 @@ export interface MediaEditorProps {
 	shouldCloseOnEsc?: boolean;
 }
 
-function MediaEditorSidebar( { tabs }: { tabs: EditorTab[] } ) {
-	// The tab list and panels must share one `<Tabs.Root>`, but they render in
-	// separate `ComplementaryArea` regions (header vs body). A non-virtual Slot
-	// reconciles both inline at the Slot, so the `Root` is lifted to wrap this
-	// Fill and that Slot together — see `MediaEditorContent`.
+interface MediaEditorSidebarProps {
+	tabs: EditorTab[];
+	activeTabId?: string;
+	onTabChange: ( tabId: string ) => void;
+}
+
+function MediaEditorSidebar( {
+	tabs,
+	activeTabId,
+	onTabChange,
+}: MediaEditorSidebarProps ) {
 	return (
 		<ComplementaryArea
 			scope="media-editor"
@@ -126,6 +132,16 @@ function MediaEditorSidebar( { tabs }: { tabs: EditorTab[] } ) {
 			panelClassName="media-editor__sidebar-panel"
 			headerClassName="media-editor__sidebar-header"
 			closeLabel={ __( 'Close media panel' ) }
+			// Makes `Tabs.Root` the container, so the tab list passed as
+			// `header` and the panels below share a subtree across the fill.
+			render={
+				<Tabs.Root
+					value={ activeTabId }
+					onValueChange={ ( value ) =>
+						onTabChange( value as string )
+					}
+				/>
+			}
 			header={
 				<Tabs.List variant="minimal">
 					{ tabs.map( ( tab ) => (
@@ -585,14 +601,12 @@ function MediaEditorContent( {
 					</div>
 				</div>
 			) : (
-				<Tabs.Root
-					className="media-editor"
-					value={ activeTabId }
-					onValueChange={ ( value ) =>
-						setSelectedTabId( value as string )
-					}
-				>
-					<MediaEditorSidebar tabs={ tabs } />
+				<div className="media-editor">
+					<MediaEditorSidebar
+						tabs={ tabs }
+						activeTabId={ activeTabId }
+						onTabChange={ setSelectedTabId }
+					/>
 					<InterfaceSkeleton
 						className="media-editor__skeleton"
 						labels={ {
@@ -632,7 +646,7 @@ function MediaEditorContent( {
 							<ComplementaryArea.Slot scope="media-editor" />
 						}
 					/>
-				</Tabs.Root>
+				</div>
 			) }
 			<ConfirmDialog
 				isOpen={ isDiscardDialogOpen }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1811,11 +1811,6 @@
 			"count": 1
 		}
 	},
-	"packages/media-editor/src/components/media-editor/index.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/media-editor/src/components/media-form/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
Follows up on #81054 by moving the media editor sidebar to the same `Tabs` rendering method: `Tabs.Root` is now passed to `ComplementaryArea` via the `render` prop instead of being lifted above the fill and the slot.

Since I was in the area, I also fixed the `Flex` component error and replaced it with `Stack`. So smoke test related action areas.

## Testing Instructions
Same as in #79664.

* Upload an image to a post or page
* Click the Crop icon in the block toolbar after selecting an image block
* Try out the Crop and Details tabs
* Try toggling the sidebar and make sure it remembers which tab you had selected

### Testing Instructions for Keyboard
Same.


## Screenshots or screencast <!-- if applicable -->

## Use of AI Tools

Assisted by Claude.
