### PR TITLE
Blocks: Declare the `@types/react-is` devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50804,6 +50804,7 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
+				"@types/react-is": "^18.3.1",
 				"deep-freeze": "^0.0.1"
 			},
 			"engines": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -78,6 +78,7 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
+		"@types/react-is": "^18.3.1",
 		"deep-freeze": "^0.0.1"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## What?

Follow up to #81148. Declares `@types/react-is` as a devDependency of `@wordpress/blocks`.

## Why?

`packages/blocks` imports `react-is` but only `packages/plugins` declares `@types/react-is`. Default npm hoisting puts it in the root `node_modules`, so `tsc` finds it by accident. Without hoisting it fails:

```
packages/blocks/src/store/process-block-type.ts(6,36): error TS7016: Could not find a declaration file for module 'react-is'.
```

Same failure on #75814: https://github.com/WordPress/gutenberg/actions/runs/30979264622/job/92219984529?pr=75814

## How?

devDependencies, not dependencies: `isValidElementType` returns a `boolean`, so no `react-is` type reaches `build-types`.

## Testing Instructions

`npx tsc --build packages/blocks/tsconfig.json` passes. To see the original failure, run `npm install --install-strategy=linked` on `trunk` first.

## Use of AI Tools

Authored with Claude Code. I have reviewed and take responsibility for the changes.
