### PR TITLE
Docs: Say how long a notice can be, in the copy guide

### DIFF
--- a/.agents/skills/defensive-data-design/SKILL.md
+++ b/.agents/skills/defensive-data-design/SKILL.md
@@ -27,7 +27,7 @@ Prefer reversible changes, and make both the change and the way back visible. An
 -   Irreversible confirms use `isDestructive` on the confirm button and say so in the label ("Delete permanently", not "Delete"). Follow the [destructive actions pattern](../../../storybook/stories/design-system/patterns/destructive-actions.mdx).
 -   Announce a mutation that succeeds, and offer Undo when the prior value is in scope. Capture that value explicitly rather than popping the undo stack, which would revert unrelated edits too.
 -   `Snackbar` renders one action only; more logs a warning and truncates to `actions[0]` (`packages/components/src/snackbar/index.tsx`). Undo or another button, not both.
--   A snackbar dismisses itself six seconds after appearing. Keep it readable in that time, and use `explicitDismiss` or a different notice for anything that must be read.
+-   A snackbar dismisses itself six seconds after appearing, so use `explicitDismiss` or a different notice for anything the user must finish reading. The copy guide covers how long the text itself can be.
 -   When a mutation fails, leave the user able to try again: keep their input, restore consistent state, release any control left busy, and make a retry safe.
 -   `saveEntityRecord` and `deleteEntityRecord` add nothing to the undo stack, so anything already persisted needs its own recovery path. `editEntityRecord` records an undo level unless called with `undoIgnore`.
 

--- a/docs/contributors/documentation/copy-guide.md
+++ b/docs/contributors/documentation/copy-guide.md
@@ -317,7 +317,7 @@ A good error message also includes some context that orients the user. “Your a
 
 #### FIVE: Remember that a message can disappear before it’s been read.
 
-A snackbar dismisses itself about six seconds after it appears, whether or not anyone has finished reading. That’s the budget for the whole message, and it doesn’t stretch to fit a longer one.
+By default a snackbar clears itself about six seconds after it appears, whether or not anyone has finished reading. That’s the budget for the whole message, and it doesn’t stretch to fit a longer one.
 
 So keep a snackbar short enough to take in at a glance—one line is a good target. Counting characters isn’t much help here, because translations often run longer than the English original: a message that sits on one line for you can wrap to three somewhere else.
 
@@ -327,4 +327,4 @@ vs.
 
 > That file couldn’t be read. Try converting it to JPEG or PNG.
 
-And when someone really does need to read a message and act on it, a snackbar is the wrong home for it. Give them a notice that stays put until they dismiss it.
+And when someone really does need to read a message and act on it, don’t leave it on that six second timer. Either keep the snackbar up until it’s dismissed, or use a notice that stays put by design.

--- a/docs/contributors/documentation/copy-guide.md
+++ b/docs/contributors/documentation/copy-guide.md
@@ -314,3 +314,17 @@ Consistency with existing UI language is great, but not when it gets in the way 
 It might seem obvious to us that the user got this message when they tried to publish something or change a setting that they don’t have permission for. It might not be so obvious to the user: people click around a lot, especially when we’re unsure how to do something, and we don’t always remember what page or setting we were just looking at (or why!).
 
 A good error message also includes some context that orients the user. “Your account does not have permission to publish posts” reminds them that they were trying to publish a post, and that that’s the particular stumbling block that caused the error.
+
+#### FIVE: Remember that a message can disappear before it’s been read.
+
+A snackbar dismisses itself about six seconds after it appears, whether or not anyone has finished reading. That’s the budget for the whole message, and it doesn’t stretch to fit a longer one.
+
+So keep a snackbar short enough to take in at a glance—one line is a good target. Counting characters isn’t much help here, because translations often run longer than the English original: a message that sits on one line for you can wrap to three somewhere else.
+
+> Failed to process the uploaded file because its format could not be determined. Please convert it to a supported format and try uploading it again.
+
+vs.
+
+> That file couldn’t be read. Try converting it to JPEG or PNG.
+
+And when someone really does need to read a message and act on it, a snackbar is the wrong home for it. Give them a notice that stays put until they dismiss it.


### PR DESCRIPTION
## What

Follow-up to #81131 to update docs with the maxims from https://make.wordpress.org/core/2026/08/04/defensive-data-design/

This is stacked on `add/defensive-data-design-agents` (#81131) because it edits the skill file that PR introduces. 

Adds a fifth tip to the copy guide's Error Messaging section, on how long a notice can be, and trims the equivalent guidance out of the defensive data design skill so it has one home.

I wanted to also add a note about "fun" from "Plain language, make it obvious, natural. (And also fun.)", but the guide already alludes to it and warns us against over doing it:

-   Error Messaging tip ONE gives "Oopsie, we can't let you do that!" as an example of sounding too cute.
-   UI Descriptions tip FOUR: "no wordplay, please! 'Personality' can—and in UI instructions, should—be subtle. We're talking about text that sounds like it was said by a human being, not forced attempts at whimsy."

