### PR TITLE
In-editor revisions: Highlight changed words in the code diff

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Add a read-only code diff to the revisions screen ([#80314](https://github.com/WordPress/gutenberg/pull/80314)).
+-   In-editor revisions: Highlight changed words in the code diff ([#81273](https://github.com/WordPress/gutenberg/pull/81273)).
 
 ### New Features
 

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -145,12 +145,11 @@ function pairChangedLines( removedLines, addedLines ) {
  *
  * @param {string} removedLine Removed line.
  * @param {string} addedLine   Added line.
+ * @param {number} timeout     Milliseconds left for this word diff.
  * @return {?{removedSegments: Array<Object>, addedSegments: Array<Object>}} Segments per side.
  */
-function getLineSegments( removedLine, addedLine ) {
-	const wordDiff = diffWordsWithSpace( removedLine, addedLine, {
-		timeout: DIFF_TIMEOUT,
-	} );
+function getLineSegments( removedLine, addedLine, timeout ) {
+	const wordDiff = diffWordsWithSpace( removedLine, addedLine, { timeout } );
 	if ( ! wordDiff ) {
 		return null;
 	}
@@ -204,7 +203,10 @@ function getLineSegments( removedLine, addedLine ) {
  */
 function getIntraLineSegments( parts ) {
 	const segmentsByPart = new Map();
-	for ( let i = 0; i < parts.length - 1; i++ ) {
+	// Share one timeout across the pass so it cannot reset for every line pair.
+	const deadline = Date.now() + DIFF_TIMEOUT;
+
+	for ( let i = 0; i < parts.length - 1 && Date.now() < deadline; i++ ) {
 		if ( ! parts[ i ].removed || ! parts[ i + 1 ].added ) {
 			continue;
 		}
@@ -214,9 +216,14 @@ function getIntraLineSegments( parts ) {
 			removedLines,
 			addedLines
 		) ) {
+			const remaining = deadline - Date.now();
+			if ( remaining <= 0 ) {
+				break;
+			}
 			const segments = getLineSegments(
 				removedLines[ removedIndex ],
-				addedLines[ addedIndex ]
+				addedLines[ addedIndex ],
+				remaining
 			);
 			if ( ! segments ) {
 				continue;

--- a/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-code-diff.js
@@ -1,4 +1,4 @@
-import { diffLines } from 'diff';
+import { diffLines, diffWordsWithSpace } from 'diff';
 import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -11,6 +11,12 @@ import { unlock } from '../../lock-unlock';
 
 const MAX_DIFF_EDIT_LENGTH = 1000;
 const DIFF_TIMEOUT = 100;
+// Skip intra-line pairing when a block needs more than 2,500 line
+// comparisons (50 × 50). Pairing is O(n*m).
+const MAX_PAIRING_COMPARISONS = 2500;
+// Match the word-diff cutoff used by
+// WP_Text_Diff_Renderer_Table::$_diff_threshold in WordPress core.
+const INTRA_LINE_DIFF_THRESHOLD = 0.6;
 
 /**
  * Diff parts often end in a newline. Remove the trailing empty item so it is
@@ -28,8 +34,215 @@ function splitLines( value ) {
 }
 
 /**
+ * Counts how often each character appears in a line.
+ *
+ * @param {string} line Source line.
+ * @return {Map<string, number>} Character counts keyed by character.
+ */
+function getCharFrequency( line ) {
+	const frequency = new Map();
+	for ( const char of line ) {
+		frequency.set( char, ( frequency.get( char ) ?? 0 ) + 1 );
+	}
+	return frequency;
+}
+
+/**
+ * Calculates the normalized distance between two character-frequency maps.
+ * This follows WP_Text_Diff_Renderer_Table::compute_string_distance() in core.
+ *
+ * @param {Map<string, number>} removedFrequency Removed line frequencies.
+ * @param {Map<string, number>} addedFrequency   Added line frequencies.
+ * @param {number}              removedLength    Removed line length.
+ * @return {number} Distance per removed-line character.
+ */
+function getStringDistance( removedFrequency, addedFrequency, removedLength ) {
+	let difference = 0;
+	for ( const [ char, count ] of removedFrequency ) {
+		difference += Math.abs( count - ( addedFrequency.get( char ) ?? 0 ) );
+	}
+	for ( const [ char, count ] of addedFrequency ) {
+		if ( ! removedFrequency.has( char ) ) {
+			difference += count;
+		}
+	}
+	return difference / removedLength;
+}
+
+/**
+ * Greedily matches removed and added lines by string distance. This follows
+ * WP_Text_Diff_Renderer_Table::interleave_changed_lines() in core. The matches
+ * control word diffing without changing row order.
+ *
+ * @param {string[]} removedLines Removed lines.
+ * @param {string[]} addedLines   Added lines.
+ * @return {Array<[number, number]>} Matched [removed, added] index pairs.
+ */
+function pairChangedLines( removedLines, addedLines ) {
+	if ( removedLines.length * addedLines.length > MAX_PAIRING_COMPARISONS ) {
+		return [];
+	}
+
+	// Skip empty lines: they have no words to highlight and would cause a
+	// division by zero.
+	const removedCandidates = [];
+	removedLines.forEach( ( line, index ) => {
+		if ( line.length ) {
+			removedCandidates.push( {
+				index,
+				frequency: getCharFrequency( line ),
+			} );
+		}
+	} );
+	const addedCandidates = [];
+	addedLines.forEach( ( line, index ) => {
+		if ( line.length ) {
+			addedCandidates.push( {
+				index,
+				frequency: getCharFrequency( line ),
+			} );
+		}
+	} );
+
+	const matches = [];
+	for ( const removed of removedCandidates ) {
+		for ( const added of addedCandidates ) {
+			matches.push( {
+				removedIndex: removed.index,
+				addedIndex: added.index,
+				distance: getStringDistance(
+					removed.frequency,
+					added.frequency,
+					removedLines[ removed.index ].length
+				),
+			} );
+		}
+	}
+	matches.sort(
+		( a, b ) =>
+			a.distance - b.distance ||
+			a.removedIndex - b.removedIndex ||
+			a.addedIndex - b.addedIndex
+	);
+
+	const usedRemoved = new Set();
+	const usedAdded = new Set();
+	const pairs = [];
+	for ( const { removedIndex, addedIndex } of matches ) {
+		if ( usedRemoved.has( removedIndex ) || usedAdded.has( addedIndex ) ) {
+			continue;
+		}
+		usedRemoved.add( removedIndex );
+		usedAdded.add( addedIndex );
+		pairs.push( [ removedIndex, addedIndex ] );
+	}
+	return pairs;
+}
+
+/**
+ * Builds word-level segments for a matched pair. Returns null when the lines
+ * are identical, too different, or take too long to compare.
+ *
+ * @param {string} removedLine Removed line.
+ * @param {string} addedLine   Added line.
+ * @return {?{removedSegments: Array<Object>, addedSegments: Array<Object>}} Segments per side.
+ */
+function getLineSegments( removedLine, addedLine ) {
+	const wordDiff = diffWordsWithSpace( removedLine, addedLine, {
+		timeout: DIFF_TIMEOUT,
+	} );
+	if ( ! wordDiff ) {
+		return null;
+	}
+
+	let changedChars = 0;
+	let commonChars = 0;
+	for ( const part of wordDiff ) {
+		if ( part.added || part.removed ) {
+			changedChars += part.value.length;
+		} else {
+			commonChars += part.value.length;
+		}
+	}
+	if ( changedChars === 0 ) {
+		return null;
+	}
+	// Shared markup counts as common content. Since this view diffs raw markup
+	// without normalizing whitespace, the cutoff is looser than core's prose
+	// diff.
+	if (
+		changedChars / ( 2 * commonChars + changedChars ) >
+		INTRA_LINE_DIFF_THRESHOLD
+	) {
+		return null;
+	}
+
+	return {
+		removedSegments: wordDiff
+			.filter( ( part ) => ! part.added )
+			.map( ( part ) =>
+				part.removed
+					? { value: part.value, removed: true }
+					: { value: part.value }
+			),
+		addedSegments: wordDiff
+			.filter( ( part ) => ! part.removed )
+			.map( ( part ) =>
+				part.added
+					? { value: part.value, added: true }
+					: { value: part.value }
+			),
+	};
+}
+
+/**
+ * Pairs lines and builds word-level segments for each changed block. A changed
+ * block is a removed part followed by an added part.
+ *
+ * @param {Array<Object>} parts Line-diff parts.
+ * @return {Map<number, Map<number, Array<Object>>>} Segments keyed by part and line index.
+ */
+function getIntraLineSegments( parts ) {
+	const segmentsByPart = new Map();
+	for ( let i = 0; i < parts.length - 1; i++ ) {
+		if ( ! parts[ i ].removed || ! parts[ i + 1 ].added ) {
+			continue;
+		}
+		const removedLines = splitLines( parts[ i ].value );
+		const addedLines = splitLines( parts[ i + 1 ].value );
+		for ( const [ removedIndex, addedIndex ] of pairChangedLines(
+			removedLines,
+			addedLines
+		) ) {
+			const segments = getLineSegments(
+				removedLines[ removedIndex ],
+				addedLines[ addedIndex ]
+			);
+			if ( ! segments ) {
+				continue;
+			}
+			if ( ! segmentsByPart.has( i ) ) {
+				segmentsByPart.set( i, new Map() );
+			}
+			if ( ! segmentsByPart.has( i + 1 ) ) {
+				segmentsByPart.set( i + 1, new Map() );
+			}
+			segmentsByPart
+				.get( i )
+				.set( removedIndex, segments.removedSegments );
+			segmentsByPart
+				.get( i + 1 )
+				.set( addedIndex, segments.addedSegments );
+		}
+		// The added part cannot start another block.
+		i++;
+	}
+	return segmentsByPart;
+}
+
+/**
  * Creates the rows shown in the code diff and adds line numbers for both
- * revisions.
+ * revisions. Closely matched changed lines also include word-level segments.
  *
  * @param {string}  previousContent Previous revision content.
  * @param {string}  currentContent  Selected revision content.
@@ -53,10 +266,12 @@ export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
 			];
 		}
 	}
+	const segmentsByPart = showDiff ? getIntraLineSegments( parts ) : new Map();
+
 	let previousLineNumber = 1;
 	let currentLineNumber = 1;
 
-	return parts.flatMap( ( part ) => {
+	return parts.flatMap( ( part, partIndex ) => {
 		let status = 'unchanged';
 		if ( part.added ) {
 			status = 'added';
@@ -64,13 +279,18 @@ export function getCodeDiffRows( previousContent, currentContent, showDiff ) {
 			status = 'removed';
 		}
 
-		return splitLines( part.value ).map( ( value ) => {
+		return splitLines( part.value ).map( ( value, lineIndex ) => {
 			const row = {
 				value,
 				status,
 				previousLineNumber: null,
 				currentLineNumber: null,
 			};
+
+			const segments = segmentsByPart.get( partIndex )?.get( lineIndex );
+			if ( segments ) {
+				row.segments = segments;
+			}
 
 			if ( status !== 'added' && showDiff ) {
 				row.previousLineNumber = previousLineNumber++;
@@ -240,6 +460,28 @@ export function RevisionsCodeDiff( {
 								statusLabel = __( 'Removed' );
 							}
 
+							// Keep word-level highlights visual because the row
+							// already announces the change.
+							const code = row.segments
+								? row.segments.map(
+										( segment, segmentIndex ) =>
+											segment.added || segment.removed ? (
+												<span
+													key={ segmentIndex }
+													className={ `editor-revisions-code-diff__segment is-${
+														segment.added
+															? 'added'
+															: 'removed'
+													}` }
+												>
+													{ segment.value }
+												</span>
+											) : (
+												segment.value
+											)
+								  )
+								: row.value;
+
 							return (
 								<tr
 									key={ index }
@@ -264,7 +506,7 @@ export function RevisionsCodeDiff( {
 										</td>
 									) }
 									<td className="editor-revisions-code-diff__code">
-										<code>{ row.value }</code>
+										<code>{ code }</code>
 									</td>
 								</tr>
 							);

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -86,6 +86,17 @@ $revision-code-diff-marker-width: 3ch;
 	}
 }
 
+// Use a stronger tint for word-level changes than for the surrounding line.
+.editor-revisions-code-diff__segment {
+	&.is-added {
+		background: rgba($revision-diff-added-color, 0.3);
+	}
+
+	&.is-removed {
+		background: rgba($revision-diff-removed-color, 0.3);
+	}
+}
+
 .editor-revisions-code-diff__line-number,
 .editor-revisions-code-diff__marker {
 	position: sticky;

--- a/packages/editor/src/components/post-revisions-preview/style.scss
+++ b/packages/editor/src/components/post-revisions-preview/style.scss
@@ -95,6 +95,18 @@ $revision-code-diff-marker-width: 3ch;
 	&.is-removed {
 		background: rgba($revision-diff-removed-color, 0.3);
 	}
+
+	// Forced colors replace both background tints, so use text decoration to
+	// keep word-level changes visible.
+	@media (forced-colors: active) {
+		&.is-added {
+			text-decoration: underline;
+		}
+
+		&.is-removed {
+			text-decoration: line-through;
+		}
+	}
 }
 
 .editor-revisions-code-diff__line-number,

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -205,6 +205,27 @@ describe( 'getCodeDiffRows', () => {
 		expect( rows.every( ( row ) => ! ( 'segments' in row ) ) ).toBe( true );
 	} );
 
+	it( 'shares one time budget across word-level diffs', () => {
+		// These unrelated lines force word diffing to time out. All word diffs
+		// share one budget.
+		const makeContent = ( seed ) =>
+			Array.from( { length: 50 }, ( _, line ) =>
+				[ ...Array( 1000 ).keys() ]
+					.map( ( token ) => `w${ seed }${ line }_${ token }` )
+					.join( ' ' )
+			).join( '\n' );
+		const previousContent = `Start\n${ makeContent( 'a' ) }\nEnd\n`;
+		const currentContent = `Start\n${ makeContent( 'b' ) }\nEnd\n`;
+
+		const start = Date.now();
+		const rows = getCodeDiffRows( previousContent, currentContent, true );
+		const elapsed = Date.now() - start;
+
+		expect( rows ).toHaveLength( 102 );
+		expect( rows.every( ( row ) => ! ( 'segments' in row ) ) ).toBe( true );
+		expect( elapsed ).toBeLessThan( 1000 );
+	} );
+
 	it( 'skips blank lines when pairing changed blocks', () => {
 		const rows = getCodeDiffRows(
 			'Start\nAlpha beta gamma\n\nDelta epsilon zeta\nEnd\n',

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-code-diff.js
@@ -127,6 +127,100 @@ describe( 'getCodeDiffRows', () => {
 			currentLineNumber: 501,
 		} );
 	} );
+
+	it( 'adds word-level segments to similar changed lines', () => {
+		const rows = getCodeDiffRows(
+			'<p>Hello world</p>\n',
+			'<p>Hello there</p>\n',
+			true
+		);
+
+		expect( rows ).toHaveLength( 2 );
+		expect( rows[ 0 ].segments ).toEqual( [
+			{ value: '<p>Hello ' },
+			{ value: 'world', removed: true },
+			{ value: '</p>' },
+		] );
+		expect( rows[ 1 ].segments ).toEqual( [
+			{ value: '<p>Hello ' },
+			{ value: 'there', added: true },
+			{ value: '</p>' },
+		] );
+		// Each side's segments reconstruct the full line.
+		for ( const row of rows ) {
+			expect(
+				row.segments.map( ( segment ) => segment.value ).join( '' )
+			).toBe( row.value );
+		}
+	} );
+
+	it( 'keeps line-level highlighting for dissimilar lines', () => {
+		const rows = getCodeDiffRows( 'abcdefgh\n', 'stuvwxyz\n', true );
+
+		expect( rows ).toHaveLength( 2 );
+		expect( rows[ 0 ] ).not.toHaveProperty( 'segments' );
+		expect( rows[ 1 ] ).not.toHaveProperty( 'segments' );
+	} );
+
+	it( 'pairs changed lines by similarity rather than position', () => {
+		const rows = getCodeDiffRows(
+			'<p>The quick brown fox</p>\n<p>Completely unrelated words</p>\n',
+			'<p>Some other sentence entirely</p>\n<p>The quick brown foxes</p>\n',
+			true
+		);
+
+		expect( rows ).toHaveLength( 4 );
+		// The first removed line matches the second added line.
+		expect( rows[ 0 ].segments ).toEqual( [
+			{ value: '<p>The quick brown ' },
+			{ value: 'fox', removed: true },
+			{ value: '</p>' },
+		] );
+		expect( rows[ 3 ].segments ).toEqual( [
+			{ value: '<p>The quick brown ' },
+			{ value: 'foxes', added: true },
+			{ value: '</p>' },
+		] );
+		// The remaining lines are too different for word highlights.
+		expect( rows[ 1 ] ).not.toHaveProperty( 'segments' );
+		expect( rows[ 2 ] ).not.toHaveProperty( 'segments' );
+	} );
+
+	it( 'skips word-level pairing when a changed block is too large', () => {
+		const previousLines = Array.from(
+			{ length: 51 },
+			( _, index ) => `Before line ${ index }`
+		);
+		const currentLines = Array.from(
+			{ length: 51 },
+			( _, index ) => `After line ${ index }`
+		);
+		const rows = getCodeDiffRows(
+			`Start\n${ previousLines.join( '\n' ) }\nEnd\n`,
+			`Start\n${ currentLines.join( '\n' ) }\nEnd\n`,
+			true
+		);
+
+		expect( rows ).toHaveLength( 104 );
+		expect( rows.every( ( row ) => ! ( 'segments' in row ) ) ).toBe( true );
+	} );
+
+	it( 'skips blank lines when pairing changed blocks', () => {
+		const rows = getCodeDiffRows(
+			'Start\nAlpha beta gamma\n\nDelta epsilon zeta\nEnd\n',
+			'Start\nAlpha beta gamma changed\nDelta epsilon zeta changed\nEnd\n',
+			true
+		);
+
+		const blankRow = rows.find( ( row ) => row.value === '' );
+		expect( blankRow.status ).toBe( 'removed' );
+		expect( blankRow ).not.toHaveProperty( 'segments' );
+		// The non-blank lines around it still pair up.
+		expect( rows[ 1 ] ).toHaveProperty( 'segments' );
+		expect( rows[ 3 ] ).toHaveProperty( 'segments' );
+		expect( rows[ 4 ] ).toHaveProperty( 'segments' );
+		expect( rows[ 5 ] ).toHaveProperty( 'segments' );
+	} );
 } );
 
 describe( 'getCodeDiffDisplayState', () => {
@@ -183,11 +277,13 @@ describe( 'RevisionsCodeDiff', () => {
 		expect(
 			screen.getByRole( 'region', { name: 'Code changes' } )
 		).toBeVisible();
+		// jsdom inserts spaces between accessible names from adjacent inline
+		// nodes; browsers do not.
 		expect(
-			screen.getByRole( 'row', { name: /Removed.*<p>Before<\/p>/ } )
+			screen.getByRole( 'row', { name: /Removed.*<p>\s*Before\s*<\/p>/ } )
 		).toHaveClass( 'is-removed' );
 		expect(
-			screen.getByRole( 'row', { name: /Added.*<p>After<\/p>/ } )
+			screen.getByRole( 'row', { name: /Added.*<p>\s*After\s*<\/p>/ } )
 		).toHaveClass( 'is-added' );
 	} );
 
@@ -226,6 +322,33 @@ describe( 'RevisionsCodeDiff', () => {
 		expect(
 			screen.getByRole( 'row', { name: /Added.*<p>Oldest<\/p>/ } )
 		).toHaveClass( 'is-added' );
+	} );
+
+	it( 'highlights changed words without announcing them separately', () => {
+		renderCodeDiff( {
+			previousContent: '<!-- wp:paragraph -->\n<p>Hello world</p>',
+			currentContent: '<!-- wp:paragraph -->\n<p>Hello there</p>',
+		} );
+
+		expect(
+			screen.getByText( 'world', {
+				selector: '.editor-revisions-code-diff__segment.is-removed',
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByText( 'there', {
+				selector: '.editor-revisions-code-diff__segment.is-added',
+			} )
+		).toBeVisible();
+		// The row announces the change once. Highlight spans do not add
+		// insertion or deletion roles.
+		expect(
+			screen.getByRole( 'row', {
+				name: /Removed.*<p>Hello\s+world\s*<\/p>/,
+			} )
+		).toHaveClass( 'is-removed' );
+		expect( screen.queryAllByRole( 'deletion' ) ).toHaveLength( 0 );
+		expect( screen.queryAllByRole( 'insertion' ) ).toHaveLength( 0 );
 	} );
 
 	it( 'preserves blank source lines without inserting text', () => {


### PR DESCRIPTION
## What

Follow up to #80314, related to https://github.com/WordPress/gutenberg/issues/79120.

The revisions code diff now calls out individual word changes when added and removed lines are similar. When they are not, it keeps the existing full-line treatment.

## Why

Line-level coloring makes small text edits hard to spot in raw markup.

## How

Like the classic revisions screen, it falls back to the full-line treatment when lines are too different for a useful word diff. Because this version runs in the browser, oversized changed blocks and timed-out word comparisons use the same fallback.

Word highlights are visual only, leaving the existing row announcements unchanged. Forced-colors mode uses a strikethrough for removed words and an underline for added words.

## Testing Instructions

1. Create two revisions that include a small text edit and a fully replaced line.
2. Open the revisions screen, choose Options → Code editor, and turn on Show changes.
3. Confirm the small edit is highlighted at word level and the replaced line keeps the full-line highlight.
4. Emulate forced colors and confirm word-level changes remain distinguishable.

## Screenshots
| Before | After |
| - | - |
| <img width="744" height="277" alt="image" src="https://github.com/user-attachments/assets/b03284cc-b71d-4b10-881d-2be023d195e3" /> | <img width="756" height="265" alt="image" src="https://github.com/user-attachments/assets/aa1c1e42-7363-44c6-a497-c4051f835937" /> |
---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
