### PR TITLE
DataViews: Pass only eligible items to a bulk action callback

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fix
 
+-   DataViews: Pass only the eligible items to a bulk action's `callback`. A bulk action is offered when any one selected item is eligible for it, so the callback could run against items it had declared, through `isEligible`, that it could not handle. [#81198](https://github.com/WordPress/gutenberg/pull/81198)
 -   DataViews: Render the filter chip for an incomplete `between` range as if no value were set — matching how the filter itself does not apply — instead of showing a dangling bound or the literal string "undefined". A `null` bound, produced when an unfilled bound round-trips through JSON persistence, is now treated as unfilled too. [#80830](https://github.com/WordPress/gutenberg/pull/80830)
 -   DataForms: Stop the `card` and `details` layouts from hijacking focus when they reveal validation errors. Errors for every field in the container are now shown once focus leaves it, instead of on each internal blur, and revealing them no longer moves focus, so the natural tab sequence is preserved. [#80685](https://github.com/WordPress/gutenberg/pull/80685)
 -   DataForms: Complete the `richtext` control's autocomplete semantics by associating the textbox with its suggestions list for assistive technology. [#80403](https://github.com/WordPress/gutenberg/pull/80403)

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -246,7 +246,7 @@ function ActionButton< Item >( {
 			action={ action }
 			onClick={ async () => {
 				setActionInProgress( action.id );
-				await action.callback( selectedItems, {
+				await action.callback( selectedEligibleItems, {
 					registry,
 				} );
 				setActionInProgress( null );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -629,6 +629,54 @@ describe( 'DataViews component', () => {
 			).toBeChecked();
 			expect( onClickItem ).not.toHaveBeenCalled();
 		} );
+
+		it( 'passes only eligible items to a bulk action callback', async () => {
+			const restore = jest.fn();
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'author' ],
+						titleField: 'title',
+					} }
+					actions={ [
+						{
+							id: 'restore',
+							label: 'Restore',
+							supportsBulk: true,
+							// Only the first item can be restored.
+							isEligible: ( item: Data ) => item.id === 1,
+							callback: restore,
+						},
+						{
+							id: 'trash',
+							label: 'Trash',
+							supportsBulk: true,
+							// Makes the second item selectable even though it
+							// is not eligible for the restore action.
+							isEligible: ( item: Data ) => item.id !== 1,
+							callback: jest.fn(),
+						},
+					] }
+				/>
+			);
+			const user = userEvent.setup();
+			await user.click(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			);
+			await user.click(
+				screen.getByRole( 'checkbox', { name: data[ 1 ].title } )
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Restore' } )
+			);
+
+			expect( restore ).toHaveBeenCalledTimes( 1 );
+			expect(
+				restore.mock.calls[ 0 ][ 0 ].map( ( item: Data ) => item.id )
+			).toEqual( [ 1 ] );
+		} );
 	} );
 
 	describe( 'in grid view', () => {


### PR DESCRIPTION
## What

Passes only the eligible items to a bulk action's `callback`, instead of every selected item.

## Why

A bulk action is offered when **any one** selected item is eligible for it — `actionsToShow` tests `selectedItems.some( ( item ) => ! action.isEligible || action.isEligible( item ) )`. The callback was then handed the whole selection, so an action ran against items it had already declared, via `isEligible`, that it could not handle.



### Reproduced on trunk

1. Create two pages: publish one, move the other to the trash.
2. Site Editor → Pages → filter **Status** to include both **Published** and **Trash**, so both are listed together.
3. Select both rows.
4. The bulk bar offers **Restore**, **Permanently delete** and **Trash** at once. None of the three applies to both rows.
5. Click **Restore**.
6. `restorePost`'s callback maps over everything it receives and sets `status: 'draft'`, so the published page is unpublished and saved, and the notice reports that both pages were restored. Live content is taken down with a success message.

https://github.com/user-attachments/assets/515a7446-53a8-488e-b226-60b13529287b


## Testing instructions

Walk through the reproduction above and confirm the published page keeps its status, and that only the trashed page is restored.

## Use of AI

Claude spotted this while researching unrelated changes. 
