### PR TITLE
Address GHSAs for phpcs, wpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 	},
 	"require-dev": {
 		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
-		"wp-coding-standards/wpcs": "^3.0",
+		"wp-coding-standards/wpcs": "^3.4.1",
+		"squizlabs/php_codesniffer": "^3.13.6",
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
 		"spatie/phpunit-watcher": "^1.23",
 		"yoast/phpunit-polyfills": "^1.1.0",

--- a/test/php/gutenberg-coding-standards/composer.json
+++ b/test/php/gutenberg-coding-standards/composer.json
@@ -20,7 +20,7 @@
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.7.2",
+		"squizlabs/php_codesniffer": "^3.13.6",
 		"phpcsstandards/phpcsutils": "^1.0.8"
 	},
 	"require-dev": {
@@ -28,7 +28,7 @@
 		"phpunit/phpunit": "^5.0 || ^6.0 || ^7.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
-		"wp-coding-standards/wpcs": "^3.0"
+		"wp-coding-standards/wpcs": "^3.4.1"
 	},
 	"suggest": {
 		"ext-mbstring": "For improved results"


### PR DESCRIPTION

## What?
Address:
- https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq
- https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v


## How?
- Bump `wpcs` dependency version.
- Add explicit dependency on `phpcs` to ensure a fixed version is used.

## Testing Instructions
CI runs and passes.
