### PR TITLE
Site Editor: Mark root ThemeProvider as isRoot

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Mark the Site Editor root `ThemeProvider` as `isRoot` so design tokens are forwarded to the document root for portals and other UI rendered outside the React subtree.
+
 ## 7.0.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -324,7 +324,7 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 			<Tooltip.Provider>
 				{ /** This needs to be within the SlotFillProvider */ }
 				<PluginArea onError={ onPluginAreaError } />
-				<ThemeProvider color={ themeColors }>
+				<ThemeProvider isRoot color={ themeColors }>
 					<Layout { ...props } />
 				</ThemeProvider>
 			</Tooltip.Provider>


### PR DESCRIPTION
## What?

Marks the Site Editor's root `ThemeProvider` as `isRoot`.

Follow up to #81112

## Why?

The Site Editor already wraps its layout in a root `ThemeProvider` seeded with admin theme colors, but it was missing `isRoot`. Without it, design tokens are scoped to the provider's wrapper div and are not forwarded to the document element. Portaled UI (modals, popovers, tooltips) rendered outside the React subtree cannot inherit those tokens.

The post editor and widgets editors already use `isRoot` on their root providers. This brings the Site Editor in line with them.

## Testing Instructions

1. Start wp-env and build the branch (`npm start`).
2. Open the Site Editor (`/wp-admin/site-editor.php`).
3. Switch admin color schemes under **Users → Profile** (e.g. Ocean, Midnight, Sunrise, Light).
4. Reload the Site Editor and confirm WPDS-styled UI reflects the chosen scheme's primary/accent colors.
5. Open portaled UI (e.g. a modal or popover in the Site Editor) and confirm it inherits the admin color scheme tokens.