### PR TITLE
Markdownlint: disable the MD033 (no-inline-html) rule project-wide

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
-	"extends": "packages/scripts/config/.markdownlint.json"
+	"extends": "packages/scripts/config/.markdownlint.json",
+	"MD033": false
 }


### PR DESCRIPTION
## What?

See https://github.com/WordPress/gutenberg/pull/81168#discussion_r3719197568

Disables the [MD033 (`no-inline-html`)](https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md) markdownlint rule for this repository, in the root `.markdownlint.json`.

## Why?

The docs and package READMEs already rely on inline HTML in hundreds of places — `npm run lint:md:docs` currently reports **564 MD033 violations** across the repository (`kbd`, `br`, `div`, `details`/`summary`, `img`, `code`, and more). Some of it is unavoidable: for example, a pipe character inside a code span in a markdown table cannot be expressed portably across renderers with backticks, so autogenerated reference docs (e.g. `theme-json-living.md`, and the view config reference from #81168, where [this was discussed](https://github.com/WordPress/gutenberg/pull/81168#discussion_r3719197568)) emit `<code>…&#124;…</code>` instead.

With that volume of pre-existing, largely intentional inline HTML, the rule's warnings drown out the rest of the linter's output without providing actionable signal. The rule is also not enforced in CI — no workflow runs `lint:md:docs` — so these warnings only surface in local runs.

## How?

Adds `"MD033": false` to the root `.markdownlint.json`. This only affects the Gutenberg repository: the shared `@wordpress/scripts` config (`packages/scripts/config/.markdownlint.json`) is untouched, so downstream consumers of `wp-scripts lint-md-docs` keep the rule.

An alternative would be keeping the rule with an `allowed_elements` list (e.g. `code`, `kbd`, `br`, …), if reviewers prefer partial enforcement over disabling it.

## Testing Instructions

1. Run `npm run lint:md:docs 2>&1 | grep -c MD033`.
2. On trunk it reports 564 violations; with this PR it reports 0.
3. Other rules still run: `npm run lint:md:docs` still reports the pre-existing MD034/MD041 warnings.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (investigation of the rule's origin and violation counts, and the config change itself). The change was reviewed and is owned by the PR author.

