### PR TITLE
admin-ui: let the Breadcrumbs nav shrink so long crumbs truncate

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Breadcrumbs`: Let the `nav` shrink below its content width (`min-width: 0`) so a long current crumb truncates with an ellipsis instead of widening the page into horizontal scrolling ([#81301](https://github.com/WordPress/gutenberg/pull/81301)).
+
 ### Internal
 
 -   Stop publishing the `src` directory to npm. The package's `exports` field only exposes the built artifacts, so the source files were unreachable by consumers and only inflated the package size ([#77285](https://github.com/WordPress/gutenberg/pull/77285)).

--- a/packages/admin-ui/src/breadcrumbs/index.tsx
+++ b/packages/admin-ui/src/breadcrumbs/index.tsx
@@ -44,7 +44,7 @@ export const Breadcrumbs = ( { items }: BreadcrumbsProps ) => {
 	}
 
 	return (
-		<nav aria-label={ __( 'Breadcrumbs' ) }>
+		<nav aria-label={ __( 'Breadcrumbs' ) } className={ styles.root }>
 			<Stack
 				render={ <ul /> }
 				direction="row"

--- a/packages/admin-ui/src/breadcrumbs/style.module.css
+++ b/packages/admin-ui/src/breadcrumbs/style.module.css
@@ -1,3 +1,12 @@
+/*
+ * The nav renders as a flex item in the page header; the default
+ * `min-width: auto` would keep the list from shrinking and the `.current`
+ * truncation styles below from engaging.
+ */
+.root {
+	min-width: 0;
+}
+
 .list {
 	list-style: none;
 	padding: 0;


### PR DESCRIPTION
## What?

Closes #81297

Lets the `admin-ui` `Breadcrumbs` `nav` shrink (`min-width: 0`), so a long current crumb truncates with its existing ellipsis instead of widening the whole page into horizontal scrolling.

> **Note:** this PR originally also gave the `Page` header's leading group `min-width: 0`. That half landed on trunk in #81954 (`.header-lockup`), so this PR has been rebased and reduced to the `Breadcrumbs` half, as suggested in https://github.com/WordPress/gutenberg/pull/81301#issuecomment-5412265943.

## Why?

The `Breadcrumbs` `nav` is a flex item inside the `Page` header's leading group. With the flexbox default `min-width: auto`, a nowrap crumb's min-content propagates up the chain and forces the page wider than its container before the truncation styles that `Breadcrumbs` already ships (`.current`'s ellipsis, the shrinkable `li:last-child`) can engage.

#81954 fixed the outer link of that chain (the header's leading group), but the `nav` itself still refuses to shrink, so the crumb keeps overflowing. Consumers currently have to patch this from outside with structural selectors (e.g. `:has(> nav[aria-label]) { min-inline-size: 0 }`), which breaks silently as soon as any wrapper — a `display: contents` one, for instance — lands between the header and the `nav`. See #81297 for the full analysis; the slot is also set to be reworked under #77039 / #77628, and this pins the propagation fix until those land.

## How?

- `breadcrumbs/index.tsx` — the `nav` gains a `root` class.
- `breadcrumbs/style.module.css` — `.root { min-width: 0; }`.
- `CHANGELOG.md` — entry under `Unreleased` → `Bug Fixes`.

No behavior change for content that fits: `min-width: 0` only removes the automatic minimum, it does not make anything smaller on its own.

## Testing Instructions

1. Render an `admin-ui` `Page` with breadcrumbs whose last item is a long unbroken string, e.g.:
   ```jsx
   <Page
   	breadcrumbs={
   		<Breadcrumbs
   			items={ [
   				{ label: 'Home', to: '/' },
   				{ label: 'VID_20260731_' + 'a'.repeat( 120 ) + '.mp4' },
   			] }
   		/>
   	}
   />
   ```
   (The `Admin UI/Page` → `WithBreadcrumbs` story with a long last label works as well.)
2. Narrow the viewport below the crumb's natural width.
3. Before: the page grows a horizontal scrollbar and the crumb never truncates. After: the crumb truncates with an ellipsis and the page keeps its width.

Note that the standalone `Breadcrumbs` stories truncate correctly even without this change — the defect only appears once the `nav` sits inside the `Page` header's flex chain.

### Testing Instructions for Keyboard

Tab through the breadcrumb links before and after narrowing the viewport: link order, focusability, and visible focus outlines are unchanged — this PR only allows the existing flex chain to shrink, it adds no interactive changes.

## Screenshots

Taken on the `Admin UI/Page` → `WithBreadcrumbs` story with the last crumb replaced by a long unbroken string (`VID_20260731_aaa….mp4`), viewport narrower than the crumb's natural width.

|Before|After|
|-|-|
|<img width="756" height="785" alt="截圖 2026-08-07 晚上11 43 01" src="https://github.com/user-attachments/assets/375c6e7a-ca11-4dde-b3e2-ce814fd193e3" />|<img width="812" height="871" alt="截圖 2026-08-07 晚上11 30 59" src="https://github.com/user-attachments/assets/6a03ae16-c039-4f7c-aa31-6a5e5c9dd490" />|

### Screencasts

#### Before
https://github.com/user-attachments/assets/2d1f67db-e1f6-42d8-b7c1-9411e5880c93

#### After
https://github.com/user-attachments/assets/4c1555ba-a2ce-4164-b878-477873f52aaf
