### PR TITLE
fix(admin-ui): reset the wp-admin li margin that misaligns Breadcrumbs

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Breadcrumbs`: reset the list item margin that wp-admin's `common.css` applies, which left the trail misaligned with the rest of the page header ([#81134](https://github.com/WordPress/gutenberg/pull/81134)).
+
 ## 2.6.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -7,9 +7,11 @@
 /*
  * Preceding items keep their intrinsic width; only the last (current) item
  * is allowed to shrink so that the truncation styles on `.current` engage.
+ * The margin reset keeps wp-admin's bottom margin on `li` out of the trail.
  */
 .list > li {
 	flex-shrink: 0;
+	margin: 0;
 }
 
 .list > li:last-child {


### PR DESCRIPTION
## What?

Resets the `margin` on the list items `Breadcrumbs` renders, so wp-admin's global list styling stops pushing the trail out of alignment with the rest of the page header.

## Why?

wp-admin's `common.css` sets `dd, li { margin-bottom: 6px }`. That reaches the `<li>` elements `Breadcrumbs` renders, so the trail's `<ul>` measures 6px taller than the text inside it. `Page`'s header centres its children, so the trail ends up sitting 3px above everything it shares the row with.

`Breadcrumbs` already resets `margin` on the list itself; only the items' margin was missing.

This is not visible in Storybook, because Storybook does not load wp-admin's stylesheets. It only shows up on a real admin page, which is likely why it has gone unnoticed.

## How?

Adds `margin: 0` to the existing `.list > li` rule.

The `@wordpress/ui` global CSS defense module is deliberately not used here. It exists because that package's styles live in a cascade layer and therefore lose to wp-admin's unlayered bare-element selectors. `@wordpress/admin-ui` has no `@layer`, so `.list > li` (0,1,1) already outranks `dd, li` (0,0,1) on specificity alone — and #80952 proposes forbidding the defense tokens outside the UI package. If #77039 moves `Breadcrumb` into `@wordpress/ui`, this line should become an `--_gcd-li-margin` token at that point.

## Testing Instructions

1. Enable the **Content Types** experiment: **Settings → Gutenberg → Content Types**.
2. Go to **Settings → Content Types → Add post type**.
3. The header shows the trail `Post Types / Add new` with a **Create** button on the right. Check that the heading text is vertically centred against the button.

On `trunk` the heading sits 3px high. Measured on the same page:

|        | `ul` height | `Add new` centre | `Create` centre | delta |
| ------ | ----------- | ---------------- | --------------- | ----- |
| Before | 30px        | y = 61           | y = 64          | −3px  |
| After  | 24px        | y = 64           | y = 64          | 0     |

The same misalignment appears on **Settings → Content Types → Taxonomies → (any taxonomy)**, which uses the same header.

### Testing Instructions for Keyboard

No interaction changes. 

## Screenshots or screencast

| Before | After |
| ------ | ----- |
|    <img width="1734" height="1081" alt="Screenshot 2026-08-04 at 3 09 10 PM" src="https://github.com/user-attachments/assets/f77d0381-392f-49be-b77c-8094688ed8a1" />    |  <img width="1730" height="1073" alt="Screenshot 2026-08-04 at 3 14 35 PM" src="https://github.com/user-attachments/assets/b6ac35d7-f993-4e46-950e-3fee9fc0ab25" /> |


## Use of AI Tools

This PR was authored with Claude Code. AI was used to trace the cause, to write the change and the changelog entry, and to draft this description. 