### PR TITLE
Add a "Show non-printing characters" preference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52275,6 +52275,7 @@
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
 				"@wordpress/latex-to-mathml": "file:../latex-to-mathml",
+				"@wordpress/preferences": "file:../preferences",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/ui": "file:../ui",

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add editor content styles that draw markers for non-printing characters. Characters that occupy space are marked with a background so that turning the preference on never reflows the text ([#72232](https://github.com/WordPress/gutenberg/issues/72232)).
+
 ### Enhancements
 
 -   Inspector controls in the standard block-supports panels (Typography, Dimensions, Border, Color, Background, Filters) now reflect the value a block inherits from Global Styles when no local override is set. Inherited controls show that value at rest (as a placeholder, preselected option, or resolved value) and mark the label with a dotted underline; setting a local override reveals a reset affordance that clears the override back to the inherited value ([#77894](https://github.com/WordPress/gutenberg/pull/77894)).

--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -54,3 +54,69 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 .rich-text [contenteditable="false"]::selection {
 	background-color: transparent;
 }
+
+// Markers for non-printing characters, shown when the "Show non-printing
+// characters" preference is on. The format that adds these wrappers exists only
+// in the editable tree and is never saved, so nothing here reaches the content.
+//
+// Markers for characters that occupy space are painted as backgrounds rather
+// than pseudo elements, so that turning the preference on never reflows the
+// text the author is reading. Only characters with no width of their own get a
+// pseudo element, since there is no box to paint on otherwise.
+[data-rich-text-non-printing-character] {
+	// Blocks and themes set their own colors, so derive the marker from the
+	// surrounding text instead of naming a color.
+	--wp-non-printing-character-color: color-mix(in srgb, currentColor 45%, transparent);
+
+	background-repeat: no-repeat;
+
+	&::before {
+		// Keep markers out of the way of writing and selecting.
+		pointer-events: none;
+		user-select: none;
+		-webkit-user-select: none;
+		color: var(--wp-non-printing-character-color);
+		// Reset the text shadow from the global styles.
+		text-shadow: none;
+	}
+}
+
+// A dot in the middle of the space, as word processors draw it.
+[data-rich-text-non-printing-character="space"] {
+	background-image: radial-gradient(circle at 50% 50%, var(--wp-non-printing-character-color) 0 0.06em, transparent 0.07em);
+}
+
+// The same dot, on a tinted box: a non-breaking space looks identical to a
+// regular one, so the marker has to say more than "there is a space here".
+[data-rich-text-non-printing-character="non-breaking-space"] {
+	background-color: color-mix(in srgb, currentColor 12%, transparent);
+	background-image: radial-gradient(circle at 50% 50%, var(--wp-non-printing-character-color) 0 0.06em, transparent 0.07em);
+	border-radius: $radius-small;
+}
+
+// A rule running the width of the tab, which varies with where the tab lands.
+[data-rich-text-non-printing-character="tab"] {
+	background-image: linear-gradient(to right, var(--wp-non-printing-character-color) 0 100%);
+	background-size: 100% 1px;
+	background-position: 0 65%;
+}
+
+// A return arrow sitting at the end of the line, before the break itself.
+[data-rich-text-non-printing-character="line-break"]::before {
+	content: "\21b5";
+	font-size: 0.9em;
+	line-height: 1;
+}
+
+// Zero width characters have no box to paint on, so give them a small tick.
+// This does shift the text by a fraction, which is the point: an invisible
+// character that takes up no room can only be revealed by making room for it.
+[data-rich-text-non-printing-character="zero-width"]::before {
+	content: "";
+	display: inline-block;
+	width: 0.2em;
+	height: 0.85em;
+	vertical-align: text-bottom;
+	border-radius: 1px;
+	background-color: var(--wp-non-printing-character-color);
+}

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Register the `showNonPrintingCharacters` preference, defaulting to off ([#72232](https://github.com/WordPress/gutenberg/issues/72232)).
+
 ### Enhancements
 
 -   Wrap the post editor layout in `ThemeProvider`, seeded with the active admin color scheme primary color ([#81112](https://github.com/WordPress/gutenberg/pull/81112)).

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -76,6 +76,7 @@ export function initializeEditor(
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		showListViewByDefault: false,
+		showNonPrintingCharacters: false,
 		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
 		showCollaborationCursor: false,

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Register the `showNonPrintingCharacters` preference, defaulting to off ([#72232](https://github.com/WordPress/gutenberg/issues/72232)).
+
 ## 7.0.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -72,6 +72,7 @@ export function initializeEditor( id, settings ) {
 		openPanels: [ 'post-status' ],
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
+		showNonPrintingCharacters: false,
 		enableChoosePatternModal: true,
 		showCollaborationCursor: false,
 		showCollaborationJoinNotifications: true,

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### New Features
 
+-   Add a "Show non-printing characters" preference under Appearance, which marks spaces, tabs, line breaks and invisible characters while editing so pasted text can be proofed ([#72232](https://github.com/WordPress/gutenberg/issues/72232)).
 -   The "Apply globally" control now opens a review modal so you can choose which of a block's modified styles are pushed to Global Styles, showing each style's current and new value ([#79839](https://github.com/WordPress/gutenberg/pull/79839)).
 -   Add a `responsiveEditingEnabled` editor setting, defaulting to `true`, which hides the "Responsive styles" option in the View menu and the viewport state control in Global Styles when set to `false` ([#80814](https://github.com/WordPress/gutenberg/pull/80814)).
 -   Add a `blockStatesEditingEnabled` editor setting, defaulting to `true`, which hides state controls for blocks in the block inspector and Global Styles when set to `false` ([#80956](https://github.com/WordPress/gutenberg/pull/80956), [#81058](https://github.com/WordPress/gutenberg/pull/81058)).

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -278,6 +278,14 @@ function PreferencesModalContents( { extraSections = {} } ) {
 								) }
 								label={ __( 'Spotlight mode' ) }
 							/>
+							<PreferenceToggleControl
+								scope="core"
+								featureName="showNonPrintingCharacters"
+								help={ __(
+									'Marks spaces, tabs, line breaks, and invisible characters while you edit. The markers never appear on your site.'
+								) }
+								label={ __( 'Show non-printing characters' ) }
+							/>
 							{ extraSections?.appearance }
 						</PreferencesModalSection>
 					),

--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a `core/non-printing-characters` format that marks spaces, non-breaking spaces, tabs, line breaks and zero width characters in the editor while the "Show non-printing characters" preference is on. The format exists only in the editable tree and is never saved, so the content is untouched ([#72232](https://github.com/WordPress/gutenberg/issues/72232)).
+
 ## 5.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -52,6 +52,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/latex-to-mathml": "file:../latex-to-mathml",
+		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/ui": "file:../ui",

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -16,6 +16,7 @@ import { unknown } from './unknown';
 import { language } from './language';
 import { math } from './math';
 import { nonBreakingSpace } from './non-breaking-space';
+import { nonPrintingCharacters } from './non-printing-characters';
 
 export default [
 	bold,
@@ -33,4 +34,5 @@ export default [
 	language,
 	math,
 	nonBreakingSpace,
+	nonPrintingCharacters,
 ];

--- a/packages/format-library/src/non-printing-characters/index.js
+++ b/packages/format-library/src/non-printing-characters/index.js
@@ -1,0 +1,129 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+const name = 'core/non-printing-characters';
+const title = __( 'Non-printing character' );
+
+/**
+ * Every character that gets a marker, paired with the kind of marker it gets.
+ * The kind ends up in the `data-rich-text-non-printing-character` attribute,
+ * which the editor content styles use to draw the marker.
+ *
+ * Characters are listed by code point rather than as literals, so that reading
+ * this file never depends on being able to see the characters it is about.
+ *
+ * Zero width joiners (U+200D) and non joiners (U+200C) are deliberately absent.
+ * They hold emoji sequences together and carry meaning in Arabic, Persian and
+ * several Indic scripts, so marking them would flag correct text as suspect.
+ *
+ * U+FEFF and U+FFFC are absent too: rich text writes them itself as padding and
+ * as the placeholder for objects, so they are never part of the author's text.
+ *
+ * @type {Array<[number, string]>}
+ */
+const CHARACTER_CODE_POINTS = [
+	// Ordinary whitespace.
+	[ 0x0020, 'space' ], // Space.
+	[ 0x0009, 'tab' ], // Character tabulation.
+	[ 0x000a, 'line-break' ], // Line feed.
+
+	// Spaces that read like an ordinary space but never break. These are the
+	// ones that arrive by accident, pasted in from a word processor.
+	[ 0x00a0, 'non-breaking-space' ], // No-break space.
+	[ 0x202f, 'non-breaking-space' ], // Narrow no-break space.
+	[ 0x2007, 'non-breaking-space' ], // Figure space.
+
+	// Fixed width spaces from the general punctuation block.
+	[ 0x2000, 'space' ], // En quad.
+	[ 0x2001, 'space' ], // Em quad.
+	[ 0x2002, 'space' ], // En space.
+	[ 0x2003, 'space' ], // Em space.
+	[ 0x2004, 'space' ], // Three-per-em space.
+	[ 0x2005, 'space' ], // Four-per-em space.
+	[ 0x2006, 'space' ], // Six-per-em space.
+	[ 0x2008, 'space' ], // Punctuation space.
+	[ 0x2009, 'space' ], // Thin space.
+	[ 0x200a, 'space' ], // Hair space.
+	[ 0x3000, 'space' ], // Ideographic space.
+
+	// Characters with no width at all, which nothing else can reveal.
+	[ 0x200b, 'zero-width' ], // Zero width space.
+	[ 0x2060, 'zero-width' ], // Word joiner.
+	[ 0x00ad, 'zero-width' ], // Soft hyphen.
+];
+
+const CHARACTER_TYPES = new Map(
+	CHARACTER_CODE_POINTS.map( ( [ codePoint, characterType ] ) => [
+		String.fromCodePoint( codePoint ),
+		characterType,
+	] )
+);
+
+/**
+ * Builds the marker format for a single character.
+ *
+ * Each character gets its own object rather than a shared one, because the tree
+ * builder reuses an element whenever adjacent characters point at the same
+ * format reference. Sharing would collapse a run of spaces into one element
+ * carrying one marker, when a run of three spaces should show three.
+ *
+ * @param {string} characterType The kind of marker to draw.
+ *
+ * @return {Object} A rich text format object.
+ */
+function createFormat( characterType ) {
+	return {
+		type: name,
+		attributes: { characterType },
+	};
+}
+
+export const nonPrintingCharacters = {
+	name,
+	title,
+	tagName: 'span',
+	className: 'rich-text-non-printing-character',
+	attributes: {
+		characterType: 'data-rich-text-non-printing-character',
+	},
+	interactive: false,
+	object: false,
+	edit: () => null,
+	__experimentalGetPropsForEditableTreePreparation( select ) {
+		return {
+			isEnabled: !! select( preferencesStore ).get(
+				'core',
+				'showNonPrintingCharacters'
+			),
+		};
+	},
+	__experimentalCreatePrepareEditableTree( { isEnabled } ) {
+		return ( formats, text ) => {
+			if ( ! isEnabled ) {
+				return formats;
+			}
+
+			let newFormats;
+
+			for ( let index = 0; index < text.length; index++ ) {
+				const characterType = CHARACTER_TYPES.get( text[ index ] );
+
+				if ( ! characterType ) {
+					continue;
+				}
+
+				// Only pay for a copy once we know there is something to mark.
+				newFormats = newFormats || formats.slice();
+				newFormats[ index ] = [
+					...( newFormats[ index ] || [] ),
+					createFormat( characterType ),
+				];
+			}
+
+			return newFormats || formats;
+		};
+	},
+};

--- a/packages/format-library/src/non-printing-characters/test/index.js
+++ b/packages/format-library/src/non-printing-characters/test/index.js
@@ -1,0 +1,163 @@
+/**
+ * Internal dependencies
+ */
+import { nonPrintingCharacters } from '../';
+
+const FORMAT_NAME = 'core/non-printing-characters';
+
+// Named by code point rather than written as literals: a test about invisible
+// characters should not itself contain invisible characters.
+const SPACE = String.fromCodePoint( 0x0020 );
+const TAB = String.fromCodePoint( 0x0009 );
+const LINE_FEED = String.fromCodePoint( 0x000a );
+const NO_BREAK_SPACE = String.fromCodePoint( 0x00a0 );
+const NARROW_NO_BREAK_SPACE = String.fromCodePoint( 0x202f );
+const FIGURE_SPACE = String.fromCodePoint( 0x2007 );
+const ZERO_WIDTH_SPACE = String.fromCodePoint( 0x200b );
+const ZERO_WIDTH_JOINER = String.fromCodePoint( 0x200d );
+const ZERO_WIDTH_NO_BREAK_SPACE = String.fromCodePoint( 0xfeff );
+const OBJECT_REPLACEMENT_CHARACTER = String.fromCodePoint( 0xfffc );
+
+/**
+ * Builds the sparse formats array that rich text hands to a prepare handler.
+ *
+ * @param {string} text The text the formats belong to.
+ *
+ * @return {Array} A sparse array of the same length as the text.
+ */
+function emptyFormats( text ) {
+	const formats = [];
+	formats.length = text.length;
+	return formats;
+}
+
+function prepare( text, { isEnabled = true, formats } = {} ) {
+	return nonPrintingCharacters.__experimentalCreatePrepareEditableTree( {
+		isEnabled,
+	} )( formats ?? emptyFormats( text ), text );
+}
+
+/**
+ * Reads back the kind of marker applied at each index, or undefined where no
+ * marker was applied.
+ *
+ * @param {Array}  formats Prepared formats.
+ * @param {string} text    The text the formats belong to.
+ *
+ * @return {Array} Kind of marker per character.
+ */
+function markersOf( formats, text ) {
+	return Array.from( text ).map( ( character, index ) => {
+		const format = ( formats[ index ] || [] ).find(
+			( { type } ) => type === FORMAT_NAME
+		);
+		return format?.attributes.characterType;
+	} );
+}
+
+function hasNoMarkers( formats ) {
+	return ! formats.some( ( formatsAtIndex ) =>
+		( formatsAtIndex || [] ).some( ( { type } ) => type === FORMAT_NAME )
+	);
+}
+
+describe( 'nonPrintingCharacters', () => {
+	it( 'returns the formats untouched when the preference is off', () => {
+		const text = `a${ SPACE }b`;
+		const formats = emptyFormats( text );
+
+		expect( prepare( text, { isEnabled: false, formats } ) ).toBe(
+			formats
+		);
+	} );
+
+	it( 'returns the formats untouched when there is nothing to mark', () => {
+		const text = 'abc';
+		const formats = emptyFormats( text );
+
+		expect( prepare( text, { formats } ) ).toBe( formats );
+	} );
+
+	it( 'marks each kind of character it knows about', () => {
+		const text = [
+			'a',
+			SPACE,
+			NO_BREAK_SPACE,
+			TAB,
+			LINE_FEED,
+			ZERO_WIDTH_SPACE,
+			'b',
+		].join( '' );
+
+		expect( markersOf( prepare( text ), text ) ).toEqual( [
+			undefined,
+			'space',
+			'non-breaking-space',
+			'tab',
+			'line-break',
+			'zero-width',
+			undefined,
+		] );
+	} );
+
+	it( 'groups the narrow and figure spaces with the non-breaking space', () => {
+		const text = `${ NARROW_NO_BREAK_SPACE }${ FIGURE_SPACE }`;
+
+		expect( markersOf( prepare( text ), text ) ).toEqual( [
+			'non-breaking-space',
+			'non-breaking-space',
+		] );
+	} );
+
+	it( 'leaves zero width joiners alone so emoji sequences are not flagged', () => {
+		// Family emoji: three people held together by zero width joiners.
+		const text = [
+			String.fromCodePoint( 0x1f468 ),
+			ZERO_WIDTH_JOINER,
+			String.fromCodePoint( 0x1f469 ),
+			ZERO_WIDTH_JOINER,
+			String.fromCodePoint( 0x1f467 ),
+		].join( '' );
+
+		expect( hasNoMarkers( prepare( text ) ) ).toBe( true );
+	} );
+
+	it( 'leaves the characters rich text writes itself alone', () => {
+		// Padding and the object replacement character are not authored text.
+		const text = `${ ZERO_WIDTH_NO_BREAK_SPACE }${ OBJECT_REPLACEMENT_CHARACTER }`;
+
+		expect( hasNoMarkers( prepare( text ) ) ).toBe( true );
+	} );
+
+	it( 'gives each character in a run its own format reference', () => {
+		// The tree builder reuses one element for adjacent characters that
+		// share a format reference, which would draw a single marker for a run
+		// of spaces instead of one marker per space.
+		const text = SPACE.repeat( 3 );
+		const formats = prepare( text );
+
+		expect( formats[ 0 ][ 0 ] ).not.toBe( formats[ 1 ][ 0 ] );
+		expect( formats[ 1 ][ 0 ] ).not.toBe( formats[ 2 ][ 0 ] );
+	} );
+
+	it( 'keeps the formats that were already there and does not mutate them', () => {
+		const text = `a${ SPACE }b`;
+		const bold = { type: 'core/bold' };
+		const formats = emptyFormats( text );
+		formats[ 1 ] = [ bold ];
+
+		const prepared = prepare( text, { formats } );
+
+		// The marker is added inside the existing format, not in place of it.
+		expect( prepared[ 1 ] ).toEqual( [
+			bold,
+			{
+				type: FORMAT_NAME,
+				attributes: { characterType: 'space' },
+			},
+		] );
+		// The array rich text handed us is left as it was.
+		expect( formats[ 1 ] ).toEqual( [ bold ] );
+		expect( prepared ).not.toBe( formats );
+	} );
+} );


### PR DESCRIPTION
## What?
Closes #72232

Adds a **Show non-printing characters** preference (Preferences → Appearance, off by default). When enabled, the editor marks spaces, non-breaking spaces, tabs, line breaks, and zero-width characters, the way Word, Pages, InDesign, and VS Code do.

The markers exist only in the editable DOM tree. Nothing is written to the content, and nothing appears on the front end.

## Why?
Text pasted from Word, Google Docs, or a client's email routinely carries non-breaking spaces, narrow no-break spaces, zero-width spaces, and soft hyphens. These are indistinguishable from ordinary characters in both the visual editor and the code editor, so the only way to find one today is to delete a space and retype it and see whether the symptom disappears.

## Testing Instructions
1. Open a post and add a Paragraph block.
2. Open **Options → Preferences → Appearance** and turn on **Show non-printing characters**.
3. Type a few words. Each space shows a dot in the middle.
4. Insert a non-breaking space with <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd>. It shows the same dot on a tinted box, distinct from an ordinary space.
5. Press <kbd>Shift</kbd> + <kbd>Enter</kbd> for a line break. A return arrow appears at the end of the line.
6. Paste some text from Word or Google Docs that contains non-breaking spaces. They are now visible.
7. Turn the preference back off. All markers disappear and the text does not shift.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/f5da53bf-7c3a-4d44-896b-0b088f16e40d

## Use of AI Tools
This PR was authored with the assistance of Claude Opus.