### PR TITLE
ESLint: Ban `@ts-ignore` in favour of `@ts-expect-error`

### DIFF
--- a/packages/api-fetch/src/middlewares/test/preloading.ts
+++ b/packages/api-fetch/src/middlewares/test/preloading.ts
@@ -101,12 +101,12 @@ describe( 'Preloading Middleware', () => {
 					const noResponseMock =
 						'undefined' === typeof window.Response;
 					if ( noResponseMock ) {
-						// @ts-expect-error
+						// @ts-expect-error The stub does not implement the full `Response` static side.
 						window.Response = class {
 							constructor( body, options ) {
-								// @ts-expect-error
+								// @ts-expect-error `body` is not a declared property on the stub.
 								this.body = JSON.parse( body );
-								// @ts-expect-error
+								// @ts-expect-error `headers` is not a declared property on the stub.
 								this.headers = options.headers;
 							}
 						};
@@ -141,7 +141,7 @@ describe( 'Preloading Middleware', () => {
 						async () => {}
 					);
 					if ( noResponseMock ) {
-						// @ts-expect-error
+						// @ts-expect-error The operand of `delete` must be optional.
 						delete window.Response;
 					}
 					return response.then( ( value ) => {

--- a/packages/blocks/src/api/matchers.ts
+++ b/packages/blocks/src/api/matchers.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-// @ts-ignore
+// @ts-expect-error `hpq` does not ship type declarations.
 export { attr, prop, text, query } from 'hpq';
 
 /**

--- a/packages/blocks/src/api/parser/get-block-attributes.ts
+++ b/packages/blocks/src/api/parser/get-block-attributes.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-// @ts-ignore
+// @ts-expect-error `hpq` does not ship type declarations.
 import { parse as hpqParse } from 'hpq';
 import memoize from 'memize';
 

--- a/packages/blocks/src/store/process-block-type.ts
+++ b/packages/blocks/src/store/process-block-type.ts
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-// @ts-ignore -- No declaration file available.
+// @ts-expect-error -- No usable declaration file available.
 import { isPlainObject } from 'is-plain-object';
-// @ts-ignore -- No declaration file available.
 import { isValidElementType } from 'react-is';
 
 /**

--- a/packages/blocks/src/store/process-block-type.ts
+++ b/packages/blocks/src/store/process-block-type.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-// @ts-expect-error -- No usable declaration file available.
+// @ts-expect-error -- Its declaration file is not exposed through the `exports` map.
 import { isPlainObject } from 'is-plain-object';
 import { isValidElementType } from 'react-is';
 

--- a/packages/boot/src/components/navigation/drilldown-item/index.tsx
+++ b/packages/boot/src/components/navigation/drilldown-item/index.tsx
@@ -10,7 +10,6 @@ import type { ReactNode } from 'react';
 import {
 	FlexBlock,
 	__experimentalItem as Item,
-	// @ts-ignore
 	__experimentalHStack as HStack,
 	Icon as WCIcon,
 } from '@wordpress/components';

--- a/packages/boot/src/components/navigation/dropdown-item/index.tsx
+++ b/packages/boot/src/components/navigation/dropdown-item/index.tsx
@@ -10,7 +10,6 @@ import type { ReactNode } from 'react';
 import {
 	FlexBlock,
 	__experimentalItem as Item,
-	// @ts-ignore
 	__experimentalHStack as HStack,
 	Icon as WCIcon,
 	__unstableMotion as motion,
@@ -72,7 +71,7 @@ export default function DropdownItem( {
 }: DropdownItemProps ) {
 	const menuItems: MenuItem[] = useSelect(
 		( select ) =>
-			// @ts-ignore
+			// @ts-expect-error The boot store is untyped, so `select()` resolves to `never`.
 			select( STORE_NAME ).getMenuItems(),
 		[]
 	);

--- a/packages/boot/src/components/navigation/dropdown-item/index.tsx
+++ b/packages/boot/src/components/navigation/dropdown-item/index.tsx
@@ -71,7 +71,7 @@ export default function DropdownItem( {
 }: DropdownItemProps ) {
 	const menuItems: MenuItem[] = useSelect(
 		( select ) =>
-			// @ts-expect-error The boot store is untyped, so `select()` resolves to `never`.
+			// @ts-expect-error Store types are not available when selecting by store name.
 			select( STORE_NAME ).getMenuItems(),
 		[]
 	);

--- a/packages/boot/src/components/navigation/index.tsx
+++ b/packages/boot/src/components/navigation/index.tsx
@@ -24,7 +24,7 @@ function Navigation() {
 		useSidebarParent();
 	const menuItems = useSelect(
 		( select ) =>
-			// @ts-expect-error The boot store is untyped, so `select()` resolves to `never`.
+			// @ts-expect-error Store types are not available when selecting by store name.
 			select( STORE_NAME ).getMenuItems() as MenuItem[],
 		[]
 	);

--- a/packages/boot/src/components/navigation/index.tsx
+++ b/packages/boot/src/components/navigation/index.tsx
@@ -24,7 +24,7 @@ function Navigation() {
 		useSidebarParent();
 	const menuItems = useSelect(
 		( select ) =>
-			// @ts-ignore
+			// @ts-expect-error The boot store is untyped, so `select()` resolves to `never`.
 			select( STORE_NAME ).getMenuItems() as MenuItem[],
 		[]
 	);

--- a/packages/boot/src/components/navigation/navigation-item/index.tsx
+++ b/packages/boot/src/components/navigation/navigation-item/index.tsx
@@ -10,7 +10,6 @@ import type { ReactNode } from 'react';
 import {
 	FlexBlock,
 	__experimentalItem as Item,
-	// @ts-ignore
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 

--- a/packages/boot/src/components/navigation/use-sidebar-parent.ts
+++ b/packages/boot/src/components/navigation/use-sidebar-parent.ts
@@ -37,7 +37,7 @@ export function useSidebarParent() {
 	const router = useRouter();
 	const menuItems = useSelect(
 		( select ) =>
-			// @ts-ignore
+			// @ts-expect-error The boot store is untyped, so `select()` resolves to `never`.
 			select( STORE_NAME ).getMenuItems(),
 		[]
 	);

--- a/packages/boot/src/components/navigation/use-sidebar-parent.ts
+++ b/packages/boot/src/components/navigation/use-sidebar-parent.ts
@@ -37,7 +37,7 @@ export function useSidebarParent() {
 	const router = useRouter();
 	const menuItems = useSelect(
 		( select ) =>
-			// @ts-expect-error The boot store is untyped, so `select()` resolves to `never`.
+			// @ts-expect-error Store types are not available when selecting by store name.
 			select( STORE_NAME ).getMenuItems(),
 		[]
 	);

--- a/packages/components/src/border-box-control/test/utils.ts
+++ b/packages/components/src/border-box-control/test/utils.ts
@@ -47,14 +47,12 @@ describe( 'BorderBoxControl Utils', () => {
 	describe( 'isEmptyBorder', () => {
 		it( 'should determine a undefined, null, and {} to be empty', () => {
 			expect( isEmptyBorder( undefined ) ).toBe( true );
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isEmptyBorder( null ) ).toBe( true );
 			expect( isEmptyBorder( {} ) ).toBe( true );
 		} );
 
 		it( 'should determine object missing all border props to be empty', () => {
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isEmptyBorder( nonBorder ) ).toBe( true );
 		} );
@@ -114,14 +112,12 @@ describe( 'BorderBoxControl Utils', () => {
 	describe( 'isCompleteBorder', () => {
 		it( 'should determine a undefined, null, and {} to be incomplete', () => {
 			expect( isCompleteBorder( undefined ) ).toBe( false );
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isCompleteBorder( null ) ).toBe( false );
 			expect( isCompleteBorder( {} ) ).toBe( false );
 		} );
 
 		it( 'should determine objects missing border props to be incomplete', () => {
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isCompleteBorder( nonBorder ) ).toBe( false );
 			expect( isCompleteBorder( partialBorder ) ).toBe( false );
@@ -157,7 +153,6 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should determine undefined, non-border or empty object as not being mixed', () => {
 			expect( hasMixedBorders( undefined ) ).toBe( false );
 			expect( hasMixedBorders( {} ) ).toBe( false );
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( hasMixedBorders( nonBorder ) ).toBe( false );
 		} );
@@ -178,14 +173,12 @@ describe( 'BorderBoxControl Utils', () => {
 	describe( 'getSplitBorders', () => {
 		it( 'should return undefined when no border provided', () => {
 			expect( getSplitBorders( undefined ) ).toEqual( undefined );
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( getSplitBorders( null ) ).toEqual( undefined );
 		} );
 
 		it( 'should return undefined when supplied border is empty', () => {
 			expect( getSplitBorders( {} ) ).toEqual( undefined );
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( getSplitBorders( nonBorder ) ).toEqual( undefined );
 		} );
@@ -207,7 +200,6 @@ describe( 'BorderBoxControl Utils', () => {
 		} );
 
 		it( 'should only return differences for border related properties', () => {
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			const diff = getBorderDiff( nonBorder, { caffeine: 'coffee' } );
 			expect( diff ).toEqual( {} );
@@ -217,7 +209,6 @@ describe( 'BorderBoxControl Utils', () => {
 			const diff = getBorderDiff( completeBorder, {
 				...completeBorder,
 				color: '#21759b',
-				// Checking for extra resilience, even if not a valid type.
 				// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 				caffeine: 'cola',
 			} );
@@ -316,7 +307,6 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should return undefined when no border provided', () => {
 			expect( getShorthandBorderStyle( undefined ) ).toEqual( undefined );
 			expect( getShorthandBorderStyle( {} ) ).toEqual( undefined );
-			// Checking for extra resilience, even if not a valid type.
 			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( getShorthandBorderStyle( nonBorder ) ).toEqual( undefined );
 		} );

--- a/packages/components/src/border-box-control/test/utils.ts
+++ b/packages/components/src/border-box-control/test/utils.ts
@@ -48,14 +48,14 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should determine a undefined, null, and {} to be empty', () => {
 			expect( isEmptyBorder( undefined ) ).toBe( true );
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isEmptyBorder( null ) ).toBe( true );
 			expect( isEmptyBorder( {} ) ).toBe( true );
 		} );
 
 		it( 'should determine object missing all border props to be empty', () => {
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isEmptyBorder( nonBorder ) ).toBe( true );
 		} );
 
@@ -115,14 +115,14 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should determine a undefined, null, and {} to be incomplete', () => {
 			expect( isCompleteBorder( undefined ) ).toBe( false );
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isCompleteBorder( null ) ).toBe( false );
 			expect( isCompleteBorder( {} ) ).toBe( false );
 		} );
 
 		it( 'should determine objects missing border props to be incomplete', () => {
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( isCompleteBorder( nonBorder ) ).toBe( false );
 			expect( isCompleteBorder( partialBorder ) ).toBe( false );
 			expect( isCompleteBorder( partialWithExtraProp ) ).toBe( false );
@@ -158,7 +158,7 @@ describe( 'BorderBoxControl Utils', () => {
 			expect( hasMixedBorders( undefined ) ).toBe( false );
 			expect( hasMixedBorders( {} ) ).toBe( false );
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( hasMixedBorders( nonBorder ) ).toBe( false );
 		} );
 
@@ -179,14 +179,14 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should return undefined when no border provided', () => {
 			expect( getSplitBorders( undefined ) ).toEqual( undefined );
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( getSplitBorders( null ) ).toEqual( undefined );
 		} );
 
 		it( 'should return undefined when supplied border is empty', () => {
 			expect( getSplitBorders( {} ) ).toEqual( undefined );
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( getSplitBorders( nonBorder ) ).toEqual( undefined );
 		} );
 
@@ -208,7 +208,7 @@ describe( 'BorderBoxControl Utils', () => {
 
 		it( 'should only return differences for border related properties', () => {
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			const diff = getBorderDiff( nonBorder, { caffeine: 'coffee' } );
 			expect( diff ).toEqual( {} );
 		} );
@@ -218,7 +218,7 @@ describe( 'BorderBoxControl Utils', () => {
 				...completeBorder,
 				color: '#21759b',
 				// Checking for extra resilience, even if not a valid type.
-				// @ts-expect-error
+				// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 				caffeine: 'cola',
 			} );
 			expect( diff ).toEqual( { color: '#21759b' } );
@@ -317,7 +317,7 @@ describe( 'BorderBoxControl Utils', () => {
 			expect( getShorthandBorderStyle( undefined ) ).toEqual( undefined );
 			expect( getShorthandBorderStyle( {} ) ).toEqual( undefined );
 			// Checking for extra resilience, even if not a valid type.
-			// @ts-expect-error
+			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
 			expect( getShorthandBorderStyle( nonBorder ) ).toEqual( undefined );
 		} );
 

--- a/packages/components/src/border-box-control/test/utils.ts
+++ b/packages/components/src/border-box-control/test/utils.ts
@@ -47,13 +47,13 @@ describe( 'BorderBoxControl Utils', () => {
 	describe( 'isEmptyBorder', () => {
 		it( 'should determine a undefined, null, and {} to be empty', () => {
 			expect( isEmptyBorder( undefined ) ).toBe( true );
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `null` is outside the declared `Border | undefined` input; resilience is tested.
 			expect( isEmptyBorder( null ) ).toBe( true );
 			expect( isEmptyBorder( {} ) ).toBe( true );
 		} );
 
 		it( 'should determine object missing all border props to be empty', () => {
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `nonBorder` has no properties in common with `Border`; resilience is tested.
 			expect( isEmptyBorder( nonBorder ) ).toBe( true );
 		} );
 
@@ -112,13 +112,13 @@ describe( 'BorderBoxControl Utils', () => {
 	describe( 'isCompleteBorder', () => {
 		it( 'should determine a undefined, null, and {} to be incomplete', () => {
 			expect( isCompleteBorder( undefined ) ).toBe( false );
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `null` is outside the declared `Border | undefined` input; resilience is tested.
 			expect( isCompleteBorder( null ) ).toBe( false );
 			expect( isCompleteBorder( {} ) ).toBe( false );
 		} );
 
 		it( 'should determine objects missing border props to be incomplete', () => {
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `nonBorder` has no properties in common with `Border`; resilience is tested.
 			expect( isCompleteBorder( nonBorder ) ).toBe( false );
 			expect( isCompleteBorder( partialBorder ) ).toBe( false );
 			expect( isCompleteBorder( partialWithExtraProp ) ).toBe( false );
@@ -153,7 +153,7 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should determine undefined, non-border or empty object as not being mixed', () => {
 			expect( hasMixedBorders( undefined ) ).toBe( false );
 			expect( hasMixedBorders( {} ) ).toBe( false );
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `nonBorder` is not assignable to `AnyBorder`; resilience is tested.
 			expect( hasMixedBorders( nonBorder ) ).toBe( false );
 		} );
 
@@ -173,13 +173,13 @@ describe( 'BorderBoxControl Utils', () => {
 	describe( 'getSplitBorders', () => {
 		it( 'should return undefined when no border provided', () => {
 			expect( getSplitBorders( undefined ) ).toEqual( undefined );
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `null` is outside the declared `Border | undefined` input; resilience is tested.
 			expect( getSplitBorders( null ) ).toEqual( undefined );
 		} );
 
 		it( 'should return undefined when supplied border is empty', () => {
 			expect( getSplitBorders( {} ) ).toEqual( undefined );
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `nonBorder` has no properties in common with `Border`; resilience is tested.
 			expect( getSplitBorders( nonBorder ) ).toEqual( undefined );
 		} );
 
@@ -200,7 +200,7 @@ describe( 'BorderBoxControl Utils', () => {
 		} );
 
 		it( 'should only return differences for border related properties', () => {
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `nonBorder` has no properties in common with `Border`; resilience is tested.
 			const diff = getBorderDiff( nonBorder, { caffeine: 'coffee' } );
 			expect( diff ).toEqual( {} );
 		} );
@@ -209,7 +209,7 @@ describe( 'BorderBoxControl Utils', () => {
 			const diff = getBorderDiff( completeBorder, {
 				...completeBorder,
 				color: '#21759b',
-				// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+				// @ts-expect-error `caffeine` is not a declared `Border` property; the test checks it is ignored.
 				caffeine: 'cola',
 			} );
 			expect( diff ).toEqual( { color: '#21759b' } );
@@ -307,7 +307,7 @@ describe( 'BorderBoxControl Utils', () => {
 		it( 'should return undefined when no border provided', () => {
 			expect( getShorthandBorderStyle( undefined ) ).toEqual( undefined );
 			expect( getShorthandBorderStyle( {} ) ).toEqual( undefined );
-			// @ts-expect-error Deliberately invalid input, to check runtime resilience.
+			// @ts-expect-error `nonBorder` has no properties in common with `Border`; resilience is tested.
 			expect( getShorthandBorderStyle( nonBorder ) ).toEqual( undefined );
 		} );
 

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { press } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,6 @@ import { plusCircle } from '@wordpress/icons';
 import _Button from '..';
 import Tooltip from '../../tooltip';
 import cleanupTooltip from '../../tooltip/test/utils';
-import { press } from '@ariakit/test';
 
 jest.mock( '../../icon', () => () => <div data-testid="test-icon" /> );
 
@@ -636,9 +636,9 @@ describe( 'Button', () => {
 			<Button href="foo" type="image/png" />
 			{ /* @ts-expect-error - if button, type must be submit/reset/button */ }
 			<Button type="image/png" />
-			{ /* @ts-expect-error */ }
+			{ /* @ts-expect-error `type` must be submit, reset or button. */ }
 			<Button type="invalidtype" />
-			{ /* @ts-expect-error */ }
+			{ /* @ts-expect-error `accessibleWhenDisabled` is not supported on a link button. */ }
 			<Button disabled accessibleWhenDisabled href="foo" />
 		</>;
 	} );

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -52,7 +52,7 @@ export const InputWithSlider = ( {
 				min={ min }
 				max={ max }
 				value={ value }
-				// @ts-expect-error `onChange` signatures differ between the input and slider.
+				// @ts-expect-error `RangeControl` may call `onChange` with `undefined`, but this expects a `number`.
 				// See: https://github.com/WordPress/gutenberg/pull/40535#issuecomment-1172418185
 				onChange={ onChange }
 				withInputField={ false }

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -52,7 +52,7 @@ export const InputWithSlider = ( {
 				min={ min }
 				max={ max }
 				value={ value }
-				// @ts-expect-error
+				// @ts-expect-error `onChange` signatures differ between the input and slider.
 				// See: https://github.com/WordPress/gutenberg/pull/40535#issuecomment-1172418185
 				onChange={ onChange }
 				withInputField={ false }

--- a/packages/components/src/context/context-connect.ts
+++ b/packages/components/src/context/context-connect.ts
@@ -122,15 +122,15 @@ export function getConnectNamespace(
 
 	let namespaces = [];
 
-	// @ts-ignore internal property
+	// @ts-expect-error `Component` is a union that has no index signature.
 	if ( Component[ CONNECT_STATIC_NAMESPACE ] ) {
-		// @ts-ignore internal property
+		// @ts-expect-error `Component` is a union that has no index signature.
 		namespaces = Component[ CONNECT_STATIC_NAMESPACE ];
 	}
 
-	// @ts-ignore
+	// @ts-expect-error `type` does not exist on every member of the `Component` union.
 	if ( Component.type && Component.type[ CONNECT_STATIC_NAMESPACE ] ) {
-		// @ts-ignore
+		// @ts-expect-error `type` does not exist on every member of the `Component` union.
 		namespaces = Component.type[ CONNECT_STATIC_NAMESPACE ];
 	}
 

--- a/packages/components/src/context/use-context-system.js
+++ b/packages/components/src/context/use-context-system.js
@@ -34,7 +34,7 @@ export function useContextSystem( props, namespace ) {
 	const contextProps = contextSystemProps?.[ namespace ] || {};
 
 	/** @type {ConnectedProps<P>} */
-	// @ts-expect-error The remaining properties are filled in below.
+	// @ts-expect-error The initial object cannot satisfy the generic `P`, whose props are copied in below.
 	const finalComponentProps = {
 		...getConnectedNamespace(),
 		...getNamespace( namespace ),

--- a/packages/components/src/context/use-context-system.js
+++ b/packages/components/src/context/use-context-system.js
@@ -34,7 +34,7 @@ export function useContextSystem( props, namespace ) {
 	const contextProps = contextSystemProps?.[ namespace ] || {};
 
 	/** @type {ConnectedProps<P>} */
-	// @ts-ignore We fill in the missing properties below
+	// @ts-expect-error The remaining properties are filled in below.
 	const finalComponentProps = {
 		...getConnectedNamespace(),
 		...getNamespace( namespace ),
@@ -60,19 +60,19 @@ export function useContextSystem( props, namespace ) {
 			: initialMergedProps.children;
 
 	for ( const key in initialMergedProps ) {
-		// @ts-ignore filling in missing props
+		// @ts-expect-error A string key cannot index the merged props type.
 		finalComponentProps[ key ] = initialMergedProps[ key ];
 	}
 
 	for ( const key in overrideProps ) {
-		// @ts-ignore filling in missing props
+		// @ts-expect-error A string key cannot index the merged props type.
 		finalComponentProps[ key ] = overrideProps[ key ];
 	}
 
 	// Setting an `undefined` explicitly can cause unintended overwrites
 	// when a `cloneElement()` is involved.
 	if ( rendered !== undefined ) {
-		// @ts-ignore
+		// @ts-expect-error `children` does not exist on `ConnectedProps<P>`.
 		finalComponentProps.children = rendered;
 	}
 

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -166,7 +166,7 @@ export function CustomGradientPicker( {
 			color: getStopCssColor( colorStop ),
 			// Although it's already been checked by `hasUnsupportedLength` in `getGradientAstWithDefault`,
 			// TypeScript doesn't know that `colorStop.length` is not undefined here.
-			// @ts-expect-error
+			// @ts-expect-error `colorStop.length` is possibly `undefined`.
 			position: parseInt( colorStop.length.value ),
 		};
 	} );

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -57,7 +57,7 @@ function Disabled( {
 	return (
 		<Provider value={ isDisabled }>
 			<div
-				// @ts-ignore Reason: inert is a recent HTML attribute
+				// @ts-expect-error React's types do not accept the string form of `inert`.
 				inert={ isDisabled ? 'true' : undefined }
 				className={
 					isDisabled

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -57,7 +57,7 @@ function Disabled( {
 	return (
 		<Provider value={ isDisabled }>
 			<div
-				// @ts-expect-error React's types do not accept the string form of `inert`.
+				// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 				inert={ isDisabled ? 'true' : undefined }
 				className={
 					isDisabled

--- a/packages/components/src/draggable/index.tsx
+++ b/packages/components/src/draggable/index.tsx
@@ -226,7 +226,7 @@ export function Draggable( {
 
 		// Aim for 60fps (16 ms per frame) for now. We can potentially use requestAnimationFrame (raf) instead,
 		// note that browsers may throttle raf below 60fps in certain conditions.
-		// @ts-ignore
+		// @ts-expect-error `throttle` expects a `(...args: unknown[]) => unknown` callback.
 		const throttledDragOver = throttle( over, 16 );
 
 		ownerDocument.addEventListener( 'dragover', throttledDragOver );

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -105,7 +105,7 @@ function Icon( {
 
 	if ( isValidElement( icon ) ) {
 		return cloneElement( icon, {
-			// @ts-ignore Just forwarding the size prop along
+			// @ts-expect-error `size` is forwarded but is not in the icon component overloads.
 			size,
 			width: size,
 			height: size,

--- a/packages/components/src/input-control/utils.ts
+++ b/packages/components/src/input-control/utils.ts
@@ -60,7 +60,7 @@ export function useDragCursor(
 		if ( isDragging ) {
 			document.documentElement.style.cursor = dragCursor;
 		} else {
-			// @ts-expect-error
+			// @ts-expect-error `cursor` is typed as `string`, but `null` clears it.
 			document.documentElement.style.cursor = null;
 		}
 	}, [ isDragging, dragCursor ] );

--- a/packages/components/src/placeholder/test/index.tsx
+++ b/packages/components/src/placeholder/test/index.tsx
@@ -47,7 +47,7 @@ const mockedSpeak = jest.mocked( speak );
 
 describe( 'Placeholder', () => {
 	beforeEach( () => {
-		// @ts-ignore
+		// @ts-expect-error The imported hook is not typed as a Jest mock.
 		useResizeObserver.mockReturnValue( [
 			<div key="1" />,
 			{ width: 320 },
@@ -164,7 +164,7 @@ describe( 'Placeholder', () => {
 
 	describe( 'resize aware', () => {
 		it( 'should not assign modifier class in first-pass `null` width from `useResizeObserver`', () => {
-			// @ts-ignore
+			// @ts-expect-error The imported hook is not typed as a Jest mock.
 			useResizeObserver.mockReturnValue( [
 				<div key="1" />,
 				{ width: 480 },
@@ -179,7 +179,7 @@ describe( 'Placeholder', () => {
 		} );
 
 		it( 'should assign modifier class', () => {
-			// @ts-ignore
+			// @ts-expect-error The imported hook is not typed as a Jest mock.
 			useResizeObserver.mockReturnValue( [
 				<div key="1" />,
 				{ width: null },

--- a/packages/components/src/query-controls/index.tsx
+++ b/packages/components/src/query-controls/index.tsx
@@ -159,7 +159,7 @@ export function QueryControls( {
 									// Keeping the fallback to `item.value` for legacy reasons,
 									// even if items of `selectedCategories` should not have a
 									// `value` property.
-									// @ts-expect-error
+									// @ts-expect-error `value` does not exist on `Category`.
 									value: item.name || item.value,
 								} ) )
 							}

--- a/packages/components/src/utils/rtl.js
+++ b/packages/components/src/utils/rtl.js
@@ -75,11 +75,11 @@ export const convertLTRToRTL = ( ltrStyles = {} ) => {
 export function rtl( ltrStyles = {}, rtlStyles ) {
 	return () => {
 		if ( rtlStyles ) {
-			// @ts-ignore: `css` types are wrong, it can accept an object: https://emotion.sh/docs/object-styles#with-css
+			// @ts-expect-error `css` accepts an object, but its types omit that overload: https://emotion.sh/docs/object-styles#with-css
 			return isRTL() ? css( rtlStyles ) : css( ltrStyles );
 		}
 
-		// @ts-ignore: `css` types are wrong, it can accept an object: https://emotion.sh/docs/object-styles#with-css
+		// @ts-expect-error `css` accepts an object, but its types omit that overload: https://emotion.sh/docs/object-styles#with-css
 		return isRTL() ? css( convertLTRToRTL( ltrStyles ) ) : css( ltrStyles );
 	};
 }

--- a/packages/components/src/utils/rtl.js
+++ b/packages/components/src/utils/rtl.js
@@ -75,11 +75,11 @@ export const convertLTRToRTL = ( ltrStyles = {} ) => {
 export function rtl( ltrStyles = {}, rtlStyles ) {
 	return () => {
 		if ( rtlStyles ) {
-			// @ts-expect-error `css` accepts an object, but its types omit that overload: https://emotion.sh/docs/object-styles#with-css
+			// @ts-expect-error `React.CSSProperties` lacks the string index signature Emotion's `CSSObject` requires.
 			return isRTL() ? css( rtlStyles ) : css( ltrStyles );
 		}
 
-		// @ts-expect-error `css` accepts an object, but its types omit that overload: https://emotion.sh/docs/object-styles#with-css
+		// @ts-expect-error `React.CSSProperties` lacks the string index signature Emotion's `CSSObject` requires.
 		return isRTL() ? css( convertLTRToRTL( ltrStyles ) ) : css( ltrStyles );
 	};
 }

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -40,7 +40,6 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 		alternative: 'useEffect',
 	} );
 
-	// @ts-ignore We don't need to fix the type-related issues because this is deprecated.
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor( /** @type {any} */ props ) {

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -19,7 +19,7 @@ const withInstanceId = createHigherOrderComponent(
 	) => {
 		return ( props: WithoutInjectedProps< C, InstanceIdProps > ) => {
 			const instanceId = useInstanceId( WrappedComponent );
-			// @ts-ignore
+			// @ts-expect-error `LibraryManagedAttributes` cannot see the injected `instanceId` prop.
 			return <WrappedComponent { ...props } instanceId={ instanceId } />;
 		};
 	},

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -66,7 +66,7 @@ const withSafeTimeout = createHigherOrderComponent(
 
 			render() {
 				return (
-					// @ts-ignore
+					// @ts-expect-error `LibraryManagedAttributes` cannot see the injected timeout props.
 					<OriginalComponent
 						{ ...this.props }
 						setTimeout={ this.setTimeout }

--- a/packages/core-data/src/awareness/block-lookup.ts
+++ b/packages/core-data/src/awareness/block-lookup.ts
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-expect-error `@wordpress/block-editor` is not typed yet.
+// @ts-expect-error `@wordpress/block-editor` does not expose type declarations for its entry point.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**

--- a/packages/core-data/src/awareness/block-lookup.ts
+++ b/packages/core-data/src/awareness/block-lookup.ts
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-ignore No exported types for block editor store selectors.
+// @ts-expect-error `@wordpress/block-editor` is not typed yet.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -3,7 +3,7 @@
  */
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-ignore No exported types for block editor store selectors.
+// @ts-expect-error `@wordpress/block-editor` is not typed yet.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -200,7 +200,7 @@ export class PostEditorAwareness extends BaseAwarenessState< PostEditorState > {
 			undoIgnore: true,
 		};
 
-		// @ts-ignore Types are not provided when using store name instead of store instance.
+		// @ts-expect-error Types are not provided when using the store name instead of the store instance.
 		dispatch( coreStore ).editEntityRecord(
 			this.kind,
 			this.name,

--- a/packages/core-data/src/awareness/post-editor-awareness.ts
+++ b/packages/core-data/src/awareness/post-editor-awareness.ts
@@ -3,7 +3,7 @@
  */
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-expect-error `@wordpress/block-editor` is not typed yet.
+// @ts-expect-error `@wordpress/block-editor` does not expose type declarations for its entry point.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**

--- a/packages/core-data/src/batch/default-processor.js
+++ b/packages/core-data/src/batch/default-processor.js
@@ -41,7 +41,6 @@ export default async function defaultProcessor( requests ) {
 
 	const results = [];
 
-	// @ts-ignore We would have crashed or never gotten to this point if we hadn't received the maxItems count.
 	for ( const batchRequests of chunk( requests, maxItems ) ) {
 		const batchResponse = await apiFetch( {
 			path: '/batch/v1',

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -208,7 +208,7 @@ export function useEntityRecordsWithPermissions< RecordType >(
 	const ids = useMemo(
 		() =>
 			data?.map(
-				// @ts-ignore
+				// @ts-expect-error `data` is `unknown[]`, so the callback signature does not line up.
 				( record: RecordType ) => record[ entityConfig?.key ?? 'id' ]
 			) ?? [],
 		[ data, entityConfig?.key ]
@@ -227,7 +227,7 @@ export function useEntityRecordsWithPermissions< RecordType >(
 	const dataWithPermissions = useMemo(
 		() =>
 			data?.map( ( record, index ) => ( {
-				// @ts-ignore
+				// @ts-expect-error `record` is `unknown`, which cannot be spread.
 				...record,
 				permissions: permissions[ index ],
 			} ) ) ?? [],

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -3,7 +3,7 @@
  */
 import { select } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-ignore No exported types for block editor store selectors.
+// @ts-expect-error `@wordpress/block-editor` is not typed yet.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**

--- a/packages/core-data/src/utils/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/crdt-user-selections.ts
@@ -3,7 +3,7 @@
  */
 import { select } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-// @ts-expect-error `@wordpress/block-editor` is not typed yet.
+// @ts-expect-error `@wordpress/block-editor` does not expose type declarations for its entry point.
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -312,7 +312,7 @@ describe( 'normalizeFormFields', () => {
 				layout: {
 					type: 'card',
 					withHeader: false,
-					// @ts-expect-error Deliberately invalid type, to verify runtime behavior.
+					// @ts-expect-error With `withHeader: false`, `isOpened` must be `true`; normalization of `false` is tested.
 					isOpened: false,
 					summary: [ { id: 'field1', visibility: 'always' } ],
 				},

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -309,11 +309,10 @@ describe( 'normalizeFormFields', () => {
 
 		it( 'card: enforces isOpened=true and summary=[] when withHeader=false', () => {
 			const form: Form = {
-				// @ts-ignore - Test intentionally uses invalid type to verify runtime behavior.
 				layout: {
 					type: 'card',
 					withHeader: false,
-					// @ts-ignore - Test intentionally uses invalid type to verify runtime behavior.
+					// @ts-expect-error Deliberately invalid type, to verify runtime behavior.
 					isOpened: false,
 					summary: [ { id: 'field1', visibility: 'always' } ],
 				},

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -229,7 +229,7 @@ export default function Filter( {
 			activeElements = [
 				{
 					value: filterInView.value,
-					// @ts-ignore
+					// @ts-expect-error `label` is a `string[]` here, but the element type expects a `string`.
 					label,
 				},
 			];

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -55,7 +55,7 @@ export default function DataViewsFooter() {
 	return (
 		<div
 			className="dataviews-footer"
-			// @ts-expect-error React's types do not accept the string form of `inert`.
+			// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 			inert={ isRefreshing ? 'true' : undefined }
 		>
 			<Stack

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -55,7 +55,7 @@ export default function DataViewsFooter() {
 	return (
 		<div
 			className="dataviews-footer"
-			// @ts-ignore
+			// @ts-expect-error React's types do not accept the string form of `inert`.
 			inert={ isRefreshing ? 'true' : undefined }
 		>
 			<Stack

--- a/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
@@ -63,7 +63,7 @@ export default function ViewActivity< Item >(
 				direction="column"
 				gap="sm"
 				className={ wrapperClassName }
-				// @ts-ignore
+				// @ts-expect-error React's types do not accept the string form of `inert`.
 				inert={ isInert ? 'true' : undefined }
 			>
 				{ groupedEntries.map(
@@ -92,7 +92,7 @@ export default function ViewActivity< Item >(
 			<div
 				className={ wrapperClassName }
 				role={ view.infiniteScrollEnabled ? 'feed' : undefined }
-				// @ts-ignore
+				// @ts-expect-error React's types do not accept the string form of `inert`.
 				inert={ isInert ? 'true' : undefined }
 			>
 				<ActivityItems< Item > { ...props } />

--- a/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/activity/index.tsx
@@ -63,7 +63,7 @@ export default function ViewActivity< Item >(
 				direction="column"
 				gap="sm"
 				className={ wrapperClassName }
-				// @ts-expect-error React's types do not accept the string form of `inert`.
+				// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 				inert={ isInert ? 'true' : undefined }
 			>
 				{ groupedEntries.map(
@@ -92,7 +92,7 @@ export default function ViewActivity< Item >(
 			<div
 				className={ wrapperClassName }
 				role={ view.infiniteScrollEnabled ? 'feed' : undefined }
-				// @ts-expect-error React's types do not accept the string form of `inert`.
+				// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 				inert={ isInert ? 'true' : undefined }
 			>
 				<ActivityItems< Item > { ...props } />

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -438,7 +438,7 @@ export default function CompositeGrid< Item >( {
 						}
 						role="feed"
 						focusWrap
-						// @ts-ignore
+						// @ts-expect-error React's types do not accept the string form of `inert`.
 						inert={ inert }
 					>
 						{ /* Render placeholders for unloaded items in first row */ }
@@ -534,7 +534,7 @@ export default function CompositeGrid< Item >( {
 						aria-busy={ isLoading }
 						aria-rowcount={ totalRows }
 						ref={ resizeObserverRef }
-						// @ts-ignore
+						// @ts-expect-error React's types do not accept the string form of `inert`.
 						inert={ inert }
 					>
 						{ chunk( data, gridColumns ).map( ( row, i ) => (

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -438,7 +438,7 @@ export default function CompositeGrid< Item >( {
 						}
 						role="feed"
 						focusWrap
-						// @ts-expect-error React's types do not accept the string form of `inert`.
+						// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 						inert={ inert }
 					>
 						{ /* Render placeholders for unloaded items in first row */ }
@@ -534,7 +534,7 @@ export default function CompositeGrid< Item >( {
 						aria-busy={ isLoading }
 						aria-rowcount={ totalRows }
 						ref={ resizeObserverRef }
-						// @ts-expect-error React's types do not accept the string form of `inert`.
+						// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 						inert={ inert }
 					>
 						{ chunk( data, gridColumns ).map( ( row, i ) => (

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -418,7 +418,7 @@ function ViewTable< Item >( {
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 				role={ isInfiniteScroll ? 'feed' : undefined }
-				// @ts-expect-error React's types do not accept the string form of `inert`.
+				// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 				inert={ ! isInfiniteScroll && isLoading ? 'true' : undefined }
 			>
 				<colgroup>

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -418,7 +418,7 @@ function ViewTable< Item >( {
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 				role={ isInfiniteScroll ? 'feed' : undefined }
-				// @ts-ignore Reason: inert is a recent HTML attribute
+				// @ts-expect-error React's types do not accept the string form of `inert`.
 				inert={ ! isInfiniteScroll && isLoading ? 'true' : undefined }
 			>
 				<colgroup>

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -89,7 +89,7 @@ export function PropertiesSection( {
 
 	const visibleLockedFields = lockedFields.filter(
 		( { isVisibleFlag } ) =>
-			// @ts-expect-error
+			// @ts-expect-error A string key cannot index `View`.
 			view[ isVisibleFlag ] ?? true
 	);
 
@@ -112,7 +112,7 @@ export function PropertiesSection( {
 			>
 				<ItemGroup isBordered isSeparated size="medium">
 					{ lockedFields.map( ( { field, isVisibleFlag } ) => {
-						// @ts-expect-error
+						// @ts-expect-error A string key cannot index `View`.
 						const isVisible = view[ isVisibleFlag ] ?? true;
 						const fieldToRender =
 							isSingleVisibleLockedField && isVisible

--- a/packages/dataviews/src/dataform/stories/layout-regular.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-regular.tsx
@@ -326,7 +326,7 @@ const getLayoutFromStoryArgs = ( {
 			type: 'card',
 		};
 		if ( withHeader !== undefined ) {
-			// @ts-ignore We want to demo the effects of configuring withHeader.
+			// @ts-expect-error `withHeader` is not part of the `CardLayout` type.
 			cardLayout.withHeader = withHeader;
 		}
 		layout = cardLayout;

--- a/packages/dataviews/src/dataform/stories/layout-regular.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-regular.tsx
@@ -326,7 +326,7 @@ const getLayoutFromStoryArgs = ( {
 			type: 'card',
 		};
 		if ( withHeader !== undefined ) {
-			// @ts-expect-error `withHeader` is not part of the `CardLayout` type.
+			// @ts-expect-error `cardLayout` is narrowed to the member whose `withHeader` can only be `true`.
 			cardLayout.withHeader = withHeader;
 		}
 		layout = cardLayout;

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -351,7 +351,7 @@ describe( 'DataViews component', () => {
 					isItemClickable={ () => true }
 					renderItemLink={ ( { item, ...props } ) => (
 						<button
-							// @ts-expect-error
+							// @ts-expect-error The action callback signature does not accept an event.
 							onClick={ ( event ) => {
 								event.preventDefault();
 								onClickItemCallback( item );
@@ -690,7 +690,7 @@ describe( 'DataViews component', () => {
 					isItemClickable={ () => true }
 					renderItemLink={ ( { item, ...props } ) => (
 						<button
-							// @ts-expect-error
+							// @ts-expect-error The action callback signature does not accept an event.
 							onClick={ ( event ) => {
 								event.preventDefault();
 								mediaClickItemCallback( item );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -351,7 +351,7 @@ describe( 'DataViews component', () => {
 					isItemClickable={ () => true }
 					renderItemLink={ ( { item, ...props } ) => (
 						<button
-							// @ts-expect-error The action callback signature does not accept an event.
+							// @ts-expect-error The spread `props.onClick` may be an anchor handler, not a button one.
 							onClick={ ( event ) => {
 								event.preventDefault();
 								onClickItemCallback( item );
@@ -690,7 +690,7 @@ describe( 'DataViews component', () => {
 					isItemClickable={ () => true }
 					renderItemLink={ ( { item, ...props } ) => (
 						<button
-							// @ts-expect-error The action callback signature does not accept an event.
+							// @ts-expect-error The spread `props.onClick` may be an anchor handler, not a button one.
 							onClick={ ( event ) => {
 								event.preventDefault();
 								mediaClickItemCallback( item );

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -294,7 +294,7 @@ describe( 'normalizeFields: default getValue', () => {
 				{
 					id: 'user',
 					filterBy: {
-						// @ts-expect-error Deliberately invalid operators, to verify runtime behavior.
+						// @ts-expect-error `invalid` and `operator` are not members of the `Operator` union.
 						operators: [ 'invalid', 'operator' ],
 					},
 				},
@@ -325,7 +325,7 @@ describe( 'normalizeFields: default getValue', () => {
 					type: 'integer',
 					filterBy: {
 						isPrimary: true,
-						// @ts-expect-error Deliberately invalid operators, to verify runtime behavior.
+						// @ts-expect-error `invalid` is not a member of the `Operator` union.
 						operators: [ 'invalid', 'lessThan' ],
 					},
 				},

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -294,7 +294,7 @@ describe( 'normalizeFields: default getValue', () => {
 				{
 					id: 'user',
 					filterBy: {
-						// @ts-ignore
+						// @ts-expect-error Deliberately invalid operators, to verify runtime behavior.
 						operators: [ 'invalid', 'operator' ],
 					},
 				},
@@ -325,7 +325,7 @@ describe( 'normalizeFields: default getValue', () => {
 					type: 'integer',
 					filterBy: {
 						isPrimary: true,
-						// @ts-ignore
+						// @ts-expect-error Deliberately invalid operators, to verify runtime behavior.
 						operators: [ 'invalid', 'lessThan' ],
 					},
 				},

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -2439,7 +2439,7 @@ describe( 'useFormValidity', () => {
 					id: 'title',
 					type: 'text',
 					isValid: {
-						// @ts-ignore returns wrong type for testing purposes
+						// @ts-expect-error Deliberately returns the wrong type, for testing purposes.
 						custom: async () =>
 							await new Promise( ( resolve ) =>
 								setTimeout( resolve, 5 )

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -2439,7 +2439,7 @@ describe( 'useFormValidity', () => {
 					id: 'title',
 					type: 'text',
 					isValid: {
-						// @ts-expect-error Deliberately returns the wrong type, for testing purposes.
+						// @ts-expect-error Resolves to `number`, but custom validators may resolve only to `string | null`.
 						custom: async () =>
 							await new Promise( ( resolve ) =>
 								setTimeout( resolve, 5 )

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -114,7 +114,6 @@ export function setSettings( dateSettings: DateSettings ) {
 				.longDateFormat( 'LTS' ) === null
 		) {
 			// Delete the misconfigured locale.
-			// @ts-ignore Type definitions are incorrect - null is permitted.
 			momentLib.defineLocale( dateSettings.l10n.locale, null );
 		} else {
 			// We have a properly configured locale, so no need to create one.

--- a/packages/e2e-test-utils-playwright/src/editor/select-blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/select-blocks.ts
@@ -29,7 +29,7 @@ export async function selectBlocks(
 	if ( endClientId ) {
 		await this.page.evaluate(
 			( [ startId, endId ] ) => {
-				// @ts-ignore
+				// @ts-expect-error `wp` is a browser global that only exists inside `page.evaluate`.
 				wp.data
 					.dispatch( 'core/block-editor' )
 					.multiSelect( startId, endId );
@@ -39,7 +39,7 @@ export async function selectBlocks(
 	} else {
 		await this.page.evaluate(
 			( [ clientId ] ) => {
-				// @ts-ignore
+				// @ts-expect-error `wp` is a browser global that only exists inside `page.evaluate`.
 				wp.data.dispatch( 'core/block-editor' ).selectBlock( clientId );
 			},
 			[ startClientId ]

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import type { Page, Browser } from '@playwright/test';
 // resolution-mode support in TypeScript 5.3 will resolve this.
 // See https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-beta/
-// @ts-expect-error
+// @ts-expect-error `web-vitals` is ESM, so a type-only import needs a `resolution-mode`.
 import type { Metric } from 'web-vitals';
 
 type EventType =

--- a/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
@@ -43,7 +43,7 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 	const output = await page.evaluate(
 		( [ _type, _clipboardData ] ) => {
 			const canvasDoc =
-				// @ts-ignore
+				// @ts-expect-error `contentDocument` only exists when the active element is an iframe.
 				document.activeElement?.contentDocument ?? document;
 			const event = new ClipboardEvent( _type, {
 				bubbles: true,

--- a/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/press-keys.ts
@@ -43,7 +43,7 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 	const output = await page.evaluate(
 		( [ _type, _clipboardData ] ) => {
 			const canvasDoc =
-				// @ts-expect-error `contentDocument` only exists when the active element is an iframe.
+				// @ts-expect-error `activeElement` is typed as `Element`, which does not declare `contentDocument`.
 				document.activeElement?.contentDocument ?? document;
 			const event = new ClipboardEvent( _type, {
 				bubbles: true,

--- a/packages/editor/src/components/style-book/color-examples.tsx
+++ b/packages/editor/src/components/style-book/color-examples.tsx
@@ -10,8 +10,7 @@ import { __experimentalGrid as Grid } from '@wordpress/components';
 import {
 	getColorClassName,
 	__experimentalGetGradientClass,
-	// @wordpress/block-editor imports are not typed.
-	// @ts-expect-error
+	// @ts-expect-error `@wordpress/block-editor` is not typed yet.
 } from '@wordpress/block-editor';
 
 /**

--- a/packages/editor/src/components/style-book/color-examples.tsx
+++ b/packages/editor/src/components/style-book/color-examples.tsx
@@ -10,7 +10,7 @@ import { __experimentalGrid as Grid } from '@wordpress/components';
 import {
 	getColorClassName,
 	__experimentalGetGradientClass,
-	// @ts-expect-error `@wordpress/block-editor` is not typed yet.
+	// @ts-expect-error `@wordpress/block-editor` does not expose type declarations for its entry point.
 } from '@wordpress/block-editor';
 
 /**

--- a/packages/editor/src/components/sync-connection-error-modal/index.tsx
+++ b/packages/editor/src/components/sync-connection-error-modal/index.tsx
@@ -3,7 +3,6 @@
  */
 import { useSelect, select } from '@wordpress/data';
 import { useCopyToClipboard } from '@wordpress/compose';
-// @ts-ignore No exported types.
 import { serialize } from '@wordpress/blocks';
 import {
 	store as coreDataStore,

--- a/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
@@ -3,9 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	// @ts-ignore
 	BlockPreview,
-	// @ts-ignore
+	// @ts-expect-error `@wordpress/block-editor` is not typed yet.
 } from '@wordpress/block-editor';
 import type { BasePost } from '@wordpress/fields';
 import { useSelect } from '@wordpress/data';
@@ -17,7 +16,6 @@ import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import { EditorProvider } from '../../../components/provider';
 import { useStyle } from '../../../components/global-styles';
 import { unlock } from '../../../lock-unlock';
-// @ts-ignore
 import { store as editorStore } from '../../../store';
 
 function PostPreviewContainer( {
@@ -71,7 +69,7 @@ export default function PostPreviewView( { item }: { item: BasePost } ) {
 				name: 'wp_template',
 			} );
 			const _settings = select( editorStore ).getEditorSettings();
-			// @ts-ignore
+			// @ts-expect-error Editor settings are typed as a bare `Object`.
 			const supportsTemplateMode = _settings.supportsTemplateMode;
 			const isViewable = getPostType( item.type )?.viewable ?? false;
 

--- a/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	BlockPreview,
-	// @ts-expect-error `@wordpress/block-editor` is not typed yet.
+	// @ts-expect-error `@wordpress/block-editor` does not expose type declarations for its entry point.
 } from '@wordpress/block-editor';
 import type { BasePost } from '@wordpress/fields';
 import { useSelect } from '@wordpress/data';

--- a/packages/editor/src/dataviews/fields/revisions/revisions-view.tsx
+++ b/packages/editor/src/dataviews/fields/revisions/revisions-view.tsx
@@ -9,7 +9,6 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-// @ts-ignore
 import { store as editorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
@@ -20,13 +19,12 @@ export default function RevisionsView() {
 				getCurrentPostLastRevisionId,
 				getCurrentPostRevisionsCount,
 				getEditorSettings,
-				// @ts-ignore
 			} = select( editorStore );
 			return {
 				lastRevisionId: getCurrentPostLastRevisionId(),
 				revisionsCount: getCurrentPostRevisionsCount(),
 				disableVisualRevisions:
-					// @ts-ignore
+					// @ts-expect-error Editor settings are typed as a bare `Object`.
 					!! getEditorSettings().disableVisualRevisions,
 			};
 		}, [] );

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -217,7 +217,7 @@ export const registerPostTypeSchema =
 			canCreate &&
 			duplicatePost;
 
-		// @ts-ignore
+		// @ts-expect-error `globalThis` has no index signature for this build-time global.
 		if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
 			// Outside Gutenberg, disable duplication except for wp_template.
 			if ( 'wp_template' !== postTypeConfig.slug ) {
@@ -226,7 +226,6 @@ export const registerPostTypeSchema =
 		}
 
 		// When template activation experiment is disabled, templates cannot be duplicated.
-		// @ts-ignore
 		if (
 			postTypeConfig.slug === 'wp_template' &&
 			! window?.__experimentalTemplateActivate
@@ -239,7 +238,6 @@ export const registerPostTypeSchema =
 			!! postTypeConfig.supports?.revisions
 				? viewPostRevisions
 				: undefined,
-			// @ts-ignore
 			canDuplicate,
 			postTypeConfig.slug === 'wp_template_part' &&
 			canCreate &&

--- a/packages/fields/src/actions/delete-post.tsx
+++ b/packages/fields/src/actions/delete-post.tsx
@@ -10,7 +10,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-// @ts-ignore
+// @ts-expect-error `@wordpress/patterns` is not typed yet.
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import type { Action } from '@wordpress/dataviews';
 import { decodeEntities } from '@wordpress/html-entities';

--- a/packages/fields/src/actions/duplicate-pattern.tsx
+++ b/packages/fields/src/actions/duplicate-pattern.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
-// @ts-ignore
+// @ts-expect-error `@wordpress/patterns` is not typed yet.
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import type { Action } from '@wordpress/dataviews';
 

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -98,7 +98,7 @@ const duplicatePost: Action< BasePost > = {
 				);
 			assignableProperties.forEach( ( property ) => {
 				if ( item.hasOwnProperty( property ) ) {
-					// @ts-ignore
+					// @ts-expect-error `property` is a dynamic string key on both objects.
 					newItemObject[ property ] = item[ property ];
 				}
 			} );

--- a/packages/fields/src/actions/duplicate-template-part.tsx
+++ b/packages/fields/src/actions/duplicate-template-part.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from '@wordpress/data';
 import { _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo } from '@wordpress/element';
-// @ts-ignore
 import { parse } from '@wordpress/blocks';
 import type { Action } from '@wordpress/dataviews';
 

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-// @ts-ignore
+// @ts-expect-error `@wordpress/patterns` is not typed yet.
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import {
 	Button,

--- a/packages/fields/src/actions/reset-post.tsx
+++ b/packages/fields/src/actions/reset-post.tsx
@@ -7,7 +7,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from '@wordpress/element';
-// @ts-ignore
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import {
 	Button,

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -14,7 +14,6 @@ import {
 	useMemo,
 	useState,
 } from '@wordpress/element';
-// @ts-ignore
 import { store as coreStore } from '@wordpress/core-data';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 import { debounce } from '@wordpress/compose';

--- a/packages/fields/src/fields/pattern-sync-status/index.tsx
+++ b/packages/fields/src/fields/pattern-sync-status/index.tsx
@@ -3,7 +3,7 @@
  */
 import type { Field } from '@wordpress/dataviews';
 import { __, _x } from '@wordpress/i18n';
-// @ts-ignore
+// @ts-expect-error `@wordpress/patterns` is not typed yet.
 import { privateApis as patternPrivateApis } from '@wordpress/patterns';
 
 /**

--- a/packages/fields/src/fields/pattern-title/view.tsx
+++ b/packages/fields/src/fields/pattern-title/view.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon, lockSmall } from '@wordpress/icons';
-// @ts-ignore
+// @ts-expect-error `@wordpress/patterns` is not typed yet.
 import { privateApis as patternPrivateApis } from '@wordpress/patterns';
 import { Tooltip, VisuallyHidden } from '@wordpress/ui';
 

--- a/packages/global-styles-engine/src/core/merge.ts
+++ b/packages/global-styles-engine/src/core/merge.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deepmerge from 'deepmerge';
-// @ts-ignore - is-plain-object doesn't have proper types
+// @ts-expect-error Its declaration file is not exposed through the `exports` map.
 import { isPlainObject } from 'is-plain-object';
 
 /**

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1922,7 +1922,7 @@ export const getBlockSelectors = (
 			!! blockType?.supports?.layout ||
 			!! blockType?.supports?.__experimentalLayout;
 		const fallbackGapValue =
-			// @ts-expect-error
+			// @ts-expect-error `blockGap` support is typed as `boolean | AxialDirection[]`.
 			blockType?.supports?.spacing?.blockGap?.__experimentalDefault;
 
 		const blockStyleVariations = getBlockStyles( name );

--- a/packages/global-styles-engine/src/utils/background.ts
+++ b/packages/global-styles-engine/src/utils/background.ts
@@ -11,7 +11,7 @@ export const BACKGROUND_BLOCK_DEFAULT_VALUES = {
 export function setBackgroundStyleDefaults( backgroundStyle: BackgroundStyle ) {
 	if (
 		! backgroundStyle ||
-		// @ts-expect-error
+		// @ts-expect-error `backgroundImage` is a union whose other members have no `url`.
 		! backgroundStyle?.backgroundImage?.url
 	) {
 		return;

--- a/packages/global-styles-engine/src/utils/common.ts
+++ b/packages/global-styles-engine/src/utils/common.ts
@@ -256,7 +256,7 @@ export function scopeFeatureSelectors(
 
 			Object.entries( selector ).forEach(
 				( [ subfeature, subfeatureSelector ] ) => {
-					// @ts-expect-error
+					// @ts-expect-error A string key cannot index `string | Record<string, string>`.
 					featureSelectors[ feature ][ subfeature ] = scopeSelector(
 						scope,
 						subfeatureSelector as string
@@ -509,7 +509,7 @@ function findInPresetsBy(
 			// Preset origins ordered by priority.
 			const origins = [ 'custom', 'theme', 'default' ];
 			for ( const origin of origins ) {
-				// @ts-expect-error
+				// @ts-expect-error `presetByOrigin` is typed as `Object`, which has no index signature.
 				const presets = presetByOrigin[ origin ];
 				if ( presets ) {
 					const presetObject = presets.find(

--- a/packages/global-styles-engine/src/utils/object.ts
+++ b/packages/global-styles-engine/src/utils/object.ts
@@ -24,12 +24,12 @@ export function setImmutably(
 	// Traverse object from root to leaf, shallowly cloning at each level
 	let prev = object;
 	for ( const key of path ) {
-		// @ts-expect-error
+		// @ts-expect-error `prev` is typed as `Object`, which has no index signature.
 		const lvl = prev[ key ];
-		// @ts-expect-error
+		// @ts-expect-error `prev` is typed as `Object`, which has no index signature.
 		prev = prev[ key ] = Array.isArray( lvl ) ? [ ...lvl ] : { ...lvl };
 	}
-	// @ts-expect-error
+	// @ts-expect-error `leaf` is possibly `undefined`, which cannot be an index type.
 	prev[ leaf ] = value;
 
 	return object;
@@ -57,7 +57,7 @@ export const getValueFromObjectPath = (
 	const arrayPath = Array.isArray( path ) ? path : path.split( '.' );
 	let value = object;
 	arrayPath.forEach( ( fieldName ) => {
-		// @ts-expect-error
+		// @ts-expect-error `value` is typed as `Object`, which has no index signature.
 		value = value?.[ fieldName ];
 	} );
 	return value ?? defaultValue;

--- a/packages/global-styles-ui/src/font-library/font-collection.tsx
+++ b/packages/global-styles-ui/src/font-library/font-collection.tsx
@@ -158,8 +158,11 @@ function FontCollection( { slug }: { slug: string } ) {
 		setPage( 1 );
 	};
 
-	// @ts-expect-error
-	const debouncedUpdateSearchInput = debounce( handleUpdateSearchInput, 300 );
+	const debouncedUpdateSearchInput = debounce(
+		// @ts-expect-error `debounce` expects a `(...args: unknown[]) => unknown` callback.
+		handleUpdateSearchInput,
+		300
+	);
 
 	const handleToggleVariant = ( font: FontFamily, face?: FontFace ) => {
 		const newFontsToInstall = toggleFont( font, face, fontsToInstall );

--- a/packages/global-styles-ui/src/font-library/utils/make-families-from-faces.ts
+++ b/packages/global-styles-ui/src/font-library/utils/make-families-from-faces.ts
@@ -24,7 +24,7 @@ export default function makeFamiliesFromFaces(
 					fontFace: [],
 				};
 			}
-			// @ts-expect-error
+			// @ts-expect-error `acc[ item.fontFamily ]` is possibly `undefined`.
 			acc[ item.fontFamily ].fontFace.push( item );
 			return acc;
 		},

--- a/packages/global-styles-ui/src/font-library/utils/set-immutably.ts
+++ b/packages/global-styles-ui/src/font-library/utils/set-immutably.ts
@@ -25,12 +25,12 @@ export function setImmutably(
 	// Traverse object from root to leaf, shallowly cloning at each level
 	let prev = object;
 	for ( const key of path ) {
-		// @ts-expect-error
+		// @ts-expect-error `prev` is typed as `Object`, which has no index signature.
 		const lvl = prev[ key ];
-		// @ts-expect-error
+		// @ts-expect-error `prev` is typed as `Object`, which has no index signature.
 		prev = prev[ key ] = Array.isArray( lvl ) ? [ ...lvl ] : { ...lvl };
 	}
-	// @ts-expect-error
+	// @ts-expect-error `leaf` is possibly `undefined`, which cannot be an index type.
 	prev[ leaf ] = value;
 
 	return object;

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -600,14 +600,14 @@ function a11ySpeak( messageKey: keyof typeof navigationTexts ) {
 			// Fallback to localized strings from Interactivity API state.
 			// @todo This block is for Core < 6.7.0. Remove when support is dropped.
 
-			// @ts-expect-error
+			// @ts-expect-error `texts` is not part of the typed navigation state.
 			if ( state.navigation.texts?.loading ) {
-				// @ts-expect-error
+				// @ts-expect-error `texts` is not part of the typed navigation state.
 				navigationTexts.loading = state.navigation.texts.loading;
 			}
-			// @ts-expect-error
+			// @ts-expect-error `texts` is not part of the typed navigation state.
 			if ( state.navigation.texts?.loaded ) {
-				// @ts-expect-error
+				// @ts-expect-error `texts` is not part of the typed navigation state.
 				navigationTexts.loaded = state.navigation.texts.loaded;
 			}
 		}

--- a/packages/interactivity/src/test/types.ts
+++ b/packages/interactivity/src/test/types.ts
@@ -39,13 +39,13 @@ describe( 'Interactivity API types', () => {
 				myStore.state.clientValue satisfies number;
 				myStore.state.derived satisfies number;
 
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
 				myStore.state.nonExistent satisfies number;
 				myStore.actions.sync( 1 ) satisfies number;
 				myStore.actions.async( 1 ) satisfies Promise< number >;
 				( await myStore.actions.async( 1 ) ) satisfies number;
 
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store actions.
 				myStore.actions.nonExistent() satisfies {};
 			};
 		} );
@@ -68,7 +68,7 @@ describe( 'Interactivity API types', () => {
 				const myStore = store< Store >( 'test', {
 					state: {
 						clientValue: 1,
-						// @ts-expect-error
+						// @ts-expect-error `nonExistent` is intentionally not part of the declared store.
 						nonExistent: 2,
 						get derived(): number {
 							return myStore.state.serverValue;
@@ -88,12 +88,12 @@ describe( 'Interactivity API types', () => {
 				myStore.state.clientValue satisfies number;
 				myStore.state.serverValue satisfies number;
 				myStore.state.derived satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
 				myStore.state.nonExistent satisfies number;
 				myStore.actions.sync( 1 ) satisfies number;
 				myStore.actions.async( 1 ) satisfies Promise< number >;
 				( await myStore.actions.async( 1 ) ) satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store actions.
 				myStore.actions.nonExistent();
 			};
 		} );
@@ -139,12 +139,12 @@ describe( 'Interactivity API types', () => {
 				myStore.state.clientValue satisfies number;
 				myStore.state.serverValue satisfies number;
 				myStore.state.derived satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
 				myStore.state.nonExistent satisfies number;
 				myStore.actions.sync( 1 ) satisfies number;
 				myStore.actions.async( 1 ) satisfies Promise< number >;
 				( await myStore.actions.async( 1 ) ) satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store actions.
 				myStore.actions.nonExistent();
 			};
 		} );
@@ -186,12 +186,12 @@ describe( 'Interactivity API types', () => {
 				myStore.state.clientValue satisfies number;
 				myStore.state.serverValue satisfies number;
 				myStore.state.derived satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
 				myStore.state.nonExistent satisfies number;
 				myStore.actions.sync( 1 ) satisfies number;
 				myStore.actions.async( 1 ) satisfies Promise< number >;
 				( await myStore.actions.async( 1 ) ) satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store actions.
 				myStore.actions.nonExistent() satisfies {};
 			};
 		} );
@@ -229,20 +229,20 @@ describe( 'Interactivity API types', () => {
 					},
 					callbacks: {
 						existent: 1,
-						// @ts-expect-error
+						// @ts-expect-error `nonExistent` is intentionally not part of the declared store.
 						nonExistent: 1,
 					},
 				} );
 
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
 				myStore.state.nonExistent satisfies number;
 				myStore.actions.sync( 1 ) satisfies number;
 				myStore.actions.async( 1 ) satisfies Promise< number >;
 				( await myStore.actions.async( 1 ) ) satisfies number;
 				myStore.callbacks.existent satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store callbacks.
 				myStore.callbacks.nonExistent satisfies number;
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store actions.
 				myStore.actions.nonExistent() satisfies {};
 			};
 		} );
@@ -296,7 +296,7 @@ describe( 'Interactivity API types', () => {
 				myStore.actions.asyncAction() satisfies Promise< number >;
 				( await myStore.actions.asyncAction() ) satisfies number;
 
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
 				myStore.state.nonExistent satisfies {};
 			};
 		} );
@@ -393,7 +393,7 @@ describe( 'Interactivity API types', () => {
 					};
 				}
 				const state = getServerState< State >();
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the state type.
 				state.nonExistent = 'error';
 				state.foo satisfies string;
 				state.bar.baz satisfies number;
@@ -420,7 +420,7 @@ describe( 'Interactivity API types', () => {
 					};
 				}
 				const context = getServerContext< Context >();
-				// @ts-expect-error
+				// @ts-expect-error `nonExistent` is intentionally absent from the context type.
 				context.nonExistent = 'error';
 				context.foo satisfies string;
 				context.bar.baz satisfies number;

--- a/packages/interactivity/src/test/types.ts
+++ b/packages/interactivity/src/test/types.ts
@@ -234,7 +234,7 @@ describe( 'Interactivity API types', () => {
 					},
 				} );
 
-				// @ts-expect-error `nonExistent` is intentionally absent from the store state.
+				// @ts-expect-error This store part declares no `state` property.
 				myStore.state.nonExistent satisfies number;
 				myStore.actions.sync( 1 ) satisfies number;
 				myStore.actions.async( 1 ) satisfies Promise< number >;

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -31,7 +31,7 @@ expect.extend( {
 
 describe( 'toVdom', () => {
 	beforeEach( () => {
-		// @ts-ignore - Accessing private property for testing.
+		// @ts-expect-error `_values` is an internal property, accessed here for testing.
 		hydratedIslands._values = new WeakMap();
 	} );
 

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -32,8 +32,7 @@ import {
 	ComplementaryArea,
 	InterfaceSkeleton,
 	PinnedItems,
-	// No type declarations available for @wordpress/interface.
-	// @ts-expect-error
+	// @ts-expect-error `@wordpress/interface` is not typed yet.
 } from '@wordpress/interface';
 import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
 

--- a/packages/project-management-automation/lib/tasks/add-milestone/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/index.js
@@ -111,7 +111,7 @@ async function addMilestone( payload, octokit ) {
 	const {
 		// The types for the `getContent` response are incorrect.
 		// see https://github.com/octokit/rest.js/issues/32
-		// @ts-ignore
+		// @ts-expect-error The `getContent` response is a union that may be a directory listing.
 		data: { content, encoding },
 	} = await octokit.rest.repos.getContent( {
 		owner,

--- a/packages/sync/src/quill-delta/Delta.ts
+++ b/packages/sync/src/quill-delta/Delta.ts
@@ -3,7 +3,6 @@
 // - lodash.clonedeep is replaced with JSON parse / stringify
 // - lodash.isequal is replaced with fast-deep-equal.
 
-// @ts-ignore
 /**
  * External dependencies
  */

--- a/packages/upload-media/src/store/index.ts
+++ b/packages/upload-media/src/store/index.ts
@@ -41,7 +41,5 @@ export const store = createReduxStore( STORE_NAME, {
 if ( ! select( store ) ) {
 	register( store );
 }
-// @ts-ignore
 unlock( store ).registerPrivateActions( privateActions );
-// @ts-ignore
 unlock( store ).registerPrivateSelectors( privateSelectors );

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -55,7 +55,6 @@ import { cancelGifToVideoOperations } from '../utils/video-conversion';
 function createRegistryWithStores() {
 	// Create a registry and register used stores.
 	const registry = createRegistry();
-	// @ts-ignore
 	[ uploadStore ].forEach( registry.register );
 	return registry;
 }
@@ -1778,7 +1777,7 @@ describe( 'actions', () => {
 
 		afterEach( () => {
 			// Clean up global mock.
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.createImageBitmap;
 		} );
 

--- a/packages/upload-media/src/test/canvas-utils.ts
+++ b/packages/upload-media/src/test/canvas-utils.ts
@@ -14,13 +14,13 @@ describe( 'canvasConvertToJpeg', () => {
 		if ( originalCreateImageBitmap ) {
 			global.createImageBitmap = originalCreateImageBitmap;
 		} else {
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.createImageBitmap;
 		}
 		if ( originalOffscreenCanvas ) {
 			global.OffscreenCanvas = originalOffscreenCanvas;
 		} else {
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.OffscreenCanvas;
 		}
 		if ( originalImageDecoder ) {

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -50,11 +50,9 @@ describe( 'feature-detection', () => {
 		// Remove navigator.deviceMemory and navigator.connection by default
 		// so they don't interfere with unrelated tests.
 		if ( 'deviceMemory' in navigator ) {
-			// @ts-expect-error `deviceMemory` is not part of the standard `Navigator` type.
 			delete navigator.deviceMemory;
 		}
 		if ( 'connection' in navigator ) {
-			// @ts-expect-error `connection` is not part of the standard `Navigator` type.
 			delete navigator.connection;
 		}
 		if ( 'hardwareConcurrency' in navigator ) {
@@ -79,7 +77,6 @@ describe( 'feature-detection', () => {
 				originalDeviceMemoryDescriptor
 			);
 		} else if ( 'deviceMemory' in navigator ) {
-			// @ts-expect-error `deviceMemory` is not part of the standard `Navigator` type.
 			delete navigator.deviceMemory;
 		}
 
@@ -91,7 +88,6 @@ describe( 'feature-detection', () => {
 				originalConnectionDescriptor
 			);
 		} else if ( 'connection' in navigator ) {
-			// @ts-expect-error `connection` is not part of the standard `Navigator` type.
 			delete navigator.connection;
 		}
 
@@ -117,7 +113,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when WebAssembly is unavailable', () => {
-			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
+			// @ts-expect-error `WebAssembly` is a non-optional global; the test assigns `undefined` to force the fallback.
 			global.WebAssembly = undefined;
 
 			const result = detectClientSideMediaSupport();
@@ -129,7 +125,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when SharedArrayBuffer is unavailable', () => {
-			// @ts-expect-error Deliberately unsets `SharedArrayBuffer` to test the fallback.
+			// @ts-expect-error `SharedArrayBuffer` is a non-optional global; the test assigns `undefined` to force the fallback.
 			global.SharedArrayBuffer = undefined;
 
 			const result = detectClientSideMediaSupport();
@@ -139,7 +135,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when Worker is unavailable', () => {
-			// @ts-expect-error Deliberately unsets `Worker` to test the fallback.
+			// @ts-expect-error `Worker` is a non-optional global; the test assigns `undefined` to force the fallback.
 			global.Worker = undefined;
 
 			const result = detectClientSideMediaSupport();
@@ -269,7 +265,7 @@ describe( 'feature-detection', () => {
 			expect( result1.supported ).toBe( true );
 
 			// Now set WebAssembly to undefined - cached result should still be returned.
-			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
+			// @ts-expect-error `WebAssembly` is a non-optional global; the test assigns `undefined` to force the fallback.
 			global.WebAssembly = undefined;
 
 			const result2 = detectClientSideMediaSupport();
@@ -284,7 +280,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns false when features are unavailable', () => {
-			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
+			// @ts-expect-error `WebAssembly` is a non-optional global; the test assigns `undefined` to force the fallback.
 			global.WebAssembly = undefined;
 
 			expect( isClientSideMediaSupported() ).toBe( false );
@@ -359,7 +355,7 @@ describe( 'feature-detection', () => {
 
 			// Clear cache and set WebAssembly to undefined.
 			clearFeatureDetectionCache();
-			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
+			// @ts-expect-error `WebAssembly` is a non-optional global; the test assigns `undefined` to force the fallback.
 			global.WebAssembly = undefined;
 
 			const result2 = detectClientSideMediaSupport();

--- a/packages/upload-media/src/test/feature-detection.ts
+++ b/packages/upload-media/src/test/feature-detection.ts
@@ -50,15 +50,15 @@ describe( 'feature-detection', () => {
 		// Remove navigator.deviceMemory and navigator.connection by default
 		// so they don't interfere with unrelated tests.
 		if ( 'deviceMemory' in navigator ) {
-			// @ts-ignore
+			// @ts-expect-error `deviceMemory` is not part of the standard `Navigator` type.
 			delete navigator.deviceMemory;
 		}
 		if ( 'connection' in navigator ) {
-			// @ts-ignore
+			// @ts-expect-error `connection` is not part of the standard `Navigator` type.
 			delete navigator.connection;
 		}
 		if ( 'hardwareConcurrency' in navigator ) {
-			// @ts-ignore
+			// @ts-expect-error `hardwareConcurrency` is a read-only property.
 			delete navigator.hardwareConcurrency;
 		}
 	} );
@@ -79,7 +79,7 @@ describe( 'feature-detection', () => {
 				originalDeviceMemoryDescriptor
 			);
 		} else if ( 'deviceMemory' in navigator ) {
-			// @ts-ignore
+			// @ts-expect-error `deviceMemory` is not part of the standard `Navigator` type.
 			delete navigator.deviceMemory;
 		}
 
@@ -91,7 +91,7 @@ describe( 'feature-detection', () => {
 				originalConnectionDescriptor
 			);
 		} else if ( 'connection' in navigator ) {
-			// @ts-ignore
+			// @ts-expect-error `connection` is not part of the standard `Navigator` type.
 			delete navigator.connection;
 		}
 
@@ -103,7 +103,7 @@ describe( 'feature-detection', () => {
 				originalHardwareConcurrencyDescriptor
 			);
 		} else if ( 'hardwareConcurrency' in navigator ) {
-			// @ts-ignore
+			// @ts-expect-error `hardwareConcurrency` is a read-only property.
 			delete navigator.hardwareConcurrency;
 		}
 	} );
@@ -117,7 +117,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when WebAssembly is unavailable', () => {
-			// @ts-ignore - Intentionally setting WebAssembly to undefined for testing.
+			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
 			global.WebAssembly = undefined;
 
 			const result = detectClientSideMediaSupport();
@@ -129,7 +129,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when SharedArrayBuffer is unavailable', () => {
-			// @ts-ignore - Intentionally setting SharedArrayBuffer to undefined for testing.
+			// @ts-expect-error Deliberately unsets `SharedArrayBuffer` to test the fallback.
 			global.SharedArrayBuffer = undefined;
 
 			const result = detectClientSideMediaSupport();
@@ -139,7 +139,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns not supported when Worker is unavailable', () => {
-			// @ts-ignore - Intentionally setting Worker to undefined for testing.
+			// @ts-expect-error Deliberately unsets `Worker` to test the fallback.
 			global.Worker = undefined;
 
 			const result = detectClientSideMediaSupport();
@@ -269,7 +269,7 @@ describe( 'feature-detection', () => {
 			expect( result1.supported ).toBe( true );
 
 			// Now set WebAssembly to undefined - cached result should still be returned.
-			// @ts-ignore - Intentionally setting WebAssembly to undefined for testing.
+			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
 			global.WebAssembly = undefined;
 
 			const result2 = detectClientSideMediaSupport();
@@ -284,7 +284,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns false when features are unavailable', () => {
-			// @ts-ignore - Intentionally setting WebAssembly to undefined for testing.
+			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
 			global.WebAssembly = undefined;
 
 			expect( isClientSideMediaSupported() ).toBe( false );
@@ -303,14 +303,14 @@ describe( 'feature-detection', () => {
 				global.createImageBitmap =
 					originalCreateImageBitmap as typeof createImageBitmap;
 			} else {
-				// @ts-ignore
+				// @ts-expect-error The operand of `delete` must be optional.
 				delete global.createImageBitmap;
 			}
 			if ( originalOffscreenCanvas !== undefined ) {
 				global.OffscreenCanvas =
 					originalOffscreenCanvas as typeof OffscreenCanvas;
 			} else {
-				// @ts-ignore
+				// @ts-expect-error The operand of `delete` must be optional.
 				delete global.OffscreenCanvas;
 			}
 		} );
@@ -325,7 +325,7 @@ describe( 'feature-detection', () => {
 		} );
 
 		it( 'returns false when createImageBitmap is unavailable', () => {
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.createImageBitmap;
 			global.OffscreenCanvas =
 				jest.fn() as unknown as typeof OffscreenCanvas;
@@ -336,16 +336,16 @@ describe( 'feature-detection', () => {
 		it( 'returns false when OffscreenCanvas is unavailable', () => {
 			global.createImageBitmap =
 				jest.fn() as unknown as typeof createImageBitmap;
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.OffscreenCanvas;
 
 			expect( isHeicCanvasSupported() ).toBe( false );
 		} );
 
 		it( 'returns false when both are unavailable', () => {
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.createImageBitmap;
-			// @ts-ignore
+			// @ts-expect-error The operand of `delete` must be optional.
 			delete global.OffscreenCanvas;
 
 			expect( isHeicCanvasSupported() ).toBe( false );
@@ -359,7 +359,7 @@ describe( 'feature-detection', () => {
 
 			// Clear cache and set WebAssembly to undefined.
 			clearFeatureDetectionCache();
-			// @ts-ignore - Intentionally setting WebAssembly to undefined for testing.
+			// @ts-expect-error Deliberately unsets `WebAssembly` to test the fallback.
 			global.WebAssembly = undefined;
 
 			const result2 = detectClientSideMediaSupport();

--- a/packages/views/src/load-view.ts
+++ b/packages/views/src/load-view.ts
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
-// @ts-ignore - Preferences package is not typed
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**

--- a/packages/views/src/test/use-view.tsx
+++ b/packages/views/src/test/use-view.tsx
@@ -7,7 +7,6 @@ import { act, renderHook } from '@testing-library/react';
  * WordPress dependencies
  */
 import { createRegistry, RegistryProvider } from '@wordpress/data';
-// @ts-ignore - Preferences package is not typed
 import { store as preferencesStore } from '@wordpress/preferences';
 import type { View } from '@wordpress/dataviews';
 

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -9,7 +9,6 @@ import { dequal } from 'dequal';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import type { View } from '@wordpress/dataviews';
-// @ts-ignore - Preferences package is not typed
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**

--- a/routes/connectors-home/ai-plugin-callout.tsx
+++ b/routes/connectors-home/ai-plugin-callout.tsx
@@ -255,7 +255,7 @@ export function AiPluginCallout() {
 				<p>
 					{ createInterpolateElement( getMessage(), {
 						strong: <strong />,
-						// @ts-ignore children are injected by createInterpolateElement at runtime.
+						// @ts-expect-error `children` is injected by `createInterpolateElement` at runtime.
 						a: <ExternalLink href={ AI_PLUGIN_URL } />,
 					} ) }
 				</p>

--- a/routes/guidelines/data.ts
+++ b/routes/guidelines/data.ts
@@ -68,7 +68,6 @@ export function blockSlug( blockName: string ): string {
 export function useContentBlocks(): ContentBlock[] {
 	return useSelect(
 		( s ) =>
-			// @ts-ignore - getBlockTypes is untyped in this context.
 			s( blocksStore )
 				.getBlockTypes()
 				.filter( ( block: ContentBlock ) =>

--- a/tools/docs/update-api-docs.js
+++ b/tools/docs/update-api-docs.js
@@ -201,7 +201,6 @@ function findDefaultSourcePath( dir ) {
 	if ( ! defaultPathMatches.length ) {
 		throw new Error( `Cannot find default source file in ${ dir }` );
 	}
-	// @ts-ignore
 	return defaultPathMatches[ 0 ];
 }
 

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -281,6 +281,20 @@ export default dedupePlugins( [
 			'import/resolver': require.resolve( './import-resolver.cjs' ),
 		},
 		rules: {
+			/*
+			 * `@ts-ignore` keeps silently passing even after the error it was
+			 * added for is gone. Require `@ts-expect-error` instead, along with
+			 * a description explaining why the suppression is needed.
+			 */
+			'@typescript-eslint/ban-ts-comment': [
+				'error',
+				{
+					'ts-expect-error': 'allow-with-description',
+					'ts-ignore': true,
+					'ts-nocheck': true,
+					'ts-check': false,
+				},
+			],
 			'react/jsx-boolean-value': 'error',
 			'react/jsx-curly-brace-presence': [
 				'error',

--- a/tools/release/commands/changelog.js
+++ b/tools/release/commands/changelog.js
@@ -15,7 +15,6 @@ const {
 } = require( '../lib/milestone' );
 const { log, warn, formats } = require( '../lib/logger' );
 const config = require( '../config' );
-// @ts-ignore
 const manifest = require( '../../../package.json' );
 
 const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -301,7 +301,7 @@ async function runPerformanceTests( branches, options ) {
 	logAtIndent( 2, 'Creating directory:', formats.success( sourceDir ) );
 	fs.mkdirSync( sourceDir );
 
-	// @ts-ignore
+	// @ts-expect-error The `simple-git` module namespace has no call signatures.
 	const sourceGit = SimpleGit( sourceDir );
 	logAtIndent(
 		2,
@@ -328,7 +328,6 @@ async function runPerformanceTests( branches, options ) {
 			'Fetching test runner branch:',
 			formats.success( options.testsBranch )
 		);
-		// @ts-ignore
 		await sourceGit.raw(
 			'fetch',
 			'--depth=1',
@@ -355,7 +354,7 @@ async function runPerformanceTests( branches, options ) {
 		'Checking out branch:',
 		formats.success( testRunnerBranch )
 	);
-	// @ts-ignore
+	// @ts-expect-error The `simple-git` module namespace has no call signatures.
 	await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
 
 	logAtIndent( 2, 'Installing dependencies and building' );
@@ -390,7 +389,7 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Creating directory:', formats.success( envDir ) );
 		fs.mkdirSync( envDir );
-		// @ts-ignore
+		// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 		branchDirs[ branch ] = envDir;
 		const buildDir = path.join( envDir, 'plugin' );
 
@@ -398,7 +397,7 @@ async function runPerformanceTests( branches, options ) {
 		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
 
 		logAtIndent( 3, 'Checking out:', formats.success( branch ) );
-		// @ts-ignore
+		// @ts-expect-error The `simple-git` module namespace has no call signatures.
 		await SimpleGit( buildDir ).raw( 'checkout', branch );
 
 		logAtIndent( 3, 'Installing dependencies and building' );
@@ -490,7 +489,7 @@ async function runPerformanceTests( branches, options ) {
 			);
 
 			const sanitizedBranchName = sanitizeBranchName( branch );
-			// @ts-ignore
+			// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 			const envDir = branchDirs[ branch ];
 
 			logAtIndent( 2, 'Starting environment' );
@@ -525,9 +524,8 @@ async function runPerformanceTests( branches, options ) {
 	//
 	//   npm run --workspace @wordpress/build-scripts resolve-trace-source-maps -- <trace> --build-dir <build-dir>
 	const headBranch = branches[ 0 ];
-	// @ts-ignore
 	const headBuildScriptsDir = path.join(
-		// @ts-ignore
+		// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 		branchDirs[ headBranch ],
 		'plugin',
 		'build',

--- a/tools/release/lib/utils.js
+++ b/tools/release/lib/utils.js
@@ -6,7 +6,6 @@ const childProcess = require( 'child_process' );
 const { randomUUID } = require( 'crypto' );
 const path = require( 'path' );
 const os = require( 'os' );
-// @ts-ignore
 const { confirm } = require( '@inquirer/prompts' );
 
 /**


### PR DESCRIPTION
## What?

Enables `@typescript-eslint/ban-ts-comment` so `@ts-ignore` is an error and `@ts-expect-error` requires a description, then fixes every existing violation.

## Why?

`@ts-ignore` keeps silently passing once the error it was added for is gone, so stale suppressions accumulate unnoticed. `@ts-expect-error` fails when it is no longer needed, which surfaces them.

That is exactly what happened here: of the 117 `@ts-ignore` comments on `trunk`, **35 (30%) were stale** — they suppressed nothing. Several also carried reasons that were no longer true, such as `// @ts-ignore - Preferences package is not typed` when `@wordpress/preferences` has been typed for a while.

Follow up to https://github.com/WordPress/gutenberg/pull/80832#discussion_r3710887994.

## How?

The rule is added to the repo config in `tools/eslint/config.mjs`. Defaults are kept, so `@ts-expect-error` needs a description of at least 3 characters. It applies to `.js` as well as `.ts`/`.tsx` — the rule only walks the comment list, so it works under the Babel parser too.

The 177 violations were resolved as:

| | Count |
|-|-|
| `@ts-ignore` converted to `@ts-expect-error` with a description | 82 |
| `@ts-ignore` deleted as stale | 35 |
| Bare `@ts-expect-error` given a description | 60 |

Each description states the reason TypeScript actually reports, taken from the compiler rather than guessed. Every directive was temporarily neutralised and `tsc --build` re-run to capture the real diagnostic, then restored.

Some paths get no signal from the build: `tsconfig.base.json` excludes `**/test/**`, and `tools/` and `routes/` are not in any TypeScript project. Directives there were checked against a temporary project extending `tsconfig.base.json`, and against `lib.dom.d.ts` and package metadata where that was the relevant fact.

Unrelated drive-by: one pre-existing `import/order` error in `packages/components/src/button/test/index.tsx` is fixed, because the pre-commit hook lints staged files under the strict config and it blocked the commit.

## Testing Instructions

1. `npm run lint:js` passes.
2. `npx tsc --build` from the repo root exits cleanly.
3. Add `// @ts-ignore` anywhere and confirm linting fails with a message pointing at `@ts-expect-error`.
4. Add a bare `// @ts-expect-error` and confirm linting asks for a description.

## Use of AI Tools

Authored with Claude Code, then audited with Codex specifically for the factual accuracy of the new comments. That audit caught descriptions that named the wrong cause and four directives that suppressed nothing; each finding was re-verified against real `tsc` output before being applied. I have reviewed and take responsibility for the changes.
