### PR TITLE
Fix: Add missing `target` to the webpack dev server proxy config

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -311,6 +311,7 @@ const scriptConfig = {
 				proxy: [
 					{
 						context: [ '/build' ],
+						target: 'http://localhost:8887',
 						pathRewrite: {
 							'^/build': '',
 						},


### PR DESCRIPTION
## What?
Follow up to #80347

Adds the missing `target` to the `devServer.proxy` entry in `@wordpress/scripts` webpack config.

## Why?
The proxy entry for `/build` has a `context` and a `pathRewrite` but no `target`, so `webpack-dev-server` has nothing to forward the request to and `/build/*` requests 404. This is not a regression from the `webpack-dev-server` v5 bump, the same 404 happens on v4.15.2 — it surfaced while testing #80347. See [this comment](https://github.com/WordPress/gutenberg/pull/80347#issuecomment-5000912198).

## How?
Points the proxy entry at the dev server itself (`http://localhost:8887`), matching the configured `host`/`port`, per the [`devServer.proxy` docs](https://webpack.js.org/configuration/dev-server/#devserverproxy).

## Testing Instructions
1. Build this branch: `npm install && npm run build:packages`.
2. Scaffold a test plugin somewhere outside the repo: `npx @wordpress/create-block test-block`.
3. In the scaffolded plugin, point `@wordpress/scripts` at this branch: `npm install /path/to/gutenberg/packages/scripts`.
4. Start the dev server: `npm start -- --hot`.
5. Request a built asset through the proxy path:
   ```
   curl -I http://localhost:8887/build/test-block/index.js
   ```
   ✅ Expected: `200`, and `curl` without `-I` returns the actual file contents.
6. Repeat steps 3–5 against `trunk`'s `@wordpress/scripts` to see the current behavior: the same request returns `404`.
