### PR TITLE
Fix: Term Description block skips display filters inside Terms Query.

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
+-   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 
 ## 10.4.0 (2026-08-12)
 

--- a/packages/block-library/src/term-description/index.php
+++ b/packages/block-library/src/term-description/index.php
@@ -23,7 +23,7 @@ function render_block_core_term_description( $attributes, $content, $block ) {
 	if ( isset( $block->context['termId'] ) && isset( $block->context['taxonomy'] ) ) {
 		$term = get_term( $block->context['termId'], $block->context['taxonomy'] );
 		if ( $term && ! is_wp_error( $term ) ) {
-			$term_description = $term->description;
+			$term_description = get_term_field( 'description', $term );
 		}
 	} elseif ( is_category() || is_tag() || is_tax() ) {
 		$term_description = term_description();


### PR DESCRIPTION
When the Term Description block renders inside a Terms Query loop, it outputs the raw `$term->description` value, skipping the `term_description` display filters. Multi-paragraph descriptions lose their paragraph tags and collapse into a single run of text, and any formatting plugins add through the filters is ignored. The same block on a taxonomy archive template renders correctly, because that path goes through `term_description()`.

This PR fixes the issue by retrieving the value with `get_term_field( 'description', $term )`, which applies the same display filters as the archive path, so both contexts render identically.

## Before
<img width="700" alt="Term descriptions rendered inside a Terms Query loop without the display filters: the two paragraphs of each description collapse into a single run of text" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/term-description-display-filters/before.png">

## After
<img width="700" alt="Term descriptions rendered inside a Terms Query loop with the display filters applied: each description keeps its two paragraphs" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/term-description-display-filters/after.png">

## Testing Instructions
1. Create a category and give it a description with two paragraphs.
2. Add a Terms Query block to a page and keep a Term Description block inside the Term Template.
3. View the page on the front end and verify the description keeps its paragraphs, matching how it renders on the category archive.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
