### PR TITLE
Theme: Add integration test coverage for seed colors in artifacts

### DIFF
--- a/packages/theme/src/color-ramps/lib/test/constants.test.ts
+++ b/packages/theme/src/color-ramps/lib/test/constants.test.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { addFallbackToVar } from '../../../../postcss-plugins/ds-token-fallbacks.mjs';
+import { DEFAULT_SEED_COLORS } from '../constants';
+
+describe( 'DEFAULT_SEED_COLORS', () => {
+	it( 'is reflected in design-tokens.css artifact', async () => {
+		const css = await readFile(
+			join(
+				import.meta.dirname,
+				'../../../../prebuilt/css/design-tokens.css'
+			),
+			'utf8'
+		);
+
+		Object.entries( {
+			'--wpds-color-background-surface-neutral':
+				DEFAULT_SEED_COLORS.background,
+			'--wpds-color-background-interactive-brand-strong':
+				DEFAULT_SEED_COLORS.primary,
+			'--wpds-color-background-interactive-error-strong':
+				DEFAULT_SEED_COLORS.error,
+		} ).forEach( ( [ name, value ] ) => {
+			expect( css ).toContain( `${ name }: ${ value };` );
+		} );
+	} );
+
+	it( 'is reflected in design-token-fallbacks.mjs artifact', () => {
+		expect(
+			addFallbackToVar( 'var(--wpds-color-background-surface-neutral)' )
+		).toBe(
+			`var(--wpds-color-background-surface-neutral, ${ DEFAULT_SEED_COLORS.background })`
+		);
+		expect(
+			addFallbackToVar(
+				'var(--wpds-color-background-interactive-brand-strong)'
+			)
+		).toBe(
+			`var(--wpds-color-background-interactive-brand-strong, var(--wp-admin-theme-color, ${ DEFAULT_SEED_COLORS.primary }))`
+		);
+		expect(
+			addFallbackToVar(
+				'var(--wpds-color-background-interactive-error-strong)'
+			)
+		).toBe(
+			`var(--wpds-color-background-interactive-error-strong, ${ DEFAULT_SEED_COLORS.error })`
+		);
+	} );
+} );


### PR DESCRIPTION
## What?

Adds a set of integration tests that validate that values within [theme constant `DEFAULT_SEED_COLORS`](https://github.com/WordPress/gutenberg/blob/b89e0946e76dbbdb0eeab12c69af0d29dfcd58ef/packages/theme/src/color-ramps/lib/constants.ts#L80-L89) are reflected in default theme artifacts [`design-tokens.css`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/prebuilt/css/design-tokens.css) and [`design-token-fallbacks.mjs`](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/prebuilt/js/design-token-fallbacks.mjs).

Follow-up to: https://github.com/WordPress/gutenberg/pull/80600#discussion_r3711752966

## Why?

In https://github.com/WordPress/gutenberg/pull/80600#discussion_r3711752966, @ciampo highlighted that in cases where ThemeProvider is not generating color properties (after the changes in the pull request), we're relying on default values from the CSS stylesheet or injected fallback values. But we don't have (and never had) any guarantees that the values between the ThemeProvider runtime were in sync with values from these artifacts. 

## How?

The changes here aim to reduce this gap by checking that values in the constants are reflected in the artifacts.

I opted to implement this as a file-relative test `constants.test.ts` even though there are some preexisting, non-file-specific integration tests for color ramps like [`seed-input.test.ts`](https://github.com/WordPress/gutenberg/tree/trunk/packages/theme/src/color-ramps/test), since I have a general preference for file-specific tests and I think it's reasonable to assert from `DEFAULT_SEED_COLORS` as the source having a cascading effect on these artifacts.

## Testing Instructions

Verify tests pass:

1. Run `npm run test:unit packages/theme/src/color-ramps/lib/test/constants.test.ts`

## Use of AI Tools

Used Cursor IDE + Auto model for investigation and initial implementation, but I refined it manually myself.