### PR TITLE
CI: resolve Playwright through the workspace that declares it

### DIFF
--- a/.github/setup-playwright/action.yml
+++ b/.github/setup-playwright/action.yml
@@ -25,7 +25,7 @@ runs:
               BROWSERS_KEY="$(echo "${BROWSERS:-all}" | tr ' ' '-')"
               # Packages cached under another runner image mostly miss.
               IMAGE="${ImageOS:-unknown}-${ImageVersion:-unknown}"
-              echo "PREFIX=playwright-apt-${RUNNER_OS}-${RUNNER_ARCH}-${IMAGE}-${VERSION}-${BROWSERS_KEY}-" >> "$GITHUB_OUTPUT"
+              echo "PREFIX=playwright-apt--os-${RUNNER_OS}--arch-${RUNNER_ARCH}--img-${IMAGE}--pw-${VERSION}--browsers-${BROWSERS_KEY}--fingerprint-" >> "$GITHUB_OUTPUT"
 
               if [ -z "$BROWSERS" ] || [ "${BROWSERS#*webkit}" != "$BROWSERS" ]; then
                   echo "CACHE_DEPS=true" >> "$GITHUB_OUTPUT"

--- a/.github/setup-playwright/action.yml
+++ b/.github/setup-playwright/action.yml
@@ -21,7 +21,7 @@ runs:
               BROWSERS: ${{ inputs.browsers }}
               WORKSPACE: ${{ inputs.workspace }}
           run: |
-              VERSION="$(npm exec --workspace "$WORKSPACE" -- node -p "require('playwright/package.json').version")"
+              VERSION="$(npm exec --no --workspace "$WORKSPACE" -- node -p "require('playwright/package.json').version")"
               BROWSERS_KEY="$(echo "${BROWSERS:-all}" | tr ' ' '-')"
               # Packages cached under another runner image mostly miss.
               IMAGE="${ImageOS:-unknown}-${ImageVersion:-unknown}"
@@ -68,7 +68,7 @@ runs:
               sudo cp -r --update=none "$HOME/apt-cache/." /var/cache/apt/archives/
 
               # shellcheck disable=SC2086 # The browser list is intentionally split into separate arguments.
-              npm exec --workspace "$WORKSPACE" -- playwright install $BROWSERS --with-deps
+              npm exec --no --workspace "$WORKSPACE" -- playwright install $BROWSERS --with-deps
 
               sudo find /var/cache/apt/archives -maxdepth 1 -name '*.deb' -exec cp --update=none -t "$HOME/apt-cache" {} +
               sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-cache"

--- a/.github/setup-playwright/action.yml
+++ b/.github/setup-playwright/action.yml
@@ -2,6 +2,9 @@ name: 'Install Playwright browsers'
 description: 'Install Playwright browsers and their system dependencies, caching the Debian packages that WebKit needs.'
 
 inputs:
+    workspace:
+        description: 'The npm workspace that declares playwright. Its copy installs the browsers, so the version installed is the one that workspace tests with.'
+        required: true
     browsers:
         description: 'Optional. Space separated list of browsers to install. When not specified, all browsers are installed.'
         required: false
@@ -16,8 +19,9 @@ runs:
           id: prepare
           env:
               BROWSERS: ${{ inputs.browsers }}
+              WORKSPACE: ${{ inputs.workspace }}
           run: |
-              VERSION="$(node -p "require('playwright-core/package.json').version")"
+              VERSION="$(npm exec --workspace "$WORKSPACE" -- node -p "require('playwright/package.json').version")"
               BROWSERS_KEY="$(echo "${BROWSERS:-all}" | tr ' ' '-')"
               # Packages cached under another runner image mostly miss.
               IMAGE="${ImageOS:-unknown}-${ImageVersion:-unknown}"
@@ -50,6 +54,7 @@ runs:
           id: install
           env:
               BROWSERS: ${{ inputs.browsers }}
