### PR TITLE
Footnotes: guard against invalid post meta values

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing, so the block shows its placeholder rather than the block crash warning ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
 
 ### Internal

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -15,7 +15,20 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 		postId
 	);
 	const footnotesSupported = 'string' === typeof meta?.footnotes;
-	const footnotes = meta?.footnotes ? JSON.parse( meta.footnotes ) : [];
+	// The meta is a string that something else may have written, so it can be
+	// malformed or hold something other than an array. Treat anything
+	// unreadable as no footnotes and fall through to the placeholder below.
+	let footnotes = [];
+	if ( meta?.footnotes ) {
+		try {
+			const parsed = JSON.parse( meta.footnotes );
+			if ( Array.isArray( parsed ) ) {
+				footnotes = parsed;
+			}
+		} catch {
+			// Not JSON this block can read.
+		}
+	}
 	const blockProps = useBlockProps();
 
 	if ( ! footnotesSupported ) {

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -18,17 +18,14 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 	// The meta is a string that something else may have written, so it can be
 	// malformed or hold something other than an array. Treat anything
 	// unreadable as no footnotes and fall through to the placeholder below.
-	let footnotes = [];
-	if ( meta?.footnotes ) {
-		try {
-			const parsed = JSON.parse( meta.footnotes );
-			if ( Array.isArray( parsed ) ) {
-				footnotes = parsed;
-			}
-		} catch {
-			// Not JSON this block can read.
-		}
+	let parsed;
+	try {
+		parsed = JSON.parse( meta?.footnotes || '[]' );
+	} catch {
+		// Left undefined, which the check below treats as no footnotes, along
+		// with a value of the wrong shape.
 	}
+	const footnotes = Array.isArray( parsed ) ? parsed : [];
 	const blockProps = useBlockProps();
 
 	if ( ! footnotesSupported ) {

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing. Malformed JSON, or valid JSON that is not an array, threw inside a store subscriber where no error boundary catches it, so the edit was dropped and the post silently stopped saving ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
 -   Ensure revision resolvers finish after fetched revisions are stored.
 
 ### Internal

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { RichTextData, create, toHTMLString } from '@wordpress/rich-text';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -23,7 +24,25 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 
 	const newOrder = getFootnotesOrder( blocks );
 
-	const footnotes = meta.footnotes ? JSON.parse( meta.footnotes ) : [];
+	// This meta is a string that something else may have written: a plugin, an
+	// import, or a direct database edit can leave it malformed or holding
+	// something other than an array. Parsing it unguarded throws inside a store
+	// subscriber, where no error boundary catches it and the edit is dropped
+	// before it reaches editEntityRecord, so the post silently stops saving.
+	let footnotes = [];
+	if ( meta.footnotes ) {
+		try {
+			const parsed = JSON.parse( meta.footnotes );
+			if ( Array.isArray( parsed ) ) {
+				footnotes = parsed;
+			} else {
+				warning( 'Footnotes post meta is not an array; ignoring it.' );
+			}
+		} catch {
+			warning( 'Footnotes post meta is not valid JSON; ignoring it.' );
+		}
+	}
+
 	const currentOrder = footnotes.map( ( fn ) => fn.id );
 
 	if ( currentOrder.join( '' ) === newOrder.join( '' ) ) {

--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -29,18 +29,19 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 	// something other than an array. Parsing it unguarded throws inside a store
 	// subscriber, where no error boundary catches it and the edit is dropped
 	// before it reaches editEntityRecord, so the post silently stops saving.
+	let parsed;
+	try {
+		parsed = JSON.parse( meta.footnotes || '[]' );
+	} catch {
+		// Left undefined, which the check below reports along with a value of
+		// the wrong shape.
+	}
+
 	let footnotes = [];
-	if ( meta.footnotes ) {
-		try {
-			const parsed = JSON.parse( meta.footnotes );
-			if ( Array.isArray( parsed ) ) {
-				footnotes = parsed;
-			} else {
-				warning( 'Footnotes post meta is not an array; ignoring it.' );
-			}
-		} catch {
-			warning( 'Footnotes post meta is not valid JSON; ignoring it.' );
-		}
+	if ( Array.isArray( parsed ) ) {
+		footnotes = parsed;
+	} else {
+		warning( 'Footnotes post meta is not a JSON array; ignoring it.' );
 	}
 
 	const currentOrder = footnotes.map( ( fn ) => fn.id );

--- a/packages/core-data/src/footnotes/test/index.js
+++ b/packages/core-data/src/footnotes/test/index.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import warning from '@wordpress/warning';
+
+/**
+ * Internal dependencies
+ */
+import { updateFootnotesFromMeta } from '../';
+
+// The real implementation logs once per distinct message, which would make
+// per-case assertions depend on the order the cases run in.
+jest.mock( '@wordpress/warning' );
+
+describe( 'updateFootnotesFromMeta', () => {
+	const blocks = [];
+
+	beforeEach( () => {
+		warning.mockClear();
+	} );
+
+	it( 'returns the blocks untouched when there is no meta', () => {
+		expect( updateFootnotesFromMeta( blocks, undefined ) ).toEqual( {
+			blocks,
+		} );
+	} );
+
+	it( 'returns the blocks untouched when the meta is not registered', () => {
+		expect( updateFootnotesFromMeta( blocks, {} ) ).toEqual( { blocks } );
+	} );
+
+	it( 'accepts an empty footnotes array without warning', () => {
+		expect(
+			updateFootnotesFromMeta( blocks, { footnotes: '[]' } )
+		).toEqual( { blocks } );
+		expect( warning ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'meta this code did not write', () => {
+		// Each of these threw before being guarded, inside a store subscriber
+		// where no error boundary catches it, so the user's edit was dropped
+		// and the post silently stopped saving.
+		it.each( [
+			[ 'valid JSON holding null', 'null' ],
+			[ 'valid JSON holding a number', '5' ],
+			[ 'valid JSON holding an object', '{"a":1}' ],
+			[ 'valid JSON holding a string', '"footnotes"' ],
+			[ 'malformed JSON', '{' ],
+			[ 'a truncated array', '[{"id":"a","content":"x"' ],
+			[ 'not JSON at all', 'footnotes' ],
+		] )( 'does not throw on %s', ( _label, footnotes ) => {
+			expect( () =>
+				updateFootnotesFromMeta( blocks, { footnotes } )
+			).not.toThrow();
+			expect( warning ).toHaveBeenCalled();
+		} );
+
+		it( 'treats an unreadable value as no footnotes', () => {
+			expect(
+				updateFootnotesFromMeta( blocks, { footnotes: 'null' } )
+			).toEqual( { blocks } );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -489,3 +489,55 @@ test.describe( 'Footnotes', () => {
 		} );
 	} );
 } );
+
+test.describe( 'Footnotes meta written by something else', () => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	// A plugin, an import, or a direct database edit can leave the meta
+	// malformed or holding something other than an array. Parsing it unguarded
+	// threw inside a store subscriber, where no error boundary catches it, so
+	// the edit never reached core-data: the keystroke showed on screen, the
+	// post never became dirty, and the work was lost with no notice at all.
+	test( 'does not stop the post from saving', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Malformed footnotes meta',
+				status: 'draft',
+				meta: { footnotes: 'null' },
+			},
+		} );
+
+		// Guard the fixture itself: without unfiltered_html the value is
+		// sanitized away, and the test would pass for the wrong reason.
+		expect( post.meta.footnotes ).toBe( 'null' );
+
+		await admin.editPost( post.id );
+		await editor.canvas
+			.locator( 'role=button[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( 'a paragraph' );
+
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Save draft' } )
+		).toBeEnabled();
+
+		await editor.saveDraft();
+
+		const saved = await requestUtils.rest( {
+			path: `/wp/v2/posts/${ post.id }`,
+			params: { context: 'edit' },
+		} );
+		expect( saved.content.raw ).toContain( 'a paragraph' );
+	} );
+} );


### PR DESCRIPTION
## What

`meta.footnotes` is parsed without a guard:

```js
const footnotes = meta.footnotes ? JSON.parse( meta.footnotes ) : [];
const currentOrder = footnotes.map( ( fn ) => fn.id );
```

If the value is malformed, or is valid JSON that is not an array, this throws. It runs inside a `registry.subscribe` callback, so no React error boundary catches it, and `editEntityRecord` on the next line never runs.

The result: the keystroke appears on screen, the post never becomes dirty, Save stays inert, and the edit is gone. No notice, no crash screen. Every keystroke after that throws too, so the post cannot be edited.

Reachable because the meta is registered as a plain string with no `sanitize_callback`, and the filter that would coerce it is only registered for users **without** `unfiltered_html`. Administrators are unprotected.

## How

Treat anything unreadable as no footnotes, and warn in development. This matches what PHP already does:[_gutenberg_filter_post_meta_footnotes](https://github.com/WordPress/gutenberg/blob/c1d8367952f4f707eed70e4d87d8a7dbafcc0d7f/lib/blocks.php#L314) returns `''` for a non-array on save, and the block's `index.php` checks `! is_array()` on render. 

This PR adds the same check in JS.

```php
	$footnotes_decoded = json_decode( $footnotes, true );
	if ( ! is_array( $footnotes_decoded ) ) {
		return '';
	}
```


## Manual testing

The best way I could find to test this was, as an administrator (so `unfiltered_html` is on) on single-site:

1. Open a post. **Options → Preferences → Panels → Custom fields → Enable**, and let the page reload.
2. In the **Custom Fields** box, add a field named `footnotes` with the value `null`. 
3. **Update**, then reload the editor.
4. Type a character in any block.

On trunk: the character appears, the post never becomes dirty, and the console shows `Uncaught TypeError: Cannot read properties of null (reading 'map')`. With this change: the post edits and saves normally.

Other values that reproduce it: `5`, `{"a":1}`, `{`. `[]` is the valid empty case.

## Use of AI

Claude discovered this while testing something else 😄 It drove, I steered.
