### PR TITLE
Style states: Fix phantom pseudo element style output

### DIFF
--- a/backport-changelog/7.1/12918.md
+++ b/backport-changelog/7.1/12918.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/12918
 
 * https://github.com/WordPress/gutenberg/pull/81265
+* https://github.com/WordPress/gutenberg/pull/81291

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3758,36 +3758,26 @@ class WP_Theme_JSON_Gutenberg {
 					// Handle any pseudo selectors for the element.
 					if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] ) ) {
 						foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
-							// Create element pseudo node if default or any responsive breakpoint has the pseudo.
-							$has_element_pseudo = isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] );
-							if ( ! $has_element_pseudo ) {
-								foreach ( array_keys( $responsive_media_queries ) as $bp ) {
-									if ( isset( $theme_json['styles']['blocks'][ $name ][ $bp ]['elements'][ $element ][ $pseudo_selector ] ) ) {
-										$has_element_pseudo = true;
-										break;
-									}
-								}
-							}
-
-						if ( $has_element_pseudo ) {
-							$element_pseudo_path = array( 'styles', 'blocks', $name, 'elements', $element );
-
-							$nodes[] = array(
-									'path'     => $element_pseudo_path,
+							// Emit the default pseudo node only when the default state styles
+							// the pseudo. Otherwise get_styles_for_block() falls back to the
+							// element's base styles, outputting a rule the theme never defined.
+							if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] ) ) {
+								$nodes[] = array(
+									'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),
 									'selector' => static::append_to_selector( $element_selector, $pseudo_selector ),
 								);
+							}
 
-								// Responsive element pseudo nodes: one node per breakpoint
-								// that has this pseudo state for this element.
-								// Cascade: a:hover{} → @media{a:hover{}}
-								foreach ( array_keys( $responsive_media_queries ) as $breakpoint ) {
-									if ( isset( $theme_json['styles']['blocks'][ $name ][ $breakpoint ]['elements'][ $element ][ $pseudo_selector ] ) ) {
-										$nodes[] = array(
-											'path'        => array( 'styles', 'blocks', $name, $breakpoint, 'elements', $element ),
-											'selector'    => static::append_to_selector( $element_selector, $pseudo_selector ),
-											'media_query' => $responsive_media_queries[ $breakpoint ],
-										);
-									}
+							// Responsive element pseudo nodes: one node per breakpoint
+							// that has this pseudo state for this element.
+							// Cascade: a:hover{} → @media{a:hover{}}
+							foreach ( array_keys( $responsive_media_queries ) as $breakpoint ) {
+								if ( isset( $theme_json['styles']['blocks'][ $name ][ $breakpoint ]['elements'][ $element ][ $pseudo_selector ] ) ) {
+									$nodes[] = array(
+										'path'        => array( 'styles', 'blocks', $name, $breakpoint, 'elements', $element ),
+										'selector'    => static::append_to_selector( $element_selector, $pseudo_selector ),
+										'media_query' => $responsive_media_queries[ $breakpoint ],
+									);
 								}
 							}
 						}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3769,16 +3769,10 @@ class WP_Theme_JSON_Gutenberg {
 								}
 							}
 
-							if ( $has_element_pseudo ) {
-								$element_pseudo_path = array( 'styles', 'blocks', $name, 'elements', $element );
-								if ( $include_node_paths_only ) {
-									$nodes[] = array(
-										'path' => $element_pseudo_path,
-									);
-									continue;
-								}
+						if ( $has_element_pseudo ) {
+							$element_pseudo_path = array( 'styles', 'blocks', $name, 'elements', $element );
 
-								$nodes[] = array(
+							$nodes[] = array(
 									'path'     => $element_pseudo_path,
 									'selector' => static::append_to_selector( $element_selector, $pseudo_selector ),
 								);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1565,6 +1565,47 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_stylesheet_does_not_duplicate_base_element_styles_into_pseudo_rule() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'text' => 'blue',
+									),
+								),
+							),
+							'@mobile'  => array(
+								'elements' => array(
+									'link' => array(
+										':hover' => array(
+											'color' => array(
+												'text' => 'darkred',
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$link_selector = ':root :where(.wp-block-group a:where(:not(.wp-element-button)))';
+		$expected      = $link_selector . '{color: blue;}' .
+			'@media (width <= 480px){:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover){color: darkred;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
 	public function test_get_styles_for_block_responsive_element_pseudo_styles_preserve_order_and_do_not_duplicate_pseudo() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
Note: PR is based on the branch from #81265. It relies on the changes there.

## What?
Fixes an issue where an incorrect pseudo style would be output (copying the base element's style) whenever a responsive+pseudo style was set for the element (but no pseudo style itself). 

## Why?
With an element styled at its root and its pseudo styled only inside a responsive state like `@mobile`:
```json
{
	"styles": {
		"blocks": {
			"core/group": {
				"elements": {
					"link": { "color": { "text": "blue" } }
				},
				"@mobile": {
					"elements": {
						"link": { ":hover": { "color": { "text": "darkred" } } }
					}
				}
			}
		}
	}
}
```

CSS like this would be incorrectly produced:
```css
:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover){color: blue;}
```

The pseudo node defined by the responsive style was being included as part of the root. `get_styles_for_block()` falls back to the element's base styles when the pseudo key is absent — outputting a rule the theme never defined.

## How?
Only output the default pseudo rule when the pseudo is styled outside a breakpoint — the same check the block-level pseudo styles already use. The breakpoint rules already decide this per breakpoint, so they're untouched.

PR also separately removes some dead code:
```php
if ( $include_node_paths_only ) {
    $nodes[] = array(
        'path' => $element_pseudo_path,
    );
    continue;
}
```
The code inside the if statement is unreachable because there's a similar `continue` statement earlier in the loop: https://github.com/WordPress/gutenberg/blob/7c36647bc4ce6be00b34dc64dbefed1640592e1b/lib/class-wp-theme-json-gutenberg.php#L3709-L3714.

## Testing Instructions
1. Add the snippet above to a theme.json
2. Create a post that has a group with a paragraph inside it that has a link
3. Preview the post.
4. In the dev tools, resize to a browser size. Inspect the link and enable :hover styles.
5. Check the element's CSS in the dev tools

On trunk - the block has a rogue style like this:
```css
:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover) {
    color: blue;
}
```

In this PR - the block doesn't have that style

## Use of AI Tools
OpenCode / Kimi K3