### PR TITLE
fix: add optional chaining for empty reusable block (#81165)

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -191,7 +191,7 @@ function ReusableBlockEdit( {
 	const canOverrideBlocks = useMemo( () => {
 		const supportedBlockTypes = Object.keys( supportedBlockTypesRaw );
 		const hasOverridableBlocks = ( _blocks ) =>
-			_blocks.some( ( block ) => {
+			_blocks?.some( ( block ) => {
 				if (
 					supportedBlockTypes.includes( block.name ) &&
 					isOverridableBlock( block )


### PR DESCRIPTION
fix: add optional chaining to prevent console error on empty reusable block

Added `_blocks?.some()` to safely handle undefined `_blocks` when inserting an empty core/block without a ref property.

Fixes: #81165

## What?

Added optional chaining (`?.`) to the `_blocks.some()` call in the reusable block edit component to prevent console errors when `_blocks` is undefined.

## Why?

When a user inserts an empty reusable block (`<!-- wp:block /-->`) without a `ref` attribute, the `_blocks` variable is undefined, causing the console error:
`Uncaught TypeError: can't access property "some", blocks is undefined`


This PR fixes that error by safely checking `_blocks` before attempting to call `.some()`.

## How?

Changed:
```javascript
const hasOverridableBlocks = ( _blocks ) =>
    _blocks.some( ( block ) => {
```
    
To:

```javascript
const hasOverridableBlocks = ( _blocks ) =>
    _blocks?.some( ( block ) => {
```