### PR TITLE
theme.json schema: responsive states belong to blocks

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2000,6 +2000,41 @@
 				}
 			]
 		},
+		"stylesBlocksResponsiveStateWithPseudoPropertiesComplete": {
+			"description": "The styles a block that supports pseudo-selectors can set inside a single responsive breakpoint state: style properties, per-element styles, and the block's pseudo-selectors.",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements" ]
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
+							}
+						]
+					}
+				}
+			]
+		},
 		"stylesBlocksResponsiveSelectorsProperties": {
 			"description": "Responsive block states keyed by breakpoint name. Each breakpoint supports the same style properties as the default block state, plus per-element styles.",
 			"type": "object",
@@ -2016,14 +2051,14 @@
 			"enum": [ "@mobile", "@tablet" ]
 		},
 		"stylesBlocksResponsiveSelectorsWithPseudoProperties": {
-			"description": "Responsive block states for blocks that support pseudo-selectors. Each breakpoint supports the same style properties as the default block state, plus the block's pseudo-selectors.",
+			"description": "Responsive block states for blocks that support pseudo-selectors. Each breakpoint supports the same style properties as the default block state, plus per-element styles and the block's pseudo-selectors.",
 			"type": "object",
 			"properties": {
 				"@mobile": {
-					"$ref": "#/definitions/stylesBlocksPropertiesAndPseudoComplete"
+					"$ref": "#/definitions/stylesBlocksResponsiveStateWithPseudoPropertiesComplete"
 				},
 				"@tablet": {
-					"$ref": "#/definitions/stylesBlocksPropertiesAndPseudoComplete"
+					"$ref": "#/definitions/stylesBlocksResponsiveStateWithPseudoPropertiesComplete"
 				}
 			}
 		},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1971,15 +1971,44 @@
 				}
 			]
 		},
+		"stylesBlocksResponsiveStatePropertiesComplete": {
+			"description": "The styles a block can set inside a single responsive breakpoint state: the same style properties as the default block state, plus per-element styles.",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements" ]
+							}
+						]
+					}
+				}
+			]
+		},
 		"stylesBlocksResponsiveSelectorsProperties": {
-			"description": "Responsive block states keyed by breakpoint name. Each breakpoint supports the same style properties as the default block state.",
+			"description": "Responsive block states keyed by breakpoint name. Each breakpoint supports the same style properties as the default block state, plus per-element styles.",
 			"type": "object",
 			"properties": {
 				"@mobile": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"$ref": "#/definitions/stylesBlocksResponsiveStatePropertiesComplete"
 				},
 				"@tablet": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"$ref": "#/definitions/stylesBlocksResponsiveStatePropertiesComplete"
 				}
 			}
 		},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2165,21 +2165,6 @@
 				":visited"
 			]
 		},
-		"stylesElementsResponsiveSelectorsProperties": {
-			"description": "Responsive element states keyed by breakpoint name. Each breakpoint supports the same style properties as the default element state.",
-			"type": "object",
-			"properties": {
-				"@mobile": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				},
-				"@tablet": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
-				}
-			}
-		},
-		"stylesElementsResponsiveSelectorsPropertyNames": {
-			"enum": [ "@mobile", "@tablet" ]
-		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
 			"type": "object",
@@ -2190,9 +2175,6 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
@@ -2201,9 +2183,6 @@
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									},
 									{
 										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
@@ -2219,9 +2198,6 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"$ref": "#/definitions/stylesElementsPseudoSelectorsProperties"
 						},
 						{
@@ -2230,9 +2206,6 @@
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									},
 									{
 										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
@@ -2248,17 +2221,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2271,17 +2238,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2294,17 +2255,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2317,17 +2272,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2340,17 +2289,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2363,17 +2306,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2386,17 +2323,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2409,17 +2340,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2432,17 +2357,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2455,17 +2374,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}
@@ -2478,17 +2391,11 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"$ref": "#/definitions/stylesElementsResponsiveSelectorsProperties"
-						},
-						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsResponsiveSelectorsPropertyNames"
 									}
 								]
 							}

