### PR TITLE
Pert Tests: Avoid inflating interaction metrics with startTracing

### DIFF
--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Metrics.startTracing()`: Run a trivial script once tracing is on, to absorb the isolate interrupt that enabling the V8 sampling profiler queues. Its cost otherwise lands in the first thing the test does, usually the interaction being measured, and grows through a spec's iterations: a stable 220ms interaction reported anywhere from 200ms to 650ms ([#81264](https://github.com/WordPress/gutenberg/pull/81264)).
 -   `Metrics.getSelectionEventDurations()`: Dispatches that nest inside another dispatch now contribute only the time not already covered by it, so summing the returned durations no longer counts the nested work twice.
 
 ## 1.52.0 (2026-07-29)

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `Metrics.startTracing()`: Run a trivial script once tracing is on, to absorb the isolate interrupt that enabling the V8 sampling profiler queues. Its cost otherwise lands in the first thing the test does, usually the interaction being measured, and grows through a spec's iterations: a stable 220ms interaction reported anywhere from 200ms to 650ms ([#81264](https://github.com/WordPress/gutenberg/pull/81264)).
+-   `Metrics.startTracing()`: Run a trivial script in every frame once tracing is on, to absorb the isolate interrupt that enabling the V8 sampling profiler queues. Its cost otherwise lands in the first thing the test does, usually the interaction being measured, and grows through a spec's iterations: a stable 220ms interaction reported anywhere from 200ms to 650ms ([#81264](https://github.com/WordPress/gutenberg/pull/81264)).
 -   `Metrics.getSelectionEventDurations()`: Dispatches that nest inside another dispatch now contribute only the time not already covered by it, so summing the returned durations no longer counts the nested work twice.
 
 ## 1.52.0 (2026-07-29)

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -230,7 +230,7 @@ export class Metrics {
 	 * @param options Options to pass to `browser.startTracing()`.
 	 */
 	async startTracing( options = {} ) {
-		const result = await this.browser.startTracing( this.page, {
+		await this.browser.startTracing( this.page, {
 			screenshots: false,
 			categories: [
 				'devtools.timeline',
@@ -246,10 +246,17 @@ export class Metrics {
 		// logs every function compiled so far. It runs on the next stack
 		// guard check, so its cost would land in the first thing the test
 		// does, which is usually the interaction being measured. Absorb it
-		// here instead.
-		await this.page.evaluate( () => {} );
-
-		return result;
+		// here instead. A cross-origin iframe runs in its own isolate and
+		// gets its own interrupt, so every frame needs the warm-up, not just
+		// the main one.
+		await Promise.all(
+			this.page
+				.frames()
+				// A frame can detach between listing and evaluating.
+				.map( ( frame ) =>
+					frame.evaluate( () => {} ).catch( () => {} )
+				)
+		);
 	}
 
 	/**

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -230,7 +230,7 @@ export class Metrics {
 	 * @param options Options to pass to `browser.startTracing()`.
 	 */
 	async startTracing( options = {} ) {
-		return await this.browser.startTracing( this.page, {
+		const result = await this.browser.startTracing( this.page, {
 			screenshots: false,
 			categories: [
 				'devtools.timeline',
@@ -241,6 +241,15 @@ export class Metrics {
 			],
 			...options,
 		} );
+
+		// Enabling the V8 sampling profiler queues an isolate interrupt that
+		// logs every function compiled so far. It runs on the next stack
+		// guard check, so its cost would land in the first thing the test
+		// does, which is usually the interaction being measured. Absorb it
+		// here instead.
+		await this.page.evaluate( () => {} );
+
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
## What?
Extracted #81244.

Disclaimer: I'm not familiar with V8 internals, and this was suggested by Claude. Results were confirmed by multiple runs of performance tests locally.

Enabling `disabled-by-default-v8.cpu_profiler` queues an isolate interrupt that logs every function V8 has compiled so far. It runs on the next stack guard check, so its cost landed on the test's first key press and was counted as interaction time. It grows through a session: here it went from 155ms to 400ms across seven iterations while the real work stayed flat at ~200ms. Running a trivial script once tracing is on absorbs it. This is why the metric read ~0.4s locally and ~1s on CI, and it affects every spec that traces inside its iteration loop.

## Testing Instructions
After CI checks are green. Check the performance test summary. They should report better numbers.

## Use of AI Tools

Assisted by Claude.