### PR TITLE
AGENTS: Update development tips section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,13 @@
 # Setup
 nvm use                    # Use the required node version
 npm install && composer install
-npm run wp-env status      # Always check status first.
-npm run wp-env start       # Only start if not already running.
+npm run wp-env-test status      # Always check status first.
+npm run wp-env-test start       # Only start if not already running.
 
 # Development
 npm start     # Development with watch
 npm run build # Production build
+npm run build -- --skip-types # Faster build; skips type generation
 ```
 
 ### Key Directories


### PR DESCRIPTION
## What?
Partially restore changes from #78718.

Only mentioned `wp-env-test` environment for agents, any automated tests run against this setup. Also mention `npm run build -- --skip-types` for faster builds, when testing various cases.

## Why?
Currently, agents always try to use the wrong environment.
