### PR TITLE
Editor: Add accessible description to disabled "Open save panel" button

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import { NavigableRegion } from '@wordpress/admin-ui';
 import { Button, Modal } from '@wordpress/components';
+import { VisuallyHidden } from '@wordpress/ui';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -16,6 +17,7 @@ import {
 } from '@wordpress/core-data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useEffect } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -139,6 +141,9 @@ export default function SavePanel() {
 		setIsSaveViewOpened( false );
 	}, [ canvas, setIsSaveViewOpened ] );
 
+	const instanceId = useInstanceId( SavePanel );
+	const saveButtonDescriptionId = `edit-site-save-panel__save-button-description-${ instanceId }`;
+
 	if ( canvas === 'view' ) {
 		return isSaveViewOpen ? (
 			<Modal
@@ -153,6 +158,9 @@ export default function SavePanel() {
 	}
 	const activateSaveEnabled = isPreviewingTheme() || isDirty;
 	const disabled = isSaving || ! activateSaveEnabled;
+	const disabledReason = isSaving
+		? __( 'Saving changes.' )
+		: __( 'No changes to save.' );
 	return (
 		<NavigableRegion
 			className={ clsx( 'edit-site-layout__actions', {
@@ -171,11 +179,19 @@ export default function SavePanel() {
 					className="edit-site-editor__toggle-save-panel-button"
 					onClick={ () => setIsSaveViewOpened( true ) }
 					aria-haspopup="dialog"
+					aria-describedby={
+						disabled ? saveButtonDescriptionId : undefined
+					}
 					disabled={ disabled }
 					accessibleWhenDisabled
 				>
 					{ __( 'Open save panel' ) }
 				</Button>
+				{ disabled && (
+					<VisuallyHidden id={ saveButtonDescriptionId }>
+						{ disabledReason }
+					</VisuallyHidden>
+				) }
 			</div>
 			{ isSaveViewOpen && (
 				<_EntitiesSavedStates onClose={ onClose } renderDialog />

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -3,8 +3,10 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, createSlotFill } from '@wordpress/components';
+import { VisuallyHidden } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { privateApis as coreDataPrivateApis } from '@wordpress/core-data';
 
 /**
@@ -57,6 +59,9 @@ export default function SavePublishPanels( {
 		[]
 	);
 
+	const instanceId = useInstanceId( SavePublishPanels );
+	const saveButtonDescriptionId = `editor-save-publish-panels__save-button-description-${ instanceId }`;
+
 	// It is ok for these components to be unmounted when not in visual use.
 	// We don't want more than one present at a time, decide which to render.
 	let unmountableContent;
@@ -91,11 +96,19 @@ export default function SavePublishPanels( {
 					onClick={ openEntitiesSavedStates }
 					aria-expanded={ false }
 					aria-haspopup="dialog"
+					aria-describedby={
+						isDirty ? undefined : saveButtonDescriptionId
+					}
 					disabled={ ! isDirty }
 					accessibleWhenDisabled
 				>
 					{ __( 'Open save panel' ) }
 				</Button>
+				{ ! isDirty && (
+					<VisuallyHidden id={ saveButtonDescriptionId }>
+						{ __( 'No changes to save.' ) }
+					</VisuallyHidden>
+				) }
 			</div>
 		);
 	}


### PR DESCRIPTION
## What?

Closes #79265

Adds an accessible description to the "Open save panel" button in both the post/page editor and the Site Editor theme preview flow. When the button is disabled, screen reader users are informed why it cannot be activated.

## Why?

The button remains focusable while disabled to support keyboard and assistive technology users. However, there was no accessible explanation for its disabled state, leaving users without feedback when focus landed on the control.

## How?

Adds an `aria-describedby` attribute that references a visually hidden description explaining the button's current state:

* **"No changes to save."** when there are no unsaved changes.
* **"Saving changes."** while a save operation is in progress.

This ensures screen readers announce the reason the button is unavailable as soon as it receives focus. The implementation follows the existing `aria-describedby` + `VisuallyHidden` pattern already used elsewhere in Gutenberg.

## Testing Instructions
1. Open a post or page in the editor.
2. Open the Settings Sidebar without making any changes.
3. Press `Tab` until focus reaches the **"Open save panel"** button.
4. With a screen reader running (VoiceOver, NVDA, etc.), verify that the button is announced with the message **"No changes to save."**
5. Make an edit so the document has unsaved changes, tab back to the button, and verify that the additional description is no longer announced and that pressing `Enter` or `Space` opens the save panel.

## Screenshots or screencast 

### Before
https://github.com/user-attachments/assets/c98c6d00-efd0-44b3-8b95-30e9d3ac22f0

### After
https://github.com/user-attachments/assets/bac97a52-3c08-4ef0-be8d-6740f4648c2f

## Use of AI Tools
This PR was developed with the assistance of Claude Code.
