### PR TITLE
Perf: Speed up select all, and stop the V8 profiler inflating traced metrics

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Performance
 
+-   Select all: Make the writing flow wrapper the editing host before dispatching the multi-selection, instead of from the layout effect that follows the render. Editability is inherited, so the wrapper invalidates the whole subtree, which cost a second full style recalculation on top of the render's. On a 1000 paragraph post this takes the interaction from 253ms to 207ms of main thread work.
 -   `hasSelectedInnerBlock`: Answer the deep check from a set of the selection's ancestors, built once per selection, instead of walking the parents of every selected block on each call. `BlockListBlock` asks once per rendered block, so the old cost was the block count multiplied by the selection size ([#81210](https://github.com/WordPress/gutenberg/pull/81210)).
 -   `BlockListBlock`: Skip that deep check behind `isSelectionWithinCurrentSection` when the block is not within a section block, where it was passed an `undefined` client ID that never matches. Together the two changes take selecting all blocks on a 1000 paragraph post from 16.8s to 0.4s ([#81210](https://github.com/WordPress/gutenberg/pull/81210)).
 -   `ListView`: Drop the `useBlockDisplayInformation` and `useBlockLock` calls from the row, select button and branch components, reading the few fields they were used for from the `useSelect` each component already has. Store subscriptions go from seven to four per rendered row, and from two to one per branch ([#81136](https://github.com/WordPress/gutenberg/pull/81136)).

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -15,6 +15,7 @@ import {
 	getBlockClientId,
 	getSelectionEditableElement,
 } from '../../utils/dom';
+import { setContentEditableWrapper } from './utils';
 
 export default function useSelectAll() {
 	const { getBlockOrder, getSelectedBlockClientIds, getBlockRootClientId } =
@@ -100,6 +101,13 @@ export default function useSelectAll() {
 				}
 				return;
 			}
+
+			// `useMultiSelection` does this from a layout effect, after the
+			// render has already changed every block. Editability is
+			// inherited, so the wrapper invalidates the whole subtree, and the
+			// focus it takes fires `focusout` mid-commit. Setting it first
+			// merges both into the render.
+			setContentEditableWrapper( node, true );
 
 			multiSelect(
 				blockClientIds[ 0 ],

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Metrics.startTracing()`: Run a trivial script once tracing is on, to absorb the isolate interrupt that enabling the V8 sampling profiler queues. Its cost otherwise lands in the first thing the test does, usually the interaction being measured, and grows through a spec's iterations: a stable 220ms interaction reported anywhere from 200ms to 650ms.
 -   `Metrics.getSelectionEventDurations()`: Also collect `pointerup` and `selectionchange` durations, and omit event types that did not fire. Selecting a block within an editing host no longer fires `focus`/`focusin`, which made the metric report zero. Dispatches that nest inside another dispatch now contribute only the time not already covered by it, so summing the returned durations no longer counts the nested work twice.
 
 ## 1.51.0 (2026-07-14)

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -230,7 +230,7 @@ export class Metrics {
 	 * @param options Options to pass to `browser.startTracing()`.
 	 */
 	async startTracing( options = {} ) {
-		return await this.browser.startTracing( this.page, {
+		const result = await this.browser.startTracing( this.page, {
 			screenshots: false,
 			categories: [
 				'devtools.timeline',
@@ -241,6 +241,15 @@ export class Metrics {
 			],
 			...options,
 		} );
+
+		// Enabling the V8 sampling profiler queues an isolate interrupt that
+		// logs every function compiled so far. It runs on the next stack
+		// guard check, so its cost would land in the first thing the test
+		// does, which is usually the interaction being measured. Absorb it
+		// here instead.
+		await this.page.evaluate( () => {} );
+
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
