### PR TITLE
Block states: pair focus states with a focus-within rule

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -178,6 +178,156 @@ function block_core_navigation_link_maybe_urldecode( $url ) {
 
 
 /**
+ * Converts preset references in a style value to CSS custom properties.
+ *
+ * State styles are emitted as CSS rules, so they cannot rely on the preset
+ * classnames the default state uses.
+ *
+ * @since 7.2.0
+ *
+ * @param mixed $value Style value.
+ * @return mixed Style value with preset references resolved.
+ */
+function block_core_navigation_link_resolve_preset_values( $value ) {
+	if ( is_array( $value ) ) {
+		foreach ( $value as $key => $nested_value ) {
+			$value[ $key ] = block_core_navigation_link_resolve_preset_values( $nested_value );
+		}
+		return $value;
+	}
+
+	if ( ! is_string( $value ) || ! str_starts_with( $value, 'var:preset|' ) ) {
+		return $value;
+	}
+
+	return 'var(--wp--' . str_replace( '|', '--', substr( $value, strlen( 'var:' ) ) ) . ')';
+}
+
+/**
+ * Returns the CSS declarations for a navigation link focus state.
+ *
+ * @since 7.2.0
+ *
+ * @param array $state_style Style object for a single focus state.
+ * @return array CSS declarations, marked important so they win over the
+ *               default state's inline styles and preset classnames.
+ */
+function block_core_navigation_link_get_focus_declarations( $state_style ) {
+	if ( ! is_array( $state_style ) || empty( $state_style ) ) {
+		return array();
+	}
+
+	$styles       = wp_style_engine_get_styles(
+		block_core_navigation_link_resolve_preset_values( $state_style )
+	);
+	$declarations = array();
+
+	foreach ( $styles['declarations'] ?? array() as $property => $value ) {
+		if ( '' === $value || null === $value ) {
+			continue;
+		}
+		$declarations[ $property ] = $value . ' !important';
+	}
+
+	return $declarations;
+}
+
+/**
+ * Builds the focus state CSS rules for a navigation link.
+ *
+ * The block's state styles are generated against the block's style root, which
+ * for a navigation link is the `<li>` wrapper. `:hover` and `:active` match an
+ * element while a descendant of it is hovered or activated, so those states
+ * work on the wrapper. Focus does not: it matches only the element that
+ * received focus, which is the `<a>` inside. Focus states therefore need rules
+ * of their own, scoped to the link.
+ *
+ * @since 7.2.0
+ *
+ * @param array $style The block's `style` attribute.
+ * @return array[] Style engine CSS rules, each with a `selector` placeholder of
+ *                 `%s` for the block instance class.
+ */
+function block_core_navigation_link_get_focus_state_rules( $style ) {
+	if ( ! is_array( $style ) ) {
+		return array();
+	}
+
+	$focus_states = array( ':focus', ':focus-visible' );
+	$rules        = array();
+
+	foreach ( $focus_states as $focus_state ) {
+		$declarations = block_core_navigation_link_get_focus_declarations( $style[ $focus_state ] ?? null );
+		if ( ! empty( $declarations ) ) {
+			$rules[] = array(
+				'selector'     => '%s > .wp-block-navigation-item__content' . $focus_state,
+				'declarations' => $declarations,
+			);
+		}
+	}
+
+	$viewport_settings        = wp_get_global_settings( array( 'viewport' ) );
+	$responsive_media_queries = array();
+	foreach ( array( 'WP_Theme_JSON_Gutenberg', 'WP_Theme_JSON' ) as $theme_json_class_name ) {
+		if ( method_exists( $theme_json_class_name, 'get_viewport_media_queries' ) ) {
+			$responsive_media_queries = $theme_json_class_name::get_viewport_media_queries( $viewport_settings );
+			break;
+		}
+	}
+
+	foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
+		foreach ( $focus_states as $focus_state ) {
+			$declarations = block_core_navigation_link_get_focus_declarations(
+				$style[ $breakpoint ][ $focus_state ] ?? null
+			);
+			if ( empty( $declarations ) ) {
+				continue;
+			}
+			$rules[] = array(
+				'selector'     => '%s > .wp-block-navigation-item__content' . $focus_state,
+				'declarations' => $declarations,
+				'rules_group'  => $media_query,
+			);
+		}
+	}
+
+	return $rules;
+}
+
+/**
+ * Registers the focus state styles for a navigation link and returns the class
+ * that scopes them to this block instance.
+ *
+ * @since 7.2.0
+ *
+ * @param array $attributes The block attributes.
+ * @return string Instance class name, or an empty string when the block has no
+ *                focus state styles.
+ */
+function block_core_navigation_link_get_focus_state_class( $attributes ) {
+	$rules = block_core_navigation_link_get_focus_state_rules( $attributes['style'] ?? null );
+
+	if ( empty( $rules ) ) {
+		return '';
+	}
+
+	// Instances with identical focus styles share a class, so the rules are
+	// only emitted once.
+	$instance_class = 'wp-nav-link-focus-' . substr( md5( wp_json_encode( $rules ) ), 0, 8 );
+
+	foreach ( $rules as $index => $rule ) {
+		$rules[ $index ]['selector'] = sprintf( $rule['selector'], ".$instance_class" );
+	}
+
+	wp_style_engine_get_stylesheet_from_css_rules(
+		$rules,
+		array( 'context' => 'block-supports' )
+	);
+
+	return $instance_class;
+}
+
+/**
  * Renders the `core/navigation-link` block.
  *
  * @since 5.9.0
@@ -224,10 +374,13 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		}
 	}
 
+	$focus_state_class = block_core_navigation_link_get_focus_state_class( $attributes );
+
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class' => $css_classes . ' wp-block-navigation-item' . ( $has_submenu ? ' has-child' : '' ) .
-				( $is_active ? ' current-menu-item' : '' ),
+				( $is_active ? ' current-menu-item' : '' ) .
+				( $focus_state_class ? " $focus_state_class" : '' ),
 		)
 	);
 	$html               = '<li ' . $wrapper_attributes . '>' .

--- a/phpunit/blocks/class-block-library-navigation-link-test.php
+++ b/phpunit/blocks/class-block-library-navigation-link-test.php
@@ -294,4 +294,104 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 			) !== false
 		);
 	}
+
+	/**
+	 * Focus states are generated against the block's style root, the `<li>`
+	 * wrapper, which never receives focus. They need rules of their own,
+	 * scoped to the link inside the item.
+	 */
+	public function test_focus_state_styles_are_scoped_to_the_link() {
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+
+		$class_name = gutenberg_block_core_navigation_link_get_focus_state_class(
+			array(
+				'style' => array(
+					':focus' => array( 'color' => array( 'text' => '#0000ff' ) ),
+				),
+			)
+		);
+
+		$this->assertNotEmpty( $class_name, 'A focus state should produce an instance class.' );
+
+		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context(
+			'block-supports',
+			array( 'prettify' => false )
+		);
+		$this->assertStringContainsString(
+			".$class_name > .wp-block-navigation-item__content:focus{color:#0000ff !important;}",
+			$stylesheet
+		);
+	}
+
+	/**
+	 * `:hover` and `:active` already match while a descendant of the wrapper is
+	 * hovered or activated, so they must not gain a second rule.
+	 */
+	public function test_hover_state_styles_are_left_to_the_states_block_support() {
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+
+		$class_name = gutenberg_block_core_navigation_link_get_focus_state_class(
+			array(
+				'style' => array(
+					':hover'  => array( 'color' => array( 'text' => '#ff0000' ) ),
+					':active' => array( 'color' => array( 'text' => '#00ff00' ) ),
+				),
+			)
+		);
+
+		$this->assertSame( '', $class_name );
+		$this->assertSame(
+			'',
+			gutenberg_style_engine_get_stylesheet_from_context(
+				'block-supports',
+				array( 'prettify' => false )
+			)
+		);
+	}
+
+	/**
+	 * Focus styles nested under a viewport state are wrapped in that
+	 * breakpoint's media query.
+	 */
+	public function test_responsive_focus_state_styles_are_wrapped_in_a_media_query() {
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+
+		$class_name = gutenberg_block_core_navigation_link_get_focus_state_class(
+			array(
+				'style' => array(
+					'@mobile' => array(
+						':focus' => array( 'color' => array( 'text' => '#0000ff' ) ),
+					),
+				),
+			)
+		);
+
+		$this->assertNotEmpty( $class_name );
+		$this->assertStringContainsString(
+			'{.' . $class_name . ' > .wp-block-navigation-item__content:focus{color:#0000ff !important;}}',
+			gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) )
+		);
+	}
+
+	/**
+	 * Preset references cannot rely on preset classnames once emitted as a CSS
+	 * rule, so they resolve to the preset custom property.
+	 */
+	public function test_focus_state_preset_values_resolve_to_custom_properties() {
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+
+		$class_name = gutenberg_block_core_navigation_link_get_focus_state_class(
+			array(
+				'style' => array(
+					':focus' => array( 'color' => array( 'text' => 'var:preset|color|accent-1' ) ),
+				),
+			)
+		);
+
+		$this->assertStringContainsString(
+			'color:var(--wp--preset--color--accent-1) !important;',
+			gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) )
+		);
+		$this->assertNotEmpty( $class_name );
+	}
 }


