### PR TITLE
DataViews: remove `kebabCase` private import by inlining it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51468,6 +51468,7 @@
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/ui": "file:../ui",
 				"@wordpress/warning": "file:../warning",
+				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.9.3",
 				"date-fns": "^4.4.0",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Internal
 
+-   DataViews: Inline a verbatim copy of the `kebabCase` utility instead of unlocking the private one from `@wordpress/components`, as part of removing the package's reliance on private cross-package APIs ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). Adds a direct `change-case` dependency; no behavior change. ([#81284](https://github.com/WordPress/gutenberg/pull/81284))
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).
 -   Update `@ariakit/react` to 0.4.35 ([#80765](https://github.com/WordPress/gutenberg/pull/80765)).

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -68,6 +68,7 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/ui": "file:../ui",
 		"@wordpress/warning": "file:../warning",
+		"change-case": "^4.1.2",
 		"clsx": "^2.1.1",
 		"colord": "^2.9.3",
 		"date-fns": "^4.4.0",

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -22,9 +22,10 @@ import { Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { kebabCase } from '../../utils/kebab-case';
 import type { Action, ActionModal as ActionModalType } from '../../types';
 
-const { Menu, kebabCase } = unlock( componentsPrivateApis );
+const { Menu } = unlock( componentsPrivateApis );
 
 export interface ActionTriggerProps< Item > {
 	action: Action< Item >;

--- a/packages/dataviews/src/utils/kebab-case.ts
+++ b/packages/dataviews/src/utils/kebab-case.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { paramCase } from 'change-case';
+
+/**
+ * Converts any string to kebab case.
+ * Backwards compatible with Lodash's `_.kebabCase()`.
+ * Backwards compatible with `_wp_to_kebab_case()`.
+ *
+ * Verbatim copy of the private `kebabCase` utility of `@wordpress/components`,
+ * inlined so DataViews does not depend on private cross-package APIs.
+ * Keep in sync with `packages/components/src/utils/strings.ts`.
+ *
+ * @see https://lodash.com/docs/4.17.15#kebabCase
+ * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/
+ *
+ * @param str String to convert.
+ * @return Kebab-cased string
+ */
+export function kebabCase( str: unknown ) {
+	let input = str?.toString?.() ?? '';
+
+	// See https://github.com/lodash/lodash/blob/b185fcee26b2133bd071f4aaca14b455c2ed1008/lodash.js#L4970
+	input = input.replace( /['\u2019]/, '' );
+
+	return paramCase( input, {
+		splitRegexp: [
+			/(?!(?:1ST|2ND|3RD|[4-9]TH)(?![a-z]))([a-z0-9])([A-Z])/g, // fooBar => foo-bar, 3Bar => 3-bar
+			/(?!(?:1st|2nd|3rd|[4-9]th)(?![a-z]))([0-9])([a-z])/g, // 3bar => 3-bar
+			/([A-Za-z])([0-9])/g, // Foo3 => foo-3, foo3 => foo-3
+			/([A-Z])([A-Z][a-z])/g, // FOOBar => foo-bar
+		],
+	} );
+}

--- a/packages/dataviews/src/utils/test/kebab-case.js
+++ b/packages/dataviews/src/utils/test/kebab-case.js
@@ -1,0 +1,102 @@
+/**
+ * Internal dependencies
+ */
+import { kebabCase } from '../kebab-case';
+
+// Mirrors the test suite of the private `kebabCase` utility of
+// `@wordpress/components` (packages/components/src/utils/test/strings.js),
+// which this function is a verbatim copy of.
+describe( 'kebabCase', () => {
+	it( 'separates lowercase letters, followed by uppercase letters', () => {
+		expect( kebabCase( 'fooBar' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'separates numbers, followed by uppercase letters', () => {
+		expect( kebabCase( '123FOO' ) ).toEqual( '123-foo' );
+	} );
+
+	it( 'separates numbers, followed by lowercase characters', () => {
+		expect( kebabCase( '123bar' ) ).toEqual( '123-bar' );
+	} );
+
+	it( 'separates uppercase letters, followed by numbers', () => {
+		expect( kebabCase( 'FOO123' ) ).toEqual( 'foo-123' );
+	} );
+
+	it( 'separates lowercase letters, followed by numbers', () => {
+		expect( kebabCase( 'foo123' ) ).toEqual( 'foo-123' );
+	} );
+
+	it( 'separates uppercase groups from capitalized groups', () => {
+		expect( kebabCase( 'FOOBar' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'removes any non-dash special characters', () => {
+		expect(
+			kebabCase( 'foo±§!@#$%^&*()-_=+/?.>,<\\|{}[]`~\'";:bar' )
+		).toEqual( 'foo-bar' );
+	} );
+
+	it( 'removes any spacing characters', () => {
+		expect( kebabCase( ' foo \t \n \r \f \v bar ' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'groups multiple dashes into a single one', () => {
+		expect( kebabCase( 'foo---bar' ) ).toEqual( 'foo-bar' );
+	} );
+
+	it( 'returns an empty string unchanged', () => {
+		expect( kebabCase( '' ) ).toEqual( '' );
+	} );
+
+	it( 'returns an existing kebab case string unchanged', () => {
+		expect( kebabCase( 'foo-123-bar' ) ).toEqual( 'foo-123-bar' );
+	} );
+
+	it( 'returns an empty string if any nullish type is passed', () => {
+		expect( kebabCase( undefined ) ).toEqual( '' );
+		expect( kebabCase( null ) ).toEqual( '' );
+	} );
+
+	it( 'converts any unexpected non-nullish type to a string', () => {
+		expect( kebabCase( 12345 ) ).toEqual( '12345' );
+		expect( kebabCase( [] ) ).toEqual( '' );
+		expect( kebabCase( {} ) ).toEqual( 'object-object' );
+	} );
+
+	/**
+	 * Should cover all test cases of `_wp_to_kebab_case()`.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/_wp_to_kebab_case/
+	 * @see https://github.com/WordPress/wordpress-develop/blob/76376fdbc3dc0b3261de377dffc350677345e7ba/tests/phpunit/tests/functions/wpToKebabCase.php#L35-L62
+	 */
+	it.each( [
+		[ 'white', 'white' ],
+		[ 'white+black', 'white-black' ],
+		[ 'white:black', 'white-black' ],
+		[ 'white*black', 'white-black' ],
+		[ 'white.black', 'white-black' ],
+		[ 'white black', 'white-black' ],
+		[ 'white	black', 'white-black' ],
+		[ 'white-to-black', 'white-to-black' ],
+		[ 'white2white', 'white-2-white' ],
+		[ 'white2nd', 'white-2nd' ],
+		[ 'white2ndcolor', 'white-2-ndcolor' ],
+		[ 'white2ndColor', 'white-2nd-color' ],
+		[ 'white2nd_color', 'white-2nd-color' ],
+		[ 'white23color', 'white-23-color' ],
+		[ 'white23', 'white-23' ],
+		[ '23color', '23-color' ],
+		[ 'white4th', 'white-4th' ],
+		[ 'font2xl', 'font-2-xl' ],
+		[ 'whiteToWhite', 'white-to-white' ],
+		[ 'whiteTOwhite', 'white-t-owhite' ],
+		[ 'WHITEtoWHITE', 'whit-eto-white' ],
+		[ 42, '42' ],
+		[ "i've done", 'ive-done' ],
+		[ '#ffffff', 'ffffff' ],
+		[ '$ffffff', 'ffffff' ],
+	] )( 'converts %s properly to %s', ( input, expected ) => {
+		expect( kebabCase( input ) ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
Part of #81230.

## What?

Removes one of the `@wordpress/components` private API usages in `@wordpress/dataviews`: the `kebabCase` utility by making a local copy within the dataviews package.

## Why?

See #81230.

## How?

- Adds `packages/dataviews/src/utils/kebab-case.ts`, a verbatim copy of the private kebabCase from `packages/components/src/utils/strings.ts`. Same implementation. Because the copy is identical, the generated action modal overlay class names will remain unchanged for any input.
- Copies the full kebabCase test suite from components, including all _wp_to_kebab_case() parity cases.

Alternatives considered:

- Inlining was chosen over making kebabCase a public export of `@wordpress/components`, since the utility was made private deliberately to avoid committing to a public utils surface. If a shared home for it ever materializes (e.g. a small dedicated package, which would also serve the other packages currently unlocking it from components), this local copy can be swapped out trivially.

## Testing Instruction

1. Run the unit tests: `npm run test:unit packages/dataviews/src/utils/test/kebab-case.js`.
2. In the site editor, open Patterns, and choose "Duplicate" on a pattern's actions menu (a modal action).
3. Inspect the modal overlay element and verify it still has the `dataviews-action-modal dataviews-action-modal__duplicate-pattern` classes and the modal is styled as before (no visual change).

## Use of AI Tools

This PR was written with Claude Code (implementation, tests, and this description), under human direction and review.