+              WORKSPACE: ${{ inputs.workspace }}
           run: |
               fingerprint() {
                   find "$HOME/apt-cache" -maxdepth 1 -name '*.deb' -printf '%f\n' | LC_ALL=C sort | sha256sum | cut -c1-16
@@ -63,7 +68,7 @@ runs:
               sudo cp -r --update=none "$HOME/apt-cache/." /var/cache/apt/archives/
 
               # shellcheck disable=SC2086 # The browser list is intentionally split into separate arguments.
-              npx playwright install $BROWSERS --with-deps
+              npm exec --workspace "$WORKSPACE" -- playwright install $BROWSERS --with-deps
 
               sudo find /var/cache/apt/archives -maxdepth 1 -name '*.deb' -exec cp --update=none -t "$HOME/apt-cache" {} +
               sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-cache"

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -49,6 +49,7 @@ jobs:
             - name: Install Playwright dependencies
               uses: ./.github/setup-playwright
               with:
+                  workspace: '@wordpress/e2e-tests-playwright'
                   browsers: chromium firefox webkit
 
             - name: Install WordPress and start the server
@@ -102,6 +103,7 @@ jobs:
             - name: Install Playwright dependencies
               uses: ./.github/setup-playwright
               with:
+                  workspace: '@wordpress/e2e-tests-playwright'
                   browsers: chromium
 
             - name: Install WordPress and start the server

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -71,6 +71,7 @@ jobs:
             - name: Install Playwright browsers
               uses: ./.github/setup-playwright
               with:
+                  workspace: '@wordpress/storybook'
                   browsers: chromium
 
             - name: Serve Storybook and run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -55193,6 +55193,7 @@
 				"@y/websocket-server": "^0.1.1",
 				"esbuild": "^0.27.2",
 				"filenamify": "^4.2.0",
+				"playwright": "^1.62.1",
 				"wasm-vips": "^0.0.18",
 				"ws": "^8.18.3",
 				"y-websocket": "^3.0.0"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -30,6 +30,7 @@
 		"@y/websocket-server": "^0.1.1",
 		"esbuild": "^0.27.2",
 		"filenamify": "^4.2.0",
+		"playwright": "^1.62.1",
 		"wasm-vips": "^0.0.18",
 		"ws": "^8.18.3",
 		"y-websocket": "^3.0.0"


### PR DESCRIPTION
## What?

Follow up to #80846. Resolve Playwright through the npm workspace that declares it instead of from the repository root, and label the segments of the apt cache key.

## Why?

The action reads the version from `playwright-core` and installs with `npx playwright install`, both resolved from the root. That only holds while npm hoists every transitive dependency there, so the step [fails](https://github.com/WordPress/gutenberg/actions/runs/30882068196/job/91905353888?pr=75814) under the isolated install strategy explored in #75814.

`npx` also does not belong in CI, for the reason given in #81017: when the local binary is missing, it installs whatever the public registry serves under that name.

The cache key was readable only to whoever wrote it:

```
playwright-apt-Linux-X64-ubuntu24-20260720.247.2-1.62.1-chromium-firefox-webkit-afecb67c668a2145
```

## How?

A required `workspace` input names the workspace that declares `playwright`, and both the version lookup and the install run through `npm exec --workspace`. `@wordpress/storybook` already declared `playwright`; `test/e2e` now does too.

The key now reads:

```
playwright-apt--os-Linux--arch-X64--img-ubuntu24-20260720.247.2--pw-1.62.1--browsers-chromium-firefox-webkit--fingerprint-afecb67c668a2145
```

Its inputs are unchanged, so existing entries miss once and are rewritten.

## Testing Instructions

1. Confirm the end-to-end and Storybook workflows pass.
2. In a shard's "Install Playwright dependencies" step, check the cache key and that the resolved version matches `test/e2e/package.json`.

## Use of AI Tools

Opus 5: the action and workflow changes, and this description.
