### PR TITLE
Interface: Increase footer breadcrumb height to prevent focus ring clipping

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -237,7 +237,7 @@
 
 @mixin snackbar-container() {
 	position: fixed;
-	bottom: 24px;
+	bottom: wpds.var("--wpds-dimension-size-md");
 	left: 0;
 	right: 0;
 	padding-inline: 16px;

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `InterfaceSkeleton`: Increase the footer height from 24px to 32px to prevent the focus ring from being clipped ([#81145](https://github.com/WordPress/gutenberg/pull/81145)).
+
 ## 9.36.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -75,7 +75,7 @@ html.interface-interface-skeleton__html-container {
 	// Footer overlap prevention
 	.has-footer & {
 		@include break-medium() {
-			padding-bottom: $button-size-small + $border-width;
+			padding-bottom: calc(var(--wpds-dimension-size-md) + #{$border-width});
 		}
 	}
 }
@@ -174,7 +174,7 @@ html.interface-interface-skeleton__html-container {
 		z-index: z-index(".edit-post-layout__footer");
 		display: flex;
 		background: $white;
-		height: $button-size-small;
+		height: var(--wpds-dimension-size-md);
 		align-items: center;
 		font-size: $default-font-size;
 		padding: 0 ($grid-unit-15 + 6px);


### PR DESCRIPTION
## What?

Backports #81145 to the `wp/7.1` branch.

The only conflict was the `packages/interface/CHANGELOG.md` entry, which was resolved manually.

## Testing Instructions

All CI checks should pass.

## Use of AI Tools

Claude Code was used to cherry-pick the commit and draft this description. All changes were reviewed by me.
