### PR TITLE
[WIP]Editor: show the welcome guide before the pattern modal

### DIFF
--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Wrap the post editor layout in `ThemeProvider`, seeded with the active admin color scheme primary color ([#81112](https://github.com/WordPress/gutenberg/pull/81112)).
 
+### Internal
+
+-   Welcome guide: Register the guide as the active modal in the interface store while it is on screen, so other editor UI can wait for it to be dismissed ([#65104](https://github.com/WordPress/gutenberg/issues/65104)).
+
 ## 8.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/edit-post/src/components/welcome-guide/index.js
+++ b/packages/edit-post/src/components/welcome-guide/index.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -9,6 +11,9 @@ import { useSelect } from '@wordpress/data';
 import WelcomeGuideDefault from './default';
 import WelcomeGuideTemplate from './template';
 import { store as editPostStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { interfaceStore } = unlock( editorPrivateApis );
 
 export default function WelcomeGuide( { postType } ) {
 	const { isActive, isEditingTemplate } = useSelect(
@@ -26,6 +31,25 @@ export default function WelcomeGuide( { postType } ) {
 		},
 		[ postType ]
 	);
+	const { openModal, closeModal } = useDispatch( interfaceStore );
+	const { isModalActive } = useSelect( interfaceStore );
+
+	// Register the guide so that other editor UI, such as the "Choose a
+	// pattern" modal, can wait for it to be dismissed before showing.
+	useEffect( () => {
+		if ( ! isActive ) {
+			return;
+		}
+
+		openModal( 'editor/welcome-guide' );
+
+		return () => {
+			// Only close if another modal hasn't taken over in the meantime.
+			if ( isModalActive( 'editor/welcome-guide' ) ) {
+				closeModal();
+			}
+		};
+	}, [ isActive, openModal, closeModal, isModalActive ] );
 
 	if ( ! isActive ) {
 		return null;

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Welcome guides: Register the visible guide as the active modal in the interface store, so other editor UI can wait for it to be dismissed ([#65104](https://github.com/WordPress/gutenberg/issues/65104)).
+
 ## 7.0.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -12,6 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import WelcomeGuideImage from './image';
+import useRegisterWelcomeGuide from './use-register-welcome-guide';
 
 export default function WelcomeGuideEditor() {
 	const { toggle } = useDispatch( preferencesStore );
@@ -26,6 +27,8 @@ export default function WelcomeGuideEditor() {
 				select( coreStore ).getCurrentTheme()?.is_block_theme,
 		};
 	}, [] );
+
+	useRegisterWelcomeGuide( isActive && isBlockBasedTheme );
 
 	if ( ! isActive || ! isBlockBasedTheme ) {
 		return null;

--- a/packages/edit-site/src/components/welcome-guide/page.js
+++ b/packages/edit-site/src/components/welcome-guide/page.js
@@ -6,6 +6,11 @@ import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 
+/**
+ * Internal dependencies
+ */
+import useRegisterWelcomeGuide from './use-register-welcome-guide';
+
 export default function WelcomeGuidePage() {
 	const { toggle } = useDispatch( preferencesStore );
 
@@ -20,6 +25,8 @@ export default function WelcomeGuidePage() {
 		);
 		return isPageActive && ! isEditorActive;
 	}, [] );
+
+	useRegisterWelcomeGuide( isVisible );
 
 	if ( ! isVisible ) {
 		return null;

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -7,6 +7,11 @@ import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import useRegisterWelcomeGuide from './use-register-welcome-guide';
+
 export default function WelcomeGuideTemplate() {
 	const { toggle } = useDispatch( preferencesStore );
 
@@ -20,6 +25,8 @@ export default function WelcomeGuideTemplate() {
 		};
 	}, [] );
 	const isVisible = isActive && hasPreviousEntity;
+
+	useRegisterWelcomeGuide( isVisible );
 
 	if ( ! isVisible ) {
 		return null;

--- a/packages/edit-site/src/components/welcome-guide/use-register-welcome-guide.js
+++ b/packages/edit-site/src/components/welcome-guide/use-register-welcome-guide.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { privateApis as editorPrivateApis } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { interfaceStore } = unlock( editorPrivateApis );
+
+/**
+ * Registers a visible welcome guide with the interface store so that other
+ * editor UI, such as the "Choose a pattern" modal, can wait for the guide to be
+ * dismissed before showing itself.
+ *
+ * @param {boolean} isVisible Whether the guide is currently on screen.
+ */
+export default function useRegisterWelcomeGuide( isVisible ) {
+	const { openModal, closeModal } = useDispatch( interfaceStore );
+	const { isModalActive } = useSelect( interfaceStore );
+
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		openModal( 'editor/welcome-guide' );
+
+		return () => {
+			// Only close if another modal hasn't taken over in the meantime.
+			if ( isModalActive( 'editor/welcome-guide' ) ) {
+				closeModal();
+			}
+		};
+	}, [ isVisible, openModal, closeModal, isModalActive ] );
+}

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   Start page options: Don't open the "Choose a pattern" modal while a welcome guide is showing. The guide introduces the editor itself, so it now takes precedence, and the pattern modal opens once the guide is dismissed ([#65104](https://github.com/WordPress/gutenberg/issues/65104)).
 -   Device Preview: Keep tablet and mobile iframe widths inside their responsive breakpoints so media queries remain accurate at browser zoom levels.
 -   Document tools: Fix icon button focus styles to use the design system `outset-ring__focus` mixin ([#81115](https://github.com/WordPress/gutenberg/pull/81115)).
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -24,6 +24,14 @@ import {
 } from '../../store/constants';
 import { store as editorStore } from '../../store';
 
+/**
+ * Name the welcome guides register themselves under in the interface store.
+ * Registration happens in each editor, so this only ever reflects a guide that
+ * is actually rendered — unlike the underlying preferences, which are shared
+ * between editors and would leak across them.
+ */
+const WELCOME_GUIDE_MODAL_NAME = 'editor/welcome-guide';
+
 export function useStartPatterns() {
 	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
 	// and it has no postTypes declared and the current post type is page or if
@@ -147,23 +155,33 @@ export default function StartPageOptions() {
 	const { isEditedPostEmpty } = useSelect( editorStore );
 	const { getEntityRecordNonTransientEdits } = useSelect( coreStore );
 	const { isModalActive } = useSelect( interfaceStore );
-	const { enabled, postType, postId } = useSelect( ( select ) => {
-		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
-		const choosePatternModalEnabled = select( preferencesStore ).get(
-			'core',
-			'enableChoosePatternModal'
-		);
-		const currentPostType = getCurrentPostType();
-		return {
-			postType: currentPostType,
-			postId: getCurrentPostId(),
-			enabled:
-				choosePatternModalEnabled &&
-				ATTACHMENT_POST_TYPE !== currentPostType &&
-				TEMPLATE_POST_TYPE !== currentPostType &&
-				TEMPLATE_PART_POST_TYPE !== currentPostType,
-		};
-	}, [] );
+	const { enabled, postType, postId, isWelcomeGuideActive } = useSelect(
+		( select ) => {
+			const { getCurrentPostId, getCurrentPostType } =
+				select( editorStore );
+			const { get: getPreference } = select( preferencesStore );
+			const choosePatternModalEnabled = getPreference(
+				'core',
+				'enableChoosePatternModal'
+			);
+			const currentPostType = getCurrentPostType();
+			return {
+				postType: currentPostType,
+				postId: getCurrentPostId(),
+				// Read reactively so that dismissing the guide re-runs the
+				// effect below and opens this modal in its place.
+				isWelcomeGuideActive: select( interfaceStore ).isModalActive(
+					WELCOME_GUIDE_MODAL_NAME
+				),
+				enabled:
+					choosePatternModalEnabled &&
+					ATTACHMENT_POST_TYPE !== currentPostType &&
+					TEMPLATE_POST_TYPE !== currentPostType &&
+					TEMPLATE_PART_POST_TYPE !== currentPostType,
+			};
+		},
+		[]
+	);
 
 	// Note: The `postId` ensures the effect re-runs when pages are switched without remounting the component.
 	// Examples: changing pages in the List View, creating a new page via Command Palette.
@@ -198,7 +216,12 @@ export default function StartPageOptions() {
 		isModalActive,
 	] );
 
-	if ( ! isOpen ) {
+	// Checked at render rather than in the effect above. The welcome guide is
+	// rendered as part of `children`, so it registers itself in the same commit
+	// that runs this component's effect, which would still see no active guide
+	// and open on top of it. Holding the modal back here is order-independent:
+	// it stays queued while a guide is on screen and appears once it closes.
+	if ( ! isOpen || isWelcomeGuideActive ) {
 		return null;
 	}
 


### PR DESCRIPTION
### Works in progress 🚧 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/65104

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
