### PR TITLE
DataViews: Use the public `@wordpress/ui` Badge instead of the private one

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 -   Remove obsolete dependency grouping comments as part of the repository-wide separator-free import migration. ([#81248](https://github.com/WordPress/gutenberg/pull/81248))
 -   DataViews: Inline a verbatim copy of the `kebabCase` utility instead of unlocking the private one from `@wordpress/components`, as part of removing the package's reliance on private cross-package APIs ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). Adds a direct `change-case` dependency; no behavior change. ([#81284](https://github.com/WordPress/gutenberg/pull/81284))
+-   DataViews: Use the public `Badge` from `@wordpress/ui` in the `grid` and `picker-grid` layouts instead of the private one from `@wordpress/components`, removing the last `unlock()` call from those files. Badges pick up the `@wordpress/ui` neutral tokens, so they gain a border and a slightly different background ([#81236](https://github.com/WordPress/gutenberg/pull/81236)).
 -   Update `@ariakit/react` to 0.4.35 ([#80765](https://github.com/WordPress/gutenberg/pull/80765)).
 
 ## 17.3.0 (2026-07-29)

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -5,13 +5,8 @@ import type {
 	HTMLAttributes,
 	CSSProperties,
 } from 'react';
-import {
-	Flex,
-	FlexItem,
-	Composite,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
-import { Stack, Tooltip } from '@wordpress/ui';
+import { Flex, FlexItem, Composite } from '@wordpress/components';
+import { Badge, Stack, Tooltip } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import {
@@ -20,7 +15,6 @@ import {
 	useRef,
 	forwardRef,
 } from '@wordpress/element';
-import { unlock } from '../../../lock-unlock';
 import { MEDIA_ASPECT_RATIOS } from '../../../constants';
 import ItemActions from '../../dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../dataviews-selection-checkbox';
@@ -37,7 +31,6 @@ import type {
 import type { SetSelection } from '../../../types/private';
 import type { SelectionProps } from '../utils/use-selection-props';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
 import { useGridColumns } from './preview-size-picker';
 import { GridItems } from '../utils/grid-items';
 import {
@@ -250,7 +243,8 @@ const GridItem = forwardRef< HTMLDivElement, GridItemProps< any > >(
 						>
 							{ badgeFields.map( ( field ) => {
 								return (
-									<WCBadge
+									/* @ts-expect-error `Badge` is text-only, but a badge field renders whatever its `render` returns. */
+									<Badge
 										key={ field.id }
 										className="dataviews-view-grid__field-value"
 									>
@@ -258,7 +252,7 @@ const GridItem = forwardRef< HTMLDivElement, GridItemProps< any > >(
 											item={ item }
 											field={ field }
 										/>
-									</WCBadge>
+									</Badge>
 								);
 							} ) }
 						</Stack>

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -1,17 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
-import {
-	Spinner,
-	Flex,
-	FlexItem,
-	privateApis as componentsPrivateApis,
-	Composite,
-} from '@wordpress/components';
+import { Spinner, Flex, FlexItem, Composite } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { useContext, useRef } from '@wordpress/element';
-import { Stack } from '@wordpress/ui';
-import { unlock } from '../../../lock-unlock';
+import { Badge, Stack } from '@wordpress/ui';
 import DataViewsSelectionCheckbox from '../../dataviews-selection-checkbox';
 import DataViewsContext from '../../dataviews-context';
 import { useIsMultiselectPicker } from '../../dataviews-picker-footer';
@@ -22,7 +15,6 @@ import type {
 } from '../../../types';
 import type { SetSelection } from '../../../types/private';
 import { GridItems } from '../utils/grid-items';
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
 import getDataByGroup from '../utils/get-data-by-group';
 import useSelectionProps from '../utils/use-selection-props';
 import type { SelectionProps } from '../utils/use-selection-props';
@@ -154,7 +146,8 @@ function GridItem< Item >( {
 					>
 						{ badgeFields.map( ( field ) => {
 							return (
-								<WCBadge
+								/* @ts-expect-error `Badge` is text-only, but a badge field renders whatever its `render` returns. */
+								<Badge
 									key={ field.id }
 									className="dataviews-view-picker-grid__field-value"
 								>
@@ -162,7 +155,7 @@ function GridItem< Item >( {
 										item={ item }
 										field={ field }
 									/>
-								</WCBadge>
+								</Badge>
 							);
 						} ) }
 					</Stack>

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -1,10 +1,7 @@
 import { useMemo, useState } from '@wordpress/element';
-import { privateApis } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import DataForm from '../index';
 import type { Field, Form } from '../../types';
-import { unlock } from '../../lock-unlock';
-
-const { Badge: WCBadge } = unlock( privateApis );
 
 const LayoutCardComponent = ( {
 	withHeader,
@@ -108,7 +105,7 @@ const LayoutCardComponent = ( {
 			label: 'Due date',
 			type: 'text',
 			render: ( { item } ) => {
-				return <WCBadge>Due on: { item.dueDate }</WCBadge>;
+				return <Badge>{ `Due on: ${ item.dueDate }` }</Badge>;
 			},
 		},
 		{
@@ -116,7 +113,7 @@ const LayoutCardComponent = ( {
 			type: 'text',
 			readOnly: true,
 			render: ( { item } ) => {
-				return <WCBadge>{ item.plan }</WCBadge>;
+				return <Badge>{ item.plan }</Badge>;
 			},
 		},
 	];

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -70,6 +70,9 @@
 		.dataviews-view-grid__field-value:has(.fields-field__pattern-sync-status-fully) {
 			background: rgba(var(--wp-block-synced-color--rgb), 0.04);
 			color: var(--wp-block-synced-color);
+			// Override the neutral border the badge's `none` intent applies,
+			// so the outline matches the synced text rather than staying gray.
+			border-color: currentColor;
 		}
 	}
 }


### PR DESCRIPTION
## What?

See #81230.

Replaces the private `Badge` from `@wordpress/components` with the public `Badge` from `@wordpress/ui` at DataViews' three call sites.

## Why?

`@wordpress/ui`'s `Badge` is the recommended one — it's on the `use-recommended-components` allowlist, and DataViews already uses it in [`validation-badge.tsx`](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/src/components/dataform-layouts/validation-badge.tsx). The two grid layouts and one story were stale.

## How?

`Badge` was the only unlocked symbol in `composite-grid.tsx`, `picker-grid/index.tsx`, and `dataform/stories/layout-card.tsx`, so the `unlock` and `privateApis` imports come out with it — those files no longer touch `@wordpress/private-apis`.

One non-mechanical part: `BadgeProps['children']` is `string`, because `Badge` is text-only by design. Badge fields render `<field.render … />`, which is not a string — the private `Badge` accepted it only because `unlock()` returns `any`, so those call sites were never type-checked at all.

Rather than relax the prop for everyone, the two grid layouts carry a `@ts-expect-error` on the `<Badge>` tag. The text-only rule stays type-enforced for every other consumer, and DataViews' opt-out is visible exactly where the tradeoff lives. `@ts-ignore` is banned by `ban-ts-comment`; `@ts-expect-error` requires a description. `@wordpress/ui` is untouched by this PR.

The `card` story passes a template literal instead of a suppression, since its label really is a string.

## Testing Instructions

1. `npm run storybook:dev`
2. **DataViews → Layouts → Grid** and **Picker Grid**: badge fields still render, wrap, and align.
3. **DataForm → Layouts → Card**: the "Due on: …" and plan badges render.

### Testing Instructions for Keyboard

No interaction changes — `Badge` is non-interactive in both implementations, and no focus order or tab stop is affected.

## Screenshots or screencast

Small intentional visual change — the neutral variants use different tokens:

| | Background | Text | Border |
|-|-|-|-|
| Before (`components`, `intent="default"`) | `$gray-100` | `$gray-800` | none |
| After (`ui`, `intent="none"`) | `--wpds-color-background-surface-neutral-strong` | `--wpds-color-foreground-content-neutral` | `--wpds-color-stroke-surface-neutral` |

No DataViews stylesheet targets `.components-badge`, so nothing else is affected by the class change.

## Alternatives considered

**Rendering badge fields with `field.getValueFormatted`** ([suggested here](https://github.com/WordPress/gutenberg/pull/81236#discussion_r3727692768)). Tried and reverted: it broke the patterns grid. `patternSyncStatusField` derives its value rather than storing it under the field id, so the default `getValue` resolved to `undefined` and the badges rendered empty; and its sync-status colour comes from a `:has()` selector matching a span only `render` emits, which no parent-selector rewrite can recover once the badge holds a bare string. Making that route work needs a dedicated `intent`/`className` API for badge fields — [left for later](https://github.com/WordPress/gutenberg/pull/81236#discussion_r3731128572).

**Widening `BadgeProps['children']` to `ReactNode`.** Also tried and reverted, in response to [@aduth](https://github.com/WordPress/gutenberg/pull/81236#discussion_r3723160110) and [@mirka](https://github.com/WordPress/gutenberg/pull/81236#discussion_r3723184060): it removed the type-level guardrail behind the text-only guideline and made the `@ts-expect-error` directives in `IncorrectBadgeWithIcon` unused. The call-site suppression keeps that guardrail intact.

## Use of AI Tools

This PR was authored by Claude Opus 5 via Claude Code, from the audit that produced #81230. I reviewed the change and am responsible for its contents.
