### PR TITLE
Visual revisions: add shareable urls

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Ensure revision resolvers finish after fetched revisions are stored.
+
 ## 7.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1067,7 +1067,7 @@ getDefaultTemplateId.shouldInvalidate = ( action ) => {
  */
 export const getRevisions =
 	( kind, name, recordKey, query = {} ) =>
-	async ( { dispatch, registry, resolveSelect } ) => {
+	async ( { dispatch, resolveSelect } ) => {
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(
 			( config ) => config.name === name && config.kind === kind
@@ -1142,37 +1142,31 @@ export const getRevisions =
 					} );
 				}
 
-				registry.batch( () => {
-					dispatch.receiveRevisions(
+				await dispatch.receiveRevisions(
+					kind,
+					name,
+					recordKey,
+					records,
+					query,
+					false,
+					meta
+				);
+
+				// Mark individual getRevision resolutions as done so that
+				// subsequent getRevision calls skip redundant API fetches.
+				const key = entityConfig.revisionKey || DEFAULT_ENTITY_KEY;
+				const normalizedQuery = normalizeQueryForResolution( rawQuery );
+				const resolutionsArgs = records
+					.filter( ( record ) => record[ key ] )
+					.map( ( record ) => [
 						kind,
 						name,
 						recordKey,
-						records,
-						query,
-						false,
-						meta
-					);
+						record[ key ],
+						normalizedQuery,
+					] );
 
-					// Mark individual getRevision resolutions as done so that
-					// subsequent getRevision calls skip redundant API fetches.
-					const key = entityConfig.revisionKey || DEFAULT_ENTITY_KEY;
-					const normalizedQuery =
-						normalizeQueryForResolution( rawQuery );
-					const resolutionsArgs = records
-						.filter( ( record ) => record[ key ] )
-						.map( ( record ) => [
-							kind,
-							name,
-							recordKey,
-							record[ key ],
-							normalizedQuery,
-						] );
-
-					dispatch.finishResolutions(
-						'getRevision',
-						resolutionsArgs
-					);
-				} );
+				dispatch.finishResolutions( 'getRevision', resolutionsArgs );
 			}
 		} finally {
 			dispatch.__unstableReleaseStoreLock( lock );
@@ -1261,7 +1255,7 @@ export const getRevision =
 			}
 
 			if ( record ) {
-				dispatch.receiveRevisions(
+				await dispatch.receiveRevisions(
 					kind,
 					name,
 					recordKey,

--- a/packages/core-data/src/test/store.js
+++ b/packages/core-data/src/test/store.js
@@ -277,6 +277,7 @@ describe( 'getRevisions', () => {
 	} );
 
 	it( 'preserves all revisions when getRevision resolves after getRevisions', async () => {
+		const revision = { id: 1 };
 		let resolveSlowFetch;
 		const slowFetchPromise = new Promise( ( resolve ) => {
 			resolveSlowFetch = resolve;
@@ -307,16 +308,15 @@ describe( 'getRevisions', () => {
 			1,
 			{ context: 'edit' }
 		);
-		await resolveSelectStore.getRevisions( KIND, NAME, RECORD_KEY, {
-			context: 'edit',
-		} );
+		await expect(
+			resolveSelectStore.getRevisions( KIND, NAME, RECORD_KEY, {
+				context: 'edit',
+			} )
+		).resolves.toEqual( REVISIONS );
 
 		// Now resolve the slow single-revision fetch.
-		resolveSlowFetch( REVISIONS[ 0 ] );
-		await revisionPromise;
-
-		// Wait for all pending thunks (receiveRevisions) to settle.
-		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		resolveSlowFetch( revision );
+		await expect( revisionPromise ).resolves.toEqual( revision );
 
 		const allRevisions = registry
 			.select( coreDataStore )

--- a/packages/e2e-tests/plugins/disable-post-revisions.php
+++ b/packages/e2e-tests/plugins/disable-post-revisions.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Disable Post Revisions
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-disable-post-revisions
+ */
+
+add_filter( 'wp_revisions_to_keep', '__return_zero' );

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -1,26 +1,54 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import useClassicRevisionRedirect from './use-classic-revision-redirect';
+
+/**
+ * Safari throws when rapid revision changes trigger more than 100 History API
+ * calls in 30 seconds.
+ */
+const URL_WRITE_DEBOUNCE_MS = 300;
 
 /**
  * Returns the Post's Edit URL.
  *
- * @param {number} postId Post ID.
+ * @param {number}  postId     Post ID.
+ * @param {?number} revisionId Revision being previewed, if any.
  *
  * @return {string} Post edit URL.
  */
-export function getPostEditURL( postId ) {
-	return addQueryArgs( 'post.php', { post: postId, action: 'edit' } );
+export function getPostEditURL( postId, revisionId ) {
+	const args = { post: postId, action: 'edit' };
+	if ( revisionId ) {
+		args.revision = revisionId;
+	}
+	return addQueryArgs( 'post.php', args );
 }
 
 export default function BrowserURL() {
-	const [ historyId, setHistoryId ] = useState( null );
-	const { postId, postStatus } = useSelect( ( select ) => {
+	useClassicRevisionRedirect();
+
+	// Read the initial revision once, before URL sync can overwrite it.
+	const [ initialRevisionId ] = useState( () => {
+		const revision = Number(
+			getQueryArg( window.location.href, 'revision' )
+		);
+		return Number.isInteger( revision ) && revision > 0 ? revision : null;
+	} );
+	const hasHandledInitialRevisionRef = useRef( false );
+
+	const { postId, postStatus, currentRevisionId } = useSelect( ( select ) => {
 		const { getCurrentPost } = select( editorStore );
+		const { getCurrentRevisionId } = unlock( select( editorStore ) );
 		const post = getCurrentPost();
 		let { id, status, type } = post;
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
@@ -33,19 +61,68 @@ export default function BrowserURL() {
 		return {
 			postId: id,
 			postStatus: status,
+			// `post.php` rejects templates because `show_ui` is false. Adding
+			// their revision ID to this URL would create a dead link.
+			currentRevisionId: isTemplate ? null : getCurrentRevisionId(),
 		};
 	}, [] );
+	const { openRevision } = unlock( useDispatch( editorStore ) );
+
+	const lastURLWriteTimeRef = useRef( null );
+	const lastPostIdRef = useRef( null );
 
 	useEffect( () => {
-		if ( postId && postId !== historyId && postStatus !== 'auto-draft' ) {
-			window.history.replaceState(
-				{ id: postId },
-				'Post ' + postId,
-				getPostEditURL( postId )
-			);
-			setHistoryId( postId );
+		if ( ! postId ) {
+			return;
 		}
-	}, [ postId, postStatus, historyId ] );
+		if ( initialRevisionId && ! hasHandledInitialRevisionRef.current ) {
+			hasHandledInitialRevisionRef.current = true;
+			openRevision( initialRevisionId );
+			return;
+		}
+		if ( postStatus === 'auto-draft' ) {
+			return;
+		}
+		const previousPostId = lastPostIdRef.current;
+		lastPostIdRef.current = postId;
+		const url = getPostEditURL( postId, currentRevisionId );
+		const write = () => {
+			lastURLWriteTimeRef.current = Date.now();
+			try {
+				window.history.replaceState(
+					{ id: postId },
+					'Post ' + postId,
+					url
+				);
+			} catch {
+				// Leave the URL unchanged. The effect can try again on the next
+				// state change.
+			}
+		};
+		if ( previousPostId !== null && previousPostId !== postId ) {
+			write();
+			return;
+		}
+		if ( lastURLWriteTimeRef.current === null ) {
+			write();
+			return;
+		}
+		if (
+			Date.now() - lastURLWriteTimeRef.current >=
+			URL_WRITE_DEBOUNCE_MS
+		) {
+			write();
+			return;
+		}
+		const timeoutId = setTimeout( write, URL_WRITE_DEBOUNCE_MS );
+		return () => clearTimeout( timeoutId );
+	}, [
+		postId,
+		postStatus,
+		currentRevisionId,
+		initialRevisionId,
+		openRevision,
+	] );
 
 	return null;
 }

--- a/packages/edit-post/src/components/browser-url/test/index.js
+++ b/packages/edit-post/src/components/browser-url/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -15,13 +15,18 @@ import { default as BrowserURL, getPostEditURL } from '../';
 
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 
-function setupUseSelectMock( { postId, postStatus } ) {
+function setupUseSelectMock( { postId, postStatus, currentRevisionId } ) {
 	useSelect.mockImplementation( () => {
 		return {
 			postId,
 			postStatus,
+			currentRevisionId,
 		};
 	} );
+}
+
+function flushURLWrites() {
+	act( () => jest.runAllTimers() );
 }
 
 describe( 'getPostEditURL', () => {
@@ -40,7 +45,13 @@ describe( 'BrowserURL', () => {
 	} );
 
 	beforeEach( () => {
+		jest.useFakeTimers();
 		replaceStateSpy.mockReset();
+	} );
+
+	afterEach( () => {
+		act( () => jest.runOnlyPendingTimers() );
+		jest.useRealTimers();
 	} );
 
 	afterAll( () => {
@@ -54,15 +65,17 @@ describe( 'BrowserURL', () => {
 		} );
 
 		render( <BrowserURL /> );
+		flushURLWrites();
 		expect( replaceStateSpy ).not.toHaveBeenCalled();
 	} );
 
-	it( 'update URL if post is no longer auto-draft', () => {
+	it( 'updates URL immediately if post is no longer auto-draft', () => {
 		setupUseSelectMock( {
 			postId: 1,
 			postStatus: 'auto-draft',
 		} );
 		const { rerender } = render( <BrowserURL /> );
+		flushURLWrites();
 
 		setupUseSelectMock( {
 			postId: 1,
@@ -77,25 +90,13 @@ describe( 'BrowserURL', () => {
 		);
 	} );
 
-	it( 'not update URL if history is already set', () => {
+	it( 'updates URL immediately if post ID changes', () => {
 		setupUseSelectMock( {
 			postId: 1,
 			postStatus: 'draft',
 		} );
 		const { rerender } = render( <BrowserURL /> );
-
-		replaceStateSpy.mockReset();
-
-		rerender( <BrowserURL /> );
-		expect( replaceStateSpy ).not.toHaveBeenCalled();
-	} );
-
-	it( 'update URL if post ID changes', () => {
-		setupUseSelectMock( {
-			postId: 1,
-			postStatus: 'draft',
-		} );
-		const { rerender } = render( <BrowserURL /> );
+		flushURLWrites();
 
 		setupUseSelectMock( {
 			postId: 2,
@@ -111,9 +112,70 @@ describe( 'BrowserURL', () => {
 		);
 	} );
 
-	it( 'renders nothing', () => {
-		const { container } = render( <BrowserURL /> );
+	it( 'appends the revision arg while previewing a revision', () => {
+		setupUseSelectMock( {
+			postId: 1,
+			postStatus: 'draft',
+			currentRevisionId: 5,
+		} );
 
-		expect( container ).toBeEmptyDOMElement();
+		render( <BrowserURL /> );
+		flushURLWrites();
+		expect( replaceStateSpy ).toHaveBeenCalledWith(
+			{ id: 1 },
+			'Post 1',
+			'post.php?post=1&action=edit&revision=5'
+		);
+	} );
+
+	it( 'writes immediately after a quiet period', () => {
+		setupUseSelectMock( {
+			postId: 1,
+			postStatus: 'draft',
+			currentRevisionId: 5,
+		} );
+		const { rerender } = render( <BrowserURL /> );
+		flushURLWrites();
+
+		act( () => jest.advanceTimersByTime( 301 ) );
+		setupUseSelectMock( {
+			postId: 1,
+			postStatus: 'draft',
+			currentRevisionId: 6,
+		} );
+		replaceStateSpy.mockReset();
+
+		rerender( <BrowserURL /> );
+		expect( replaceStateSpy ).toHaveBeenCalledWith(
+			{ id: 1 },
+			'Post 1',
+			'post.php?post=1&action=edit&revision=6'
+		);
+	} );
+
+	it( 'removes the revision arg after exiting revisions mode', () => {
+		setupUseSelectMock( {
+			postId: 1,
+			postStatus: 'draft',
+			currentRevisionId: 5,
+		} );
+		const { rerender } = render( <BrowserURL /> );
+		flushURLWrites();
+
+		setupUseSelectMock( {
+			postId: 1,
+			postStatus: 'draft',
+			currentRevisionId: null,
+		} );
+		replaceStateSpy.mockReset();
+
+		rerender( <BrowserURL /> );
+		expect( replaceStateSpy ).not.toHaveBeenCalled();
+		flushURLWrites();
+		expect( replaceStateSpy ).toHaveBeenCalledWith(
+			{ id: 1 },
+			'Post 1',
+			'post.php?post=1&action=edit'
+		);
 	} );
 } );

--- a/packages/edit-post/src/components/browser-url/use-classic-revision-redirect.js
+++ b/packages/edit-post/src/components/browser-url/use-classic-revision-redirect.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { useRegistry, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { useEffect } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Redirects an editor URL that already contains a revision ID to the classic
+ * screen when visual revisions are disabled. Revision buttons already link
+ * there, but the URL can load before the editor finishes checking for meta boxes.
+ */
+export default function useClassicRevisionRedirect() {
+	const registry = useRegistry();
+	const { disableVisualRevisions, currentRevisionId, postType, postId } =
+		useSelect( ( select ) => {
+			const editor = select( editorStore );
+			return {
+				disableVisualRevisions:
+					!! editor.getEditorSettings().disableVisualRevisions,
+				currentRevisionId: unlock( editor ).getCurrentRevisionId(),
+				postType: editor.getCurrentPostType(),
+				postId: editor.getCurrentPostId(),
+			};
+		}, [] );
+	const hasClassicRevisionScreen = ! [
+		'wp_template',
+		'wp_template_part',
+	].includes( postType );
+
+	useEffect( () => {
+		if (
+			! disableVisualRevisions ||
+			! hasClassicRevisionScreen ||
+			! currentRevisionId ||
+			! postType ||
+			! postId
+		) {
+			return;
+		}
+
+		let cancelled = false;
+		// Invalid IDs trigger `wp_die()` before JavaScript loads. Check that the
+		// revision belongs to this post before redirecting.
+		registry
+			.resolveSelect( coreStore )
+			.getRevision( 'postType', postType, postId, currentRevisionId, {
+				context: 'edit',
+				_fields: 'id',
+			} )
+			.then( ( revision ) => {
+				if ( cancelled || ! revision ) {
+					return;
+				}
+
+				const editor = registry.select( editorStore );
+				const isStillSelected =
+					!! editor.getEditorSettings().disableVisualRevisions &&
+					editor.getCurrentPostType() === postType &&
+					String( editor.getCurrentPostId() ) === String( postId ) &&
+					unlock( editor ).getCurrentRevisionId() ===
+						currentRevisionId;
+				if ( ! isStillSelected ) {
+					return;
+				}
+
+				// Replace the editor URL so Back does not reopen it and trigger
+				// the redirect again.
+				window.location.replace(
+					addQueryArgs( 'revision.php', {
+						revision: currentRevisionId,
+					} )
+				);
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		disableVisualRevisions,
+		hasClassicRevisionScreen,
+		currentRevisionId,
+		postType,
+		postId,
+		registry,
+	] );
+}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -35,6 +35,7 @@ import SiteEditorMoreMenu from '../more-menu';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
 import { ViewportSync } from '../block-editor/use-viewport-sync';
 import useEditorTitle from './use-editor-title';
+import useRevisionsURLSync from './use-revisions-url-sync';
 import { useIsSiteEditorLoading } from '../layout/hooks';
 import { useAdaptEditorToCanvas } from './use-adapt-editor-to-canvas';
 import {
@@ -79,7 +80,7 @@ function getNavigationPath( location, postType ) {
 	) {
 		return getListPathForPostType( postType );
 	}
-	return addQueryArgs( path, { canvas: undefined } );
+	return addQueryArgs( path, { canvas: undefined, revision: undefined } );
 }
 
 export default function EditSiteEditor( { isHomeRoute = false } ) {
@@ -97,13 +98,13 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 		[]
 	);
 	const postWithTemplate = !! context?.postId;
-	useEditorTitle(
-		postWithTemplate ? context.postType : postType,
-		postWithTemplate ? context.postId : postId
-	);
+	const editorPostType = postWithTemplate ? context.postType : postType;
+	const editorPostId = postWithTemplate ? context.postId : postId;
+	useEditorTitle( editorPostType, editorPostId );
 	const _isPreviewingTheme = isPreviewingTheme();
 	const iframeProps = useEditorIframeProps();
 	const isEditMode = canvas === 'edit';
+	useRevisionsURLSync( isEditMode, editorPostType, editorPostId );
 	const loadingProgressId = useInstanceId(
 		CanvasLoader,
 		'edit-site-editor__loading-progress'

--- a/packages/edit-site/src/components/editor/use-revisions-url-sync.js
+++ b/packages/edit-site/src/components/editor/use-revisions-url-sync.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { useHistory, useLocation } = unlock( routerPrivateApis );
+
+/**
+ * Safari throws after more than 100 History API calls in 30 seconds.
+ */
+const URL_WRITE_DEBOUNCE_MS = 300;
+
+export default function useRevisionsURLSync( enabled, postType, postId ) {
+	const location = useLocation();
+	const history = useHistory();
+	const { currentPostType, currentPostId, currentRevisionId } = useSelect(
+		( select ) => {
+			const editor = select( editorStore );
+			return {
+				currentPostType: editor.getCurrentPostType(),
+				currentPostId: editor.getCurrentPostId(),
+				currentRevisionId: unlock( editor ).getCurrentRevisionId(),
+			};
+		},
+		[]
+	);
+	const { openRevision, setCurrentRevisionId } = unlock(
+		useDispatch( editorStore )
+	);
+	const entityKey = postType && postId ? `${ postType }:${ postId }` : null;
+	const isCurrentEntity =
+		!! entityKey &&
+		currentPostType === postType &&
+		String( currentPostId ) === String( postId );
+
+	// The route can change before the editor store. Wait until both point to the
+	// same entity so a revision from the previous entity is not copied into the
+	// new URL.
+	const handledEntityKeyRef = useRef( null );
+	const lastURLWriteTimeRef = useRef( null );
+	useEffect( () => {
+		if ( ! enabled ) {
+			handledEntityKeyRef.current = null;
+			return;
+		}
+		if (
+			! isCurrentEntity ||
+			! entityKey ||
+			handledEntityKeyRef.current === entityKey
+		) {
+			return;
+		}
+
+		lastURLWriteTimeRef.current = null;
+		handledEntityKeyRef.current = entityKey;
+		const revision = Number( location.query.revision );
+		if ( Number.isInteger( revision ) && revision > 0 ) {
+			openRevision( revision );
+		} else if ( currentRevisionId ) {
+			setCurrentRevisionId( null );
+		}
+	}, [
+		enabled,
+		isCurrentEntity,
+		entityKey,
+		location.query.revision,
+		currentRevisionId,
+		openRevision,
+		setCurrentRevisionId,
+	] );
+
+	useEffect( () => {
+		if (
+			! enabled ||
+			! isCurrentEntity ||
+			! entityKey ||
+			handledEntityKeyRef.current !== entityKey
+		) {
+			return;
+		}
+		if ( lastURLWriteTimeRef.current === null ) {
+			lastURLWriteTimeRef.current = Date.now();
+		}
+		const revisionArg = currentRevisionId
+			? String( currentRevisionId )
+			: undefined;
+		if ( location.query.revision === revisionArg ) {
+			return;
+		}
+		const write = async () => {
+			// Route matching can lag behind the address bar. Writing the stale
+			// match back would undo the navigation.
+			const addressBarArg =
+				new URLSearchParams( window.location.search ).get(
+					'revision'
+				) ?? undefined;
+			if ( addressBarArg !== location.query.revision ) {
+				return;
+			}
+			lastURLWriteTimeRef.current = Date.now();
+			// Passing `undefined` removes `revision` without dropping the other
+			// query args.
+			try {
+				await history.navigate(
+					addQueryArgs( location.path, { revision: revisionArg } ),
+					{ replace: true }
+				);
+			} catch {
+				// Leave the URL unchanged. The effect can try again on the next
+				// state change.
+			}
+		};
+		if (
+			Date.now() - lastURLWriteTimeRef.current >=
+			URL_WRITE_DEBOUNCE_MS
+		) {
+			write();
+			return;
+		}
+		const timeoutId = setTimeout( write, URL_WRITE_DEBOUNCE_MS );
+		return () => clearTimeout( timeoutId );
+	}, [
+		enabled,
+		isCurrentEntity,
+		entityKey,
+		currentRevisionId,
+		location,
+		history,
+	] );
+}

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -666,6 +666,115 @@ export const setRevisionPage =
 		} );
 	};
 
+function createRevisionsLoadFailedNotice( registry ) {
+	registry
+		.dispatch( noticesStore )
+		.createNotice( 'warning', __( 'Revisions could not be loaded.' ), {
+			type: 'snackbar',
+			id: 'editor-revisions-load-failed',
+		} );
+}
+
+/**
+ * Open a revision from a shared URL and select the page that contains it.
+ *
+ * @param {number} revisionId The revision ID to open.
+ */
+export const openRevision =
+	( revisionId ) =>
+	async ( { dispatch, select, registry } ) => {
+		// Set the revision before loading its page so the canvas and slider
+		// can show loading states.
+		dispatch.setCurrentRevisionId( revisionId );
+
+		const postType = select.getCurrentPostType();
+		const postId = select.getCurrentPostId();
+		const entityConfig = registry
+			.select( coreStore )
+			.getEntityConfig( 'postType', postType );
+		const revisionKey = entityConfig?.revisionKey || 'id';
+
+		// Fetch all IDs in the slider's order so the revision's index points
+		// to the right page.
+		const revisions = await registry
+			.resolveSelect( coreStore )
+			.getRevisions( 'postType', postType, postId, {
+				per_page: -1,
+				context: 'edit',
+				orderby: 'date',
+				order: 'desc',
+				_fields: revisionKey,
+			} );
+
+		// Ignore stale results if the user navigated during the request.
+		if ( select.getCurrentRevisionId() !== revisionId ) {
+			return;
+		}
+
+		// core-data swallows request errors, so a missing result means the
+		// request failed. Keep the selection so a reload can try again.
+		if ( ! revisions ) {
+			createRevisionsLoadFailedNotice( registry );
+			return;
+		}
+
+		const index = revisions.findIndex(
+			( revision ) => revision[ revisionKey ] === revisionId
+		);
+		if ( index === -1 ) {
+			// Autosaves can be missing from the collection when revisions are
+			// disabled. Fetch the record directly so a request failure is not
+			// mistaken for a 404.
+			let revision;
+			try {
+				revision = await apiFetch( {
+					path: addQueryArgs(
+						entityConfig.getRevisionsUrl( postId, revisionId ),
+						{ context: 'edit' }
+					),
+				} );
+			} catch ( error ) {
+				if ( select.getCurrentRevisionId() !== revisionId ) {
+					return;
+				}
+				if ( error?.data?.status !== 404 ) {
+					createRevisionsLoadFailedNotice( registry );
+					return;
+				}
+
+				dispatch.setCurrentRevisionId( null );
+				registry
+					.dispatch( noticesStore )
+					.createNotice( 'warning', __( 'Invalid revision ID.' ), {
+						type: 'snackbar',
+						id: 'editor-revision-invalid',
+					} );
+				return;
+			}
+
+			if ( select.getCurrentRevisionId() !== revisionId ) {
+				return;
+			}
+			if ( ! revision ) {
+				createRevisionsLoadFailedNotice( registry );
+				return;
+			}
+			await registry
+				.dispatch( coreStore )
+				.receiveRevisions( 'postType', postType, postId, revision, {
+					context: 'edit',
+				} );
+			return;
+		}
+
+		const page = Math.floor( index / select.getRevisionsPerPage() ) + 1;
+		if ( page !== select.getRevisionPage() ) {
+			// `setRevisionPage()` would replace the deep-linked revision with
+			// the newest revision on the page.
+			dispatch( { type: 'SET_REVISION_PAGE', page } );
+		}
+	};
+
 /**
  * Set whether the revision diff highlighting is shown.
  *

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -565,8 +565,23 @@ export const getCurrentRevision = createRegistrySelector(
 		if ( ! revisions ) {
 			return null;
 		}
+		const revision = revisions.find(
+			( record ) => record[ revisionKey ] === revisionId
+		);
+		if ( revision ) {
+			return revision;
+		}
+
+		// When revisions are disabled, autosaves are missing from the collection
+		// but still available through the individual endpoint.
 		return (
-			revisions.find( ( r ) => r[ revisionKey ] === revisionId ) ?? null
+			select( coreStore ).getRevision(
+				'postType',
+				postType,
+				postId,
+				revisionId,
+				{ context: 'edit' }
+			) ?? null
 		);
 	}
 );

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a `replace` option to `useHistory().navigate` to update the current history entry instead of pushing a new one.
+
 ## 1.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -65,6 +65,7 @@ interface Config {
 export interface NavigationOptions {
 	transition?: string;
 	state?: Record< string, any >;
+	replace?: boolean;
 }
 
 const RoutesContext = createContext< Match | null >( null );
@@ -106,7 +107,7 @@ export function useHistory() {
 				const result = beforeNavigate
 					? beforeNavigate( { path, query } )
 					: { path, query };
-				return history.push(
+				return history[ options.replace ? 'replace' : 'push' ](
 					{
 						search: buildQueryString( {
 							[ pathArg ]: result.path,

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -337,6 +337,73 @@ test.describe( 'Post revisions with classic meta boxes', () => {
 			} )
 		).toHaveCount( 0 );
 	} );
+
+	test( 'redirects revision deep links to the classic screen', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Meta box deep link',
+				content:
+					'<!-- wp:paragraph --><p>Original content</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/posts/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Updated content</p><!-- /wp:paragraph -->',
+			},
+		} );
+		const revisions = await requestUtils.rest( {
+			path: `/wp/v2/posts/${ post.id }/revisions`,
+		} );
+		const oldestRevisionId = revisions[ revisions.length - 1 ].id;
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit&revision=${ oldestRevisionId }`
+		);
+
+		await expect( page ).toHaveURL(
+			new RegExp( `revision\\.php\\?revision=${ oldestRevisionId }` )
+		);
+	} );
+
+	test( 'keeps invalid revision deep links in the editor', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Meta box invalid deep link',
+				content:
+					'<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit&revision=99999999`
+		);
+
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Invalid revision ID.' } )
+		).toBeVisible();
+		expect( new URL( page.url() ).pathname ).toContain( '/post.php' );
+	} );
 } );
 
 test.describe( 'Post revisions slider pagination', () => {
@@ -585,5 +652,237 @@ test.describe( 'Template and template part revisions', () => {
 				},
 			] );
 		} );
+	} );
+} );
+
+test.describe( 'Post revisions shareable URLs', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'should open the revision from the URL and keep it in sync', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Creating a post does not create a revision, so update it twice.
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Shareable URL Test',
+				content:
+					'<!-- wp:paragraph --><p>Original content</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/posts/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>First revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/posts/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Second revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+
+		// The REST API returns revisions newest first, so the oldest is last.
+		const revisions = await requestUtils.rest( {
+			path: `/wp/v2/posts/${ post.id }/revisions`,
+		} );
+		const oldestRevisionId = revisions[ revisions.length - 1 ].id;
+		const newestRevisionId = revisions[ 0 ].id;
+
+		// `editPost()` dismisses the welcome guide and turns off fullscreen
+		// mode before opening the revision URL directly.
+		await admin.editPost( post.id );
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit&revision=${ oldestRevisionId }`
+		);
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toHaveText( 'First revision' );
+
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await slider.focus();
+		await page.keyboard.press( 'End' );
+		// Poll because URL writes are debounced.
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( String( newestRevisionId ) );
+
+		await page.getByRole( 'button', { name: 'Exit' } ).click();
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( null );
+	} );
+
+	test( 'should show a notice when the URL revision is invalid', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Invalid revision test',
+				content:
+					'<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+
+		await admin.editPost( post.id );
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit&revision=99999999`
+		);
+
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Invalid revision ID.' } )
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeHidden();
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( null );
+	} );
+
+	test( 'should keep the URL revision when the request fails', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Failing revision test',
+				content:
+					'<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+		const revisionId = 99999999;
+
+		// Do not treat a server error as a missing revision.
+		await page.route(
+			( url ) =>
+				url.href.includes( `revisions/${ revisionId }` ) ||
+				url.href.includes( `revisions%2F${ revisionId }` ),
+			async ( route ) => {
+				await route.fulfill( {
+					status: 500,
+					json: {
+						code: 'internal_server_error',
+						message: 'Server error.',
+						data: { status: 500 },
+					},
+				} );
+			}
+		);
+
+		await admin.editPost( post.id );
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit&revision=${ revisionId }`
+		);
+
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Revisions could not be loaded.' } )
+		).toBeVisible();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Invalid revision ID.' } )
+		).toBeHidden();
+
+		// The selection survives so a reload can try again.
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( String( revisionId ) );
+	} );
+} );
+
+test.describe( 'Post autosave shareable URLs with revisions disabled', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-disable-post-revisions'
+		);
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-post-revisions'
+		);
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'should render an autosave that is absent from the revisions collection', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Autosave URL Test',
+				content:
+					'<!-- wp:paragraph --><p>Saved content</p><!-- /wp:paragraph -->',
+				status: 'draft',
+			},
+		} );
+		const autosave = await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/posts/${ post.id }/autosaves`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Autosaved content</p><!-- /wp:paragraph -->',
+			},
+		} );
+		const revisions = await requestUtils.rest( {
+			path: `/wp/v2/posts/${ post.id }/revisions`,
+		} );
+		expect( revisions ).toHaveLength( 0 );
+
+		await admin.editPost( post.id );
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit&revision=${ autosave.id }`
+		);
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+		).toHaveText( 'Autosaved content' );
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( String( autosave.id ) );
 	} );
 } );

--- a/test/e2e/specs/site-editor/revisions.spec.js
+++ b/test/e2e/specs/site-editor/revisions.spec.js
@@ -1,0 +1,170 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Site editor revisions shareable URLs', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPages();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'should open the revision from the URL and keep it in sync', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Creating a page does not create a revision, so update it twice.
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/pages',
+			data: {
+				title: 'Revisions URL Page',
+				content:
+					'<!-- wp:paragraph --><p>Original content</p><!-- /wp:paragraph -->',
+				status: 'publish',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/pages/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>First revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/pages/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Second revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+
+		// The REST API returns revisions newest first, so the oldest is last.
+		const revisions = await requestUtils.rest( {
+			path: `/wp/v2/pages/${ post.id }/revisions`,
+		} );
+		const oldestRevisionId = revisions[ revisions.length - 1 ].id;
+		const newestRevisionId = revisions[ 0 ].id;
+
+		// `visitSiteEditor()` dismisses the welcome guide before opening the
+		// revision URL directly.
+		await admin.visitSiteEditor();
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`p=${ encodeURIComponent(
+				`/page/${ post.id }`
+			) }&canvas=edit&revision=${ oldestRevisionId }`
+		);
+
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toHaveText( 'First revision' );
+
+		const slider = page.getByRole( 'slider', { name: 'Revision' } );
+		await slider.focus();
+		await page.keyboard.press( 'End' );
+		// Poll because URL writes are debounced.
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( String( newestRevisionId ) );
+
+		await page.getByRole( 'button', { name: 'Exit' } ).click();
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'revision' ) )
+			.toBe( null );
+		expect( new URL( page.url() ).searchParams.get( 'canvas' ) ).toBe(
+			'edit'
+		);
+	} );
+
+	test( 'should not carry a revision to another page', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+		requestUtils,
+	} ) => {
+		const source = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/pages',
+			data: {
+				title: 'Revision source page',
+				content:
+					'<!-- wp:paragraph --><p>Original source content</p><!-- /wp:paragraph -->',
+				status: 'publish',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/pages/${ source.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Revised source content</p><!-- /wp:paragraph -->',
+			},
+		} );
+		const revisions = await requestUtils.rest( {
+			path: `/wp/v2/pages/${ source.id }/revisions`,
+		} );
+		const sourceRevisionId = revisions[ revisions.length - 1 ].id;
+		const target = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/pages',
+			data: {
+				title: 'Revision target page',
+				content:
+					'<!-- wp:paragraph --><p>Target page content</p><!-- /wp:paragraph -->',
+				status: 'publish',
+			},
+		} );
+
+		await admin.visitSiteEditor();
+		await admin.visitAdminPage(
+			'site-editor.php',
+			`p=${ encodeURIComponent(
+				`/page/${ source.id }`
+			) }&canvas=edit&revision=${ sourceRevisionId }`
+		);
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeVisible();
+
+		await pageUtils.pressKeys( 'primary+k' );
+		await page
+			.getByRole( 'combobox', {
+				name: 'Search commands and settings',
+			} )
+			.fill( 'Revision target page' );
+		await page
+			.getByRole( 'option', {
+				name: 'Revision target page',
+			} )
+			.click();
+
+		await expect
+			.poll( () => new URL( page.url() ).searchParams.get( 'p' ) )
+			.toBe( `/page/${ target.id }` );
+		await expect(
+			editor.canvas.getByText( 'Target page content' )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: 'Restore' } )
+		).toBeHidden();
+		expect( new URL( page.url() ).searchParams.get( 'revision' ) ).toBe(
+			null
+		);
+	} );
+} );


### PR DESCRIPTION
## What?

Backport of #79934 to the `wp/7.1` branch.

## How?

Cherry-pick of #79934. The only conflicts were in CHANGELOG files.

## Testing Instructions

All CI checks should pass.
