### PR TITLE
Core Data: Prevent unchanged synced records from being marked as edited

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Prevent no-op synced entity updates from marking records as dirty and triggering unsaved-changes warnings.
 -   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing. Malformed JSON, or valid JSON that is not an array, threw inside a store subscriber where no error boundary catches it, so the edit was dropped and the post silently stopped saving ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
 -   Ensure revision resolvers finish after fetched revisions are stored.
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1,18 +1,7 @@
-/**
- * External dependencies
- */
 import { camelCase } from 'change-case';
-
-/**
- * WordPress dependencies
- */
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * Internal dependencies
- */
 import { STORE_NAME } from './name';
 import { additionalEntityConfigLoaders, DEFAULT_ENTITY_KEY } from './entities';
 import { getSyncManager } from './sync';
@@ -23,6 +12,7 @@ import {
 	getUserPermissionsFromAllowHeader,
 	ALLOWED_RESOURCE_ACTIONS,
 	RECEIVE_INTERMEDIATE_RESULTS,
+	clearUnchangedEdits,
 	isNumericID,
 	normalizeQueryForResolution,
 	saveCRDTDoc,
@@ -212,12 +202,36 @@ export const getEntityRecord =
 								return;
 							}
 
+							const normalizedEdits = clearUnchangedEdits(
+								edits,
+								select.getRawEntityRecord( kind, name, key )
+							);
+							const currentEdits =
+								select.getEntityRecordEdits(
+									kind,
+									name,
+									key
+								) ?? {};
+							// An undefined normalized value is still meaningful when it
+							// clears an existing local edit.
+							const hasChangesToApply = Object.entries(
+								normalizedEdits
+							).some(
+								( [ property, value ] ) =>
+									undefined !== value ||
+									property in currentEdits
+							);
+
+							if ( ! hasChangesToApply ) {
+								return;
+							}
+
 							dispatch( {
 								type: 'EDIT_ENTITY_RECORD',
 								kind,
 								name,
 								recordId: key,
-								edits,
+								edits: normalizedEdits,
 								meta: {
 									undo: undefined,
 								},

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,22 +1,5 @@
-/**
- * WordPress dependencies
- */
 import triggerFetch from '@wordpress/api-fetch';
-
-/**
- * Internal dependencies
- */
 import { getSyncManager } from '../sync';
-
-jest.mock( '@wordpress/api-fetch' );
-jest.mock( '../sync', () => ( {
-	getSyncManager: jest.fn(),
-	LOCAL_UNDO_IGNORED_ORIGIN: 'local-undo-ignored',
-} ) );
-
-/**
- * Internal dependencies
- */
 import {
 	getEntityRecord,
 	getEntityRecords,
@@ -26,6 +9,12 @@ import {
 	getCurrentUser,
 } from '../resolvers';
 import { RECEIVE_INTERMEDIATE_RESULTS } from '../utils';
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '../sync', () => ( {
+	getSyncManager: jest.fn(),
+	LOCAL_UNDO_IGNORED_ORIGIN: 'local-undo-ignored',
+} ) );
 
 describe( 'getEntityRecord', () => {
 	const POST_TYPE = { slug: 'post' };
@@ -61,6 +50,44 @@ describe( 'getEntityRecord', () => {
 		};
 		getSyncManager.mockImplementation( () => syncManager );
 	} );
+
+	const loadSyncedPost = async ( postRecord, currentEdits = {} ) => {
+		const postResponse = {
+			json: () => Promise.resolve( postRecord ),
+		};
+		const entitiesWithSync = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				baseURLParams: { context: 'edit' },
+				syncConfig: {},
+			},
+		];
+		const select = {
+			getEntityRecordEdits: jest.fn( () => currentEdits ),
+			getRawEntityRecord: jest.fn( () => postRecord ),
+		};
+		const resolveSelectWithSync = {
+			getEntitiesConfig: jest.fn( () => entitiesWithSync ),
+			getEditedEntityRecord: jest.fn(),
+		};
+
+		triggerFetch.mockImplementation( () => postResponse );
+
+		await getEntityRecord(
+			'postType',
+			'post',
+			1
+		)( {
+			select,
+			dispatch,
+			registry,
+			resolveSelect: resolveSelectWithSync,
+		} );
+
+		return syncManager.load.mock.calls[ 0 ][ 4 ];
+	};
 
 	it( 'yields with requested post type', async () => {
 		// Provide response
@@ -181,6 +208,52 @@ describe( 'getEntityRecord', () => {
 				restoreUndoMeta: expect.any( Function ),
 			}
 		);
+	} );
+
+	it( 'does not mark an entity as edited when a synced update matches the persisted record', async () => {
+		const POST_RECORD = {
+			id: 1,
+			meta: { nested: [ 'value' ] },
+			title: 'Test Post',
+		};
+		const handlers = await loadSyncedPost( POST_RECORD );
+		handlers.editRecord( { meta: { nested: [ 'value' ] } } );
+
+		expect( dispatch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'applies a synced update when it differs from the persisted record', async () => {
+		const POST_RECORD = { id: 1, title: 'Test Post' };
+		const handlers = await loadSyncedPost( POST_RECORD );
+		handlers.editRecord( { title: 'Synced title' } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: { title: 'Synced title' },
+			meta: { undo: undefined },
+			options: {},
+		} );
+	} );
+
+	it( 'clears a local edit when a synced update restores the persisted value', async () => {
+		const POST_RECORD = { id: 1, title: 'Test Post' };
+		const handlers = await loadSyncedPost( POST_RECORD, {
+			title: 'Local title',
+		} );
+		handlers.editRecord( { title: 'Test Post' } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: { title: undefined },
+			meta: { undo: undefined },
+			options: {},
+		} );
 	} );
 
 	it( 'does not load entity with sync manager when collaboration is unsupported', async () => {


### PR DESCRIPTION
## What?

Prevents synced entity updates from marking a record as edited when the incoming values are unchanged.

See #79776.

## Why?

The unsaved-changes warning checks Core Data for dirty entity records. Synced updates could bypass the usual unchanged-value filtering and create an edit even when the incoming data matched the persisted record, causing a false leave-page warning.

## How?

Normalize synced edits against the persisted entity record before dispatching them.

Unchanged updates are ignored, while genuine remote changes are still applied. The implementation also preserves the case where a synced update restores the persisted value and needs to clear an existing local edit.

## Testing Instructions

1. Confirm all tests pass.
2. Create or open a post and wait until it is saved.
3. Leave the editor open without making further changes, then close the tab.
4. Confirm the browser does not show an unsaved-changes warning.
5. Open another post, make an actual edit, and close the tab without saving.
6. Confirm the unsaved-changes warning still appears.

### Testing Instructions for Keyboard

There are no user-interface changes.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to investigate the issue and assist with the implementation, tests, and PR description. The resulting changes were reviewed and verified by the author.