### PR TITLE
Components: Use p elements for callout alerts in README docs

### DIFF
--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -627,14 +627,10 @@ Each component that is exported from the `@wordpress/components` package should 
 # `ComponentName`
 
 <!-- If component is experimental, add the following section: -->
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 <!-- If component is deprecated, add the following section: -->
-<div class="callout callout-alert">
-This component is deprecated. Please use `{other component}` from the `{other package}` package instead.
-</div>
+<p class="callout callout-alert">This component is deprecated. Please use `{other component}` from the `{other package}` package instead.</p>
 
 Description of the component.
 

--- a/packages/components/src/button-group/README.md
+++ b/packages/components/src/button-group/README.md
@@ -1,8 +1,6 @@
 # ButtonGroup
 
-<div class="callout callout-alert">
-	This component is deprecated. Use `ToggleGroupControl` instead.
-</div>
+<p class="callout callout-alert">This component is deprecated. Use `ToggleGroupControl` instead.</p>
 
 ButtonGroup can be used to group any related buttons together. To emphasize related buttons, a group should share a common container.
 

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -1,8 +1,6 @@
 # `CircularOptionPicker`
 
-<div class="callout callout-alert">
-This component is not exported, and therefore can only be used internally to the `@wordpress/components` package.
-</div>
+<p class="callout callout-alert">This component is not exported, and therefore can only be used internally to the `@wordpress/components` package.</p>
 
 `CircularOptionPicker` is a component that displays a set of options as circular buttons.
 

--- a/packages/components/src/clipboard-button/README.md
+++ b/packages/components/src/clipboard-button/README.md
@@ -1,8 +1,6 @@
 # ClipboardButton
 
-<div class="callout callout-alert">
-This component is deprecated. Please use the `useCopyToClipboard` hook from the `@wordpress/compose` package instead.
-</div>
+<p class="callout callout-alert">This component is deprecated. Please use the `useCopyToClipboard` hook from the `@wordpress/compose` package instead.</p>
 
 With a clipboard button, users copy text (or other elements) with a single click or tap.
 

--- a/packages/components/src/divider/README.md
+++ b/packages/components/src/divider/README.md
@@ -1,8 +1,6 @@
 # Divider
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Divider` is a layout component that separates groups of related content.
 

--- a/packages/components/src/elevation/README.md
+++ b/packages/components/src/elevation/README.md
@@ -1,8 +1,6 @@
 # Elevation
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Elevation` is a core component that renders shadow, using the component system's shadow system.
 

--- a/packages/components/src/grid/README.md
+++ b/packages/components/src/grid/README.md
@@ -1,8 +1,6 @@
 # Grid
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Grid` is a primitive layout component that can arrange content in a grid configuration.
 

--- a/packages/components/src/h-stack/README.md
+++ b/packages/components/src/h-stack/README.md
@@ -1,8 +1,6 @@
 # HStack
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `HStack` (Horizontal Stack) arranges child elements in a horizontal line.
 

--- a/packages/components/src/heading/README.md
+++ b/packages/components/src/heading/README.md
@@ -1,8 +1,6 @@
 # Heading
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Heading` renders headings and titles using the library's typography system.
 

--- a/packages/components/src/input-control/README.md
+++ b/packages/components/src/input-control/README.md
@@ -1,8 +1,6 @@
 # InputControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 InputControl components let users enter and edit text. This is an experimental component intended to (in time) merge with or replace [TextControl](../text-control).
 

--- a/packages/components/src/item-group/item-group/README.md
+++ b/packages/components/src/item-group/item-group/README.md
@@ -1,8 +1,6 @@
 # `ItemGroup`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `ItemGroup` displays a list of `Item`s grouped and styled together.
 

--- a/packages/components/src/item-group/item/README.md
+++ b/packages/components/src/item-group/item/README.md
@@ -1,8 +1,6 @@
 # `Item`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Item` is used in combination with `ItemGroup` to display a list of items grouped and styled together.
 

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -1,8 +1,6 @@
 # NumberControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 NumberControl is an enhanced HTML [`input[type="number"]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element.
 

--- a/packages/components/src/radio-group/README.md
+++ b/packages/components/src/radio-group/README.md
@@ -1,12 +1,8 @@
 # RadioGroup
 
-<div class="callout callout-alert">
-This component is deprecated. Consider using `RadioControl` or `ToggleGroupControl` instead.
-</div>
+<p class="callout callout-alert">This component is deprecated. Consider using `RadioControl` or `ToggleGroupControl` instead.</p>
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 Use a RadioGroup component when you want users to select one option from a small set of options.
 

--- a/packages/components/src/scrollable/README.md
+++ b/packages/components/src/scrollable/README.md
@@ -1,8 +1,6 @@
 # Scrollable
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Scrollable` is a layout component that puts content in a scrollable container.
 

--- a/packages/components/src/spacer/README.md
+++ b/packages/components/src/spacer/README.md
@@ -1,8 +1,6 @@
 # Spacer
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Spacer` is a primitive layout component that providers inner (`padding`) or outer (`margin`) space in-between components. It can also be used to adaptively provide space within an `HStack` or `VStack`.
 

--- a/packages/components/src/surface/README.md
+++ b/packages/components/src/surface/README.md
@@ -1,8 +1,6 @@
 # Surface
 
