### PR TITLE
Media Attached to: Fix issue with the popover unexpectedly flipping, tweak wording

### DIFF
--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `attached_to`: Reserve room for the suggestions so the field's DataForm panel dropdown is placed with space for them, instead of being sized to the row and then crushing them into a box too small to scroll comfortably. Also don't expand the suggestion list until the user searches, debounce the search so a request isn't fired per keystroke, allow re-attaching straight after detaching, and drop the detach link from the help text in favour of the field's own reset button ([#81122](https://github.com/WordPress/gutenberg/issues/81122)).
+
 ## 0.16.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -5,10 +5,10 @@ import {
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { Button, ComboboxControl } from '@wordpress/components';
+import { ComboboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, createInterpolateElement } from '@wordpress/element';
-import { debounce } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+import { useDebounce, useEvent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 
@@ -76,7 +76,6 @@ export default function MediaAttachedToEdit( {
 			_embedded: { ...data?._embedded, 'wp:attached-to': undefined },
 		} );
 		setValue( null );
-		setOptions( [] );
 	};
 
 	const onValueChange = async ( filterValue: string ) => {
@@ -103,6 +102,12 @@ export default function MediaAttachedToEdit( {
 		setOptions( suggestions.concat( includeCurrent ? defaultPost : [] ) );
 		setIsLoading( false );
 	};
+
+	// `onValueChange` closes over state, so it's wrapped in `useEvent` to give
+	// `useDebounce` a stable function. Debouncing an inline function instead
+	// rebuilds the timer on every render, so nothing is debounced and each
+	// keystroke fires its own request.
+	const debouncedValueChange = useDebounce( useEvent( onValueChange ), 300 );
 
 	/**
 	 * Handle selection.
@@ -150,38 +155,22 @@ export default function MediaAttachedToEdit( {
 		}
 	};
 
-	const help = createInterpolateElement(
-		__(
-			'Search for a post or page to attach this media to or <button>detach current</button>.'
-		),
-		{
-			button: (
-				<Button
-					__next40pxDefaultSize
-					onClick={ handleDetach }
-					variant="link"
-					accessibleWhenDisabled
-					disabled={ ! value }
-				/>
-			),
-		}
-	);
-
 	return (
 		<ComboboxControl
 			className="dataviews-media-field__attached-to"
 			isLoading={ isLoading }
 			label={ __( 'Attached to' ) }
-			help={ help }
+			help={ __( 'Attach this file to a single post or page.' ) }
 			value={ value }
 			options={ options }
-			onFilterValueChange={ debounce(
-				( filterValue: unknown ) =>
-					onValueChange( filterValue as string ),
-				300
-			) }
+			onFilterValueChange={ ( filterValue: unknown ) =>
+				debouncedValueChange( filterValue as string )
+			}
 			onChange={ handleSelectOption }
 			hideLabelFromVision
+			// Opening the panel shouldn't imply the user has decided to change
+			// the attachment, so wait for them to search before showing the list.
+			expandOnFocus={ false }
 		/>
 	);
 }

--- a/packages/media-fields/src/attached_to/style.scss
+++ b/packages/media-fields/src/attached_to/style.scss
@@ -1,0 +1,36 @@
+@use "@wordpress/base-styles/variables" as *;
+
+// Height of the suggestion list: three rows, the most `fetchLinkSuggestions`
+// returns while it is called with `isInitialSuggestions` (see the @TODO in
+// edit.tsx).
+$suggestions-height: $button-size-compact * 3;
+
+// When this field is edited from a DataForm panel it renders inside a popover
+// that floating-ui measures and places when it opens. `ComboboxControl` renders
+// its suggestions inline, so they arrive after that measurement: the popover
+// can't grow, and the list ends up scrolling inside a box too small to scroll
+// comfortably — worst low on screen, where the space is smallest.
+//
+// See https://github.com/WordPress/gutenberg/issues/81122.
+.components-popover__content:has(.dataviews-media-field__attached-to) {
+	// Reserve the space the suggestions will need before they exist. The popover
+	// is absolutely positioned, so it contains this margin rather than collapsing
+	// it, and floating-ui measures the reserved height when it decides which way
+	// to open — and caps the popover's height against it too, so the cap already
+	// allows for the suggestions. The margin is transparent, so nothing is
+	// visibly reserved.
+	margin-bottom: $suggestions-height;
+
+	// Once the suggestions are there they occupy that space instead, so the
+	// popover's total height is unchanged and it has no reason to move.
+	&:has(.components-form-token-field__suggestions-list) {
+		margin-bottom: 0;
+	}
+
+	// Hold the list at the reserved height rather than letting it grow and shrink
+	// with the number of matches, which would resize the popover as you type.
+	.components-form-token-field__suggestions-list {
+		height: $suggestions-height;
+		max-height: none;
+	}
+}

--- a/packages/media-fields/src/style.scss
+++ b/packages/media-fields/src/style.scss
@@ -1,3 +1,4 @@
+@use "./attached_to/style.scss" as *;
 @use "./author/style.scss" as *;
 @use "./filename/style.scss" as *;
 @use "./media_thumbnail/style.scss" as *;


### PR DESCRIPTION
## What?

Part of #81122

For the media "Attached to" field, fix some of the jankiness noticed during 7.1 testing:

* Try to ensure there's enough room for the popover by applied a margin to account for how the Combobox expands
* Simplify the help text and remove the explicit "Detach" link/button as there isn't enough room in this context to adequately explain what it does

## Why?

During testing it turns out the bottom placement of the Attached to field means that the popover gets cutoff / reduced visually in size unless you're on a really big monitor (I am, which is why I didn't notice this issue!)

Additionally, attempt to simplify the wording. This is a little opinionated, but my hunch is that we'll have a better time at reintroducing a "Detach" button in 7.2 when we can look at these controls more holistically.

## How?

* Some hacky CSS to ensure the popover doesn't flip unexpectedly — this isn't ideal, but the longer-term fix will be using the combobox in the new `ui` package which isn't ready for use yet. That one will fix things on its own as the suggestions appear in a popover instead of extending the vertical area of the current block. So, this is intentionally a short-term fix
* Remove the "Detach" link / button. It's still possible to detach via the X icon, but this has been de-emphasised
* Ensure the value changes are actually debounced (this was buggy)

## Testing Instructions

* Upload an image to a post or page
* Use the crop button in the block toolbar
* Go to the details sidebar of the cropping modal
* Scroll down to the Attached to field and click it: the popover shouldn't be stuck at the bottom and should no longer be awkwardly small

## Screenshots or screencast <!-- if applicable -->

The popover now opens a bit higher so that it always has room to expand. This means it doesn't unexpectedly flip or shrink:

https://github.com/user-attachments/assets/53064d00-511b-498f-a606-6ac6830d2781

## Use of AI Tools

Claude Code