### PR TITLE
Spacing Sizes Control: Make the control label translatable independently of the input aria label.

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   Background block support: Fix gradients not being applied to a block when a theme opts out of `settings.background.gradient` in `theme.json` ([#81056](https://github.com/WordPress/gutenberg/pull/81056)).
 -   `LinkControl`: Restore the preview title underline by slightly increasing the title's line height, which was too tight for the underline to be visible ([#81083](https://github.com/WordPress/gutenberg/pull/81083)).
 -   `URLInput`: Skip link search requests while an IME composition is in progress; the search now fires once with the confirmed value on `compositionend` ([#80602](https://github.com/WordPress/gutenberg/pull/80602)).
+-   `SpacingSizesControl`: Give the control's visible label its own translation context instead of sharing an entry with the side input's aria label, which feeds the same placeholders in the opposite order — a single shared translation could not be correct for both ([#81240](https://github.com/WordPress/gutenberg/pull/81240)).
 
 ## 16.1.0 (2026-07-29)
 

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -125,8 +125,8 @@ export default function SpacingSizesControl( {
 		ALL_SIDES.includes( view ) && showSideInLabel ? LABELS[ view ] : '';
 
 	const label = sprintf(
-		// translators: 1: The side of the block being modified (top, bottom, left etc.). 2. Type of spacing being modified (padding, margin, etc).
-		_x( '%1$s %2$s', 'spacing' ),
+		// translators: 1: Type of spacing being modified (Padding, Margin, etc.). 2: The side of the block being modified (Top, Bottom, Left, etc.).
+		_x( '%1$s %2$s', 'spacing control label' ),
 		labelProp,
 		sideLabel
 	).trim();


### PR DESCRIPTION
Fixes the two spacing control labels that share a single translation entry while feeding their placeholders in opposite orders, so no translation can be correct for both.

The visible label of `SpacingSizesControl` ("Padding Top") and the aria label of each `SpacingInputControl` ("Top padding") both use `_x( '%1$s %2$s', 'spacing' )`, so translators see a single catalog entry. The control label passes the spacing type as `%1$s` and the side as `%2$s`, while the aria label passes them the other way around. The shared translator comment (1: side, 2: type) only matches the aria label, so any locale that reorders the placeholders — the whole point of positional placeholders — fixes one label and breaks the other. The two call sites started out with the same context-less `__( '%1$s %2$s' )` and were merged into the shared `spacing` context by the i18n cleanup in #66510, which kept each site's argument order.

To fix this the visible label gets its own `spacing control label` context with a translator comment that matches its arguments, following the core pattern of disambiguating identical format strings with distinct contexts (for example `archive title` and `calendar caption`). The aria label keeps the existing `spacing` context: its arguments already match that entry's translator comment, so existing translations remain valid. English output is unchanged for both labels, since the untranslated string renders the arguments in the same order as before.

## Testing Instructions

1. Run `npm run test:unit -- packages/block-editor/src/components/spacing-sizes-control` and verify the tests pass.
2. In the post editor, add a Group block, enable Padding, and unlink the sides: each input's accessible label still reads "Top padding", "Right padding", and so on.
3. Verify the two `sprintf` calls in `packages/block-editor/src/components/spacing-sizes-control/` now use distinct `_x()` contexts (`spacing control label` in `index.js`, `spacing` in `input-controls/spacing-input-control.js`), each with a translator comment matching its argument order, so they are extracted as two separately translatable entries.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
