### PR TITLE
Global styles: render element styles set only inside a breakpoint

### DIFF
--- a/backport-changelog/7.1/12918.md
+++ b/backport-changelog/7.1/12918.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12918
+
+* https://github.com/WordPress/gutenberg/pull/81265

--- a/backport-changelog/7.1/12926.md
+++ b/backport-changelog/7.1/12926.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/12926
-
-* https://github.com/WordPress/gutenberg/pull/81265

--- a/backport-changelog/7.1/12926.md
+++ b/backport-changelog/7.1/12926.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12926
+
+* https://github.com/WordPress/gutenberg/pull/81265

--- a/docs/how-to-guides/themes/global-settings-and-styles.md
+++ b/docs/how-to-guides/themes/global-settings-and-styles.md
@@ -1110,7 +1110,7 @@ Responsive overrides can be placed directly on a block node:
 @media (width <= 480px) { :root :where(.wp-block-group) { color: hotpink; } }
 ```
 
-They can also be placed on element nodes within a block:
+A breakpoint can also carry styles for a block's elements, including their pseudo selectors:
 
 ```json
 {
@@ -1143,10 +1143,35 @@ They can also be placed on element nodes within a block:
 ```
 
 ```css
-:root :where(.wp-block-group a)        { color: blue; }
-@media (width <= 480px) { :root :where(.wp-block-group a)       { color: red; } }
-:root :where(.wp-block-group a:hover)  { color: navy; }
-@media (width <= 480px) { :root :where(.wp-block-group a:hover) { color: darkred; } }
+:root :where(.wp-block-group a:where(:not(.wp-element-button))) { color: blue; }
+@media (width <= 480px) { :root :where(.wp-block-group a:where(:not(.wp-element-button))) { color: red; } }
+:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover) { color: navy; }
+@media (width <= 480px) { :root :where(.wp-block-group a:where(:not(.wp-element-button)):hover) { color: darkred; } }
+```
+
+An element does not need styles outside the breakpoint. Styling it only inside one is valid, and outputs a single rule inside the media query:
+
+```json
+{
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"@mobile": {
+					"elements": {
+						"link": {
+							"color": { "text": "red" }
+						}
+					}
+				}
+			}
+		}
+	}
+}
+```
+
+```css
+@media (width <= 480px) { :root :where(.wp-block-group a:where(:not(.wp-element-button))) { color: red; } }
 ```
 
 Responsive overrides are always output after the default styles they override, so the cascade order is preserved without needing to increase specificity.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3703,22 +3703,45 @@ class WP_Theme_JSON_Gutenberg {
 					}
 				}
 			}
-			if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
-				foreach ( $theme_json['styles']['blocks'][ $name ]['elements'] as $element => $node ) {
+			/*
+			 * Elements can be styled outside any breakpoint, inside one, or both,
+			 * so collect the names from all of those places before looping. An
+			 * element styled only inside a breakpoint still needs a node.
+			 */
+			$block_node    = $theme_json['styles']['blocks'][ $name ] ?? array();
+			$element_names = array_keys( $block_node['elements'] ?? array() );
+			foreach ( array_keys( $responsive_media_queries ) as $breakpoint ) {
+				$element_names = array_merge(
+					$element_names,
+					array_keys( $block_node[ $breakpoint ]['elements'] ?? array() )
+				);
+			}
+			$element_names = array_unique( $element_names );
+
+			if ( ! empty( $element_names ) ) {
+				foreach ( $element_names as $element ) {
 					$element_path = array( 'styles', 'blocks', $name, 'elements', $element );
 					if ( $include_node_paths_only ) {
-						$nodes[] = array(
-							'path' => $element_path,
-						);
+						if ( isset( $block_node['elements'][ $element ] ) ) {
+							$nodes[] = array(
+								'path' => $element_path,
+							);
+						}
+						continue;
+					}
+
+					if ( ! isset( $selectors[ $name ]['elements'][ $element ] ) ) {
 						continue;
 					}
 
 					$element_selector = $selectors[ $name ]['elements'][ $element ];
 
-					$nodes[] = array(
-						'path'     => $element_path,
-						'selector' => $element_selector,
-					);
+					if ( isset( $block_node['elements'][ $element ] ) ) {
+						$nodes[] = array(
+							'path'     => $element_path,
+							'selector' => $element_selector,
+						);
+					}
 
 					// Responsive element nodes: one node per breakpoint that has
 					// styles for this element. Cascade: a{} → @media{a{}}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1462,6 +1462,109 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_stylesheet_renders_element_styles_defined_only_in_a_breakpoint() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'@mobile' => array(
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'text' => 'red',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = '@media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button))){color: red;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
+	public function test_get_stylesheet_renders_element_pseudo_styles_defined_only_in_a_breakpoint() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'@mobile' => array(
+								'elements' => array(
+									'link' => array(
+										':hover' => array(
+											'color' => array(
+												'text' => 'red',
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = '@media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover){color: red;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
+	public function test_get_stylesheet_renders_element_styles_defined_only_in_separate_breakpoints() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'@mobile' => array(
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'text' => 'red',
+										),
+									),
+								),
+							),
+							'@tablet' => array(
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'text' => 'blue',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$link_selector = ':root :where(.wp-block-group a:where(:not(.wp-element-button)))';
+		$expected      = '@media (width <= 480px){' . $link_selector . '{color: red;}}' .
+			'@media (480px < width <= 782px){' . $link_selector . '{color: blue;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
 	public function test_get_styles_for_block_responsive_element_pseudo_styles_preserve_order_and_do_not_duplicate_pseudo() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
## What?
Blocks #81253. Raised by review on that PR.

Element styles written inside `@mobile` or `@tablet` now produce CSS whether or not the same element is also styled outside the breakpoint.

## Why?
`get_block_nodes()` looks for a block's elements under `styles.blocks.<block>.elements` and emits the breakpoint nodes from inside that loop (`lib/class-wp-theme-json-gutenberg.php:3706-3733`). An element styled only inside a breakpoint is never looped over, so no node is created and no CSS is output. Add a link colour outside the breakpoint and the same theme.json starts working, which makes it look theme-dependent rather than like a missing loop.

Sanitization already keeps these styles (`:1320`), and the element pseudo handling just below already accounts for a state that exists only in a breakpoint, so this reads as an oversight. `docs/how-to-guides/themes/global-settings-and-styles.md` already promises the unconditional behaviour: "Any style property that is valid at the block or element level can be nested under one of these keys."

## How?
Collect element names from the block node and from each breakpoint before looping. Only emit the default node when the element is styled outside a breakpoint.

Docs gain an example of the breakpoint-only case, and the existing CSS sample is corrected to the selector WordPress actually outputs (`.wp-block-group a:where(:not(.wp-element-button))`, not `.wp-block-group a`).

## Testing Instructions
```
npm run test:unit:php
```

Three new cases in `phpunit/class-wp-theme-json-test.php`. All three fail on trunk and pass here.

Or in a theme's `theme.json`:

```json
{
	"version": 3,
	"styles": {
		"blocks": {
			"core/group": {
				"@mobile": {
					"elements": {
						"link": { "color": { "text": "red" } }
					}
				}
			}
		}
	}
}
```

Before: no CSS at all. After:

```css
@media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button))){color: red;}}
```

Add `"elements": { "link": { "color": { "text": "blue" } } }` next to `@mobile` and both rules appear, on trunk and here, which is the behaviour that masked this.

## Not included
Three other paths accept styles that never render, all unrelated to breakpoints or fixed here: `styles.blocks.<block>.elements.<el>["@mobile"]`, `styles.elements.<el>["@mobile"]`, and `styles.blocks.<block>.variations.<v>.elements` / `.blocks`. Worth separate issues.
