### PR TITLE
Date: Pad the ISO week number to two digits, matching PHP

### DIFF
--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
-## 5.53.0 (2026-08-12)
+### Bug Fixes
 
+-   `format` now pads the `W` (ISO week number) format character to two digits, matching PHP. Previously `format( 'W', '2024-01-15' )` returned `'3'` where PHP's `date( 'W' )` returns `'03'`, so any week before the tenth of the year came out a character short ([#81299](https://github.com/WordPress/gutenberg/pull/81299)).
+
+## 5.53.0 (2026-08-12)
 
 ## 5.52.0 (2026-07-29)
 

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -286,7 +286,9 @@ const formatMap = {
 	},
 
 	// Week.
-	W: 'W',
+	// `WW` rather than `W`, because PHP pads the ISO week number to two digits
+	// and Moment's unpadded `W` would give `3` where PHP gives `03`.
+	W: 'WW',
 
 	// Month.
 	F: 'MMMM',

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -218,6 +218,21 @@ describe( 'Function date', () => {
 	} );
 } );
 
+describe( 'Function date, ISO week number padding', () => {
+	// PHP pads the ISO week number to two digits, so a single digit week has to
+	// come back as `03` rather than `3`. Expected values are PHP's:
+	//   php -r 'echo date( "W", strtotime( "2024-01-15" ) );'
+	test.each( [
+		[ '2024-01-15T11:00:00.000Z', '03' ],
+		[ '2024-01-01T11:00:00.000Z', '01' ],
+		[ '2020-02-29T11:00:00.000Z', '09' ],
+		[ '2024-03-05T11:00:00.000Z', '10' ],
+		[ '2026-12-31T11:00:00.000Z', '53' ],
+	] )( 'should pad the week number for %s', ( dateValue, expected ) => {
+		expect( dateNoI18n( 'W', dateValue ) ).toBe( expected );
+	} );
+} );
+
 describe( 'Function gmdate', () => {
 	test.each( [
 		[ 'j/n/y', '18/6/19' ],


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/81298

`format` returns an unpadded ISO week number where PHP pads it to two digits. This maps `W` onto Moment's padded `WW`.

## Why?

The `formatMap` entry is `W: 'W'`. Moment's `W` is the ISO week without padding, PHP's `date( 'W' )` pads to two digits, so weeks 1 to 9 come back a character short:

```js
format( 'W', '2024-01-15' ); // '3', PHP gives '03'
```

Weeks 10 and up are already two characters and agree, which is why this has been quiet. It fails by returning a plausible string rather than raising anything, so a wrong value propagates instead of surfacing.

Verified against PHP 8.4.24:

| Date | PHP | before | after |
| --- | --- | --- | --- |
| 2024-01-15 | `03` | `3` | `03` |
| 2024-01-01 | `01` | `1` | `01` |
| 2020-02-29 | `09` | `9` | `09` |
| 2024-03-05 | `10` | `10` | `10` |
| 2026-12-31 | `53` | `53` | `53` |

I checked the other format characters with custom handling in that map against PHP over the same dates, including a leap day and both ISO year boundaries. `z`, `t`, `L`, `o`, `N`, `w` and `S` all already agree. `W` was the only divergence.

## How?

One character: `W: 'W'` becomes `W: 'WW'`.

Five test cases are added. The existing test for `W` uses 18 June 2019, week 25, which is two digits and therefore passes either way. The new cases use single digit weeks, and three of the five fail without the source change.

## Testing Instructions

1. Open a post or page.
2. Open the console.
3. Run `wp.date.format( 'W', '2024-01-15' )`.
4. On trunk it returns `'3'`. With this branch it returns `'03'`, matching `date( 'W' )` in PHP.

Or run the package tests:

```
npm run test:unit -- packages/date
```

115 pass. Reverting only the change to `packages/date/src/index.ts` and rerunning drops three of the new cases to failing, which is the check that they are testing the right thing.

## Testing Instructions for Keyboard

Not applicable, this is a package-level change with no UI.

## Screenshots or screencast

Not applicable.
