### PR TITLE
Customizer widgets: Add ThemeProvider for admin color schemes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51329,6 +51329,7 @@
 			"version": "5.51.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/admin-ui": "file:../admin-ui",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/block-library": "file:../block-library",
@@ -51349,6 +51350,7 @@
 				"@wordpress/media-utils": "file:../media-utils",
 				"@wordpress/preferences": "file:../preferences",
 				"@wordpress/private-apis": "file:../private-apis",
+				"@wordpress/theme": "file:../theme",
 				"@wordpress/ui": "file:../ui",
 				"@wordpress/widgets": "file:../widgets",
 				"clsx": "^2.1.1",

--- a/packages/customize-widgets/CHANGELOG.md
+++ b/packages/customize-widgets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Wrap the Customizer widgets editor in `ThemeProvider`, seeded with the active admin color scheme primary color.
+
 ## 5.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/customize-widgets/CHANGELOG.md
+++ b/packages/customize-widgets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Wrap the Customizer widgets editor in `ThemeProvider`, seeded with the active admin color scheme primary color.
+-   Wrap the Customizer widgets editor in `ThemeProvider`, seeded with the active admin color scheme primary color ([#81174](https://github.com/WordPress/gutenberg/pull/81174)).
 
 ## 5.51.0 (2026-07-14)
 

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -39,6 +39,7 @@
 	},
 	"wpScript": true,
 	"dependencies": {
+		"@wordpress/admin-ui": "file:../admin-ui",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/block-library": "file:../block-library",
@@ -59,6 +60,7 @@
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/private-apis": "file:../private-apis",
+		"@wordpress/theme": "file:../theme",
 		"@wordpress/ui": "file:../ui",
 		"@wordpress/widgets": "file:../widgets",
 		"clsx": "^2.1.1",

--- a/packages/customize-widgets/src/components/customize-widgets/index.js
+++ b/packages/customize-widgets/src/components/customize-widgets/index.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { getAdminThemeColors } from '@wordpress/admin-ui';
 import {
 	useState,
@@ -11,10 +8,6 @@ import {
 } from '@wordpress/element';
 import { SlotFillProvider, Popover } from '@wordpress/components';
 import { ThemeProvider } from '@wordpress/theme';
-
-/**
- * Internal dependencies
- */
 import ErrorBoundary from '../error-boundary';
 import SidebarBlockEditor from '../sidebar-block-editor';
 import FocusControl from '../focus-control';

--- a/packages/customize-widgets/src/components/customize-widgets/index.js
+++ b/packages/customize-widgets/src/components/customize-widgets/index.js
@@ -1,8 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useRef, createPortal } from '@wordpress/element';
+import { getAdminThemeColors } from '@wordpress/admin-ui';
+import {
+	useState,
+	useEffect,
+	useRef,
+	createPortal,
+	useMemo,
+} from '@wordpress/element';
 import { SlotFillProvider, Popover } from '@wordpress/components';
+import { ThemeProvider } from '@wordpress/theme';
 
 /**
  * Internal dependencies
@@ -23,6 +31,7 @@ export default function CustomizeWidgets( {
 		'customize-theme-controls'
 	);
 	const popoverRef = useRef();
+	const adminPrimary = useMemo( () => getAdminThemeColors().primary, [] );
 
 	useClearSelectedBlock( activeSidebarControl, popoverRef );
 
@@ -68,15 +77,20 @@ export default function CustomizeWidgets( {
 
 	return (
 		<SlotFillProvider>
-			<SidebarControls
-				sidebarControls={ sidebarControls }
-				activeSidebarControl={ activeSidebarControl }
-			>
-				<FocusControl api={ api } sidebarControls={ sidebarControls }>
-					{ activeSidebar }
-					{ popover }
-				</FocusControl>
-			</SidebarControls>
+			<ThemeProvider isRoot color={ { primary: adminPrimary } }>
+				<SidebarControls
+					sidebarControls={ sidebarControls }
+					activeSidebarControl={ activeSidebarControl }
+				>
+					<FocusControl
+						api={ api }
+						sidebarControls={ sidebarControls }
+					>
+						{ activeSidebar }
+						{ popover }
+					</FocusControl>
+				</SidebarControls>
+			</ThemeProvider>
 		</SlotFillProvider>
 	);
 }


### PR DESCRIPTION
## What?

Wraps the Customizer widgets editor in a root `ThemeProvider`, seeded with the active admin color scheme primary color.

Follow up to #81112

## Why?

UI in the Customizer widgets block editor need a `ThemeProvider` ancestor to pick up design token overrides. The post editor and Site Editor already do this at their layout layers; the Customizer widgets editor did not.

The Customizer widgets UI uses white/near-white surfaces, so only the admin primary is seeded. Background tokens fall back to the design system default (`#fcfcfc`). `isRoot` forwards tokens to the document element so portaled UI can inherit them.


## Testing Instructions

1. Start wp-env and build the branch (`npm start`).
2. Activate a classic theme with widget areas (e.g. Twenty Twenty).
3. Open the Customizer (`/wp-admin/customize.php`).
4. Expand **Widgets** and open a widget area.
5. Switch admin color schemes under **Users → Profile** (e.g. Ocean, Midnight, Sunrise, Light).
6. Reload the Customizer and confirm WPDS-styled UI reflects the chosen scheme's primary/accent colors with readable contrast on white surfaces.
