### PR TITLE
DataViews: Pass only eligible items to a bulk action callback (#81198)

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+-   DataViews: Pass only the eligible items to a bulk action's `callback`. A bulk action is offered when any one selected item is eligible for it, so the callback could run against items it had declared, through `isEligible`, that it could not handle. [#81198](https://github.com/WordPress/gutenberg/pull/81198)
 -   DataForms: Complete the `richtext` control's autocomplete semantics by associating the textbox with its suggestions list for assistive technology. [#80403](https://github.com/WordPress/gutenberg/pull/80403)
 - DataViews: Fix the `list` layout ignoring the density setting, the refreshing state, and the loading state when `groupBy` is set. [#80255](https://github.com/WordPress/gutenberg/pull/80255)
 - Fix Dataviews popover hover text color readability issue on WordPress 7.0. [#80105](https://github.com/WordPress/gutenberg/pull/80105)

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -246,7 +246,7 @@ function ActionButton< Item >( {
 			action={ action }
 			onClick={ async () => {
 				setActionInProgress( action.id );
-				await action.callback( selectedItems, {
+				await action.callback( selectedEligibleItems, {
 					registry,
 				} );
 				setActionInProgress( null );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -629,6 +629,54 @@ describe( 'DataViews component', () => {
 			).toBeChecked();
 			expect( onClickItem ).not.toHaveBeenCalled();
 		} );
+
+		it( 'passes only eligible items to a bulk action callback', async () => {
+			const restore = jest.fn();
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'author' ],
+						titleField: 'title',
+					} }
+					actions={ [
+						{
+							id: 'restore',
+							label: 'Restore',
+							supportsBulk: true,
+							// Only the first item can be restored.
+							isEligible: ( item: Data ) => item.id === 1,
+							callback: restore,
+						},
+						{
+							id: 'trash',
+							label: 'Trash',
+							supportsBulk: true,
+							// Makes the second item selectable even though it
+							// is not eligible for the restore action.
+							isEligible: ( item: Data ) => item.id !== 1,
+							callback: jest.fn(),
+						},
+					] }
+				/>
+			);
+			const user = userEvent.setup();
+			await user.click(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			);
+			await user.click(
+				screen.getByRole( 'checkbox', { name: data[ 1 ].title } )
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Restore' } )
+			);
+
+			expect( restore ).toHaveBeenCalledTimes( 1 );
+			expect(
+				restore.mock.calls[ 0 ][ 0 ].map( ( item: Data ) => item.id )
+			).toEqual( [ 1 ] );
+		} );
 	} );
 
 	describe( 'in grid view', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Manual backport of: https://github.com/WordPress/gutenberg/pull/81198