### PR DESCRIPTION
## What?

Closes #81256

Pairs a block's `:focus` and `:focus-visible` state styles with a rule that matches focus *inside* the styled element, so focus states apply to Navigation Link — on the front end as well as in the editor.

## Why?

Block state styles are generated against the block's style root. `core/navigation-link` declares no `selectors.root`, so its state CSS targets the block wrapper — the `<li>`:

```css
.wp-states-9d155b7a:hover { … }
.wp-states-9d155b7a:focus { … }   /* never matches */
```

`:hover` and `:active` match an element while a descendant of it is hovered or activated, so those states work: hovering the link hovers the item. Focus does not propagate that way — it matches only the element that received focus, the `<a>` inside. So `:focus` and `:focus-visible` on a Navigation Link had no effect at all, in the editor or on the front end.

`core/button` is unaffected because its `selectors.root` (`.wp-block-button .wp-block-button__link`) already points at the element that receives focus. That is the inconsistency reported in the issue.

## How?

For each focus state, emit a second rule with the equivalent "focus is inside me" selector — `:focus-within` for `:focus`, `:has(:focus-visible)` for `:focus-visible`:

- `lib/block-supports/states.php`: new `gutenberg_get_state_styles_with_focus_pairs()`, applied in the pseudo-state and responsive pseudo-state loops of `gutenberg_render_block_states_support()`.
- `packages/block-editor/src/hooks/style.js`: the same map in `getPseudoStateCSSRules()`, for the editor's block-instance state CSS.

