### PR TITLE
Button: turn on the width setting by default in theme.json

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -319,6 +319,7 @@
 					"radius": true
 				},
 				"dimensions": {
+					"width": true,
 					"dimensionSizes": [
 						{
 							"name": "25%",


### PR DESCRIPTION
## What?

Turns on `settings.blocks.core/button.dimensions.width` in the bundled `lib/theme.json` so the Button block's Width control is available again in themes that don't opt into appearance tools.

Fixes the regression reported in https://github.com/WordPress/gutenberg/pull/74242#issuecomment-5187172064.

## Why?

Before #74242 the Button block rendered its own `WidthPanel`, which was always visible. That PR replaced it with the shared `dimensions.width` block support, and the shared Dimensions panel only renders the control when the resolved theme.json setting is truthy

## How?

One line in `lib/theme.json`:

```diff
 "core/button": {
 	"border": { "radius": true },
 	"dimensions": {
+		"width": true,
 		"dimensionSizes": [ ... ]
 	}
 }
```

Themes can still turn it off with `settings.blocks."core/button".dimensions.width: false`.

## Testing Instructions

Test HTML

```html
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

1. Activate a classic theme that does not call `add_theme_support( 'appearance-tools' )` for example Twenty Twenty-One.
2. Add a Button block and open the block inspector.
3. **Before this change:** there is no Width control in the Dimensions panel.
4. **After this change:** the Width control is there, with the 25/50/75/100% presets and a custom value input.
5. Repeat in Styles > Blocks > Button and confirm the Width control appears there too.
6. Switch to a block theme with `appearanceTools: true` (e.g. Twenty Twenty-Five) and confirm nothing changed there.



| Before  | After |
|--------|--------|
| <img width="1082" height="592" alt="Screenshot 2026-08-05 at 2 39 50 pm" src="https://github.com/user-attachments/assets/6acf116e-0159-4b80-806f-181089041340" /> | <img width="1080" height="559" alt="Screenshot 2026-08-05 at 2 39 39 pm" src="https://github.com/user-attachments/assets/94d55334-fdbe-4d8b-82b9-5c0c7a7b791a" /> | 





