### PR TITLE
Fix missing return value in force_filtered_html_on_import footnotes filter

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -374,7 +374,7 @@ function _gutenberg_footnotes_kses_init() {
  */
 function _gutenberg_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	if ( function_exists( '_wp_filter_post_meta_footnotes' ) ) {
-		return;
+		return $arg;
 	}
 	// force_filtered_html_on_import is true we need to init the global styles kses filters.
 	if ( $arg ) {


### PR DESCRIPTION
## What?

This PR adds back a missing return value of the `force_filtered_html_on_import` filter in the `_gutenberg_footnotes_force_filtered_html_on_import_filter` callback. Previously it did not return a value on one of its branches.

## Why?

A filter callback must always return the value it receives. In our function, when the core function `_wp_filter_post_meta_footnotes()` exists, the code did return;. This returns `null` instead of the original value.

## How?

The fix is very small. On the short-circuit branch we now return the input value instead of nothing:

```php
if ( function_exists( '_wp_filter_post_meta_footnotes' ) ) {
	return $arg; // Before: return;
}
```

## Testing Instructions

Verify PHP tests pass.

## Use of AI Tools

Changes applied manually.