### PR TITLE
List View: Split the context and drop dead props to cut re-renders on expand and collapse

### DIFF
--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -12,15 +12,15 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
-import { useListViewContext } from './context';
+import { useInsertedBlockClientId, useListViewContext } from './context';
 import Inserter from '../inserter';
 import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
 
 export const Appender = forwardRef(
 	( { nestingLevel, blockCount, clientId, ...props }, ref ) => {
-		const { insertedBlockClientId, setInsertedBlockClientId } =
-			useListViewContext();
+		const { setInsertedBlockClientId } = useListViewContext();
+		const insertedBlockClientId = useInsertedBlockClientId();
 
 		const instanceId = useInstanceId( Appender );
 		const { directInsert, hideInserter } = useSelect(

--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -8,7 +8,32 @@ import { forwardRef } from '@wordpress/element';
  */
 import ListViewBlockSelectButton from './block-select-button';
 import BlockDraggable from '../block-draggable';
-import { useListViewContext } from './context';
+import { useInsertedBlockClientId, useListViewContext } from './context';
+
+/**
+ * Renders the additional block content for the row of the block that was just
+ * inserted. Reading the inserted block from its own context keeps an insert
+ * from re-rendering the contents of every other row.
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.clientId The client ID of the block for this row.
+ */
+function InsertedBlockContent( { clientId } ) {
+	const { AdditionalBlockContent, setInsertedBlockClientId } =
+		useListViewContext();
+	const insertedBlockClientId = useInsertedBlockClientId();
+
+	if ( ! AdditionalBlockContent || insertedBlockClientId !== clientId ) {
+		return null;
+	}
+
+	return (
+		<AdditionalBlockContent
+			insertedBlockClientId={ insertedBlockClientId }
+			setInsertedBlockClientId={ setInsertedBlockClientId }
+		/>
+	);
+}
 
 const ListViewBlockContents = forwardRef(
 	(
@@ -16,22 +41,12 @@ const ListViewBlockContents = forwardRef(
 			onClick,
 			onToggleExpanded,
 			clientId,
-			isSelected,
-			position,
-			siblingBlockCount,
-			level,
 			isExpanded,
 			selectedClientIds,
 			...props
 		},
 		ref
 	) => {
-		const {
-			AdditionalBlockContent,
-			insertedBlockClientId,
-			setInsertedBlockClientId,
-		} = useListViewContext();
-
 		// Only include all selected blocks if the currently clicked on block
 		// is one of the selected blocks. This ensures that if a user attempts
 		// to drag a block that isn't part of the selection, they're still able
@@ -40,19 +55,9 @@ const ListViewBlockContents = forwardRef(
 			? selectedClientIds
 			: [ clientId ];
 
-		// The additional content is only relevant to the row of the block that
-		// was just inserted, so the other rows skip mounting it entirely.
-		const showAdditionalBlockContent =
-			!! AdditionalBlockContent && insertedBlockClientId === clientId;
-
 		return (
 			<>
-				{ showAdditionalBlockContent && (
-					<AdditionalBlockContent
-						insertedBlockClientId={ insertedBlockClientId }
-						setInsertedBlockClientId={ setInsertedBlockClientId }
-					/>
-				) }
+				<InsertedBlockContent clientId={ clientId } />
 				<BlockDraggable
 					appendToOwnerDocument
 					clientIds={ draggableClientIds }
@@ -65,10 +70,6 @@ const ListViewBlockContents = forwardRef(
 							clientId={ clientId }
 							onClick={ onClick }
 							onToggleExpanded={ onToggleExpanded }
-							isSelected={ isSelected }
-							position={ position }
-							siblingBlockCount={ siblingBlockCount }
-							level={ level }
 							draggable={ draggable }
 							onDragStart={ onDragStart }
 							onDragEnd={ onDragEnd }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -177,7 +177,7 @@ function ListViewBlock( {
 	const {
 		BlockSettingsMenu,
 		listViewInstanceId,
-		expansionState,
+		getExpansionState,
 		updateExpansion,
 		setInsertedBlockClientId,
 		treeGridElementRef,
@@ -664,10 +664,6 @@ function ListViewBlock( {
 							onToggleExpanded={
 								isDisabled ? undefined : toggleExpanded
 							}
-							isSelected={ isSelected }
-							position={ position }
-							siblingBlockCount={ siblingBlockCount }
-							level={ level }
 							ref={ ref }
 							tabIndex={ getListViewBlockTabIndex( tabIndex ) }
 							onFocus={ onFocus }
@@ -745,7 +741,7 @@ function ListViewBlock( {
 								size: 'small',
 							} }
 							disableOpenOnArrowDown
-							expansionState={ expansionState }
+							getExpansionState={ getExpansionState }
 							updateExpansion={ updateExpansion }
 							setInsertedBlockClientId={
 								setInsertedBlockClientId

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -177,7 +177,6 @@ function ListViewBlock( {
 	const {
 		BlockSettingsMenu,
 		listViewInstanceId,
-		getExpansionState,
 		updateExpansion,
 		setInsertedBlockClientId,
 		treeGridElementRef,
@@ -377,8 +376,7 @@ function ListViewBlock( {
 			const { firstBlockClientId } = getBlocksToUpdate();
 			const blockParents = getBlockParents( firstBlockClientId, false );
 			// Collapse all blocks and expand the block's parents.
-			updateExpansion( { type: 'clear' } );
-			updateExpansion( { type: 'expand', clientIds: blockParents } );
+			updateExpansion( { type: 'replace', clientIds: blockParents } );
 		} else if ( isMatch( 'core/block-editor/group', event ) ) {
 			const { blocksToUpdate } = getBlocksToUpdate();
 			if ( blocksToUpdate.length > 1 && isGroupable( blocksToUpdate ) ) {
@@ -475,7 +473,7 @@ function ListViewBlock( {
 			}
 			updateExpansion( {
 				type: isExpanded ? 'collapse' : 'expand',
-				clientIds: clientId,
+				clientIds: [ clientId ],
 			} );
 		},
 		[ clientId, updateExpansion, isExpanded ]
@@ -741,7 +739,6 @@ function ListViewBlock( {
 								size: 'small',
 							} }
 							disableOpenOnArrowDown
-							getExpansionState={ getExpansionState }
 							updateExpansion={ updateExpansion }
 							setInsertedBlockClientId={
 								setInsertedBlockClientId

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -13,7 +13,7 @@ import { AsyncModeProvider, useSelect } from '@wordpress/data';
  */
 import { Appender } from './appender';
 import ListViewBlock from './block';
-import { useListViewContext } from './context';
+import { useListViewTreeState } from './context';
 import {
 	BLOCK_LIST_ITEM_HEIGHT,
 	getDragDisplacementValues,
@@ -77,7 +77,6 @@ function ListViewBranch( props ) {
 		fixedListWindow,
 		isExpanded,
 		parentId,
-		shouldShowInnerBlocks = true,
 		isSyncedBranch = false,
 		showAppender: showAppenderProp = true,
 	} = props;
@@ -107,7 +106,7 @@ function ListViewBranch( props ) {
 		blockIndexes,
 		expansionState,
 		draggedClientIds,
-	} = useListViewContext();
+	} = useListViewTreeState();
 
 	if ( ! canParentExpand ) {
 		return null;
@@ -170,10 +169,9 @@ function ListViewBranch( props ) {
 			path.length > 0 ? `${ path }_${ position }` : `${ position }`;
 		const hasNestedBlocks = !! innerBlocks?.length;
 
-		const shouldExpand =
-			hasNestedBlocks && shouldShowInnerBlocks
-				? expansionState[ clientId ] ?? isExpanded
-				: undefined;
+		const shouldExpand = hasNestedBlocks
+			? expansionState[ clientId ] ?? isExpanded
+			: undefined;
 
 		// Make updates to the selected or dragged blocks synchronous,
 		// but asynchronous for any other block.
@@ -239,7 +237,6 @@ function ListViewBranch( props ) {
 						showBlockMovers={ showBlockMovers }
 						path={ updatedPath }
 						isExpanded={ isDragged ? false : shouldExpand }
-						listPosition={ blockListPosition }
 						selectedClientIds={ selectedClientIds }
 						isSyncedBranch={ syncedBranch }
 						displacement={ displacement }

--- a/packages/block-editor/src/components/list-view/context.js
+++ b/packages/block-editor/src/components/list-view/context.js
@@ -3,7 +3,31 @@
  */
 import { createContext, useContext } from '@wordpress/element';
 
+/**
+ * Values that never change for the lifetime of a List View, such as the
+ * components passed in as props, the tree grid element ref, and the stable
+ * state updaters.
+ */
 export const ListViewContext = createContext( {} );
 ListViewContext.displayName = 'ListViewContext';
 
 export const useListViewContext = () => useContext( ListViewContext );
+
+/**
+ * Expansion and drag state. Only `ListViewBranch` reads it, so the frequent
+ * updates during a drag stop short of the individual rows.
+ */
+export const ListViewTreeStateContext = createContext( {} );
+ListViewTreeStateContext.displayName = 'ListViewTreeStateContext';
+
+export const useListViewTreeState = () =>
+	useContext( ListViewTreeStateContext );
+
+/**
+ * The client ID of the block that was just inserted, or `null`.
+ */
+export const ListViewInsertedBlockContext = createContext( null );
+ListViewInsertedBlockContext.displayName = 'ListViewInsertedBlockContext';
+
+export const useInsertedBlockClientId = () =>
+	useContext( ListViewInsertedBlockContext );

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -7,6 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
+	useEvent,
 	useInstanceId,
 	useMergeRefs,
 	__experimentalUseFixedWindowList as useFixedWindowList,
@@ -29,7 +30,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ListViewBranch from './branch';
-import { ListViewContext } from './context';
+import {
+	ListViewContext,
+	ListViewInsertedBlockContext,
+	ListViewTreeStateContext,
+} from './context';
 import ListViewDropIndicatorPreview from './drop-indicator';
 import useBlockSelection from './use-block-selection';
 import useListViewBlockIndexes from './use-list-view-block-indexes';
@@ -132,6 +137,10 @@ function ListViewComponent(
 	const { updateBlockSelection } = useBlockSelection();
 
 	const [ expansionState, updateExpansion ] = useReducer( expansion, {} );
+
+	// A getter keeps the block settings menu out of the expansion state
+	// subscription, which would otherwise re-render every row on expand.
+	const getExpansionState = useEvent( () => expansionState );
 
 	const [ insertedBlockClientId, setInsertedBlockClientId ] =
 		useState( null );
@@ -249,22 +258,38 @@ function ListViewComponent(
 			};
 		}, [ blockDropTarget, blockIndexes, firstDraggedBlockClientId ] );
 
+	// Values that stay stable for the lifetime of the List View.
 	const contextValue = useMemo(
+		() => ( {
+			AdditionalBlockContent,
+			BlockSettingsMenu,
+			getExpansionState,
+			listViewInstanceId: instanceId,
+			rootClientId,
+			setInsertedBlockClientId,
+			treeGridElementRef: elementRef,
+			updateExpansion,
+		} ),
+		[
+			AdditionalBlockContent,
+			BlockSettingsMenu,
+			getExpansionState,
+			instanceId,
+			rootClientId,
+			setInsertedBlockClientId,
+			updateExpansion,
+		]
+	);
+
+	// Values that change while expanding, collapsing, or dragging.
+	const treeStateContextValue = useMemo(
 		() => ( {
 			blockDropPosition,
 			blockDropTargetIndex,
 			blockIndexes,
 			draggedClientIds,
 			expansionState,
-			updateExpansion,
 			firstDraggedBlockIndex,
-			BlockSettingsMenu,
-			listViewInstanceId: instanceId,
-			AdditionalBlockContent,
-			insertedBlockClientId,
-			setInsertedBlockClientId,
-			treeGridElementRef: elementRef,
-			rootClientId,
 		} ),
 		[
 			blockDropPosition,
@@ -272,14 +297,7 @@ function ListViewComponent(
 			blockIndexes,
 			draggedClientIds,
 			expansionState,
-			updateExpansion,
 			firstDraggedBlockIndex,
-			BlockSettingsMenu,
-			instanceId,
-			AdditionalBlockContent,
-			insertedBlockClientId,
-			setInsertedBlockClientId,
-			rootClientId,
 		]
 	);
 
@@ -344,16 +362,24 @@ function ListViewComponent(
 				} }
 			>
 				<ListViewContext.Provider value={ contextValue }>
-					<ListViewBranch
-						blocks={ clientIdsTree }
-						parentId={ rootClientId }
-						selectBlock={ selectEditorBlock }
-						showBlockMovers={ showBlockMovers }
-						fixedListWindow={ fixedListWindow }
-						selectedClientIds={ selectedClientIds }
-						isExpanded={ isExpanded }
-						showAppender={ showAppender }
-					/>
+					<ListViewInsertedBlockContext.Provider
+						value={ insertedBlockClientId }
+					>
+						<ListViewTreeStateContext.Provider
+							value={ treeStateContextValue }
+						>
+							<ListViewBranch
+								blocks={ clientIdsTree }
+								parentId={ rootClientId }
+								selectBlock={ selectEditorBlock }
+								showBlockMovers={ showBlockMovers }
+								fixedListWindow={ fixedListWindow }
+								selectedClientIds={ selectedClientIds }
+								isExpanded={ isExpanded }
+								showAppender={ showAppender }
+							/>
+						</ListViewTreeStateContext.Provider>
+					</ListViewInsertedBlockContext.Provider>
 				</ListViewContext.Provider>
 			</TreeGrid>
 		</AsyncModeProvider>

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -7,11 +7,11 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	useEvent,
 	useInstanceId,
 	useMergeRefs,
 	__experimentalUseFixedWindowList as useFixedWindowList,
 } from '@wordpress/compose';
+import { isShallowEqual } from '@wordpress/is-shallow-equal';
 import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
 import { VisuallyHidden } from '@wordpress/ui';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
@@ -48,20 +48,33 @@ import { BLOCK_LIST_ITEM_HEIGHT, focusListItem } from './utils';
 import useClipboardHandler from './use-clipboard-handler';
 
 const expansion = ( state, action ) => {
-	if ( action.type === 'clear' ) {
-		return {};
+	const { type, clientIds } = action;
+
+	// Overwrite the state: only the listed blocks stay expanded, every other
+	// block falls back to the list view's default.
+	if ( type === 'replace' ) {
+		const next = Object.fromEntries(
+			clientIds.map( ( id ) => [ id, true ] )
+		);
+		return isShallowEqual( state, next ) ? state : next;
 	}
 
-	const clientIds = [ action.clientIds ].flat().filter( Boolean );
-	if ( ! clientIds.length ) {
+	if ( type !== 'expand' && type !== 'collapse' ) {
+		return state;
+	}
+
+	const isExpand = type === 'expand';
+	// An unrecorded block is not the same as an explicitly collapsed one,
+	// because the fallback depends on the `isExpanded` prop.
+	const changed = clientIds.filter( ( id ) => state[ id ] !== isExpand );
+
+	if ( ! changed.length ) {
 		return state;
 	}
 
 	return {
 		...state,
-		...Object.fromEntries(
-			clientIds.map( ( id ) => [ id, action.type === 'expand' ] )
-		),
+		...Object.fromEntries( changed.map( ( id ) => [ id, isExpand ] ) ),
 	};
 };
 
@@ -138,10 +151,6 @@ function ListViewComponent(
 
 	const [ expansionState, updateExpansion ] = useReducer( expansion, {} );
 
-	// A getter keeps the block settings menu out of the expansion state
-	// subscription, which would otherwise re-render every row on expand.
-	const getExpansionState = useEvent( () => expansionState );
-
 	const [ insertedBlockClientId, setInsertedBlockClientId ] =
 		useState( null );
 
@@ -167,7 +176,6 @@ function ListViewComponent(
 
 	const { ref: dropZoneRef, target: blockDropTarget } = useListViewDropZone( {
 		dropZoneElement,
-		expansionState,
 		updateExpansion,
 	} );
 	const elementRef = useRef();
@@ -198,10 +206,16 @@ function ListViewComponent(
 	] );
 
 	const expandRow = useCallback( ( row ) => {
-		updateExpansion( { type: 'expand', clientIds: row?.dataset?.block } );
+		const clientId = row?.dataset?.block;
+		if ( clientId ) {
+			updateExpansion( { type: 'expand', clientIds: [ clientId ] } );
+		}
 	}, [] );
 	const collapseRow = useCallback( ( row ) => {
-		updateExpansion( { type: 'collapse', clientIds: row?.dataset?.block } );
+		const clientId = row?.dataset?.block;
+		if ( clientId ) {
+			updateExpansion( { type: 'collapse', clientIds: [ clientId ] } );
+		}
 	}, [] );
 	const focusRow = useCallback(
 		( event, startRow, endRow ) => {
@@ -263,7 +277,6 @@ function ListViewComponent(
 		() => ( {
 			AdditionalBlockContent,
 			BlockSettingsMenu,
-			getExpansionState,
 			listViewInstanceId: instanceId,
 			rootClientId,
 			setInsertedBlockClientId,
@@ -273,7 +286,6 @@ function ListViewComponent(
 		[
 			AdditionalBlockContent,
 			BlockSettingsMenu,
-			getExpansionState,
 			instanceId,
 			rootClientId,
 			setInsertedBlockClientId,

--- a/packages/block-editor/src/components/list-view/use-list-view-collapse-items.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-collapse-items.js
@@ -26,8 +26,7 @@ export default function useListViewCollapseItems( { updateExpansion } ) {
 		if ( expandedBlock ) {
 			const blockParents = getBlockParents( expandedBlock, false );
 			// Collapse all blocks and expand the block's parents.
-			updateExpansion( { type: 'clear' } );
-			updateExpansion( { type: 'expand', clientIds: blockParents } );
+			updateExpansion( { type: 'replace', clientIds: blockParents } );
 		}
 	}, [ updateExpansion, expandedBlock, getBlockParents ] );
 }

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -412,14 +412,12 @@ const EXPAND_THROTTLE_OPTIONS = {
  *
  * @param {Object}       props                   Named parameters.
  * @param {?HTMLElement} [props.dropZoneElement] Optional element to be used as the drop zone.
- * @param {Object}       [props.expansionState]  The expansion state of the blocks in the list view.
  * @param {Function}     [props.updateExpansion] Dispatch to update the expansion state of a list of block clientIds.
  *
  * @return {WPListViewDropZoneTarget} The drop target.
  */
 export default function useListViewDropZone( {
 	dropZoneElement,
-	expansionState,
 	updateExpansion,
 } ) {
 	const {
@@ -440,21 +438,18 @@ export default function useListViewDropZone( {
 	const previousRootClientId = usePrevious( targetRootClientId );
 
 	const maybeExpandBlock = useCallback(
-		( _expansionState, _target ) => {
+		( _target ) => {
 			// If the user is attempting to drop a block inside a collapsed block,
 			// that is, using a nesting gesture flagged by 'inside' dropPosition,
-			// expand the block within the list view, if it isn't already.
+			// expand the block within the list view.
 			const { rootClientId } = _target || {};
 			if ( ! rootClientId ) {
 				return;
 			}
-			if (
-				_target?.dropPosition === 'inside' &&
-				! _expansionState[ rootClientId ]
-			) {
+			if ( _target?.dropPosition === 'inside' ) {
 				updateExpansion( {
 					type: 'expand',
-					clientIds: rootClientId,
+					clientIds: [ rootClientId ],
 				} );
 			}
 		},
@@ -478,13 +473,8 @@ export default function useListViewDropZone( {
 			throttledMaybeExpandBlock.cancel();
 			return;
 		}
-		throttledMaybeExpandBlock( expansionState, target );
-	}, [
-		expansionState,
-		previousRootClientId,
-		target,
-		throttledMaybeExpandBlock,
-	] );
+		throttledMaybeExpandBlock( target );
+	}, [ previousRootClientId, target, throttledMaybeExpandBlock ] );
 
 	const draggedBlockClientIds = getDraggedBlockClientIds();
 	const throttled = useThrottle(

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -36,7 +36,7 @@ function AddSubmenuItem( {
 	clientId,
 	onClose,
 	isDisabled,
-	expansionState,
+	getExpansionState,
 	updateExpansion,
 	setInsertedBlockClientId,
 } ) {
@@ -91,7 +91,7 @@ function AddSubmenuItem( {
 				// the Link UI for this new block.
 				setInsertedBlockClientId( newLink.clientId );
 
-				if ( ! expansionState[ clientId ] ) {
+				if ( ! getExpansionState()[ clientId ] ) {
 					updateExpansion( { type: 'expand', clientIds: clientId } );
 				}
 				onClose();
@@ -210,7 +210,7 @@ export default function LeafMoreMenu( props ) {
 							clientId={ clientId }
 							onClose={ onClose }
 							isDisabled={ isSubmenuDisabled }
-							expansionState={ props.expansionState }
+							getExpansionState={ props.getExpansionState }
 							updateExpansion={ props.updateExpansion }
 							setInsertedBlockClientId={
 								props.setInsertedBlockClientId

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -36,7 +36,6 @@ function AddSubmenuItem( {
 	clientId,
 	onClose,
 	isDisabled,
-	getExpansionState,
 	updateExpansion,
 	setInsertedBlockClientId,
 } ) {
@@ -90,10 +89,7 @@ function AddSubmenuItem( {
 				// This is required for the Nav Block to determine whether or not to display
 				// the Link UI for this new block.
 				setInsertedBlockClientId( newLink.clientId );
-
-				if ( ! getExpansionState()[ clientId ] ) {
-					updateExpansion( { type: 'expand', clientIds: clientId } );
-				}
+				updateExpansion( { type: 'expand', clientIds: [ clientId ] } );
 				onClose();
 			} }
 		>
@@ -102,9 +98,12 @@ function AddSubmenuItem( {
 	);
 }
 
-export default function LeafMoreMenu( props ) {
-	const { clientId } = props;
-
+export default function LeafMoreMenu( {
+	clientId,
+	updateExpansion,
+	setInsertedBlockClientId,
+	...props
+} ) {
 	const {
 		moveBlocksDown,
 		moveBlocksUp,
@@ -210,10 +209,9 @@ export default function LeafMoreMenu( props ) {
 							clientId={ clientId }
 							onClose={ onClose }
 							isDisabled={ isSubmenuDisabled }
-							getExpansionState={ props.getExpansionState }
-							updateExpansion={ props.updateExpansion }
+							updateExpansion={ updateExpansion }
 							setInsertedBlockClientId={
-								props.setInsertedBlockClientId
+								setInsertedBlockClientId
 							}
 						/>
 						{ canDuplicate && (


### PR DESCRIPTION
## What?
PR splits the single `ListViewContext` into three, hands the block settings menu a `getExpansionState()` getter instead of the `expansionState` object, and removes props that were passed but never read.

We don't really have measurements in perf tests for similar refactorings, but local render observations are better for the list view, plus this unruly context has been bothering me for a while now.

## Why?
One context value mixed five update frequencies, so expanding a branch re-rendered every consumer and `memo()` could not guard the rows at all. Two separate things defeated the memo, and fixing either one alone changes nothing:

1. `block.js` and `block-contents.js` read a context carrying `expansionState`, and `memo` cannot guard a context read.
2. `branch.js` passed `listPosition` to `ListViewBlock`, which never destructured it. That value is a running subtree count, so expanding a branch shifted it for every row below, and the shallow prop compare re-rendered all of them.

The `ListViewBranch` memoization still doesn't work at the moment, but I also plan to look into it.

## How?
- `ListViewContext` now holds only values that never change for the life of the list. `ListViewTreeStateContext` holds drag and expansion state and is read by `branch.js` alone. `ListViewInsertedBlockContext` holds the inserted client ID.
- `getExpansionState` is a `useEvent` callback, so it is stable and throws if called during render. The `blockSettingsMenu` prop contract changes from `expansionState` to `getExpansionState`, updated in the navigation block's `LeafMoreMenu`.
- Drops the dead `listPosition` prop, the `isSelected` / `position` / `siblingBlockCount` / `level` props forwarded to `ListViewBlockSelectButton`, and the `shouldShowInnerBlocks` parameter that no call site passes. Only the `listPosition` removal affects rendering; the rest is cleanup.

## Testing Instructions
1. Open List View on a post with nested blocks.
2. Expand and collapse branches, insert blocks from the appender, drag rows to reorder, and use the block settings menu.
3. In the navigation block's off-canvas List View, use "Add submenu link" and confirm the parent expands and the Link UI appears on the new item.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
