### PR TITLE
Fix ESLint warnings for 'navigateRegionsProps' spread (#81052)

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -104,7 +104,6 @@ function Layout() {
 			{ canvas === 'view' && <SaveKeyboardShortcut /> }
 			<div
 				{ ...navigateRegionsProps }
-				ref={ navigateRegionsProps.ref }
 				className={ clsx(
 					'edit-site-layout',
 					navigateRegionsProps.className,

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -36,11 +36,7 @@ function Layout( { blockEditorSettings } ) {
 
 	return (
 		<ErrorBoundary>
-			<div
-				className={ navigateRegionsProps.className }
-				{ ...navigateRegionsProps }
-				ref={ navigateRegionsProps.ref }
-			>
+			<div { ...navigateRegionsProps }>
 				<WidgetAreasBlockEditorProvider
 					blockEditorSettings={ blockEditorSettings }
 				>

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1084,11 +1084,6 @@
 			"count": 2
 		}
 	},
-	"packages/edit-site/src/components/layout/index.js": {
-		"react-hooks/refs": {
-			"count": 3
-		}
-	},
 	"packages/edit-site/src/components/page-templates/fields.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1126,11 +1121,6 @@
 	},
 	"packages/edit-site/src/components/sidebar-navigation-screen/index.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 3
-		}
-	},
-	"packages/edit-widgets/src/components/layout/index.js": {
-		"react-hooks/refs": {
 			"count": 3
 		}
 	},


### PR DESCRIPTION
Manual backport of #81052 to the `wp/7.1` branch.

The automated cherry-pick failed, so the commit was applied manually. The only conflict was in `tools/eslint/suppressions.json`, which was resolved by removing the corresponding suppression entries.

CI checks are expected to pass.