`:hover` and `:active` are left alone — they already match while a descendant is hovered or activated. The paired rules are emitted separately, not as a selector list, so a browser without `:has()` support still honours the plain focus state. For blocks whose state styles already target the focusable element, the paired selector matches the same element and changes nothing. No block selectors change, so Global Styles output is untouched.

https://github.com/user-attachments/assets/a6eba14a-e04d-4881-95c2-9f3cc79f13d9

## Testing Instructions

1. Add a Navigation block with a Custom Link, and a Button block, to a page.
2. On the link, use the state control in the block card header to set **Hover** → red text, 40px, and **Focus** → blue text, 40px. Set the same on the Button. Return the state control to **Default**.
3. With the Navigation block selected, hover the link on the canvas → hover style applies. Click into the link's text → focus style applies. On `trunk` the focus style does nothing.
4. Save and view the page. Hover the link → hover style. <kbd>Tab</kbd> to the link → focus style applies. On `trunk` it never does.
5. Confirm the Button behaves exactly as on `trunk`.
6. Regression check: in Styles → Blocks → Custom Link, set a plain (Default state) text colour and confirm it still applies on the front end.

### Testing Instructions for Keyboard

Step 4 is the keyboard path: <kbd>Tab</kbd> through the navigation until the styled link receives focus and confirm the configured focus style applies. In the editor, move the caret into the link's text with the keyboard and confirm the focus style previews.
