### PR TITLE
Block Editor: Fix Select all freezing on large posts

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Performance
 
+-   `BlockListBlock`: Skip the `hasSelectedInnerBlock` deep check behind `isSelectionWithinCurrentSection` when the block is not within a section block. The check was passed an `undefined` client ID, which can never match, but still walked the parents of every selected block. On a post with 1000 top-level blocks, selecting all of them with Cmd+A spent about 6.6 seconds in this call alone.
+
 -   `ListView`: Drop the `useBlockDisplayInformation` and `useBlockLock` calls from the row, select button and branch components, reading the few fields they were used for from the `useSelect` each component already has. Store subscriptions go from seven to four per rendered row, and from two to one per branch ([#81136](https://github.com/WordPress/gutenberg/pull/81136)).
 -   `ListView`: Collapse the placeholder rows that stand in for blocks outside of the render window into a single spacer row per run, instead of rendering a `<tr>`/`<td>` pair for every block. On a post with 1000 top-level blocks this removes ~1900 elements (about 60% of the List View's DOM and nearly half of the document's elements), which cuts the style recalculation and layout work done when the List View opens ([#80953](https://github.com/WordPress/gutenberg/pull/80953)).
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Performance
 
+-   `hasSelectedInnerBlock`: Answer the deep check from a set of the selection's ancestors, built once per selection, instead of walking the parents of every selected block on every call. The old form was quadratic in the number of selected blocks, since `BlockListBlock` calls it once per rendered block.
+
 -   `BlockListBlock`: Skip the `hasSelectedInnerBlock` deep check behind `isSelectionWithinCurrentSection` when the block is not within a section block. The check was passed an `undefined` client ID, which can never match, but still walked the parents of every selected block. On a post with 1000 top-level blocks, selecting all of them with Cmd+A spent about 6.6 seconds in this call alone.
 
 -   `ListView`: Drop the `useBlockDisplayInformation` and `useBlockLock` calls from the row, select button and branch components, reading the few fields they were used for from the `useSelect` each component already has. Store subscriptions go from seven to four per rendered row, and from two to one per branch ([#81136](https://github.com/WordPress/gutenberg/pull/81136)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,10 +11,8 @@
 
 ### Performance
 
--   `hasSelectedInnerBlock`: Answer the deep check from a set of the selection's ancestors, built once per selection, instead of walking the parents of every selected block on every call. The old form was quadratic in the number of selected blocks, since `BlockListBlock` calls it once per rendered block.
-
--   `BlockListBlock`: Skip the `hasSelectedInnerBlock` deep check behind `isSelectionWithinCurrentSection` when the block is not within a section block. The check was passed an `undefined` client ID, which can never match, but still walked the parents of every selected block. On a post with 1000 top-level blocks, selecting all of them with Cmd+A spent about 6.6 seconds in this call alone.
-
+-   `hasSelectedInnerBlock`: Answer the deep check from a set of the selection's ancestors, built once per selection, instead of walking the parents of every selected block on each call. `BlockListBlock` asks once per rendered block, so the old cost was the block count multiplied by the selection size ([#81210](https://github.com/WordPress/gutenberg/pull/81210)).
+-   `BlockListBlock`: Skip that deep check behind `isSelectionWithinCurrentSection` when the block is not within a section block, where it was passed an `undefined` client ID that never matches. Together the two changes take selecting all blocks on a 1000 paragraph post from 16.8s to 0.4s ([#81210](https://github.com/WordPress/gutenberg/pull/81210)).
 -   `ListView`: Drop the `useBlockDisplayInformation` and `useBlockLock` calls from the row, select button and branch components, reading the few fields they were used for from the `useSelect` each component already has. Store subscriptions go from seven to four per rendered row, and from two to one per branch ([#81136](https://github.com/WordPress/gutenberg/pull/81136)).
 -   `ListView`: Collapse the placeholder rows that stand in for blocks outside of the render window into a single spacer row per run, instead of rendering a `<tr>`/`<td>` pair for every block. On a post with 1000 top-level blocks this removes ~1900 elements (about 60% of the List View's DOM and nearly half of the document's elements), which cuts the style recalculation and layout work done when the List View opens ([#80953](https://github.com/WordPress/gutenberg/pull/80953)).
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -682,9 +682,17 @@ function BlockListBlockProvider( props ) {
 				clientId,
 				checkDeep
 			);
-			const sectionBlockClientId = _isSectionBlock( clientId )
+			const isSectionBlock = _isSectionBlock( clientId );
+			const sectionBlockClientId = isSectionBlock
 				? clientId
 				: getParentSectionBlock( clientId );
+			// Without a section block there is nothing for the deep check to
+			// match, and it walks the parents of every selected block to find
+			// that out.
+			const isSelectionWithinCurrentSection =
+				isBlockSelected( sectionBlockClientId ) ||
+				( !! sectionBlockClientId &&
+					hasSelectedInnerBlock( sectionBlockClientId, checkDeep ) );
 
 			const multiple = hasBlockSupport( blockName, 'multiple', true );
 
@@ -702,11 +710,9 @@ function BlockListBlockProvider( props ) {
 				mode: getBlockMode( clientId ),
 				isSelectionEnabled: isSelectionEnabled(),
 				isLocked: !! getTemplateLock( rootClientId ),
-				isSectionBlock: _isSectionBlock( clientId ),
+				isSectionBlock,
 				isWithinSectionBlock: !! sectionBlockClientId,
-				isSelectionWithinCurrentSection:
-					isBlockSelected( sectionBlockClientId ) ||
-					hasSelectedInnerBlock( sectionBlockClientId, checkDeep ),
+				isSelectionWithinCurrentSection,
 				blockType,
 				canRemove,
 				canMove,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1317,6 +1317,35 @@ export function isBlockSelected( state, clientId ) {
 }
 
 /**
+ * Returns the ancestors of the current selection, as a set. A block is not its
+ * own ancestor, so the selected blocks themselves are not in the set.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {Set<string>} Client IDs of the ancestors of the selection.
+ */
+const getSelectedBlockAncestors = createSelector(
+	( state ) => {
+		const ancestors = new Set();
+
+		for ( const clientId of getSelectedBlockClientIds( state ) ) {
+			let current = clientId;
+			while ( ( current = state.blocks.parents.get( current ) ) ) {
+				// An earlier block already walked the rest of this chain.
+				if ( ancestors.has( current ) ) {
+					break;
+				}
+
+				ancestors.add( current );
+			}
+		}
+
+		return ancestors;
+	},
+	( state ) => getSelectedBlockClientIds.getDependants( state )
+);
+
+/**
  * Returns true if one of the block's inner blocks is selected.
  *
  * @param {Object}  state    Editor state.
@@ -1333,11 +1362,10 @@ export function hasSelectedInnerBlock( state, clientId, deep = false ) {
 	}
 
 	if ( deep ) {
-		return selectedBlockClientIds.some( ( id ) =>
-			// Pass true because we don't care about order and it's more
-			// performant.
-			getBlockParents( state, id, true ).includes( clientId )
-		);
+		// Callers ask this once per rendered block, so walking the parents of
+		// every selected block on each call is quadratic. The set is built
+		// once per selection instead.
+		return getSelectedBlockAncestors( state ).has( clientId );
 	}
 
 	return selectedBlockClientIds.some(

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1362,9 +1362,8 @@ export function hasSelectedInnerBlock( state, clientId, deep = false ) {
 	}
 
 	if ( deep ) {
-		// Callers ask this once per rendered block, so walking the parents of
-		// every selected block on each call is quadratic. The set is built
-		// once per selection instead.
+		// Callers ask once per rendered block, so the set is built once per
+		// selection rather than walking the selection on every call.
 		return getSelectedBlockAncestors( state ).has( clientId );
 	}
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2049,6 +2049,138 @@ describe( 'selectors', () => {
 			};
 			expect( hasSelectedInnerBlock( state, '3' ) ).toBe( false );
 		} );
+
+		it( 'should return true for a deep check if the selected block is a descendant of the given ClientId', () => {
+			const state = {
+				selection: {
+					selectionStart: { clientId: '3' },
+					selectionEnd: { clientId: '3' },
+				},
+				blocks: {
+					order: new Map(
+						Object.entries( {
+							1: [ '2' ],
+							2: [ '3' ],
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							2: '1',
+							3: '2',
+						} )
+					),
+				},
+			};
+
+			expect( hasSelectedInnerBlock( state, '1', true ) ).toBe( true );
+			expect( hasSelectedInnerBlock( state, '2', true ) ).toBe( true );
+			// Without a deep check only the direct parent matches.
+			expect( hasSelectedInnerBlock( state, '1' ) ).toBe( false );
+			expect( hasSelectedInnerBlock( state, '2' ) ).toBe( true );
+		} );
+
+		it( 'should return false for a deep check if the given ClientId is the selected block itself', () => {
+			const state = {
+				selection: {
+					selectionStart: { clientId: '3' },
+					selectionEnd: { clientId: '3' },
+				},
+				blocks: {
+					order: new Map(
+						Object.entries( {
+							1: [ '2' ],
+							2: [ '3' ],
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							2: '1',
+							3: '2',
+						} )
+					),
+				},
+			};
+
+			expect( hasSelectedInnerBlock( state, '3', true ) ).toBe( false );
+		} );
+
+		it( 'should return true for a deep check if a multi selection contains a descendant of the block with the given ClientId', () => {
+			const state = {
+				selection: {
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '3' },
+				},
+				blocks: {
+					order: new Map(
+						Object.entries( {
+							'': [ '1' ],
+							1: [ '2', '3' ],
+							3: [ '4' ],
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							1: '',
+							2: '1',
+							3: '1',
+							4: '3',
+						} )
+					),
+				},
+			};
+
+			expect( hasSelectedInnerBlock( state, '1', true ) ).toBe( true );
+			// '3' is selected, and it is not its own ancestor.
+			expect( hasSelectedInnerBlock( state, '3', true ) ).toBe( false );
+			expect( hasSelectedInnerBlock( state, '4', true ) ).toBe( false );
+		} );
+
+		it( 'should return an up to date deep check after the selection moves to another branch', () => {
+			// The same blocks throughout, so only the selection changes.
+			const blocks = {
+				order: new Map(
+					Object.entries( {
+						'': [ '1', '4' ],
+						1: [ '2' ],
+						4: [ '5' ],
+					} )
+				),
+				parents: new Map(
+					Object.entries( {
+						1: '',
+						2: '1',
+						4: '',
+						5: '4',
+					} )
+				),
+			};
+
+			const state = {
+				blocks,
+				selection: {
+					selectionStart: { clientId: '2' },
+					selectionEnd: { clientId: '2' },
+				},
+			};
+
+			expect( hasSelectedInnerBlock( state, '1', true ) ).toBe( true );
+			expect( hasSelectedInnerBlock( state, '4', true ) ).toBe( false );
+
+			const nextState = {
+				blocks,
+				selection: {
+					selectionStart: { clientId: '5' },
+					selectionEnd: { clientId: '5' },
+				},
+			};
+
+			expect( hasSelectedInnerBlock( nextState, '1', true ) ).toBe(
+				false
+			);
+			expect( hasSelectedInnerBlock( nextState, '4', true ) ).toBe(
+				true
+			);
+		} );
 	} );
 
 	describe( 'isBlockWithinSelection', () => {

--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -30,6 +30,7 @@ export interface WPRawPerformanceResults {
 	typeWithTopToolbar: number[];
 	typeContainer: number[];
 	focus: number[];
+	selectAll: number[];
 	inserterOpen: number[];
 	inserterSearch: number[];
 	inserterHover: number[];
@@ -73,6 +74,7 @@ export interface WPPerformanceResults {
 	typeWithTopToolbar?: PerformanceStats;
 	typeContainer?: PerformanceStats;
 	focus?: PerformanceStats;
+	selectAll?: PerformanceStats;
 	inserterOpen?: PerformanceStats;
 	inserterSearch?: PerformanceStats;
 	inserterHover?: PerformanceStats;
@@ -118,6 +120,7 @@ export function curateResults(
 		typeWithTopToolbar: stats( results.typeWithTopToolbar ),
 		typeContainer: stats( results.typeContainer ),
 		focus: stats( results.focus ),
+		selectAll: stats( results.selectAll ),
 		inserterOpen: stats( results.inserterOpen ),
 		inserterSearch: stats( results.inserterSearch ),
 		inserterHover: stats( results.inserterHover ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -352,7 +352,11 @@ test.describe( 'Post Editor Performance', () => {
 				name: /Block: Paragraph/i,
 			} );
 
-			const samples = 10;
+			// Fewer samples than the other metrics take. The comparison runs
+			// this spec against builds that predate the selection fix, where a
+			// single iteration costs seconds, and ten of them exceed the test
+			// timeout.
+			const samples = 3;
 			const throwaway = 1;
 			const iterations = samples + throwaway;
 			for ( let i = 1; i <= iterations; i++ ) {

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -28,6 +28,7 @@ const results = {
 	typeWithTopToolbar: [],
 	typeContainer: [],
 	focus: [],
+	selectAll: [],
 	listViewOpen: [],
 	inserterOpen: [],
 	inserterHover: [],
@@ -328,6 +329,63 @@ test.describe( 'Post Editor Performance', () => {
 							return acc + sum( eventDurations );
 						}, 0 )
 					);
+				}
+			}
+		} );
+	} );
+
+	test.describe( 'Selecting all blocks', () => {
+		let draftId = null;
+
+		test( 'Set up the test post', async ( { admin, perfUtils } ) => {
+			await admin.createNewPost();
+			await perfUtils.load1000Paragraphs();
+			draftId = await perfUtils.saveDraft();
+		} );
+
+		test( 'Run the test', async ( { admin, page, perfUtils, metrics } ) => {
+			await admin.editPost( draftId );
+			await perfUtils.disableAutosave();
+			const canvas = await perfUtils.getCanvas();
+
+			const paragraphs = canvas.getByRole( 'document', {
+				name: /Block: Paragraph/i,
+			} );
+
+			const samples = 10;
+			const throwaway = 1;
+			const iterations = samples + throwaway;
+			for ( let i = 1; i <= iterations; i++ ) {
+				// Put the caret in a paragraph, so the selection is a single
+				// block with a collapsed caret again.
+				await paragraphs.nth( i ).click();
+
+				// The first press selects the contents of the block; only the
+				// second one multi-selects every block.
+				await page.keyboard.press( 'ControlOrMeta+a' );
+
+				// Wait for the browser to be idle before starting the monitoring.
+				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
+				await page.waitForTimeout( BROWSER_IDLE_WAIT );
+
+				// Start tracing.
+				await metrics.startTracing();
+
+				// Select all blocks.
+				await page.keyboard.press( 'ControlOrMeta+a' );
+
+				// Stop tracing. Save just one representative sample.
+				await metrics.stopTracing(
+					i === Math.floor( iterations / 2 ) &&
+						'post-editor-select-all'
+				);
+
+				// Get the durations.
+				const [ keyDownEvents ] = metrics.getTypingEventDurations();
+
+				// Save the results.
+				if ( i > throwaway ) {
+					results.selectAll.push( sum( keyDownEvents ) );
 				}
 			}
 		} );


### PR DESCRIPTION
## What?
Originally reported by @andrewserong - https://github.com/WordPress/gutenberg/pull/80953#issuecomment-5173057785.

Pressing the Select all shortcut a second time froze the editor on large posts. On a post with 1000 paragraphs, the keydown took 16.8 seconds. It now takes 0.4 seconds.

## Why?

`hasSelectedInnerBlock( clientId, true )` walks the parents of every selected block, and `BlockListBlock` calls it once per rendered block. With everything selected, that is 1,000,000 lookups. Each one went through `getBlockParents`, a rememo selector whose cache is a linked list, so a miss scanned hundreds of cached entries with `isShallowEqual`. That cache scan, not the tree walk, was most of the cost.

`BlockListBlock` also made a second call that could never match. `isSelectionWithinCurrentSection` passed `sectionBlockClientId`, which is `undefined` when the block is not inside a section. Parent arrays only ever hold truthy client IDs, so that call always returned false after a full scan. It accounted for half the total.

## How?

Two commits:
1. Skip the deep check when there is no section block. The result was always false, so this preserves behavior. 16.8s to 8.3s.
2. Answer the deep check from a set of the selection's ancestors, built once per selection, instead of walking parents on every call. The set walks `state.blocks.parents` directly and so bypasses the rememo cache. 8.3s to 0.4s.

Inlining the walk instead of memoizing it is about as fast on flat content, but degrades sharply when the selection itself is nested, so the set is kept.

## Testing Instructions

1. Create a post with roughly 1000 paragraphs.
2. Put the caret in a paragraph and press the Select all shortcut twice.
3. All blocks are selected, and the editor does not freeze.

Automated coverage:

- `npm run test:unit packages/block-editor/src/store` (630 tests)
- `npm run test:e2e test/e2e/specs/editor/various/multi-block-selection.spec.js`
  (121 tests across Chromium, WebKit and Firefox)
- A `selectAll` metric was added to `test/performance/specs/post-editor.spec.js`

### Testing Instructions for Keyboard

Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e40d4d3f-542f-4053-b359-65a7e2e309f9

## Use of AI Tools

Assisted by Claude.
