### PR TITLE
Fix: Date block renders with double UTC offset when date is manually set

### DIFF
--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -57,7 +57,12 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	}
 
 	$unformatted_date = $attributes['datetime'];
-	$post_timestamp   = strtotime( $unformatted_date );
+	// Timezoneless strings from the date picker represent site-local time, not UTC.
+	// date_create_immutable with wp_timezone() parses them correctly; if the string
+	// already carries a timezone indicator, DateTimeImmutable ignores the $timezone
+	// parameter, so this is safe for both cases.
+	$date_obj       = date_create_immutable( $unformatted_date, wp_timezone() );
+	$post_timestamp = $date_obj ? $date_obj->getTimestamp() : false;
 
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
 		if ( $post_timestamp > time() ) {

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -130,6 +130,62 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		$this->assertStringContainsString( $expected_date, $output );
 	}
 
+	/**
+	 * Regression test for https://github.com/WordPress/gutenberg/issues/81084.
+	 *
+	 * A timezone-naive datetime string set manually via the date picker must be
+	 * interpreted as site-local time. Previously, strtotime() assumed UTC and
+	 * wp_date() then applied the site offset again — shifting the displayed time
+	 * by the full UTC offset.
+	 *
+	 * @covers ::render_block_core_post_date
+	 */
+	public function test_render_with_explicit_date_does_not_double_apply_timezone_offset() {
+		$original_timezone = get_option( 'timezone_string' );
+		$original_offset   = get_option( 'gmt_offset' );
+
+		// Use UTC+5:30 — a clearly non-UTC offset where the double-shift is obvious.
+		update_option( 'timezone_string', 'Asia/Kolkata' );
+		update_option( 'gmt_offset', '' );
+
+		try {
+			$attributes = array(
+				// Timezone-naive string, exactly as emitted by DateTimePicker.
+				'datetime' => '2026-07-30T04:30:00',
+				'format'   => 'H:i',
+			);
+
+			$block = new WP_Block(
+				array(
+					'blockName' => 'core/post-date',
+					'attrs'     => $attributes,
+				),
+				array(
+					'postId' => self::$post_id,
+				)
+			);
+
+			$output = $block->render();
+
+			// The rendered time must match the manually-set site-local time.
+			$this->assertStringContainsString(
+				'04:30',
+				$output,
+				'The time should render in site-local time, not UTC.'
+			);
+
+			// Confirm the double-offset value (04:30 + 5:30 = 10:00) is absent.
+			$this->assertStringNotContainsString(
+				'10:00',
+				$output,
+				'The site timezone offset must not be applied twice.'
+			);
+		} finally {
+			update_option( 'timezone_string', $original_timezone );
+			update_option( 'gmt_offset', $original_offset );
+		}
+	}
+
 	public function test_render_modified_date_before_publish_date() {
 		$this->update_post_modified( self::$post_id, '2025-07-01 00:00:00' );
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `core/post-date` block displaying the wrong time on the front end when a date is manually set via the date picker. On sites with a non-UTC timezone, the displayed time was shifted by the site's UTC offset — as if it were applied twice.

**Example (UTC+5:30):**
- Editor: Date block set to `30 July 2026, 4:30 AM`
- Front end (before fix): `30 July 2026, 10:00 AM` ❌
- Front end (after fix): `30 July 2026, 4:30 AM` ✅

## Root cause

When a date is manually picked, `DateTimePicker` emits a timezone-naive string such as `"2026-07-30T04:30:00"` with no UTC offset or `Z` suffix. The render function passed this directly to `strtotime()`:

```php
$post_timestamp = strtotime( $unformatted_date );
```

WordPress forces PHP's default timezone to UTC, so `strtotime()` treats the string as UTC. `wp_date()` then converts that already-wrong UTC timestamp into the site's local timezone — applying the site offset a second time.

## Fix

Replace `strtotime()` with `date_create_immutable()` paired with `wp_timezone()`, which explicitly interprets the timezone-naive string as site-local time from the start:

```php
$date_obj       = date_create_immutable( $unformatted_date, wp_timezone() );
$post_timestamp = $date_obj ? $date_obj->getTimestamp() : false;
```

If the string already carries a timezone indicator (e.g. a `Z` or `+HH:MM` suffix, as produced by the "Now" path), `DateTimeImmutable` ignores the `$timezone` argument — so this is backward-compatible for both code paths.

This is the same principle applied in #71430, which fixed the related bug in the fallback/legacy render path (`isset() === false`). This PR fixes the remaining broken path: when a custom `datetime` is explicitly set (`isset() === true`).

## How has this been tested?

- Manually verified on a local WordPress installation with site timezone set to UTC+5:30 (Asia/Kolkata):
  - Inserted a Date block and manually picked `30 July 2026, 4:30 AM`
  - **Before fix:** front end displayed `10:00 AM` (offset applied twice)
  - **After fix:** front end displays `4:30 AM` (correct)
  - Confirmed the "Now" toolbar shortcut continues to render correctly
- PHP unit regression test added to `phpunit/blocks/render-block-core-post-date.php`


https://github.com/user-attachments/assets/e3894ca9-c927-4c46-8999-42386ddfc677



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code is tested
- [x] My code follows the WordPress coding standards
- [x] My pull request is for a single issue and focused on that issue
- [x] I have linked this PR to the relevant issue (#81084)