### PR TITLE
List View: Migrate label wrapper to UI Stack and drop Badge from the anchor

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,11 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	__experimentalTruncate as Truncate,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { __experimentalTruncate as Truncate } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -22,8 +18,7 @@ import {
 	unseen,
 } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
-
-import { Tooltip } from '@wordpress/ui';
+import { Stack, Tooltip } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -34,8 +29,6 @@ import ListViewExpander from './expander';
 import useListViewImages from './use-list-view-images';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
 function ListViewBlockSelectButton(
 	{
@@ -148,20 +141,20 @@ function ListViewBlockSelectButton(
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
 			<BlockIcon icon={ icon } showColors context="list-view" />
-			<HStack
-				alignment="center"
+			<Stack
+				align="center"
 				className="block-editor-list-view-block-select-button__label-wrapper"
 				justify="flex-start"
-				spacing={ 1 }
+				gap="xs"
 			>
 				<span className="block-editor-list-view-block-select-button__title">
 					<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
 				</span>
 				{ !! anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor-wrapper">
-						<WCBadge className="block-editor-list-view-block-select-button__anchor">
+						<span className="block-editor-list-view-block-select-button__anchor">
 							{ anchor }
-						</WCBadge>
+						</span>
 					</span>
 				) }
 				{ isSticky && (
@@ -212,7 +205,7 @@ function ListViewBlockSelectButton(
 						<Icon icon={ lock } />
 					</span>
 				) }
-			</HStack>
+			</Stack>
 		</a>
 	);
 }

--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -7,14 +7,13 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	__experimentalHStack as HStack,
-	__experimentalTruncate as Truncate,
 	Popover,
+	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-
 import { getScrollContainer } from '@wordpress/dom';
 import { useCallback, useMemo } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -327,18 +326,18 @@ export default function ListViewDropIndicatorPreview( {
 							showColors
 							context="list-view"
 						/>
-						<HStack
-							alignment="center"
+						<Stack
+							align="center"
 							className="block-editor-list-view-block-select-button__label-wrapper"
 							justify="flex-start"
-							spacing={ 1 }
+							gap="xs"
 						>
 							<span className="block-editor-list-view-block-select-button__title">
 								<Truncate ellipsizeMode="auto">
 									{ blockTitle }
 								</Truncate>
 							</span>
-						</HStack>
+						</Stack>
 					</div>
 					<div className="block-editor-list-view-block__menu-cell"></div>
 				</div>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -382,10 +382,18 @@
 		}
 	}
 
-	// Style lock and position icons in line with image previews.
-	.block-editor-list-view-block-select-button__label-wrapper svg {
-		left: $grid-unit-05 * 0.5; // 2px.
-		position: relative;
+	.block-editor-list-view-block-select-button__label-wrapper {
+		width: 100%;
+
+		> * {
+			min-width: 0;
+		}
+
+		// Style lock and position icons in line with image previews.
+		svg {
+			left: $grid-unit-05 * 0.5; // 2px.
+			position: relative;
+		}
 	}
 
 	.block-editor-list-view-block-select-button__title {
@@ -409,6 +417,17 @@
 		position: absolute;
 		right: 0;
 		transform: translateY(-50%);
+		box-sizing: border-box;
+		max-width: 100%;
+		padding: 2px $grid-unit-10;
+		border-radius: $radius-small;
+		background: $gray-100;
+		color: $gray-800;
+		font-size: $font-size-small;
+		line-height: $font-line-height-small;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	&.is-selected .block-editor-list-view-block-select-button__anchor {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -260,16 +260,6 @@
 			"count": 3
 		}
 	},
-	"packages/block-editor/src/components/list-view/block-select-button.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/block-editor/src/components/list-view/drop-indicator.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-editor/src/components/multi-selection-inspector/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
Fixes the two `@wordpress/use-recommended-components` ESLint suppressions in List View and removes the private `Badge` usage from the block select button.

I've debated about the `Badge` and decided to replace it with custom CSS. Anchor just another data in the List View tree; it doesn't require any action or attention.

## Testing Instructions
1. Open a sizable post with different blocks.
2. Ensure some headings have anchors.
3. Confirm that the List View renders as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="358" height="762" alt="CleanShot 2026-08-06 at 09 47 44" src="https://github.com/user-attachments/assets/0b92e394-9433-4306-ac0a-a7b19cdb4c6b" />


## Use of AI Tools

Assisted by Claude.
