### PR TITLE
Block Directory: Make downloadable block item labels translatable.

### DIFF
--- a/packages/block-directory/CHANGELOG.md
+++ b/packages/block-directory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Wrap the downloadable block item labels in `__()` so they can be translated ([#81237](https://github.com/WordPress/gutenberg/pull/81237)).
+
 ## 5.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -30,24 +30,36 @@ function getDownloadableBlockLabel(
 	const stars = Math.round( rating / 0.5 ) * 0.5;
 
 	if ( ! isInstalled && hasNotice ) {
-		/* translators: %s: block title */
-		return sprintf( 'Retry installing %s.', decodeEntities( title ) );
+		return sprintf(
+			/* translators: %s: block title */
+			__( 'Retry installing %s.' ),
+			decodeEntities( title )
+		);
 	}
 
 	if ( isInstalled ) {
-		/* translators: %s: block title */
-		return sprintf( 'Add %s.', decodeEntities( title ) );
+		return sprintf(
+			/* translators: %s: block title */
+			__( 'Add %s.' ),
+			decodeEntities( title )
+		);
 	}
 
 	if ( isInstalling ) {
-		/* translators: %s: block title */
-		return sprintf( 'Installing %s.', decodeEntities( title ) );
+		return sprintf(
+			/* translators: %s: block title */
+			__( 'Installing %s.' ),
+			decodeEntities( title )
+		);
 	}
 
 	// No ratings yet, just use the title.
 	if ( ratingCount < 1 ) {
-		/* translators: %s: block title */
-		return sprintf( 'Install %s.', decodeEntities( title ) );
+		return sprintf(
+			/* translators: %s: block title */
+			__( 'Install %s.' ),
+			decodeEntities( title )
+		);
 	}
 
 	return sprintf(


### PR DESCRIPTION
Fixes the four downloadable block item labels in the Block Directory that could not be translated.

The `getDownloadableBlockLabel` helper in `downloadable-block-list-item` passes its format strings straight to `sprintf` without wrapping them in `__()`. The translator comments are in place, but because the strings never go through an i18n function they are not extracted for translation and always render in English. These are the "Install %s.", "Add %s.", "Installing %s." and "Retry installing %s." labels used for the tooltip and the accessible label of each result in the inserter's Block Directory search.

To fix this we wrap the four format strings in `__()`, matching the `_n()` call already used for the rated variant in the same function. A sweep of the repository did not turn up this pattern anywhere else — the remaining unwrapped `sprintf` calls are developer-facing error messages, HTML `id` attributes, or code samples, which should not be translated.

## Testing Instructions

1. Run `npm run test:unit -- packages/block-directory` and verify the tests pass.
2. In the post editor, open the inserter and search for a block that is not installed, so Block Directory results appear.
3. Hover a result and verify its tooltip and accessible label still read "Install <block title>. …" as before.
4. Verify the four strings in `packages/block-directory/src/components/downloadable-block-list-item/index.js` are wrapped in `__()` with their translator comments, so they get extracted for translation.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
