### PR TITLE
Views: Add React to the package's dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54450,7 +54450,9 @@
 				"dequal": "^2.0.3"
 			},
 			"devDependencies": {
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/views/CHANGELOG.md
+++ b/packages/views/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `useView`, `loadView`. Resolve the view as a stack of layers — `defaultView`, `defaultLayouts` (for the effective type), `activeViewOverrides`, the user's preference, and the URL query params — and persist only the properties the user actually modified. Previously the whole view was persisted, so a later change to any of the lower layers stopped showing through, an override could bounce back a value the user had picked, and a partial `sort` or `layout` override marked the view as modified forever. `page` and `search` are now sourced from the URL alone, and `layout`, `groupBy` and `sort` merge leaf by leaf, so an override for one field's styles no longer wipes the other fields'. Persisted modifications that happen to coincide with the current view's base are retained on update, so a change made in one view no longer drops a pick made in another view sharing the preference. [#80832](https://github.com/WordPress/gutenberg/pull/80832)
 
+### Internal
+
+-   Add `react` and `react-dom` to the package's dev dependencies, so the tests resolve them from the package rather than relying on a hoisted install. [#81139](https://github.com/WordPress/gutenberg/pull/81139)
+
 ## 1.18.0 (2026-07-14)
 
 ## 1.17.0 (2026-07-01)

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -50,7 +50,9 @@
 		"dequal": "^2.0.3"
 	},
 	"devDependencies": {
-		"@testing-library/react": "^16.3.2"
+		"@testing-library/react": "^16.3.2",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?

Noticed in https://github.com/WordPress/gutenberg/pull/80832#discussion_r3710887994

Adds `react` and `react-dom` to the `@wordpress/views` package's `devDependencies`.

## Why?

`packages/views/src/test/use-view.tsx` is JSX and pulls in `@testing-library/react`, so running the tests needs `react/jsx-runtime` and `react-dom` resolvable from within the package. Neither is declared, so the package relies on React being hoisted to the root `node_modules`.

That holds with the default hoisted install, but breaks as soon as dependencies are isolated — the test suite fails to run with `Cannot find module 'react/jsx-runtime' from 'packages/views/src/test/use-view.tsx'` (surfaced in [#75814](https://github.com/WordPress/gutenberg/pull/75814)).

## How?

Declares both as `devDependencies`, not `peerDependencies`. `packages/views/src` is entirely `.ts` with no React import — the shipped build never references React; hooks come in through `@wordpress/element`, which declares the React peer itself and propagates it to consumers. So React is a test-time need only, which is what `devDependencies` expresses. Same shape as `@wordpress/private-apis`.

## Testing Instructions

```
npm run test:unit packages/views
```

Both suites should pass.

## Use of AI Tools

Claude Code assisted with the dependency analysis and PR description; changes reviewed and verified by me.
