### PR TITLE
Blocks: Strip separator whitespace from inner blocks content

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -386,3 +386,23 @@ function _gutenberg_footnotes_force_filtered_html_on_import_filter( $arg ) {
 add_action( 'init', '_gutenberg_footnotes_kses_init' );
 add_action( 'set_current_user', '_gutenberg_footnotes_kses_init' );
 add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtered_html_on_import_filter', 999 );
+
+/**
+ * Strips serializer generated separator whitespace from block inner content,
+ * allowing CSS :empty to match if all inner blocks rendered empty.
+ *
+ * @param array $parsed_block The parsed block array.
+ * @return array Filtered parsed block array.
+ */
+function gutenberg_remove_inner_blocks_separator_whitespace( $parsed_block ) {
+	if ( ! empty( $parsed_block['innerContent'] ) ) {
+		foreach ( $parsed_block['innerContent'] as $key => $item ) {
+			// Replace newline separator with empty string.
+			if ( is_string( $item ) && '' === trim( $item ) ) {
+				$parsed_block['innerContent'][ $key ] = '';
+			}
+		}
+	}
+	return $parsed_block;
+}
+add_filter( 'render_block_data', 'gutenberg_remove_inner_blocks_separator_whitespace' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #80667 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Presently, blocks in gutenberg are stored to database via serialization process which adds two newline characters for sibling blocks (`serializer.tsx: Lines 515-530 -> serialize() function`). When parsed in PHP, these newlines are represented as separator strings '`\n\n'` in the parent block's `innerContent` array.

However, during the rendering of the PHP template on the frontend, if adjacent dynamic blocks (like the Post Tags block) render to empty strings (e.g., because no tags exist), the parsed newline separators still remain in the parent block container (like a Group block).

Impact caused: Since the html element (Group block in this case) now still contains newline characters, it is not considered empty by browsers. Consequently, the CSS `:empty` selector fails to match, preventing editors (using the "Additional CSS" block settings), developers, themes from hiding empty wrapping containers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- The PR primarily trims out newline string elements from `innerContent` of parent blocks.
- This is done by hooking into `render_block_data` in `lib/blocks.php`.
- New function: `gutenberg_remove_inner_blocks_separator_whitespace()`
  - It iterates over the parsed blocks and strips out only the serializer generated newline strings by replacing them with an empty string `''`.
  - This thus ensures clean HTML frontend render which can be targeted by `:empty` CSS pseudo-class. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create a new Post/Page. Make sure the post has no tags assigned to it.
2. In the editor, insert a **Group** block.
3. Inside the Group block, insert **two Post Tags** blocks.
4. Give the Group block some padding/margin and a background color (to make it visible) using the block settings sidebar.
5. In the Group block's **Advanced → Additional CSS** settings, add the following CSS rule:
   ```css
   &:empty {
       display: none;
   }
   ```
6. Publish the post and view it on the frontend.
7. **Verify:**
   - The empty Group block (with padding and background color) should be completely hidden from the page.
   - Inspecting the DOM in Dev Tools should show that the Group block's HTML element is completely empty: `<div class="wp-block-group ..."></div>` with no internal whitespace/newlines.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/a7a17325-d9da-4437-a348-e000c7daf1a5



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Antigravity IDE
Model(s): Gemini 3.5 Flash (Low)
Used for: Help in identifying the relevant code lines for the root cause, approach of the fix. Final implementation was reviewed and tested by me.
