### PR TITLE
Block Editor: Return false from isBlockSelected when there is no client ID

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Bug Fixes
 
+-   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1313,7 +1313,9 @@ export function isBlockSelected( state, clientId ) {
 		return false;
 	}
 
-	return selectionStart.clientId === clientId;
+	// Both sides are `undefined` when nothing is selected and the caller
+	// passes an optional client ID.
+	return !! clientId && selectionStart.clientId === clientId;
 }
 
 /**

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -1945,6 +1945,17 @@ describe( 'selectors', () => {
 
 			expect( isBlockSelected( state, '23' ) ).toBe( false );
 		} );
+
+		it( 'should return false if there is no client ID', () => {
+			const state = {
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
+			};
+
+			expect( isBlockSelected( state, undefined ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'hasSelectedInnerBlock', () => {


### PR DESCRIPTION
## What?

PR makes `isBlockSelected` return `false` when it is called without a client ID.

## Why?

The selector compared the argument against `state.selection.selectionStart.clientId`. Both are `undefined` when the editor has no selection, so a caller passing an optional client ID was told its block is selected.

`BlockListBlock` hits this. It computes `isSelectionWithinCurrentSection` from `isBlockSelected( sectionBlockClientId )`, and `sectionBlockClientId` is `undefined` for blocks outside a section. With nothing selected, every block reports the selection as being within its section, which turns on `mayDisplayPatternEditingControls`. The `content` and `list` inspectors fill and render for blocks when they shouldn't. The sidebar later corrects itself.

## How?

Guard the comparison with `!! clientId`. All other call sites pass a real client ID, so their behavior remains unchanged.

## Testing Instructions

1. Open a large post from perf tests.
2. Select a block.
3. Confirm that the content and list don't render.

## Screenshots or screencast <!-- if applicable -->

Using throttled CPU 4x to highlight the bug.

**Before**

https://github.com/user-attachments/assets/8890e1aa-03bc-43e1-8131-a35ccde2bbcf

**After**

https://github.com/user-attachments/assets/57254be2-12f5-4fe0-b135-8ef8e7c9dce9

## Use of AI Tools

Assisted by Claude.
