### PR TITLE
Fix spacing 'None' storing a reference to a nonexistent preset

### DIFF
--- a/packages/block-editor/src/components/preset-input-control/index.js
+++ b/packages/block-editor/src/components/preset-input-control/index.js
@@ -190,20 +190,28 @@ export default function PresetInputControl( {
 	const customTooltipContent = ( newValue ) =>
 		value === undefined ? undefined : presets[ newValue ]?.name;
 
-	const getNewPresetValue = ( next, controlType ) => {
+	const getNewPresetValue = ( next ) => {
 		const newValue = parseInt( next, 10 );
+		const matchedPreset = presets[ newValue ];
 
-		if ( controlType === 'selectList' ) {
-			if ( newValue === 0 && presets[ 0 ]?.slug === '0' ) {
-				return '0';
-			}
-			if ( newValue === 0 ) {
-				return undefined;
-			}
-		} else if ( newValue === 0 ) {
+		// The synthetic "Default" entry (added when there are more presets
+		// than RANGE_CONTROL_MAX_SIZE) means "no value set", not an actual
+		// preset to reference.
+		if ( matchedPreset?.slug === 'default' ) {
+			return undefined;
+		}
+
+		// The "None" preset (slug '0') has no matching `--wp--preset--*`
+		// custom property registered anywhere, so referencing it via
+		// `var:preset|…|0` would point at something that's never defined.
+		// Store the literal value instead. Matching by slug (rather than
+		// assuming it's always at index 0) keeps this correct even when a
+		// "Default" entry shifts every other preset's index by one.
+		if ( matchedPreset?.slug === '0' ) {
 			return '0';
 		}
-		return `var:preset|${ presetType }|${ presets[ next ]?.slug }`;
+
+		return `var:preset|${ presetType }|${ matchedPreset?.slug }`;
 	};
 
 	return (
@@ -286,10 +294,7 @@ export default function PresetInputControl( {
 							setShowCustomValueControl( true );
 						} else {
 							onChange(
-								getNewPresetValue(
-									selection.selectedItem.key,
-									'selectList'
-								)
+								getNewPresetValue( selection.selectedItem.key )
 							);
 						}
 					} }

--- a/packages/block-editor/src/components/preset-input-control/test/index.js
+++ b/packages/block-editor/src/components/preset-input-control/test/index.js
@@ -210,6 +210,75 @@ describe( 'PresetInputControl', () => {
 		} );
 	} );
 
+	it( 'selects "None" as a literal 0, not a preset reference, in the select dropdown', async () => {
+		const user = userEvent.setup();
+
+		// Mirrors what useSpacingSizes() builds once there are more sizes
+		// than RANGE_CONTROL_MAX_SIZE: a synthetic "Default" entry gets
+		// prepended, pushing "None" from index 0 to index 1.
+		const presetsWithDefault = [
+			{ name: 'Default', slug: 'default', size: undefined },
+			{ name: 'None', slug: '0', size: '0' },
+			...Array.from( { length: 8 }, ( _, i ) => ( {
+				name: `Preset ${ i + 1 }`,
+				slug: `preset-${ i + 1 }`,
+				size: `${ ( i + 1 ) * 5 }px`,
+			} ) ),
+		];
+
+		render(
+			<PresetInputControl
+				{ ...defaultProps }
+				presets={ presetsWithDefault }
+			/>
+		);
+
+		const combobox = await screen.findByRole( 'combobox' );
+		await user.click( combobox );
+
+		const noneOption = await screen.findByRole( 'option', {
+			name: 'None',
+		} );
+		await user.click( noneOption );
+
+		// "None" has no matching `--wp--preset--*` custom property
+		// registered anywhere, so it must be stored as a literal 0 rather
+		// than `var:preset|spacing|0`, which would reference nothing.
+		expect( mockOnChange ).toHaveBeenCalledWith( '0' );
+	} );
+
+	it( 'clears the value when "Default" is selected in the select dropdown', async () => {
+		const user = userEvent.setup();
+
+		const presetsWithDefault = [
+			{ name: 'Default', slug: 'default', size: undefined },
+			{ name: 'None', slug: '0', size: '0' },
+			...Array.from( { length: 8 }, ( _, i ) => ( {
+				name: `Preset ${ i + 1 }`,
+				slug: `preset-${ i + 1 }`,
+				size: `${ ( i + 1 ) * 5 }px`,
+			} ) ),
+		];
+
+		render(
+			<PresetInputControl
+				{ ...defaultProps }
+				presets={ presetsWithDefault }
+				value="var:preset|spacing|preset-1"
+			/>
+		);
+
+		const combobox = await screen.findByRole( 'combobox' );
+		await user.click( combobox );
+
+		const defaultOption = await screen.findByRole( 'option', {
+			name: 'Default',
+		} );
+		await user.click( defaultOption );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( undefined );
+	} );
+
 	it( 'supports mixed value states', () => {
 		render(
 			<PresetInputControl


### PR DESCRIPTION
## What this fixes

When you set spacing (like padding or margin) to "None" using the spacing size dropdown, it sometimes stores `var:preset|spacing|0` instead of just `0`. That variable is never actually defined anywhere, so the browser just falls back to zero by accident — it looks right, but the underlying CSS is broken.

Closes #81079

## Why this happens

The spacing control can show up in two different ways depending on how many spacing sizes are available: a slider (when there are 8 or fewer sizes) or a dropdown (when there are more than 8).

When there are more than 8 sizes, an extra "Default" option gets added to the top of the list, which pushes every other option down by one position — including "None", which is normally first.

The code that decides what to actually save only checked "is this the very first option in the list?" to decide whether to save `0`. Once "Default" pushed "None" down to the second spot, that check stopped matching, and "None" started getting treated like any other regular preset — building a reference to a preset that doesn't exist.

## How I confirmed it

I reproduced this locally: added one extra spacing size to a theme so the total went over 8, which switched the control to the dropdown. Selecting "None" from that dropdown stored `var:preset|spacing|0` in the block's attributes, and the saved markup had no matching CSS variable defined anywhere — exactly what the issue describes.

## What this PR does

Instead of checking "is this the first item in the list," the code now checks "does the option I actually selected represent 'None'?" — by looking at its slug rather than its position. This keeps working correctly no matter how many extra items get added to the list before it.

Also adds two regression tests that build the same preset list shape `useSpacingSizes()` produces once there are more than 8 sizes (with the "Default" entry pushing "None" down), and confirm selecting "None" saves a literal `'0'` and selecting "Default" clears the value.

## Testing instructions

1. Set up a theme (or add a filter) so there are more than 8 spacing size options — enough that the spacing control shows as a dropdown instead of a slider.
2. Add a Group block (or any block with spacing support), open the padding or margin control, and pick "None" from the dropdown.
3. Check the block's saved attributes (Code Editor view works) — it should show `"padding":{"top":"0"}` etc., not `"var:preset|spacing|0"`.
4. Publish the post and inspect the element on the frontend — the padding should be a plain `0`, not a `var(--wp--preset--spacing--0)` reference.
5. As a sanity check, also confirm the normal slider (8 or fewer sizes) still saves "None" correctly, since that path shouldn't have changed.

## Use of AI Tools

Used an AI coding assistant to help investigate the root cause and implement this fix.
