### PR TITLE
Block Inspector: Disable the 'Edit original' button when the entity ID is missing

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
@@ -13,43 +14,42 @@ import useContentOnlySectionEdit from '../../hooks/use-content-only-section-edit
 import { store as blockEditorStore } from '../../store';
 
 function IsolatedEditButton( {
-	block,
+	attributes = {},
 	onNavigateToEntityRecord,
-	isSyncedPattern,
 	isTemplatePartBlock,
 } ) {
-	const blockAttributes = block?.attributes || {};
+	const { ref, theme, slug } = attributes;
+	const entityId = isTemplatePartBlock
+		? theme && slug && `${ theme }//${ slug }`
+		: ref;
 
 	const handleClick = () => {
-		if ( isSyncedPattern ) {
-			onNavigateToEntityRecord( {
-				postId: blockAttributes.ref,
-				postType: 'wp_block',
-			} );
-		} else if ( isTemplatePartBlock ) {
-			const { theme, slug } = blockAttributes;
-			const templatePartId =
-				theme && slug ? `${ theme }//${ slug }` : null;
-			if ( templatePartId ) {
-				onNavigateToEntityRecord( {
-					postId: templatePartId,
-					postType: 'wp_template_part',
-				} );
-			}
+		if ( ! entityId ) {
+			return;
 		}
+
+		onNavigateToEntityRecord( {
+			postId: entityId,
+			postType: isTemplatePartBlock ? 'wp_template_part' : 'wp_block',
+		} );
 	};
 
 	return (
-		<VStack className="block-editor-block-inspector-edit-contents" expanded>
+		<Stack
+			direction="column"
+			className="block-editor-block-inspector-edit-contents"
+		>
 			<Button
 				className="block-editor-block-inspector-edit-contents__button"
 				__next40pxDefaultSize
 				variant="secondary"
 				onClick={ handleClick }
+				accessibleWhenDisabled
+				disabled={ ! entityId }
 			>
 				{ __( 'Edit original' ) }
 			</Button>
-		</VStack>
+		</Stack>
 	);
 }
 
@@ -72,7 +72,10 @@ function InlineEditButton( {
 	};
 
 	return (
-		<VStack className="block-editor-block-inspector-edit-contents" expanded>
+		<Stack
+			direction="column"
+			className="block-editor-block-inspector-edit-contents"
+		>
 			<Button
 				className="block-editor-block-inspector-edit-contents__button"
 				__next40pxDefaultSize
@@ -85,7 +88,7 @@ function InlineEditButton( {
 					: /* translators: Button label to enter pattern editing mode. */
 					  __( 'Edit pattern' ) }
 			</Button>
-		</VStack>
+		</Stack>
 	);
 }
 
@@ -124,9 +127,8 @@ export default function EditContents( { clientId } ) {
 	if ( shouldUseIsolatedEditor ) {
 		return (
 			<IsolatedEditButton
-				block={ block }
+				attributes={ block?.attributes }
 				onNavigateToEntityRecord={ onNavigateToEntityRecord }
-				isSyncedPattern={ isSyncedPattern }
 				isTemplatePartBlock={ isTemplatePartBlock }
 			/>
 		);

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -24,11 +24,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-editor/src/components/block-inspector/edit-contents.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-editor/src/components/block-inspector/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
Noticed while testing #81177.

PR simplifies `IsolatedEditButton` in the block inspector's "Edit contents" panel and disables the "Edit original" button when the target entity can't be resolved.

The click handler branched on `isSyncedPattern` / `isTemplatePartBlock` and called `onNavigateToEntityRecord` from two places, with the template part ID guard buried inside the handler.

I've also migrated to the `Stack` component to resolve suppressed ESLint error.


## Testing Instructions
1. Open a post and switch to the code editor.
2. Add synced pattern without `ref` - `<!-- wp:block /-->`.
3. Switch back to visual.
4. Confirm that Edit original is disabled.
5. Repeat the same step with the missing template part. 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1379" height="548" alt="CleanShot 2026-08-06 at 17 38 01" src="https://github.com/user-attachments/assets/9c438fa1-cf32-4e88-8ea3-dba3a4afcb55" />

## Use of AI Tools

Assisted by Grammarly 😄 