### PR TITLE
Block Library: Document security patch releases

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -23,6 +23,8 @@
 ### Bug Fixes
 
 -   Playlist: Update `@arraypress/waveform-player` to `^1.23.0`, which no longer sets `crossorigin="anonymous"` on its audio element, fixing playback of tracks served without CORS headers such as media offloaded to a CDN ([#80533](https://github.com/WordPress/gutenberg/pull/80533)).
+-   Post Content: Restrict the wrapper tag to the supported values offered in the editor.
+-   Post Date: Escape date values and link URLs before rendering the block.
 
 ### Internal
 
@@ -103,6 +105,13 @@
 
 ## 9.34.0 (2025-10-29)
 
+## 9.33.11 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Content: Restrict the wrapper tag to the supported values offered in the editor.
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 9.33.0 (2025-10-17)
 
 ### Enhancements
@@ -139,6 +148,12 @@
 
 -   Query Loop Block: Enable custom order or `menu_order` ordering option for post types that support it. ([#68781](https://github.com/WordPress/gutenberg/pull/68781))
 
+## 9.19.7 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 9.19.0 (2025-02-28)
 
 ## 9.18.0 (2025-02-12)
@@ -161,6 +176,12 @@
 
 ## 9.9.0 (2024-10-03)
 
+## 9.8.18 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 9.8.0 (2024-09-19)
 
 ## 9.7.0 (2024-09-05)
@@ -180,6 +201,12 @@
 ## 9.2.0 (2024-06-26)
 
 ## 9.1.0 (2024-06-15)
+
+## 9.0.9 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
 
 ## 9.0.0 (2024-05-31)
 
@@ -206,6 +233,12 @@
 
 ## 8.29.0 (2024-02-21)
 
+## 8.28.13 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 8.28.0 (2024-02-09)
 
 ## 8.27.0 (2024-01-24)
@@ -228,6 +261,12 @@
 
 ## 8.20.0 (2023-10-05)
 
+## 8.19.19 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 8.19.0 (2023-09-20)
 
 ## 8.18.0 (2023-08-31)
@@ -241,6 +280,12 @@
 ## 8.14.0 (2023-07-05)
 
 ## 8.13.0 (2023-06-23)
+
+## 8.12.21 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
 
 ## 8.12.0 (2023-06-07)
 
@@ -259,6 +304,12 @@
 ## 8.5.0 (2023-03-01)
 
 ## 8.4.0 (2023-02-15)
+
+## 8.3.17 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
 
 ## 8.3.0 (2023-02-01)
 
@@ -281,6 +332,12 @@
 ## 7.16.0 (2022-10-05)
 
 ## 7.15.0 (2022-09-21)
+
+## 7.14.16 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
 
 ## 7.14.0 (2022-09-13)
 
@@ -316,6 +373,12 @@
 
 ## 7.4.0 (2022-04-21)
 
+## 7.3.20 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 7.3.0 (2022-04-08)
 
 ## 7.2.0 (2022-03-23)
@@ -345,6 +408,12 @@
 
 -   Code quality: Add block schema to each core block ([#35900](https://github.com/WordPress/gutenberg/pull/35900)).
 
+## 6.0.32 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 6.0.0 (2021-09-09)
 
 ### Breaking Changes
@@ -366,6 +435,12 @@
 ### Bug Fixes
 
 -   Include missing attributes when upgrading embed block ([#33235](https://github.com/WordPress/gutenberg/pull/33235))
+
+## 3.2.22 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
 
 ## 3.2.0 (2021-05-24)
 


### PR DESCRIPTION
## What?

Documents the recently published `@wordpress/block-library` patch releases for WordPress 5.8 through 6.9. It also records the matching Post Content and Post Date fixes in the trunk `Unreleased` section.

## Why?

The packages were published and verified, but the Block Library changelog did not include the new version sections or the corresponding trunk entries.

## How?

Adds all 12 patch versions dated 2026-08-06. Every release documents the Post Date output escaping fix, while 9.33.11 also documents the Post Content wrapper-tag restriction.

## Testing Instructions

1. Open `packages/block-library/CHANGELOG.md`.
2. Confirm `Unreleased > Bug Fixes` includes the Post Content and Post Date entries.
3. Confirm the changelog includes versions `3.2.22`, `6.0.32`, `7.3.20`, `7.14.16`, `8.3.17`, `8.12.21`, `8.19.19`, `8.28.13`, `9.0.9`, `9.8.18`, `9.19.7`, and `9.33.11`.
4. Confirm only `9.33.11` includes the Post Content entry.

## Use of AI Tools

Codex was used to compare the published npm artifacts, update the changelog, run focused validation, and prepare this pull request.