--- a/test/integration/fixtures/schemas/stylesBlocksCustomStatesProperties_elements.json
+++ b/test/integration/fixtures/schemas/stylesBlocksCustomStatesProperties_elements.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/navigation-link": {
+				"-current": {
+					"elements": {
+						"link": {
+							"color": {
+								"text": "red"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesBlocksResponsiveStatePropertiesComplete.json
+++ b/test/integration/fixtures/schemas/stylesBlocksResponsiveStatePropertiesComplete.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"@mobile": {
+					"blocks": {
+						"core/paragraph": {
+							"color": {
+								"text": "red"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesBlocksResponsiveStatePropertiesComplete_elements.json
+++ b/test/integration/fixtures/schemas/stylesBlocksResponsiveStatePropertiesComplete_elements.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"@mobile": {
+					"elements": {
+						"notanelement": {
+							"color": {
+								"text": "red"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesBlocksResponsiveStateWithPseudoPropertiesComplete.json
+++ b/test/integration/fixtures/schemas/stylesBlocksResponsiveStateWithPseudoPropertiesComplete.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/button": {
+				"@mobile": {
+					"blocks": {
+						"core/paragraph": {
+							"color": {
+								"text": "red"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_blockBreakpoint.json
+++ b/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_blockBreakpoint.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"elements": {
+					"link": {
+						"@mobile": {
+							"color": {
+								"text": "red"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_breakpoint.json
+++ b/test/integration/fixtures/schemas/stylesElementsPropertiesComplete_breakpoint.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"elements": {
+			"link": {
+				"@mobile": {
+					"color": {
+						"text": "red"
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/theme-json/responsive-elements/theme.json
+++ b/test/integration/fixtures/theme-json/responsive-elements/theme.json
@@ -1,0 +1,72 @@
+{
+	"$schema": "../../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"@mobile": {
+					"spacing": {
+						"padding": {
+							"top": "1rem",
+							"bottom": "1rem"
+						}
+					},
+					"elements": {
+						"link": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							},
+							":hover": {
+								"color": {
+									"text": "var(--wp--preset--color--secondary)"
+								}
+							}
+						},
+						"h2": {
+							"typography": {
+								"fontSize": "1.5rem"
+							}
+						}
+					}
+				},
+				"@tablet": {
+					"elements": {
+						"button": {
+							"color": {
+								"background": "var(--wp--preset--color--primary)"
+							}
+						}
+					}
+				}
+			},
+			"my-plugin/custom-block": {
+				"@mobile": {
+					"elements": {
+						"link": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							}
+						}
+					}
+				}
+			}
+		},
+		"variations": {
+			"custom-variation": {
+				"blocks": {
+					"core/group": {
+						"@mobile": {
+							"elements": {
+								"link": {
+									"color": {
+										"text": "var(--wp--preset--color--primary)"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/theme-json/responsive-elements/theme.json
+++ b/test/integration/fixtures/theme-json/responsive-elements/theme.json
@@ -39,6 +39,51 @@
 					}
 				}
 			},
+			"core/button": {
+				"@mobile": {
+					"elements": {
+						"link": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							}
+						}
+					},
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--secondary)"
+						}
+					}
+				},
+				"variations": {
+					"outline": {
+						"@mobile": {
+							"elements": {
+								"link": {
+									"color": {
+										"text": "var(--wp--preset--color--primary)"
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"core/navigation-link": {
+				"@tablet": {
+					"elements": {
+						"link": {
+							"color": {
+								"text": "var(--wp--preset--color--primary)"
+							},
+							":hover": {
+								"color": {
+									"text": "var(--wp--preset--color--secondary)"
+								}
+							}
+						}
+					}
+				}
+			},
 			"my-plugin/custom-block": {
 				"@mobile": {
 					"elements": {
@@ -55,6 +100,17 @@
 			"custom-variation": {
 				"blocks": {
 					"core/group": {
+						"@mobile": {
+							"elements": {
+								"link": {
+									"color": {
+										"text": "var(--wp--preset--color--primary)"
+									}
+								}
+							}
+						}
+					},
+					"core/button": {
 						"@mobile": {
 							"elements": {
 								"link": {


### PR DESCRIPTION
## What?
Follow up to #81209. Makes the schema agree with what WordPress renders for responsive states, in both directions.

**Accepts** `elements` inside a block's breakpoint, for every block:

```json
{
	"version": 3,
	"styles": {
		"blocks": {
			"core/group": {
				"@mobile": {
					"elements": {
						"link": {
							"color": { "text": "red" }
						}
					}
				}
			}
		}
	}
}
```

**Rejects** a breakpoint set directly on an element, at block level and top level:

```json
{
	"version": 3,
	"styles": {
		"elements": {
			"link": {
				"@mobile": {
					"color": { "text": "red" }
				}
			}
		},
		"blocks": {
			"core/group": {
				"elements": {
					"link": {
						"@mobile": {
							"color": { "text": "red" }
						}
					}
				}
			}
		}
	}
}
```

## Why?
The target structures are listed at `lib/class-wp-theme-json-gutenberg.php:1277-1279`:

```
- top level elements:        styles.elements.link[':hover']
- block level elements:      styles.blocks['core/button'].elements.link[':hover']
- block responsive elements: styles.blocks['core/button']['@tablet'].elements.link[':hover']
```

Responsive states sit on the block, with `elements` inside them. The schema had it backwards on both counts: it rejected the supported spelling and accepted two that render nothing.

Run each through `get_stylesheet()` on trunk:

```
blocks.group['@mobile'].elements.link  → @media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button))){color: red;}}
blocks.group.elements.link['@mobile']  → (no output)
elements.link['@mobile']               → (no output)
```

## How?
- `stylesBlocksResponsiveStatePropertiesComplete`: a breakpoint body carrying `elements`, used by the generic block definition.
- `stylesBlocksResponsiveStateWithPseudoPropertiesComplete`: the same plus pseudo-selectors, for `core/button` and `core/navigation-link`, which take their breakpoints from the definition added in #81209. Without it those two would be the only blocks that could not style an element inside a breakpoint.
- Removed the element-level breakpoint refs from all thirteen element definitions, and the two definitions that then had no references left.

`stylesBlocksPropertiesAndPseudoComplete` is deliberately untouched. It is also the body of `-current`, and custom states have no element support: `core/navigation-link["-current"].elements` renders nothing.

## Testing Instructions
```
npm run test:unit -- test/integration/theme-schema.test.js
```

`test/integration/fixtures/theme-json/responsive-elements/theme.json` is rejected on trunk and accepted here, covering `core/group`, a third-party block, `core/button` and `core/navigation-link`, at block level, inside a block style variation and inside a shared variation.

Six invalid fixtures keep the rejected shapes rejected: a breakpoint on a top-level element, a breakpoint on a block element, `blocks` inside a breakpoint, `:visited` inside a breakpoint, `-current.elements`, and an unknown element name.

To check in an editor, point a theme.json `$schema` at this branch and confirm `@mobile` under `core/group` is accepted while `elements.link["@mobile"]` is flagged:

```
https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/fix/theme-json-schema-responsive-elements/schemas/json/theme.json
```

## Related
- #81265 fixed the renderer so `blocks.<block>["@mobile"].elements` produces CSS. Merged.
- #81312 stops the sanitizer keeping the two rejected shapes. Optional, no output change.
- #81309 allows responsive states on block style variations.
