### PR TITLE
Style states: fix state deselection when selecting the already selected block

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2339,7 +2339,14 @@ export function selectedBlockStyleState( state = undefined, action ) {
 
 		case 'SELECT_BLOCK':
 		case 'SELECTION_CHANGE': {
-			if ( state?.clientId && state.clientId !== action.clientId ) {
+			const startClientId = action.clientId ?? action.start?.clientId;
+			const endClientId = action.clientId ?? action.end?.clientId;
+
+			if (
+				state?.clientId &&
+				( startClientId !== endClientId ||
+					state.clientId !== startClientId )
+			) {
 				return undefined;
 			}
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -6108,6 +6108,36 @@ describe( 'state', () => {
 			expect( state ).toBeUndefined();
 		} );
 
+		it( 'keeps the selected state for selection changes within the same block', () => {
+			const originalState = {
+				clientId: 'client-1',
+				value: { viewport: 'default', pseudo: ':hover' },
+			};
+			const state = selectedBlockStyleState( originalState, {
+				type: 'SELECTION_CHANGE',
+				start: { clientId: 'client-1' },
+				end: { clientId: 'client-1' },
+			} );
+
+			expect( state ).toBe( originalState );
+		} );
+
+		it( 'clears the selected state for selection changes across multiple blocks', () => {
+			const state = selectedBlockStyleState(
+				{
+					clientId: 'client-1',
+					value: { viewport: 'default', pseudo: ':hover' },
+				},
+				{
+					type: 'SELECTION_CHANGE',
+					start: { clientId: 'client-1' },
+					end: { clientId: 'client-2' },
+				}
+			);
+
+			expect( state ).toBeUndefined();
+		} );
+
 		it( 'keeps the selected state when selection resets to the same block', () => {
 			const originalState = {
 				clientId: 'client-1',


### PR DESCRIPTION
## What?
Fixes #81254, the selected style state was being lost whenever clicking into the already selected block.

## How?
The bug was due to an incorrect case in the reducer for the selected style state. The `SELECTION_CHANGE` action usually dispatches a `start.clientId` and `end.clientId`, not just a `clientId`. The reducer was not handling this.

The code is now updated to preserve the selected state for single block selections if the selected block doesn't change.

## Testing Instructions
1. Add a button block
2. Open the inspector and select the 'Hover' state
3. Click the button in the canvas

In trunk: The 'Hover' state becomes deselected
In this PR: The 'Hover' state remains

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/dd0876a6-3f58-460b-abb3-199a1cb8f355

## Use of AI Tools
OpenCode / Codex