### PR TITLE
List View: Replace expand/collapse callbacks with reducer dispatch

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -169,12 +169,10 @@ function ListViewBlock( {
 	const descriptionId = `list-view-block-select-button__description-${ instanceId }`;
 
 	const {
-		expand,
-		collapse,
-		collapseAll,
 		BlockSettingsMenu,
 		listViewInstanceId,
-		expandedState,
+		expansionState,
+		updateExpansion,
 		setInsertedBlockClientId,
 		treeGridElementRef,
 		rootClientId,
@@ -372,10 +370,9 @@ function ListViewBlock( {
 			event.preventDefault();
 			const { firstBlockClientId } = getBlocksToUpdate();
 			const blockParents = getBlockParents( firstBlockClientId, false );
-			// Collapse all blocks.
-			collapseAll();
-			// Expand all parents of the current block.
-			expand( blockParents );
+			// Collapse all blocks and expand the block's parents.
+			updateExpansion( { type: 'clear' } );
+			updateExpansion( { type: 'expand', clientIds: blockParents } );
 		} else if ( isMatch( 'core/block-editor/group', event ) ) {
 			const { blocksToUpdate } = getBlocksToUpdate();
 			if ( blocksToUpdate.length > 1 && isGroupable( blocksToUpdate ) ) {
@@ -467,13 +464,15 @@ function ListViewBlock( {
 			// Prevent shift+click from opening link in a new window when toggling.
 			event.preventDefault();
 			event.stopPropagation();
-			if ( isExpanded === true ) {
-				collapse( clientId );
-			} else if ( isExpanded === false ) {
-				expand( clientId );
+			if ( isExpanded === undefined ) {
+				return;
 			}
+			updateExpansion( {
+				type: isExpanded ? 'collapse' : 'expand',
+				clientIds: clientId,
+			} );
 		},
-		[ clientId, expand, collapse, isExpanded ]
+		[ clientId, updateExpansion, isExpanded ]
 	);
 
 	// Allow right-clicking an item in the List View to open up the block settings dropdown.
@@ -740,8 +739,8 @@ function ListViewBlock( {
 								size: 'small',
 							} }
 							disableOpenOnArrowDown
-							expand={ expand }
-							expandedState={ expandedState }
+							expansionState={ expansionState }
+							updateExpansion={ updateExpansion }
 							setInsertedBlockClientId={
 								setInsertedBlockClientId
 							}

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -30,14 +30,14 @@ import useBlockDisplayInformation from '../use-block-display-information';
  * implementation dragged blocks and their children are not counted.
  *
  * @param {Object}  block               block tree
- * @param {Object}  expandedState       state that notes which branches are collapsed
+ * @param {Object}  expansionState      state that notes which branches are collapsed
  * @param {Array}   draggedClientIds    a list of dragged client ids
  * @param {boolean} isExpandedByDefault flag to determine the default fallback expanded state.
  * @return {number} block count
  */
 function countBlocks(
 	block,
-	expandedState,
+	expansionState,
 	draggedClientIds,
 	isExpandedByDefault
 ) {
@@ -45,7 +45,7 @@ function countBlocks(
 	if ( isDragged ) {
 		return 0;
 	}
-	const isExpanded = expandedState[ block.clientId ] ?? isExpandedByDefault;
+	const isExpanded = expansionState[ block.clientId ] ?? isExpandedByDefault;
 	if ( ! isExpanded ) {
 		return 1;
 	}
@@ -54,7 +54,7 @@ function countBlocks(
 			count +
 			countBlocks(
 				innerBlock,
-				expandedState,
+				expansionState,
 				draggedClientIds,
 				isExpandedByDefault
 			),
@@ -100,7 +100,7 @@ function ListViewBranch( props ) {
 		blockDropTargetIndex,
 		firstDraggedBlockIndex,
 		blockIndexes,
-		expandedState,
+		expansionState,
 		draggedClientIds,
 	} = useListViewContext();
 
@@ -150,7 +150,7 @@ function ListViewBranch( props ) {
 		const blockListPosition = nextPosition;
 		nextPosition += countBlocks(
 			block,
-			expandedState,
+			expansionState,
 			draggedClientIds,
 			isExpanded
 		);
@@ -167,7 +167,7 @@ function ListViewBranch( props ) {
 
 		const shouldExpand =
 			hasNestedBlocks && shouldShowInnerBlocks
-				? expandedState[ clientId ] ?? isExpanded
+				? expansionState[ clientId ] ?? isExpanded
 				: undefined;
 
 		// Make updates to the selected or dragged blocks synchronous,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -42,23 +42,22 @@ import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dro
 import { BLOCK_LIST_ITEM_HEIGHT, focusListItem } from './utils';
 import useClipboardHandler from './use-clipboard-handler';
 
-const expanded = ( state, action ) => {
+const expansion = ( state, action ) => {
 	if ( action.type === 'clear' ) {
 		return {};
 	}
-	if ( Array.isArray( action.clientIds ) ) {
-		return {
-			...state,
-			...action.clientIds.reduce(
-				( newState, id ) => ( {
-					...newState,
-					[ id ]: action.type === 'expand',
-				} ),
-				{}
-			),
-		};
+
+	const clientIds = [ action.clientIds ].flat().filter( Boolean );
+	if ( ! clientIds.length ) {
+		return state;
 	}
-	return state;
+
+	return {
+		...state,
+		...Object.fromEntries(
+			clientIds.map( ( id ) => [ id, action.type === 'expand' ] )
+		),
+	};
 };
 
 /** @typedef {React.ComponentType} ComponentType */
@@ -132,14 +131,14 @@ function ListViewComponent(
 
 	const { updateBlockSelection } = useBlockSelection();
 
-	const [ expandedState, setExpandedState ] = useReducer( expanded, {} );
+	const [ expansionState, updateExpansion ] = useReducer( expansion, {} );
 
 	const [ insertedBlockClientId, setInsertedBlockClientId ] =
 		useState( null );
 
 	const { setSelectedTreeId } = useListViewExpandSelectedItem( {
 		firstSelectedBlockClientId: selectedClientIds[ 0 ],
-		setExpandedState,
+		updateExpansion,
 	} );
 	const selectEditorBlock = useCallback(
 		/**
@@ -159,8 +158,8 @@ function ListViewComponent(
 
 	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
 		dropZoneElement,
-		expandedState,
-		setExpandedState,
+		expansionState,
+		updateExpansion,
 	} );
 	const elementRef = useRef();
 
@@ -189,42 +188,12 @@ function ListViewComponent(
 		ref,
 	] );
 
-	const expand = useCallback(
-		( clientId ) => {
-			if ( ! clientId ) {
-				return;
-			}
-			const clientIds = Array.isArray( clientId )
-				? clientId
-				: [ clientId ];
-			setExpandedState( { type: 'expand', clientIds } );
-		},
-		[ setExpandedState ]
-	);
-	const collapse = useCallback(
-		( clientId ) => {
-			if ( ! clientId ) {
-				return;
-			}
-			setExpandedState( { type: 'collapse', clientIds: [ clientId ] } );
-		},
-		[ setExpandedState ]
-	);
-	const collapseAll = useCallback( () => {
-		setExpandedState( { type: 'clear' } );
-	}, [ setExpandedState ] );
-	const expandRow = useCallback(
-		( row ) => {
-			expand( row?.dataset?.block );
-		},
-		[ expand ]
-	);
-	const collapseRow = useCallback(
-		( row ) => {
-			collapse( row?.dataset?.block );
-		},
-		[ collapse ]
-	);
+	const expandRow = useCallback( ( row ) => {
+		updateExpansion( { type: 'expand', clientIds: row?.dataset?.block } );
+	}, [] );
+	const collapseRow = useCallback( ( row ) => {
+		updateExpansion( { type: 'collapse', clientIds: row?.dataset?.block } );
+	}, [] );
 	const focusRow = useCallback(
 		( event, startRow, endRow ) => {
 			if ( event.shiftKey ) {
@@ -238,10 +207,7 @@ function ListViewComponent(
 		[ updateBlockSelection ]
 	);
 
-	useListViewCollapseItems( {
-		collapseAll,
-		expand,
-	} );
+	useListViewCollapseItems( { updateExpansion } );
 
 	const firstDraggedBlockClientId = draggedClientIds?.[ 0 ];
 
@@ -289,11 +255,9 @@ function ListViewComponent(
 			blockDropTargetIndex,
 			blockIndexes,
 			draggedClientIds,
-			expandedState,
-			expand,
+			expansionState,
+			updateExpansion,
 			firstDraggedBlockIndex,
-			collapse,
-			collapseAll,
 			BlockSettingsMenu,
 			listViewInstanceId: instanceId,
 			AdditionalBlockContent,
@@ -307,11 +271,9 @@ function ListViewComponent(
 			blockDropTargetIndex,
 			blockIndexes,
 			draggedClientIds,
-			expandedState,
-			expand,
+			expansionState,
+			updateExpansion,
 			firstDraggedBlockIndex,
-			collapse,
-			collapseAll,
 			BlockSettingsMenu,
 			instanceId,
 			AdditionalBlockContent,
@@ -331,7 +293,7 @@ function ListViewComponent(
 			// switch the list view to a tall list view with a scrollbar, and vice versa.
 			// When this happens, the windowing logic needs to be recalculated to ensure that
 			// the correct number of blocks are rendered, by rechecking for a scroll container.
-			expandedState,
+			expandedState: expansionState,
 			useWindowing: true,
 			windowOverscan: 40,
 		}

--- a/packages/block-editor/src/components/list-view/use-list-view-collapse-items.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-collapse-items.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-export default function useListViewCollapseItems( { collapseAll, expand } ) {
+export default function useListViewCollapseItems( { updateExpansion } ) {
 	const { expandedBlock, getBlockParents } = useSelect( ( select ) => {
 		const { getBlockParents: _getBlockParents, getExpandedBlock } = unlock(
 			select( blockEditorStore )
@@ -26,8 +26,8 @@ export default function useListViewCollapseItems( { collapseAll, expand } ) {
 		if ( expandedBlock ) {
 			const blockParents = getBlockParents( expandedBlock, false );
 			// Collapse all blocks and expand the block's parents.
-			collapseAll();
-			expand( blockParents );
+			updateExpansion( { type: 'clear' } );
+			updateExpansion( { type: 'expand', clientIds: blockParents } );
 		}
-	}, [ collapseAll, expand, expandedBlock, getBlockParents ] );
+	}, [ updateExpansion, expandedBlock, getBlockParents ] );
 }

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -410,17 +410,17 @@ const EXPAND_THROTTLE_OPTIONS = {
 /**
  * A react hook for implementing a drop zone in list view.
  *
- * @param {Object}       props                    Named parameters.
- * @param {?HTMLElement} [props.dropZoneElement]  Optional element to be used as the drop zone.
- * @param {Object}       [props.expandedState]    The expanded state of the blocks in the list view.
- * @param {Function}     [props.setExpandedState] Function to set the expanded state of a list of block clientIds.
+ * @param {Object}       props                   Named parameters.
+ * @param {?HTMLElement} [props.dropZoneElement] Optional element to be used as the drop zone.
+ * @param {Object}       [props.expansionState]  The expansion state of the blocks in the list view.
+ * @param {Function}     [props.updateExpansion] Dispatch to update the expansion state of a list of block clientIds.
  *
  * @return {WPListViewDropZoneTarget} The drop target.
  */
 export default function useListViewDropZone( {
 	dropZoneElement,
-	expandedState,
-	setExpandedState,
+	expansionState,
+	updateExpansion,
 } ) {
 	const {
 		getBlockRootClientId,
@@ -440,7 +440,7 @@ export default function useListViewDropZone( {
 	const previousRootClientId = usePrevious( targetRootClientId );
 
 	const maybeExpandBlock = useCallback(
-		( _expandedState, _target ) => {
+		( _expansionState, _target ) => {
 			// If the user is attempting to drop a block inside a collapsed block,
 			// that is, using a nesting gesture flagged by 'inside' dropPosition,
 			// expand the block within the list view, if it isn't already.
@@ -450,15 +450,15 @@ export default function useListViewDropZone( {
 			}
 			if (
 				_target?.dropPosition === 'inside' &&
-				! _expandedState[ rootClientId ]
+				! _expansionState[ rootClientId ]
 			) {
-				setExpandedState( {
+				updateExpansion( {
 					type: 'expand',
-					clientIds: [ rootClientId ],
+					clientIds: rootClientId,
 				} );
 			}
 		},
-		[ setExpandedState ]
+		[ updateExpansion ]
 	);
 
 	// Throttle the maybeExpandBlock function to avoid expanding the block
@@ -478,9 +478,9 @@ export default function useListViewDropZone( {
 			throttledMaybeExpandBlock.cancel();
 			return;
 		}
-		throttledMaybeExpandBlock( expandedState, target );
+		throttledMaybeExpandBlock( expansionState, target );
 	}, [
-		expandedState,
+		expansionState,
 		previousRootClientId,
 		target,
 		throttledMaybeExpandBlock,

--- a/packages/block-editor/src/components/list-view/use-list-view-expand-selected-item.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-expand-selected-item.js
@@ -11,7 +11,7 @@ import { store as blockEditorStore } from '../../store';
 
 export default function useListViewExpandSelectedItem( {
 	firstSelectedBlockClientId,
-	setExpandedState,
+	updateExpansion,
 } ) {
 	const [ selectedTreeId, setSelectedTreeId ] = useState( null );
 	const { selectedBlockParentClientIds } = useSelect(
@@ -39,7 +39,7 @@ export default function useListViewExpandSelectedItem( {
 		if ( selectedBlockParentClientIds?.length ) {
 			// If the selected block has parents,
 			// expand the tree branch.
-			setExpandedState( {
+			updateExpansion( {
 				type: 'expand',
 				clientIds: selectedBlockParentClientIds,
 			} );
@@ -48,7 +48,7 @@ export default function useListViewExpandSelectedItem( {
 		firstSelectedBlockClientId,
 		selectedBlockParentClientIds,
 		selectedTreeId,
-		setExpandedState,
+		updateExpansion,
 	] );
 
 	return {

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -36,8 +36,8 @@ function AddSubmenuItem( {
 	clientId,
 	onClose,
 	isDisabled,
-	expandedState,
-	expand,
+	expansionState,
+	updateExpansion,
 	setInsertedBlockClientId,
 } ) {
 	const { insertBlock, replaceBlock, replaceInnerBlocks } =
@@ -91,8 +91,8 @@ function AddSubmenuItem( {
 				// the Link UI for this new block.
 				setInsertedBlockClientId( newLink.clientId );
 
-				if ( ! expandedState[ clientId ] ) {
-					expand( clientId );
+				if ( ! expansionState[ clientId ] ) {
+					updateExpansion( { type: 'expand', clientIds: clientId } );
 				}
 				onClose();
 			} }
@@ -210,8 +210,8 @@ export default function LeafMoreMenu( props ) {
 							clientId={ clientId }
 							onClose={ onClose }
 							isDisabled={ isSubmenuDisabled }
-							expandedState={ props.expandedState }
-							expand={ props.expand }
+							expansionState={ props.expansionState }
+							updateExpansion={ props.updateExpansion }
 							setInsertedBlockClientId={
 								props.setInsertedBlockClientId
 							}


### PR DESCRIPTION
## What?
`ListViewContext` carried three callbacks, `expand`, `collapse`, and `collapseAll`, that only wrapped the same `useReducer` dispatch. This passes the dispatch itself instead, so the context holds one stable field where it held three. Consumers build actions directly.

The guard that lived in the wrappers, skipping falsy client IDs, moves into the reducer, which now also accepts either a single client ID or an array. When nothing is left after filtering, the reducer returns the existing state, so a no-op dispatch does not force a render.

Also renames `expandedState` to `expansionState` and `setExpandedState` to `updateExpansion`. The state is a per-block override map, where `true` means expanded, `false` means collapsed, and a missing entry falls back to the `isExpanded` prop. The old name read as "the set of expanded blocks", and `setExpandedState( { type: 'collapse' } )` contradicted itself.

`LeafMoreMenu` in the Navigation block is updated because it is a `blockSettingsMenu` substitution and receives these values as props.

No behavior change. This is groundwork for splitting the context by update frequency, so that drag-and-expand state stops re-rendering every row.

## Testing Instructions
The collapse/expand state has good e2e test coverage. Smoke tests these states in the List View component.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
