### PR TITLE
Block Editor: Simplify InspectorControlsFill rendering logic

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -46,6 +46,9 @@ export default function InspectorControlsFill( {
 	}
 
 	const context = useBlockEditContext();
+	const isSelectedBlock = context[ mayDisplayControlsKey ];
+	const isPatternEditing = context[ mayDisplayPatternEditingControlsKey ];
+	const isInListViewTree = context[ isInListViewBlockSupportTreeKey ];
 
 	const Fill = groups[ group ]?.Fill;
 	if ( ! Fill ) {
@@ -57,7 +60,7 @@ export default function InspectorControlsFill( {
 	// - All blocks can show pattern editing groups (content, list).
 	// - Template parts can show any inspector group.
 	// - Other blocks cannot show a settings tab.
-	if ( context[ mayDisplayPatternEditingControlsKey ] ) {
+	if ( isPatternEditing ) {
 		// Template parts have also historically supported
 		// any block inspector groups for extenders. The settings
 		// tab is also used by core for the 'Design' panel. Specifically
@@ -69,49 +72,38 @@ export default function InspectorControlsFill( {
 		if ( ! canShowGroup ) {
 			return null;
 		}
-	}
-
-	// Outside pattern editing, use the standard rules for displaying controls.
-	if (
-		! context[ mayDisplayPatternEditingControlsKey ] &&
-		! context[ mayDisplayControlsKey ]
-	) {
+	} else if ( ! isSelectedBlock ) {
+		// Outside pattern editing, use the standard rules for displaying controls.
 		return null;
 	}
 
 	// When inside a section with a parent that has ListView block support,
 	// content controls are rendered as part of the ListView via a popover.
-	if (
-		group === 'content' &&
-		!! context[ isInListViewBlockSupportTreeKey ] &&
-		!! context[ mayDisplayPatternEditingControlsKey ]
-	) {
-		if ( context[ mayDisplayControlsKey ] ) {
-			return (
-				<StyleProvider document={ document }>
-					<ListViewContentFill>{ children }</ListViewContentFill>
-				</StyleProvider>
-			);
-		}
+	const rendersInListView =
+		group === 'content' && isPatternEditing && isInListViewTree;
 
-		// When using the ListView fill, only render controls for the selected
-		// block. Other blocks return `null`.
+	// When using the ListView fill, only render controls for the selected
+	// block. Other blocks return `null`.
+	if ( rendersInListView && ! isSelectedBlock ) {
 		return null;
 	}
 
 	return (
 		<StyleProvider document={ document }>
-			<Fill>
-				{ ( fillProps ) => {
-					return (
+			{ rendersInListView ? (
+				<ListViewContentFill>{ children }</ListViewContentFill>
+			) : (
+				<Fill>
+					{ ( fillProps ) => (
 						<ToolsPanelInspectorControl
 							fillProps={ fillProps }
-							children={ children }
 							resetAllFilter={ resetAllFilter }
-						/>
-					);
-				} }
-			</Fill>
+						>
+							{ children }
+						</ToolsPanelInspectorControl>
+					) }
+				</Fill>
+			) }
 		</StyleProvider>
 	);
 }


### PR DESCRIPTION
## What?
I was experimenting with [deferred inspector rendering](https://github.com/WordPress/gutenberg/pull/81214) and realized the component exit points became a bit hard to follow. This is my attempt to simplify it a little bit.

## Changes

- Names the three context reads as locals (`isSelectedBlock`, `isPatternEditing`, `isInListViewTree`) instead of repeating symbol lookups.
- Merges the two visibility checks into one `if`/`else if`. The second check's condition was exactly the `else` branch of the first.
- Splits the List View popover case into a `rendersInListView` flag plus its own guard, so routing (which fill to use) is separate from gating (is this the selected block).
- Returns once, with a single `StyleProvider` wrapping either fill.
- Passes `children` as JSX children rather than as a prop.

## Testing Instructions
I think this should have decent e2e test coverage, but a smoke test controls for various blocks - Navigation, Template Parts, Text blocks. Confirm they are rendered as before.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.