### PR TITLE
fix: order site identity changes predictably

### DIFF
--- a/packages/core-data/src/components/entities-saved-states/hooks/use-is-dirty.js
+++ b/packages/core-data/src/components/entities-saved-states/hooks/use-is-dirty.js
@@ -37,11 +37,15 @@ export const useIsDirty = () => {
 
 		const siteEntityLabels = siteEntityConfig?.meta?.labels ?? {};
 		const {
+			title: siteTitleEdit,
+			description: siteDescriptionEdit,
 			site_logo: siteLogoEdit,
 			site_icon: siteIconEdit,
 			...otherSiteEdits
 		} = siteEdits ?? {};
 		const orderedSiteProperties = [
+			siteTitleEdit !== undefined && 'title',
+			siteDescriptionEdit !== undefined && 'description',
 			siteLogoEdit !== undefined && 'site_logo',
 			siteIconEdit !== undefined && 'site_icon',
 			...Object.keys( otherSiteEdits ),

--- a/packages/core-data/src/components/entities-saved-states/test/use-is-dirty.js
+++ b/packages/core-data/src/components/entities-saved-states/test/use-is-dirty.js
@@ -24,9 +24,19 @@ jest.mock( '@wordpress/data', () => {
 						] ),
 					getEntityRecordEdits: jest.fn().mockReturnValue( {
 						title: 'My Site',
+						description: 'My Tagline',
+						site_logo: 123,
+						site_icon: 456,
 					} ),
 					getEntityConfig: jest.fn().mockReturnValue( {
-						meta: { labels: { title: 'Title' } },
+						meta: {
+							labels: {
+								title: 'Site Title',
+								description: 'Site Tagline',
+								site_logo: 'Site Logo',
+								site_icon: 'Site Icon',
+							},
+						},
 					} ),
 				};
 			};
@@ -36,7 +46,7 @@ jest.mock( '@wordpress/data', () => {
 } );
 
 describe( 'useIsDirty', () => {
-	it( 'should calculate dirtyEntityRecords', () => {
+	it( 'should calculate dirtyEntityRecords in the expected order', () => {
 		const { result } = renderHook( () => useIsDirty() );
 		expect( result.current.dirtyEntityRecords ).toEqual( [
 			{
@@ -45,7 +55,30 @@ describe( 'useIsDirty', () => {
 				property: 'property',
 				title: 'title',
 			},
-			{ kind: 'root', name: 'site', property: 'title', title: 'Title' },
+			{
+				kind: 'root',
+				name: 'site',
+				property: 'title',
+				title: 'Site Title',
+			},
+			{
+				kind: 'root',
+				name: 'site',
+				property: 'description',
+				title: 'Site Tagline',
+			},
+			{
+				kind: 'root',
+				name: 'site',
+				property: 'site_logo',
+				title: 'Site Logo',
+			},
+			{
+				kind: 'root',
+				name: 'site',
+				property: 'site_icon',
+				title: 'Site Icon',
+			},
 		] );
 	} );
 	it( 'should return `isDirty: true` when there are changes', () => {
@@ -71,7 +104,40 @@ describe( 'useIsDirty', () => {
 					kind: 'root',
 					name: 'site',
 					key: 'key',
-					property: 'property',
+					property: 'title',
+				},
+				false
+			);
+		} );
+		act( () => {
+			result.current.setUnselectedEntities(
+				{
+					kind: 'root',
+					name: 'site',
+					key: 'key',
+					property: 'description',
+				},
+				false
+			);
+		} );
+		act( () => {
+			result.current.setUnselectedEntities(
+				{
+					kind: 'root',
+					name: 'site',
+					key: 'key',
+					property: 'site_logo',
+				},
+				false
+			);
+		} );
+		act( () => {
+			result.current.setUnselectedEntities(
+				{
+					kind: 'root',
+					name: 'site',
+					key: 'key',
+					property: 'site_icon',
 				},
 				false
 			);


### PR DESCRIPTION
## What?

Closes #81251

This PR sorts the modified Site Identity properties listed in the "Review changes" modal to match the visual ordering of fields in the Site Identity form.

## Why?

Currently, when editing multiple Site Identity properties (Site Title, Site Tagline, Site Logo, Site Icon) and clicking the "Review changes" button, the pending changes are listed in an arbitrary order (Site Logo, Site Icon, Site Title, Site Tagline). Having them in a mismatching order makes it harder for the user to review their changes against their original intent.

## How?

Modified the `useIsDirty` hook in `packages/editor/src/components/entities-saved-states/hooks/use-is-dirty.js` to explicitly extract and order `title` (Site Title) and `description` (Site Tagline) before `site_logo` and `site_icon` in the `orderedSiteProperties` array. Also updated the corresponding unit tests to verify the sorting order.

## Testing Instructions
1. Open the Site Editor and go to **Design** -> **Identity**.
2. Modify the **Site Title**, **Site Tagline**, select/upload a **Site Logo**, and select/upload a **Site Icon**.
3. Click the **Save** or **Review changes** button at the bottom of the sidebar.
4. Verify that the changes listed under the Site panel are in the following order: **Site Title, Site Tagline, Site Logo, Site Icon**.

### Testing Instructions for Keyboard

1. Use `Tab` keys to navigate the Site Editor sidebar and access **Design** -> **Identity**.
2. Modify the Site Identity settings using the keyboard.
3. Tab to the **Save** button and press `Enter` to open the "Review changes" dialog.
4. Use arrow keys or `Tab` to navigate through the listed changes and verify they are ordered correctly: **Site Title, Site Tagline, Site Logo, Site Icon**.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| Logo, Icon, Title, Tagline | Title, Tagline, Logo, Icon |
<img width="395" height="453" alt="Screenshot 2026-08-06 at 6 02 09 PM" src="https://github.com/user-attachments/assets/c1cd4e37-30b0-4bba-9476-1da5050fca4c" />

<img width="392" height="493" alt="Screenshot 2026-08-06 at 6 25 24 PM" src="https://github.com/user-attachments/assets/fe17ec07-7398-49dd-a79c-d49d74a950c7" />


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
 Gemini 3.5 Flash.
```