### PR TITLE
Backport: Theme: Omit color properties when neither provided nor inherited

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Avoid `ThemeProvider` assigning CSS color properties when a seed value is not provided and there is no ancestor to inherit from. This is consistent with how `cursor` and `cornerRadius` behave, and resolves an issue where `ThemeProvider` may forcibly override colors to the default color scheme in situations where the admin color scheme properties may be provided elsewhere ([#80600](https://github.com/WordPress/gutenberg/pull/80600)).
+
 ## 1.0.0 (2026-07-14)
 
 ### Stable Release

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -112,7 +112,7 @@ The `cursor` prop accepts an object with the following optional properties:
 
 The `cornerRadius` prop sets the overall roundness preset for the theme subtree. Accepts `'none'` (square corners), `'subtle'`, `'moderate'`, or `'pronounced'` (most rounded) (default: `'subtle'`). This scales the primitive `--wpds-border-radius-*` tokens for the provider subtree. The preset sets the overall amount of roundness, not an individual border-radius token size.
 
-When the `color`, `cursor`, or `cornerRadius` prop is omitted, the theme inherits the value from the closest parent `ThemeProvider`, or uses the default value if none is inherited.
+When a setting is omitted, it inherits from the closest parent `ThemeProvider`. If there is no parent value, the prebuilt defaults from the design-tokens stylesheet apply.
 
 `ThemeProvider` does not accept wrapper customization props such as `className`, `style`, `as`, `render`, or `ref`.
 

--- a/packages/theme/src/test/semantic-color-contrast.test.ts
+++ b/packages/theme/src/test/semantic-color-contrast.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { getContrast } from '../color-ramps/lib/color-utils';
 import { useThemeProviderStyles } from '../use-theme-provider-styles';
+import { DEFAULT_SEED_COLORS } from '../color-ramps';
 
 const MINIMUM_TEXT_CONTRAST = 4.5;
 const CUSTOM_PRIMARY = '#0057b8';
@@ -9,7 +10,12 @@ const CUSTOM_BACKGROUND = '#f6f3ef';
 const THEME_PROVIDER_STYLE_CASES = [
 	{
 		name: 'default seed colors',
-		settings: undefined,
+		settings: {
+			color: {
+				primary: DEFAULT_SEED_COLORS.primary,
+				background: DEFAULT_SEED_COLORS.background,
+			},
+		},
 	},
 	{
 		name: 'custom seed colors',

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -113,6 +113,19 @@ describe( 'ThemeProvider', () => {
 		expect( readProp( provider, SURFACE_BG ) ).toBe( BACKGROUND );
 	} );
 
+	it( 'does not define color tokens if neither customized nor inherited', () => {
+		render(
+			<ThemeProvider>
+				<div data-testid="child">x</div>
+			</ThemeProvider>
+		);
+
+		const provider = getScopingProvider( screen.getByTestId( 'child' ) );
+		expect( readProp( provider, BRAND_BG ) ).toBe( '' );
+		expect( readProp( provider, SURFACE_BG ) ).toBe( '' );
+		expect( readProp( provider, '--wp-admin-theme-color' ) ).toBe( '' );
+	} );
+
 	it( 'does not define the custom property outside of the provider', () => {
 		render(
 			<ThemeProvider color={ { primary: PRIMARY } }>
@@ -356,7 +369,8 @@ describe( 'ThemeProvider', () => {
 				screen.getByTestId( 'overriding' )
 			);
 
-			// A nested provider with no settings of its own inherits everything.
+			// A nested provider with no settings of its own inherits everything
+			// and re-applies color tokens so portaled descendants have them.
 			expect( readProp( inheriting, BRAND_BG ) ).toBe( PRIMARY );
 			expect( readProp( inheriting, SURFACE_BG ) ).toBe( BACKGROUND );
 			expect( readProp( inheriting, CURSOR_CONTROL ) ).toBe( 'pointer' );

--- a/packages/theme/src/test/use-theme-provider-styles.test.tsx
+++ b/packages/theme/src/test/use-theme-provider-styles.test.tsx
@@ -2,8 +2,11 @@
 // tests focus on what the hook uniquely owns:
 //
 // - `resolvedSettings`: how each setting is resolved (local prop > inherited from
-//   a parent provider > built-in default), which is the value propagated through
-//   context to descendant providers.
+//   a parent provider > built-in default when generating), which is the value
+//   propagated through context to descendant providers. Color stays unset when
+//   neither local nor inherited seeds are present.
+// - when color custom properties are emitted (any resolved color) vs omitted
+//   (total default only)
 // - the legacy `wp-admin` / `wp-components` bridge in `themeProviderStyles`, which
 //   the `ThemeProvider` tests intentionally do not cover.
 //
@@ -18,13 +21,10 @@ import { DEFAULT_SEED_COLORS } from '../color-ramps';
 
 describe( 'useThemeProviderStyles', () => {
 	describe( 'resolvedSettings', () => {
-		it( 'falls back to the default seed colors and no cursor', () => {
+		it( 'leaves color unset by default, expecting that CSS or build fallbacks apply', () => {
 			const { result } = renderHook( () => useThemeProviderStyles() );
 
-			expect( result.current.resolvedSettings.color ).toEqual( {
-				primary: DEFAULT_SEED_COLORS.primary,
-				background: DEFAULT_SEED_COLORS.background,
-			} );
+			expect( result.current.resolvedSettings.color ).toEqual( {} );
 			expect( result.current.resolvedSettings.cursor ).toBeUndefined();
 			// `cornerRadius` falls back to the prebuilt default.
 			expect( result.current.resolvedSettings.cornerRadius ).toBe(
@@ -107,6 +107,62 @@ describe( 'useThemeProviderStyles', () => {
 		} );
 	} );
 
+	describe( 'color styles', () => {
+		it( 'omits color custom properties by default', () => {
+			const { result } = renderHook( () => useThemeProviderStyles() );
+
+			expect( result.current.themeProviderStyles ).not.toHaveProperty(
+				'--wp-admin-theme-color'
+			);
+			expect( result.current.themeProviderStyles ).not.toHaveProperty(
+				'--wpds-color-background-interactive-brand-strong'
+			);
+		} );
+
+		it( 'emits color properties when at least one setting is provided', () => {
+			const { result } = renderHook( () =>
+				useThemeProviderStyles( { color: { primary: '#1e90ff' } } )
+			);
+
+			expect( result.current.resolvedSettings.color ).toEqual( {
+				primary: '#1e90ff',
+				background: DEFAULT_SEED_COLORS.background,
+			} );
+			expect(
+				result.current.themeProviderStyles[
+					'--wpds-color-background-interactive-brand-strong'
+				]
+			).toBe( '#1e90ff' );
+		} );
+
+		it( 're-emits inherited color tokens so portaled subtrees can re-apply them', () => {
+			const wrapper = ( { children }: { children: ReactNode } ) => (
+				<ThemeProvider
+					color={ { primary: '#abcdef', background: '#222222' } }
+				>
+					{ children }
+				</ThemeProvider>
+			);
+
+			const { result } = renderHook( () => useThemeProviderStyles(), {
+				wrapper,
+			} );
+
+			expect( result.current.resolvedSettings.color ).toEqual( {
+				primary: '#abcdef',
+				background: '#222222',
+			} );
+			expect( result.current.themeProviderStyles ).toHaveProperty(
+				'--wp-admin-theme-color',
+				'#abcdef'
+			);
+			expect( result.current.themeProviderStyles ).toHaveProperty(
+				'--wpds-color-background-interactive-brand-strong',
+				'#abcdef'
+			);
+		} );
+	} );
+
 	describe( 'legacy wp-admin / wp-components bridge', () => {
 		it( 'derives the wp-admin theme color from the primary seed', () => {
 			const { result } = renderHook( () =>
@@ -121,7 +177,9 @@ describe( 'useThemeProviderStyles', () => {
 		} );
 
 		it( 'aliases the wp-components colors onto the wp-admin and semantic tokens', () => {
-			const { result } = renderHook( () => useThemeProviderStyles() );
+			const { result } = renderHook( () =>
+				useThemeProviderStyles( { color: { primary: '#1e90ff' } } )
+			);
 			const styles = result.current.themeProviderStyles;
 
 			expect( styles[ '--wp-components-color-accent' ] ).toBe(

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -15,8 +15,8 @@ export interface ThemeProviderSettings {
 		 * (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and throw an
 		 * error.
 		 *
-		 * By default, it inherits from parent `ThemeProvider`,
-		 * and fallbacks to statically built CSS.
+		 * When omitted, inherits from the parent `ThemeProvider`. If there is
+		 * no parent value, the prebuilt default applies.
 		 */
 		primary?: string;
 		/**
@@ -27,8 +27,8 @@ export interface ThemeProviderSettings {
 		 * (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and throw an
 		 * error.
 		 *
-		 * By default, it inherits from parent `ThemeProvider`,
-		 * and fallbacks to statically built CSS.
+		 * When omitted, inherits from the parent `ThemeProvider`. If there is
+		 * no parent value, the prebuilt default applies.
 		 */
 		background?: string;
 	};
@@ -41,8 +41,8 @@ export interface ThemeProviderSettings {
 		 * The cursor style for interactive controls that are not links
 		 * (e.g. buttons, checkboxes, and toggles).
 		 *
-		 * By default, it inherits from the parent `ThemeProvider`,
-		 * and falls back to the prebuilt default (`pointer`).
+		 * When omitted, inherits from the parent `ThemeProvider`. If there is
+		 * no parent value, the prebuilt default applies (`pointer`).
 		 */
 		control?: 'default' | 'pointer';
 	};
@@ -55,8 +55,8 @@ export interface ThemeProviderSettings {
 	 * subtree; it sets the overall amount of roundness, not a single token
 	 * size.
 	 *
-	 * By default, it inherits from the parent `ThemeProvider`,
-	 * and falls back to the prebuilt default (`subtle`).
+	 * When omitted, inherits from the parent `ThemeProvider`. If there is no
+	 * parent value, the prebuilt default applies (`subtle`).
 	 */
 	cornerRadius?: CornerRadiusPreset;
 }

--- a/packages/theme/src/use-theme-provider-styles.ts
+++ b/packages/theme/src/use-theme-provider-styles.ts
@@ -171,18 +171,31 @@ export function useThemeProviderStyles( {
 } = {} ) {
 	const { resolvedSettings: inheritedSettings } = useContext( ThemeContext );
 
+	// Color styles are only emitted when seeds are either applied locally or
+	// inherited from an ancestor. Otherwise, the expectation is that static CSS
+	// stylesheet, build fallbacks, or CSS properties defined elsewhere apply
+	// (e.g. `@wordpress/base-styles`). Inherited seed values must always be
+	// reapplied so portaled subtrees retain the values.
+	const hasColor =
+		color.primary !== undefined ||
+		color.background !== undefined ||
+		inheritedSettings.color?.primary !== undefined ||
+		inheritedSettings.color?.background !== undefined;
+
 	// Compute settings:
 	// - used provided prop value;
-	// - otherwise, use inherited value from parent instance;
-	// - otherwise, use fallback value (where applicable).
-	const primary =
-		color.primary ??
-		inheritedSettings.color?.primary ??
-		DEFAULT_SEED_COLORS.primary;
-	const background =
-		color.background ??
-		inheritedSettings.color?.background ??
-		DEFAULT_SEED_COLORS.background;
+	// - otherwise, if a parent instance exists, use its inherited value or default;
+	// - otherwise, omit.
+	const primary = hasColor
+		? color.primary ??
+		  inheritedSettings.color?.primary ??
+		  DEFAULT_SEED_COLORS.primary
+		: undefined;
+	const background = hasColor
+		? color.background ??
+		  inheritedSettings.color?.background ??
+		  DEFAULT_SEED_COLORS.background
+		: undefined;
 	const cursorControl = cursor?.control ?? inheritedSettings.cursor?.control;
 	const cornerRadiusPreset =
 		cornerRadius ?? inheritedSettings.cornerRadius ?? 'subtle';
@@ -200,6 +213,10 @@ export function useThemeProviderStyles( {
 	);
 
 	const colorStyles = useMemo( () => {
+		if ( primary === undefined || background === undefined ) {
+			return {};
+		}
+
 		// Determine which seeds are needed for generating ramps.
 		const seeds = {
 			...DEFAULT_SEED_COLORS,


### PR DESCRIPTION
## What?

Backports #80600 to `wp/7.1`, which [failed automated backporting](https://github.com/WordPress/gutenberg/pull/80600#issuecomment-5180854398) due to merge conflicts in `packages/theme/CHANGELOG.md`.

## Testing Instructions

Confirm that the changes here match what's included in #80600.

## Use of AI Tools

No AI was used.