### PR TITLE
components/Menu: Restore Modal focus return when menu items close

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+-   `Modal`: Prevent background page scrolling without relying on WordPress global styles when using the default `bodyOpenClassName` ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Menu`: Return focus to the root trigger after closing a legacy `Modal` opened from a menu item, while preserving the menu-to-Modal scroll-lock handoff ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+-   `Menu`: Return focus to the root trigger after closing a legacy `Modal` opened from a menu item, while preserving the menu-to-Modal scroll-lock handoff ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 
 ### TypeScript

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Bug Fixes
 
+-   `Menu`: Return focus to the root trigger after closing a legacy `Modal` opened from a menu item, while preserving the menu-to-Modal scroll-lock handoff ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).

--- a/packages/components/src/menu/checkbox-item.tsx
+++ b/packages/components/src/menu/checkbox-item.tsx
@@ -5,33 +5,35 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { CheckboxItemProps } from './types';
 import * as Styled from './styles';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 export const CheckboxItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< CheckboxItemProps, 'div', false >
 >( function CheckboxItem(
-	{ suffix, children, disabled = false, hideOnClick = false, ...props },
+	{ suffix, children, disabled = false, ...props },
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const store = menuContext?.store;
+	const hideOnClick = useMenuItemHideOnClick( store );
 
-	if ( ! menuContext?.store ) {
+	if ( ! store ) {
 		throw new Error(
 			'Menu.CheckboxItem can only be rendered inside a Menu component'
 		);
 	}
-
 	return (
 		<Styled.CheckboxItem
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
+			store={ store }
 			hideOnClick={ hideOnClick }
-			store={ menuContext.store }
 		>
 			<Ariakit.MenuItemCheck
-				store={ menuContext.store }
+				store={ store }
 				render={ <Styled.ItemPrefixWrapper /> }
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }

--- a/packages/components/src/menu/checkbox-item.tsx
+++ b/packages/components/src/menu/checkbox-item.tsx
@@ -11,12 +11,12 @@ export const CheckboxItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< CheckboxItemProps, 'div', false >
 >( function CheckboxItem(
-	{ suffix, children, disabled = false, ...props },
+	{ suffix, children, disabled = false, hideOnClick = false, ...props },
 	ref
 ) {
 	const menuContext = useContext( Context );
 	const store = menuContext?.store;
-	const hideOnClick = useMenuItemHideOnClick( store );
+	const computedHideOnClick = useMenuItemHideOnClick( store, hideOnClick );
 
 	if ( ! store ) {
 		throw new Error(
@@ -30,7 +30,7 @@ export const CheckboxItem = forwardRef<
 			accessibleWhenDisabled
 			disabled={ disabled }
 			store={ store }
-			hideOnClick={ hideOnClick }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Ariakit.MenuItemCheck
 				store={ store }

--- a/packages/components/src/menu/checkbox-item.tsx
+++ b/packages/components/src/menu/checkbox-item.tsx
@@ -22,12 +22,12 @@ export const CheckboxItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< CheckboxItemProps, 'div', false >
 >( function CheckboxItem(
-	{ suffix, children, disabled = false, ...props },
+	{ suffix, children, disabled = false, hideOnClick = false, ...props },
 	ref
 ) {
 	const menuContext = useContext( Context );
 	const store = menuContext?.store;
-	const hideOnClick = useMenuItemHideOnClick( store );
+	const computedHideOnClick = useMenuItemHideOnClick( store, hideOnClick );
 
 	if ( ! store ) {
 		throw new Error(
@@ -41,7 +41,7 @@ export const CheckboxItem = forwardRef<
 			accessibleWhenDisabled
 			disabled={ disabled }
 			store={ store }
-			hideOnClick={ hideOnClick }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Ariakit.MenuItemCheck
 				store={ store }

--- a/packages/components/src/menu/checkbox-item.tsx
+++ b/packages/components/src/menu/checkbox-item.tsx
@@ -16,33 +16,35 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { CheckboxItemProps } from './types';
 import * as Styled from './styles';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 export const CheckboxItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< CheckboxItemProps, 'div', false >
 >( function CheckboxItem(
-	{ suffix, children, disabled = false, hideOnClick = false, ...props },
+	{ suffix, children, disabled = false, ...props },
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const store = menuContext?.store;
+	const hideOnClick = useMenuItemHideOnClick( store );
 
-	if ( ! menuContext?.store ) {
+	if ( ! store ) {
 		throw new Error(
 			'Menu.CheckboxItem can only be rendered inside a Menu component'
 		);
 	}
-
 	return (
 		<Styled.CheckboxItem
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
+			store={ store }
 			hideOnClick={ hideOnClick }
-			store={ menuContext.store }
 		>
 			<Ariakit.MenuItemCheck
-				store={ menuContext.store }
+				store={ store }
 				render={ <Styled.ItemPrefixWrapper /> }
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }

--- a/packages/components/src/menu/item.tsx
+++ b/packages/components/src/menu/item.tsx
@@ -3,25 +3,20 @@ import type { WordPressComponentProps } from '../context';
 import type { ItemProps } from './types';
 import * as Styled from './styles';
 import { Context } from './context';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 export const Item = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< ItemProps, 'div', false >
 >( function Item(
-	{
-		prefix,
-		suffix,
-		children,
-		disabled = false,
-		hideOnClick = true,
-		store,
-		...props
-	},
+	{ prefix, suffix, children, disabled = false, store, ...props },
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const computedStore = store ?? menuContext?.store;
+	const hideOnClick = useMenuItemHideOnClick( computedStore );
 
-	if ( ! menuContext?.store ) {
+	if ( ! menuContext?.store || ! computedStore ) {
 		throw new Error(
 			'Menu.Item can only be rendered inside a Menu component'
 		);
@@ -31,16 +26,14 @@ export const Item = forwardRef<
 	// created by the top-level menu component). But in rare cases (ie.
 	// `Menu.SubmenuTriggerItem`), the context store wouldn't be correct. This is
 	// why the component accepts a `store` prop to override the context store.
-	const computedStore = store ?? menuContext.store;
-
 	return (
 		<Styled.Item
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
-			hideOnClick={ hideOnClick }
 			store={ computedStore }
+			hideOnClick={ hideOnClick }
 		>
 			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 

--- a/packages/components/src/menu/item.tsx
+++ b/packages/components/src/menu/item.tsx
@@ -9,12 +9,23 @@ export const Item = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< ItemProps, 'div', false >
 >( function Item(
-	{ prefix, suffix, children, disabled = false, store, ...props },
+	{
+		prefix,
+		suffix,
+		children,
+		disabled = false,
+		hideOnClick = true,
+		store,
+		...props
+	},
 	ref
 ) {
 	const menuContext = useContext( Context );
 	const computedStore = store ?? menuContext?.store;
-	const hideOnClick = useMenuItemHideOnClick( computedStore );
+	const computedHideOnClick = useMenuItemHideOnClick(
+		computedStore,
+		hideOnClick
+	);
 
 	if ( ! menuContext?.store || ! computedStore ) {
 		throw new Error(
@@ -33,7 +44,7 @@ export const Item = forwardRef<
 			accessibleWhenDisabled
 			disabled={ disabled }
 			store={ computedStore }
-			hideOnClick={ hideOnClick }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 

--- a/packages/components/src/menu/item.tsx
+++ b/packages/components/src/menu/item.tsx
@@ -16,12 +16,23 @@ export const Item = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< ItemProps, 'div', false >
 >( function Item(
-	{ prefix, suffix, children, disabled = false, store, ...props },
+	{
+		prefix,
+		suffix,
+		children,
+		disabled = false,
+		hideOnClick = true,
+		store,
+		...props
+	},
 	ref
 ) {
 	const menuContext = useContext( Context );
 	const computedStore = store ?? menuContext?.store;
-	const hideOnClick = useMenuItemHideOnClick( computedStore );
+	const computedHideOnClick = useMenuItemHideOnClick(
+		computedStore,
+		hideOnClick
+	);
 
 	if ( ! menuContext?.store || ! computedStore ) {
 		throw new Error(
@@ -40,7 +51,7 @@ export const Item = forwardRef<
 			accessibleWhenDisabled
 			disabled={ disabled }
 			store={ computedStore }
-			hideOnClick={ hideOnClick }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 

--- a/packages/components/src/menu/item.tsx
+++ b/packages/components/src/menu/item.tsx
@@ -10,25 +10,20 @@ import type { WordPressComponentProps } from '../context';
 import type { ItemProps } from './types';
 import * as Styled from './styles';
 import { Context } from './context';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 export const Item = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< ItemProps, 'div', false >
 >( function Item(
-	{
-		prefix,
-		suffix,
-		children,
-		disabled = false,
-		hideOnClick = true,
-		store,
-		...props
-	},
+	{ prefix, suffix, children, disabled = false, store, ...props },
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const computedStore = store ?? menuContext?.store;
+	const hideOnClick = useMenuItemHideOnClick( computedStore );
 
-	if ( ! menuContext?.store ) {
+	if ( ! menuContext?.store || ! computedStore ) {
 		throw new Error(
 			'Menu.Item can only be rendered inside a Menu component'
 		);
@@ -38,16 +33,14 @@ export const Item = forwardRef<
 	// created by the top-level menu component). But in rare cases (ie.
 	// `Menu.SubmenuTriggerItem`), the context store wouldn't be correct. This is
 	// why the component accepts a `store` prop to override the context store.
-	const computedStore = store ?? menuContext.store;
-
 	return (
 		<Styled.Item
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
-			hideOnClick={ hideOnClick }
 			store={ computedStore }
+			hideOnClick={ hideOnClick }
 		>
 			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 

--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -6,6 +6,7 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { RadioItemProps } from './types';
 import * as Styled from './styles';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 const radioCheck = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -16,29 +17,27 @@ const radioCheck = (
 export const RadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< RadioItemProps, 'div', false >
->( function RadioItem(
-	{ suffix, children, disabled = false, hideOnClick = false, ...props },
-	ref
-) {
+>( function RadioItem( { suffix, children, disabled = false, ...props }, ref ) {
 	const menuContext = useContext( Context );
+	const store = menuContext?.store;
+	const hideOnClick = useMenuItemHideOnClick( store );
 
-	if ( ! menuContext?.store ) {
+	if ( ! store ) {
 		throw new Error(
 			'Menu.RadioItem can only be rendered inside a Menu component'
 		);
 	}
-
 	return (
 		<Styled.RadioItem
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
+			store={ store }
 			hideOnClick={ hideOnClick }
-			store={ menuContext.store }
 		>
 			<Ariakit.MenuItemCheck
-				store={ menuContext.store }
+				store={ store }
 				render={ <Styled.ItemPrefixWrapper /> }
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }

--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -17,10 +17,13 @@ const radioCheck = (
 export const RadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< RadioItemProps, 'div', false >
->( function RadioItem( { suffix, children, disabled = false, ...props }, ref ) {
+>( function RadioItem(
+	{ suffix, children, disabled = false, hideOnClick = false, ...props },
+	ref
+) {
 	const menuContext = useContext( Context );
 	const store = menuContext?.store;
-	const hideOnClick = useMenuItemHideOnClick( store );
+	const computedHideOnClick = useMenuItemHideOnClick( store, hideOnClick );
 
 	if ( ! store ) {
 		throw new Error(
@@ -34,7 +37,7 @@ export const RadioItem = forwardRef<
 			accessibleWhenDisabled
 			disabled={ disabled }
 			store={ store }
-			hideOnClick={ hideOnClick }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Ariakit.MenuItemCheck
 				store={ store }

--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -28,10 +28,13 @@ const radioCheck = (
 export const RadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< RadioItemProps, 'div', false >
->( function RadioItem( { suffix, children, disabled = false, ...props }, ref ) {
+>( function RadioItem(
+	{ suffix, children, disabled = false, hideOnClick = false, ...props },
+	ref
+) {
 	const menuContext = useContext( Context );
 	const store = menuContext?.store;
-	const hideOnClick = useMenuItemHideOnClick( store );
+	const computedHideOnClick = useMenuItemHideOnClick( store, hideOnClick );
 
 	if ( ! store ) {
 		throw new Error(
@@ -45,7 +48,7 @@ export const RadioItem = forwardRef<
 			accessibleWhenDisabled
 			disabled={ disabled }
 			store={ store }
-			hideOnClick={ hideOnClick }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Ariakit.MenuItemCheck
 				store={ store }

--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -17,6 +17,7 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { RadioItemProps } from './types';
 import * as Styled from './styles';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 const radioCheck = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -27,29 +28,27 @@ const radioCheck = (
 export const RadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< RadioItemProps, 'div', false >
->( function RadioItem(
-	{ suffix, children, disabled = false, hideOnClick = false, ...props },
-	ref
-) {
+>( function RadioItem( { suffix, children, disabled = false, ...props }, ref ) {
 	const menuContext = useContext( Context );
+	const store = menuContext?.store;
+	const hideOnClick = useMenuItemHideOnClick( store );
 
-	if ( ! menuContext?.store ) {
+	if ( ! store ) {
 		throw new Error(
 			'Menu.RadioItem can only be rendered inside a Menu component'
 		);
 	}
-
 	return (
 		<Styled.RadioItem
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
+			store={ store }
 			hideOnClick={ hideOnClick }
-			store={ menuContext.store }
 		>
 			<Ariakit.MenuItemCheck
-				store={ menuContext.store }
+				store={ store }
 				render={ <Styled.ItemPrefixWrapper /> }
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -415,10 +415,7 @@ export const WithModals: StoryObj< typeof Menu > = {
 						Open menu
 					</Menu.TriggerButton>
 					<Menu.Popover>
-						<Menu.Item
-							onClick={ () => setOuterModalOpen( true ) }
-							hideOnClick={ false }
-						>
+						<Menu.Item onClick={ () => setOuterModalOpen( true ) }>
 							<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
 						</Menu.Item>
 						<Menu.Item

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -1,9 +1,7 @@
 import type { StoryObj, Meta } from '@storybook/react-vite';
-import { css } from '@emotion/react';
 import { fn } from 'storybook/test';
 import { customLink, formatCapitalize } from '@wordpress/icons';
 import { useState, useMemo, useContext } from '@wordpress/element';
-import { useCx } from '../../utils';
 import { Menu } from '..';
 import Icon from '../../icon';
 import Button from '../../button';
@@ -390,19 +388,9 @@ export const WithRadios: StoryObj< typeof Menu > = {
 	},
 };
 
-const modalOnTopOfMenuPopover = css`
-	&& {
-		z-index: 1000000;
-	}
-`;
-
-export const WithModals: StoryObj< typeof Menu > = {
-	render: function WithModals( props: Props ) {
-		const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
-		const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
-
-		const cx = useCx();
-		const modalOverlayClassName = cx( modalOnTopOfMenuPopover );
+export const WithModal: StoryObj< typeof Menu > = {
+	render: function WithModal( props: Props ) {
+		const [ isModalOpen, setModalOpen ] = useState( false );
 
 		return (
 			<>
@@ -415,39 +403,15 @@ export const WithModals: StoryObj< typeof Menu > = {
 						Open menu
 					</Menu.TriggerButton>
 					<Menu.Popover>
-						<Menu.Item onClick={ () => setOuterModalOpen( true ) }>
-							<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
+						<Menu.Item onClick={ () => setModalOpen( true ) }>
+							<Menu.ItemLabel>Open modal</Menu.ItemLabel>
 						</Menu.Item>
-						<Menu.Item
-							onClick={ () => setInnerModalOpen( true ) }
-							hideOnClick={ false }
-						>
-							<Menu.ItemLabel>Open inner modal</Menu.ItemLabel>
-						</Menu.Item>
-						{ isInnerModalOpen && (
-							<Modal
-								onRequestClose={ () =>
-									setInnerModalOpen( false )
-								}
-								overlayClassName={ modalOverlayClassName }
-							>
-								Modal&apos;s contents
-								<button
-									onClick={ () => setInnerModalOpen( false ) }
-								>
-									Close
-								</button>
-							</Modal>
-						) }
 					</Menu.Popover>
 				</Menu>
-				{ isOuterModalOpen && (
-					<Modal
-						onRequestClose={ () => setOuterModalOpen( false ) }
-						overlayClassName={ modalOverlayClassName }
-					>
+				{ isModalOpen && (
+					<Modal onRequestClose={ () => setModalOpen( false ) }>
 						Modal&apos;s contents
-						<button onClick={ () => setOuterModalOpen( false ) }>
+						<button onClick={ () => setModalOpen( false ) }>
 							Close
 						</button>
 					</Modal>

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -426,10 +426,7 @@ export const WithModals: StoryObj< typeof Menu > = {
 						Open menu
 					</Menu.TriggerButton>
 					<Menu.Popover>
-						<Menu.Item
-							onClick={ () => setOuterModalOpen( true ) }
-							hideOnClick={ false }
-						>
+						<Menu.Item onClick={ () => setOuterModalOpen( true ) }>
 							<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
 						</Menu.Item>
 						<Menu.Item

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -359,10 +359,7 @@ describe( 'Menu', () => {
 			await waitFor( () => expect( trigger ).toHaveFocus() );
 		} );
 
-		it.each( [
-			[ 'Enter', '{Enter}' ],
-			[ 'Space', ' ' ],
-		] )( 'should return focus after %s opens a modal', async ( _, key ) => {
+		it( 'should return focus after Enter opens a modal', async () => {
 			render( <MenuWithModal /> );
 
 			const trigger = screen.getByRole( 'button', {
@@ -372,7 +369,7 @@ describe( 'Menu', () => {
 			await user.keyboard( '{ArrowDown}' );
 			await waitForFocusedMenuItem( 'Open modal' );
 
-			await user.keyboard( key );
+			await user.keyboard( '{Enter}' );
 			await waitForClosedMenu();
 			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 			await user.click(

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -276,7 +276,25 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should retain outside focus when outside interaction closes the menu', async () => {
+		it( 'should close when clicking outside of the content', async () => {
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item>Menu item</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Click on the body (ie. outside of the dropdown menu)
+			await user.click( document.body );
+
+			await waitForClosedMenu();
+		} );
+
+		it( 'should retain outside focus when outside interaction closes a non-modal menu', async () => {
 			render(
 				<>
 					<Menu defaultOpen>

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from '@wordpress/element';
 import { Menu } from '..';
+import Modal from '../../modal';
 
 const waitForFocusedMenu = () =>
 	waitFor( () => expect( screen.getByRole( 'menu' ) ).toHaveFocus() );
@@ -11,8 +12,61 @@ const waitForFocusedMenuItem = ( name: string ) =>
 		expect( screen.getByRole( 'menuitem', { name } ) ).toHaveFocus()
 	);
 
+const waitForClosedMenu = () =>
+	waitFor( () =>
+		expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
+	);
+
+const openMenu = async ( user: ReturnType< typeof userEvent.setup > ) => {
+	await user.click( screen.getByRole( 'button', { name: 'Open dropdown' } ) );
+	await waitForFocusedMenu();
+};
+
+const isBodyScrollLocked = () =>
+	document.body.style.overflow === 'hidden' ||
+	document.body.classList.contains( 'modal-open' );
+
 const resetTypeahead = () => {
 	act( () => jest.advanceTimersByTime( 500 ) );
+};
+
+const MenuWithModal = ( { nested = false }: { nested?: boolean } ) => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const modalItem = (
+		<Menu.Item onClick={ () => setIsModalOpen( true ) }>
+			Open modal
+		</Menu.Item>
+	);
+
+	return (
+		<>
+			<Menu>
+				<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+				<Menu.Popover>
+					{ nested ? (
+						<Menu>
+							<Menu.SubmenuTriggerItem>
+								Open submenu
+							</Menu.SubmenuTriggerItem>
+							<Menu.Popover>{ modalItem }</Menu.Popover>
+						</Menu>
+					) : (
+						modalItem
+					) }
+				</Menu.Popover>
+			</Menu>
+			{ isModalOpen && (
+				<Modal
+					title="Modal"
+					onRequestClose={ () => setIsModalOpen( false ) }
+				>
+					<button onClick={ () => setIsModalOpen( false ) }>
+						Close modal
+					</button>
+				</Modal>
+			) }
+		</>
+	);
 };
 
 // Open dropdown => open menu
@@ -222,24 +276,28 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should close when clicking outside of the content', async () => {
+		it( 'should retain outside focus when outside interaction closes the menu', async () => {
 			render(
-				<Menu defaultOpen>
-					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
-					<Menu.Popover>
-						<Menu.Item>Menu item</Menu.Item>
-					</Menu.Popover>
-				</Menu>
+				<>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item>Menu item</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+					<button>Outside destination</button>
+				</>
 			);
 
 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+			const outsideDestination = screen.getByRole( 'button', {
+				name: 'Outside destination',
+			} );
 
-			// Click on the body (ie. outside of the dropdown menu)
-			await user.click( document.body );
+			await user.click( outsideDestination );
 
-			await waitFor( () =>
-				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
-			);
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
 		} );
 
 		it( 'should close when clicking on a menu item', async () => {
@@ -262,7 +320,94 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should not close when clicking on a menu item when the `hideOnClick` prop is set to `false`', async () => {
+		it( 'should return focus to the root trigger after a modal opened by pointer closes', async () => {
+			render( <MenuWithModal /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			await user.click( trigger );
+			await waitForFocusedMenu();
+			await user.click(
+				screen.getByRole( 'menuitem', { name: 'Open modal' } )
+			);
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it.each( [
+			[ 'Enter', '{Enter}' ],
+			[ 'Space', ' ' ],
+		] )( 'should return focus after %s opens a modal', async ( _, key ) => {
+			render( <MenuWithModal /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+			await openMenu( user );
+			await user.keyboard( '{ArrowDown}' );
+			await waitForFocusedMenuItem( 'Open modal' );
+
+			await user.keyboard( key );
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should return focus to the root trigger after a nested menu opens a modal', async () => {
+			render( <MenuWithModal nested /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+			await openMenu( user );
+			await user.keyboard( '{ArrowDown}' );
+			await waitForFocusedMenuItem( 'Open submenu' );
+			await user.keyboard( '{ArrowRight}' );
+			await waitForFocusedMenuItem( 'Open modal' );
+			await user.keyboard( '{Enter}' );
+			await waitForClosedMenu();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should keep body scroll locked while handing off to a modal', async () => {
+			render( <MenuWithModal /> );
+
+			expect( isBodyScrollLocked() ).toBe( false );
+			await openMenu( user );
+			expect( isBodyScrollLocked() ).toBe( true );
+
+			await user.click(
+				screen.getByRole( 'menuitem', { name: 'Open modal' } )
+			);
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			expect( isBodyScrollLocked() ).toBe( true );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+			await waitFor( () =>
+				expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+			);
+			await waitFor( () => expect( isBodyScrollLocked() ).toBe( false ) );
+		} );
+
+		it( 'should close when `hideOnClick` is `false`', async () => {
 			render(
 				<Menu defaultOpen>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
@@ -274,7 +419,74 @@ describe( 'Menu', () => {
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
 
-			// Clicking a menu item will close the menu
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+		} );
+
+		it( 'should close without invoking a `hideOnClick` callback', async () => {
+			const hideOnClick = jest.fn( () => false );
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item hideOnClick={ hideOnClick }>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( hideOnClick ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should retain focus moved outside by an item click handler', async () => {
+			let outsideDestination: HTMLButtonElement | null = null;
+			render(
+				<>
+					<button
+						ref={ ( element ) => {
+							outsideDestination = element;
+						} }
+					>
+						Outside destination
+					</button>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item
+								onClick={ () => outsideDestination?.focus() }
+							>
+								Menu item
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
+		} );
+
+		it( 'should not close when item activation is prevented', async () => {
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item
+							onClick={ ( event ) => event.preventDefault() }
+						>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
 			await user.click( screen.getByRole( 'menuitem' ) );
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
@@ -434,8 +646,9 @@ describe( 'Menu', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
+		it( 'should check radio items and close the menu when clicking (controlled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
+			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ radioValue, setRadioValue ] = useState( 'two' );
@@ -455,6 +668,7 @@ describe( 'Menu', () => {
 									value="radio-one"
 									checked={ radioValue === 'radio-one' }
 									onChange={ onRadioChange }
+									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item one
 								</Menu.RadioItem>
@@ -463,6 +677,7 @@ describe( 'Menu', () => {
 									value="radio-two"
 									checked={ radioValue === 'radio-two' }
 									onChange={ onRadioChange }
+									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item two
 								</Menu.RadioItem>
@@ -492,12 +707,13 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
+			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
 
-			// Make sure that first radio is checked
+			await openMenu( user );
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).toBeChecked();
@@ -505,25 +721,26 @@ describe( 'Menu', () => {
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).not.toBeChecked();
 
-			// Click second radio item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			);
+			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-two'
 			);
 
-			// Make sure that second radio is selected
+			await openMenu( user );
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).not.toBeChecked();
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).toBeChecked();
+			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
+		it( 'should check radio items and close the menu when clicking (uncontrolled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
 			render(
 				<Menu>
@@ -572,39 +789,16 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
+			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
-
-			// Make sure that first radio is checked
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-			).toBeChecked();
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-			).not.toBeChecked();
-
-			// Click second radio item, make sure that the callback fires
-			await user.click(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-			);
-			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
-			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
-				'radio-two'
-			);
-
-			// Make sure that second radio is selected
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-			).not.toBeChecked();
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-			).toBeChecked();
 		} );
 
-		it( 'should check checkbox items and keep the menu open when clicking (controlled)', async () => {
+		it( 'should check checkbox items and close the menu when clicking (controlled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
+			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ itemOneChecked, setItemOneChecked ] =
@@ -620,6 +814,7 @@ describe( 'Menu', () => {
 								name="item-one"
 								value="item-one-value"
 								checked={ itemOneChecked }
+								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -636,6 +831,7 @@ describe( 'Menu', () => {
 								name="item-two"
 								value="item-two-value"
 								checked={ itemTwoChecked }
+								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -680,6 +876,7 @@ describe( 'Menu', () => {
 					name: 'Checkbox item one',
 				} )
 			);
+			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-one',
@@ -687,6 +884,7 @@ describe( 'Menu', () => {
 				true
 			);
 
+			await openMenu( user );
 			// Make sure that first checkbox is checked
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -700,6 +898,7 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
+			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -707,6 +906,7 @@ describe( 'Menu', () => {
 				true
 			);
 
+			await openMenu( user );
 			// Make sure that second checkbox is selected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -720,6 +920,7 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
+			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -727,15 +928,17 @@ describe( 'Menu', () => {
 				false
 			);
 
+			await openMenu( user );
 			// Make sure that second checkbox is unselected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			).not.toBeChecked();
+			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check checkbox items and keep the menu open when clicking (uncontrolled)', async () => {
+		it( 'should check checkbox items and close the menu when clicking (uncontrolled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
 
 			render(
@@ -794,65 +997,19 @@ describe( 'Menu', () => {
 				} )
 			).toBeChecked();
 
-			// Click first checkbox item, make sure that the callback fires
-			await user.click(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item one',
-				} )
-			);
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
-			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-				'item-one',
-				'item-one-value',
-				true
-			);
-
-			// Make sure that first checkbox is checked
-			expect(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item one',
-				} )
-			).toBeChecked();
-
-			// Click second checkbox item, make sure that the callback fires
+			// Click the checked item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			);
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			await waitForClosedMenu();
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
 				'item-two-value',
 				false
 			);
-
-			// Make sure that second checkbox is unchecked
-			expect(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item two',
-				} )
-			).not.toBeChecked();
-
-			// Click second checkbox item, make sure that the callback fires
-			await user.click(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item two',
-				} )
-			);
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
-			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-				'item-two',
-				'item-two-value',
-				true
-			);
-
-			// Make sure that second checkbox is unselected
-			expect(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item two',
-				} )
-			).toBeChecked();
 		} );
 	} );
 
@@ -920,7 +1077,7 @@ describe( 'Menu', () => {
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the Menu to close.
 			await user.tab();
-			expect( outerButton ).toBeVisible();
+			expect( outerButton ).toHaveFocus();
 			await waitFor( () =>
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
 			);

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -22,6 +22,9 @@ const openMenu = async ( user: ReturnType< typeof userEvent.setup > ) => {
 	await waitForFocusedMenu();
 };
 
+// TODO: Add browser coverage for the computed overflow once component stories
+// use interaction tests. Jest mocks stylesheet imports, so this only verifies
+// the handoff between Ariakit's inline lock and Modal's body class.
 const isBodyScrollLocked = () =>
 	document.body.style.overflow === 'hidden' ||
 	document.body.classList.contains( 'modal-open' );

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -425,7 +425,7 @@ describe( 'Menu', () => {
 			await waitFor( () => expect( isBodyScrollLocked() ).toBe( false ) );
 		} );
 
-		it( 'should close when `hideOnClick` is `false`', async () => {
+		it( 'should stay open when `hideOnClick` is `false`', async () => {
 			render(
 				<Menu defaultOpen>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
@@ -439,10 +439,10 @@ describe( 'Menu', () => {
 
 			await user.click( screen.getByRole( 'menuitem' ) );
 
-			await waitForClosedMenu();
+			expect( screen.getByRole( 'menu' ) ).toBeVisible();
 		} );
 
-		it( 'should close without invoking a `hideOnClick` callback', async () => {
+		it( 'should use a `hideOnClick` callback to decide whether to close', async () => {
 			const hideOnClick = jest.fn( () => false );
 			render(
 				<Menu defaultOpen>
@@ -457,9 +457,66 @@ describe( 'Menu', () => {
 
 			await user.click( screen.getByRole( 'menuitem' ) );
 
-			await waitForClosedMenu();
-			expect( hideOnClick ).not.toHaveBeenCalled();
+			expect( screen.getByRole( 'menu' ) ).toBeVisible();
+			expect( hideOnClick ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( 'should close when a `hideOnClick` callback returns `true`', async () => {
+			const hideOnClick = jest.fn( () => true );
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item hideOnClick={ hideOnClick }>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( hideOnClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it.each( [ 'checkbox', 'radio' ] )(
+			'should close a %s item when `hideOnClick` is `true`',
+			async ( itemType ) => {
+				render(
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover>
+							{ itemType === 'checkbox' ? (
+								<Menu.CheckboxItem
+									name="checkbox"
+									value="checkbox"
+									hideOnClick
+								>
+									Checkbox item
+								</Menu.CheckboxItem>
+							) : (
+								<Menu.RadioItem
+									name="radio"
+									value="radio"
+									hideOnClick
+								>
+									Radio item
+								</Menu.RadioItem>
+							) }
+						</Menu.Popover>
+					</Menu>
+				);
+
+				await user.click( screen.getByRole( `menuitem${ itemType }` ) );
+
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'menu' )
+					).not.toBeInTheDocument()
+				);
+			}
+		);
 
 		it( 'should retain focus moved outside by an item click handler', async () => {
 			let outsideDestination: HTMLButtonElement | null = null;
@@ -477,6 +534,39 @@ describe( 'Menu', () => {
 						<Menu.Popover modal={ false }>
 							<Menu.Item
 								onClick={ () => outsideDestination?.focus() }
+							>
+								Menu item
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
+		} );
+
+		it( 'should retain focus moved outside by a `hideOnClick` callback', async () => {
+			let outsideDestination: HTMLButtonElement | null = null;
+			render(
+				<>
+					<button
+						ref={ ( element ) => {
+							outsideDestination = element;
+						} }
+					>
+						Outside destination
+					</button>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item
+								hideOnClick={ () => {
+									outsideDestination?.focus();
+									return true;
+								} }
 							>
 								Menu item
 							</Menu.Item>
@@ -664,9 +754,8 @@ describe( 'Menu', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'should check radio items and close the menu when clicking (controlled)', async () => {
+		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
-			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ radioValue, setRadioValue ] = useState( 'two' );
@@ -686,7 +775,6 @@ describe( 'Menu', () => {
 									value="radio-one"
 									checked={ radioValue === 'radio-one' }
 									onChange={ onRadioChange }
-									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item one
 								</Menu.RadioItem>
@@ -695,7 +783,6 @@ describe( 'Menu', () => {
 									value="radio-two"
 									checked={ radioValue === 'radio-two' }
 									onChange={ onRadioChange }
-									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item two
 								</Menu.RadioItem>
@@ -725,13 +812,12 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
-			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
 
-			await openMenu( user );
+			// Make sure that first radio is checked
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).toBeChecked();
@@ -742,23 +828,21 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			);
-			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-two'
 			);
 
-			await openMenu( user );
+			// Make sure that second radio is selected
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).not.toBeChecked();
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).toBeChecked();
-			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check radio items and close the menu when clicking (uncontrolled)', async () => {
+		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
 			render(
 				<Menu>
@@ -807,16 +891,39 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
-			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
+
+			// Make sure that first radio is checked
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).not.toBeChecked();
+
+			// Click second radio item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			);
+			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+				'radio-two'
+			);
+
+			// Make sure that second radio is selected
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).toBeChecked();
 		} );
 
-		it( 'should check checkbox items and close the menu when clicking (controlled)', async () => {
+		it( 'should check checkbox items and keep the menu open when clicking (controlled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
-			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ itemOneChecked, setItemOneChecked ] =
@@ -832,7 +939,6 @@ describe( 'Menu', () => {
 								name="item-one"
 								value="item-one-value"
 								checked={ itemOneChecked }
-								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -849,7 +955,6 @@ describe( 'Menu', () => {
 								name="item-two"
 								value="item-two-value"
 								checked={ itemTwoChecked }
-								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -894,7 +999,6 @@ describe( 'Menu', () => {
 					name: 'Checkbox item one',
 				} )
 			);
-			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-one',
@@ -902,7 +1006,6 @@ describe( 'Menu', () => {
 				true
 			);
 
-			await openMenu( user );
 			// Make sure that first checkbox is checked
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -916,7 +1019,6 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
-			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -924,7 +1026,6 @@ describe( 'Menu', () => {
 				true
 			);
 
-			await openMenu( user );
 			// Make sure that second checkbox is selected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -938,7 +1039,6 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
-			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -946,17 +1046,15 @@ describe( 'Menu', () => {
 				false
 			);
 
-			await openMenu( user );
 			// Make sure that second checkbox is unselected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			).not.toBeChecked();
-			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check checkbox items and close the menu when clicking (uncontrolled)', async () => {
+		it( 'should check checkbox items and keep the menu open when clicking (uncontrolled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
 
 			render(
@@ -1015,19 +1113,65 @@ describe( 'Menu', () => {
 				} )
 			).toBeChecked();
 
-			// Click the checked item, make sure that the callback fires
+			// Click first checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-one',
+				'item-one-value',
+				true
+			);
+
+			// Make sure that first checkbox is checked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			).toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			);
-			await waitForClosedMenu();
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
 				'item-two-value',
 				false
 			);
+
+			// Make sure that second checkbox is unchecked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).not.toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-two',
+				'item-two-value',
+				true
+			);
+
+			// Make sure that second checkbox is selected
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).toBeChecked();
 		} );
 	} );
 

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -287,7 +287,25 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should retain outside focus when outside interaction closes the menu', async () => {
+		it( 'should close when clicking outside of the content', async () => {
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item>Menu item</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+
+			// Click on the body (ie. outside of the dropdown menu)
+			await user.click( document.body );
+
+			await waitForClosedMenu();
+		} );
+
+		it( 'should retain outside focus when outside interaction closes a non-modal menu', async () => {
 			render(
 				<>
 					<Menu defaultOpen>

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -436,7 +436,7 @@ describe( 'Menu', () => {
 			await waitFor( () => expect( isBodyScrollLocked() ).toBe( false ) );
 		} );
 
-		it( 'should close when `hideOnClick` is `false`', async () => {
+		it( 'should stay open when `hideOnClick` is `false`', async () => {
 			render(
 				<Menu defaultOpen>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
@@ -450,10 +450,10 @@ describe( 'Menu', () => {
 
 			await user.click( screen.getByRole( 'menuitem' ) );
 
-			await waitForClosedMenu();
+			expect( screen.getByRole( 'menu' ) ).toBeVisible();
 		} );
 
-		it( 'should close without invoking a `hideOnClick` callback', async () => {
+		it( 'should use a `hideOnClick` callback to decide whether to close', async () => {
 			const hideOnClick = jest.fn( () => false );
 			render(
 				<Menu defaultOpen>
@@ -468,9 +468,66 @@ describe( 'Menu', () => {
 
 			await user.click( screen.getByRole( 'menuitem' ) );
 
-			await waitForClosedMenu();
-			expect( hideOnClick ).not.toHaveBeenCalled();
+			expect( screen.getByRole( 'menu' ) ).toBeVisible();
+			expect( hideOnClick ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( 'should close when a `hideOnClick` callback returns `true`', async () => {
+			const hideOnClick = jest.fn( () => true );
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item hideOnClick={ hideOnClick }>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( hideOnClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it.each( [ 'checkbox', 'radio' ] )(
+			'should close a %s item when `hideOnClick` is `true`',
+			async ( itemType ) => {
+				render(
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover>
+							{ itemType === 'checkbox' ? (
+								<Menu.CheckboxItem
+									name="checkbox"
+									value="checkbox"
+									hideOnClick
+								>
+									Checkbox item
+								</Menu.CheckboxItem>
+							) : (
+								<Menu.RadioItem
+									name="radio"
+									value="radio"
+									hideOnClick
+								>
+									Radio item
+								</Menu.RadioItem>
+							) }
+						</Menu.Popover>
+					</Menu>
+				);
+
+				await user.click( screen.getByRole( `menuitem${ itemType }` ) );
+
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'menu' )
+					).not.toBeInTheDocument()
+				);
+			}
+		);
 
 		it( 'should retain focus moved outside by an item click handler', async () => {
 			let outsideDestination: HTMLButtonElement | null = null;
@@ -488,6 +545,39 @@ describe( 'Menu', () => {
 						<Menu.Popover modal={ false }>
 							<Menu.Item
 								onClick={ () => outsideDestination?.focus() }
+							>
+								Menu item
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
+		} );
+
+		it( 'should retain focus moved outside by a `hideOnClick` callback', async () => {
+			let outsideDestination: HTMLButtonElement | null = null;
+			render(
+				<>
+					<button
+						ref={ ( element ) => {
+							outsideDestination = element;
+						} }
+					>
+						Outside destination
+					</button>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item
+								hideOnClick={ () => {
+									outsideDestination?.focus();
+									return true;
+								} }
 							>
 								Menu item
 							</Menu.Item>
@@ -675,9 +765,8 @@ describe( 'Menu', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'should check radio items and close the menu when clicking (controlled)', async () => {
+		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
-			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ radioValue, setRadioValue ] = useState( 'two' );
@@ -697,7 +786,6 @@ describe( 'Menu', () => {
 									value="radio-one"
 									checked={ radioValue === 'radio-one' }
 									onChange={ onRadioChange }
-									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item one
 								</Menu.RadioItem>
@@ -706,7 +794,6 @@ describe( 'Menu', () => {
 									value="radio-two"
 									checked={ radioValue === 'radio-two' }
 									onChange={ onRadioChange }
-									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item two
 								</Menu.RadioItem>
@@ -736,13 +823,12 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
-			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
 
-			await openMenu( user );
+			// Make sure that first radio is checked
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).toBeChecked();
@@ -753,23 +839,21 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			);
-			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-two'
 			);
 
-			await openMenu( user );
+			// Make sure that second radio is selected
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).not.toBeChecked();
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).toBeChecked();
-			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check radio items and close the menu when clicking (uncontrolled)', async () => {
+		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
 			render(
 				<Menu>
@@ -818,16 +902,39 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
-			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
+
+			// Make sure that first radio is checked
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).not.toBeChecked();
+
+			// Click second radio item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			);
+			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
+				'radio-two'
+			);
+
+			// Make sure that second radio is selected
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
+			).toBeChecked();
 		} );
 
-		it( 'should check checkbox items and close the menu when clicking (controlled)', async () => {
+		it( 'should check checkbox items and keep the menu open when clicking (controlled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
-			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ itemOneChecked, setItemOneChecked ] =
@@ -843,7 +950,6 @@ describe( 'Menu', () => {
 								name="item-one"
 								value="item-one-value"
 								checked={ itemOneChecked }
-								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -860,7 +966,6 @@ describe( 'Menu', () => {
 								name="item-two"
 								value="item-two-value"
 								checked={ itemTwoChecked }
-								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -905,7 +1010,6 @@ describe( 'Menu', () => {
 					name: 'Checkbox item one',
 				} )
 			);
-			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-one',
@@ -913,7 +1017,6 @@ describe( 'Menu', () => {
 				true
 			);
 
-			await openMenu( user );
 			// Make sure that first checkbox is checked
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -927,7 +1030,6 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
-			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -935,7 +1037,6 @@ describe( 'Menu', () => {
 				true
 			);
 
-			await openMenu( user );
 			// Make sure that second checkbox is selected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -949,7 +1050,6 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
-			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -957,17 +1057,15 @@ describe( 'Menu', () => {
 				false
 			);
 
-			await openMenu( user );
 			// Make sure that second checkbox is unselected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			).not.toBeChecked();
-			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check checkbox items and close the menu when clicking (uncontrolled)', async () => {
+		it( 'should check checkbox items and keep the menu open when clicking (uncontrolled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
 
 			render(
@@ -1026,19 +1124,65 @@ describe( 'Menu', () => {
 				} )
 			).toBeChecked();
 
-			// Click the checked item, make sure that the callback fires
+			// Click first checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-one',
+				'item-one-value',
+				true
+			);
+
+			// Make sure that first checkbox is checked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item one',
+				} )
+			).toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			);
-			await waitForClosedMenu();
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
 				'item-two-value',
 				false
 			);
+
+			// Make sure that second checkbox is unchecked
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).not.toBeChecked();
+
+			// Click second checkbox item, make sure that the callback fires
+			await user.click(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			);
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
+			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
+				'item-two',
+				'item-two-value',
+				true
+			);
+
+			// Make sure that second checkbox is selected
+			expect(
+				screen.getByRole( 'menuitemcheckbox', {
+					name: 'Checkbox item two',
+				} )
+			).toBeChecked();
 		} );
 	} );
 

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { Menu } from '..';
+import Modal from '../../modal';
 
 const waitForFocusedMenu = () =>
 	waitFor( () => expect( screen.getByRole( 'menu' ) ).toHaveFocus() );
@@ -22,8 +23,61 @@ const waitForFocusedMenuItem = ( name: string ) =>
 		expect( screen.getByRole( 'menuitem', { name } ) ).toHaveFocus()
 	);
 
+const waitForClosedMenu = () =>
+	waitFor( () =>
+		expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
+	);
+
+const openMenu = async ( user: ReturnType< typeof userEvent.setup > ) => {
+	await user.click( screen.getByRole( 'button', { name: 'Open dropdown' } ) );
+	await waitForFocusedMenu();
+};
+
+const isBodyScrollLocked = () =>
+	document.body.style.overflow === 'hidden' ||
+	document.body.classList.contains( 'modal-open' );
+
 const resetTypeahead = () => {
 	act( () => jest.advanceTimersByTime( 500 ) );
+};
+
+const MenuWithModal = ( { nested = false }: { nested?: boolean } ) => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const modalItem = (
+		<Menu.Item onClick={ () => setIsModalOpen( true ) }>
+			Open modal
+		</Menu.Item>
+	);
+
+	return (
+		<>
+			<Menu>
+				<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+				<Menu.Popover>
+					{ nested ? (
+						<Menu>
+							<Menu.SubmenuTriggerItem>
+								Open submenu
+							</Menu.SubmenuTriggerItem>
+							<Menu.Popover>{ modalItem }</Menu.Popover>
+						</Menu>
+					) : (
+						modalItem
+					) }
+				</Menu.Popover>
+			</Menu>
+			{ isModalOpen && (
+				<Modal
+					title="Modal"
+					onRequestClose={ () => setIsModalOpen( false ) }
+				>
+					<button onClick={ () => setIsModalOpen( false ) }>
+						Close modal
+					</button>
+				</Modal>
+			) }
+		</>
+	);
 };
 
 // Open dropdown => open menu
@@ -233,24 +287,28 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should close when clicking outside of the content', async () => {
+		it( 'should retain outside focus when outside interaction closes the menu', async () => {
 			render(
-				<Menu defaultOpen>
-					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
-					<Menu.Popover>
-						<Menu.Item>Menu item</Menu.Item>
-					</Menu.Popover>
-				</Menu>
+				<>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item>Menu item</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+					<button>Outside destination</button>
+				</>
 			);
 
 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+			const outsideDestination = screen.getByRole( 'button', {
+				name: 'Outside destination',
+			} );
 
-			// Click on the body (ie. outside of the dropdown menu)
-			await user.click( document.body );
+			await user.click( outsideDestination );
 
-			await waitFor( () =>
-				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
-			);
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
 		} );
 
 		it( 'should close when clicking on a menu item', async () => {
@@ -273,7 +331,94 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should not close when clicking on a menu item when the `hideOnClick` prop is set to `false`', async () => {
+		it( 'should return focus to the root trigger after a modal opened by pointer closes', async () => {
+			render( <MenuWithModal /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			await user.click( trigger );
+			await waitForFocusedMenu();
+			await user.click(
+				screen.getByRole( 'menuitem', { name: 'Open modal' } )
+			);
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it.each( [
+			[ 'Enter', '{Enter}' ],
+			[ 'Space', ' ' ],
+		] )( 'should return focus after %s opens a modal', async ( _, key ) => {
+			render( <MenuWithModal /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+			await openMenu( user );
+			await user.keyboard( '{ArrowDown}' );
+			await waitForFocusedMenuItem( 'Open modal' );
+
+			await user.keyboard( key );
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should return focus to the root trigger after a nested menu opens a modal', async () => {
+			render( <MenuWithModal nested /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+			await openMenu( user );
+			await user.keyboard( '{ArrowDown}' );
+			await waitForFocusedMenuItem( 'Open submenu' );
+			await user.keyboard( '{ArrowRight}' );
+			await waitForFocusedMenuItem( 'Open modal' );
+			await user.keyboard( '{Enter}' );
+			await waitForClosedMenu();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should keep body scroll locked while handing off to a modal', async () => {
+			render( <MenuWithModal /> );
+
+			expect( isBodyScrollLocked() ).toBe( false );
+			await openMenu( user );
+			expect( isBodyScrollLocked() ).toBe( true );
+
+			await user.click(
+				screen.getByRole( 'menuitem', { name: 'Open modal' } )
+			);
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			expect( isBodyScrollLocked() ).toBe( true );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+			await waitFor( () =>
+				expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+			);
+			await waitFor( () => expect( isBodyScrollLocked() ).toBe( false ) );
+		} );
+
+		it( 'should close when `hideOnClick` is `false`', async () => {
 			render(
 				<Menu defaultOpen>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
@@ -285,7 +430,74 @@ describe( 'Menu', () => {
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
 
-			// Clicking a menu item will close the menu
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+		} );
+
+		it( 'should close without invoking a `hideOnClick` callback', async () => {
+			const hideOnClick = jest.fn( () => false );
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item hideOnClick={ hideOnClick }>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( hideOnClick ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should retain focus moved outside by an item click handler', async () => {
+			let outsideDestination: HTMLButtonElement | null = null;
+			render(
+				<>
+					<button
+						ref={ ( element ) => {
+							outsideDestination = element;
+						} }
+					>
+						Outside destination
+					</button>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item
+								onClick={ () => outsideDestination?.focus() }
+							>
+								Menu item
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
+		} );
+
+		it( 'should not close when item activation is prevented', async () => {
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item
+							onClick={ ( event ) => event.preventDefault() }
+						>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
 			await user.click( screen.getByRole( 'menuitem' ) );
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
@@ -445,8 +657,9 @@ describe( 'Menu', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'should check radio items and keep the menu open when clicking (controlled)', async () => {
+		it( 'should check radio items and close the menu when clicking (controlled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
+			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ radioValue, setRadioValue ] = useState( 'two' );
@@ -466,6 +679,7 @@ describe( 'Menu', () => {
 									value="radio-one"
 									checked={ radioValue === 'radio-one' }
 									onChange={ onRadioChange }
+									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item one
 								</Menu.RadioItem>
@@ -474,6 +688,7 @@ describe( 'Menu', () => {
 									value="radio-two"
 									checked={ radioValue === 'radio-two' }
 									onChange={ onRadioChange }
+									hideOnClick={ hideOnClickSpy }
 								>
 									Radio item two
 								</Menu.RadioItem>
@@ -503,12 +718,13 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
+			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
 
-			// Make sure that first radio is checked
+			await openMenu( user );
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).toBeChecked();
@@ -516,25 +732,26 @@ describe( 'Menu', () => {
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).not.toBeChecked();
 
-			// Click second radio item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			);
+			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-two'
 			);
 
-			// Make sure that second radio is selected
+			await openMenu( user );
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			).not.toBeChecked();
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).toBeChecked();
+			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
+		it( 'should check radio items and close the menu when clicking (uncontrolled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
 			render(
 				<Menu>
@@ -583,39 +800,16 @@ describe( 'Menu', () => {
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
 			);
+			await waitForClosedMenu();
 			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
 				'radio-one'
 			);
-
-			// Make sure that first radio is checked
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-			).toBeChecked();
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-			).not.toBeChecked();
-
-			// Click second radio item, make sure that the callback fires
-			await user.click(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-			);
-			expect( onRadioValueChangeSpy ).toHaveBeenCalledTimes( 2 );
-			expect( onRadioValueChangeSpy ).toHaveBeenLastCalledWith(
-				'radio-two'
-			);
-
-			// Make sure that second radio is selected
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item one' } )
-			).not.toBeChecked();
-			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
-			).toBeChecked();
 		} );
 
-		it( 'should check checkbox items and keep the menu open when clicking (controlled)', async () => {
+		it( 'should check checkbox items and close the menu when clicking (controlled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
+			const hideOnClickSpy = jest.fn( () => false );
 
 			const ControlledRadioGroup = () => {
 				const [ itemOneChecked, setItemOneChecked ] =
@@ -631,6 +825,7 @@ describe( 'Menu', () => {
 								name="item-one"
 								value="item-one-value"
 								checked={ itemOneChecked }
+								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -647,6 +842,7 @@ describe( 'Menu', () => {
 								name="item-two"
 								value="item-two-value"
 								checked={ itemTwoChecked }
+								hideOnClick={ hideOnClickSpy }
 								onChange={ ( e ) => {
 									onCheckboxValueChangeSpy(
 										e.target.name,
@@ -691,6 +887,7 @@ describe( 'Menu', () => {
 					name: 'Checkbox item one',
 				} )
 			);
+			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-one',
@@ -698,6 +895,7 @@ describe( 'Menu', () => {
 				true
 			);
 
+			await openMenu( user );
 			// Make sure that first checkbox is checked
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -711,6 +909,7 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
+			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -718,6 +917,7 @@ describe( 'Menu', () => {
 				true
 			);
 
+			await openMenu( user );
 			// Make sure that second checkbox is selected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
@@ -731,6 +931,7 @@ describe( 'Menu', () => {
 					name: 'Checkbox item two',
 				} )
 			);
+			await waitForClosedMenu();
 			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
@@ -738,15 +939,17 @@ describe( 'Menu', () => {
 				false
 			);
 
+			await openMenu( user );
 			// Make sure that second checkbox is unselected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			).not.toBeChecked();
+			expect( hideOnClickSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should check checkbox items and keep the menu open when clicking (uncontrolled)', async () => {
+		it( 'should check checkbox items and close the menu when clicking (uncontrolled)', async () => {
 			const onCheckboxValueChangeSpy = jest.fn();
 
 			render(
@@ -805,65 +1008,19 @@ describe( 'Menu', () => {
 				} )
 			).toBeChecked();
 
-			// Click first checkbox item, make sure that the callback fires
-			await user.click(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item one',
-				} )
-			);
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
-			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-				'item-one',
-				'item-one-value',
-				true
-			);
-
-			// Make sure that first checkbox is checked
-			expect(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item one',
-				} )
-			).toBeChecked();
-
-			// Click second checkbox item, make sure that the callback fires
+			// Click the checked item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
 				} )
 			);
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 2 );
+			await waitForClosedMenu();
+			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
 				'item-two',
 				'item-two-value',
 				false
 			);
-
-			// Make sure that second checkbox is unchecked
-			expect(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item two',
-				} )
-			).not.toBeChecked();
-
-			// Click second checkbox item, make sure that the callback fires
-			await user.click(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item two',
-				} )
-			);
-			expect( onCheckboxValueChangeSpy ).toHaveBeenCalledTimes( 3 );
-			expect( onCheckboxValueChangeSpy ).toHaveBeenLastCalledWith(
-				'item-two',
-				'item-two-value',
-				true
-			);
-
-			// Make sure that second checkbox is unselected
-			expect(
-				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Checkbox item two',
-				} )
-			).toBeChecked();
 		} );
 	} );
 
@@ -931,7 +1088,7 @@ describe( 'Menu', () => {
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the Menu to close.
 			await user.tab();
-			expect( outerButton ).toBeVisible();
+			expect( outerButton ).toHaveFocus();
 			await waitFor( () =>
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
 			);

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -169,12 +169,13 @@ export interface ItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * This prop has no effect and remains available for backward compatibility.
-	 * Boolean and callback values are ignored, and callback values are not
-	 * invoked. Every eligible `Menu.Item` activation closes the menu.
+	 * Determines if the menu should hide when this item is clicked.
 	 *
-	 * Ariakit's safeguards for disabled items, prevented events, modified links,
-	 * downloads, and submenu triggers still apply.
+	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
+	 * link and modifier keys are used to either open the link in a new tab or
+	 * download it.
+	 *
+	 * @default true
 	 */
 	hideOnClick?: Ariakit.MenuItemProps[ 'hideOnClick' ];
 	/**
@@ -196,7 +197,7 @@ export interface ItemProps {
 	 * The ariakit menu store. This prop is only meant for internal use.
 	 * @ignore
 	 */
-	store?: Ariakit.MenuStore;
+	store?: Ariakit.MenuItemProps[ 'store' ];
 }
 
 export interface CheckboxItemProps {
@@ -211,12 +212,13 @@ export interface CheckboxItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * This prop has no effect and remains available for backward compatibility.
-	 * Boolean and callback values are ignored, and callback values are not
-	 * invoked. Every eligible `Menu.CheckboxItem` activation closes the menu.
+	 * Determines if the menu should hide when this item is clicked.
 	 *
-	 * Ariakit's safeguards for disabled items, prevented events, modified links,
-	 * downloads, and submenu triggers still apply.
+	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
+	 * link and modifier keys are used to either open the link in a new tab or
+	 * download it.
+	 *
+	 * @default false
 	 */
 	hideOnClick?: Ariakit.MenuItemCheckboxProps[ 'hideOnClick' ];
 	/**
@@ -274,12 +276,13 @@ export interface RadioItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * This prop has no effect and remains available for backward compatibility.
-	 * Boolean and callback values are ignored, and callback values are not
-	 * invoked. Every eligible `Menu.RadioItem` activation closes the menu.
+	 * Determines if the menu should hide when this item is clicked.
 	 *
-	 * Ariakit's safeguards for disabled items, prevented events, modified links,
-	 * downloads, and submenu triggers still apply.
+	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
+	 * link and modifier keys are used to either open the link in a new tab or
+	 * download it.
+	 *
+	 * @default false
 	 */
 	hideOnClick?: Ariakit.MenuItemRadioProps[ 'hideOnClick' ];
 	/**

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -169,13 +169,12 @@ export interface ItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Determines if the menu should hide when this item is clicked.
+	 * This prop has no effect and remains available for backward compatibility.
+	 * Boolean and callback values are ignored, and callback values are not
+	 * invoked. Every eligible `Menu.Item` activation closes the menu.
 	 *
-	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
-	 * link and modifier keys are used to either open the link in a new tab or
-	 * download it.
-	 *
-	 * @default true
+	 * Ariakit's safeguards for disabled items, prevented events, modified links,
+	 * downloads, and submenu triggers still apply.
 	 */
 	hideOnClick?: Ariakit.MenuItemProps[ 'hideOnClick' ];
 	/**
@@ -197,7 +196,7 @@ export interface ItemProps {
 	 * The ariakit menu store. This prop is only meant for internal use.
 	 * @ignore
 	 */
-	store?: Ariakit.MenuItemProps[ 'store' ];
+	store?: Ariakit.MenuStore;
 }
 
 export interface CheckboxItemProps {
@@ -212,13 +211,12 @@ export interface CheckboxItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Determines if the menu should hide when this item is clicked.
+	 * This prop has no effect and remains available for backward compatibility.
+	 * Boolean and callback values are ignored, and callback values are not
+	 * invoked. Every eligible `Menu.CheckboxItem` activation closes the menu.
 	 *
-	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
-	 * link and modifier keys are used to either open the link in a new tab or
-	 * download it.
-	 *
-	 * @default false
+	 * Ariakit's safeguards for disabled items, prevented events, modified links,
+	 * downloads, and submenu triggers still apply.
 	 */
 	hideOnClick?: Ariakit.MenuItemCheckboxProps[ 'hideOnClick' ];
 	/**
@@ -276,13 +274,12 @@ export interface RadioItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Determines if the menu should hide when this item is clicked.
+	 * This prop has no effect and remains available for backward compatibility.
+	 * Boolean and callback values are ignored, and callback values are not
+	 * invoked. Every eligible `Menu.RadioItem` activation closes the menu.
 	 *
-	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
-	 * link and modifier keys are used to either open the link in a new tab or
-	 * download it.
-	 *
-	 * @default false
+	 * Ariakit's safeguards for disabled items, prevented events, modified links,
+	 * downloads, and submenu triggers still apply.
 	 */
 	hideOnClick?: Ariakit.MenuItemRadioProps[ 'hideOnClick' ];
 	/**

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -172,13 +172,12 @@ export interface ItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Determines if the menu should hide when this item is clicked.
+	 * This prop has no effect and remains available for backward compatibility.
+	 * Boolean and callback values are ignored, and callback values are not
+	 * invoked. Every eligible `Menu.Item` activation closes the menu.
 	 *
-	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
-	 * link and modifier keys are used to either open the link in a new tab or
-	 * download it.
-	 *
-	 * @default true
+	 * Ariakit's safeguards for disabled items, prevented events, modified links,
+	 * downloads, and submenu triggers still apply.
 	 */
 	hideOnClick?: Ariakit.MenuItemProps[ 'hideOnClick' ];
 	/**
@@ -200,7 +199,7 @@ export interface ItemProps {
 	 * The ariakit menu store. This prop is only meant for internal use.
 	 * @ignore
 	 */
-	store?: Ariakit.MenuItemProps[ 'store' ];
+	store?: Ariakit.MenuStore;
 }
 
 export interface CheckboxItemProps {
@@ -215,13 +214,12 @@ export interface CheckboxItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Determines if the menu should hide when this item is clicked.
+	 * This prop has no effect and remains available for backward compatibility.
+	 * Boolean and callback values are ignored, and callback values are not
+	 * invoked. Every eligible `Menu.CheckboxItem` activation closes the menu.
 	 *
-	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
-	 * link and modifier keys are used to either open the link in a new tab or
-	 * download it.
-	 *
-	 * @default false
+	 * Ariakit's safeguards for disabled items, prevented events, modified links,
+	 * downloads, and submenu triggers still apply.
 	 */
 	hideOnClick?: Ariakit.MenuItemCheckboxProps[ 'hideOnClick' ];
 	/**
@@ -279,13 +277,12 @@ export interface RadioItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * Determines if the menu should hide when this item is clicked.
+	 * This prop has no effect and remains available for backward compatibility.
+	 * Boolean and callback values are ignored, and callback values are not
+	 * invoked. Every eligible `Menu.RadioItem` activation closes the menu.
 	 *
-	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
-	 * link and modifier keys are used to either open the link in a new tab or
-	 * download it.
-	 *
-	 * @default false
+	 * Ariakit's safeguards for disabled items, prevented events, modified links,
+	 * downloads, and submenu triggers still apply.
 	 */
 	hideOnClick?: Ariakit.MenuItemRadioProps[ 'hideOnClick' ];
 	/**

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -172,12 +172,13 @@ export interface ItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * This prop has no effect and remains available for backward compatibility.
-	 * Boolean and callback values are ignored, and callback values are not
-	 * invoked. Every eligible `Menu.Item` activation closes the menu.
+	 * Determines if the menu should hide when this item is clicked.
 	 *
-	 * Ariakit's safeguards for disabled items, prevented events, modified links,
-	 * downloads, and submenu triggers still apply.
+	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
+	 * link and modifier keys are used to either open the link in a new tab or
+	 * download it.
+	 *
+	 * @default true
 	 */
 	hideOnClick?: Ariakit.MenuItemProps[ 'hideOnClick' ];
 	/**
@@ -199,7 +200,7 @@ export interface ItemProps {
 	 * The ariakit menu store. This prop is only meant for internal use.
 	 * @ignore
 	 */
-	store?: Ariakit.MenuStore;
+	store?: Ariakit.MenuItemProps[ 'store' ];
 }
 
 export interface CheckboxItemProps {
@@ -214,12 +215,13 @@ export interface CheckboxItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * This prop has no effect and remains available for backward compatibility.
-	 * Boolean and callback values are ignored, and callback values are not
-	 * invoked. Every eligible `Menu.CheckboxItem` activation closes the menu.
+	 * Determines if the menu should hide when this item is clicked.
 	 *
-	 * Ariakit's safeguards for disabled items, prevented events, modified links,
-	 * downloads, and submenu triggers still apply.
+	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
+	 * link and modifier keys are used to either open the link in a new tab or
+	 * download it.
+	 *
+	 * @default false
 	 */
 	hideOnClick?: Ariakit.MenuItemCheckboxProps[ 'hideOnClick' ];
 	/**
@@ -277,12 +279,13 @@ export interface RadioItemProps {
 	 */
 	suffix?: React.ReactNode;
 	/**
-	 * This prop has no effect and remains available for backward compatibility.
-	 * Boolean and callback values are ignored, and callback values are not
-	 * invoked. Every eligible `Menu.RadioItem` activation closes the menu.
+	 * Determines if the menu should hide when this item is clicked.
 	 *
-	 * Ariakit's safeguards for disabled items, prevented events, modified links,
-	 * downloads, and submenu triggers still apply.
+	 * **Note**: This behavior isn't triggered if this menu item is rendered as a
+	 * link and modifier keys are used to either open the link in a new tab or
+	 * download it.
+	 *
+	 * @default false
 	 */
 	hideOnClick?: Ariakit.MenuItemRadioProps[ 'hideOnClick' ];
 	/**

--- a/packages/components/src/menu/use-menu-item-hide-on-click.ts
+++ b/packages/components/src/menu/use-menu-item-hide-on-click.ts
@@ -28,31 +28,47 @@ function focusDisclosureElement( disclosureElement: HTMLElement ) {
 	);
 }
 
-export function useMenuItemHideOnClick( store?: Ariakit.MenuStore ) {
-	return useCallback( () => {
-		if ( ! store ) {
+export function useMenuItemHideOnClick(
+	store: Ariakit.MenuItemProps[ 'store' ],
+	hideOnClick: Ariakit.MenuItemProps[ 'hideOnClick' ]
+) {
+	return useCallback(
+		( event: React.MouseEvent< HTMLElement > ) => {
+			const shouldHide =
+				typeof hideOnClick === 'function'
+					? hideOnClick( event )
+					: hideOnClick;
+
+			if ( ! shouldHide ) {
+				return false;
+			}
+
+			if ( ! store || ! ( 'hideAll' in store ) ) {
+				return true;
+			}
+
+			const menuElement = store.getState().contentElement;
+			const activeElement = menuElement?.ownerDocument.activeElement;
+
+			if ( menuElement?.contains( activeElement ?? null ) ) {
+				let rootStore = store;
+				while ( rootStore.parent ) {
+					rootStore = rootStore.parent;
+				}
+
+				const disclosureElement =
+					rootStore.getState().disclosureElement;
+
+				// Ariakit calls this immediately before it hides and unmounts the
+				// menu. Move focus first so an overlay opened by the item's onClick
+				// captures the root trigger as its focus return target.
+				if ( disclosureElement ) {
+					focusDisclosureElement( disclosureElement );
+				}
+			}
+
 			return true;
-		}
-
-		const menuElement = store.getState().contentElement;
-		const activeElement = menuElement?.ownerDocument.activeElement;
-
-		if ( menuElement?.contains( activeElement ?? null ) ) {
-			let rootStore = store;
-			while ( rootStore.parent ) {
-				rootStore = rootStore.parent;
-			}
-
-			const disclosureElement = rootStore.getState().disclosureElement;
-
-			// Ariakit calls this immediately before it hides and unmounts the
-			// menu. Move focus first so an overlay opened by the item's onClick
-			// captures the root trigger as its focus return target.
-			if ( disclosureElement ) {
-				focusDisclosureElement( disclosureElement );
-			}
-		}
-
-		return true;
-	}, [ store ] );
+		},
+		[ hideOnClick, store ]
+	);
 }

--- a/packages/components/src/menu/use-menu-item-hide-on-click.ts
+++ b/packages/components/src/menu/use-menu-item-hide-on-click.ts
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import type * as Ariakit from '@ariakit/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+function focusDisclosureElement( disclosureElement: HTMLElement ) {
+	disclosureElement.focus();
+
+	if ( disclosureElement.ownerDocument.activeElement === disclosureElement ) {
+		return;
+	}
+
+	// A modal Ariakit menu disables the document tree outside the menu. Modern
+	// browsers use `inert`; Ariakit's fallback replaces each element's `focus`
+	// method. Ariakit restores either mechanism as soon as the menu hides.
+	const inertAncestor = disclosureElement.closest< HTMLElement >( '[inert]' );
+	if ( inertAncestor ) {
+		inertAncestor.inert = false;
+	}
+
+	disclosureElement.ownerDocument.defaultView?.HTMLElement.prototype.focus.call(
+		disclosureElement
+	);
+}
+
+export function useMenuItemHideOnClick( store?: Ariakit.MenuStore ) {
+	return useCallback( () => {
+		if ( ! store ) {
+			return true;
+		}
+
+		const menuElement = store.getState().contentElement;
+		const activeElement = menuElement?.ownerDocument.activeElement;
+
+		if ( menuElement?.contains( activeElement ?? null ) ) {
+			let rootStore = store;
+			while ( rootStore.parent ) {
+				rootStore = rootStore.parent;
+			}
+
+			const disclosureElement = rootStore.getState().disclosureElement;
+
+			// Ariakit calls this immediately before it hides and unmounts the
+			// menu. Move focus first so an overlay opened by the item's onClick
+			// captures the root trigger as its focus return target.
+			if ( disclosureElement ) {
+				focusDisclosureElement( disclosureElement );
+			}
+		}
+
+		return true;
+	}, [ store ] );
+}

--- a/packages/components/src/menu/use-menu-item-hide-on-click.ts
+++ b/packages/components/src/menu/use-menu-item-hide-on-click.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import type * as Ariakit from '@ariakit/react';
-
-/**
- * WordPress dependencies
- */
 import { useCallback } from '@wordpress/element';
 
 function focusDisclosureElement( disclosureElement: HTMLElement ) {

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -163,6 +163,7 @@ Titles are required for accessibility reasons, see `contentLabel` and `title` fo
 #### `bodyOpenClassName`: `string`
 
 Class name added to the body element when the modal is open.
+If you use a custom class name, its styles must set `overflow: hidden` to preserve the Modal's scroll lock.
 
 -   Required: No
 -   Default: `modal-open`

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,6 +5,10 @@
 @use "@wordpress/base-styles/z-index" as *;
 @use "../utils/theme-variables" as *;
 
+body.modal-open {
+	overflow: hidden;
+}
+
 // The scrim behind the modal window.
 .components-modal__screen-overlay {
 	position: fixed;

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -20,6 +20,8 @@ export type ModalProps = {
 	};
 	/**
 	 * Class name added to the body element when the modal is open.
+	 * If you use a custom class name, its styles must set `overflow: hidden`
+	 * to preserve the Modal's scroll lock.
 	 *
 	 * @default 'modal-open'
 	 */

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -761,11 +761,6 @@
 			"count": 3
 		}
 	},
-	"packages/components/src/menu/stories/index.story.tsx": {
-		"no-restricted-imports": {
-			"count": 1
-		}
-	},
 	"packages/components/src/menu/styles.ts": {
 		"no-restricted-imports": {
 			"count": 2


### PR DESCRIPTION
## What?

Closes #80734.

Restores focus return when a legacy `Modal` opens from a closing Menu. It also makes the default Modal scroll lock work without WordPress `common.css`.

The existing `hideOnClick` behavior is unchanged.

## Why?

#77460 made menus unmount immediately to preserve the menu-to-Modal scroll-lock handoff. The focused item now disappeared before Modal captured its focus-return target, so focus returned to the page instead of the root menu button.

## How?

When an item is about to close its menu and focus is still inside it, focus moves to the root menu button before Ariakit unmounts the menu. The immediate teardown and Ariakit activation safeguards remain unchanged.

Modal now includes the default `body.modal-open { overflow: hidden; }` style. Custom `bodyOpenClassName` values still require their own scroll-lock CSS.

## Testing Instructions

1. Open **Components / Actions / Menu / With Modal** in Storybook with **Global CSS: Font only**.
2. Open the menu and select **Open modal**.
3. Confirm that the menu closes and scrolling stays locked.
4. Close the Modal.
5. Confirm that scrolling is restored and focus returns to **Open menu**.

### Testing Instructions for Keyboard

Repeat using Enter to select **Open modal**.

## Screenshots or screencast

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/580c7722-375c-455f-90cc-0142f5a9713b" /> | <video src="https://github.com/user-attachments/assets/1fd03818-a788-466a-aa41-5822795ad28b" /> |

## Use of AI Tools

Codex was used to inspect the regression history and installed source, implement the focused change and tests, and run verification. The resulting diff and test evidence were reviewed locally.