-<div class="callout callout-alert">
-This component is deprecated. Write your own CSS instead, preferably using the <a href="https://wordpress.github.io/gutenberg/?path=/docs/design-system-tokens-introduction--docs">design tokens</a> available in <code>@wordpress/theme</code>.
-</div>
+<p class="callout callout-alert">This component is deprecated. Write your own CSS instead, preferably using the <a href="https://wordpress.github.io/gutenberg/?path=/docs/design-system-tokens-introduction--docs">design tokens</a> available in <code>@wordpress/theme</code>.</p>
 
 `Surface` is a core component that renders a primary background color.
 

--- a/packages/components/src/text/README.md
+++ b/packages/components/src/text/README.md
@@ -1,8 +1,6 @@
 # Text
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Text` is a core component that renders text in the library, using the library's typography system.
 

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/README.md
@@ -1,8 +1,6 @@
 # `ToggleGroupControlOptionBase`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `ToggleGroupControlOptionBase` is a form component and is meant to be used as an internal, generic component for any children of [`ToggleGroupControl`](/packages/components/src/toggle-group-control/toggle-group-control/README.md).
 

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/README.md
@@ -1,8 +1,6 @@
 # `ToggleGroupControlOptionIcon`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `ToggleGroupControlOptionIcon` is a form component which is meant to be used as a child of [`ToggleGroupControl`](/packages/components/src/toggle-group-control/toggle-group-control/README.md) and displays an icon.
 

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
@@ -1,8 +1,6 @@
 # `ToggleGroupControlOption`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `ToggleGroupControlOption` is a form component and is meant to be used as a child of [`ToggleGroupControl`](/packages/components/src/toggle-group-control/toggle-group-control/README.md).
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control/README.md
@@ -1,8 +1,6 @@
 # `ToggleGroupControl`
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `ToggleGroupControl` is a form component that lets users choose options represented in horizontal segments. To render options for this control use [`ToggleGroupControlOption`](/packages/components/src/toggle-group-control/toggle-group-control-option/README.md) component.
 

--- a/packages/components/src/tools-panel/tools-panel-header/README.md
+++ b/packages/components/src/tools-panel/tools-panel-header/README.md
@@ -1,8 +1,6 @@
 # ToolsPanelHeader
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 <br />
 
 This component renders a tools panel's header including a menu.
@@ -12,9 +10,7 @@ This component renders a tools panel's header including a menu.
 This component is generated automatically by its parent
 `ToolsPanel`.
 
-<div class="callout callout-alert">
-<strong>In general, this should not be used directly.</strong>
-</div>
+<p class="callout callout-alert"><strong>In general, this should not be used directly.</strong></p>
 
 ## Props
 

--- a/packages/components/src/tools-panel/tools-panel-item/README.md
+++ b/packages/components/src/tools-panel/tools-panel-item/README.md
@@ -1,9 +1,7 @@
 # ToolsPanelItem
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early
-implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early
+implementation subject to drastic and breaking changes.</p>
 <br />
 
 This component acts as a wrapper and controls the display of items to be contained

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -1,9 +1,7 @@
 # ToolsPanel
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early
-implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early
+implementation subject to drastic and breaking changes.</p>
 <br />
 These panels provide progressive discovery options for their children. For
 example the controls provided via block supports.

--- a/packages/components/src/tree-grid/README.md
+++ b/packages/components/src/tree-grid/README.md
@@ -1,8 +1,6 @@
 # TreeGrid
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 ## Development guidelines
 

--- a/packages/components/src/truncate/README.md
+++ b/packages/components/src/truncate/README.md
@@ -1,8 +1,6 @@
 # Truncate
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `Truncate` is a typography primitive that trims text content. For almost all cases, it is recommended that `Text`, `Heading`, or `Subheading` is used to render text content. However, `Truncate` is available for custom implementations.
 

--- a/packages/components/src/unit-control/README.md
+++ b/packages/components/src/unit-control/README.md
@@ -1,8 +1,6 @@
 # UnitControl
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `UnitControl` allows the user to set a numeric quantity as well as a unit (e.g. `px`).
 

--- a/packages/components/src/v-stack/README.md
+++ b/packages/components/src/v-stack/README.md
@@ -1,8 +1,6 @@
 # VStack
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `VStack` (or Vertical Stack) is a layout component that arranges child elements in a vertical line.
 

--- a/packages/components/src/view/README.md
+++ b/packages/components/src/view/README.md
@@ -1,8 +1,6 @@
 # View
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 `View` is a core component that renders everything in the library. It is the principle component in the entire library.
 

--- a/packages/components/src/z-stack/README.md
+++ b/packages/components/src/z-stack/README.md
@@ -1,8 +1,6 @@
 # ZStack
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
+<p class="callout callout-alert">This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.</p>
 
 ## Usage
 


### PR DESCRIPTION
## What?

Updates callout alert markup in `@wordpress/components` README files from `<div class="callout callout-alert">` to `<p class="callout callout-alert">`.

## Why?

`p` elements render more legibly than `div`s when the readme file is viewed on GitHub, because there will be some whitespace between the callout text and the content that follows.

## Testing Instructions

1. Open a few updated README files (for example `packages/components/src/grid/README.md`) and confirm callout markup uses `p` elements.
2. Preview the rendered docs on GitHub and confirm callouts display without running into the content to that follows.