### PR TITLE
Icon: Fix margin being applied twice in the editor

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing, so the block shows its placeholder rather than the block crash warning ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
 -   Playlist: Improve handling of declarative waveform player configuration ([#81342](https://github.com/WordPress/gutenberg/pull/81342)).
 -   Cover: Pass `'full'` instead of `null` as the featured image size for parallax and repeated backgrounds, so a null array offset is no longer reached on PHP 8.5 ([#81444](https://github.com/WordPress/gutenberg/pull/81444)).
+-   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 
 ### Internal
 

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -59,7 +59,15 @@ export function Edit( { attributes, setAttributes } ) {
 	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
 
 	const colorProps = useColorProps( attributes );
-	const spacingProps = useSpacingProps( attributes );
+	// Only padding is applied to the inner SVG element, matching the front
+	// end. The margin support is serialized to the block wrapper instead.
+	const spacingProps = useSpacingProps( {
+		style: {
+			spacing: {
+				padding: attributes.style?.spacing?.padding,
+			},
+		},
+	} );
 	const borderProps = useBorderProps( attributes );
 	const dimensionsProps = useDimensionsProps( attributes );
 


### PR DESCRIPTION
Fixes the Icon block applying margin twice in the editor.

The margin block support is serialized to the block wrapper, but in the editor the inner SVG element was also receiving the margin styles, because the full spacing styles were spread onto it. On the front end only padding is applied to the SVG, so a block with a margin looked considerably more spaced out in the editor canvas than on the published page. To fix this we pass only the padding to the spacing styles applied to the inner SVG element, matching the front-end output.

## Screenshots

An Icon block with a background color, `24px` padding and a `48px` margin, placed inside a Group with a contrasting background, so the margin is visible as the purple space around the icon.

### Before

The margin is applied on both the block wrapper and the inner SVG, so the editor renders `96px` of extra space (2 × `48px`) compared to the front end.

| Editor | Front end |
| --- | --- |
| <img width="420" alt="Editor before the fix, with twice the margin around the icon" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/icon-editor-double-margin-2/group-before-editor.png"> | <img width="420" alt="Front end before the fix, with the margin applied once" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/icon-editor-double-margin-2/group-before-front.png"> |

### After

The editor matches the front end.

| Editor | Front end |
| --- | --- |
| <img width="420" alt="Editor after the fix, matching the front end" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/icon-editor-double-margin-2/group-after-editor.png"> | <img width="420" alt="Front end after the fix, unchanged" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/icon-editor-double-margin-2/group-after-front.png"> |

## Testing Instructions

1. Insert a Group block, and give it a background color.
2. Insert an Icon block inside the group and choose an icon.
3. In the inspector, set a different background color for the icon, some padding, and a large margin (e.g., 48px).
4. Verify the space around the icon in the editor canvas matches the front end.
5. Verify padding and the other supports (colors, borders, width) still apply correctly in both.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
