### PR TITLE
Clarify the GIF Video variation description

### DIFF
--- a/packages/block-library/src/video/variations.js
+++ b/packages/block-library/src/video/variations.js
@@ -32,7 +32,7 @@ const variations = [
 		name: 'video',
 		title: __( 'Video' ),
 		description: __(
-			'Embed a video from your media library or upload a new one.'
+			'A video with customizable playback and interaction controls.'
 		),
 		icon: videoIcon,
 		attributes: { controls: true },


### PR DESCRIPTION
## What?

Updates the Video variation description to "A video with customizable playback and interaction controls." - the wording @fcoveram suggested on the issue.

Fixes https://github.com/WordPress/gutenberg/issues/81124

## Why?

The Video and GIF variations both appear in the block switcher, and the old Video description ("Embed a video from your media library or upload a new one.") didn't explain how the two differ. The new wording pairs with the GIF description ("A muted, looping video that plays automatically like an animated GIF.") so the difference - playback controls vs. a silent loop - is visible right in the menu.

Per the discussion on the issue this is the minimal change for now. An at-upload prompt explaining the performance benefit of the video format is a possible follow-up for 7.2, see https://github.com/WordPress/gutenberg/pull/80075 for previous exploration there.

## How?

Single string change in `packages/block-library/src/video/variations.js`. The block's inserter description in `block.json` is unchanged.

## Testing Instructions

[![Test in WordPress Playground](https://img.shields.io/badge/Test%20in-WordPress%20Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=81181)

1. Insert a Video block and add a video.
2. With the block selected, open the block switcher in the toolbar.
3. Hover the "Video" and "GIF" options and compare the descriptions.
4. Confirm the Video description reads "A video with customizable playback and interaction controls."
