### PR TITLE
Widgets editor: Add ThemeProvider for admin color schemes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51815,6 +51815,7 @@
 			"version": "6.51.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Wrap the widgets editor layout in `ThemeProvider`, seeded with the active admin color scheme primary color.
+
 ## 6.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Wrap the widgets editor layout in `ThemeProvider`, seeded with the active admin color scheme primary color.
+-   Wrap the widgets editor layout in `ThemeProvider`, seeded with the active admin color scheme primary color ([#81173](https://github.com/WordPress/gutenberg/pull/81173)).
 
 ## 6.51.0 (2026-07-14)
 

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -47,6 +47,7 @@
 		]
 	},
 	"dependencies": {
+		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,11 +1,14 @@
 /**
  * WordPress dependencies
  */
+import { getAdminThemeColors } from '@wordpress/admin-ui';
 import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { PluginArea } from '@wordpress/plugins';
 import { store as noticesStore } from '@wordpress/notices';
 import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
+import { ThemeProvider } from '@wordpress/theme';
 
 /**
  * Internal dependencies
@@ -33,21 +36,26 @@ function Layout( { blockEditorSettings } ) {
 	}
 
 	const navigateRegionsProps = useNavigateRegions();
+	const adminPrimary = useMemo( () => getAdminThemeColors().primary, [] );
 
 	return (
-		<ErrorBoundary>
-			<div { ...navigateRegionsProps }>
-				<WidgetAreasBlockEditorProvider
-					blockEditorSettings={ blockEditorSettings }
-				>
-					<Interface blockEditorSettings={ blockEditorSettings } />
-					<Sidebar />
-					<PluginArea onError={ onPluginAreaError } />
-					<UnsavedChangesWarning />
-					<WelcomeGuide />
-				</WidgetAreasBlockEditorProvider>
-			</div>
-		</ErrorBoundary>
+		<ThemeProvider isRoot color={ { primary: adminPrimary } }>
+			<ErrorBoundary>
+				<div { ...navigateRegionsProps }>
+					<WidgetAreasBlockEditorProvider
+						blockEditorSettings={ blockEditorSettings }
+					>
+						<Interface
+							blockEditorSettings={ blockEditorSettings }
+						/>
+						<Sidebar />
+						<PluginArea onError={ onPluginAreaError } />
+						<UnsavedChangesWarning />
+						<WelcomeGuide />
+					</WidgetAreasBlockEditorProvider>
+				</div>
+			</ErrorBoundary>
+		</ThemeProvider>
 	);
 }
 

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { getAdminThemeColors } from '@wordpress/admin-ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
@@ -9,10 +6,6 @@ import { PluginArea } from '@wordpress/plugins';
 import { store as noticesStore } from '@wordpress/notices';
 import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
 import { ThemeProvider } from '@wordpress/theme';
-
-/**
- * Internal dependencies
- */
 import ErrorBoundary from '../error-boundary';
 import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provider';
 import Sidebar from '../sidebar';


### PR DESCRIPTION
## What?

Wraps the widgets editor layout in a root `ThemeProvider`, seeded with the active admin color scheme primary color.

Follow up to #81112

## Why?

UI in the widgets editor need a `ThemeProvider` ancestor to pick up the admin color scheme. The post editor and Site Editor already do this at their layout layers; the widgets editor did not.

The widgets screen uses white/near-white surfaces, so only the admin primary is seeded. Background tokens fall back to the design system default (`#fcfcfc`). `isRoot` forwards tokens to the document element so portaled UI can inherit them.

## Testing Instructions

1. Start wp-env and build the branch (`npm start`).
2. Activate a classic theme with widget areas (e.g. Twenty Twenty).
3. Open the widgets editor (`/wp-admin/widgets.php`).
4. Switch admin color schemes under **Users → Profile** (e.g. Ocean, Midnight, Sunrise, Light).
5. Reload the widgets editor and confirm WPDS-styled UI reflects the chosen scheme's primary/accent colors with readable contrast on white surfaces.
