### PR TITLE
Notes: fix the mention notification email composition

### DIFF
--- a/backport-changelog/7.1/12548.md
+++ b/backport-changelog/7.1/12548.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/12548
 
 * https://github.com/WordPress/gutenberg/pull/79606
+* https://github.com/WordPress/gutenberg/pull/81187

--- a/lib/compat/wordpress-7.1/notes-mentions.php
+++ b/lib/compat/wordpress-7.1/notes-mentions.php
@@ -72,12 +72,12 @@ function gutenberg_get_note_mentioned_user_ids( string $content ): array {
  *
  * @since 7.1.0
  *
- * @param WP_Comment $comment  The note that was just inserted.
- * @param mixed      $request  The REST request. Unused.
- * @param bool       $creating Whether this is a create (true) or update (false).
+ * @param WP_Comment|null $comment  The note that was just inserted. Null only if it was deleted in the meantime.
+ * @param mixed           $request  The REST request. Unused.
+ * @param bool            $creating Whether this is a create (true) or update (false).
  */
-function gutenberg_notify_note_mentions( WP_Comment $comment, $request = null, bool $creating = true ): void {
-	if ( ! $creating ) {
+function gutenberg_notify_note_mentions( ?WP_Comment $comment, $request = null, bool $creating = true ): void {
+	if ( ! $creating || ! $comment ) {
 		return;
 	}
 
@@ -92,9 +92,12 @@ function gutenberg_notify_note_mentions( WP_Comment $comment, $request = null, b
 
 	$mentioned = gutenberg_get_note_mentioned_user_ids( $comment->comment_content );
 
-	$author_id      = (int) $comment->user_id;
-	$post           = get_post( (int) $comment->comment_post_ID );
-	$post_author_id = $post ? (int) $post->post_author : 0;
+	$author_id = (int) $comment->user_id;
+
+	// get_post() falls back to the global post when passed 0, which would compose the email about the wrong post.
+	$comment_post_id = (int) $comment->comment_post_ID;
+	$post            = $comment_post_id ? get_post( $comment_post_id ) : null;
+	$post_author_id  = $post ? (int) $post->post_author : 0;
 
 	/*
 	 * The recipient set is bounded and small (one note's mentions), so
@@ -169,11 +172,31 @@ add_action( 'rest_insert_comment', 'gutenberg_notify_note_mentions', 10, 3 );
 function gutenberg_send_note_notification( WP_User $user, WP_Comment $comment, ?WP_Post $post ): bool {
 	$switched_locale = switch_to_user_locale( $user->ID );
 
+	/*
+	 * The site title and the post title are escaped on the way into the database,
+	 * and note content is stored as HTML. Both are reversed once here for the
+	 * plain text arena of emails. Decoding a second time would go too far and
+	 * resolve entities the author meant to be read literally. Tags are stripped
+	 * before decoding, so escaped text such as "&lt;code&gt;" survives as text
+	 * rather than being read as a tag and dropped.
+	 */
 	$blogname    = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 	$post_title  = $post ? wp_specialchars_decode( get_the_title( $post ), ENT_QUOTES ) : '';
 	$author_name = $comment->comment_author ? $comment->comment_author : __( 'Someone', 'gutenberg' );
-	$content     = wp_strip_all_tags( wp_specialchars_decode( $comment->comment_content ) );
-	$edit_link   = $post ? get_edit_post_link( $post->ID, 'url' ) : '';
+	$content     = wp_specialchars_decode( wp_strip_all_tags( $comment->comment_content ) );
+
+	/*
+	 * The rest of the message is composed for the recipient, and so is the editor
+	 * link: get_edit_post_link() answers for whoever is current, which here is the
+	 * note's author over REST and nobody at all under WP-Cron.
+	 */
+	$edit_link = '';
+	if ( $post ) {
+		$previous_user_id = get_current_user_id();
+		wp_set_current_user( $user->ID );
+		$edit_link = (string) get_edit_post_link( $post->ID, 'url' );
+		wp_set_current_user( $previous_user_id );
+	}
 
 	/* translators: %1$s: commenter name, %2$s: post title. */
 	$message = sprintf( __( '%1$s mentioned you in a note on "%2$s".', 'gutenberg' ), $author_name, $post_title );
@@ -183,13 +206,16 @@ function gutenberg_send_note_notification( WP_User $user, WP_Comment $comment, ?
 	$lines = array( $message, '' );
 	if ( '' !== $content ) {
 		$lines[] = $content;
-		$lines[] = '';
 	}
 	if ( $edit_link ) {
-		$lines[] = $edit_link;
+		$lines[] = '';
+		$lines[] = __( 'Edit This', 'gutenberg' ) . ': ' . $edit_link;
 	}
 
-	$sent = wp_mail( $user->user_email, wp_specialchars_decode( $subject ), implode( "\n", $lines ) );
+	// Declared explicitly so a filtered default cannot turn the message into HTML.
+	$headers = 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . '"';
+
+	$sent = wp_mail( $user->user_email, $subject, implode( "\n", $lines ), $headers );
 
 	if ( $switched_locale ) {
 		restore_previous_locale();


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/81186

The note `@`mention notification landed in Core as https://core.trac.wordpress.org/changeset/63012, and @westonruter's review on that patch turned up several bugs in how the email is composed. The plugin still has the version those fixes were made against, and since `lib/compat/wordpress-7.1/notes-mentions.php` removes Core's `wp_notify_note_mentions()` and registers its own copy, the plugin's version is the one that runs on 7.1 when the plugin is active. This ports the fixes over.

## What changed

- The editor link is now built for the recipient. `get_edit_post_link()` answers for whoever is the current user, which over REST is the note's author and under WP-Cron is nobody at all, so the link was either built against the wrong capabilities or dropped entirely. It now brackets `wp_set_current_user()` the same way `switch_to_user_locale()` is already bracketed a few lines up.
- The subject is decoded once instead of twice, so a site or post title where the author meant `&amp;` literally is not flattened.
- Note content is stripped before it is decoded, so escaped text like `&lt;code&gt;` is not turned into a tag and then dropped from the message body.
- `Content-Type: text/plain; charset=<blog_charset>` is declared explicitly, so a filtered `wp_mail()` default cannot turn the message into HTML. Matches `wp_notify_postauthor()`.
- `$comment` is now `?WP_Comment` with a guard. The REST controller passes whatever `get_comment()` returns, so a comment deleted in between would hit the non-nullable type hint and fatal.
- A `comment_post_ID` of 0 no longer falls through to the global post - `get_post()` treats 0 as empty and substitutes `$GLOBALS['post']`.
- The editor link is labeled `Edit This: <url>` to match Core, so the email does not change shape depending on whether the plugin is active.

## Testing instructions

[![Test with WordPress Playground](https://img.shields.io/badge/Test%20with-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=81187)

You will want a mail logger to read the messages, eg. https://wordpress.org/plugins/wp-mail-logging/.

1. Create a second user with an editor role.
2. Open a post as a different user, add a note to a block, and `@`mention the editor.
3. Check the logged email. It should be plain text, and the last line should read `Edit This: <url>` with a link into the post editor.

To see the link fix specifically, the editor account needs different capabilities than the note author - eg. mention a user who cannot edit the post's parent but can `edit_comment` the note. Before this change the link was generated against the note author's capabilities.

For the decoding fixes:

4. Set the site title to something with an escaped entity, eg. `Tom &amp; Jerry`, and confirm the subject keeps it as `Tom &amp; Jerry` rather than resolving it to `Tom & Jerry`.
5. Write a note whose text includes an escaped tag, eg. type `&lt;code&gt;` literally, and confirm it still appears in the email body. Before this change it was decoded to `<code>` and then stripped out.

## Types of changes

Bug fix. No new public functions and no signature changes other than widening `$comment` to accept null, which is source compatible.

There are no PHP tests for this file in the plugin. Core has coverage for the same fixes in `tests/phpunit/tests/comment/wpNotifyNoteMentions.php`, including `test_editor_link_is_built_for_the_recipient` and `test_email_is_sent_as_plain_text`.
