### PR TITLE
Backport/80577

### DIFF
--- a/packages/e2e-tests/plugins/view-config-extensibility.php
+++ b/packages/e2e-tests/plugins/view-config-extensibility.php
@@ -105,6 +105,6 @@ function gutenberg_test_customize_page_view_config( $data ) {
 	return $data;
 }
 add_filter(
-	'get_entity_view_config_postType_page',
+	'get_entity_view_config_posttype_page',
 	'gutenberg_test_customize_page_view_config'
 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Manual backport of the change in the test file from the already backported https://github.com/WordPress/gutenberg/pull/81068/. 

https://github.com/WordPress/gutenberg/pull/80577 is already backported.