### PR TITLE
Try: scope the editable root to the nearest block list container

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -73,20 +73,20 @@ export function useFocusHandler( clientId ) {
 					return;
 				}
 
-				// While the wrapper is an editing host, it holds focus on
-				// behalf of the caret inside it. When the caret lives in a
-				// descendant block, focus arriving on the wrapper is host
-				// engagement, not the user targeting this block: the caret
-				// decides the selection.
-				if (
-					event.target === node &&
-					node.contentEditable === 'true'
-				) {
+				// An engaged editing host (the block's own element, or its
+				// inner block list) holds focus on behalf of the caret
+				// inside it. When the caret lives in a descendant block,
+				// focus arriving on such an editable is host engagement,
+				// not the user targeting this block: the caret decides the
+				// selection. Only block lists contain other blocks, so an
+				// editable target containing another block's caret can only
+				// be an engaged host.
+				if ( event.target.contentEditable === 'true' ) {
 					const { anchorNode } =
 						node.ownerDocument.defaultView.getSelection();
 					if (
 						anchorNode &&
-						node.contains( anchorNode ) &&
+						event.target.contains( anchorNode ) &&
 						getBlockClientId( anchorNode ) !== clientId
 					) {
 						return;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -10,7 +10,7 @@ import {
 /**
  * Internal dependencies
  */
-import { isInsideRootBlock } from '../../../utils/dom';
+import { getBlockClientId, isInsideRootBlock } from '../../../utils/dom';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
@@ -71,6 +71,26 @@ export function useFocusHandler( clientId ) {
 				// setting the selected block.
 				if ( ! isInsideRootBlock( node, event.target ) ) {
 					return;
+				}
+
+				// While the wrapper is an editing host, it holds focus on
+				// behalf of the caret inside it. When the caret lives in a
+				// descendant block, focus arriving on the wrapper is host
+				// engagement, not the user targeting this block: the caret
+				// decides the selection.
+				if (
+					event.target === node &&
+					node.contentEditable === 'true'
+				) {
+					const { anchorNode } =
+						node.ownerDocument.defaultView.getSelection();
+					if (
+						anchorNode &&
+						node.contains( anchorNode ) &&
+						getBlockClientId( anchorNode ) !== clientId
+					) {
+						return;
+					}
 				}
 
 				// For editable targets, select without initial caret

--- a/packages/block-editor/src/components/block-list/use-editable-root-host.js
+++ b/packages/block-editor/src/components/block-list/use-editable-root-host.js
@@ -53,6 +53,7 @@ export default function useEditableRootHost( rootClientId = '' ) {
 				getSelectionStart,
 				getBlockRootClientId,
 				hasMultiSelection,
+				isMultiSelecting,
 				getSelectedBlockClientId,
 				canHostEditableRoot,
 			} = unlock( select( blockEditorStore ) );
@@ -62,7 +63,11 @@ export default function useEditableRootHost( rootClientId = '' ) {
 				return (
 					getBlockRootClientId( selectedClientId ) ===
 						rootClientId &&
-					canHostEditableRoot( selectedClientId )
+					( canHostEditableRoot( selectedClientId ) ||
+						// A selection gesture in progress (e.g. a drag
+						// leaving the block) needs the list editable so the
+						// native selection can extend across its blocks.
+						isMultiSelecting() )
 				);
 			}
 

--- a/packages/block-editor/src/components/block-list/use-editable-root-host.js
+++ b/packages/block-editor/src/components/block-list/use-editable-root-host.js
@@ -10,6 +10,31 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const layoutElements = new WeakSet();
+
+/**
+ * Registers a block list layout element. A ref callback: every layout
+ * element rendered by useInnerBlocksProps registers itself.
+ *
+ * @param {?HTMLElement} element Layout element.
+ */
+export function registerBlockListLayout( element ) {
+	if ( element ) {
+		layoutElements.add( element );
+	}
+}
+
+/**
+ * Whether the element is a block list layout element.
+ *
+ * @param {HTMLElement} element Element to check.
+ *
+ * @return {boolean} Whether the element is a block list layout.
+ */
+export function isBlockListLayout( element ) {
+	return layoutElements.has( element );
+}
+
 /**
  * Makes the block list layout element declare itself the editing host while
  * it is the nearest block list containing the selection: the selected block

--- a/packages/block-editor/src/components/block-list/use-editable-root-host.js
+++ b/packages/block-editor/src/components/block-list/use-editable-root-host.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Makes the block list layout element declare itself the editing host while
+ * it is the nearest block list containing the selection: the selected block
+ * supports `editableRoot`, or a multi-selection spans the list's blocks. The
+ * host presents as a named multiline textbox, per the WAI-ARIA textbox role.
+ *
+ * @param {?string} rootClientId The client ID of the block whose inner
+ *                               blocks the layout element renders, if any.
+ *
+ * @return {Object} Props to apply to the layout element.
+ */
+export default function useEditableRootHost( rootClientId = '' ) {
+	const isHost = useSelect(
+		( select ) => {
+			const {
+				getSelectionStart,
+				getBlockRootClientId,
+				hasMultiSelection,
+				getSelectedBlockClientId,
+				canHostEditableRoot,
+			} = unlock( select( blockEditorStore ) );
+			const selectedClientId = getSelectedBlockClientId();
+
+			if ( selectedClientId ) {
+				return (
+					getBlockRootClientId( selectedClientId ) ===
+						rootClientId &&
+					canHostEditableRoot( selectedClientId )
+				);
+			}
+
+			// A multi-selection always makes its list the editing host so
+			// the native selection can extend across the blocks. The store
+			// promotes multi-selections to sibling level, so the start
+			// block's root is the list containing the whole selection.
+			if ( hasMultiSelection() ) {
+				return (
+					getBlockRootClientId( getSelectionStart().clientId ) ===
+					rootClientId
+				);
+			}
+
+			return false;
+		},
+		[ rootClientId ]
+	);
+
+	if ( ! isHost ) {
+		return {};
+	}
+
+	return {
+		contentEditable: 'true',
+		suppressContentEditableWarning: true,
+		role: 'textbox',
+		'aria-multiline': 'true',
+		'aria-label': __( 'Editor canvas' ),
+	};
+}

--- a/packages/block-editor/src/components/block-list/use-editable-root-host.js
+++ b/packages/block-editor/src/components/block-list/use-editable-root-host.js
@@ -22,7 +22,7 @@ import { unlock } from '../../lock-unlock';
  * @return {Object} Props to apply to the layout element.
  */
 export default function useEditableRootHost( rootClientId = '' ) {
-	const isHost = useSelect(
+	const hostState = useSelect(
 		( select ) => {
 			const {
 				getSelectionStart,
@@ -42,7 +42,8 @@ export default function useEditableRootHost( rootClientId = '' ) {
 						// A selection gesture in progress (e.g. a drag
 						// leaving the block) needs the list editable so the
 						// native selection can extend across its blocks.
-						isMultiSelecting() )
+						isMultiSelecting() ) &&
+					'single'
 				);
 			}
 
@@ -53,7 +54,7 @@ export default function useEditableRootHost( rootClientId = '' ) {
 			if ( hasMultiSelection() ) {
 				return (
 					getBlockRootClientId( getSelectionStart().clientId ) ===
-					rootClientId
+						rootClientId && 'multi'
 				);
 			}
 
@@ -62,7 +63,7 @@ export default function useEditableRootHost( rootClientId = '' ) {
 		[ rootClientId ]
 	);
 
-	if ( ! isHost ) {
+	if ( ! hostState ) {
 		return {};
 	}
 
@@ -71,6 +72,9 @@ export default function useEditableRootHost( rootClientId = '' ) {
 		suppressContentEditableWarning: true,
 		role: 'textbox',
 		'aria-multiline': 'true',
-		'aria-label': __( 'Editor canvas' ),
+		'aria-label':
+			hostState === 'multi'
+				? __( 'Multiple selected blocks' )
+				: __( 'Editor canvas' ),
 	};
 }

--- a/packages/block-editor/src/components/block-list/use-editable-root-host.js
+++ b/packages/block-editor/src/components/block-list/use-editable-root-host.js
@@ -10,31 +10,6 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const layoutElements = new WeakSet();
-
-/**
- * Registers a block list layout element. A ref callback: every layout
- * element rendered by useInnerBlocksProps registers itself.
- *
- * @param {?HTMLElement} element Layout element.
- */
-export function registerBlockListLayout( element ) {
-	if ( element ) {
-		layoutElements.add( element );
-	}
-}
-
-/**
- * Whether the element is a block list layout element.
- *
- * @param {HTMLElement} element Element to check.
- *
- * @return {boolean} Whether the element is a block list layout.
- */
-export function isBlockListLayout( element ) {
-	return layoutElements.has( element );
-}
-
 /**
  * Makes the block list layout element declare itself the editing host while
  * it is the nearest block list containing the selection: the selected block

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -28,7 +28,9 @@ import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
-import useEditableRootHost from '../block-list/use-editable-root-host';
+import useEditableRootHost, {
+	registerBlockListLayout,
+} from '../block-list/use-editable-root-host';
 import useBlockDropZone from '../use-block-drop-zone';
 import { unlock } from '../../lock-unlock';
 
@@ -268,6 +270,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 	const ref = useMergeRefs( [
 		props.ref,
+		registerBlockListLayout,
 		__unstableDisableDropZone ||
 		isDropZoneDisabled ||
 		( layout?.isManualPlacement &&

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -28,9 +28,7 @@ import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
-import useEditableRootHost, {
-	registerBlockListLayout,
-} from '../block-list/use-editable-root-host';
+import useEditableRootHost from '../block-list/use-editable-root-host';
 import useBlockDropZone from '../use-block-drop-zone';
 import { unlock } from '../../lock-unlock';
 
@@ -270,7 +268,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 	const ref = useMergeRefs( [
 		props.ref,
-		registerBlockListLayout,
 		__unstableDisableDropZone ||
 		isDropZoneDisabled ||
 		( layout?.isManualPlacement &&

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -28,6 +28,7 @@ import { BlockContextProvider } from '../block-context';
 import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
+import useEditableRootHost from '../block-list/use-editable-root-host';
 import useBlockDropZone from '../use-block-drop-zone';
 import { unlock } from '../../lock-unlock';
 
@@ -263,6 +264,8 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		parentClientId,
 	} );
 
+	const hostProps = useEditableRootHost( clientId );
+
 	const ref = useMergeRefs( [
 		props.ref,
 		__unstableDisableDropZone ||
@@ -289,6 +292,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 	return {
 		...props,
+		...hostProps,
 		ref,
 		className: clsx(
 			props.className,

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -28,6 +28,7 @@ import useClickSelection from './use-click-selection';
 import useInput from './use-input';
 import useClipboardHandler from './use-clipboard-handler';
 import { store as blockEditorStore } from '../../store';
+import { getEditableRootElement } from './utils';
 
 export function useWritingFlow() {
 	const [ before, ref, after ] = useTabNav();
@@ -73,7 +74,7 @@ export function useWritingFlow() {
 						// The wrapper may remain the editing host (the
 						// collapsed block supports `editableRoot`): keep it
 						// named, as the textbox role requires.
-						if ( node.contentEditable === 'true' ) {
+						if ( getEditableRootElement( node ) ) {
 							node.setAttribute(
 								'aria-label',
 								__( 'Editor canvas' )

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -64,24 +64,10 @@ export function useWritingFlow() {
 						};
 					}
 
-					node.setAttribute(
-						'aria-label',
-						__( 'Multiple selected blocks' )
-					);
-
+					// The editing host names itself (see
+					// useEditableRootHost).
 					return () => {
 						delete node.dataset.hasMultiSelection;
-						// The wrapper may remain the editing host (the
-						// collapsed block supports `editableRoot`): keep it
-						// named, as the textbox role requires.
-						if ( getEditableRootElement( node ) ) {
-							node.setAttribute(
-								'aria-label',
-								__( 'Editor canvas' )
-							);
-						} else {
-							node.removeAttribute( 'aria-label' );
-						}
 					};
 				},
 				[ hasMultiSelection ]

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -174,6 +174,7 @@ export function getClosestTabbable(
 
 export default function useArrowNav() {
 	const {
+		getBlockRootClientId,
 		getMultiSelectedBlocksStartClientId,
 		getMultiSelectedBlocksEndClientId,
 		getNextBlockClientId,
@@ -193,15 +194,6 @@ export default function useArrowNav() {
 
 		function onMouseDown() {
 			verticalRect = null;
-		}
-
-		function isClosestTabbableABlock( target, isReverse ) {
-			const closestTabbable = getClosestTabbable(
-				target,
-				isReverse,
-				node
-			);
-			return closestTabbable && getBlockClientId( closestTabbable );
 		}
 
 		function onKeyDown( event ) {
@@ -280,6 +272,36 @@ export default function useArrowNav() {
 							event.preventDefault();
 						}
 					}
+
+					// A partial multi-selection extends natively, keeping
+					// character granularity. The extension can enter a block
+					// beyond the engaged editing host (e.g. the paragraph
+					// before a list): a native selection cannot leave its
+					// host, so the host must become the block list
+					// containing both the selection and that block.
+					if ( ! event.defaultPrevented ) {
+						let endClientId = getMultiSelectedBlocksEndClientId();
+						let adjacentClientId;
+						while ( endClientId && ! adjacentClientId ) {
+							adjacentClientId = isReverse
+								? getPreviousBlockClientId( endClientId )
+								: getNextBlockClientId( endClientId );
+							if ( ! adjacentClientId ) {
+								endClientId =
+									getBlockRootClientId( endClientId );
+							}
+						}
+						const within =
+							adjacentClientId &&
+							ownerDocument.getElementById(
+								'block-' + adjacentClientId
+							);
+						if ( within ) {
+							setContentEditableWrapper( node, true, {
+								within,
+							} );
+						}
+					}
 					return;
 				}
 
@@ -346,8 +368,23 @@ export default function useArrowNav() {
 
 			if ( shiftKey ) {
 				if ( isNavEdge( target, isReverse ) ) {
-					if ( isClosestTabbableABlock( target, isReverse ) ) {
-						setContentEditableWrapper( node, true );
+					const closestTabbable = getClosestTabbable(
+						target,
+						isReverse,
+						node
+					);
+					if (
+						closestTabbable &&
+						getBlockClientId( closestTabbable )
+					) {
+						// The selection is about to extend into the adjacent
+						// block, which can lie outside the engaged editing
+						// host (e.g. the paragraph after a list): a native
+						// selection cannot leave its host, so the host must
+						// be the block list containing both.
+						setContentEditableWrapper( node, true, {
+							within: closestTabbable,
+						} );
 					} else if ( getEditableRootElement( node ) ) {
 						// There is no block to extend the selection into.
 						// Within an editable wrapper the selection could

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -248,18 +248,24 @@ export default function useArrowNav() {
 			// selection to the start or end of the selection.
 			if ( hasMultiSelection() ) {
 				if ( shiftKey ) {
-					// A fully selected multi-selection has no native
-					// selection to extend (use-multi-selection cleared it),
-					// so grow or shrink it by one block at the focus end.
-					// Only without a usable native selection: a selection
-					// that is fully selected because it resolves to a
-					// nesting ancestor keeps its native selection, which
-					// the browser extends natively (and the observer
-					// promotes to the common level).
+					// A fully selected multi-selection is represented
+					// natively by a range with block-element boundaries
+					// (see use-multi-selection), which cannot extend
+					// natively: the browser drops the element-level anchor
+					// and re-anchors at the focus. Grow or shrink it by one
+					// block at the focus end instead. A selection anchored
+					// in text (e.g. fully selected because it resolves to a
+					// nesting ancestor) extends natively, keeping character
+					// granularity, and the observer promotes to the common
+					// level.
 					const selection = defaultView.getSelection();
+					const { anchorNode } = selection;
+					const hasTextAnchor =
+						anchorNode &&
+						anchorNode.nodeType === anchorNode.TEXT_NODE;
 					if (
 						__unstableIsFullySelected() &&
-						( ! selection.rangeCount || selection.isCollapsed )
+						( ! hasTextAnchor || selection.isCollapsed )
 					) {
 						const anchorClientId =
 							getMultiSelectedBlocksStartClientId();

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -20,7 +20,7 @@ import { useRefEffect } from '@wordpress/compose';
  */
 import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
-import { setContentEditableWrapper } from './utils';
+import { getEditableRootElement, setContentEditableWrapper } from './utils';
 
 /**
  * Returns true if the element should consider edge navigation upon a keyboard
@@ -216,7 +216,7 @@ export default function useArrowNav() {
 			// selected block supports `editableRoot`), the event targets the
 			// wrapper; resolve the editable element containing the selection.
 			const target =
-				( event.target === node &&
+				( event.target === getEditableRootElement( node ) &&
 					getSelectionEditableElement(
 						node.ownerDocument.defaultView.getSelection(),
 						node
@@ -342,7 +342,7 @@ export default function useArrowNav() {
 				if ( isNavEdge( target, isReverse ) ) {
 					if ( isClosestTabbableABlock( target, isReverse ) ) {
 						setContentEditableWrapper( node, true );
-					} else if ( node.contentEditable === 'true' ) {
+					} else if ( getEditableRootElement( node ) ) {
 						// There is no block to extend the selection into.
 						// Within an editable wrapper the selection could
 						// natively escape into surrounding editable elements

--- a/packages/block-editor/src/components/writing-flow/use-drag-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-drag-selection.js
@@ -136,10 +136,10 @@ export default function useDragSelection() {
 				// `mouseup` happens anywhere in the window.
 				defaultView.addEventListener( 'mouseup', onMouseUp );
 
-				// Allow cross contentEditable selection by temporarily making
-				// all content editable. We can't rely on using the store and
-				// React because re-rending happens too slowly. We need to be
-				// able to select across instances immediately.
+				// The layout host hook also makes the list editable in
+				// response to `startMultiSelect`, but a React commit does not
+				// reliably land before the drag crosses the block boundary;
+				// engage synchronously and let the render agree.
 				setContentEditableWrapper( node, true );
 			}
 

--- a/packages/block-editor/src/components/writing-flow/use-editable-root-event-handlers.js
+++ b/packages/block-editor/src/components/writing-flow/use-editable-root-event-handlers.js
@@ -11,6 +11,7 @@ import { useContext } from '@wordpress/element';
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 import { BlockRefs } from '../provider/block-refs-provider';
+import { getEditableRootElement } from './utils';
 
 // The React `on*` props the host bridges, mapped to their DOM event type. Only
 // editing events are redirected under `editableRoot` (the wrapper becomes the
@@ -187,9 +188,9 @@ export default function useEditableRootEventHandlers() {
 				// handler to call.
 				if (
 					! eventHandlers.size ||
-					event.target !== node ||
+					event.target !== getEditableRootElement( node ) ||
 					! event.isTrusted ||
-					node.contentEditable !== 'true' ||
+
 					hasMultiSelection()
 				) {
 					return;

--- a/packages/block-editor/src/components/writing-flow/use-editable-root.js
+++ b/packages/block-editor/src/components/writing-flow/use-editable-root.js
@@ -90,11 +90,19 @@ export default function useEditableRoot() {
 				// If the wrapper held focus, return focus to the editable
 				// element containing the selection, which is focusable
 				// again now that the wrapper is no longer an editing host.
-				// Only do so if that element belongs to the selected block:
-				// when the selection moved to another block through the
-				// store, the stale DOM selection must not reclaim block
-				// selection through its focus handler.
-				if ( node.ownerDocument.activeElement === disengaged ) {
+				// Focus can also have dropped to the document default
+				// already: a focus restore attempt targeting the host after
+				// it lost editability falls through to the body. Only do so
+				// if that element belongs to the selected block: when the
+				// selection moved to another block through the store, the
+				// stale DOM selection must not reclaim block selection
+				// through its focus handler.
+				if (
+					node.ownerDocument.activeElement === disengaged ||
+					( node.ownerDocument.activeElement ===
+						node.ownerDocument.body &&
+						node.ownerDocument.hasFocus() )
+				) {
 					const editable = getSelectionEditableElement(
 						node.ownerDocument.defaultView.getSelection(),
 						node

--- a/packages/block-editor/src/components/writing-flow/use-editable-root.js
+++ b/packages/block-editor/src/components/writing-flow/use-editable-root.js
@@ -8,7 +8,7 @@ import { useRefEffect } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { setContentEditableWrapper } from './utils';
+import { getEditableRootElement, setContentEditableWrapper } from './utils';
 import { getBlockClientId, getSelectionEditableElement } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
 
@@ -58,10 +58,11 @@ export default function useEditableRoot() {
 			// placed the caret yet; moving focus now would cancel the
 			// pending caret placement. The selection observer moves focus
 			// once the selection lands.
+			const host = getEditableRootElement( node );
 			const { activeElement } = node.ownerDocument;
 			const selection = node.ownerDocument.defaultView.getSelection();
 			if (
-				activeElement !== node &&
+				activeElement !== host &&
 				activeElement?.isContentEditable &&
 				node.contains( activeElement ) &&
 				getBlockClientId( activeElement ) ===
@@ -69,7 +70,7 @@ export default function useEditableRoot() {
 				selection.anchorNode &&
 				activeElement.contains( selection.anchorNode )
 			) {
-				node.focus();
+				host.focus();
 			}
 
 			return () => {
@@ -83,6 +84,7 @@ export default function useEditableRoot() {
 					return;
 				}
 
+				const disengaged = getEditableRootElement( node );
 				setContentEditableWrapper( node, false );
 
 				// If the wrapper held focus, return focus to the editable
@@ -92,7 +94,7 @@ export default function useEditableRoot() {
 				// when the selection moved to another block through the
 				// store, the stale DOM selection must not reclaim block
 				// selection through its focus handler.
-				if ( node.ownerDocument.activeElement === node ) {
+				if ( node.ownerDocument.activeElement === disengaged ) {
 					const editable = getSelectionEditableElement(
 						node.ownerDocument.defaultView.getSelection(),
 						node

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -16,7 +16,7 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { setContentEditableWrapper } from './utils';
+import { getEditableRootElement, setContentEditableWrapper } from './utils';
 import { getSelectionEditableElement } from '../../utils/dom';
 
 /**
@@ -54,7 +54,7 @@ export default function useInput() {
 			// a single selection when the selected block supports
 			// `editableRoot`; in that case edits within the block's editable
 			// element are handled by its rich text instance.
-			if ( node.contentEditable !== 'true' ) {
+			if ( ! getEditableRootElement( node ) ) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -78,12 +78,13 @@ export default function useMultiSelection() {
 			// happens BEFORE selection removal.
 			setContentEditableWrapper( node, true );
 
-			// Make the native selection span the multi-selected blocks
-			// instead of clearing it: an editing host that holds focus with
-			// no selection gets a caret re-seeded at its start (Chromium),
-			// which the first block's rich text then syncs to the store,
-			// collapsing the multi-selection. A selection that agrees with
-			// the store is stable, and native copy matches what is selected.
+			// Make the native selection agree with the store: a range
+			// spanning the multi-selected blocks. Clearing it instead makes
+			// the focused host re-seed a caret at its start (Chromium),
+			// which the first block's rich text syncs back, collapsing the
+			// multi-selection; leaving the text-level range that formed the
+			// multi-selection makes block-level operations act on the wrong
+			// selection. Both alternatives were measured against this.
 			const firstElement = ownerDocument.getElementById(
 				'block-' + multiSelectedBlockClientIds[ 0 ]
 			);

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -78,7 +78,27 @@ export default function useMultiSelection() {
 			// happens BEFORE selection removal.
 			setContentEditableWrapper( node, true );
 
-			defaultView.getSelection().removeAllRanges();
+			// Make the native selection span the multi-selected blocks
+			// instead of clearing it: an editing host that holds focus with
+			// no selection gets a caret re-seeded at its start (Chromium),
+			// which the first block's rich text then syncs to the store,
+			// collapsing the multi-selection. A selection that agrees with
+			// the store is stable, and native copy matches what is selected.
+			const firstElement = ownerDocument.getElementById(
+				'block-' + multiSelectedBlockClientIds[ 0 ]
+			);
+			const lastElement = ownerDocument.getElementById(
+				'block-' + multiSelectedBlockClientIds[ length - 1 ]
+			);
+
+			if ( firstElement && lastElement ) {
+				const selection = defaultView.getSelection();
+				const range = ownerDocument.createRange();
+				range.setStartBefore( firstElement );
+				range.setEndAfter( lastElement );
+				selection.removeAllRanges();
+				selection.addRange( range );
+			}
 		},
 		[
 			hasMultiSelection,

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -95,8 +95,12 @@ export default function useMultiSelection() {
 			if ( firstElement && lastElement ) {
 				const selection = defaultView.getSelection();
 				const range = ownerDocument.createRange();
-				range.setStartBefore( firstElement );
-				range.setEndAfter( lastElement );
+				// Anchor the boundaries within the block elements, not
+				// around them: a boundary in the parent layout resolves to
+				// the layout's own block (e.g. the column) in the selection
+				// observer, which would rewrite the store selection to it.
+				range.setStart( firstElement, 0 );
+				range.setEnd( lastElement, lastElement.childNodes.length );
 				selection.removeAllRanges();
 				selection.addRange( range );
 			}

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -71,9 +71,14 @@ export default function useSelectAll() {
 			event.preventDefault();
 
 			const [ firstSelectedClientId ] = selectedClientIds;
-			const activeClientId = getBlockClientId(
-				ownerDocument.activeElement
-			);
+			// The engaged editing host holds focus on behalf of the selection
+			// inside it. It can be a block's own element (a block list that
+			// is also a block, e.g. a column), which must not count as the
+			// user focusing that block.
+			const activeClientId =
+				ownerDocument.activeElement === getEditableRootElement( node )
+					? undefined
+					: getBlockClientId( ownerDocument.activeElement );
 
 			// Handle the case when an appender is selected.
 			if (

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -10,6 +10,7 @@ import { useRefEffect } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { getEditableRootElement } from './utils';
 import {
 	isInsideRootBlock,
 	getBlockClientId,
@@ -35,7 +36,7 @@ export default function useSelectAll() {
 			// selected block supports `editableRoot`), the event targets the
 			// wrapper; resolve the editable element containing the selection.
 			const editable =
-				( event.target === node &&
+				( event.target === getEditableRootElement( node ) &&
 					getSelectionEditableElement( selection, node ) ) ||
 				event.target;
 
@@ -47,7 +48,10 @@ export default function useSelectAll() {
 				// would select the entire canvas. Select the contents of the
 				// editable element instead, like the default does when the
 				// element itself holds focus.
-				if ( event.target === node && editable !== node ) {
+				if (
+					event.target === getEditableRootElement( node ) &&
+					editable !== getEditableRootElement( node )
+				) {
 					event.preventDefault();
 					const range = ownerDocument.createRange();
 					range.selectNodeContents( editable );

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -14,7 +14,7 @@ import { isSelectionForward } from '@wordpress/dom';
  */
 import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
-import { setContentEditableWrapper } from './utils';
+import { getEditableRootElement, setContentEditableWrapper } from './utils';
 import { unlock } from '../../lock-unlock';
 
 const { ownsSelection } = unlock( richTextPrivateApis );
@@ -195,21 +195,22 @@ export default function useSelectionObserver() {
 						// (e.g. buttons) or editables outside the block (e.g.
 						// the post title). The rich text instance owning the
 						// selection syncs it to the store itself.
+						const host = getEditableRootElement( node );
 						const { activeElement } = ownerDocument;
 						if (
-							activeElement !== node &&
+							activeElement !== host &&
 							activeElement?.isContentEditable &&
 							node.contains( activeElement ) &&
 							getBlockClientId( activeElement ) ===
 								collapsedClientId
 						) {
-							node.focus();
+							host.focus();
 						}
 						return;
 					}
 
 					if (
-						node.contentEditable === 'true' &&
+						getEditableRootElement( node ) &&
 						! isMultiSelecting()
 					) {
 						setContentEditableWrapper( node, false );

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -16,6 +16,7 @@ import {
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/pasting';
+import { isBlockListLayout } from '../block-list/use-editable-root-host';
 import { store as blockEditorStore } from '../../store';
 
 export const requiresWrapperOnCopy = Symbol( 'requiresWrapperOnCopy' );
@@ -161,24 +162,26 @@ export function getEditableRootElement( node ) {
  */
 function resolveEditableRootElement( node ) {
 	const selection = node.ownerDocument.defaultView.getSelection();
-	let element = null;
 
-	if ( selection.rangeCount ) {
-		const { commonAncestorContainer } = selection.getRangeAt( 0 );
-		element =
-			commonAncestorContainer.nodeType ===
-			commonAncestorContainer.ELEMENT_NODE
-				? commonAncestorContainer
-				: commonAncestorContainer.parentElement;
+	if ( ! selection.rangeCount ) {
+		return node;
 	}
 
-	const host = element?.closest( '.block-editor-block-list__layout' );
+	const { commonAncestorContainer } = selection.getRangeAt( 0 );
+	let element =
+		commonAncestorContainer.nodeType ===
+		commonAncestorContainer.ELEMENT_NODE
+			? commonAncestorContainer
+			: commonAncestorContainer.parentElement;
 
-	if ( host && node.contains( host ) ) {
-		return host;
+	while ( element && element !== node ) {
+		if ( isBlockListLayout( element ) ) {
+			return element;
+		}
+		element = element.parentElement;
 	}
 
-	return node.querySelector( '.is-root-container' ) ?? node;
+	return node;
 }
 
 export function setContentEditableWrapper(

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -16,7 +16,6 @@ import {
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/pasting';
-import { isBlockListLayout } from '../block-list/use-editable-root-host';
 import { store as blockEditorStore } from '../../store';
 
 export const requiresWrapperOnCopy = Symbol( 'requiresWrapperOnCopy' );
@@ -167,21 +166,36 @@ function resolveEditableRootElement( node ) {
 		return node;
 	}
 
-	const { commonAncestorContainer } = selection.getRangeAt( 0 );
-	let element =
-		commonAncestorContainer.nodeType ===
-		commonAncestorContainer.ELEMENT_NODE
-			? commonAncestorContainer
-			: commonAncestorContainer.parentElement;
+	const closestBlock = ( selectionNode ) => {
+		const element =
+			selectionNode?.nodeType === selectionNode?.ELEMENT_NODE
+				? selectionNode
+				: selectionNode?.parentElement;
+		return element?.closest( '[data-block]' ) ?? null;
+	};
+	const anchorBlock = closestBlock( selection.anchorNode );
+	const focusBlock = closestBlock( selection.focusNode ) ?? anchorBlock;
 
-	while ( element && element !== node ) {
-		if ( isBlockListLayout( element ) ) {
-			return element;
-		}
-		element = element.parentElement;
+	if ( ! anchorBlock ) {
+		return node;
 	}
 
-	return node;
+	// A block list is the direct parent of its blocks. Promote to the outer
+	// list, through the block wrapping it, until the list contains the whole
+	// selection.
+	let layout = anchorBlock.parentElement;
+
+	while (
+		layout &&
+		node.contains( layout ) &&
+		! layout.contains( focusBlock )
+	) {
+		layout =
+			layout.parentElement?.closest( '[data-block]' )?.parentElement ??
+			null;
+	}
+
+	return layout && node.contains( layout ) ? layout : node;
 }
 
 export function setContentEditableWrapper(

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -124,14 +124,16 @@ function toPlainText( html ) {
  * active editing host it must present as a named multiline textbox, per the
  * WAI-ARIA textbox role, which requires an accessible name.
  *
- * @param {HTMLElement} node          Wrapper element.
- * @param {boolean}     value         Whether the wrapper should be an
- *                                    editing host.
- * @param {Object}      options
- * @param {boolean}     options.focus Move focus to the wrapper when it
- *                                    becomes an editing host (Firefox does
- *                                    not automatically move it). Default
- *                                    true.
+ * @param {HTMLElement}  node           Wrapper element.
+ * @param {boolean}      value          Whether the wrapper should be an
+ *                                      editing host.
+ * @param {Object}       options
+ * @param {boolean}      options.focus  Move focus to the wrapper when it
+ *                                      becomes an editing host (Firefox
+ *                                      does not automatically move it).
+ *                                      Default true.
+ * @param {?HTMLElement} options.within An element the host must contain,
+ *                                      in addition to the selection.
  *
  * @return {boolean} Whether the wrapper is an editing host now.
  */
@@ -165,11 +167,14 @@ export function getEditableRootElement( node ) {
  * block content (never e.g. the post title), and nests with the block
  * structure. Falls back to the root block list container, then the wrapper.
  *
- * @param {HTMLElement} node Wrapper element.
+ * @param {HTMLElement}  node   Wrapper element.
+ * @param {?HTMLElement} within An element the host must contain, in
+ *                              addition to the selection (e.g. the block a
+ *                              selection is about to extend into).
  *
  * @return {HTMLElement} The element to make the editing host.
  */
-function resolveEditableRootElement( node ) {
+function resolveEditableRootElement( node, within ) {
 	const selection = node.ownerDocument.defaultView.getSelection();
 
 	if ( ! selection.rangeCount ) {
@@ -198,11 +203,12 @@ function resolveEditableRootElement( node ) {
 	while (
 		layout &&
 		node.contains( layout ) &&
-		! layout.contains( focusBlock )
+		( ! layout.contains( focusBlock ) ||
+			( within && ! layout.contains( within ) ) )
 	) {
-		layout =
-			layout.parentElement?.closest( '[data-block]' )?.parentElement ??
-			null;
+		// The next list up is the parent of the block containing this list.
+		// A list that is a block's own element counts as its own container.
+		layout = layout.closest( '[data-block]' )?.parentElement ?? null;
 	}
 
 	return layout && node.contains( layout ) ? layout : node;
@@ -211,7 +217,7 @@ function resolveEditableRootElement( node ) {
 export function setContentEditableWrapper(
 	node,
 	value,
-	{ focus = true } = {}
+	{ focus = true, within } = {}
 ) {
 	const engaged = editableRootElements.get( node );
 
@@ -228,7 +234,7 @@ export function setContentEditableWrapper(
 		return false;
 	}
 
-	const host = resolveEditableRootElement( node );
+	const host = resolveEditableRootElement( node, within );
 
 	// Check first: this is called on every selection change, and setting
 	// contentEditable triggers a style recalculation.

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -135,45 +135,109 @@ function toPlainText( html ) {
  *
  * @return {boolean} Whether the wrapper is an editing host now.
  */
+const editableRootElements = new WeakMap();
+
+/**
+ * Returns the element currently acting as the editing host for the wrapper,
+ * or null when none is engaged.
+ *
+ * @param {HTMLElement} node Wrapper element.
+ *
+ * @return {?HTMLElement} The engaged editing host.
+ */
+export function getEditableRootElement( node ) {
+	return editableRootElements.get( node ) ?? null;
+}
+
+/**
+ * Resolves the element that should act as the editing host: the closest
+ * block list container of the current selection, so the host wraps only
+ * block content (never e.g. the post title), and nests with the block
+ * structure. Falls back to the root block list container, then the wrapper.
+ *
+ * @param {HTMLElement} node Wrapper element.
+ *
+ * @return {HTMLElement} The element to make the editing host.
+ */
+function resolveEditableRootElement( node ) {
+	const selection = node.ownerDocument.defaultView.getSelection();
+	let element = null;
+
+	if ( selection.rangeCount ) {
+		const { commonAncestorContainer } = selection.getRangeAt( 0 );
+		element =
+			commonAncestorContainer.nodeType ===
+			commonAncestorContainer.ELEMENT_NODE
+				? commonAncestorContainer
+				: commonAncestorContainer.parentElement;
+	}
+
+	const host = element?.closest( '.block-editor-block-list__layout' );
+
+	if ( host && node.contains( host ) ) {
+		return host;
+	}
+
+	return node.querySelector( '.is-root-container' ) ?? node;
+}
+
 export function setContentEditableWrapper(
 	node,
 	value,
 	{ focus = true } = {}
 ) {
-	// Check first: this is called on every selection change, and setting
-	// contentEditable triggers a style recalculation.
-	if ( node.contentEditable === String( value ) ) {
-		return value;
-	}
-
-	node.contentEditable = value;
+	const engaged = editableRootElements.get( node );
 
 	if ( ! value ) {
-		node.removeAttribute( 'role' );
-		node.removeAttribute( 'aria-multiline' );
-		node.removeAttribute( 'aria-label' );
+		if ( ! engaged ) {
+			return false;
+		}
+		editableRootElements.delete( node );
+		engaged.contentEditable = false;
+		engaged.removeAttribute( 'contenteditable' );
+		engaged.removeAttribute( 'role' );
+		engaged.removeAttribute( 'aria-multiline' );
+		engaged.removeAttribute( 'aria-label' );
 		return false;
 	}
 
+	const host = resolveEditableRootElement( node );
+
+	// Check first: this is called on every selection change, and setting
+	// contentEditable triggers a style recalculation.
+	if ( engaged === host && host.contentEditable === 'true' ) {
+		return true;
+	}
+
+	if ( engaged && engaged !== host ) {
+		setContentEditableWrapper( node, false );
+	}
+
+	const target = host;
+	editableRootElements.set( node, target );
+
+	target.contentEditable = value;
+
 	// Only act as an editing host if the environment supports it (JSDOM
 	// does not implement contentEditable): without editing host semantics
-	// the wrapper must not claim focus or textbox semantics.
-	if ( ! node.isContentEditable ) {
-		node.removeAttribute( 'contenteditable' );
+	// the element must not claim focus or textbox semantics.
+	if ( ! target.isContentEditable ) {
+		target.removeAttribute( 'contenteditable' );
+		editableRootElements.delete( node );
 		return false;
 	}
 
 	// Expose the host as a named multiline textbox so it has a role and
 	// accessible name once it takes focus. The label is generic because the
 	// host can span several blocks.
-	node.setAttribute( 'role', 'textbox' );
-	node.setAttribute( 'aria-multiline', 'true' );
-	node.setAttribute( 'aria-label', __( 'Editor canvas' ) );
+	target.setAttribute( 'role', 'textbox' );
+	target.setAttribute( 'aria-multiline', 'true' );
+	target.setAttribute( 'aria-label', __( 'Editor canvas' ) );
 
 	if ( focus ) {
-		// Without preventScroll, focusing the wrapper scrolls the
-		// viewport to the top of the wrapper.
-		node.focus( { preventScroll: true } );
+		// Without preventScroll, focusing the host scrolls the viewport to
+		// the top of the host.
+		target.focus( { preventScroll: true } );
 	}
 
 	return true;

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -146,7 +146,17 @@ const editableRootElements = new WeakMap();
  * @return {?HTMLElement} The engaged editing host.
  */
 export function getEditableRootElement( node ) {
-	return editableRootElements.get( node ) ?? null;
+	const engaged = editableRootElements.get( node );
+
+	if ( engaged?.contentEditable === 'true' ) {
+		return engaged;
+	}
+
+	// The layout host hook engages declaratively, without going through
+	// setContentEditableWrapper: derive the engaged element instead of
+	// trusting the bookkeeping.
+	const resolved = resolveEditableRootElement( node );
+	return resolved?.contentEditable === 'true' ? resolved : null;
 }
 
 /**

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -256,7 +256,8 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		// The wrapper hosts editing for the selected block: it must present
 		// as a named multiline textbox for as long as it is the editing
 		// host, including while a selection crosses blocks.
-		const host = editor.canvas.locator( 'body' );
+		// The editing host is the block list containing the selection.
+		const host = editor.canvas.locator( '.is-root-container' );
 		await expect( host ).toHaveAttribute( 'contenteditable', 'true' );
 		await expect( host ).toHaveAttribute( 'role', 'textbox' );
 		await expect( host ).toHaveAttribute( 'aria-multiline', 'true' );
@@ -293,7 +294,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.click();
-		await expect( host ).toHaveAttribute( 'contenteditable', 'false' );
+		await expect( host ).not.toHaveAttribute( 'contenteditable', 'true' );
 		await expect( host ).not.toHaveAttribute( 'role' );
 		await expect( host ).not.toHaveAttribute( 'aria-multiline' );
 		await expect( host ).not.toHaveAttribute( 'aria-label' );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -35,7 +35,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		// The element owning the caret: the focused element, or the selected
 		// block while a focused editing host owns the selection.
 		const activeElementLocator = editor.canvas.locator(
-			'body:not(:focus) :focus, body:focus .is-selected'
+			'body :focus:not( .block-editor-block-list__layout[contenteditable="true"] ), :is( body, .block-editor-block-list__layout[contenteditable="true"] ):focus .is-selected'
 		);
 
 		// Arrow up into nested context focuses last text input.
@@ -121,7 +121,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		// Verify the element owning the caret has the paragraph content.
 		const activeElementLocator = editor.canvas.locator(
-			'body:not(:focus) :focus, body:focus .is-selected'
+			'body :focus:not( .block-editor-block-list__layout[contenteditable="true"] ), :is( body, .block-editor-block-list__layout[contenteditable="true"] ):focus .is-selected'
 		);
 		await expect( activeElementLocator ).toHaveText( 'First paragraph' );
 	} );
@@ -1381,7 +1381,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		// The element owning the caret should be the second paragraph, which
 		// contains a link.
 		const focusedElement = editor.canvas.locator(
-			'body:not(:focus) :focus, body:focus .is-selected'
+			'body :focus:not( .block-editor-block-list__layout[contenteditable="true"] ), :is( body, .block-editor-block-list__layout[contenteditable="true"] ):focus .is-selected'
 		);
 		await expect( focusedElement.locator( 'a[href="#"]' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
## What?

An alternative direction for `editableRoot`: the editing host becomes the **nearest block list container** of the selection instead of the writing flow wrapper (the canvas body). Children keep `contenteditable="true"` exactly as on trunk for now.

## Why?

1. **The post title leaves the host universe.** Guards that exist only to protect the title from the engaged host become unnecessary.
2. **Focus falls to the host by geometry.** The host sits below any tabbable block wrapper on the path from a clicked child, so incidental focus on wrappers (and the compensations for it) cannot occur.
3. **Padding gestures become native.** Clicks and multi-clicks on list padding happen inside the host, so the browser handles them as text gestures.
4. **Hosts nest with the block structure.** Engagement can follow the selection to the deepest containing list, mirroring how the store promotes multi-selections, and makes per-level always-engaged plausible later.

## How?

Phase 1 (this PR): `setContentEditableWrapper` resolves the element to engage from the selection's closest block list container (root container fallback) and tracks the engaged element; host-state reads go through `getEditableRootElement`. Planned refactor: the block list layout should declare itself the host via a hook rather than the utility mutating it. Phase 2 (after green): render the selected block's editable without a `contenteditable` attribute.

## Testing Instructions

Single-block flows (click, type, split, merge) work. Cross-block flows are the open work: multi-block-selection (chromium) currently 31/42, failures all in cross-list selection/clipboard flows and specs asserting host semantics on the body.

Written with Claude Code.