### PR TITLE
Block Editor: Keep the selected pseudo-state when the caret moves within the block

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 
+-   `selectedBlockStyleState`: Resolve the client ID from the `start`/`end` payload shape of `SELECTION_CHANGE`, so a caret change inside the block's rich text no longer clears the selected pseudo-state. Placing the caret in a Button's label reverted the block inspector's state picker to Default ([#81254](https://github.com/WordPress/gutenberg/issues/81254)).
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   Gate the HEIC canvas conversion fallback on `window.__clientSideMediaProcessing` instead of the redundant `window.__heicUploadSupport` flag, fixing client-side HEIC conversion in Safari on core WordPress installs ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 -   `URLInput`: Request suggestions for a value the field is mounted with, instead of waiting for the input to be focused, and stop requesting initial suggestions on mount when `disableSuggestions` is set ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2339,7 +2339,22 @@ export function selectedBlockStyleState( state = undefined, action ) {
 
 		case 'SELECT_BLOCK':
 		case 'SELECTION_CHANGE': {
-			if ( state?.clientId && state.clientId !== action.clientId ) {
+			if ( ! state?.clientId ) {
+				break;
+			}
+
+			// `SELECTION_CHANGE` has two payload shapes: a flat one with a
+			// `clientId`, and one carrying `start`/`end` selection points
+			// instead, as dispatched by rich text on every caret change.
+			const clientIds = [
+				action.clientId,
+				action.start?.clientId,
+				action.end?.clientId,
+			].filter( Boolean );
+
+			// Without a client ID there's nothing to compare against, so the
+			// selected state is left untouched rather than cleared.
+			if ( clientIds.length && ! clientIds.includes( state.clientId ) ) {
 				return undefined;
 			}
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -6108,6 +6108,60 @@ describe( 'state', () => {
 			expect( state ).toBeUndefined();
 		} );
 
+		it( 'keeps the selected state for rich text selection changes in the same block', () => {
+			const originalState = {
+				clientId: 'client-1',
+				value: { viewport: 'default', pseudo: ':hover' },
+			};
+			const state = selectedBlockStyleState( originalState, {
+				type: 'SELECTION_CHANGE',
+				start: {
+					clientId: 'client-1',
+					attributeKey: 'text',
+					offset: 0,
+				},
+				end: { clientId: 'client-1', attributeKey: 'text', offset: 0 },
+			} );
+
+			expect( state ).toBe( originalState );
+		} );
+
+		it( 'clears the selected state for rich text selection changes in another block', () => {
+			const state = selectedBlockStyleState(
+				{
+					clientId: 'client-1',
+					value: { viewport: 'default', pseudo: ':hover' },
+				},
+				{
+					type: 'SELECTION_CHANGE',
+					start: {
+						clientId: 'client-2',
+						attributeKey: 'text',
+						offset: 0,
+					},
+					end: {
+						clientId: 'client-2',
+						attributeKey: 'text',
+						offset: 0,
+					},
+				}
+			);
+
+			expect( state ).toBeUndefined();
+		} );
+
+		it( 'keeps the selected state for selection changes without a client ID', () => {
+			const originalState = {
+				clientId: 'client-1',
+				value: { viewport: 'default', pseudo: ':hover' },
+			};
+			const state = selectedBlockStyleState( originalState, {
+				type: 'SELECTION_CHANGE',
+			} );
+
+			expect( state ).toBe( originalState );
+		} );
+
 		it( 'keeps the selected state when selection resets to the same block', () => {
 			const originalState = {
 				clientId: 'client-1',

--- a/test/e2e/specs/editor/various/block-style-state-selection.spec.js
+++ b/test/e2e/specs/editor/various/block-style-state-selection.spec.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Block pseudo-state selection', () => {
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/buttons',
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: { text: 'Click me' },
+				},
+			],
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'keeps the selected pseudo-state when the caret moves within the block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const buttonText = editor.canvas.getByRole( 'textbox', {
+			name: 'Button text',
+		} );
+		await buttonText.click();
+
+		// Switch the block's editing context to the Hover pseudo-state.
+		await page.getByRole( 'button', { name: 'State: Default' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Hover' } ).click();
+		await page.keyboard.press( 'Escape' );
+
+		const hoverToggle = page.getByRole( 'button', {
+			name: 'State: Hover',
+		} );
+		await expect( hoverToggle ).toBeVisible();
+
+		// Clicking the button's label to edit it dispatches a rich text
+		// selection change, which used to clear the selected pseudo-state.
+		await buttonText.click();
+
+		await expect( hoverToggle ).toBeVisible();
+	} );
+
+	test( 'clears the selected pseudo-state when another block is selected', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'A paragraph' },
+		} );
+		await editor.openDocumentSettingsSidebar();
+
+		const buttonText = editor.canvas.getByRole( 'textbox', {
+			name: 'Button text',
+		} );
+		await buttonText.click();
+
+		await page.getByRole( 'button', { name: 'State: Default' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Hover' } ).click();
+		await page.keyboard.press( 'Escape' );
+
+		await expect(
+			page.getByRole( 'button', { name: 'State: Hover' } )
+		).toBeVisible();
+
+		// Selecting a different block resets the state.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+		await buttonText.click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'State: Default' } )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
## What?

Fixes #81254

Fixes the block inspector's pseudo-state picker resetting to Default when you click a Button block to style its Hover / Focus / Active state.

## Why?
`selectionChange` has two payload shapes — a flat one carrying `clientId`, and one carrying `start`/`end` selection points instead: https://github.com/WordPress/gutenberg/blob/6e365e3537/packages/block-editor/src/store/actions.js#L1659-L1676

Rich text dispatches the second on every caret change: https://github.com/WordPress/gutenberg/blob/6e365e3537/packages/block-editor/src/components/rich-text/index.js#L327

The `selectedBlockStyleState` reducer only handled the flat shape: https://github.com/WordPress/gutenberg/blob/6e365e3537/packages/block-editor/src/store/reducer.js#L2340-L2347

For the `start`/`end` shape `action.clientId` is `undefined`, so `state.clientId !== action.clientId` always held and the selected state was cleared. A Button's label is a rich text field, so the very act of clicking the button to configure its style flipped the inspector out of the state being configured.

## How?
Resolve the client ID from either payload shape before comparing, and leave the selected state untouched when no client ID can be determined — there is nothing to compare against, so clearing is the wrong default.

`RESET_SELECTION` already reads `action.selectionStart?.clientId`, so it was unaffected.

## Testing Instructions
1. Add a Buttons block with a Button.
2. Select the Button, and in the Block sidebar open the state menu (⋮ in the block card) → **Pseudo state** → **Hover**.
3. Confirm the sidebar shows the **Hover** badge and the **Show state on canvas** toggle.
4. Click the button's label in the canvas to edit it.
5. The **Hover** badge stays. On trunk it disappears and the inspector reverts to the default state.
6. Regression check: with Hover selected, click a *different* block, then reselect the Button — the state should be back to Default.

### Testing Instructions for Keyboard
1. Follow steps 1–3 above, opening the state menu with <kbd>Enter</kbd> and choosing Hover with the arrow keys.
2. Press <kbd>Escape</kbd> to close the menu, then move focus into the canvas and to the Button's label (<kbd>Enter</kbd> to enter edit mode, arrow keys to move the caret within the text).
3. Moving the caret with the arrow keys keeps the **Hover** badge in the sidebar.

## Screenshots or screencast

|<img width="280" height="591" alt="01-hover-selected" src="https://github.com/user-attachments/assets/9a546cd1-e4ed-4ced-9c5d-da8f6e489892" />|<img width="280" height="591" alt="01-hover-selected" src="https://github.com/user-attachments/assets/7203244d-9240-48ed-bb45-febca7aee9bb" />|
|<img width="280" height="591" alt="02-after-click" src="https://github.com/user-attachments/assets/b22efcb6-9026-4755-8834-5a8fa4dd2615" />|<img width="280" height="591" alt="02-after-click" src="https://github.com/user-attachments/assets/930fd705-f16f-4c14-b53e-3d1e252cb859" />|

## Use of AI Tools

Usage of AI: Yes
Model: Claude Code Opus 5
Used for: To trace the root cause, write the fix, and write the unit and e2e test coverage