### PR TITLE
Types: Replace remaining `@ts-expect-error` suppressions with proper typing

### DIFF
--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -840,8 +840,17 @@ export interface TypographyProps {
 export interface SpacingProps {
 	/**
 	 * Enable block gap control.
+	 *
+	 * The object form declares the sides the control applies to, and the gap
+	 * value to fall back to when neither the theme nor the user has set one.
 	 */
-	blockGap: boolean | AxialDirection[];
+	blockGap:
+		| boolean
+		| AxialDirection[]
+		| {
+				__experimentalDefault?: string;
+				sides?: AxialDirection[];
+		  };
 
 	/**
 	 * Enable margin control UI for all or specified element directions.

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -25,6 +25,13 @@ export type IconType =
 	| ( ( props: { size?: number } ) => React.JSX.Element )
 	| React.JSX.Element;
 
+/* The sizing props forwarded to an icon element that is not an `SVG` or a `Dashicon`. */
+type SizeProps = {
+	size?: number;
+	width?: number | string;
+	height?: number | string;
+};
+
 type AdditionalProps< T > = T extends ComponentType< infer U >
 	? U
 	: T extends DashiconIconKey
@@ -103,9 +110,8 @@ function Icon( {
 		return <SVG { ...appliedProps } />;
 	}
 
-	if ( isValidElement( icon ) ) {
+	if ( isValidElement< SizeProps >( icon ) ) {
 		return cloneElement( icon, {
-			// @ts-expect-error `size` is forwarded but is not in the icon component overloads.
 			size,
 			width: size,
 			height: size,

--- a/packages/components/src/input-control/utils.ts
+++ b/packages/components/src/input-control/utils.ts
@@ -60,8 +60,7 @@ export function useDragCursor(
 		if ( isDragging ) {
 			document.documentElement.style.cursor = dragCursor;
 		} else {
-			// @ts-expect-error `cursor` is typed as `string`, but `null` clears it.
-			document.documentElement.style.cursor = null;
+			document.documentElement.style.removeProperty( 'cursor' );
 		}
 	}, [ isDragging, dragCursor ] );
 

--- a/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/properties-section.tsx
@@ -80,7 +80,7 @@ export function PropertiesSection( {
 		},
 	].filter( ( { field } ) => isDefined( field ) ) as Array< {
 		field: NormalizedField< any >;
-		isVisibleFlag: string;
+		isVisibleFlag: 'showTitle' | 'showMedia' | 'showDescription';
 	} >;
 	const visibleFieldIds = view.fields ?? [];
 	const visibleRegularFieldsCount = regularFields.filter( ( f ) =>
@@ -88,9 +88,7 @@ export function PropertiesSection( {
 	).length;
 
 	const visibleLockedFields = lockedFields.filter(
-		( { isVisibleFlag } ) =>
-			// @ts-expect-error A string key cannot index `View`.
-			view[ isVisibleFlag ] ?? true
+		( { isVisibleFlag } ) => view[ isVisibleFlag ] ?? true
 	);
 
 	// If only one field (locked or regular) is visible, prevent it from being hidden
@@ -112,7 +110,6 @@ export function PropertiesSection( {
 			>
 				<ItemGroup isBordered isSeparated size="medium">
 					{ lockedFields.map( ( { field, isVisibleFlag } ) => {
-						// @ts-expect-error A string key cannot index `View`.
 						const isVisible = view[ isVisibleFlag ] ?? true;
 						const fieldToRender =
 							isSingleVisibleLockedField && isVisible

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -1921,9 +1921,12 @@ export const getBlockSelectors = (
 		const hasLayoutSupport =
 			!! blockType?.supports?.layout ||
 			!! blockType?.supports?.__experimentalLayout;
+		const blockGapSupport = blockType?.supports?.spacing?.blockGap;
 		const fallbackGapValue =
-			// @ts-expect-error `blockGap` support is typed as `boolean | AxialDirection[]`.
-			blockType?.supports?.spacing?.blockGap?.__experimentalDefault;
+			typeof blockGapSupport === 'object' &&
+			! Array.isArray( blockGapSupport )
+				? blockGapSupport.__experimentalDefault
+				: undefined;
 
 		const blockStyleVariations = getBlockStyles( name );
 		const styleVariationSelectors: Record< string, string > = {};

--- a/packages/global-styles-engine/src/utils/background.ts
+++ b/packages/global-styles-engine/src/utils/background.ts
@@ -8,11 +8,29 @@ export const BACKGROUND_BLOCK_DEFAULT_VALUES = {
 	backgroundPosition: '50% 50%', // used only when backgroundSize is 'contain'.
 };
 
+/**
+ * Whether a background image resolves to a URL, as opposed to a reference or an
+ * unresolved value.
+ *
+ * @param backgroundImage The background image value.
+ *
+ * @return Whether the value carries a URL.
+ */
+function hasImageUrl(
+	backgroundImage: BackgroundStyle[ 'backgroundImage' ]
+): backgroundImage is { url: string } {
+	return (
+		typeof backgroundImage === 'object' &&
+		backgroundImage !== null &&
+		'url' in backgroundImage &&
+		!! backgroundImage.url
+	);
+}
+
 export function setBackgroundStyleDefaults( backgroundStyle: BackgroundStyle ) {
 	if (
 		! backgroundStyle ||
-		// @ts-expect-error `backgroundImage` is a union whose other members have no `url`.
-		! backgroundStyle?.backgroundImage?.url
+		! hasImageUrl( backgroundStyle.backgroundImage )
 	) {
 		return;
 	}


### PR DESCRIPTION
## What?

Follow up to #81148

Removes five `@ts-expect-error` suppressions by typing the code properly instead of documenting why the suppression was needed.

## Why?

Review feedback on #81148 flagged several of the backfilled descriptions as cases where the disabling comment was hiding a fix rather than a genuine type limitation.

## How?

- **`input-control`**: `document.documentElement.style.removeProperty( 'cursor' )` instead of assigning `null`, which only worked through WebIDL's `LegacyNullToEmptyString` coercion.
- **`Icon`**: pass the forwarded sizing props as the type argument to `isValidElement`, so `cloneElement` accepts `size`/`width`/`height`.
- **DataViews properties section**: type `isVisibleFlag` as `'showTitle' | 'showMedia' | 'showDescription'` so it can index `View`. Removes two suppressions.
- **Block supports**: type the object form of `spacing.blockGap` (`{ __experimentalDefault?, sides? }`), which blocks like `core/columns` already use, and narrow at the call site in the global styles engine.
- **Global styles background**: narrow `backgroundImage` to the member carrying a `url` with a type predicate.

Two comments from the review are intentionally not addressed here, as both need more than a local fix:

- `inert` in `dataviews-footer`: React 18's types do not declare it and React 19's type it as `boolean`, so no single literal typechecks against both. The same suppression exists in `@wordpress/boot`, so this wants one shared answer.
- `label` in `dataviews-filters/filter.tsx`: `getOperatorByName` returns a union, so typing the `between` operator's `string[]` label means threading a new element type through every operator definition.

## Testing Instructions

No behaviour changes. CI type checks and unit tests cover this.

1. `npm run build:package-types` passes.
2. Confirm dragging a `NumberControl`/`RangeControl` label still shows the drag cursor and restores the default cursor on release.

### Testing Instructions for Keyboard

N/A, no UI changes.

## Use of AI Tools

The changes were drafted with Claude Code and reviewed by me.
