### PR TITLE
In-editor revisions: Show title and excerpt changes in the revisions sidebar

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Revisions: Rename the Meta panel to Fields and show title and excerpt changes alongside post meta ([#81281](https://github.com/WordPress/gutenberg/pull/81281)).
 -   Add a read-only code diff to the revisions screen ([#80314](https://github.com/WordPress/gutenberg/pull/80314)).
 
 ### New Features

--- a/packages/editor/src/components/revision-diff-panel/index.js
+++ b/packages/editor/src/components/revision-diff-panel/index.js
@@ -11,16 +11,20 @@ import PostPanelRow from '../post-panel-row';
 /**
  * Renders a panel of word-level diffs.
  *
- * @param {Object}  props
- * @param {string}  props.title       Panel title.
- * @param {Object}  props.entries     Map of key → diffWords parts arrays.
- * @param {boolean} props.initialOpen Whether the panel starts open.
- * @param {string}  [props.className] Optional class for the content wrapper.
+ * @param {Object}   props
+ * @param {string}   props.title       Panel title.
+ * @param {Object}   props.entries     Map of key → diffWords parts arrays.
+ * @param {boolean}  props.initialOpen Whether the panel starts open.
+ * @param {boolean}  [props.opened]    Current open state in controlled mode.
+ * @param {Function} [props.onToggle]  Receives the next open state.
+ * @param {string}   [props.className] Optional class for the content wrapper.
  */
 export default function RevisionDiffPanel( {
 	title,
 	entries,
 	initialOpen,
+	opened,
+	onToggle,
 	className,
 } ) {
 	if ( ! entries ) {
@@ -58,7 +62,12 @@ export default function RevisionDiffPanel( {
 	) );
 
 	return (
-		<PanelBody title={ title } initialOpen={ initialOpen }>
+		<PanelBody
+			title={ title }
+			initialOpen={ initialOpen }
+			opened={ opened }
+			onToggle={ onToggle }
+		>
 			<div className={ className }>{ fields }</div>
 		</PanelBody>
 	);

--- a/packages/editor/src/components/revision-fields-diff/index.js
+++ b/packages/editor/src/components/revision-fields-diff/index.js
@@ -12,7 +12,7 @@ import { diffWordsWithSpace } from 'diff';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -49,58 +49,106 @@ function isEmptyMeta( str ) {
 }
 
 /**
- * Panel that shows meta field diffs between the current revision and
- * the previous revision in the document sidebar during revision mode.
+ * Builds the field diffs shown in the sidebar.
+ *
+ * Title and excerpt only appear when they changed. Meta fields keep their
+ * existing behavior and appear when either revision has a non-empty value.
+ *
+ * @param {Object}      revision         The current revision record.
+ * @param {Object|null} previousRevision The previous revision record.
+ * @return {Object} Field diff entries and whether the title or excerpt changed.
+ */
+export function getFieldsDiffEntries( revision, previousRevision ) {
+	if ( ! revision ) {
+		return { entries: null, hasChangedPostFields: false };
+	}
+
+	const entries = {};
+	let hasChangedPostFields = false;
+
+	for ( const [ label, field ] of [
+		[ __( 'Title' ), 'title' ],
+		[ __( 'Excerpt' ), 'excerpt' ],
+	] ) {
+		const revStr = revision[ field ]?.raw ?? '';
+		const prevStr = previousRevision?.[ field ]?.raw ?? '';
+
+		if ( revStr !== prevStr ) {
+			entries[ label ] = diffWordsWithSpace( prevStr, revStr );
+			hasChangedPostFields = true;
+		}
+	}
+
+	const revisionMeta = revision.meta ?? {};
+	const previousMeta = previousRevision?.meta ?? {};
+	const allMetaKeys = new Set( [
+		...Object.keys( revisionMeta ),
+		...Object.keys( previousMeta ),
+	] );
+
+	for ( const key of allMetaKeys ) {
+		const revStr = stringifyValue( revisionMeta[ key ] );
+		const prevStr = stringifyValue( previousMeta[ key ] );
+
+		if ( isEmptyMeta( revStr ) && isEmptyMeta( prevStr ) ) {
+			continue;
+		}
+
+		entries[ key ] = diffWordsWithSpace( prevStr, revStr );
+	}
+
+	if ( Object.keys( entries ).length === 0 ) {
+		return { entries: null, hasChangedPostFields: false };
+	}
+
+	return { entries, hasChangedPostFields };
+}
+
+/**
+ * Shows title, excerpt, and meta field changes in the revisions sidebar.
  */
 export default function RevisionFieldsDiffPanel() {
-	const { revision, previousRevision } = useSelect( ( select ) => {
-		const { getCurrentRevision, getPreviousRevision } = unlock(
-			select( editorStore )
-		);
+	const { revision, previousRevision, revisionId } = useSelect(
+		( select ) => {
+			const {
+				getCurrentRevision,
+				getPreviousRevision,
+				getCurrentRevisionId,
+			} = unlock( select( editorStore ) );
 
-		return {
-			revision: getCurrentRevision(),
-			previousRevision: getPreviousRevision(),
-		};
-	}, [] );
+			return {
+				revision: getCurrentRevision(),
+				previousRevision: getPreviousRevision(),
+				revisionId: getCurrentRevisionId(),
+			};
+		},
+		[]
+	);
 
-	const entries = useMemo( () => {
-		if ( ! revision ) {
-			return null;
+	const { entries, hasChangedPostFields } = useMemo(
+		() => getFieldsDiffEntries( revision, previousRevision ),
+		[ revision, previousRevision ]
+	);
+
+	const [ isOpen, setIsOpen ] = useState( hasChangedPostFields );
+
+	/*
+	 * `PanelBody` only reads `initialOpen` when it mounts, but this panel stays
+	 * mounted while the selected revision changes. Open it for title or excerpt
+	 * changes. Once open, leave it open until the user closes it.
+	 */
+	useEffect( () => {
+		if ( hasChangedPostFields ) {
+			setIsOpen( true );
 		}
-
-		const revisionMeta = revision.meta ?? {};
-		const previousMeta = previousRevision?.meta ?? {};
-		const allMetaKeys = new Set( [
-			...Object.keys( revisionMeta ),
-			...Object.keys( previousMeta ),
-		] );
-
-		const result = {};
-
-		for ( const key of allMetaKeys ) {
-			const revStr = stringifyValue( revisionMeta[ key ] );
-			const prevStr = stringifyValue( previousMeta[ key ] );
-
-			if ( isEmptyMeta( revStr ) && isEmptyMeta( prevStr ) ) {
-				continue;
-			}
-
-			result[ key ] = diffWordsWithSpace( prevStr, revStr );
-		}
-
-		if ( Object.keys( result ).length === 0 ) {
-			return null;
-		}
-
-		return result;
-	}, [ revision, previousRevision ] );
+	}, [ revisionId, hasChangedPostFields ] );
 
 	return (
 		<RevisionDiffPanel
-			title={ __( 'Meta' ) }
+			title={ __( 'Fields' ) }
 			entries={ entries }
-			initialOpen={ false }
+			opened={ isOpen }
+			onToggle={ setIsOpen }
 			className="editor-revision-meta-diff__content"
 		/>
 	);

--- a/packages/editor/src/components/revision-fields-diff/test/index.js
+++ b/packages/editor/src/components/revision-fields-diff/test/index.js
@@ -1,0 +1,89 @@
+/**
+ * Internal dependencies
+ */
+import { getFieldsDiffEntries } from '../';
+
+function getText( parts, type ) {
+	return parts
+		.filter( ( part ) => Boolean( part[ type ] ) )
+		.map( ( part ) => part.value )
+		.join( '' );
+}
+
+describe( 'getFieldsDiffEntries', () => {
+	it( 'returns no entries without a revision', () => {
+		expect( getFieldsDiffEntries( null, null ) ).toEqual( {
+			entries: null,
+			hasChangedPostFields: false,
+		} );
+	} );
+
+	it( 'diffs the title against the previous revision', () => {
+		const { entries, hasChangedPostFields } = getFieldsDiffEntries(
+			{ title: { raw: 'New title' } },
+			{ title: { raw: 'Old title' } }
+		);
+
+		expect( hasChangedPostFields ).toBe( true );
+		expect( getText( entries.Title, 'removed' ) ).toBe( 'Old' );
+		expect( getText( entries.Title, 'added' ) ).toBe( 'New' );
+	} );
+
+	it( 'diffs the excerpt against the previous revision', () => {
+		const { entries, hasChangedPostFields } = getFieldsDiffEntries(
+			{ excerpt: { raw: 'A short summary' } },
+			{ excerpt: { raw: 'A long summary' } }
+		);
+
+		expect( hasChangedPostFields ).toBe( true );
+		expect( getText( entries.Excerpt, 'removed' ) ).toBe( 'long' );
+		expect( getText( entries.Excerpt, 'added' ) ).toBe( 'short' );
+	} );
+
+	it( 'omits unchanged title and excerpt rows', () => {
+		const { entries, hasChangedPostFields } = getFieldsDiffEntries(
+			{
+				title: { raw: 'Same' },
+				excerpt: { raw: 'Same' },
+				meta: { footer: 'text' },
+			},
+			{
+				title: { raw: 'Same' },
+				excerpt: { raw: 'Same' },
+				meta: { footer: 'text' },
+			}
+		);
+
+		expect( hasChangedPostFields ).toBe( false );
+		expect( entries ).toEqual( { footer: expect.any( Array ) } );
+	} );
+
+	it( 'marks the whole title as added on the oldest revision', () => {
+		const { entries } = getFieldsDiffEntries(
+			{ title: { raw: 'First title' } },
+			null
+		);
+
+		expect( getText( entries.Title, 'added' ) ).toBe( 'First title' );
+		expect( getText( entries.Title, 'removed' ) ).toBe( '' );
+	} );
+
+	it( 'keeps non-empty meta values and skips empty ones', () => {
+		const { entries, hasChangedPostFields } = getFieldsDiffEntries(
+			{ meta: { kept: 'unchanged', emptyish: '[]' } },
+			{ meta: { kept: 'unchanged', emptyish: '[]' } }
+		);
+
+		expect( hasChangedPostFields ).toBe( false );
+		expect( entries ).toEqual( { kept: expect.any( Array ) } );
+	} );
+
+	it( 'returns no entries when fields are unchanged and meta is empty', () => {
+		expect(
+			getFieldsDiffEntries(
+				{ title: { raw: 'Same' }, meta: {} },
+				{ title: { raw: 'Same' }, meta: {} }
+			)
+		).toEqual( { entries: null, hasChangedPostFields: false } );
+	} );
+} );

--- a/test/e2e/specs/editor/various/revision-fields-diff.spec.js
+++ b/test/e2e/specs/editor/various/revision-fields-diff.spec.js
@@ -59,8 +59,8 @@ test.describe( 'Revision Fields Diff Panel', () => {
 			page.getByRole( 'button', { name: 'Restore' } )
 		).toBeVisible();
 
-		// Expand the Meta panel.
-		await settingsSidebar.getByRole( 'button', { name: 'Meta' } ).click();
+		// Expand the Fields panel.
+		await settingsSidebar.getByRole( 'button', { name: 'Fields' } ).click();
 
 		const footnotesRow = settingsSidebar.locator(
 			'.editor-post-panel__row',


### PR DESCRIPTION
## What

Follow-up to [this comment on #80314](https://github.com/WordPress/gutenberg/pull/80314#discussion_r3703832033).

The existing Meta panel is renamed to Fields to also show Title and Excerpt alongside the meta rows, with word-level diffs when either value changes. Title and Excerpt only appear when their values differ.

## Why

Restoring an older revision can replace the post title and excerpt. Until now, neither change appeared in the comparison before clicking Restore.

## How

The shared diff panel can now receive its open state from a caller. Selecting a revision with a Title or Excerpt change opens Fields. Selecting one without those changes leaves the panel alone, so an open meta comparison such as footnotes does not suddenly collapse. The block attributes panel continues to manage its own state.

## Testing Instructions

1. Create a post with the title `First title`, the excerpt `First excerpt`, and a footnote containing `alpha`. Save it.
2. Change the title to `Second title` and the excerpt to `Second excerpt`. Add a footnote containing `beta`, then save again.
3. Add a third footnote containing `gamma` without changing the title or excerpt, then save once more.
4. Open the revisions screen. Open Fields, check that Title and Excerpt are not listed for the latest revision, and confirm that the footnotes row contains `gamma`. Close Fields.
5. Move to the previous revision. Check that Fields opens on its own and shows the Title and Excerpt diffs. Return to the latest revision and check that the panel stays open while the Title and Excerpt rows disappear.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
