### PR TITLE
Interface: Increase footer breadcrumb height to prevent focus ring clipping

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -239,7 +239,7 @@
 
 @mixin snackbar-container() {
 	position: fixed;
-	bottom: 32px;
+	bottom: wpds.var("--wpds-dimension-size-md");
 	left: 0;
 	right: 0;
 	padding-inline: 16px;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -239,7 +239,7 @@
 
 @mixin snackbar-container() {
 	position: fixed;
-	bottom: 24px;
+	bottom: 32px;
 	left: 0;
 	right: 0;
 	padding-inline: 16px;

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).
+-   `InterfaceSkeleton`: Increase the footer height from 24px to 32px to prevent the focus ring from being clipped ([#81145](https://github.com/WordPress/gutenberg/pull/81145)).
 
 ### Internal
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -75,7 +75,7 @@ html.interface-interface-skeleton__html-container {
 	// Footer overlap prevention
 	.has-footer & {
 		@include break-medium() {
-			padding-bottom: $button-size-compact + $border-width;
+			padding-bottom: calc(var(--wpds-dimension-size-md) + #{$border-width});
 		}
 	}
 }
@@ -174,7 +174,7 @@ html.interface-interface-skeleton__html-container {
 		z-index: z-index(".edit-post-layout__footer");
 		display: flex;
 		background: $white;
-		height: $button-size-compact;
+		height: var(--wpds-dimension-size-md);
 		align-items: center;
 		font-size: $default-font-size;
 		padding: 0 ($grid-unit-15 + 6px);

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -75,7 +75,7 @@ html.interface-interface-skeleton__html-container {
 	// Footer overlap prevention
 	.has-footer & {
 		@include break-medium() {
-			padding-bottom: $button-size-small + $border-width;
+			padding-bottom: $button-size-compact + $border-width;
 		}
 	}
 }
@@ -174,7 +174,7 @@ html.interface-interface-skeleton__html-container {
 		z-index: z-index(".edit-post-layout__footer");
 		display: flex;
 		background: $white;
-		height: $button-size-small;
+		height: $button-size-compact;
 		align-items: center;
 		font-size: $default-font-size;
 		padding: 0 ($grid-unit-15 + 6px);


### PR DESCRIPTION
## What?

Prevents the focus ring from being clipped in the footer block breadcrumb.

### Before

<img width="592" height="107" alt="image" src="https://github.com/user-attachments/assets/18a08780-233c-4af0-954b-74dc2836a820" />

### After

<img width="586" height="104" alt="image" src="https://github.com/user-attachments/assets/1731adfc-52a6-4a1b-bd1e-13b23d0c46ad" />



## Why?

The focus ring changed from a `box-shadow`-based style to an `outline`-based one. Because `outline-offset` renders the ring slightly outside the element, it no longer fits within the 24px footer height.

## How?

Increases the breadcrumb height from 24px to 32px.

I think this is acceptable, but if it isn't, we need to consider another approach — for example, a negative `outline-offset`. That would, however, remove the rounded corners of the focus ring.

## Testing Instructions

1. Open the editor and create nested blocks.
2. Focus an item in the footer breadcrumb.
3. Confirm the focus ring is fully visible and not clipped.

## Use of AI Tools

Claude Code was used to apply the style changes and draft this description. All changes were reviewed by me.
