### PR TITLE
Interactivity API: Lazy hydration of interactive islands, with an idle-time fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52509,10 +52509,12 @@
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
 				"@preact/signals-core": "^1.7.0",
-				"preact": "^10.29.1"
+				"preact": "^10.29.1",
+				"requestidlecallback": "^0.3.0"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0"
+				"@types/jest": "^30.0.0",
+				"@types/requestidlecallback": "^0.3.4"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52508,10 +52508,12 @@
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
 				"@preact/signals-core": "^1.7.0",
-				"preact": "^10.29.1"
+				"preact": "^10.29.1",
+				"requestidlecallback": "^0.3.0"
 			},
 			"devDependencies": {
-				"@types/jest": "^30.0.0"
+				"@types/jest": "^30.0.0",
+				"@types/requestidlecallback": "^0.3.4"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "test/router-lazy-hydration",
+	"title": "E2E Interactivity tests - router lazy hydration",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/render.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * HTML for testing lazy hydration combined with the router.
+ *
+ * The router region sits at the top of the page. Two additional islands are
+ * pushed far below the viewport (the observer's rootMargin is one viewport
+ * height, so islands more than two viewport heights down stay unobserved
+ * until the user scrolls, the idle sweep fires, or the router force-hydrates).
+ *
+ * @package gutenberg-test-interactive-blocks
+ *
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ */
+?>
+<div
+	data-wp-interactive="router-lazy-hydration"
+	data-wp-router-region="lazy-hydration/region"
+>
+	<p data-testid="region-ssr">content from page <?php echo $attributes['page']; ?></p>
+	<p data-testid="region-hydrated" data-wp-text="state.hydrated">no</p>
+
+	<?php if ( isset( $attributes['next'] ) ) : ?>
+		<a
+			data-testid="next"
+			data-wp-on--click="actions.router.navigate"
+			href="<?php echo $attributes['next']; ?>"
+		>Next</a>
+	<?php else : ?>
+		<a
+			data-testid="back"
+			data-wp-on--click="actions.router.back"
+			href="#"
+		>Back</a>
+	<?php endif; ?>
+</div>
+
+<!-- The spacer pushes the islands below. The default viewport is 720px high and
+     the observer rootMargin is 100%, so an island needs to be more than
+     ~1440px down to stay unobserved on load. -->
+<div style="height: 2500px" aria-hidden="true"></div>
+
+<div data-wp-interactive="router-lazy-hydration" data-testid="below-island">
+	<p data-testid="below-hydrated" data-wp-text="state.hydrated">no</p>
+	<button
+		data-testid="below-button"
+		data-wp-text="state.count"
+		data-wp-on--click="actions.increment"
+	>0</button>
+</div>
+
+<div style="height: 3000px" aria-hidden="true"></div>
+
+<div data-wp-interactive="router-lazy-hydration" data-testid="deep-island">
+	<p data-testid="deep-hydrated" data-wp-text="state.hydrated">no</p>
+	<button
+		data-testid="deep-button"
+		data-wp-text="state.count"
+		data-wp-on--click="actions.increment"
+	>0</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/render.php
@@ -35,8 +35,8 @@
 </div>
 
 <!-- The spacer pushes the islands below. The default viewport is 720px high and
-     the observer rootMargin is 100%, so an island needs to be more than
-     ~1440px down to stay unobserved on load. -->
+	the observer rootMargin is 100%, so an island needs to be more than
+	~1440px down to stay unobserved on load. -->
 <div style="height: 2500px" aria-hidden="true"></div>
 
 <div data-wp-interactive="router-lazy-hydration" data-testid="below-island">

--- a/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/view.asset.php
@@ -1,0 +1,9 @@
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+		array(
+			'id'     => '@wordpress/interactivity-router',
+			'import' => 'dynamic',
+		),
+	),
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-lazy-hydration/view.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
+const { state } = store( 'router-lazy-hydration', {
+	state: {
+		hydrated: 'yes',
+		count: 0,
+	},
+	actions: {
+		router: {
+			// `withSyncEvent` is required so `event.preventDefault()` runs
+			// synchronously — `wp-on` actions are async by default, and an
+			// async `preventDefault()` lets the browser follow the link
+			// before the router can intercept it (full page reload).
+			navigate: withSyncEvent( function* ( e ) {
+				e.preventDefault();
+				const { actions } = yield import(
+					'@wordpress/interactivity-router'
+				);
+				yield actions.navigate( e.target.href );
+			} ),
+			back: withSyncEvent( function* ( e ) {
+				e.preventDefault();
+				history.back();
+			} ),
+		},
+		increment() {
+			state.count += 1;
+		},
+	},
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/throwing-island/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/throwing-island/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "test/throwing-island",
+	"title": "E2E Interactivity tests - throwing island",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/throwing-island/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/throwing-island/render.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Island that throws during hydration. Used to test that a single failing
+ * island does not break the hydration of other islands or the router.
+ *
+ * The `data-wp-run` callback throws synchronously during render, which
+ * propagates out of `hydrate()` and aborts whatever hydration loop is
+ * processing this island (the IntersectionObserver callback or the idle-time
+ * sweep) unless that loop guards against errors.
+ *
+ * @package gutenberg-test-interactive-blocks
+ *
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ */
+?>
+<div data-wp-interactive="throwing-island" data-testid="throwing-island">
+	<p data-wp-run="callbacks.boom" data-testid="throwing-text">throwing island</p>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/throwing-island/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/throwing-island/view.asset.php
@@ -1,0 +1,5 @@
+<?php return array(
+	'dependencies' => array(
+		'@wordpress/interactivity',
+	),
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/throwing-island/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/throwing-island/view.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { store } from '@wordpress/interactivity';
+
+/*
+ * `data-wp-run` resolves the path via the legacy (dotted-path) evaluate
+ * path, which does not catch errors, and then invokes the resolved function
+ * during render. So the throw below propagates synchronously out of
+ * `hydrate()`.
+ */
+store( 'throwing-island', {
+	callbacks: {
+		boom() {
+			throw new Error( 'throwing island boom' );
+		},
+	},
+} );

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -16,6 +16,7 @@ import {
 
 const {
 	getRegionRootFragment,
+	hydrateAllRemaining,
 	initialVdomPromise,
 	toVdom,
 	render,
@@ -338,6 +339,10 @@ window.addEventListener( 'popstate', async () => {
 	const pagePath = getPagePath( window.location.href ); // Remove hash.
 	const page = pages.has( pagePath ) && ( await pages.get( pagePath ) );
 	if ( page ) {
+		// Force-hydrate all islands on the current page so its router regions
+		// are hydrated and can be diffed against the cached page. With lazy
+		// hydration, islands the user never scrolled to may still be pending.
+		await hydrateAllRemaining();
 		batch( () => {
 			state.url = window.location.href;
 			renderPage( page );
@@ -362,18 +367,27 @@ window.document
 	.querySelectorAll< HTMLScriptElement >( 'script[type=module][src]' )
 	.forEach( ( { src } ) => markScriptModuleAsResolved( src ) );
 
-// Await hydration completion before setting the initial page to ensure initialVdom is populated.
-( async () => {
-	const initialVdomMap = await initialVdomPromise;
+/*
+ * Cache the initial page using the vDOM produced by hydration, so the router
+ * diffs against the same vDOM that's live on the page. This awaits
+ * `initialVdomPromise`, which resolves once every island is hydrated — either
+ * by the IntersectionObserver or by the idle-time sweep
+ * (`requestIdleCallback` with a `timeout`), so it is guaranteed to resolve
+ * even if the user never scrolls.
+ *
+ * Do NOT call `preparePage` here without the `vdom` param: its `toVdom`
+ * fallback would mark islands as "hydrated" in `hydratedIslands` before
+ * hydration runs, causing them to be skipped (see the router race-condition
+ * regression test).
+ */
+initialVdomPromise.then( ( initialVdom ) => {
 	pages.set(
 		getPagePath( window.location.href ),
-		Promise.resolve(
-			preparePage( getPagePath( window.location.href ), document, {
-				vdom: initialVdomMap,
-			} )
-		)
+		preparePage( getPagePath( window.location.href ), document, {
+			vdom: initialVdom,
+		} )
 	);
-} )();
+} );
 
 // Variable to store the current navigation.
 let navigatingTo = '';
@@ -502,6 +516,13 @@ export const { state, actions } = store< Store >( 'core/router', {
 				! page.initialData?.config?.[ 'core/router' ]
 					?.clientNavigationDisabled
 			) {
+				// Force-hydrate all islands on the current page so its router
+				// regions are hydrated and can be diffed when the new page is
+				// rendered. With lazy hydration, islands the user never scrolled
+				// to may still be pending; the diff would silently no-op on
+				// unhydrated regions.
+				yield hydrateAllRemaining();
+
 				yield importScriptModules( page.scriptModules );
 
 				batch( () => {

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -35,10 +35,12 @@
 	"dependencies": {
 		"@preact/signals": "^1.3.0",
 		"@preact/signals-core": "^1.7.0",
-		"preact": "^10.29.1"
+		"preact": "^10.29.1",
+		"requestidlecallback": "^0.3.0"
 	},
 	"devDependencies": {
-		"@types/jest": "^30.0.0"
+		"@types/jest": "^30.0.0",
+		"@types/requestidlecallback": "^0.3.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -61,6 +61,7 @@ const hydrateNode = async ( node: Element ) => {
 		return;
 	}
 	try {
+		await splitTask();
 		const fragment = getRegionRootFragment( node );
 		const vdom = toVdom( node );
 		initialVdom.set( node, vdom );
@@ -70,8 +71,6 @@ const hydrateNode = async ( node: Element ) => {
 		warn(
 			`Failed to hydrate island: ${( e as Error ).message ?? e}`
 		);
-	} finally {
-		await splitTask();
 	}
 };
 

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -37,19 +37,71 @@ export const initialVdomPromise = new Promise<
 	resolveInitialVdom = resolve;
 } );
 
-// Initialize the router with the initial DOM.
+/*
+ * Lazily hydrates all interactive regions: instead of hydrating every island
+ * at DOMContentLoaded, an IntersectionObserver hydrates each island when it
+ * approaches the viewport (within one viewport height, from the top or
+ * bottom). This avoids running hydration JS for off-screen blocks during page
+ * load.
+ */
 export const hydrateRegions = async () => {
 	const nodes = document.querySelectorAll( `[data-wp-interactive]` );
 
-	for ( const node of nodes ) {
-		if ( ! hydratedIslands.has( node ) ) {
-			await splitTask();
-			const fragment = getRegionRootFragment( node );
-			const vdom = toVdom( node );
-			initialVdom.set( node, vdom );
-			await splitTask();
-			hydrate( vdom, fragment );
+	let observedNodeCount = 0;
+
+	const intersectionObserver = new window.IntersectionObserver(
+		async ( entries ) => {
+			for ( const entry of entries ) {
+				if ( ! entry.isIntersecting ) {
+					continue;
+				}
+
+				const node = entry.target;
+				intersectionObserver.unobserve( node );
+				observedNodeCount--;
+				if ( observedNodeCount === 0 ) {
+					intersectionObserver.disconnect();
+				}
+
+				if ( ! hydratedIslands.has( node ) ) {
+					const fragment = getRegionRootFragment( node );
+					const vdom = toVdom( node );
+					initialVdom.set( node, vdom );
+					await splitTask();
+					hydrate( vdom, fragment );
+					await splitTask();
+				}
+			}
+		},
+		{
+			root: null, // To watch for intersection relative to the device's viewport.
+			rootMargin: '100% 0% 100% 0%', // Intersect when within 1 viewport approaching from top or bottom.
+			threshold: 0.0, // As soon as even one pixel is visible.
 		}
+	);
+
+	/*
+	 * This `await` with setTimeout is required to apparently ensure that the
+	 * interactive blocks have their stores fully initialized prior to
+	 * hydrating the blocks. If this is not present, then an error occurs, for
+	 * example:
+	 * > view.js:46 Uncaught (in promise) ReferenceError: Cannot access 'state' before initialization
+	 * This occurs when splitTask() is implemented with scheduler.yield() as
+	 * opposed to setTimeout(), as with the former split tasks are added to the
+	 * front of the task queue whereas with the latter they are added to the
+	 * end of the queue.
+	 */
+	await new Promise( ( resolve ) => {
+		setTimeout( resolve, 0 );
+	} );
+
+	observedNodeCount = nodes.length;
+	for ( const node of nodes ) {
+		if ( hydratedIslands.has( node ) ) {
+			observedNodeCount--;
+			continue;
+		}
+		intersectionObserver.observe( node );
 	}
 
 	// Resolve the promise with the fully populated initialVdom after all regions are hydrated.

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -144,21 +144,6 @@ export const hydrateRegions = async () => {
 	);
 	intersectionObserver = intersectionObserverInstance;
 
-	/*
-	 * This `await` with setTimeout is required to apparently ensure that the
-	 * interactive blocks have their stores fully initialized prior to
-	 * hydrating the blocks. If this is not present, then an error occurs, for
-	 * example:
-	 * > view.js:46 Uncaught (in promise) ReferenceError: Cannot access 'state' before initialization
-	 * This occurs when splitTask() is implemented with scheduler.yield() as
-	 * opposed to setTimeout(), as with the former split tasks are added to the
-	 * front of the task queue whereas with the latter they are added to the
-	 * end of the queue.
-	 */
-	await new Promise( ( resolve ) => {
-		setTimeout( resolve, 0 );
-	} );
-
 	for ( const node of nodes ) {
 		if ( hydratedIslands.has( node ) ) {
 			continue;

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -172,5 +172,5 @@ export const hydrateRegions = async () => {
 	 * `window.requestIdleCallback` when native support is missing, and is a
 	 * no-op on browsers that have it.
 	 */
-	window.requestIdleCallback( hydrateAllRemaining, { timeout: 2000 } );
+	requestIdleCallback( hydrateAllRemaining, { timeout: 2000 } );
 };

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { hydrate, type ContainerNode, type ComponentChild } from 'preact';
+import 'requestidlecallback';
 /**
  * Internal dependencies
  */
@@ -37,19 +38,83 @@ export const initialVdomPromise = new Promise<
 	resolveInitialVdom = resolve;
 } );
 
+// The IntersectionObserver used to hydrate islands as they approach the
+// viewport. Module-level so `hydrateAllRemaining` can disconnect it.
+let intersectionObserver: IntersectionObserver | null = null;
+
+// Whether hydration has already completed — either the idle-time sweep ran,
+// or the observer finished all islands. `hydrateAllRemaining` is one-shot:
+// once it runs, it is permanently disarmed. Islands inserted into the DOM
+// later (e.g. raw HTML) are NOT auto-hydrated; developers should hydrate
+// injected markup explicitly (e.g. with `renderElement`).
+let idleFired = false;
+
+/**
+ * Hydrates a single island: builds its vdom, registers it in initialVdom,
+ * and hydrates it. Shared by the IntersectionObserver callback, the idle-time
+ * sweep, and `hydrateAllRemaining`.
+ *
+ * @param node The island element to hydrate.
+ */
+const hydrateNode = async ( node: Element ) => {
+	if ( hydratedIslands.has( node ) ) {
+		return;
+	}
+	const fragment = getRegionRootFragment( node );
+	const vdom = toVdom( node );
+	initialVdom.set( node, vdom );
+	await splitTask();
+	hydrate( vdom, fragment );
+	await splitTask();
+};
+
+/**
+ * Force-hydrates every island that hasn't been hydrated yet, disconnects the
+ * observer, and resolves the initialVdom promise.
+ *
+ * Called when the CPU goes idle (or the idle timeout elapses) so islands the
+ * user never scrolls to still become interactive, and by the router before
+ * navigating so its regions are always hydrated for diffing.
+ *
+ * One-shot: after the first run (or when the observer finishes all islands),
+ * this is a permanent no-op. Router-rendered regions are preact-rendered
+ * (fully interactive) and must not be re-hydrated.
+ */
+export const hydrateAllRemaining = async () => {
+	if ( idleFired ) {
+		return;
+	}
+	idleFired = true;
+	intersectionObserver?.disconnect();
+	// Hydrate every island currently in the DOM that isn't hydrated yet.
+	for ( const node of document.querySelectorAll( '[data-wp-interactive]' ) ) {
+		await hydrateNode( node );
+	}
+	resolveInitialVdom( initialVdom );
+};
+
 /*
  * Lazily hydrates all interactive regions: instead of hydrating every island
  * at DOMContentLoaded, an IntersectionObserver hydrates each island when it
  * approaches the viewport (within one viewport height, from the top or
  * bottom). This avoids running hydration JS for off-screen blocks during page
  * load.
+ *
+ * As a fallback, all remaining unhydrated islands are also hydrated when the
+ * CPU goes idle (or after a bounded timeout). This guarantees interactive
+ * content — and the router regions the router needs to diff during navigation —
+ * is eventually hydrated even if the user never scrolls to it.
  */
 export const hydrateRegions = async () => {
-	const nodes = document.querySelectorAll( `[data-wp-interactive]` );
+	const nodes = document.querySelectorAll( '[data-wp-interactive]' );
+	// The islands still awaiting hydration via the observer. A `Set` rather
+	// than a counter: `Set.delete` is idempotent, so duplicate intersection
+	// entries for the same node cannot corrupt the "all done" detection (a
+	// counter would double-decrement and prematurely fire `idleFired`,
+	// disarming the router's force-hydrate while islands remain unhydrated).
+	const observedNodes = new Set< Element >();
 
-	let observedNodeCount = 0;
-
-	const intersectionObserver = new window.IntersectionObserver(
+	const intersectionObserverInstance = new window.IntersectionObserver(
 		async ( entries ) => {
 			for ( const entry of entries ) {
 				if ( ! entry.isIntersecting ) {
@@ -57,20 +122,18 @@ export const hydrateRegions = async () => {
 				}
 
 				const node = entry.target;
-				intersectionObserver.unobserve( node );
-				observedNodeCount--;
-				if ( observedNodeCount === 0 ) {
-					intersectionObserver.disconnect();
+				intersectionObserverInstance.unobserve( node );
+				observedNodes.delete( node );
+				if ( observedNodes.size === 0 ) {
+					intersectionObserverInstance.disconnect();
+					// All islands have been hydrated: resolve the promise with
+					// the fully populated initialVdom so the router can start
+					// doing the DOM diffing between the previous and next pages.
+					idleFired = true; // Disarm the idle-time sweep.
+					resolveInitialVdom( initialVdom );
 				}
 
-				if ( ! hydratedIslands.has( node ) ) {
-					const fragment = getRegionRootFragment( node );
-					const vdom = toVdom( node );
-					initialVdom.set( node, vdom );
-					await splitTask();
-					hydrate( vdom, fragment );
-					await splitTask();
-				}
+				await hydrateNode( node );
 			}
 		},
 		{
@@ -79,6 +142,7 @@ export const hydrateRegions = async () => {
 			threshold: 0.0, // As soon as even one pixel is visible.
 		}
 	);
+	intersectionObserver = intersectionObserverInstance;
 
 	/*
 	 * This `await` with setTimeout is required to apparently ensure that the
@@ -95,15 +159,32 @@ export const hydrateRegions = async () => {
 		setTimeout( resolve, 0 );
 	} );
 
-	observedNodeCount = nodes.length;
 	for ( const node of nodes ) {
 		if ( hydratedIslands.has( node ) ) {
-			observedNodeCount--;
 			continue;
 		}
+		observedNodes.add( node );
 		intersectionObserver.observe( node );
 	}
 
-	// Resolve the promise with the fully populated initialVdom after all regions are hydrated.
-	resolveInitialVdom( initialVdom );
+	// All nodes were already hydrated (nothing to observe): resolve the
+	// promise immediately, since the observer callback will never fire.
+	if ( observedNodes.size === 0 ) {
+		idleFired = true; // Disarm the idle-time sweep.
+		resolveInitialVdom( initialVdom );
+		return;
+	}
+
+	/*
+	 * Fallback: hydrate everything when the CPU is idle, so islands the user
+	 * never scrolls to (and router regions) still become interactive. The
+	 * `timeout` bounds how long we wait even on a busy CPU. Whichever fires
+	 * first — viewport entry or idle — wins; `idleFired` disarms the other.
+	 *
+	 * No feature detection is needed: the `requestidlecallback` polyfill
+	 * (already used by `@wordpress/priority-queue`) installs
+	 * `window.requestIdleCallback` when native support is missing, and is a
+	 * no-op on browsers that have it.
+	 */
+	window.requestIdleCallback( hydrateAllRemaining, { timeout: 2000 } );
 };

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -7,7 +7,7 @@ import 'requestidlecallback';
  * Internal dependencies
  */
 import { toVdom, hydratedIslands } from './vdom';
-import { createRootFragment, splitTask } from './utils';
+import { createRootFragment, splitTask, warn } from './utils';
 
 // Keep the same root fragment for each interactive region node.
 const regionRootFragments = new WeakMap();
@@ -60,12 +60,19 @@ const hydrateNode = async ( node: Element ) => {
 	if ( hydratedIslands.has( node ) ) {
 		return;
 	}
-	const fragment = getRegionRootFragment( node );
-	const vdom = toVdom( node );
-	initialVdom.set( node, vdom );
-	await splitTask();
-	hydrate( vdom, fragment );
-	await splitTask();
+	try {
+		const fragment = getRegionRootFragment( node );
+		const vdom = toVdom( node );
+		initialVdom.set( node, vdom );
+		await splitTask();
+		hydrate( vdom, fragment );
+	} catch ( e ) {
+		warn(
+			`Failed to hydrate island: ${( e as Error ).message ?? e}`
+		);
+	} finally {
+		await splitTask();
+	}
 };
 
 /**
@@ -88,7 +95,7 @@ export const hydrateAllRemaining = async () => {
 	intersectionObserver?.disconnect();
 	// Hydrate every island currently in the DOM that isn't hydrated yet.
 	for ( const node of document.querySelectorAll( '[data-wp-interactive]' ) ) {
-		await hydrateNode( node );
+		await hydrateNode( node as Element );
 	}
 	resolveInitialVdom( initialVdom );
 };
@@ -121,20 +128,25 @@ export const hydrateRegions = async () => {
 					continue;
 				}
 
-				const node = entry.target;
+				const node = entry.target as Element;
 				intersectionObserverInstance.unobserve( node );
 				observedNodes.delete( node );
-
+				// `hydrateNode` handles its own errors, so a single
+				// failing island cannot abort the rest of the batch.
 				await hydrateNode( node );
+			}
 
-				if ( observedNodes.size === 0 ) {
-					intersectionObserverInstance.disconnect();
-					// All islands have been hydrated: resolve the promise with
-					// the fully populated initialVdom so the router can start
-					// doing the DOM diffing between the previous and next pages.
-					idleFired = true; // Disarm the idle-time sweep.
-					resolveInitialVdom( initialVdom );
-				}
+			// All observed islands have been hydrated: resolve the promise
+			// with the fully populated initialVdom so the router can start
+			// doing the DOM diffing between the previous and next pages.
+			// Resolving AFTER the batch's hydration attempts (rather than
+			// before the last node's hydrate) guarantees the router never
+			// reads a partially hydrated island list.
+			if ( observedNodes.size === 0 ) {
+				intersectionObserverInstance.disconnect();
+				// Disarm the idle-time sweep.
+				idleFired = true;
+				resolveInitialVdom( initialVdom );
 			}
 		},
 		{

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -124,6 +124,9 @@ export const hydrateRegions = async () => {
 				const node = entry.target;
 				intersectionObserverInstance.unobserve( node );
 				observedNodes.delete( node );
+
+				await hydrateNode( node );
+
 				if ( observedNodes.size === 0 ) {
 					intersectionObserverInstance.disconnect();
 					// All islands have been hydrated: resolve the promise with
@@ -132,8 +135,6 @@ export const hydrateRegions = async () => {
 					idleFired = true; // Disarm the idle-time sweep.
 					resolveInitialVdom( initialVdom );
 				}
-
-				await hydrateNode( node );
 			}
 		},
 		{

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -16,6 +16,7 @@ import { routerRegions } from './directives/router-region';
 import {
 	initialVdomPromise,
 	hydrateRegions,
+	hydrateAllRemaining,
 	getRegionRootFragment,
 } from './hydration';
 import { toVdom } from './vdom';
@@ -80,6 +81,7 @@ export const privateApis = (
 		return {
 			getRegionRootFragment,
 			initialVdomPromise,
+			hydrateAllRemaining,
 			toVdom,
 			directive,
 			getNamespace,

--- a/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
+++ b/test/e2e/specs/interactivity/fixtures/interactivity-utils.ts
@@ -90,6 +90,34 @@ export default class InteractivityUtils {
 		return this.getLink( alias );
 	}
 
+	/**
+	 * Creates a post with several TOP-LEVEL blocks (e.g. a router block plus
+	 * an island that throws during hydration), as `addPostWithBlock` only
+	 * supports a single block.
+	 *
+	 * @param blocks      The top-level blocks, in document order.
+	 * @param options     Options object.
+	 * @param options.alias The alias used to retrieve the post's link.
+	 * @return The post's link, with the directives SSR disabled.
+	 */
+	async addPostWithBlocks(
+		blocks: Block[],
+		{ alias }: { alias: string }
+	) {
+		const content = blocks.map( generateBlockMarkup ).join( '' );
+
+		const payload = {
+			content,
+			status: 'publish' as 'publish',
+			date_gmt: '2023-01-01T00:00:00',
+			title: alias,
+		};
+
+		const { link } = await this.requestUtils.createPost( payload );
+		this.links.set( alias, link );
+		return this.getLink( alias );
+	}
+
 	async deleteAllPosts() {
 		await this.requestUtils.deleteAllPosts();
 		this.links.clear();

--- a/test/e2e/specs/interactivity/lazy-hydration.spec.ts
+++ b/test/e2e/specs/interactivity/lazy-hydration.spec.ts
@@ -165,3 +165,83 @@ test.describe( 'Lazy hydration and the router', () => {
 		await expect( rawButton ).toHaveText( '0' ); // Still not hydrated.
 	} );
 } );
+
+test.describe( 'Lazy hydration failure resilience', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		// Page 2 is a plain router page. Page 1 carries the router region
+		// plus an island that throws during hydration as a SIBLING block, so
+		// the idle sweep reaches it last (after all of the router block's
+		// islands, in document order).
+		const next = await utils.addPostWithBlock(
+			'test/router-lazy-hydration',
+			{
+				alias: 'lazy hydration failure - page 2',
+				attributes: { page: 2 },
+			}
+		);
+		await utils.addPostWithBlocks(
+			[
+				[ 'test/router-lazy-hydration', { page: 1, next } ],
+				[ 'test/throwing-island' ],
+			],
+			{ alias: 'lazy hydration failure - page 1' }
+		);
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'lazy hydration failure - page 1' ) );
+
+		// Wait for the router region to hydrate so the `next` link's click
+		// handler is attached — otherwise the browser follows the raw link
+		// (full reload) instead of a client-side navigation.
+		await expect( page.getByTestId( 'region-hydrated' ) ).toHaveText(
+			'yes'
+		);
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should keep the router working when an island throws during the idle sweep', async ( {
+		page,
+	} ) => {
+		// The idle sweep hydrates islands in document order: router region,
+		// below, deep — and the throwing island comes next. The deep island
+		// is far below the fold (only reachable via the sweep), so once it
+		// has flipped, the sweep has already attempted — and, pre-fix,
+		// thrown at — the throwing island. `initialVdomPromise` therefore
+		// never resolved and the initial page was never cached by the router.
+		await expect( page.getByTestId( 'deep-hydrated' ) ).toHaveText(
+			'yes'
+		);
+
+		// Forward navigation still works: the router prefetches the
+		// destination page independently of the initial-page cache. The
+		// marker surviving proves this was a client-side navigation.
+		await page.evaluate( () => {
+			( window as any ).__clientSideNavMarker = true;
+		} );
+		await page.getByTestId( 'next' ).click();
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 2'
+		);
+		expect(
+			await page.evaluate( () => ( window as any ).__clientSideNavMarker )
+		).toBe( true );
+
+		// Back navigation must restore the initial page from the router
+		// cache. With a throwing island, the initial page is never cached,
+		// so the router falls back to a full page reload, which wipes the
+		// marker.
+		await page.getByTestId( 'back' ).click();
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 1'
+		);
+		expect(
+			await page.evaluate( () => ( window as any ).__clientSideNavMarker )
+		).toBe( true );
+	} );
+} );

--- a/test/e2e/specs/interactivity/lazy-hydration.spec.ts
+++ b/test/e2e/specs/interactivity/lazy-hydration.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'Lazy hydration and the router', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		const next = await utils.addPostWithBlock(
+			'test/router-lazy-hydration',
+			{
+				alias: 'lazy hydration - page 2',
+				attributes: { page: 2 },
+			}
+		);
+		await utils.addPostWithBlock( 'test/router-lazy-hydration', {
+			alias: 'lazy hydration - page 1',
+			attributes: { page: 1, next },
+		} );
+	} );
+
+	test.beforeEach( async ( { interactivityUtils: utils, page } ) => {
+		await page.goto( utils.getLink( 'lazy hydration - page 1' ) );
+
+		// Wait for the router region to hydrate so the `next` link's click
+		// handler is attached — otherwise the browser follows the raw link
+		// (full reload) instead of a client-side navigation. This results in
+		// sporadic test failures.
+		await expect( page.getByTestId( 'region-hydrated' ) ).toHaveText(
+			'yes'
+		);
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should navigate without scrolling and hydrate the below-fold island', async ( {
+		page,
+	} ) => {
+		const belowHydrated = page.getByTestId( 'below-hydrated' );
+		const belowButton = page.getByTestId( 'below-button' );
+
+		// Navigate client-side. The router force-hydrates the current page's
+		// remaining islands before rendering — including the below-the-fold
+		// island the observer hasn't reached yet.
+		await page.getByTestId( 'next' ).click();
+
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 2'
+		);
+		await expect( belowHydrated ).toHaveText( 'yes' );
+		await belowButton.click();
+		await expect( belowButton ).toHaveText( '1' );
+	} );
+
+	test( 'should navigate after partially scrolling and hydrate the remaining island', async ( {
+		page,
+	} ) => {
+		const deepHydrated = page.getByTestId( 'deep-hydrated' );
+		const deepButton = page.getByTestId( 'deep-button' );
+
+		// Scroll partway: the mid island hydrates via the observer.
+		await page.evaluate( () => window.scrollTo( 0, 3000 ) );
+		await expect( page.getByTestId( 'below-hydrated' ) ).toHaveText(
+			'yes'
+		);
+
+		// Navigate client-side. The router force-hydrates the remaining
+		// (deep) island before rendering.
+		await page.getByTestId( 'next' ).click();
+
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 2'
+		);
+		await expect( deepHydrated ).toHaveText( 'yes' );
+		await deepButton.click();
+		await expect( deepButton ).toHaveText( '1' );
+	} );
+
+	test( 'should navigate after scrolling everything into view', async ( {
+		page,
+	} ) => {
+		// Scroll through the page so the observer hydrates each island as it
+		// approaches the viewport. (Scrolling straight to the bottom would
+		// leave the mid island stranded above the observer's rootMargin.)
+		await page.evaluate( () => window.scrollTo( 0, 3000 ) );
+		await expect( page.getByTestId( 'below-hydrated' ) ).toHaveText(
+			'yes'
+		);
+		await page.evaluate( () =>
+			window.scrollTo( 0, document.body.scrollHeight )
+		);
+		await expect( page.getByTestId( 'deep-hydrated' ) ).toHaveText( 'yes' );
+
+		await page.getByTestId( 'next' ).click();
+
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 2'
+		);
+		await page.getByTestId( 'below-button' ).click();
+		await expect( page.getByTestId( 'below-button' ) ).toHaveText( '1' );
+	} );
+
+	test( 'should hydrate below-the-fold islands when the idle sweep fires, then navigate', async ( {
+		page,
+	} ) => {
+		const belowHydrated = page.getByTestId( 'below-hydrated' );
+		const belowButton = page.getByTestId( 'below-button' );
+
+		// The real idle sweep runs (within the 2000ms timeout on an idle
+		// page), hydrating the below-the-fold island without any scrolling.
+		// Auto-waiting handles the timing.
+		await expect( belowHydrated ).toHaveText( 'yes' );
+
+		await belowButton.click();
+		await expect( belowButton ).toHaveText( '1' );
+
+		// Navigation still works after the sweep.
+		await page.getByTestId( 'next' ).click();
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 2'
+		);
+	} );
+
+	test( 'should not auto-hydrate raw HTML inserted after load (developers should use renderElement)', async ( {
+		page,
+	} ) => {
+		// Wait for the idle sweep to have fired: `below-hydrated` only turns
+		// "yes" via the sweep (the island is below the observer's reach
+		// without scrolling), so this guarantees `hydrateAllRemaining` has
+		// already run and is now one-shot.
+		await expect( page.getByTestId( 'below-hydrated' ) ).toHaveText(
+			'yes'
+		);
+
+		// Insert an island via raw HTML, bypassing the interactivity API's
+		// rendering helpers.
+		await page.evaluate( () => {
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				'<div data-wp-interactive="router-lazy-hydration" data-testid="raw-island"><button data-testid="raw-button" data-wp-text="state.count" data-wp-on--click="actions.increment">0</button></div>'
+			);
+		} );
+
+		const rawButton = page.getByTestId( 'raw-button' );
+
+		// The raw island stays inert: hydration is one-shot and already ran,
+		// so the button's click handler is never attached.
+		await expect( rawButton ).toHaveText( '0' );
+		await rawButton.click();
+		await expect( rawButton ).toHaveText( '0' ); // No change — not hydrated.
+
+		// Navigation does not hydrate it either: `hydrateAllRemaining` is a
+		// permanent no-op after its first run. Developers must hydrate
+		// injected markup explicitly (e.g. with `renderElement`).
+		await page.getByTestId( 'next' ).click();
+
+		await expect( page.getByTestId( 'region-ssr' ) ).toHaveText(
+			'content from page 2'
+		);
+		await expect( rawButton ).toHaveText( '0' );
+		await rawButton.click();
+		await expect( rawButton ).toHaveText( '0' ); // Still not hydrated.
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes #58225

**Relates to:** [PR #58284](https://github.com/WordPress/gutenberg/pull/58284) — "Interactivity API: Defer hydration until node is scrolled near the viewport" (@westonruter ). This is an updated, rebased-on-trunk version of that work, incorporating the maintainer discussion (notably @luisherranz's  request for an idle-CPU fallback) and fixes for regressions found along the way.

I was not able to edit #58284 directly, so just ported those changes to `trunk` and added idle hydration and tests. I dont know how to, so feel free to add attribution to whoever should have it (I see @westonruter, @felixarntz, @luisherranz. @sirreal). I removed @sirreal's scroll-to-bottom edits to the wp-each directive test, as they were no longer necessary after my improvements.

---

## The problem

Today, `@wordpress/interactivity` hydrates **every** interactive island at `DOMContentLoaded`. On pages with many blocks below the fold, that means running hydration JS (and firing `data-wp-init` / `data-wp-watch` callbacks) for content the user may never scroll to — contributing to slow initial load on long pages (feeds, archives, long-form posts).

## What this does

Defers hydration of each interactive island until it is **near the viewport**, and guarantees the rest are hydrated when the CPU is idle:

- An `IntersectionObserver` (rootMargin: one viewport height, top and bottom) hydrates each island as it approaches the viewport.
- A one-shot **idle-time sweep** (`requestIdleCallback`, bounded by a `timeout: 2000`) hydrates everything remaining within a bounded time, guaranteeing that islands the user never scrolls to — and the router regions the router needs to diff — are hydrated even on a busy page. This also keeps the router's `initialVdomPromise` caching reliable (the original hang that plagued early iterations of #58284 is gone). Implemented via the `requestidlecallback` npm package, already used by `@wordpress/priority-queue`, which provides a comprehensive polyfill for Safari.
- **Router integration**: the router force-hydrates all remaining islands before rendering a navigation, so its regions are always available for diffing regardless of scroll position or idle timing. Router-rendered regions are preact-rendered (fully interactive) and are never re-hydrated.

Once hydration has completed (idle sweep ran, or the observer finished all islands), `hydrateAllRemaining()` is a permanent no-op:

- Islands inserted into the DOM later (e.g. raw HTML) are **not** auto-hydrated — developers hydrate injected markup explicitly (see the companion `renderElement()` / `renderHTML()` PR #81190).
- The observer's "all done" detection uses a `Set` of observed nodes (idempotent `delete`) instead of a counter. We hit a flake during integration where duplicate intersection entries double-decremented the counter and prematurely disarmed the sweep; the `Set` makes it idempotent.
- The router caches the initial page from `initialVdomPromise` rather than re-running `toVdom` on the live DOM at module-eval time. Under lazy hydration, islands may not be hydrated yet when the router initializes, so `toVdom` could mark them as hydrated before hydration actually ran — a regression we hit when integrating the idle sweep with the router (the static-import race-condition failures).

## Testing

- New `lazy-hydration` e2e spec: 5 tests, all passing, run 10+ times with zero flakes.
- Full interactivity e2e suite: 234/234 passing.
- Unit tests unaffected (this is e2e-tested behavior; the observer/sweep are browser-timing features).


## Screenshots
Here's a Performance Profile for a site with 978 `data-wp-` attributes in the document. 6x Slowdown. Filtered/highlighted for `interactivity`.

Before:
<img width="953" height="575" alt="Screenshot_2026-08-05_19-48-47" src="https://github.com/user-attachments/assets/dae685fd-8284-428d-a467-c1598df4ad49" />

After:
<img width="953" height="575" alt="Screenshot_2026-08-05_19-48-37" src="https://github.com/user-attachments/assets/0f645c84-eaa7-45b8-8543-75e888a26cf8" />

The bulk moved to after the Load event. Interestingly, but perhaps unsurprisingly, the processing looks a lot more fragmented and takes longer. 

I commented-out splitTask and the bars get much tighter. All test pass like this - is splitTask truly needed?

<img width="756" height="519" alt="Screenshot_2026-08-05_20-05-43" src="https://github.com/user-attachments/assets/8a5e1e7c-1025-4a85-8a3d-8dde7230ec77" />


## Decisions for reviewers

1. **`timeout: 2000`** — bounds how long we wait for a quiet CPU. On an idle page the sweep fires at the first idle moment (typically well under 2s); the timeout only caps the worst case (busy main thread). Do you want to increase the limit, or get rid of it altogether (waiting until whenever the main thread frees up, if ever)? I'm actually preferential to not forcing the hydration at all - hydrating elements/directives that are out of the viewport is just wasted battery life on mobile phones. The hydration will happen if they scroll and will ultimately be forced before a router navigation.
2. **`requestidlecallback` polyfill** — reused from `@wordpress/priority-queue` rather than a new polyfill; no-op on modern browsers. Similar to the previous point, this adds over 1KB min.gz to the bundle, which is a lot for something that we might not even need... 
3. **One-shot semantics** — Concerns were raised in in #58284 about how to handle html that might have been 
added outside of the iAPI. @luisherranz decided "I don’t think we should consider that scenario. If someone wants to modify the DOM and have the Interactivity API recognize those changes, they should do it through the methods provided by the Interactivity API."
  As it turns out, there's currently no such mechanism in the iAPI for doing this. As such, PR #81462 could be considered a companion to this PR, as it brings precisely these capabilities via its `renderHTML()` function. Of course anything there is open to discussion and change.

4. Are the two `splitTask()` calls that wrap `toVdom()` necessary? It seems to perform much better without them, and all tests pass. 

## Use of AI Tools

Deepseek V4 Flash via vscode
