### PR TITLE
Fix: Trunk e2e failures caused by the navigation spec leaving plain permalinks

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1122,14 +1122,19 @@ test.describe( 'Navigation block', () => {
 		test.afterEach( async ( { admin, page, requestUtils } ) => {
 			await requestUtils.deleteAllPages();
 
-			// Restore plain permalinks
-			// TODO: Encapsulate permalink teardown in an admin.setPermalinks( '' ) style util
+			// Restore the "Day and name" permalink structure
+			// (/%year%/%monthnum%/%day%/%postname%/) that wp-env configures at
+			// install time. Restoring "Plain" instead would leave the shared
+			// site without pretty permalinks for every spec that runs after
+			// this one in the same shard (e.g. the preload specs assert
+			// /wp-json/-style request URLs).
+			// TODO: Encapsulate permalink teardown in an admin.setPermalinks() style util
 			// We need to run this in afterEach instead of afterAll since we don't have page context
 			// in afterAll
 			await admin.visitAdminPage( 'options-permalink.php' );
 
-			// Select Plain permalinks
-			await page.locator( '#permalink-input-plain' ).click();
+			// Select the Day and name permalink structure
+			await page.locator( '#permalink-input-day-name' ).click();
 
 			// Click Save Changes
 			await page.locator( '#submit' ).click();
@@ -1137,10 +1142,8 @@ test.describe( 'Navigation block', () => {
 			// Wait for settings to be saved
 			await page.waitForSelector( '.notice-success' );
 
-			// Force re-discovery of REST API root URL after disabling pretty permalinks.
-			// When permalinks change from pretty to plain, the REST API URL changes
-			// from /wp-json/ back to /?rest_route=/. We need to refresh the cached URL
-			// to prevent 404 errors.
+			// Force re-discovery of the REST API root URL after changing the
+			// permalink structure, so the cached URL cannot go stale.
 			await requestUtils.setupRest();
 		} );
 

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -17,6 +17,11 @@ test.describe( 'Preload', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.resetPreferences();
+		// Posts left behind by earlier specs change the startup requests:
+		// with at least one post, emptytheme's index template query loop
+		// renders the Post Excerpt block, whose editor component fetches
+		// /wp/v2/types/post?context=edit.
+		await requestUtils.deleteAllPosts();
 		const pg = await requestUtils.createPage( {
 			content:
 				'<!-- wp:heading -->\n<h2 class="wp-block-heading">Hello</h2>\n<!-- /wp:heading -->',


### PR DESCRIPTION
Fixes the e2e failures affecting trunk and all PRs since August 5th (first fully red run: [31028376396](https://github.com/WordPress/gutenberg/actions/runs/31028376396)). The "Navigation Link Entity bindings" tests enable pretty permalinks in `beforeEach`, but their `afterEach` "restores" the Plain structure instead of the `/%year%/%monthnum%/%day%/%postname%/` structure wp-env installs with, leaving the shared site on plain permalinks for every spec that runs after them in the same shard. #80602 reshuffled the shard balancing so `navigation.spec.js` now runs before `preload/site-editor.spec.js`, which asserts `/wp-json/`-style request URLs. To fix this the teardown now restores the "Day and name" structure. The WordPress 7.1 RC 1 nightly that landed in the same window is not the cause — the last green run already used it.

The same reshuffle also placed `editor/various/undo.spec.js` — which publishes three posts and doesn't clean up — before the preload spec. With a published post present, emptytheme's index template query loop renders the Post Excerpt block, whose editor component fetches `/wp/v2/types/post?context=edit`, adding an extra request to the assertion. The preload spec now deletes leftover posts in its `beforeAll`.

## Testing Instructions

1. Start the test environment: `npm run wp-env-test start`.
2. On trunk: run `npm run test:e2e -- specs/editor/blocks/navigation.spec.js --grep "Entity bindings"`, then open http://localhost:8889/wp-admin/options-permalink.php — "Plain" is selected — and `npm run test:e2e -- specs/preload/site-editor.spec.js` fails with every URL in `rest_route=` form.
3. With this PR: run the same navigation tests — http://localhost:8889/wp-admin/options-permalink.php shows "Day and name" selected — and the preload tests pass, even with a published post present (e.g. after running `npm run test:e2e -- specs/editor/various/undo.spec.js`).

AI usage disclosure: investigation, fix and description drafted with AI assistance and reviewed by me.
