### PR TITLE
Fix: flaky list view paste block styles e2e test

### DIFF
--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -638,6 +638,17 @@ test.describe( 'List View', () => {
 			} )
 			.click();
 
+		// Wait for the copy confirmation. It only shows up once the styles
+		// have actually been written to the clipboard: the click on "Copy
+		// Styles" resolves before the asynchronous clipboard write settles,
+		// so pasting right away can read the clipboard before the styles
+		// are in it.
+		await expect(
+			page
+				.getByTestId( 'snackbar' )
+				.getByText( 'Styles copied to clipboard.' )
+		).toBeVisible();
+
 		// Open List View.
 		await listViewUtils.openListView();
 

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -641,6 +641,17 @@ test.describe( 'List View', () => {
 			} )
 			.click();
 
+		// Wait for the copy confirmation. It only shows up once the styles
+		// have actually been written to the clipboard: the click on "Copy
+		// Styles" resolves before the asynchronous clipboard write settles,
+		// so pasting right away can read the clipboard before the styles
+		// are in it.
+		await expect(
+			page
+				.getByTestId( 'snackbar' )
+				.getByText( 'Styles copied to clipboard.' )
+		).toBeVisible();
+
 		// Open List View.
 		await listViewUtils.openListView();
 


### PR DESCRIPTION
Fixes #78759

Fixes the flaky "should paste block styles using keyboard" e2e test in `list-view.spec.js`.

The test clicks "Copy styles" on the second block and immediately opens the list view and pastes onto the first block with `primaryAlt+v`. Copying styles writes to the clipboard through the asynchronous `navigator.clipboard.writeText()`, and the click resolves before that write settles. On a busy CI runner the paste can then read the clipboard before the styles are in it: the paste aborts with the "Unable to paste styles" warning, the first block never changes, and the `expect.poll` times out with exactly the diff recorded in the issue (first block missing the pasted style, second block untouched).

To fix this we wait for the "Styles copied to clipboard." snackbar before opening the list view. The confirmation is only created once the clipboard write has settled, so the paste can no longer read a stale clipboard.

## Testing Instructions

1. Run `npm run test:e2e -- test/e2e/specs/editor/various/list-view.spec.js --grep "paste block styles" --repeat-each=10` and verify it passes.
2. To reproduce the flake on trunk, widen the race window like a busy CI runner by delaying the clipboard write: apply the following patch without this PR's change and the test fails with the same diff as the issue. With this PR's change the same widened runs pass.

```diff
diff --git a/test/e2e/specs/editor/various/list-view.spec.js b/test/e2e/specs/editor/various/list-view.spec.js
--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -632,6 +632,17 @@
 		} );
 
 		// Copy the styles from the second block.
+		// Simulate a slow clipboard write, like on a loaded CI runner.
+		await page.evaluate( () => {
+			const original = navigator.clipboard.writeText.bind(
+				navigator.clipboard
+			);
+			navigator.clipboard.writeText = async ( text ) => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 800 ) );
+				return original( text );
+			};
+		} );
 		await editor.clickBlockToolbarButton( 'Options' );
```

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
