### PR TITLE
[wp/7.1] Backport: Pass Playlist controls to track blocks

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
+-   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery will keep its current images but stop updating automatically ([#80727](https://github.com/WordPress/gutenberg/pull/80727)).
 
 ### Bug Fixes

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -53,7 +53,7 @@ const PlaylistTrackEdit = ( {
 	const showImages = context?.showImages ?? true;
 	const imageButton = useRef();
 	const blockProps = useBlockProps();
-	const { currentTrackClientId, setCurrentTrackClientId, addTracks } =
+	const { currentTrackClientId, setCurrentTrackClientId } =
 		useContext( PlaylistContext );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
@@ -161,20 +161,6 @@ const PlaylistTrackEdit = ( {
 					variant="toolbar"
 				/>
 			</BlockControls>
-			{ !! addTracks && (
-				<BlockControls group="block">
-					<MediaReplaceFlow
-						name={ __( 'Add' ) }
-						onSelect={ addTracks }
-						accept="audio/*"
-						multiple
-						handleUpload={ false }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						onError={ onUploadError }
-						variant="toolbar"
-					/>
-				</BlockControls>
-			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextControl

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -16,9 +16,7 @@ import { PlaylistContext } from '../../playlist/context';
 import { useUploadMediaFromBlobURL } from '../../utils/hooks';
 
 jest.mock( '@wordpress/block-editor', () => ( {
-	BlockControls: ( { children, group = 'default' } ) => (
-		<div data-testid={ `block-controls-${ group }` }>{ children }</div>
-	),
+	BlockControls: ( { children } ) => <div>{ children }</div>,
 	BlockIcon: () => <span />,
 	InspectorControls: ( { children } ) => <div>{ children }</div>,
 	MediaPlaceholder: () => <div />,
@@ -76,14 +74,12 @@ const defaultAttributes = {
 function renderEdit( props = {} ) {
 	const setAttributes = jest.fn();
 	const setCurrentTrackClientId = props.setCurrentTrackClientId || jest.fn();
-	const addTracks = props.addTracks;
 
 	render(
 		<PlaylistContext.Provider
 			value={ {
 				currentTrackClientId: props.currentTrackClientId ?? null,
 				setCurrentTrackClientId,
-				addTracks,
 			} }
 		>
 			<PlaylistTrackEdit
@@ -188,31 +184,5 @@ describe( 'PlaylistTrackEdit', () => {
 				url: 'blob:https://example.com/temporary-track',
 			} )
 		);
-	} );
-
-	it( 'allows tracks to be added from the track toolbar', () => {
-		const addTracks = jest.fn();
-		renderEdit( { addTracks } );
-
-		fireEvent.click( screen.getByRole( 'button', { name: 'Add' } ) );
-
-		expect( addTracks ).toHaveBeenCalledWith( {} );
-	} );
-
-	it( 'renders the add track control in a different toolbar group from replace', () => {
-		renderEdit( { addTracks: jest.fn() } );
-
-		expect(
-			within( screen.getByTestId( 'block-controls-other' ) ).getByRole(
-				'button',
-				{ name: 'Replace' }
-			)
-		).toBeInTheDocument();
-		expect(
-			within( screen.getByTestId( 'block-controls-block' ) ).getByRole(
-				'button',
-				{ name: 'Add' }
-			)
-		).toBeInTheDocument();
 	} );
 } );

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -69,6 +69,7 @@
 	"supports": {
 		"anchor": true,
 		"align": true,
+		"__experimentalExposeControlsToChildren": true,
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/packages/block-library/src/playlist/context.js
+++ b/packages/block-library/src/playlist/context.js
@@ -6,5 +6,4 @@ import { createContext } from '@wordpress/element';
 export const PlaylistContext = createContext( {
 	currentTrackClientId: null,
 	setCurrentTrackClientId: () => {},
-	addTracks: undefined,
 } );

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -278,9 +278,8 @@ const PlaylistEdit = ( {
 		() => ( {
 			currentTrackClientId,
 			setCurrentTrackClientId,
-			addTracks: onAddTracks,
 		} ),
-		[ currentTrackClientId, onAddTracks, setCurrentTrackClientId ]
+		[ currentTrackClientId, setCurrentTrackClientId ]
 	);
 
 	// Get current track data by finding the track with matching client ID.
@@ -483,9 +482,9 @@ const PlaylistEdit = ( {
 
 	return (
 		<>
-			<BlockControls group="other">
+			<BlockControls group="other" __experimentalShareWithChildBlocks>
 				<MediaReplaceFlow
-					name={ __( 'Add' ) }
+					name={ __( 'Add track' ) }
 					onSelect={ onAddTracks }
 					accept="audio/*"
 					multiple

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,19 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	BlockIcon: () => <span />,
 	InspectorControls: ( { children } ) => <div>{ children }</div>,
 	MediaPlaceholder: () => <div />,
-	MediaReplaceFlow: () => <div />,
+	MediaReplaceFlow: ( { name, onSelect } ) => (
+		<button
+			onClick={ () =>
+				onSelect( {
+					id: 2,
+					url: 'https://example.com/second-track.mp3',
+					title: 'Second track',
+				} )
+			}
+		>
+			{ name }
+		</button>
+	),
 	useBlockProps: () => ( { className: 'wp-block-playlist' } ),
 	useInnerBlocksProps: ( blockProps ) => ( {
 		...blockProps,
@@ -95,11 +107,16 @@ const defaultAttributes = {
 };
 
 describe( 'PlaylistEdit', () => {
+	let replaceInnerBlocks;
+	let selectBlock;
+
 	beforeEach( () => {
+		replaceInnerBlocks = jest.fn();
+		selectBlock = jest.fn();
 		useDispatch.mockReturnValue( {
 			createErrorNotice: jest.fn(),
-			replaceInnerBlocks: jest.fn(),
-			selectBlock: jest.fn(),
+			replaceInnerBlocks,
+			selectBlock,
 		} );
 		useSelect.mockReturnValue( {
 			innerBlockTracks: [
@@ -135,5 +152,37 @@ describe( 'PlaylistEdit', () => {
 			'wp-block-playlist__tracklist-is-hidden'
 		);
 		expect( screen.getByTestId( 'playlist-track' ) ).toBeInTheDocument();
+	} );
+
+	it( 'adds tracks from the add track control', () => {
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Add track',
+			} )
+		);
+
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
+			expect.objectContaining( { clientId: 'track-1' } ),
+			expect.objectContaining( {
+				clientId: 'new-track',
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					id: 2,
+					src: 'https://example.com/second-track.mp3',
+					title: 'Second track',
+				} ),
+			} ),
+		] );
+		expect( selectBlock ).toHaveBeenCalledWith( 'new-track' );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/playlist.spec.js
+++ b/test/e2e/specs/editor/blocks/playlist.spec.js
@@ -38,6 +38,53 @@ test.describe( 'Playlist block', () => {
 		await requestUtils.deleteAllMedia();
 	} );
 
+	test( 'shows the add track control when a playlist track is selected', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await expect( editor.canvas.locator( 'body' ) ).toBeVisible();
+		await page.waitForFunction(
+			() => window?.wp?.blocks && window?.wp?.data
+		);
+
+		await page.evaluate( ( audio ) => {
+			const track = window.wp.blocks.createBlock( 'core/playlist-track', {
+				id: audio.id,
+				src: audio.source_url,
+				title: 'Selected Track',
+				artist: 'Test Artist',
+				length: '0:12',
+			} );
+			const playlist = window.wp.blocks.createBlock(
+				'core/playlist',
+				{},
+				[ track ]
+			);
+
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.insertBlock( playlist );
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.selectBlock( track.clientId );
+		}, uploadedAudio );
+
+		await expect(
+			editor.canvas
+				.locator( '[data-type="core/playlist-track"].is-selected' )
+				.first()
+		).toBeVisible();
+		await editor.showBlockToolbar();
+
+		await expect(
+			page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Add track' } )
+		).toBeVisible();
+	} );
+
 	test( 'waveform seek control can be reached and operated with the keyboard on the frontend', async ( {
 		page,
 		requestUtils,


### PR DESCRIPTION
## What

Backport #80368, which shares the Playlist block's Add control with selected Playlist Track child blocks, to the `wp/7.1` branch.

## Why

The automated backport could not cherry-pick the merged commit cleanly.

## How

Resolve the changelog and Playlist Track test conflicts for the 7.1 codebase, retaining end-to-end coverage for the shared parent toolbar control.

## Testing Instructions

1. Insert a Playlist block with at least one track.
2. Select a Playlist Track child block.
3. Confirm the Playlist toolbar is displayed and includes the Add control.
4. Confirm Replace and the existing Playlist Track controls still work.

## Tests Run

- `npm run test:unit -- packages/block-library/src/playlist-track/test/edit.js packages/block-library/src/playlist/test/edit-component.js`
