### PR TITLE
Cover: inherit the text alignment from the block

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -303,7 +303,7 @@ Add an image or video with a text overlay.
 
 -	**Name:** [core/cover](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/core-block-cover/)
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
--	**Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, allowedBlocks, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
 -	**Attributes:** allowedVideoProviders, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
 
 ## Details

--- a/packages/block-library/src/cover/README.md
+++ b/packages/block-library/src/cover/README.md
@@ -117,6 +117,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`dimensions`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#dimensions):
   - `aspectRatio`: `true`
 - [`typography`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography):
+  - [`textAlign`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-textalign): `true`
   - [`fontSize`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-fontsize): `true`
   - [`lineHeight`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-lineheight): `true`
 - [`layout`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout):

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -137,6 +137,7 @@
 			"aspectRatio": true
 		},
 		"typography": {
+			"textAlign": true,
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -66,11 +66,6 @@ const INNER_BLOCKS_TEMPLATE = [
 	[
 		'core/heading',
 		{
-			style: {
-				typography: {
-					textAlign: 'center',
-				},
-			},
 			placeholder: __( 'Write title…' ),
 		},
 	],
@@ -225,16 +220,28 @@ function CoverEdit( {
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
 	// Create the initial inner heading when the block gains a background
-	// and has no content yet.
+	// and has no content yet. The text alignment is set on the cover itself
+	// so every inner block inherits it.
 	const scaffoldInnerBlocks = () => {
 		const {
 			getBlocks,
+			getBlockAttributes,
 			isBlockSelected,
 			getSelectedBlocksInitialCaretPosition,
 		} = registry.select( blockEditorStore );
 		if ( getBlocks( clientId ).length > 0 ) {
 			return;
 		}
+		const { style } = getBlockAttributes( clientId ) ?? {};
+		setAttributes( {
+			style: {
+				...style,
+				typography: {
+					...style?.typography,
+					textAlign: 'center',
+				},
+			},
+		} );
 		replaceInnerBlocks(
 			clientId,
 			createBlocksFromInnerBlocksTemplate( INNER_BLOCKS_TEMPLATE ),

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -63,8 +63,6 @@
 
 	// The .wp-block-cover class is used just to increase selector specificity.
 	.wp-block-cover__inner-container {
-		// Avoid text align inherit from cover image align.
-		text-align: left;
 		margin-left: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
## What?

The cover block sets the text alignment on itself instead of stamping it on its scaffolded child, so every inner block inherits it. Builds on #81257.

## Why?

The scaffold stamped `textAlign: center` onto the initial child only: a second paragraph typed into a cover came out left-aligned next to a centered title, and the alignment was a per-instance attribute the user never chose. Alignment of the cover's content is a property of the cover.

## How?

1. Cover gains the `textAlign` typography support, so it renders the standard alignment control and the `has-text-align-*` class on the wrapper, which inner text inherits through the CSS cascade.
2. The scaffold sets `textAlign: center` on the cover itself when it gains a background, and the child template loses the stamp.
3. Existing covers are untouched: the attribute is only set at creation, and old markup revalidates unchanged.

## Testing Instructions

1. Insert a Cover block and pick a background: the scaffolded heading is centered.
2. Add a second block inside the cover: it is centered too.
3. Change the alignment from the cover's toolbar: all inner text follows.
4. Existing covers render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQNdFF1FUU9JXfNGZev2na
