### PR TITLE
List View: Reduce per-row store subscriptions

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Performance
 
+-   `ListView`: Drop the `useBlockDisplayInformation` and `useBlockLock` calls from the row, select button and branch components, reading the few fields they were used for from the `useSelect` each component already has. Store subscriptions go from seven to four per rendered row, and from two to one per branch ([#81136](https://github.com/WordPress/gutenberg/pull/81136)).
 -   `ListView`: Collapse the placeholder rows that stand in for blocks outside of the render window into a single spacer row per run, instead of rendering a `<tr>`/`<td>` pair for every block. On a post with 1000 top-level blocks this removes ~1900 elements (about 60% of the List View's DOM and nearly half of the document's elements), which cuts the style recalculation and layout work done when the List View opens ([#80953](https://github.com/WordPress/gutenberg/pull/80953)).
 
 ### Internal

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -76,8 +76,8 @@ function ListViewBlockSelectButton(
 			const attributes = getBlockAttributes( clientId );
 			const blockName = getBlockName( clientId );
 
-			// A block that came from a pattern is displayed as a pattern,
-			// matching the identity `useBlockDisplayInformation` returns.
+			// Pattern-sourced section blocks show the pattern icon.
+			// Everything else resolves its variation or block type icon.
 			let blockIcon = symbol;
 			if (
 				! attributes?.metadata?.patternName ||

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -12,7 +12,15 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lockSmall as lock, pinSmall, unseen } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
+import {
+	Icon,
+	lockSmall as lock,
+	pinSmall,
+	symbol,
+	unseen,
+} from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 
 import { Tooltip } from '@wordpress/ui';
@@ -21,11 +29,10 @@ import { Tooltip } from '@wordpress/ui';
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
-import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
-import { useBlockLock } from '../block-lock';
 import useListViewImages from './use-list-view-images';
+import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
@@ -50,15 +57,52 @@ function ListViewBlockSelectButton(
 	},
 	ref
 ) {
-	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
 		context: 'list-view',
 	} );
-	const { isLocked } = useBlockLock( clientId );
+	const { icon, anchor, isSticky, isLocked } = useSelect(
+		( select ) => {
+			const {
+				getBlockName,
+				getBlockAttributes,
+				getBlock,
+				isSectionBlock,
+				isLockedBlock,
+			} = unlock( select( blockEditorStore ) );
+			const { getBlockType, getActiveBlockVariation } =
+				select( blocksStore );
+
+			const attributes = getBlockAttributes( clientId );
+			const blockName = getBlockName( clientId );
+
+			// A block that came from a pattern is displayed as a pattern,
+			// matching the identity `useBlockDisplayInformation` returns.
+			let blockIcon = symbol;
+			if (
+				! attributes?.metadata?.patternName ||
+				! isSectionBlock( clientId )
+			) {
+				const match = getActiveBlockVariation(
+					blockName,
+					attributes,
+					undefined,
+					getBlock( clientId )?.innerContent
+				);
+				blockIcon = match?.icon || getBlockType( blockName )?.icon;
+			}
+
+			return {
+				icon: blockIcon,
+				anchor: attributes?.anchor,
+				isSticky: attributes?.style?.position?.type === 'sticky',
+				isLocked: isLockedBlock( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	const shouldShowLockIcon = isLocked;
-	const isSticky = blockInformation?.positionType === 'sticky';
 	const images = useListViewImages( { clientId, isExpanded } );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
@@ -103,11 +147,7 @@ function ListViewBlockSelectButton(
 			aria-expanded={ isExpanded }
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
-			<BlockIcon
-				icon={ blockInformation?.icon }
-				showColors
-				context="list-view"
-			/>
+			<BlockIcon icon={ icon } showColors context="list-view" />
 			<HStack
 				alignment="center"
 				className="block-editor-list-view-block-select-button__label-wrapper"
@@ -117,10 +157,10 @@ function ListViewBlockSelectButton(
 				<span className="block-editor-list-view-block-select-button__title">
 					<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
 				</span>
-				{ blockInformation?.anchor && (
+				{ !! anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor-wrapper">
 						<WCBadge className="block-editor-list-view-block-select-button__anchor">
-							{ blockInformation.anchor }
+							{ anchor }
 						</WCBadge>
 					</span>
 				) }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -45,9 +45,8 @@ import {
 } from './utils';
 import { store as blockEditorStore } from '../../store';
 import { groupBlocks } from '../../utils/group-blocks';
-import useBlockDisplayInformation from '../use-block-display-information';
-import { useBlockLock } from '../block-lock';
-import { useBlockRename, BlockRenameModal } from '../block-rename';
+import { getPositionTypeLabel } from '../use-block-display-information';
+import { BlockRenameModal } from '../block-rename';
 import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
 import usePasteStyles from '../use-paste-styles';
@@ -78,7 +77,6 @@ function ListViewBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ settingsAnchorRect, setSettingsAnchorRect ] = useState();
 	const [ isRenameModalOpen, setIsRenameModalOpen ] = useState( false );
-	const { isLocked } = useBlockLock( clientId );
 
 	const isFirstSelectedBlock =
 		isSelected && selectedClientIds[ 0 ] === clientId;
@@ -119,7 +117,6 @@ function ListViewBlock( {
 	} = useSelect( blockEditorStore );
 	const { getGroupingBlockName } = useSelect( blocksStore );
 
-	const blockInformation = useBlockDisplayInformation( clientId );
 	const pasteStyles = usePasteStyles();
 
 	const {
@@ -130,6 +127,9 @@ function ListViewBlock( {
 		editedSection,
 		viewportSettings,
 		blockVisibilitySetting,
+		positionLabel,
+		isSynced,
+		isLocked,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -138,13 +138,15 @@ function ListViewBlock( {
 				getBlockEditingMode: getBlockEditingModeForClientId,
 				getSettings,
 				getEditedContentOnlySection,
+				isSyncedBlock,
+				isLockedBlock,
 			} = unlock( select( blockEditorStore ) );
 			const settings = getSettings();
+			const attributes = getBlockAttributes( clientId );
 
 			return {
 				blockName: getBlockName( clientId ),
-				blockVisibility:
-					getBlockAttributes( clientId )?.metadata?.blockVisibility,
+				blockVisibility: attributes?.metadata?.blockVisibility,
 				blockEditingMode: getBlockEditingModeForClientId( clientId ),
 				allowRightClickOverrides: settings.allowRightClickOverrides,
 				editedSection: getEditedContentOnlySection(),
@@ -152,13 +154,17 @@ function ListViewBlock( {
 				blockVisibilitySetting:
 					settings.__experimentalFeatures?.blockVisibility
 						?.allowEditing,
+				positionLabel: getPositionTypeLabel( attributes ),
+				isSynced: isSyncedBlock( clientId ),
+				isLocked: isLockedBlock( clientId ),
 			};
 		},
 		[ clientId ]
 	);
 
 	const isDisabled = blockEditingMode === 'disabled';
-	const { canRename } = useBlockRename( blockName );
+	const canRename =
+		!! blockName && hasBlockSupport( blockName, 'renaming', true );
 
 	const showBlockActions =
 		// When a block hides its toolbar it also hides the block settings menu,
@@ -554,7 +560,7 @@ function ListViewBlock( {
 	);
 
 	const blockPropertiesDescription = getBlockPropertiesDescription(
-		blockInformation,
+		positionLabel,
 		isLocked
 	);
 
@@ -592,7 +598,7 @@ function ListViewBlock( {
 		'is-synced-branch': isSyncedBranch,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
-		'is-synced': blockInformation?.isSynced,
+		'is-synced': isSynced,
 		'is-draggable': canMoveBlock && ! isDisabled,
 		'is-displacement-normal': displacement === 'normal',
 		'is-displacement-up': displacement === 'up',

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -20,7 +20,7 @@ import {
 	isClientIdSelected,
 } from './utils';
 import { store as blockEditorStore } from '../../store';
-import useBlockDisplayInformation from '../use-block-display-information';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Given a block, returns the total number of blocks in that subtree. This is used to help determine
@@ -82,18 +82,23 @@ function ListViewBranch( props ) {
 		showAppender: showAppenderProp = true,
 	} = props;
 
-	const parentBlockInformation = useBlockDisplayInformation( parentId );
-	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
-
-	const canParentExpand = useSelect(
+	const { canParentExpand, isParentSynced } = useSelect(
 		( select ) => {
 			if ( ! parentId ) {
-				return true;
+				return { canParentExpand: true, isParentSynced: false };
 			}
-			return select( blockEditorStore ).canEditBlock( parentId );
+			const { canEditBlock, isSyncedBlock } = unlock(
+				select( blockEditorStore )
+			);
+			return {
+				canParentExpand: canEditBlock( parentId ),
+				isParentSynced: isSyncedBlock( parentId ),
+			};
 		},
 		[ parentId ]
 	);
+
+	const syncedBranch = isSyncedBranch || isParentSynced;
 
 	const {
 		blockDropPosition,

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -17,13 +17,13 @@ export const getBlockPositionDescription = ( position, siblingCount, level ) =>
 		level
 	);
 
-export const getBlockPropertiesDescription = ( blockInformation, isLocked ) =>
+export const getBlockPropertiesDescription = ( positionLabel, isLocked ) =>
 	[
-		blockInformation?.positionLabel
+		positionLabel
 			? `${ sprintf(
 					// translators: %s: Position of selected block, e.g. "Sticky" or "Fixed".
 					__( 'Position: %s' ),
-					blockInformation.positionLabel
+					positionLabel
 			  ) }.`
 			: undefined,
 		isLocked ? __( 'This block is locked.' ) : undefined,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -38,7 +38,7 @@ import { unlock } from '../../lock-unlock';
  * @param {Object} attributes Block attributes.
  * @return {string} The position type label.
  */
-function getPositionTypeLabel( attributes ) {
+export function getPositionTypeLabel( attributes ) {
 	const positionType = attributes?.style?.position?.type;
 
 	if ( positionType === 'sticky' ) {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -848,6 +848,29 @@ export function isSectionBlock( state, clientId ) {
 }
 
 /**
+ * Returns whether the block is displayed as a synced block, meaning a synced
+ * pattern or a template part. A block that carries pattern metadata is
+ * displayed as a pattern instead, so it is not considered synced.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client Id of the block.
+ *
+ * @return {boolean} Whether the block is displayed as a synced block.
+ */
+export function isSyncedBlock( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+	// Checked first so that the section lookup below, which walks the block's
+	// ancestors, is only reached for the few blocks that can be synced.
+	if ( blockName !== 'core/block' && blockName !== 'core/template-part' ) {
+		return false;
+	}
+
+	const patternName = getBlockAttributes( state, clientId )?.metadata
+		?.patternName;
+	return ! ( patternName && isSectionBlock( state, clientId ) );
+}
+
+/**
  * Retrieves the client ID of the block that is a contentOnly section but is
  * currently being temporarily edited (contentOnly is deactivated).
  *

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -28,6 +28,7 @@ import {
 	isBlockHiddenAtViewport,
 	getViewportModalClientIds,
 	isSectionBlock,
+	isSyncedBlock,
 	getParentSectionBlock,
 	getSelectedBlockStyleState,
 	hasSelectedStyleState,
@@ -2509,6 +2510,55 @@ describe( 'private selectors', () => {
 			};
 			// pattern-b is not the edited section and not within it
 			expect( isSectionBlock( state, 'pattern-b' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isSyncedBlock', () => {
+		const createState = ( { blockName, patternName } = {} ) => ( {
+			blocks: {
+				byClientId: new Map( [ [ 'block-1', { name: blockName } ] ] ),
+				attributes: new Map( [
+					[
+						'block-1',
+						patternName ? { metadata: { patternName } } : {},
+					],
+				] ),
+				parents: new Map( [ [ 'block-1', '' ] ] ),
+			},
+		} );
+
+		it( 'returns true for synced patterns', () => {
+			const state = createState( { blockName: 'core/block' } );
+			expect( isSyncedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'returns true for template parts', () => {
+			const state = createState( { blockName: 'core/template-part' } );
+			expect( isSyncedBlock( state, 'block-1' ) ).toBe( true );
+		} );
+
+		it( 'returns false for blocks that are neither', () => {
+			const state = createState( { blockName: 'core/group' } );
+			expect( isSyncedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'returns false for a synced block that is displayed as a pattern', () => {
+			const state = createState( {
+				blockName: 'core/template-part',
+				patternName: 'my-pattern',
+			} );
+			expect( isSyncedBlock( state, 'block-1' ) ).toBe( false );
+		} );
+
+		it( 'returns true for a synced block whose pattern is being edited', () => {
+			const state = {
+				...createState( {
+					blockName: 'core/template-part',
+					patternName: 'my-pattern',
+				} ),
+				editedContentOnlySection: 'block-1',
+			};
+			expect( isSyncedBlock( state, 'block-1' ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
## What

List View rows called `useBlockDisplayInformation` and `useBlockLock` to get a handful of fields.

Each hook runs its own `useSelect` and `useBlockDisplayInformation` matches block variations, parses patterns and builds a title just to produce a result that the callers take one to three fields from. This PR drops both calls and reads the same values from the `useSelect` each component already has.

## Store subscriptions

Per rendered row:

| Component | trunk | this PR |
| --- | --- | --- |
| `ListViewBlock` | 3 | 1 |
| `ListViewBlockSelectButton` | 4 | 3 |
| **total** | **7** | **4** |

`ListViewBranch` goes from 2 to 1 per branch.

## Changes

- Add a private `isSyncedBlock` selector for the `is-synced` row class and the synced branch check.
- Export `getPositionTypeLabel` so the row can build its position label from the attributes it already selects.
- Read the icon, anchor and position type in the select button's own `useSelect`.
- Replace `useBlockLock` with `isLockedBlock`, the only field either caller used.
- Inline `useBlockRename` as `hasBlockSupport( blockName, 'renaming', true )`. That hook holds no state and made no subscription, so this is only about the extra indirection.

## Testing instructions

1. Open List View on a post with synced patterns, template parts and a locked block.
2. Confirm block icons, titles, anchor badges, the synced styling on rows and nested branches, the lock icon, sticky pin and the row's accessible description are unchanged.
3. Confirm rename is still offered only for blocks that support it.


## Use of AI Tools

Assisted by Claude.
