### PR TITLE
Docs: explain how the theme.json schema fixtures work

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -63,7 +63,7 @@ npm run fixtures:regenerate
 | Location | Expectation |
 |---|---|
 | any `theme.json` under `lib/`, `phpunit/`, `test/`, or `packages/*/src/` | must validate, and must set `$schema` |
-| any file in `fixtures/schemas/` | must fail validation |
+| any `.json` file directly in `fixtures/schemas/` | must fail validation |
 
 Name an invalid fixture after the schema definition that rejects it, adding a `_suffix` when one definition needs several cases, as in `stylesPropertiesAndElementsComplete_pseudo.json`. Nothing enforces the name, so check the failure comes from the definition you meant to test.
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -40,6 +40,8 @@ npm run test:unit -- test/integration/blocks-schema.test.js
 
 ## Fixtures
 
+### Block fixtures
+
 The `fixtures/blocks/` directory contains serialized block fixtures used by `full-content.test.js` to verify that blocks serialize and parse correctly.
 
 To generate missing fixtures:
@@ -53,6 +55,17 @@ To regenerate all fixtures from scratch:
 ```bash
 npm run fixtures:regenerate
 ```
+
+### theme.json schema fixtures
+
+`theme-schema.test.js` decides what to expect from where a file sits, so adding a case means adding a file and nothing else.
+
+| Location | Expectation |
+|---|---|
+| any `theme.json` under `lib/`, `phpunit/`, `test/`, or `packages/*/src/` | must validate, and must set `$schema` |
+| any file in `fixtures/schemas/` | must fail validation |
+
+Name an invalid fixture after the schema definition that rejects it, adding a `_suffix` when one definition needs several cases, as in `stylesPropertiesAndElementsComplete_pseudo.json`. Nothing enforces the name, so check the failure comes from the definition you meant to test.
 
 ## Jest Configuration
 


### PR DESCRIPTION
## What?
Documents how `test/integration/theme-schema.test.js` picks up fixtures. Came out of a review question on #81209.

## Why?
The test takes its expectation from where a file sits. Nothing says so, so it isn't obvious how to add a case or where the assertion lives.

## How?
Adds a `### theme.json schema fixtures` subsection to `test/integration/README.md` covering the two locations and the naming convention for invalid fixtures. Also puts the existing block fixture text under its own heading so the two don't run together.

Docs only, 13 added lines.

## Testing Instructions
Read `test/integration/README.md` and check it matches the globs at `test/integration/theme-schema.test.js:13-20`.
