### PR TITLE
Cover: scaffold a heading instead of a large paragraph

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -62,22 +62,19 @@ import { unlock } from '../../lock-unlock';
 
 const { openMediaEditorModalKey } = unlock( blockEditorPrivateApis );
 
-function getInnerBlocksTemplate( attributes ) {
-	return [
-		[
-			'core/paragraph',
-			{
-				style: {
-					typography: {
-						textAlign: 'center',
-					},
+const INNER_BLOCKS_TEMPLATE = [
+	[
+		'core/heading',
+		{
+			style: {
+				typography: {
+					textAlign: 'center',
 				},
-				placeholder: __( 'Write title…' ),
-				...attributes,
 			},
-		],
-	];
-}
+			placeholder: __( 'Write title…' ),
+		},
+	],
+];
 
 /**
  * Is the URL a temporary blob URL? A blob URL is one that is used temporarily while
@@ -227,7 +224,7 @@ function CoverEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
-	// Create the initial inner paragraph when the block gains a background
+	// Create the initial inner heading when the block gains a background
 	// and has no content yet.
 	const scaffoldInnerBlocks = () => {
 		const {
@@ -238,19 +235,9 @@ function CoverEdit( {
 		if ( getBlocks( clientId ).length > 0 ) {
 			return;
 		}
-		// Check for fontSize support before we pass a fontSize attribute to
-		// the innerBlocks.
-		const [ fontSizes ] = unlock(
-			registry.select( blockEditorStore )
-		).getBlockSettings( clientId, 'typography.fontSizes' );
-		const hasFontSizes = fontSizes?.length > 0;
 		replaceInnerBlocks(
 			clientId,
-			createBlocksFromInnerBlocksTemplate(
-				getInnerBlocksTemplate( {
-					fontSize: hasFontSizes ? 'large' : undefined,
-				} )
-			),
+			createBlocksFromInnerBlocksTemplate( INNER_BLOCKS_TEMPLATE ),
 			isBlockSelected( clientId ),
 			getSelectedBlocksInitialCaretPosition()
 		);

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -151,7 +151,7 @@ describe( 'Cover block', () => {
 				} )
 			);
 
-			const title = screen.getByLabelText( 'Empty block;', {
+			const title = screen.getByLabelText( 'Block: Heading', {
 				exact: false,
 			} );
 			await userEvent.click( title );

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -200,16 +200,15 @@ test.describe( 'Cover', () => {
 			} )
 			.click();
 
-		// Activate the paragraph block inside the Cover block.
-		// The name of the block differs depending on whether text has been entered or not.
-		const coverBlockParagraph = coverBlock.getByRole( 'document', {
-			name: /Block: Paragraph|Empty block; start writing or type forward slash to choose a block/,
+		// Activate the heading block inside the Cover block.
+		const coverBlockHeading = coverBlock.getByRole( 'document', {
+			name: 'Block: Heading',
 		} );
-		await expect( coverBlockParagraph ).toBeEditable();
+		await expect( coverBlockHeading ).toBeEditable();
 
-		await coverBlockParagraph.fill( titleText );
+		await coverBlockHeading.fill( titleText );
 
-		await expect( coverBlockParagraph ).toContainText( titleText );
+		await expect( coverBlockHeading ).toContainText( titleText );
 	} );
 
 	test( 'can be resized using drag & drop', async ( { page, editor } ) => {

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -186,7 +186,7 @@ test.describe( 'List View', () => {
 		// The child heading block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Heading',
+				name: 'Heading 2',
 				exact: true,
 				selected: true,
 			} )
@@ -221,7 +221,7 @@ test.describe( 'List View', () => {
 		// The child heading block in List View should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Heading',
+				name: 'Heading 2',
 				exact: true,
 				selected: true,
 			} )
@@ -232,7 +232,7 @@ test.describe( 'List View', () => {
 		await expect( listView.getByRole( 'row' ) ).toHaveCount( 3 );
 
 		await listView
-			.getByRole( 'gridcell', { name: 'Heading', exact: true } )
+			.getByRole( 'gridcell', { name: 'Heading 2', exact: true } )
 			.click();
 
 		// Move down to the Group block.

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -183,10 +183,10 @@ test.describe( 'List View', () => {
 			} )
 		).toBeVisible();
 
-		// The child paragraph block should be selected.
+		// The child heading block should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Heading',
 				exact: true,
 				selected: true,
 			} )
@@ -215,24 +215,24 @@ test.describe( 'List View', () => {
 		// Click the Cover block title placeholder.
 		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Cover' } )
-			.getByRole( 'document', { name: /Empty block/i } )
+			.getByRole( 'document', { name: 'Block: Heading' } )
 			.click();
 
-		// The child paragraph block in List View should be selected.
+		// The child heading block in List View should be selected.
 		await expect(
 			listView.getByRole( 'gridcell', {
-				name: 'Paragraph',
+				name: 'Heading',
 				exact: true,
 				selected: true,
 			} )
 		).toBeVisible();
 
 		// Check that blocks are expanded:
-		// 3 blocks: (one Cover block containing a Paragraph block, one Group block).
+		// 3 blocks: (one Cover block containing a Heading block, one Group block).
 		await expect( listView.getByRole( 'row' ) ).toHaveCount( 3 );
 
 		await listView
-			.getByRole( 'gridcell', { name: 'Paragraph', exact: true } )
+			.getByRole( 'gridcell', { name: 'Heading', exact: true } )
 			.click();
 
 		// Move down to the Group block.


### PR DESCRIPTION
## What?

The cover block scaffolds a heading instead of a large paragraph when it gains a background. New covers only; existing content is untouched.

## Why?

The large paragraph was never a design decision. Cover originally stored its title as an attribute rendered as `<p class="wp-block-cover-text">`; the inner blocks conversion (#13822, 2019) had to migrate that markup faithfully, so it produced a paragraph with `fontSize: large` to reproduce the old CSS. The insertion template copied the migration's block, and #80028 ported it to the scaffold unchanged.

The placeholder says "Write title…", and the honest block for a title is a heading: it sizes itself through the theme, and it enters the document outline, which is what a hero title should do. The `fontSize` stamp, a per-instance attribute users never chose, goes away with it.

## How?

The scaffold template becomes a centered `core/heading` with the same placeholder. The font size plumbing (`getBlockSettings` lookup and the conditional `fontSize: 'large'`) is deleted. The migration deprecations are untouched: old covers still convert their title to a paragraph, exactly as saved.

## Testing Instructions

1. Insert a Cover block and pick a background color or image.
2. The block scaffolds an empty centered heading with the "Write title…" placeholder; typing produces a heading sized by the theme.
3. Existing covers with paragraphs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQNdFF1FUU9JXfNGZev2na
