### PR TITLE
Block editor: render a real default block in place of the default appender

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1098,7 +1098,37 @@ _Returns_
 
 ### useBlockProps
 
-Undocumented declaration.
+This hook is used to lightly mark an element as a block element. The element should be the outermost element of a block. Call this hook and pass the returned props to the element to mark as a block. If you define a ref for the element, it is important to pass the ref to this hook, which the hook in turn will pass to the component through the props it returns. Optionally, you can also pass any other props through this hook, and they will be merged and returned.
+
+Use of this hook on the outermost element of a block is required if using API >= v2.
+
+_Usage_
+
+```js
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit() {
+	const blockProps = useBlockProps( {
+		className: 'my-custom-class',
+		style: {
+			color: '#222222',
+			backgroundColor: '#eeeeee',
+		},
+	} );
+
+	return <div { ...blockProps }></div>;
+}
+```
+
+_Parameters_
+
+-   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
+-   _options_ `Object`: Options for internal use only.
+-   _options.\_\_unstableIsHtml_ `boolean`:
+
+_Returns_
+
+-   `Object`: Props to pass to the element to mark as a block.
 
 ### useCachedTruthy
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1098,37 +1098,7 @@ _Returns_
 
 ### useBlockProps
 
-This hook is used to lightly mark an element as a block element. The element should be the outermost element of a block. Call this hook and pass the returned props to the element to mark as a block. If you define a ref for the element, it is important to pass the ref to this hook, which the hook in turn will pass to the component through the props it returns. Optionally, you can also pass any other props through this hook, and they will be merged and returned.
-
-Use of this hook on the outermost element of a block is required if using API >= v2.
-
-_Usage_
-
-```js
-import { useBlockProps } from '@wordpress/block-editor';
-
-export default function Edit() {
-	const blockProps = useBlockProps( {
-		className: 'my-custom-class',
-		style: {
-			color: '#222222',
-			backgroundColor: '#eeeeee',
-		},
-	} );
-
-	return <div { ...blockProps }></div>;
-}
-```
-
-_Parameters_
-
--   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
--   _options_ `Object`: Options for internal use only.
--   _options.\_\_unstableIsHtml_ `boolean`:
-
-_Returns_
-
--   `Object`: Props to pass to the element to mark as a block.
+Undocumented declaration.
 
 ### useCachedTruthy
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -23,6 +23,7 @@ import {
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
+import { _x } from '@wordpress/i18n';
 import { compose, useRefEffect } from '@wordpress/compose';
 import { safeHTML } from '@wordpress/dom';
 import BlockEdit from '../block-edit';
@@ -893,6 +894,13 @@ function BlockListBlockProvider( props ) {
 
 	const privateContext = {
 		isPreviewMode,
+		ariaLabel:
+			ghostBlock && ghostBlock.clientId === clientId
+				? _x(
+						'Add default block',
+						'accessible name of the default block ghost'
+				  )
+				: undefined,
 		clientId,
 		className,
 		index,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -1,5 +1,12 @@
 import clsx from 'clsx';
-import { memo, RawHTML, useContext, useMemo } from '@wordpress/element';
+import {
+	memo,
+	RawHTML,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 import {
 	getBlockType,
 	getSaveContent,
@@ -15,7 +22,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { withDispatch, useSelect } from '@wordpress/data';
+import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
 import { compose, useRefEffect } from '@wordpress/compose';
 import { safeHTML } from '@wordpress/dom';
 import BlockEdit from '../block-edit';
@@ -24,6 +31,7 @@ import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import { useBlockProps } from './use-block-props';
+import { useBlockElement } from './use-block-props/use-block-refs';
 import { store as blockEditorStore } from '../../store';
 import { useLayout } from './layout';
 import { PrivateBlockContext } from './private-block-context';
@@ -562,8 +570,46 @@ BlockListBlock = compose(
 // props are public API. To avoid adding to the public API, we use a private
 // context to pass the rest of the information to the filtered BlockListBlock
 // component, and useBlockProps.
+/**
+ * Inserts a ghost block when the user enters it: the same block object the
+ * ghost has rendered from all along, so nothing about the element changes.
+ *
+ * @param {string}  clientId     The block client ID.
+ * @param {string}  rootClientId The block's root client ID.
+ * @param {?Object} ghostBlock   The ghost block object, while not inserted.
+ */
+function useGhostMaterialize( clientId, rootClientId, ghostBlock ) {
+	const { insertBlocks } = useDispatch( blockEditorStore );
+	const element = useBlockElement( clientId );
+	const materializedRef = useRef( false );
+
+	useEffect( () => {
+		materializedRef.current = false;
+	}, [ ghostBlock ] );
+
+	useEffect( () => {
+		if ( ! element || ! ghostBlock ) {
+			return;
+		}
+		function materialize() {
+			if ( materializedRef.current ) {
+				return;
+			}
+			materializedRef.current = true;
+			insertBlocks( [ ghostBlock ], undefined, rootClientId, false );
+		}
+		element.addEventListener( 'pointerdown', materialize, true );
+		element.addEventListener( 'focusin', materialize, true );
+		return () => {
+			element.removeEventListener( 'pointerdown', materialize, true );
+			element.removeEventListener( 'focusin', materialize, true );
+		};
+	}, [ element, ghostBlock, rootClientId, insertBlocks ] );
+}
+
 function BlockListBlockProvider( props ) {
 	const { clientId, rootClientId, ghostBlock } = props;
+	useGhostMaterialize( clientId, rootClientId, ghostBlock );
 	const selectedProps = useSelect(
 		( select ) => {
 			const {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -16,7 +16,6 @@ import {
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { withDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { compose, useRefEffect } from '@wordpress/compose';
 import { safeHTML } from '@wordpress/dom';
 import BlockEdit from '../block-edit';
@@ -858,10 +857,6 @@ function BlockListBlockProvider( props ) {
 		isPreviewMode,
 		ghostBlock,
 		rootClientId,
-		ariaLabel:
-			ghostBlock && ghostBlock.clientId === clientId
-				? __( 'Add default block' )
-				: undefined,
 		clientId,
 		className,
 		index,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -32,7 +32,6 @@ import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import { useBlockProps } from './use-block-props';
-import { useBlockElement } from './use-block-props/use-block-refs';
 import { store as blockEditorStore } from '../../store';
 import { useLayout } from './layout';
 import { PrivateBlockContext } from './private-block-context';
@@ -572,25 +571,26 @@ BlockListBlock = compose(
 // context to pass the rest of the information to the filtered BlockListBlock
 // component, and useBlockProps.
 /**
- * Inserts a ghost block when the user enters it: the same block object the
- * ghost has rendered from all along, so nothing about the element changes.
+ * Returns block props that insert a ghost block when the user enters it:
+ * the same block object the ghost has rendered from all along, so nothing
+ * about the element changes.
  *
- * @param {string}  clientId     The block client ID.
  * @param {string}  rootClientId The block's root client ID.
  * @param {?Object} ghostBlock   The ghost block object, while not inserted.
+ *
+ * @return {?Object} Props for the block element, while a ghost.
  */
-function useGhostMaterialize( clientId, rootClientId, ghostBlock ) {
+function useGhostMaterialize( rootClientId, ghostBlock ) {
 	const { insertBlocks } = useDispatch( blockEditorStore );
-	const element = useBlockElement( clientId );
 	const materializedRef = useRef( false );
 
 	useEffect( () => {
 		materializedRef.current = false;
 	}, [ ghostBlock ] );
 
-	useEffect( () => {
-		if ( ! element || ! ghostBlock ) {
-			return;
+	return useMemo( () => {
+		if ( ! ghostBlock ) {
+			return undefined;
 		}
 		function materialize() {
 			if ( materializedRef.current ) {
@@ -601,18 +601,16 @@ function useGhostMaterialize( clientId, rootClientId, ghostBlock ) {
 			// only be at its start, and the undo level records it.
 			insertBlocks( [ ghostBlock ], undefined, rootClientId, true, 0 );
 		}
-		element.addEventListener( 'pointerdown', materialize, true );
-		element.addEventListener( 'focusin', materialize, true );
-		return () => {
-			element.removeEventListener( 'pointerdown', materialize, true );
-			element.removeEventListener( 'focusin', materialize, true );
+		return {
+			onPointerDownCapture: materialize,
+			onFocusCapture: materialize,
 		};
-	}, [ element, ghostBlock, rootClientId, insertBlocks ] );
+	}, [ ghostBlock, rootClientId, insertBlocks ] );
 }
 
 function BlockListBlockProvider( props ) {
 	const { clientId, rootClientId, ghostBlock } = props;
-	useGhostMaterialize( clientId, rootClientId, ghostBlock );
+	const ghostProps = useGhostMaterialize( rootClientId, ghostBlock );
 	// Stable fallback so the selector returns referentially equal values.
 	const ghostBlockWithoutAttributes = useMemo(
 		() =>
@@ -904,6 +902,7 @@ function BlockListBlockProvider( props ) {
 
 	const privateContext = {
 		isPreviewMode,
+		ghostProps,
 		ariaLabel:
 			ghostBlock && ghostBlock.clientId === clientId
 				? __( 'Add default block' )

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -1,12 +1,5 @@
 import clsx from 'clsx';
-import {
-	memo,
-	RawHTML,
-	useContext,
-	useEffect,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
+import { memo, RawHTML, useContext, useMemo } from '@wordpress/element';
 import {
 	getBlockType,
 	getSaveContent,
@@ -22,7 +15,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
+import { withDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { compose, useRefEffect } from '@wordpress/compose';
 import { safeHTML } from '@wordpress/dom';
@@ -570,47 +563,8 @@ BlockListBlock = compose(
 // props are public API. To avoid adding to the public API, we use a private
 // context to pass the rest of the information to the filtered BlockListBlock
 // component, and useBlockProps.
-/**
- * Returns block props that insert a ghost block when the user enters it:
- * the same block object the ghost has rendered from all along, so nothing
- * about the element changes.
- *
- * @param {string}  rootClientId The block's root client ID.
- * @param {?Object} ghostBlock   The ghost block object, while not inserted.
- *
- * @return {?Object} Props for the block element, while a ghost.
- */
-function useGhostMaterialize( rootClientId, ghostBlock ) {
-	const { insertBlocks } = useDispatch( blockEditorStore );
-	const materializedRef = useRef( false );
-
-	useEffect( () => {
-		materializedRef.current = false;
-	}, [ ghostBlock ] );
-
-	return useMemo( () => {
-		if ( ! ghostBlock ) {
-			return undefined;
-		}
-		function materialize() {
-			if ( materializedRef.current ) {
-				return;
-			}
-			materializedRef.current = true;
-			// Update the selection: the ghost is empty, so the caret can
-			// only be at its start, and the undo level records it.
-			insertBlocks( [ ghostBlock ], undefined, rootClientId, true, 0 );
-		}
-		return {
-			onPointerDownCapture: materialize,
-			onFocusCapture: materialize,
-		};
-	}, [ ghostBlock, rootClientId, insertBlocks ] );
-}
-
 function BlockListBlockProvider( props ) {
 	const { clientId, rootClientId, ghostBlock } = props;
-	const ghostProps = useGhostMaterialize( rootClientId, ghostBlock );
 	// Stable fallback so the selector returns referentially equal values.
 	const ghostBlockWithoutAttributes = useMemo(
 		() =>
@@ -902,7 +856,8 @@ function BlockListBlockProvider( props ) {
 
 	const privateContext = {
 		isPreviewMode,
-		ghostProps,
+		ghostBlock,
+		rootClientId,
 		ariaLabel:
 			ghostBlock && ghostBlock.clientId === clientId
 				? __( 'Add default block' )

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -597,7 +597,9 @@ function useGhostMaterialize( clientId, rootClientId, ghostBlock ) {
 				return;
 			}
 			materializedRef.current = true;
-			insertBlocks( [ ghostBlock ], undefined, rootClientId, false );
+			// Update the selection: the ghost is empty, so the caret can
+			// only be at its start, and the undo level records it.
+			insertBlocks( [ ghostBlock ], undefined, rootClientId, true, 0 );
 		}
 		element.addEventListener( 'pointerdown', materialize, true );
 		element.addEventListener( 'focusin', materialize, true );
@@ -611,6 +613,18 @@ function useGhostMaterialize( clientId, rootClientId, ghostBlock ) {
 function BlockListBlockProvider( props ) {
 	const { clientId, rootClientId, ghostBlock } = props;
 	useGhostMaterialize( clientId, rootClientId, ghostBlock );
+	// Stable fallback so the selector returns referentially equal values.
+	const ghostBlockWithoutAttributes = useMemo(
+		() =>
+			ghostBlock
+				? {
+						clientId: ghostBlock.clientId,
+						name: ghostBlock.name,
+						isValid: true,
+				  }
+				: undefined,
+		[ ghostBlock ]
+	);
 	const selectedProps = useSelect(
 		( select ) => {
 			const {
@@ -649,12 +663,8 @@ function BlockListBlockProvider( props ) {
 				getBlockWithoutAttributes( clientId ) ??
 				// An appender ghost renders from its block object until it
 				// is inserted on entry; it is never selected before that.
-				( ghostBlock && clientId === ghostBlock.clientId
-					? {
-							clientId,
-							name: ghostBlock.name,
-							isValid: true,
-					  }
+				( clientId === ghostBlockWithoutAttributes?.clientId
+					? ghostBlockWithoutAttributes
 					: undefined );
 
 			// This is a temporary fix.
@@ -809,7 +819,7 @@ function BlockListBlockProvider( props ) {
 				viewportSettings,
 			};
 		},
-		[ clientId, rootClientId, ghostBlock ]
+		[ clientId, rootClientId, ghostBlock, ghostBlockWithoutAttributes ]
 	);
 
 	const defaultViewRef = useRefEffect( ( element ) => {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -563,7 +563,7 @@ BlockListBlock = compose(
 // context to pass the rest of the information to the filtered BlockListBlock
 // component, and useBlockProps.
 function BlockListBlockProvider( props ) {
-	const { clientId, rootClientId } = props;
+	const { clientId, rootClientId, ghostBlock } = props;
 	const selectedProps = useSelect(
 		( select ) => {
 			const {
@@ -599,7 +599,16 @@ function BlockListBlockProvider( props ) {
 				getSelectedBlocksInitialCaretPosition,
 			} = unlock( select( blockEditorStore ) );
 			const blockWithoutAttributes =
-				getBlockWithoutAttributes( clientId );
+				getBlockWithoutAttributes( clientId ) ??
+				// An appender ghost renders from its block object until it
+				// is inserted on entry; it is never selected before that.
+				( ghostBlock && clientId === ghostBlock.clientId
+					? {
+							clientId,
+							name: ghostBlock.name,
+							isValid: true,
+					  }
+					: undefined );
 
 			// This is a temporary fix.
 			// This function should never be called when a block is not
@@ -613,7 +622,8 @@ function BlockListBlockProvider( props ) {
 				hasBlockSupport: _hasBlockSupport,
 				getActiveBlockVariation,
 			} = select( blocksStore );
-			const attributes = getBlockAttributes( clientId );
+			const attributes =
+				getBlockAttributes( clientId ) ?? ghostBlock?.attributes;
 			const { name: blockName, isValid } = blockWithoutAttributes;
 			const blockType = getBlockType( blockName );
 			const settings = getSettings();
@@ -675,9 +685,13 @@ function BlockListBlockProvider( props ) {
 			const sectionBlockClientId = isSectionBlock
 				? clientId
 				: getParentSectionBlock( clientId );
+			// Without a section block there is nothing for the deep check to
+			// match, and it walks the parents of every selected block to find
+			// that out.
 			const isSelectionWithinCurrentSection =
 				isBlockSelected( sectionBlockClientId ) ||
-				hasSelectedInnerBlock( sectionBlockClientId, checkDeep );
+				( !! sectionBlockClientId &&
+					hasSelectedInnerBlock( sectionBlockClientId, checkDeep ) );
 
 			const multiple = hasBlockSupport( blockName, 'multiple', true );
 
@@ -748,7 +762,7 @@ function BlockListBlockProvider( props ) {
 				viewportSettings,
 			};
 		},
-		[ clientId, rootClientId ]
+		[ clientId, rootClientId, ghostBlock ]
 	);
 
 	const defaultViewRef = useRefEffect( ( element ) => {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -23,7 +23,7 @@ import {
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { compose, useRefEffect } from '@wordpress/compose';
 import { safeHTML } from '@wordpress/dom';
 import BlockEdit from '../block-edit';
@@ -896,10 +896,7 @@ function BlockListBlockProvider( props ) {
 		isPreviewMode,
 		ariaLabel:
 			ghostBlock && ghostBlock.clientId === clientId
-				? _x(
-						'Add default block',
-						'accessible name of the default block ghost'
-				  )
+				? __( 'Add default block' )
 				: undefined,
 		clientId,
 		className,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -328,7 +328,7 @@ function Items( {
 				</AsyncModeProvider>
 			) ) }
 			{ order.length < 1 && placeholder }
-			{ shouldRenderAppender && (
+			{ shouldRenderAppender && ! showGhost && (
 				<BlockListAppender
 					tagName={ __experimentalAppenderTagName }
 					rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -245,23 +245,28 @@ function Items( {
 
 			const templateLock = getTemplateLock( rootClientId );
 
+			const appenderAllowed =
+				( ! isSectionBlock( rootClientId ) ||
+					isContainerInsertableToInContentOnlyMode(
+						getBlockName( selectedBlockClientId ),
+						rootClientId
+					) ) &&
+				getBlockEditingMode( rootClientId ) !== 'disabled' &&
+				( ! templateLock || templateLock === 'contentOnly' ) &&
+				hasAppender &&
+				! _isZoomOut();
+
 			return {
 				order: _order,
 				selectedBlocks: selectedBlockClientIds,
 				visibleBlocks: __unstableGetVisibleBlocks(),
 				isZoomOut: _isZoomOut(),
-				ghostBlockName: _ghostBlockName,
+				// The ghost is the block list's empty state: it renders
+				// whether or not the block is selected.
+				ghostBlockName: appenderAllowed ? _ghostBlockName : undefined,
 				ghostBlockAttributes: _ghostBlockAttributes,
 				shouldRenderAppender:
-					( ! isSectionBlock( rootClientId ) ||
-						isContainerInsertableToInContentOnlyMode(
-							getBlockName( selectedBlockClientId ),
-							rootClientId
-						) ) &&
-					getBlockEditingMode( rootClientId ) !== 'disabled' &&
-					( ! templateLock || templateLock === 'contentOnly' ) &&
-					hasAppender &&
-					! _isZoomOut() &&
+					appenderAllowed &&
 					( hasCustomAppender ||
 						hasSelectedRoot ||
 						showRootAppender ),
@@ -280,7 +285,7 @@ function Items( {
 				: null,
 		[ ghostBlockName, ghostBlockAttributes ]
 	);
-	const showGhost = !! ghostBlock && shouldRenderAppender;
+	const showGhost = !! ghostBlock;
 
 	const items = showGhost ? [ ...order, ghostBlock.clientId ] : order;
 
@@ -323,7 +328,7 @@ function Items( {
 				</AsyncModeProvider>
 			) ) }
 			{ order.length < 1 && placeholder }
-			{ shouldRenderAppender && ! showGhost && (
+			{ shouldRenderAppender && (
 				<BlockListAppender
 					tagName={ __experimentalAppenderTagName }
 					rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -11,17 +11,11 @@ import {
 	useEffect,
 	useMemo,
 	useCallback,
-	useRef,
 } from '@wordpress/element';
-import {
-	createBlock,
-	getDefaultBlockName,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import { useInBetweenInserter } from './use-in-between-inserter';
-import { useBlockElement } from './use-block-props/use-block-refs';
 import { store as blockEditorStore } from '../../store';
 import { LayoutProvider, defaultLayout } from './layout';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
@@ -168,52 +162,6 @@ export default function BlockList( settings ) {
 const EMPTY_ARRAY = [];
 const EMPTY_SET = new Set();
 
-/**
- * Renders the ghost of a block list's default block while the list is
- * empty: a real block object rendered before it exists in the store, and
- * inserted, unchanged, when the user enters it.
- *
- * @param {Object} props              Component props.
- * @param {string} props.rootClientId The block list's root client ID.
- * @param {Object} props.block        The ghost block object.
- */
-function GhostBlock( { rootClientId, block } ) {
-	const { insertBlocks } = useDispatch( blockEditorStore );
-	const element = useBlockElement( block.clientId );
-	const materializedRef = useRef( false );
-
-	useEffect( () => {
-		materializedRef.current = false;
-	}, [ block ] );
-
-	useEffect( () => {
-		if ( ! element ) {
-			return;
-		}
-		function materialize() {
-			if ( materializedRef.current ) {
-				return;
-			}
-			materializedRef.current = true;
-			insertBlocks( [ block ], undefined, rootClientId, false );
-		}
-		element.addEventListener( 'pointerdown', materialize, true );
-		element.addEventListener( 'focusin', materialize, true );
-		return () => {
-			element.removeEventListener( 'pointerdown', materialize, true );
-			element.removeEventListener( 'focusin', materialize, true );
-		};
-	}, [ element, block, rootClientId, insertBlocks ] );
-
-	return (
-		<BlockListBlock
-			rootClientId={ rootClientId }
-			clientId={ block.clientId }
-			ghostBlock={ block }
-		/>
-	);
-}
-
 function Items( {
 	placeholder,
 	rootClientId,
@@ -268,10 +216,7 @@ function Items( {
 			let _ghostBlockAttributes;
 			if ( hasAppender && ! hasCustomAppender && ! _order.length ) {
 				const defaultBlock = ( rootClientId
-					? getBlockListSettings( rootClientId )?.defaultBlock ??
-					  select( blocksStore ).getBlockType(
-							getBlockName( rootClientId )
-					  )?.defaultBlock
+					? getBlockListSettings( rootClientId )?.defaultBlock
 					: undefined ) ?? { name: getDefaultBlockName() };
 				if (
 					defaultBlock.name &&
@@ -337,14 +282,17 @@ function Items( {
 	);
 	const showGhost = !! ghostBlock && shouldRenderAppender;
 
+	const items = showGhost ? [ ...order, ghostBlock.clientId ] : order;
+
 	return (
 		<LayoutProvider value={ layout }>
-			{ order.map( ( clientId ) => (
+			{ items.map( ( clientId ) => (
 				<AsyncModeProvider
 					key={ clientId }
 					value={
 						// Only provide data asynchronously if the block is
-						// not visible and not selected.
+						// not visible, not selected, and not the ghost.
+						clientId !== ghostBlock?.clientId &&
 						! visibleBlocks.has( clientId ) &&
 						! selectedBlocks.includes( clientId )
 					}
@@ -359,6 +307,11 @@ function Items( {
 					<BlockListBlock
 						rootClientId={ rootClientId }
 						clientId={ clientId }
+						ghostBlock={
+							clientId === ghostBlock?.clientId
+								? ghostBlock
+								: undefined
+						}
 					/>
 					{ isZoomOut && (
 						<ZoomOutSeparator
@@ -369,14 +322,6 @@ function Items( {
 					) }
 				</AsyncModeProvider>
 			) ) }
-			{ showGhost && (
-				<AsyncModeProvider key={ ghostBlock.clientId } value={ false }>
-					<GhostBlock
-						rootClientId={ rootClientId }
-						block={ ghostBlock }
-					/>
-				</AsyncModeProvider>
-			) }
 			{ order.length < 1 && placeholder }
 			{ shouldRenderAppender && ! showGhost && (
 				<BlockListAppender

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -11,11 +11,17 @@ import {
 	useEffect,
 	useMemo,
 	useCallback,
+	useRef,
 } from '@wordpress/element';
-import { getDefaultBlockName } from '@wordpress/blocks';
+import {
+	createBlock,
+	getDefaultBlockName,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import { useInBetweenInserter } from './use-in-between-inserter';
+import { useBlockElement } from './use-block-props/use-block-refs';
 import { store as blockEditorStore } from '../../store';
 import { LayoutProvider, defaultLayout } from './layout';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
@@ -162,6 +168,52 @@ export default function BlockList( settings ) {
 const EMPTY_ARRAY = [];
 const EMPTY_SET = new Set();
 
+/**
+ * Renders the ghost of a block list's default block while the list is
+ * empty: a real block object rendered before it exists in the store, and
+ * inserted, unchanged, when the user enters it.
+ *
+ * @param {Object} props              Component props.
+ * @param {string} props.rootClientId The block list's root client ID.
+ * @param {Object} props.block        The ghost block object.
+ */
+function GhostBlock( { rootClientId, block } ) {
+	const { insertBlocks } = useDispatch( blockEditorStore );
+	const element = useBlockElement( block.clientId );
+	const materializedRef = useRef( false );
+
+	useEffect( () => {
+		materializedRef.current = false;
+	}, [ block ] );
+
+	useEffect( () => {
+		if ( ! element ) {
+			return;
+		}
+		function materialize() {
+			if ( materializedRef.current ) {
+				return;
+			}
+			materializedRef.current = true;
+			insertBlocks( [ block ], undefined, rootClientId, false );
+		}
+		element.addEventListener( 'pointerdown', materialize, true );
+		element.addEventListener( 'focusin', materialize, true );
+		return () => {
+			element.removeEventListener( 'pointerdown', materialize, true );
+			element.removeEventListener( 'focusin', materialize, true );
+		};
+	}, [ element, block, rootClientId, insertBlocks ] );
+
+	return (
+		<BlockListBlock
+			rootClientId={ rootClientId }
+			clientId={ block.clientId }
+			ghostBlock={ block }
+		/>
+	);
+}
+
 function Items( {
 	placeholder,
 	rootClientId,
@@ -178,6 +230,8 @@ function Items( {
 		isZoomOut,
 		selectedBlocks,
 		visibleBlocks,
+		ghostBlockName,
+		ghostBlockAttributes,
 		shouldRenderAppender,
 	} = useSelect(
 		( select ) => {
@@ -191,6 +245,7 @@ function Items( {
 				isSectionBlock,
 				isContainerInsertableToInContentOnlyMode,
 				getBlockName,
+				getBlockListSettings,
 				isZoomOut: _isZoomOut,
 				canInsertBlockType,
 			} = unlock( select( blockEditorStore ) );
@@ -203,6 +258,28 @@ function Items( {
 					selectedBlocks: EMPTY_ARRAY,
 					visibleBlocks: EMPTY_SET,
 				};
+			}
+
+			// A block list without a custom appender renders a ghost of
+			// the container's default block while empty: a real block
+			// object rendered before it exists in the store, inserted on
+			// entry.
+			let _ghostBlockName;
+			let _ghostBlockAttributes;
+			if ( hasAppender && ! hasCustomAppender && ! _order.length ) {
+				const defaultBlock = ( rootClientId
+					? getBlockListSettings( rootClientId )?.defaultBlock ??
+					  select( blocksStore ).getBlockType(
+							getBlockName( rootClientId )
+					  )?.defaultBlock
+					: undefined ) ?? { name: getDefaultBlockName() };
+				if (
+					defaultBlock.name &&
+					canInsertBlockType( defaultBlock.name, rootClientId )
+				) {
+					_ghostBlockName = defaultBlock.name;
+					_ghostBlockAttributes = defaultBlock.attributes;
+				}
 			}
 
 			const selectedBlockClientIds = getSelectedBlockClientIds();
@@ -228,6 +305,8 @@ function Items( {
 				selectedBlocks: selectedBlockClientIds,
 				visibleBlocks: __unstableGetVisibleBlocks(),
 				isZoomOut: _isZoomOut(),
+				ghostBlockName: _ghostBlockName,
+				ghostBlockAttributes: _ghostBlockAttributes,
 				shouldRenderAppender:
 					( ! isSectionBlock( rootClientId ) ||
 						isContainerInsertableToInContentOnlyMode(
@@ -245,6 +324,18 @@ function Items( {
 		},
 		[ rootClientId, hasAppender, hasCustomAppender ]
 	);
+
+	// One ghost per empty period: regenerated when the list empties again
+	// or the default block changes, stable in between so the client ID,
+	// and with it the DOM, survives materialization.
+	const ghostBlock = useMemo(
+		() =>
+			ghostBlockName
+				? createBlock( ghostBlockName, ghostBlockAttributes )
+				: null,
+		[ ghostBlockName, ghostBlockAttributes ]
+	);
+	const showGhost = !! ghostBlock && shouldRenderAppender;
 
 	return (
 		<LayoutProvider value={ layout }>
@@ -278,8 +369,16 @@ function Items( {
 					) }
 				</AsyncModeProvider>
 			) ) }
+			{ showGhost && (
+				<AsyncModeProvider key={ ghostBlock.clientId } value={ false }>
+					<GhostBlock
+						rootClientId={ rootClientId }
+						block={ ghostBlock }
+					/>
+				</AsyncModeProvider>
+			) }
 			{ order.length < 1 && placeholder }
-			{ shouldRenderAppender && (
+			{ shouldRenderAppender && ! showGhost && (
 				<BlockListAppender
 					tagName={ __experimentalAppenderTagName }
 					rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useContext, useEffect, useRef } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 import { useMergeRefs, useDisabled, useRefEffect } from '@wordpress/compose';
@@ -37,22 +37,19 @@ import { useBlockVisibility } from '../../block-visibility/';
  */
 function useGhostMaterialize( rootClientId, ghostBlock ) {
 	const { insertBlocks } = useDispatch( blockEditorStore );
-	const materializedRef = useRef( false );
-
-	useEffect( () => {
-		materializedRef.current = false;
-	}, [ ghostBlock ] );
 
 	return useRefEffect(
 		( element ) => {
 			if ( ! ghostBlock ) {
 				return;
 			}
+			function remove() {
+				element.removeEventListener( 'pointerdown', materialize, true );
+				element.removeEventListener( 'focusin', materialize, true );
+			}
 			function materialize() {
-				if ( materializedRef.current ) {
-					return;
-				}
-				materializedRef.current = true;
+				// One gesture fires both events; insert once.
+				remove();
 				// Update the selection: the ghost is empty, so the caret
 				// can only be at its start, and the undo level records it.
 				insertBlocks(
@@ -65,10 +62,7 @@ function useGhostMaterialize( rootClientId, ghostBlock ) {
 			}
 			element.addEventListener( 'pointerdown', materialize, true );
 			element.addEventListener( 'focusin', materialize, true );
-			return () => {
-				element.removeEventListener( 'pointerdown', materialize, true );
-				element.removeEventListener( 'focusin', materialize, true );
-			};
+			return remove;
 		},
 		[ ghostBlock, rootClientId, insertBlocks ]
 	);

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -1,10 +1,12 @@
 import clsx from 'clsx';
-import { useContext } from '@wordpress/element';
+import { useContext, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 import { useMergeRefs, useDisabled, useRefEffect } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
 import warning from '@wordpress/warning';
 import useMovingAnimation from '../../use-moving-animation';
+import { store as blockEditorStore } from '../../../store';
 import { PrivateBlockContext } from '../private-block-context';
 import { useFocusFirstElement } from './use-focus-first-element';
 import { useIsHovered } from './use-is-hovered';
@@ -64,6 +66,44 @@ import { useBlockVisibility } from '../../block-visibility/';
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
+/**
+ * Returns block props that insert a ghost block when the user enters it:
+ * the same block object the ghost has rendered from all along, so nothing
+ * about the element changes.
+ *
+ * @param {string}  rootClientId The block's root client ID.
+ * @param {?Object} ghostBlock   The ghost block object, while not inserted.
+ *
+ * @return {?Object} Props for the block element, while a ghost.
+ */
+export function useGhostMaterialize( rootClientId, ghostBlock ) {
+	const { insertBlocks } = useDispatch( blockEditorStore );
+	const materializedRef = useRef( false );
+
+	useEffect( () => {
+		materializedRef.current = false;
+	}, [ ghostBlock ] );
+
+	return useMemo( () => {
+		if ( ! ghostBlock ) {
+			return undefined;
+		}
+		function materialize() {
+			if ( materializedRef.current ) {
+				return;
+			}
+			materializedRef.current = true;
+			// Update the selection: the ghost is empty, so the caret can
+			// only be at its start, and the undo level records it.
+			insertBlocks( [ ghostBlock ], undefined, rootClientId, true, 0 );
+		}
+		return {
+			onPointerDownCapture: materialize,
+			onFocusCapture: materialize,
+		};
+	}, [ ghostBlock, rootClientId, insertBlocks ] );
+}
+
 export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const {
 		clientId,
@@ -97,8 +137,10 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		deviceType,
 		viewportSettings,
 		ariaLabel,
-		ghostProps,
+		ghostBlock,
+		rootClientId,
 	} = useContext( PrivateBlockContext );
+	const ghostProps = useGhostMaterialize( rootClientId, ghostBlock );
 
 	useRegisterBlockEventHandlers( clientId, wrapperProps );
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -219,7 +219,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		ref: mergedRefs,
 		id: `block-${ clientId }${ htmlSuffix }`,
 		role: 'document',
-		'aria-label': ariaLabel ?? blockLabel,
+		'aria-label': ariaLabel ?? props[ 'aria-label' ] ?? blockLabel,
 		...ghostProps,
 		'data-block': clientId,
 		'data-type': name,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useContext, useEffect, useMemo, useRef } from '@wordpress/element';
+import { useContext, useEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableGetBlockProps as getBlockProps } from '@wordpress/blocks';
 import { useMergeRefs, useDisabled, useRefEffect } from '@wordpress/compose';
@@ -23,6 +23,56 @@ import { useScrollIntoView } from './use-scroll-into-view';
 import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
 import { useFirefoxDraggableCompatibility } from './use-firefox-draggable-compatibility';
 import { useBlockVisibility } from '../../block-visibility/';
+
+/**
+ * Returns a ref that inserts a ghost block when the user enters it: the
+ * same block object the ghost has rendered from all along, so nothing
+ * about the element changes. Native listeners, so blocks' own handlers
+ * are never clashed with.
+ *
+ * @param {string}  rootClientId The block's root client ID.
+ * @param {?Object} ghostBlock   The ghost block object, while not inserted.
+ *
+ * @return {Function} Ref effect for the block element.
+ */
+function useGhostMaterialize( rootClientId, ghostBlock ) {
+	const { insertBlocks } = useDispatch( blockEditorStore );
+	const materializedRef = useRef( false );
+
+	useEffect( () => {
+		materializedRef.current = false;
+	}, [ ghostBlock ] );
+
+	return useRefEffect(
+		( element ) => {
+			if ( ! ghostBlock ) {
+				return;
+			}
+			function materialize() {
+				if ( materializedRef.current ) {
+					return;
+				}
+				materializedRef.current = true;
+				// Update the selection: the ghost is empty, so the caret
+				// can only be at its start, and the undo level records it.
+				insertBlocks(
+					[ ghostBlock ],
+					undefined,
+					rootClientId,
+					true,
+					0
+				);
+			}
+			element.addEventListener( 'pointerdown', materialize, true );
+			element.addEventListener( 'focusin', materialize, true );
+			return () => {
+				element.removeEventListener( 'pointerdown', materialize, true );
+				element.removeEventListener( 'focusin', materialize, true );
+			};
+		},
+		[ ghostBlock, rootClientId, insertBlocks ]
+	);
+}
 
 /**
  * This hook is used to lightly mark an element as a block element. The element
@@ -66,44 +116,6 @@ import { useBlockVisibility } from '../../block-visibility/';
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
-/**
- * Returns block props that insert a ghost block when the user enters it:
- * the same block object the ghost has rendered from all along, so nothing
- * about the element changes.
- *
- * @param {string}  rootClientId The block's root client ID.
- * @param {?Object} ghostBlock   The ghost block object, while not inserted.
- *
- * @return {?Object} Props for the block element, while a ghost.
- */
-export function useGhostMaterialize( rootClientId, ghostBlock ) {
-	const { insertBlocks } = useDispatch( blockEditorStore );
-	const materializedRef = useRef( false );
-
-	useEffect( () => {
-		materializedRef.current = false;
-	}, [ ghostBlock ] );
-
-	return useMemo( () => {
-		if ( ! ghostBlock ) {
-			return undefined;
-		}
-		function materialize() {
-			if ( materializedRef.current ) {
-				return;
-			}
-			materializedRef.current = true;
-			// Update the selection: the ghost is empty, so the caret can
-			// only be at its start, and the undo level records it.
-			insertBlocks( [ ghostBlock ], undefined, rootClientId, true, 0 );
-		}
-		return {
-			onPointerDownCapture: materialize,
-			onFocusCapture: materialize,
-		};
-	}, [ ghostBlock, rootClientId, insertBlocks ] );
-}
-
 export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const {
 		clientId,
@@ -140,7 +152,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		ghostBlock,
 		rootClientId,
 	} = useContext( PrivateBlockContext );
-	const ghostProps = useGhostMaterialize( rootClientId, ghostBlock );
+	const ghostRef = useGhostMaterialize( rootClientId, ghostBlock );
 
 	useRegisterBlockEventHandlers( clientId, wrapperProps );
 
@@ -159,6 +171,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const isHoverEnabled = ! isWithinSectionBlock;
 	const mergedRefs = useMergeRefs( [
 		props.ref,
+		ghostRef,
 		defaultViewRef,
 		useFocusFirstElement( { clientId, initialPosition } ),
 		useBlockRefProvider( clientId ),
@@ -226,7 +239,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				: undefined ) ??
 			props[ 'aria-label' ] ??
 			blockLabel,
-		...ghostProps,
 		'data-block': clientId,
 		'data-type': name,
 		'data-title': blockTitle,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -219,7 +219,13 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		ref: mergedRefs,
 		id: `block-${ clientId }${ htmlSuffix }`,
 		role: 'document',
-		'aria-label': ariaLabel ?? props[ 'aria-label' ] ?? blockLabel,
+		'aria-label':
+			ariaLabel ??
+			( clientId === ghostBlock?.clientId
+				? __( 'Add default block' )
+				: undefined ) ??
+			props[ 'aria-label' ] ??
+			blockLabel,
 		...ghostProps,
 		'data-block': clientId,
 		'data-type': name,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -97,6 +97,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		deviceType,
 		viewportSettings,
 		ariaLabel,
+		ghostProps,
 	} = useContext( PrivateBlockContext );
 
 	useRegisterBlockEventHandlers( clientId, wrapperProps );
@@ -177,6 +178,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		id: `block-${ clientId }${ htmlSuffix }`,
 		role: 'document',
 		'aria-label': ariaLabel ?? blockLabel,
+		...ghostProps,
 		'data-block': clientId,
 		'data-type': name,
 		'data-title': blockTitle,

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -12,18 +12,14 @@ import {
 	useBlockProps,
 	useSettings,
 	useBlockEditingMode,
-	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import { formatLTR } from '@wordpress/icons';
-import { useContext } from '@wordpress/element';
 import { useOnEnter } from './use-enter';
 import useDeprecatedAlign from './deprecated-attributes';
 import { unlock } from '../lock-unlock';
-
-const { PrivateBlockContext } = unlock( blockEditorPrivateApis );
 
 function ParagraphRTLControl( { direction, setDirection } ) {
 	return (
@@ -123,9 +119,13 @@ function ParagraphBlock( {
 			'has-drop-cap': hasDropCapDisabled( textAlign ) ? false : dropCap,
 		} ),
 		style: { direction },
+		'aria-label': RichText.isEmpty( content )
+			? __(
+					'Empty block; start writing or type forward slash to choose a block'
+			  )
+			: __( 'Block: Paragraph' ),
 	} );
 	const blockEditingMode = useBlockEditingMode();
-	const { ariaLabel } = useContext( PrivateBlockContext );
 
 	return (
 		<>
@@ -158,14 +158,6 @@ function ParagraphBlock( {
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 				onRemove={ onRemove }
-				aria-label={
-					ariaLabel ??
-					( RichText.isEmpty( content )
-						? __(
-								'Empty block; start writing or type forward slash to choose a block'
-						  )
-						: __( 'Block: Paragraph' ) )
-				}
 				data-empty={ RichText.isEmpty( content ) }
 				placeholder={ placeholder || __( 'Type / to choose a block' ) }
 				data-custom-placeholder={ placeholder ? true : undefined }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import {
-	InnerBlocks,
 	InspectorControls,
 	useBlockProps,
 	useInnerBlocksProps,
@@ -82,11 +81,6 @@ function EditableContentLoaded( {
 		value: blocks,
 		onInput,
 		onChange,
-		// Show a writing prompt for empty content, even when the block
-		// is not selected, so the content area remains discoverable.
-		renderAppender: blocks?.length
-			? undefined
-			: InnerBlocks.DefaultBlockAppender,
 	} );
 	return <TagName { ...props } />;
 }

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Buttons', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/buttons' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Buttons', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/buttons' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -7,7 +7,7 @@ test.describe( 'Code', () => {
 
 	test( 'can be created by three backticks', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '```<?php' );
 

--- a/test/e2e/specs/editor/blocks/code.spec.js
+++ b/test/e2e/specs/editor/blocks/code.spec.js
@@ -7,7 +7,7 @@ test.describe( 'Code', () => {
 
 	test( 'can be created by three backticks', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '```<?php' );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -42,7 +42,7 @@ test.describe( 'Gallery', () => {
 		} );
 
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+v' );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -42,7 +42,7 @@ test.describe( 'Gallery', () => {
 		} );
 
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+v' );
 

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Group', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/group' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Group', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/group' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -10,7 +10,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '### 3' );
 
@@ -27,7 +27,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '4' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -46,7 +46,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '## 1. H' );
 
@@ -63,7 +63,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '## `code`' );
 
@@ -188,7 +188,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '### Heading' );
 		await editor.openDocumentSettingsSidebar();
@@ -226,7 +226,7 @@ test.describe( 'Heading', () => {
 
 	test( 'should correctly apply named colors', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 		await editor.openDocumentSettingsSidebar();
@@ -270,7 +270,7 @@ test.describe( 'Heading', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 
@@ -305,7 +305,7 @@ test.describe( 'Heading', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 
@@ -340,7 +340,7 @@ test.describe( 'Heading', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -10,7 +10,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '### 3' );
 
@@ -27,7 +27,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '4' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -46,7 +46,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## 1. H' );
 
@@ -63,7 +63,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## `code`' );
 
@@ -188,7 +188,7 @@ test.describe( 'Heading', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '### Heading' );
 		await editor.openDocumentSettingsSidebar();
@@ -226,7 +226,7 @@ test.describe( 'Heading', () => {
 
 	test( 'should correctly apply named colors', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 		await editor.openDocumentSettingsSidebar();
@@ -270,7 +270,7 @@ test.describe( 'Heading', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 
@@ -305,7 +305,7 @@ test.describe( 'Heading', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 
@@ -340,7 +340,7 @@ test.describe( 'Heading', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -8,7 +8,7 @@ test.describe( 'HTML block', () => {
 	test( 'can be created by typing "/html"', async ( { editor, page } ) => {
 		// Create a Custom HTML block with the slash shortcut.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '/html' );
 		await expect(
@@ -41,7 +41,7 @@ test.describe( 'HTML block', () => {
 	test( 'should not encode <', async ( { editor, page } ) => {
 		// Create a Custom HTML block with the slash shortcut.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '/html' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/html.spec.js
+++ b/test/e2e/specs/editor/blocks/html.spec.js
@@ -8,7 +8,7 @@ test.describe( 'HTML block', () => {
 	test( 'can be created by typing "/html"', async ( { editor, page } ) => {
 		// Create a Custom HTML block with the slash shortcut.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '/html' );
 		await expect(
@@ -41,7 +41,7 @@ test.describe( 'HTML block', () => {
 	test( 'should not encode <', async ( { editor, page } ) => {
 		// Create a Custom HTML block with the slash shortcut.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '/html' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -1245,7 +1245,7 @@ test.describe( 'Links', () => {
 	} ) => {
 		// Create a paragraph with text and select it
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Link text' );
 

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -1245,7 +1245,7 @@ test.describe( 'Links', () => {
 	} ) => {
 		// Create a paragraph with text and select it
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Link text' );
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -41,7 +41,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		// Create a block with some text that will trigger a list creation.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* A list item' );
 
@@ -68,7 +68,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		// Create a list with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 4 } );
@@ -88,7 +88,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		// Create a block with some text that will trigger a list creation.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1) A list item' );
 
@@ -107,7 +107,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1. ' );
 		await pageUtils.pressKeys( 'primary+z' );
@@ -124,7 +124,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Backspace' );
@@ -141,7 +141,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await expect(
@@ -161,7 +161,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await editor.showBlockToolbar();
@@ -179,7 +179,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.evaluate( () => delete window.requestIdleCallback );
 		await page.keyboard.type( '* ' );
@@ -200,7 +200,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Escape' );
@@ -217,7 +217,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* a' );
 		await page.keyboard.press( 'Backspace' );
@@ -249,7 +249,7 @@ test.describe( 'List (@firefox)', () => {
 	test( 'can be created by typing "/list"', async ( { editor, page } ) => {
 		// Create a list with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/list' );
 		await expect(
@@ -272,7 +272,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/list' );
@@ -291,7 +291,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
@@ -322,7 +322,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await pageUtils.pressKeys( 'shift+Enter' );
@@ -348,7 +348,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await pageUtils.pressKeys( 'shift+Enter' );
@@ -623,7 +623,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1. one' );
 		await page.keyboard.press( 'Enter' );
@@ -989,7 +989,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( '* 1' ); // Should be at level 0.
@@ -1104,7 +1104,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1137,7 +1137,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( '* 1' );
@@ -1162,7 +1162,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		// Tests the shortcut with a non breaking space.
@@ -1180,7 +1180,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		// Tests the shortcut with a non breaking space.
@@ -1246,7 +1246,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1273,7 +1273,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1305,7 +1305,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1. a' );
 		await page.keyboard.press( 'Enter' );
@@ -1364,7 +1364,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* a' );
 		await page.keyboard.press( 'Enter' );
@@ -1409,7 +1409,7 @@ test.describe( 'List (@firefox)', () => {
 
 	test( 'can be exited to selected paragraph', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Enter' );
@@ -1615,7 +1615,7 @@ test.describe( 'List (@firefox)', () => {
 		for ( const key of [ 'Backspace', 'Delete' ] ) {
 			test( key, async ( { editor, page, pageUtils } ) => {
 				await editor.canvas
-					.locator( 'role=document[name*="Empty block"i]' )
+					.locator( 'role=document[name="Add default block"i]' )
 					.click();
 				await page.keyboard.type( '* ab' );
 				await page.keyboard.press( 'Enter' );
@@ -1694,7 +1694,7 @@ test.describe( 'List (@firefox)', () => {
 		for ( const key of [ 'Backspace', 'Delete' ] ) {
 			test( key, async ( { editor, page, pageUtils } ) => {
 				await editor.canvas
-					.locator( 'role=document[name*="Empty block"i]' )
+					.locator( 'role=document[name="Add default block"i]' )
 					.click();
 				await page.keyboard.type( '* ab' );
 				await page.keyboard.press( 'Enter' );
@@ -1767,7 +1767,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -1860,7 +1860,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -1940,7 +1940,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -2004,7 +2004,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -2106,7 +2106,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* one' );
 		await page.keyboard.press( 'Enter' );
@@ -2174,7 +2174,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* one' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -41,7 +41,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		// Create a block with some text that will trigger a list creation.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* A list item' );
 
@@ -68,7 +68,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		// Create a list with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 4 } );
@@ -88,7 +88,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		// Create a block with some text that will trigger a list creation.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1) A list item' );
 
@@ -107,7 +107,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1. ' );
 		await pageUtils.pressKeys( 'primary+z' );
@@ -124,7 +124,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Backspace' );
@@ -141,7 +141,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await expect(
@@ -161,7 +161,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await editor.showBlockToolbar();
@@ -179,7 +179,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.evaluate( () => delete window.requestIdleCallback );
 		await page.keyboard.type( '* ' );
@@ -200,7 +200,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Escape' );
@@ -217,7 +217,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* a' );
 		await page.keyboard.press( 'Backspace' );
@@ -249,7 +249,7 @@ test.describe( 'List (@firefox)', () => {
 	test( 'can be created by typing "/list"', async ( { editor, page } ) => {
 		// Create a list with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/list' );
 		await expect(
@@ -272,7 +272,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/list' );
@@ -291,7 +291,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
@@ -322,7 +322,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await pageUtils.pressKeys( 'shift+Enter' );
@@ -348,7 +348,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await pageUtils.pressKeys( 'shift+Enter' );
@@ -623,7 +623,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1. one' );
 		await page.keyboard.press( 'Enter' );
@@ -989,7 +989,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( '* 1' ); // Should be at level 0.
@@ -1104,7 +1104,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1137,7 +1137,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( '* 1' );
@@ -1162,7 +1162,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		// Tests the shortcut with a non breaking space.
@@ -1180,7 +1180,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		// Tests the shortcut with a non breaking space.
@@ -1246,7 +1246,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1273,7 +1273,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
@@ -1305,7 +1305,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1. a' );
 		await page.keyboard.press( 'Enter' );
@@ -1364,7 +1364,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* a' );
 		await page.keyboard.press( 'Enter' );
@@ -1409,7 +1409,7 @@ test.describe( 'List (@firefox)', () => {
 
 	test( 'can be exited to selected paragraph', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ' );
 		await page.keyboard.press( 'Enter' );
@@ -1615,7 +1615,7 @@ test.describe( 'List (@firefox)', () => {
 		for ( const key of [ 'Backspace', 'Delete' ] ) {
 			test( key, async ( { editor, page, pageUtils } ) => {
 				await editor.canvas
-					.locator( 'role=button[name="Add default block"i]' )
+					.locator( 'role=document[name*="Empty block"i]' )
 					.click();
 				await page.keyboard.type( '* ab' );
 				await page.keyboard.press( 'Enter' );
@@ -1694,7 +1694,7 @@ test.describe( 'List (@firefox)', () => {
 		for ( const key of [ 'Backspace', 'Delete' ] ) {
 			test( key, async ( { editor, page, pageUtils } ) => {
 				await editor.canvas
-					.locator( 'role=button[name="Add default block"i]' )
+					.locator( 'role=document[name*="Empty block"i]' )
 					.click();
 				await page.keyboard.type( '* ab' );
 				await page.keyboard.press( 'Enter' );
@@ -1767,7 +1767,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -1860,7 +1860,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -1940,7 +1940,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -2004,7 +2004,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* ab' );
 		await page.keyboard.press( 'Enter' );
@@ -2106,7 +2106,7 @@ test.describe( 'List (@firefox)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* one' );
 		await page.keyboard.press( 'Enter' );
@@ -2174,7 +2174,7 @@ test.describe( 'List (@firefox)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* one' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/blocks/navigation-passive-rendering.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-passive-rendering.spec.js
@@ -121,5 +121,16 @@ test.describe( 'Navigation passive rendering', () => {
 		await expect
 			.poll( () => getDirtyEntityRecords( page ) )
 			.toEqual( [ { kind: 'postType', name: 'post', key: post.id } ] );
+
+		// Clear the preference in the page session too. The preference
+		// save is debounced and outlives the page, so it can land after
+		// the teardown's reset; this makes a late flush persist the
+		// cleared state instead of re-enabling Show template for every
+		// later post editor suite under a block theme.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core', 'renderingModes', undefined );
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/pullquote.spec.js
+++ b/test/e2e/specs/editor/blocks/pullquote.spec.js
@@ -10,7 +10,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( 'test' );

--- a/test/e2e/specs/editor/blocks/pullquote.spec.js
+++ b/test/e2e/specs/editor/blocks/pullquote.spec.js
@@ -10,7 +10,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( 'test' );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -73,7 +73,6 @@ test.describe( 'Quote', () => {
 			} )
 		).toBeVisible();
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.type( 'refilled' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -69,7 +69,7 @@ test.describe( 'Quote', () => {
 		// paragraph inside the quote.
 		await expect(
 			editor.canvas.getByRole( 'document', {
-				name: /Empty block/i,
+				name: 'Add default block',
 			} )
 		).toBeVisible();
 		await page.keyboard.press( 'ArrowUp' );
@@ -97,7 +97,7 @@ test.describe( 'Quote', () => {
 	} ) => {
 		// Create a block with some text that will trigger a paragraph creation.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '> A quote' );
 		// Create a second paragraph.
@@ -122,7 +122,7 @@ test.describe( 'Quote', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 'test'.length } );
@@ -139,7 +139,7 @@ test.describe( 'Quote', () => {
 	test( 'can be created by typing "/quote"', async ( { editor, page } ) => {
 		// Create a list with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/quote' );
 		await expect(
@@ -161,7 +161,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/quote' );
@@ -179,7 +179,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -68,8 +68,8 @@ test.describe( 'Quote', () => {
 		// arrowing up from the citation onto the appender inserts a fresh
 		// paragraph inside the quote.
 		await expect(
-			editor.canvas.getByRole( 'button', {
-				name: 'Add default block',
+			editor.canvas.getByRole( 'document', {
+				name: /Empty block/i,
 			} )
 		).toBeVisible();
 		await page.keyboard.press( 'ArrowUp' );
@@ -97,7 +97,7 @@ test.describe( 'Quote', () => {
 	} ) => {
 		// Create a block with some text that will trigger a paragraph creation.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '> A quote' );
 		// Create a second paragraph.
@@ -122,7 +122,7 @@ test.describe( 'Quote', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'ArrowLeft', { times: 'test'.length } );
@@ -139,7 +139,7 @@ test.describe( 'Quote', () => {
 	test( 'can be created by typing "/quote"', async ( { editor, page } ) => {
 		// Create a list with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/quote' );
 		await expect(
@@ -161,7 +161,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await editor.transformBlockTo( 'core/quote' );
@@ -179,7 +179,7 @@ test.describe( 'Quote', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/blocks/separator.spec.js
+++ b/test/e2e/specs/editor/blocks/separator.spec.js
@@ -7,7 +7,7 @@ test.describe( 'Separator', () => {
 
 	test( 'can be created by three dashes', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		// Should be able to keep typing after the separator transform.
 		await page.keyboard.type( '---a' );

--- a/test/e2e/specs/editor/blocks/separator.spec.js
+++ b/test/e2e/specs/editor/blocks/separator.spec.js
@@ -7,7 +7,7 @@ test.describe( 'Separator', () => {
 
 	test( 'can be created by three dashes', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		// Should be able to keep typing after the separator transform.
 		await page.keyboard.type( '---a' );

--- a/test/e2e/specs/editor/blocks/spacer.spec.js
+++ b/test/e2e/specs/editor/blocks/spacer.spec.js
@@ -8,7 +8,7 @@ test.describe( 'Spacer', () => {
 	test( 'can be created by typing "/spacer"', async ( { editor, page } ) => {
 		// Create a spacer with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/spacer' );
 		await expect(
@@ -25,7 +25,7 @@ test.describe( 'Spacer', () => {
 	} ) => {
 		// Create a spacer with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/spacer' );
 		await expect(

--- a/test/e2e/specs/editor/blocks/spacer.spec.js
+++ b/test/e2e/specs/editor/blocks/spacer.spec.js
@@ -8,7 +8,7 @@ test.describe( 'Spacer', () => {
 	test( 'can be created by typing "/spacer"', async ( { editor, page } ) => {
 		// Create a spacer with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/spacer' );
 		await expect(
@@ -25,7 +25,7 @@ test.describe( 'Spacer', () => {
 	} ) => {
 		// Create a spacer with the slash block shortcut.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/spacer' );
 		await expect(

--- a/test/e2e/specs/editor/collaboration/collaboration-autodraft-autosave-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-autodraft-autosave-loss.spec.ts
@@ -78,7 +78,7 @@ test.describe( 'Collaboration - auto-draft autosave retention', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( title );
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( marker );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-autodraft-autosave-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-autodraft-autosave-loss.spec.ts
@@ -78,7 +78,7 @@ test.describe( 'Collaboration - auto-draft autosave retention', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( title );
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( marker );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-autodraft-collaborator-autosave-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-autodraft-collaborator-autosave-loss.spec.ts
@@ -88,7 +88,7 @@ test.describe( 'Collaboration - auto-draft collaborator autosave retention', () 
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( title );
 		await collaboratorEditor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await collaboratorPage.keyboard.type( marker );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-autodraft-collaborator-autosave-loss.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-autodraft-collaborator-autosave-loss.spec.ts
@@ -88,7 +88,7 @@ test.describe( 'Collaboration - auto-draft collaborator autosave retention', () 
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( title );
 		await collaboratorEditor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await collaboratorPage.keyboard.type( marker );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-block-gauntlet.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-block-gauntlet.spec.ts
@@ -63,7 +63,7 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 
 		// Paragraph: click the default block appender and type.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Gauntlet paragraph' );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-block-gauntlet.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-block-gauntlet.spec.ts
@@ -63,7 +63,7 @@ test.describe( 'Collaboration - Block Gauntlet', () => {
 
 		// Paragraph: click the default block appender and type.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Gauntlet paragraph' );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -18,7 +18,7 @@ test.describe( 'Collaboration - Refresh', () => {
 		await collaborationUtils.openPost( post.id );
 
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Saved content from User A' );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-refresh.spec.ts
@@ -18,7 +18,7 @@ test.describe( 'Collaboration - Refresh', () => {
 		await collaborationUtils.openPost( post.id );
 
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Saved content from User A' );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-navigation-block.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-navigation-block.spec.ts
@@ -141,7 +141,7 @@ test.describe( 'Collaboration - Undo with a navigation block', () => {
 		// exists in an empty document, so the navigation block cannot
 		// be followed by a click on it.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( USER_A_FIRST_PARAGRAPH );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-navigation-block.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-navigation-block.spec.ts
@@ -141,7 +141,7 @@ test.describe( 'Collaboration - Undo with a navigation block', () => {
 		// exists in an empty document, so the navigation block cannot
 		// be followed by a click on it.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( USER_A_FIRST_PARAGRAPH );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
@@ -318,7 +318,7 @@ test.describe( 'Collaboration - Undo/Redo', () => {
 		await loadDefaultCategoryViaPublishPanel( page );
 
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'abcdef' );
 		await page.keyboard.press( LINE_START_KEY );

--- a/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-undo-redo.spec.ts
@@ -318,7 +318,7 @@ test.describe( 'Collaboration - Undo/Redo', () => {
 		await loadDefaultCategoryViaPublishPanel( page );
 
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'abcdef' );
 		await page.keyboard.press( LINE_START_KEY );

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -46,7 +46,7 @@ test.describe( 'Block variations', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Large Quote' );
 		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
@@ -82,7 +82,7 @@ test.describe( 'Block variations', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
 		await page
@@ -101,7 +101,7 @@ test.describe( 'Block variations', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Columns' );
 		await page
@@ -128,7 +128,7 @@ test.describe( 'Block variations', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Large Quote' );
 		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
@@ -165,7 +165,7 @@ test.describe( 'Block variations', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
 		await page
@@ -203,7 +203,7 @@ test.describe( 'Block variations', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
 		await page

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -46,7 +46,7 @@ test.describe( 'Block variations', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Large Quote' );
 		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
@@ -82,7 +82,7 @@ test.describe( 'Block variations', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
 		await page
@@ -101,7 +101,7 @@ test.describe( 'Block variations', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Columns' );
 		await page
@@ -128,7 +128,7 @@ test.describe( 'Block variations', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Large Quote' );
 		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
@@ -165,7 +165,7 @@ test.describe( 'Block variations', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
 		await page
@@ -203,7 +203,7 @@ test.describe( 'Block variations', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
 		await page

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Child Blocks', () => {
 				name: 'Block: Child Blocks Unrestricted Parent',
 			} )
 			.getByRole( 'document', {
-				name: /Empty block/i,
+				name: 'Add default block',
 			} )
 			.click();
 
@@ -76,7 +76,7 @@ test.describe( 'Child Blocks', () => {
 				name: 'Block: Child Blocks Restricted Parent',
 			} )
 			.getByRole( 'document', {
-				name: /Empty block/i,
+				name: 'Add default block',
 			} )
 			.click();
 

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -37,8 +37,8 @@ test.describe( 'Child Blocks', () => {
 			.getByRole( 'document', {
 				name: 'Block: Child Blocks Unrestricted Parent',
 			} )
-			.getByRole( 'button', {
-				name: 'Add default block',
+			.getByRole( 'document', {
+				name: /Empty block/i,
 			} )
 			.click();
 
@@ -75,8 +75,8 @@ test.describe( 'Child Blocks', () => {
 			.getByRole( 'document', {
 				name: 'Block: Child Blocks Restricted Parent',
 			} )
-			.getByRole( 'button', {
-				name: 'Add default block',
+			.getByRole( 'document', {
+				name: /Empty block/i,
 			} )
 			.click();
 

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Test Custom Post Types', () => {
 	} ) => {
 		await admin.createNewPost( { postType: 'hierar-no-title' } );
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Parent Post' );
 		await editor.publishPost();
@@ -44,7 +44,7 @@ test.describe( 'Test Custom Post Types', () => {
 		const parentPage = await parentPageLocator.inputValue();
 
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Child Post' );
 		await editor.publishPost();

--- a/test/e2e/specs/editor/plugins/custom-post-types.spec.js
+++ b/test/e2e/specs/editor/plugins/custom-post-types.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Test Custom Post Types', () => {
 	} ) => {
 		await admin.createNewPost( { postType: 'hierar-no-title' } );
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Parent Post' );
 		await editor.publishPost();
@@ -44,7 +44,7 @@ test.describe( 'Test Custom Post Types', () => {
 		const parentPage = await parentPageLocator.inputValue();
 
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Child Post' );
 		await editor.publishPost();

--- a/test/e2e/specs/editor/plugins/format-api.spec.js
+++ b/test/e2e/specs/editor/plugins/format-api.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Using Format API', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
@@ -65,7 +65,7 @@ test.describe( 'Using Format API', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );

--- a/test/e2e/specs/editor/plugins/format-api.spec.js
+++ b/test/e2e/specs/editor/plugins/format-api.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Using Format API', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
@@ -65,7 +65,7 @@ test.describe( 'Using Format API', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Using Hooks API', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await page
@@ -37,7 +37,7 @@ test.describe( 'Using Hooks API', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 

--- a/test/e2e/specs/editor/plugins/hooks-api.spec.js
+++ b/test/e2e/specs/editor/plugins/hooks-api.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Using Hooks API', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await page
@@ -37,7 +37,7 @@ test.describe( 'Using Hooks API', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 

--- a/test/e2e/specs/editor/plugins/iframed-enqueue-block-editor-settings.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-enqueue-block-editor-settings.spec.js
@@ -21,8 +21,8 @@ test.describe( 'iframed block editor settings styles', () => {
 		editor,
 		page,
 	} ) => {
-		const defaultBlock = editor.canvas.getByRole( 'button', {
-			name: 'Add default block',
+		const defaultBlock = editor.canvas.getByRole( 'document', {
+			name: /Empty block/i,
 		} );
 
 		// Expect a red border (added in PHP).
@@ -55,8 +55,8 @@ test.describe( 'iframed block editor settings styles', () => {
 		editor,
 		page,
 	} ) => {
-		const defaultBlock = editor.canvas.getByRole( 'button', {
-			name: 'Add default block',
+		const defaultBlock = editor.canvas.getByRole( 'document', {
+			name: /Empty block/i,
 		} );
 
 		await page.evaluate( () => {

--- a/test/e2e/specs/editor/plugins/iframed-enqueue-block-editor-settings.spec.js
+++ b/test/e2e/specs/editor/plugins/iframed-enqueue-block-editor-settings.spec.js
@@ -22,7 +22,7 @@ test.describe( 'iframed block editor settings styles', () => {
 		page,
 	} ) => {
 		const defaultBlock = editor.canvas.getByRole( 'document', {
-			name: /Empty block/i,
+			name: 'Add default block',
 		} );
 
 		// Expect a red border (added in PHP).
@@ -56,7 +56,7 @@ test.describe( 'iframed block editor settings styles', () => {
 		page,
 	} ) => {
 		const defaultBlock = editor.canvas.getByRole( 'document', {
-			name: /Empty block/i,
+			name: 'Add default block',
 		} );
 
 		await page.evaluate( () => {

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -114,7 +114,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/Allowed Blocks Dynamic' );
 		await expect(

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -114,7 +114,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Allowed Blocks Dynamic' );
 		await expect(

--- a/test/e2e/specs/editor/plugins/meta-boxes.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-boxes.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Meta boxes', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'canvas text' );
 
@@ -109,7 +109,7 @@ test.describe( 'Meta boxes', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'A published post' );
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Excerpt from content.' );
 
@@ -127,7 +127,7 @@ test.describe( 'Meta boxes', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Excerpt from content.' );
 		await editor.canvas

--- a/test/e2e/specs/editor/plugins/meta-boxes.spec.js
+++ b/test/e2e/specs/editor/plugins/meta-boxes.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Meta boxes', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'canvas text' );
 
@@ -109,7 +109,7 @@ test.describe( 'Meta boxes', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'A published post' );
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Excerpt from content.' );
 
@@ -127,7 +127,7 @@ test.describe( 'Meta boxes', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Excerpt from content.' );
 		await editor.canvas

--- a/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
+++ b/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
@@ -4,7 +4,7 @@ test.describe( 'Preventing Pattern Recursion (client)', () => {
 	test.beforeEach( async ( { admin, editor, page } ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.evaluate( () => {
 			window.wp.data.dispatch( 'core/block-editor' ).updateSettings( {

--- a/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
+++ b/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
@@ -4,7 +4,7 @@ test.describe( 'Preventing Pattern Recursion (client)', () => {
 	test.beforeEach( async ( { admin, editor, page } ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.evaluate( () => {
 			window.wp.data.dispatch( 'core/block-editor' ).updateSettings( {

--- a/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
+++ b/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
@@ -16,7 +16,7 @@ test.describe( 'adding inline tokens', () => {
 	} ) => {
 		// Create a paragraph.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( 'a ' );

--- a/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
+++ b/test/e2e/specs/editor/various/adding-inline-tokens.spec.js
@@ -16,7 +16,7 @@ test.describe( 'adding inline tokens', () => {
 	} ) => {
 		// Create a paragraph.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( 'a ' );

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -102,7 +102,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await expect(
@@ -167,7 +167,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Stuck in the middle with you.' );
 			await pageUtils.pressKeys( 'ArrowLeft', { times: 'you.'.length } );
@@ -210,7 +210,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( testData.firstTriggerString );
 			await expect(
@@ -254,7 +254,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await page
@@ -292,7 +292,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await expect(
@@ -329,7 +329,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await expect(
@@ -350,7 +350,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 				editor,
 			} ) => {
 				await editor.canvas
-					.locator( 'role=document[name*="Empty block"i]' )
+					.locator( 'role=document[name="Add default block"i]' )
 					.click();
 				// The 'Grapes' option is disabled in our test plugin, so it should not insert the grapes emoji
 				await page.keyboard.type( 'Sorry, we are all out of ~g' );
@@ -418,7 +418,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 
 			for ( let i = 0; i < 4; i++ ) {
@@ -483,7 +483,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( '@fr' );
@@ -524,7 +524,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '@fr' );
 		await expect(
@@ -542,7 +542,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '@' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -566,7 +566,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/' );
 		await expect(
@@ -595,7 +595,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		const mentionOption = page.getByRole( 'option', {
 			name: 'Bilbo Baggins thebetterhobbit',
@@ -625,7 +625,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		'should not re-trigger autocomplete after accepting a mention and changing text near it',
 		async ( { editor, page, pageUtils } ) => {
 			await editor.canvas
-				.getByRole( 'document', { name: /Empty block/i } )
+				.getByRole( 'document', { name: 'Add default block' } )
 				.click();
 
 			await page.keyboard.type( '@bi' );
@@ -670,7 +670,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( '@bi' );
@@ -708,7 +708,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( 'hello @fr' );
@@ -738,7 +738,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( '@fr' );
@@ -771,7 +771,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( '@შოთა' );

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -102,7 +102,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await expect(
@@ -167,7 +167,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( 'Stuck in the middle with you.' );
 			await pageUtils.pressKeys( 'ArrowLeft', { times: 'you.'.length } );
@@ -210,7 +210,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( testData.firstTriggerString );
 			await expect(
@@ -254,7 +254,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await page
@@ -292,7 +292,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await expect(
@@ -329,7 +329,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( testData.triggerString );
 			await expect(
@@ -350,7 +350,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 				editor,
 			} ) => {
 				await editor.canvas
-					.locator( 'role=button[name="Add default block"i]' )
+					.locator( 'role=document[name*="Empty block"i]' )
 					.click();
 				// The 'Grapes' option is disabled in our test plugin, so it should not insert the grapes emoji
 				await page.keyboard.type( 'Sorry, we are all out of ~g' );
@@ -418,7 +418,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 			}
 
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 
 			for ( let i = 0; i < 4; i++ ) {
@@ -483,7 +483,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( '@fr' );
@@ -524,7 +524,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '@fr' );
 		await expect(
@@ -542,7 +542,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '@' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -566,7 +566,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '/' );
 		await expect(
@@ -595,7 +595,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		const mentionOption = page.getByRole( 'option', {
 			name: 'Bilbo Baggins thebetterhobbit',
@@ -625,7 +625,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		'should not re-trigger autocomplete after accepting a mention and changing text near it',
 		async ( { editor, page, pageUtils } ) => {
 			await editor.canvas
-				.getByRole( 'button', { name: 'Add default block' } )
+				.getByRole( 'document', { name: /Empty block/i } )
 				.click();
 
 			await page.keyboard.type( '@bi' );
@@ -670,7 +670,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( '@bi' );
@@ -708,7 +708,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( 'hello @fr' );
@@ -738,7 +738,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( '@fr' );
@@ -771,7 +771,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( '@შოთა' );

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -16,7 +16,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -54,7 +54,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -101,7 +101,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -137,7 +137,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -172,7 +172,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -245,7 +245,7 @@ test.describe( 'Autosave', () => {
 			.filter( { hasText: 'Draft saved' } );
 
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -281,7 +281,7 @@ test.describe( 'Autosave', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await editor.publishPost();
@@ -338,7 +338,7 @@ test.describe( 'Autosave', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await editor.publishPost();

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -16,7 +16,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -54,7 +54,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -101,7 +101,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -137,7 +137,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -172,7 +172,7 @@ test.describe( 'Autosave', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -245,7 +245,7 @@ test.describe( 'Autosave', () => {
 			.filter( { hasText: 'Draft saved' } );
 
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await pageUtils.pressKeys( 'primary+s' );
@@ -281,7 +281,7 @@ test.describe( 'Autosave', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await editor.publishPost();
@@ -338,7 +338,7 @@ test.describe( 'Autosave', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'before save' );
 		await editor.publishPost();

--- a/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
+++ b/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 async function addTestParagraphBlocks( { editor, page } ) {
 	await test.step( 'add test paragraph blocks', async () => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1st' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
+++ b/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 async function addTestParagraphBlocks( { editor, page } ) {
 	await test.step( 'add test paragraph blocks', async () => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1st' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -169,7 +169,7 @@ test.describe( 'Navigating the block hierarchy', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'You say goodbye' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -169,7 +169,7 @@ test.describe( 'Navigating the block hierarchy', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'You say goodbye' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -7,7 +7,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can prevent removal', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Some paragraph' );
 
@@ -27,7 +27,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can disable movement', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 
@@ -57,7 +57,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can lock everything', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Some paragraph' );
 
@@ -78,7 +78,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can unlock from toolbar', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Some paragraph' );
 

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -7,7 +7,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can prevent removal', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Some paragraph' );
 
@@ -27,7 +27,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can disable movement', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 
@@ -57,7 +57,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can lock everything', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Some paragraph' );
 
@@ -78,7 +78,7 @@ test.describe( 'Block Locking', () => {
 
 	test( 'can unlock from toolbar', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Some paragraph' );
 

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Block Switcher', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
@@ -58,7 +58,7 @@ test.describe( 'Block Switcher', () => {
 
 		// Insert a list block.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
@@ -94,7 +94,7 @@ test.describe( 'Block Switcher', () => {
 	} ) => {
 		// Insert a list block.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'alt+F10' );
@@ -122,7 +122,7 @@ test.describe( 'Block Switcher', () => {
 	} ) => {
 		// Insert a list block.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'alt+F10' );
@@ -140,7 +140,7 @@ test.describe( 'Block Switcher', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await page.keyboard.press( 'ArrowUp' );
@@ -166,7 +166,7 @@ test.describe( 'Block Switcher', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Block Switcher', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
@@ -58,7 +58,7 @@ test.describe( 'Block Switcher', () => {
 
 		// Insert a list block.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'primary+a', { times: 2 } );
@@ -94,7 +94,7 @@ test.describe( 'Block Switcher', () => {
 	} ) => {
 		// Insert a list block.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'alt+F10' );
@@ -122,7 +122,7 @@ test.describe( 'Block Switcher', () => {
 	} ) => {
 		// Insert a list block.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'alt+F10' );
@@ -140,7 +140,7 @@ test.describe( 'Block Switcher', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await page.keyboard.press( 'ArrowUp' );
@@ -166,7 +166,7 @@ test.describe( 'Block Switcher', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '- List content' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -167,7 +167,7 @@ test.describe( 'Change detection', () => {
 		changeDetectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 
@@ -193,7 +193,7 @@ test.describe( 'Change detection', () => {
 		changeDetectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Hello World' );
 
@@ -379,7 +379,7 @@ test.describe( 'Change detection', () => {
 	} ) => {
 		// Enter content.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 
@@ -435,7 +435,7 @@ test.describe( 'Change detection', () => {
 
 		// Insert a paragraph.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Hello, World!' );
 
@@ -505,7 +505,7 @@ test.describe( 'Change detection', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Hello World' );
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -167,7 +167,7 @@ test.describe( 'Change detection', () => {
 		changeDetectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 
@@ -193,7 +193,7 @@ test.describe( 'Change detection', () => {
 		changeDetectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Hello World' );
 
@@ -379,7 +379,7 @@ test.describe( 'Change detection', () => {
 	} ) => {
 		// Enter content.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 
@@ -435,7 +435,7 @@ test.describe( 'Change detection', () => {
 
 		// Insert a paragraph.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Hello, World!' );
 
@@ -505,7 +505,7 @@ test.describe( 'Change detection', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Hello World' );
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Paragraph' );
 

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Copy - collapsed selection' );
 		await page.keyboard.press( 'Enter' );
@@ -31,7 +31,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Cut - collapsed selection' );
 		await page.keyboard.press( 'Enter' );
@@ -89,7 +89,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( 'First block' );
@@ -243,7 +243,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await page.keyboard.press( 'Enter' );
@@ -276,7 +276,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( { name: 'core/spacer' } );
@@ -310,7 +310,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await page.keyboard.press( 'Enter' );
@@ -343,7 +343,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( { name: 'core/spacer' } );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Copy - collapsed selection' );
 		await page.keyboard.press( 'Enter' );
@@ -31,7 +31,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Cut - collapsed selection' );
 		await page.keyboard.press( 'Enter' );
@@ -89,7 +89,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( 'First block' );
@@ -243,7 +243,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await page.keyboard.press( 'Enter' );
@@ -276,7 +276,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( { name: 'core/spacer' } );
@@ -310,7 +310,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await page.keyboard.press( 'Enter' );
@@ -343,7 +343,7 @@ test.describe( 'Copy/cut/paste', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A block' );
 		await editor.insertBlock( { name: 'core/spacer' } );

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -22,7 +22,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "small"' );
 			await page
@@ -46,7 +46,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph reset - custom size' );
 			await page
@@ -139,7 +139,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 			await page
@@ -162,7 +162,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
@@ -198,7 +198,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'
@@ -237,7 +237,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 			await page
@@ -257,7 +257,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
@@ -291,7 +291,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=button[name="Add default block"i]' )
+				.locator( 'role=document[name*="Empty block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -22,7 +22,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "small"' );
 			await page
@@ -46,7 +46,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph reset - custom size' );
 			await page
@@ -139,7 +139,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 			await page
@@ -162,7 +162,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
@@ -198,7 +198,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'
@@ -237,7 +237,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 			await page
@@ -257,7 +257,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using tools panel menu'
@@ -291,7 +291,7 @@ test.describe( 'Font Size Picker', () => {
 		} ) => {
 			await editor.openDocumentSettingsSidebar();
 			await editor.canvas
-				.locator( 'role=document[name*="Empty block"i]' )
+				.locator( 'role=document[name="Add default block"i]' )
 				.click();
 			await page.keyboard.type(
 				'Paragraph with font size reset using input field'

--- a/test/e2e/specs/editor/various/footnotes-revisions.spec.js
+++ b/test/e2e/specs/editor/various/footnotes-revisions.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Footnotes in Revisions UI', () => {
 	} ) => {
 		// --- Revision 1: paragraph with footnote "alpha" ---
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Paragraph one' );
 

--- a/test/e2e/specs/editor/various/footnotes-revisions.spec.js
+++ b/test/e2e/specs/editor/various/footnotes-revisions.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Footnotes in Revisions UI', () => {
 	} ) => {
 		// --- Revision 1: paragraph with footnote "alpha" ---
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Paragraph one' );
 

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -25,7 +25,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'can be inserted', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'first paragraph' );
 		await page.keyboard.press( 'Enter' );
@@ -189,7 +189,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'can be inserted in a list', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await editor.clickBlockToolbarButton( 'More' );
@@ -289,7 +289,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'works with revisions', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'first paragraph' );
 		await page.keyboard.press( 'Enter' );
@@ -394,7 +394,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'can be previewed when published', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'a' );
 
@@ -519,7 +519,7 @@ test.describe( 'Footnotes meta written by something else', () => {
 
 		await admin.editPost( post.id );
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'a paragraph' );
 

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -25,7 +25,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'can be inserted', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'first paragraph' );
 		await page.keyboard.press( 'Enter' );
@@ -189,7 +189,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'can be inserted in a list', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '* 1' );
 		await editor.clickBlockToolbarButton( 'More' );
@@ -289,7 +289,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'works with revisions', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'first paragraph' );
 		await page.keyboard.press( 'Enter' );
@@ -394,7 +394,7 @@ test.describe( 'Footnotes', () => {
 
 	test( 'can be previewed when published', async ( { editor, page } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'a' );
 
@@ -519,7 +519,7 @@ test.describe( 'Footnotes meta written by something else', () => {
 
 		await admin.editPost( post.id );
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'a paragraph' );
 

--- a/test/e2e/specs/editor/various/format-library/math.spec.js
+++ b/test/e2e/specs/editor/various/format-library/math.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Format Library - Math', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( 'equation: ' );
@@ -92,7 +92,7 @@ test.describe( 'Format Library - Math', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		// Type the LaTeX as plain text, then select it.

--- a/test/e2e/specs/editor/various/format-library/math.spec.js
+++ b/test/e2e/specs/editor/various/format-library/math.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Format Library - Math', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( 'equation: ' );
@@ -92,7 +92,7 @@ test.describe( 'Format Library - Math', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		// Type the LaTeX as plain text, then select it.

--- a/test/e2e/specs/editor/various/format-library/text-color.spec.js
+++ b/test/e2e/specs/editor/various/format-library/text-color.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Format Library - Text color', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 
 		await page.keyboard.type( '1' );

--- a/test/e2e/specs/editor/various/format-library/text-color.spec.js
+++ b/test/e2e/specs/editor/various/format-library/text-color.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Format Library - Text color', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		await page.keyboard.type( '1' );

--- a/test/e2e/specs/editor/various/gif-to-video.spec.js
+++ b/test/e2e/specs/editor/various/gif-to-video.spec.js
@@ -166,7 +166,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		// inserting: an insert dispatched during setup is wiped by the
 		// editor's initial blocks reset.
 		await expect(
-			editor.canvas.getByRole( 'button', { name: 'Add default block' } )
+			editor.canvas.getByRole( 'document', { name: /Empty block/i } )
 		).toBeVisible();
 
 		// The GIF uploads as a normal image attachment and a transcoded
@@ -347,7 +347,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		 * the upload queue, so the spinner never cleared.
 		 */
 		await expect(
-			editor.canvas.getByRole( 'button', { name: 'Add default block' } )
+			editor.canvas.getByRole( 'document', { name: /Empty block/i } )
 		).toBeVisible();
 
 		await editor.insertBlock( { name: 'core/image' } );
@@ -431,7 +431,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		 * https://github.com/WordPress/gutenberg/issues/80266.
 		 */
 		await expect(
-			editor.canvas.getByRole( 'button', { name: 'Add default block' } )
+			editor.canvas.getByRole( 'document', { name: /Empty block/i } )
 		).toBeVisible();
 
 		await editor.insertBlock( { name: 'core/image' } );

--- a/test/e2e/specs/editor/various/gif-to-video.spec.js
+++ b/test/e2e/specs/editor/various/gif-to-video.spec.js
@@ -166,7 +166,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		// inserting: an insert dispatched during setup is wiped by the
 		// editor's initial blocks reset.
 		await expect(
-			editor.canvas.getByRole( 'document', { name: /Empty block/i } )
+			editor.canvas.getByRole( 'document', { name: 'Add default block' } )
 		).toBeVisible();
 
 		// The GIF uploads as a normal image attachment and a transcoded
@@ -347,7 +347,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		 * the upload queue, so the spinner never cleared.
 		 */
 		await expect(
-			editor.canvas.getByRole( 'document', { name: /Empty block/i } )
+			editor.canvas.getByRole( 'document', { name: 'Add default block' } )
 		).toBeVisible();
 
 		await editor.insertBlock( { name: 'core/image' } );
@@ -431,7 +431,7 @@ test.describe( 'Video conversion: animated GIF to video', () => {
 		 * https://github.com/WordPress/gutenberg/issues/80266.
 		 */
 		await expect(
-			editor.canvas.getByRole( 'document', { name: /Empty block/i } )
+			editor.canvas.getByRole( 'document', { name: 'Add default block' } )
 		).toBeVisible();
 
 		await editor.insertBlock( { name: 'core/image' } );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -492,7 +492,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '/tag cloud' );
 
@@ -514,7 +514,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await page.keyboard.press( 'Enter' );
@@ -568,7 +568,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await editor.insertBlock( { name: 'core/image' } );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -492,7 +492,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '/tag cloud' );
 
@@ -514,7 +514,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await page.keyboard.press( 'Enter' );
@@ -568,7 +568,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'First paragraph' );
 		await editor.insertBlock( { name: 'core/image' } );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -778,6 +778,51 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 	} );
 } );
 
+test.describe( 'Default block ghost', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'materialises in the same DOM element', async ( {
+		editor,
+		page,
+	} ) => {
+		const ghost = editor.canvas.getByRole( 'document', {
+			name: 'Add default block',
+		} );
+		await expect( ghost ).toBeVisible();
+
+		// The ghost is not part of the content yet.
+		expect( await editor.getBlocks() ).toEqual( [] );
+
+		// Tag the DOM node and record its block id.
+		const idBefore = await ghost.evaluate( ( element ) => {
+			element.__ghostNode = true;
+			return element.getAttribute( 'data-block' );
+		} );
+
+		await ghost.click();
+		await page.keyboard.type( 'Hello' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Hello' },
+			},
+		] );
+
+		// Same client ID, same DOM node: nothing remounted.
+		const after = await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.evaluate( ( element ) => ( {
+				id: element.getAttribute( 'data-block' ),
+				sameNode: element.__ghostNode === true,
+			} ) );
+		expect( after.id ).toBe( idBefore );
+		expect( after.sameNode ).toBe( true );
+	} );
+} );
+
 test.describe( 'insert media from inserter', () => {
 	let uploadedMedia;
 

--- a/test/e2e/specs/editor/various/invalid-block.spec.js
+++ b/test/e2e/specs/editor/various/invalid-block.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Invalid blocks', () => {
 	} ) => {
 		// Create an empty paragraph with the focus in the block.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'hello' );
 

--- a/test/e2e/specs/editor/various/invalid-block.spec.js
+++ b/test/e2e/specs/editor/various/invalid-block.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Invalid blocks', () => {
 	} ) => {
 		// Create an empty paragraph with the focus in the block.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'hello' );
 

--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Keep styles on block transforms', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 
@@ -52,7 +52,7 @@ test.describe( 'Keep styles on block transforms', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.keyboard.press( 'Enter' );
@@ -89,7 +89,7 @@ test.describe( 'Keep styles on block transforms', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.getByRole( 'radio', { name: 'Large', exact: true } ).click();

--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Keep styles on block transforms', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
 
@@ -52,7 +52,7 @@ test.describe( 'Keep styles on block transforms', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.keyboard.press( 'Enter' );
@@ -89,7 +89,7 @@ test.describe( 'Keep styles on block transforms', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Line 1 to be made large' );
 		await page.getByRole( 'radio', { name: 'Large', exact: true } ).click();

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -82,7 +82,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Shift+Enter' );
@@ -109,7 +109,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		multiBlockSelectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '12' );
@@ -132,7 +132,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Shift+ArrowUp' );
@@ -244,7 +244,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -290,7 +290,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		multiBlockSelectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -588,7 +588,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '12' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -655,7 +655,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '123' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -773,7 +773,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 	} ) => {
 		await editor.canvas
 			.getByRole( 'document', {
-				name: /Empty block/i,
+				name: 'Add default block',
 			} )
 			.click();
 		await page.keyboard.type( '1' );
@@ -864,7 +864,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1' );
 
@@ -1266,7 +1266,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1[' );
 		await page.keyboard.press( 'Enter' );
@@ -1295,7 +1295,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '1[' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -82,7 +82,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Shift+Enter' );
@@ -109,7 +109,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		multiBlockSelectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '12' );
@@ -132,7 +132,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Shift+ArrowUp' );
@@ -244,7 +244,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -290,7 +290,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		multiBlockSelectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -588,7 +588,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '12' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -655,7 +655,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '123' );
 		await page.keyboard.press( 'ArrowLeft' );
@@ -772,8 +772,8 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		multiBlockSelectionUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', {
-				name: 'Add default block',
+			.getByRole( 'document', {
+				name: /Empty block/i,
 			} )
 			.click();
 		await page.keyboard.type( '1' );
@@ -864,7 +864,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1' );
 
@@ -1266,7 +1266,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1[' );
 		await page.keyboard.press( 'Enter' );
@@ -1295,7 +1295,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '1[' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -56,7 +56,7 @@ test.describe( 'Pattern Overrides', () => {
 				.click();
 
 			await editor.canvas
-				.getByRole( 'document', { name: /Empty block/i } )
+				.getByRole( 'document', { name: 'Add default block' } )
 				.click();
 			await page.keyboard.type( 'This paragraph can be edited' );
 			await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -56,7 +56,7 @@ test.describe( 'Pattern Overrides', () => {
 				.click();
 
 			await editor.canvas
-				.getByRole( 'button', { name: 'Add default block' } )
+				.getByRole( 'document', { name: /Empty block/i } )
 				.click();
 			await page.keyboard.type( 'This paragraph can be edited' );
 			await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -1073,7 +1073,7 @@ test.describe( 'Synced pattern', () => {
 
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( '/Awesome block' );
 		await page.getByRole( 'option', { name: 'Awesome block' } ).click();

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -1073,7 +1073,7 @@ test.describe( 'Synced pattern', () => {
 
 		await admin.createNewPost();
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( '/Awesome block' );
 		await page.getByRole( 'option', { name: 'Awesome block' } ).click();

--- a/test/e2e/specs/editor/various/revision-fields-diff.spec.js
+++ b/test/e2e/specs/editor/various/revision-fields-diff.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Revision Fields Diff Panel', () => {
 	} ) => {
 		// Revision 1: paragraph with footnote "alpha".
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Paragraph one' );
 		await editor.showBlockToolbar();

--- a/test/e2e/specs/editor/various/revision-fields-diff.spec.js
+++ b/test/e2e/specs/editor/various/revision-fields-diff.spec.js
@@ -11,7 +11,7 @@ test.describe( 'Revision Fields Diff Panel', () => {
 	} ) => {
 		// Revision 1: paragraph with footnote "alpha".
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Paragraph one' );
 		await editor.showBlockToolbar();

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -21,7 +21,7 @@ test.describe( 'Post revisions', () => {
 			.fill( 'Revisions Test' );
 
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Original content' );
 
@@ -407,7 +407,7 @@ test.describe( 'Post revisions with classic meta boxes', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Revisions with meta box' );
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Original content' );
 		await editor.saveDraft();

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -21,7 +21,7 @@ test.describe( 'Post revisions', () => {
 			.fill( 'Revisions Test' );
 
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Original content' );
 
@@ -407,7 +407,7 @@ test.describe( 'Post revisions with classic meta boxes', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Revisions with meta box' );
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Original content' );
 		await editor.saveDraft();

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -37,7 +37,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'primary+a' );
@@ -57,7 +57,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Some ' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -79,7 +79,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await pageUtils.pressKeys( 'primary+i' );
@@ -102,7 +102,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
@@ -127,7 +127,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'Some ' );
 		await editor.clickBlockToolbarButton( 'Bold' );
@@ -149,7 +149,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A `backtick`' );
 
@@ -172,7 +172,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
 		// Wait until the backtick transformation is recorded as an automatic change.
@@ -192,7 +192,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
 		await page.keyboard.type( 'b' );
@@ -207,7 +207,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
@@ -225,7 +225,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A `backtick` and more.' );
 
@@ -243,7 +243,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'A selection test.' );
 		await page.keyboard.press( 'Home' );
@@ -275,7 +275,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -370,7 +370,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
@@ -402,7 +402,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '12' );
@@ -426,7 +426,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Tab' );
@@ -449,7 +449,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		// Simulate moving focus to a different app, then moving focus back,
@@ -482,7 +482,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -512,7 +512,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'primary+a' );
@@ -535,7 +535,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -562,7 +562,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -584,7 +584,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
@@ -613,7 +613,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		// Add text and select to color.
@@ -670,7 +670,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		// Create two lines of text in a paragraph.
 		await page.keyboard.type( '1' );
@@ -721,7 +721,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		// Create an indented list of two lines.
@@ -772,7 +772,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 
 	test( 'should navigate around emoji', async ( { page, editor } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '🍓' );
 		// Only one press on arrow left should be required to move in front of
@@ -792,7 +792,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		// Playwright doesn't support composition, so emulate it by inserting
 		// text in the DOM directly, setting selection in the right place, and
@@ -832,7 +832,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -37,7 +37,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await pageUtils.pressKeys( 'primary+a' );
@@ -57,7 +57,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Some ' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -79,7 +79,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await pageUtils.pressKeys( 'primary+i' );
@@ -102,7 +102,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
@@ -127,7 +127,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'Some ' );
 		await editor.clickBlockToolbarButton( 'Bold' );
@@ -149,7 +149,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A `backtick`' );
 
@@ -172,7 +172,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
 		// Wait until the backtick transformation is recorded as an automatic change.
@@ -192,7 +192,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
 		await page.keyboard.type( 'b' );
@@ -207,7 +207,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '`a`' );
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
@@ -225,7 +225,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A `backtick` and more.' );
 
@@ -243,7 +243,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'A selection test.' );
 		await page.keyboard.press( 'Home' );
@@ -275,7 +275,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -370,7 +370,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
@@ -402,7 +402,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '12' );
@@ -426,7 +426,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Tab' );
@@ -449,7 +449,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		// Simulate moving focus to a different app, then moving focus back,
@@ -482,7 +482,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -512,7 +512,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '2' );
 		await pageUtils.pressKeys( 'primary+a' );
@@ -535,7 +535,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await pageUtils.pressKeys( 'primary+b' );
@@ -562,7 +562,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -584,7 +584,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );
@@ -613,7 +613,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		// Add text and select to color.
@@ -670,7 +670,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		// Create two lines of text in a paragraph.
 		await page.keyboard.type( '1' );
@@ -721,7 +721,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		// Create an indented list of two lines.
@@ -772,7 +772,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 
 	test( 'should navigate around emoji', async ( { page, editor } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '🍓' );
 		// Only one press on arrow left should be required to move in front of
@@ -792,7 +792,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		// Playwright doesn't support composition, so emulate it by inserting
 		// text in the DOM directly, setting selection in the right place, and
@@ -832,7 +832,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( '1' );

--- a/test/e2e/specs/editor/various/rtl.spec.js
+++ b/test/e2e/specs/editor/various/rtl.spec.js
@@ -148,7 +148,7 @@ test.describe( 'RTL', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( ARABIC_ONE );

--- a/test/e2e/specs/editor/various/rtl.spec.js
+++ b/test/e2e/specs/editor/various/rtl.spec.js
@@ -148,7 +148,7 @@ test.describe( 'RTL', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await pageUtils.pressKeys( 'primary+b' );
 		await page.keyboard.type( ARABIC_ONE );

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -18,7 +18,7 @@ test.describe( 'undo', () => {
 		undoUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'before pause' );
 		await editor.page.waitForTimeout( 1000 );
@@ -90,7 +90,7 @@ test.describe( 'undo', () => {
 		undoUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( 'before keyboard ' );
@@ -166,7 +166,7 @@ test.describe( 'undo', () => {
 
 	test( 'should undo bold', async ( { page, pageUtils, editor } ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await editor.saveDraft();
@@ -205,7 +205,7 @@ test.describe( 'undo', () => {
 		undoUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		const firstBlock = await editor.getEditedPostContent();
@@ -356,7 +356,7 @@ test.describe( 'undo', () => {
 
 		// Issue is demonstrated from an edited post: create, save, and reload.
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'original' );
 		await editor.saveDraft();
@@ -391,7 +391,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await editor.saveDraft();
@@ -406,7 +406,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await editor.publishPost();
@@ -421,7 +421,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 
 		await page.keyboard.type( '1' );
@@ -463,7 +463,7 @@ test.describe( 'undo', () => {
 		// and skipping `undo` history steps.
 		const text = 'tonis';
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( text );
 		await editor.publishPost();
@@ -495,7 +495,7 @@ test.describe( 'undo', () => {
 			.type( 'a' ); // First step.
 		await page.keyboard.press( 'Backspace' ); // Second step.
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click(); // third step.
 
 		// Title should be empty
@@ -534,7 +534,7 @@ test.describe( 'undo', () => {
 			.click();
 
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Howdy!' );
 
@@ -574,7 +574,7 @@ test.describe( 'undo', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'some linked text here' );
 		// Select the word "linked".
@@ -610,7 +610,7 @@ test.describe( 'undo', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'first' );
 		await page.keyboard.press( 'Enter' );
@@ -654,7 +654,7 @@ test.describe( 'undo', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'a paragraph' );
 		await editor.insertBlock( {

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -18,7 +18,7 @@ test.describe( 'undo', () => {
 		undoUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'before pause' );
 		await editor.page.waitForTimeout( 1000 );
@@ -90,7 +90,7 @@ test.describe( 'undo', () => {
 		undoUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( 'before keyboard ' );
@@ -166,7 +166,7 @@ test.describe( 'undo', () => {
 
 	test( 'should undo bold', async ( { page, pageUtils, editor } ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'test' );
 		await editor.saveDraft();
@@ -205,7 +205,7 @@ test.describe( 'undo', () => {
 		undoUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		const firstBlock = await editor.getEditedPostContent();
@@ -356,7 +356,7 @@ test.describe( 'undo', () => {
 
 		// Issue is demonstrated from an edited post: create, save, and reload.
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'original' );
 		await editor.saveDraft();
@@ -391,7 +391,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await editor.saveDraft();
@@ -406,7 +406,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( '1' );
 		await editor.publishPost();
@@ -421,7 +421,7 @@ test.describe( 'undo', () => {
 		pageUtils,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 
 		await page.keyboard.type( '1' );
@@ -463,7 +463,7 @@ test.describe( 'undo', () => {
 		// and skipping `undo` history steps.
 		const text = 'tonis';
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( text );
 		await editor.publishPost();
@@ -495,7 +495,7 @@ test.describe( 'undo', () => {
 			.type( 'a' ); // First step.
 		await page.keyboard.press( 'Backspace' ); // Second step.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click(); // third step.
 
 		// Title should be empty
@@ -534,7 +534,7 @@ test.describe( 'undo', () => {
 			.click();
 
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Howdy!' );
 
@@ -574,7 +574,7 @@ test.describe( 'undo', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'some linked text here' );
 		// Select the word "linked".
@@ -610,7 +610,7 @@ test.describe( 'undo', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'first' );
 		await page.keyboard.press( 'Enter' );
@@ -654,7 +654,7 @@ test.describe( 'undo', () => {
 		editor,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'a paragraph' );
 		await editor.insertBlock( {

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -835,7 +835,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=document[name*="Empty block"i]' )
+			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( 'First' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -835,7 +835,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await editor.canvas
-			.locator( 'role=button[name="Add default block"i]' )
+			.locator( 'role=document[name*="Empty block"i]' )
 			.click();
 		await page.keyboard.type( 'First' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -47,7 +47,7 @@ async function addPageContent( editor, page ) {
 			name: 'Block: Content',
 		} )
 		.getByRole( 'document', {
-			name: /Empty block/i,
+			name: 'Add default block',
 		} )
 		.click();
 
@@ -287,7 +287,7 @@ test.describe( 'Pages', () => {
 		// A single click on the prompt inserts a paragraph and moves the
 		// caret into it; no click to select the Content block is needed.
 		await contentBlock
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'Typed after one click' );
 

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -46,8 +46,8 @@ async function addPageContent( editor, page ) {
 		.getByRole( 'document', {
 			name: 'Block: Content',
 		} )
-		.getByRole( 'button', {
-			name: 'Add default block',
+		.getByRole( 'document', {
+			name: /Empty block/i,
 		} )
 		.click();
 
@@ -287,7 +287,7 @@ test.describe( 'Pages', () => {
 		// A single click on the prompt inserts a paragraph and moves the
 		// caret into it; no click to select the Content block is needed.
 		await contentBlock
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'Typed after one click' );
 

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -69,7 +69,7 @@ test.describe( 'Patterns', () => {
 		).toBeVisible();
 
 		await editor.canvas
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'My pattern' );
 

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -69,7 +69,7 @@ test.describe( 'Patterns', () => {
 		).toBeVisible();
 
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: /Empty block/i } )
 			.click();
 		await page.keyboard.type( 'My pattern' );
 

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -15,6 +15,12 @@ test.describe( 'Template Activate', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
+		// The templates endpoint lists templates for the active theme, and
+		// the last test switches to twentytwentyfive. Switch back first so
+		// the home template created under emptytheme is found and deleted;
+		// left behind, it replaces the front page of every later emptytheme
+		// suite on the same site.
+		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 		await requestUtils.activateTheme( 'twentytwentyone' );


### PR DESCRIPTION
## What?

Renders a ghost of the container's default block in place of the default block appender while the block list is empty: a real block object, rendered before it exists in the store, and inserted unchanged when the user enters it. The client ID, the DOM element, and the caret survive materialization. The default block resolves from the block list settings, then the editor default: the empty canvas ghosts a paragraph, an empty buttons block ghosts a button.

## Why?

The default appender is a lookalike `<p role="button">`. Rendering the actual block instead means:

-   The empty state looks like the block the user gets: real styles, real placeholder, real markup.
-   The CSS styles and the DOM structure are the same before and after entry, so there is no appender-to-block swap and no layout shift.
-   Entering it replaces and refocuses nothing: the element, the caret and the client ID carry over.
-   It is announced as a block, with the appender's accessible name kept until entry.
-   Blocks can now add attributes to the default block (via the block list settings' `defaultBlock`), and the empty state renders them: the appender could only ever look like a plain paragraph. This makes it possible to [replace the cover block's scaffolded title paragraph](https://github.com/WordPress/gutenberg/pull/80028#issuecomment-4955554175) with a declared default block, in a follow-up.

## How?

1. `Items` derives the ghost while the list is empty: `createBlock` of the resolved default, memoized so the object is stable per empty period, rendered through the ordinary `BlockListBlock` with the ghost object as a fallback data source.
2. `BlockListBlockProvider` falls back to the ghost object when the store has no entry; the ghost is never selected before entry, so the selection dependent selectors are moot.
3. Entering the ghost (pointerdown or focusin) inserts that same object. Same client ID, same key, same element; the provider's data source flips from the prop to the store.

Nothing is registered in the store before entry: no state, no actions, no lifecycle. On keyboard entry there is a theoretical one-tick window where a focus-time selection dispatch could precede the insert; in practice the selection sync rides the asynchronous `selectionchange` event and lands after the insert, and React consumers render once per task, so no inconsistent state has been observable.

## Testing Instructions

1. Create a new post. The body shows a real empty paragraph with the usual placeholder instead of the appender. The post has no content until you enter it.
2. Click it and type. The caret stays put; the paragraph becomes the first block.
3. Press Escape or click outside. A new trailing paragraph renders after the content.
4. Insert a Group block and select it while empty. The paragraph renders inside it.
5. Insert an empty Buttons block: a ghost button renders. Note: selecting the container moves focus into the ghost, which materialises it; that is the focus rule working, but it means selecting an empty restricted container creates its first child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)









