### PR TITLE
ESLint: Define dependency import rules

### DIFF
--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
-	'*.{js,json,ts,tsx,yml,yaml}': [ 'wp-scripts format' ],
-	'**/*.{js,ts,tsx,jsx}': [
+	'*.{cjs,js,json,jsx,mjs,ts,tsx,yml,yaml}': [ 'wp-scripts format' ],
+	'**/*.{cjs,js,jsx,mjs,ts,tsx}': [
 		() => 'npm run prelint:js',
 		'node ./tools/eslint/lint-js.cjs --config eslint.config.strict.cjs',
 	],

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The `dependency-group` rule's `"never"` mode now recognizes dependency comments regardless of capitalization or a trailing period while preserving other comments.
+
 ## 25.7.0 (2026-07-14)
 
 ## 25.6.0 (2026-07-01)

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   The `dependency-group` rule's `"never"` mode now recognizes dependency comments regardless of capitalization or a trailing period while preserving other comments.
+-   The `dependency-group` rule's `"never"` mode now recognizes dependency comments regardless of capitalization or a trailing period while preserving other comments. ([#81246](https://github.com/WordPress/gutenberg/pull/81246))
 
 ## 25.7.0 (2026-07-14)
 

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { RuleTester } from 'eslint';
-
-/**
- * Internal dependencies
- */
 import rule from '../dependency-group';
 
 const ruleTester = new RuleTester( {
@@ -59,6 +52,14 @@ import { camelCase } from 'change-case';
 import clsx from 'clsx';
 import { Component } from '@wordpress/element';
 import edit from './edit';`,
+			options: [ 'never' ],
+		},
+		{
+			code: `
+/**
+ * Keep external dependencies up to date.
+ */
+import clsx from 'clsx';`,
 			options: [ 'never' ],
 		},
 	],
@@ -163,6 +164,58 @@ import { Component } from '@wordpress/element';`,
 			output: `
 import { camelCase } from 'change-case';
 import { Component } from '@wordpress/element';`,
+		},
+		{
+			code: `
+/*
+ * external Dependencies.
+ */
+import { camelCase } from 'change-case';
+
+/**
+ * Keep external dependencies up to date.
+ */
+import clsx from 'clsx';
+
+/**
+ * NODE DEPENDENCIES
+ */
+import 'node:fs';
+
+/**
+ * wordpress dependencies.
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * internal Dependencies.
+ */
+import edit from './edit';`,
+			options: [ 'never' ],
+			errors: [
+				{
+					message: 'Unexpected dependency group comment block',
+				},
+				{
+					message: 'Unexpected dependency group comment block',
+				},
+				{
+					message: 'Unexpected dependency group comment block',
+				},
+				{
+					message: 'Unexpected dependency group comment block',
+				},
+			],
+			output: `
+import { camelCase } from 'change-case';
+
+/**
+ * Keep external dependencies up to date.
+ */
+import clsx from 'clsx';
+import 'node:fs';
+import { Component } from '@wordpress/element';
+import edit from './edit';`,
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -2,9 +2,6 @@
 /** @typedef {import('estree').Node} Node */
 /** @typedef {import('estree').SourceLocation} SourceLocation */
 
-const DEPENDENCY_BLOCK_PATTERN =
-	/^\*?\n \* (External|Node|WordPress|Internal) dependencies\n $/;
-
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	meta: {
@@ -112,9 +109,8 @@ module.exports = {
 		 * @return {boolean} Whether comment node is a dependency block.
 		 */
 		function isDependencyBlock( node ) {
-			return (
-				node.type === 'Block' &&
-				DEPENDENCY_BLOCK_PATTERN.test( node.value )
+			return [ 'External', 'WordPress', 'Internal' ].some( ( locality ) =>
+				isLocalityDependencyBlock( node, locality )
 			);
 		}
 

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { createRequire } from 'module';
 import { join, resolve } from 'path';
 import globals from 'globals';
@@ -12,11 +9,12 @@ import testingLibraryPlugin from 'eslint-plugin-testing-library';
 import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
 import wpBuildConfig from '../../packages/wp-build/eslint-overrides.cjs';
-
 const require = createRequire( import.meta.url );
 const rootDir = resolve( import.meta.dirname, '../..' );
+// React is loaded conditionally below, so these CommonJS imports cannot form
+// one contiguous block.
+// eslint-disable-next-line import/order
 const wpPlugin = require( '@wordpress/eslint-plugin' );
-
 // Prefer the installed React version for linting, but fall back to the detected version.
 let reactVersion = 'detect';
 try {
@@ -326,8 +324,22 @@ export default dedupePlugins( [
 					},
 				},
 			],
+			'@wordpress/dependency-group': [ 'error', 'never' ],
 			'import/default': 'error',
 			'import/named': 'error',
+			'import/order': [
+				'error',
+				{
+					groups: [
+						'builtin', // Node.js built-in modules
+						'external', // npm packages
+						'internal', // Aliased modules
+						[ 'parent', 'sibling', 'index' ], // Relative imports
+					],
+					'newlines-between': 'never',
+					warnOnUnassignedImports: true,
+				},
+			],
 			'no-restricted-imports': [
 				'error',
 				{
@@ -863,19 +875,6 @@ export default dedupePlugins( [
 		files: [ 'packages/interactivity*/src/**' ],
 		rules: {
 			'react/react-in-jsx-scope': 'error',
-		},
-	},
-
-	// Override: Packages which have eliminated dependency grouping comments
-	// and explicitly prevent new additions.
-	{
-		files: [
-			'packages/design-system-mcp/**',
-			'packages/ui/**',
-			'packages/theme/**',
-		],
-		rules: {
-			'@wordpress/dependency-group': [ 'error', 'never' ],
 		},
 	},
 

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -9,12 +9,11 @@ import testingLibraryPlugin from 'eslint-plugin-testing-library';
 import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
 import wpBuildConfig from '../../packages/wp-build/eslint-overrides.cjs';
+
 const require = createRequire( import.meta.url );
 const rootDir = resolve( import.meta.dirname, '../..' );
-// React is loaded conditionally below, so these CommonJS imports cannot form
-// one contiguous block.
-// eslint-disable-next-line import/order
 const wpPlugin = require( '@wordpress/eslint-plugin' );
+
 // Prefer the installed React version for linting, but fall back to the detected version.
 let reactVersion = 'detect';
 try {
@@ -324,22 +323,8 @@ export default dedupePlugins( [
 					},
 				},
 			],
-			'@wordpress/dependency-group': [ 'error', 'never' ],
 			'import/default': 'error',
 			'import/named': 'error',
-			'import/order': [
-				'error',
-				{
-					groups: [
-						'builtin', // Node.js built-in modules
-						'external', // npm packages
-						'internal', // Aliased modules
-						[ 'parent', 'sibling', 'index' ], // Relative imports
-					],
-					'newlines-between': 'never',
-					warnOnUnassignedImports: true,
-				},
-			],
 			'no-restricted-imports': [
 				'error',
 				{
@@ -875,6 +860,19 @@ export default dedupePlugins( [
 		files: [ 'packages/interactivity*/src/**' ],
 		rules: {
 			'react/react-in-jsx-scope': 'error',
+		},
+	},
+
+	// Override: Packages which have eliminated dependency grouping comments
+	// and explicitly prevent new additions.
+	{
+		files: [
+			'packages/design-system-mcp/**',
+			'packages/ui/**',
+			'packages/theme/**',
+		],
+		rules: {
+			'@wordpress/dependency-group': [ 'error', 'never' ],
 		},
 	},
 

--- a/tools/eslint/config.strict.mjs
+++ b/tools/eslint/config.strict.mjs
@@ -9,6 +9,7 @@ export default [
 	...baseConfig,
 	{
 		rules: {
+			'@wordpress/dependency-group': [ 'error', 'never' ],
 			// Enforce import ordering on modified files
 			'import/order': [
 				'error',
@@ -23,6 +24,14 @@ export default [
 					warnOnUnassignedImports: true,
 				},
 			],
+		},
+	},
+	{
+		// This config conditionally loads plugins, so its CommonJS imports
+		// cannot form one static import block.
+		files: [ 'tools/eslint/config.mjs' ],
+		rules: {
+			'import/order': 'off',
 		},
 	},
 ];

--- a/tools/eslint/config.strict.mjs
+++ b/tools/eslint/config.strict.mjs
@@ -19,6 +19,8 @@ export default [
 						'internal', // Aliased modules
 						[ 'parent', 'sibling', 'index' ], // Relative imports
 					],
+					'newlines-between': 'never',
+					warnOnUnassignedImports: true,
 				},
 			],
 		},


### PR DESCRIPTION
Follow-up to #81188.

## What?

Hardens the dependency-group lint rule and enforces the final dependency import convention on staged files. It also adds CommonJS and ES module files to staged formatting and linting.

## Why?

This prevents new dependency comments and import blank lines while the existing repository-wide violations are cleaned up in #81248. Keeping global activation in that follow-up lets this PR pass the full lint suite independently.

## How?

- Expands the dependency-group rule's `"never"` mode to recognize capitalization and trailing-period variants while preserving meaningful comments.
- Enables `@wordpress/dependency-group` and `import/order` with `newlines-between: "never"` in the strict staged-file configuration.
- Preserves side-effect import order.
- Extends staged coverage to `*.cjs` and `*.mjs`.

## Testing Instructions

1. Run `npm run test:unit -- packages/eslint-plugin/rules/__tests__/dependency-group.js --runInBand`.
2. Run `npm run lint:js -- --format compact --quiet --prune-suppressions`.
3. Run ESLint with `eslint.config.strict.cjs` on the changed JavaScript files.
4. Confirm the lint-staged JavaScript glob matches `.cjs`, `.js`, `.jsx`, `.mjs`, `.ts`, and `.tsx`.

### Testing Instructions for Keyboard

Not applicable. This PR has no user interface changes.

## TODO / Follow-ups

#81248 applies the safe repository-wide fixes and suppressions, enables both rules in the base configuration, and removes the strict configuration.

## Use of AI Tools

This PR was authored with Codex.