### PR TITLE
Monitor all setup-related composite Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     - package-ecosystem: 'github-actions'
       directories:
           - '.github/workflows'
-          - '.github/setup-node'
+          - '.github/setup-*'
       schedule:
           interval: 'daily'
       open-pull-requests-limit: 20


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds  the `.github/setup-playwright` directory to the list of GitHub Actions ecosystem-related files for Dependabot to monitor for dependency updates.

Follow up to #80846.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Because actions are pinned to full-length SHA values following [GItHub's official secure use recommendations](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions), new releases for each third-party Action are not automatically utilized. Dependeabot helps keep these dependencies up to date.

## How?
This adds the new composite Action to the list by specifying a `.github/setup-*` globbing pattern. With this adjustment, all future `.github/setup-` Actions files that are added will be automatically monitored without needing to update the `dependabot.yml` file.

## Use of AI Tools

None.