### PR TITLE
PanelColorSettings: Restore the missing space below the panel header

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -104,7 +104,8 @@ export const PanelColorGradientSettingsInner = ( {
 				/>
 				{ !! children && (
 					<>
-						<Spacer marginY={ 4 } /> { children }
+						<Spacer marginTop={ 4 } marginBottom={ 0 } />
+						{ children }
 					</>
 				) }
 			</div>

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -65,6 +65,7 @@ export const PanelColorGradientSettingsInner = ( {
 				'block-editor-panel-color-gradient-settings',
 				className
 			) }
+			hasInnerWrapper
 			label={ showTitle ? title : undefined }
 			resetAll={ () => {
 				batch( () => {
@@ -88,23 +89,25 @@ export const PanelColorGradientSettingsInner = ( {
 			__experimentalFirstVisibleItemClass="first"
 			__experimentalLastVisibleItemClass="last"
 		>
-			<ColorGradientSettingsDropdown
-				settings={ settings }
-				panelId={ panelId }
-				{ ...{
-					colors,
-					gradients,
-					disableCustomColors,
-					disableCustomGradients,
-					__experimentalIsRenderedInSidebar,
-					enableAlpha,
-				} }
-			/>
-			{ !! children && (
-				<>
-					<Spacer marginY={ 4 } /> { children }
-				</>
-			) }
+			<div className="block-editor-panel-color-gradient-settings__inner-wrapper">
+				<ColorGradientSettingsDropdown
+					settings={ settings }
+					panelId={ panelId }
+					{ ...{
+						colors,
+						gradients,
+						disableCustomColors,
+						disableCustomGradients,
+						__experimentalIsRenderedInSidebar,
+						enableAlpha,
+					} }
+				/>
+				{ !! children && (
+					<>
+						<Spacer marginY={ 4 } /> { children }
+					</>
+				) }
+			</div>
 		</ToolsPanel>
 	);
 };

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -42,7 +42,18 @@ $swatch-gap: 12px;
 	/* Increased specificity required to remove the slot wrapper's row gap */
 	&#{&} {
 		.block-editor-panel-color-gradient-settings__inner-wrapper {
+			// `ToolsPanel` spans the inner wrapper across its grid via a
+			// positional selector that assumes a header is present. This panel
+			// can render without one (`showTitle={ false }`), so span it here.
+			grid-column: 1 / -1;
 			row-gap: 0;
+
+			// Unlike the other panels using an inner wrapper, this component
+			// accepts arbitrary children. Those carry no `ToolsPanelItem`
+			// class, so they'd otherwise be auto-placed into a single column.
+			> * {
+				grid-column: 1 / -1;
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -24,13 +24,6 @@ $swatch-gap: 12px;
 	min-width: 0;
 }
 
-.block-editor-panel-color-gradient-settings.block-editor-panel-color-gradient-settings {
-	&,
-	& > div:not(:first-of-type) {
-		display: block;
-	}
-}
-
 .block-editor-panel-color-gradient-settings {
 	@media screen and (min-width: $break-medium) {
 		.components-circular-option-picker__swatches {
@@ -46,6 +39,12 @@ $swatch-gap: 12px;
 		margin-bottom: inherit;
 	}
 
+	/* Increased specificity required to remove the slot wrapper's row gap */
+	&#{&} {
+		.block-editor-panel-color-gradient-settings__inner-wrapper {
+			row-gap: 0;
+		}
+	}
 }
 
 .block-editor-panel-color-gradient-settings__dropdown-content {


### PR DESCRIPTION
## What?

Follow up to #77279

This PR restores the missing space below the header of the `PanelColorSettings` component.

| Before | After |
|--------|--------|
| <img width="313" height="174" alt="image" src="https://github.com/user-attachments/assets/7610c0d8-997b-411b-a831-9c672b1361c9" /> | <img width="299" height="169" alt="image" src="https://github.com/user-attachments/assets/fe0ed22e-c764-42e1-921d-919e5a897251" /> |

## Why?

`PanelColorSettings` is a kind of wrapper around `ToolsPanel`, but its layout is a little special: it rewrote the grid layout into a block layout, and applied a top margin to the first content item instead.

```css
.block-editor-panel-color-gradient-settings.block-editor-panel-color-gradient-settings {
	display: block;
}

.block-editor-tools-panel-color-gradient-settings__item:nth-child(1 of .block-editor-tools-panel-color-gradient-settings__item) {
	margin-top: 24px;
}
```

However, that top margin was removed by #77279, which relocated the color panels:

https://github.com/WordPress/gutenberg/pull/77279/changes#diff-f8eade1e60733a0129d36b5626aafa3a918e4e560964b1388abfdb7e12bfdc96L90

`PanelColorSettings` is no longer used within Gutenberg, but the component is public, so the lost spacing should be restored.

## How?

To begin with, it is questionable why `display: block` is needed for `PanelColorSettings` at all. The style [was added 4 years ago](https://github.com/WordPress/gutenberg/pull/41091/changes#diff-f8eade1e60733a0129d36b5626aafa3a918e4e560964b1388abfdb7e12bfdc96R13) and looks unnecessary today. Removing it and laying the panel out with the same approach as the other color panels — `hasInnerWrapper` on the `ToolsPanel`, with the row gap zeroed out on the inner wrapper — should make everything work.

## Testing Instructions

Run the following code in the browser console, select any block, and check the panel layout.

```js
( () => {
	const { createElement: el, Fragment } = wp.element;
	const { createHigherOrderComponent } = wp.compose;
	const { InspectorControls, PanelColorSettings } = wp.blockEditor;

	const withColorPanel = createHigherOrderComponent(
		( BlockEdit ) => ( props ) => {
			const [ colorA, setColorA ] = wp.element.useState();
			const [ colorB, setColorB ] = wp.element.useState();

			return el(
				Fragment,
				null,
				el( BlockEdit, props ),
				props.isSelected &&
					el(
						InspectorControls,
						{},
						el( PanelColorSettings, {
							__experimentalIsRenderedInSidebar: true,
							title: 'Debug Color Settings',
							colorSettings: [
								{
									value: colorA,
									onChange: setColorA,
									label: 'Color A',
								},
								{
									value: colorB,
									onChange: setColorB,
									label: 'Color B',
								},
							],
						} )
					)
			);
		},
		'withColorPanel'
	);

	wp.hooks.addFilter(
		'editor.BlockEdit',
		'debug/panel-color-settings',
		withColorPanel
	);

	// Force a re-render so already mounted blocks pick up the filter.
	wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
} )();
```
## Use of AI Tools

Claude Code was used to draft the commit message and this pull request description. The code changes were authored manually.
