### PR TITLE
Validated form controls: attach validation errors to the interactive element

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug Fixes
 
+-   Validated form controls: Attach validation messages to the interactive element rather than the hidden validation delegate, so screen reader users hear the error on the control they focus. Affects `ValidatedFormTokenField`, `ValidatedToggleGroupControl`, and `ValidatedCustomSelectControl` ([#76741](https://github.com/WordPress/gutenberg/issues/76741)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).

--- a/packages/components/src/validated-form-controls/components/custom-select-control.tsx
+++ b/packages/components/src/validated-form-controls/components/custom-select-control.tsx
@@ -1,14 +1,14 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import type { ValidatedControlProps } from './types';
 import CustomSelectControl from '../../custom-select-control';
+
+/**
+ * The element the user actually interacts with. `ValidatedCustomSelectControl`
+ * validates through a hidden delegate `<select>`, so this has to be resolved
+ * from the DOM — both to delegate focus and to attach the validity message.
+ */
+const INTERACTIVE_TARGET_SELECTOR = '[role="combobox"]';
 
 const UnforwardedValidatedCustomSelectControl = (
 	{
@@ -22,6 +22,11 @@ const UnforwardedValidatedCustomSelectControl = (
 ) => {
 	const validityTargetRef = useRef< HTMLSelectElement >( null );
 
+	const getInteractiveTarget = () =>
+		validityTargetRef.current?.previousElementSibling?.querySelector(
+			INTERACTIVE_TARGET_SELECTOR
+		);
+
 	return (
 		<div
 			className="components-validated-control__wrapper-with-error-delegate"
@@ -32,6 +37,7 @@ const UnforwardedValidatedCustomSelectControl = (
 				markWhenOptional={ markWhenOptional }
 				customValidity={ customValidity }
 				getValidityTarget={ () => validityTargetRef.current }
+				getInteractiveTarget={ getInteractiveTarget }
 			>
 				<CustomSelectControl
 					// TODO: Upstream limitation - Required isn't passed down correctly,
@@ -49,7 +55,7 @@ const UnforwardedValidatedCustomSelectControl = (
 				onFocus={ ( e ) => {
 					e.target.previousElementSibling
 						?.querySelector< HTMLButtonElement >(
-							'[role="combobox"]'
+							INTERACTIVE_TARGET_SELECTOR
 						)
 						?.focus();
 				} }

--- a/packages/components/src/validated-form-controls/components/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/components/form-token-field.tsx
@@ -1,14 +1,16 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import type { ValidatedControlProps } from './types';
 import { FormTokenField } from '../../form-token-field';
+
+/**
+ * The element the user actually interacts with. `ValidatedFormTokenField`
+ * validates through a hidden delegate input, so this has to be resolved from
+ * the DOM — both to delegate focus and to attach the validity message.
+ *
+ * This input also carries `role="combobox"`.
+ */
+const INTERACTIVE_TARGET_SELECTOR = 'input[type="text"]';
 
 const UnforwardedValidatedFormTokenField = (
 	{
@@ -21,6 +23,11 @@ const UnforwardedValidatedFormTokenField = (
 ) => {
 	const validityTargetRef = useRef< HTMLInputElement >( null );
 
+	const getInteractiveTarget = () =>
+		validityTargetRef.current?.previousElementSibling?.querySelector(
+			INTERACTIVE_TARGET_SELECTOR
+		);
+
 	return (
 		<div
 			className="components-validated-control__wrapper-with-error-delegate"
@@ -31,6 +38,7 @@ const UnforwardedValidatedFormTokenField = (
 				markWhenOptional={ markWhenOptional }
 				customValidity={ customValidity }
 				getValidityTarget={ () => validityTargetRef.current }
+				getInteractiveTarget={ getInteractiveTarget }
 			>
 				<FormTokenField { ...restProps } />
 			</ControlWithError>
@@ -49,7 +57,7 @@ const UnforwardedValidatedFormTokenField = (
 				onFocus={ ( e ) => {
 					e.target.previousElementSibling
 						?.querySelector< HTMLInputElement >(
-							'input[type="text"]'
+							INTERACTIVE_TARGET_SELECTOR
 						)
 						?.focus();
 				} }

--- a/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
@@ -1,14 +1,24 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useId, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import type { ValidatedControlProps } from './types';
 import { ToggleGroupControl } from '../../toggle-group-control';
+
+/**
+ * The option currently holding the roving tabindex. Focus on the hidden
+ * delegate is redirected here.
+ */
+const ACTIVE_ITEM_SELECTOR = '[data-active-item="true"]';
+
+/**
+ * The group container. A group-level description is what a screen reader
+ * announces on entering the group, so the validity message goes here rather
+ * than on an individual option — and unlike the active item, this element is
+ * always present.
+ *
+ * `ToggleGroupControl` renders a `radiogroup` by default and a `group` in its
+ * deselectable mode.
+ */
+const GROUP_SELECTOR = '[role="radiogroup"],[role="group"]';
 
 const UnforwardedValidatedToggleGroupControl = (
 	{
@@ -24,6 +34,11 @@ const UnforwardedValidatedToggleGroupControl = (
 
 	const nameAttr = useId();
 
+	const getInteractiveTarget = () =>
+		validityTargetRef.current?.previousElementSibling?.querySelector(
+			GROUP_SELECTOR
+		);
+
 	return (
 		<div className="components-validated-control__wrapper-with-error-delegate">
 			<ControlWithError
@@ -31,6 +46,7 @@ const UnforwardedValidatedToggleGroupControl = (
 				markWhenOptional={ markWhenOptional }
 				customValidity={ customValidity }
 				getValidityTarget={ () => validityTargetRef.current }
+				getInteractiveTarget={ getInteractiveTarget }
 			>
 				<ToggleGroupControl ref={ forwardedRef } { ...restProps } />
 			</ControlWithError>
@@ -47,7 +63,7 @@ const UnforwardedValidatedToggleGroupControl = (
 				onFocus={ ( e ) => {
 					e.target.previousElementSibling
 						?.querySelector< HTMLButtonElement | HTMLInputElement >(
-							'[data-active-item="true"]'
+							ACTIVE_ITEM_SELECTOR
 						)
 						?.focus();
 				} }

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import {
 	cloneElement,
@@ -9,10 +6,6 @@ import {
 	useId,
 	useState,
 } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { ValidatedControlProps } from './components/types';
 import { ValidityIndicator } from './validity-indicator';
 
@@ -66,6 +59,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		markWhenOptional,
 		customValidity,
 		getValidityTarget,
+		getInteractiveTarget,
 		children,
 	}: {
 		/**
@@ -81,6 +75,15 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		 * A function that returns the actual element on which the validity data should be applied.
 		 */
 		getValidityTarget: () => ValidityTarget | null | undefined;
+		/**
+		 * A function that returns the element that the validity message should
+		 * describe. Defaults to the validity target.
+		 *
+		 * Controls that validate through a visually hidden delegate element must
+		 * provide this, so the message reaches the element the user actually
+		 * focuses rather than the delegate.
+		 */
+		getInteractiveTarget?: () => Element | null | undefined;
 		/**
 		 * The control component to apply validation to.
 		 *
@@ -279,11 +282,11 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 
 	const visibleMessage = showMessage ? message : null;
 
-	// Imperatively manage `aria-describedby` on the validity target so we
+	// Imperatively manage `aria-describedby` on the described element so we
 	// merge with any value the child control sets internally (e.g. from a
 	// `help` prop), rather than competing with it at the props level.
 	useEffect( () => {
-		const target = getValidityTarget();
+		const target = getInteractiveTarget?.() ?? getValidityTarget();
 		if ( ! target ) {
 			return;
 		}
@@ -307,7 +310,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		setDescribedBy( target, !! visibleMessage );
 
 		return () => setDescribedBy( target, false );
-	}, [ visibleMessage, messageId, getValidityTarget ] );
+	}, [ visibleMessage, messageId, getValidityTarget, getInteractiveTarget ] );
 
 	return (
 		<div className={ className } ref={ forwardedRef } onBlur={ onBlur }>

--- a/packages/components/src/validated-form-controls/test/custom-select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/custom-select-control.tsx
@@ -57,4 +57,32 @@ describe( 'ValidatedCustomSelectControl', () => {
 			);
 		} );
 	} );
+
+	it( 'should connect the validation error to the interactive combobox', async () => {
+		const user = userEvent.setup();
+		render(
+			<form onSubmit={ ( e ) => e.preventDefault() }>
+				<ValidatedCustomSelectControl
+					label="Font Size"
+					options={ options }
+					value={ undefined }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const combobox = await screen.findByRole( 'combobox', {
+			name: /^Font Size/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( combobox ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+	} );
 } );

--- a/packages/components/src/validated-form-controls/test/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/test/form-token-field.tsx
@@ -37,9 +37,8 @@ describe( 'ValidatedFormTokenField', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
 
-		// The validation error targets the hidden delegate input, not the
-		// interactive combobox. The combobox's built-in description should
-		// be unaffected.
+		// The validation error is attached to the interactive combobox, and
+		// merges with — rather than replaces — the built-in description.
 		await waitFor( () => {
 			expect(
 				screen.getByText( 'Constraints not satisfied' )
@@ -48,5 +47,30 @@ describe( 'ValidatedFormTokenField', () => {
 		expect( input ).toHaveAccessibleDescription(
 			expect.stringContaining( 'Separate with commas or the Enter key.' )
 		);
+	} );
+
+	it( 'should connect the validation error to the interactive combobox', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedFormTokenField
+					label="Tags"
+					value={ [] }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const input = screen.getByRole( 'combobox', { name: /^Tags/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( input ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ValidatedToggleGroupControl } from '../components';
 import { ToggleGroupControlOption } from '../../toggle-group-control';
 
@@ -24,5 +25,33 @@ describe( 'ValidatedToggleGroupControl', () => {
 		expect(
 			screen.getByRole( 'radiogroup', { name: 'Alignment' } )
 		).toHaveAccessibleDescription( 'Choose text alignment.' );
+	} );
+
+	it( 'should connect the validation error to the toggle group', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedToggleGroupControl
+					label="Alignment"
+					value={ undefined }
+					onChange={ () => {} }
+					required
+				>
+					<ToggleGroupControlOption label="Left" value="left" />
+					<ToggleGroupControlOption label="Center" value="center" />
+				</ValidatedToggleGroupControl>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const group = screen.getByRole( 'radiogroup', { name: /^Alignment/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( group ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
## What

For validated controls that use a visually hidden element as a validation delegate — `ValidatedFormTokenField`, `ValidatedToggleGroupControl`, and `ValidatedCustomSelectControl` — the error message's `aria-describedby` was attached to the delegate rather than to the element the user actually focuses. A screen reader user who moves focus back to the control never hears the error.

Fixes #76741.

## How

`ControlWithError` gains an optional resolver:

```ts
getInteractiveTarget?: () => Element | null | undefined;
```

Only the `aria-describedby` effect consults it, falling back to `getValidityTarget()`. Every other use of `getValidityTarget()` — the `invalid` listeners, `setCustomValidity()`, the native popover suppression, `data-validity-visible` — is unchanged, because those genuinely belong on the delegate, which is what the Constraint Validation API acts on.

Each delegate control already contained the selector it needed inside its `onFocus` handler. Those are now module-level constants shared by both the focus delegation and the description, so the two cannot drift.

`ValidatedToggleGroupControl` is the exception and uses two distinct selectors. Focus belongs on the option holding the roving tabindex (`[data-active-item="true"]`), but the *description* belongs on the group container that `Ariakit.RadioGroup` renders: a group-level description is what a screen reader announces on entering the group, and unlike the active item that element is present regardless of interaction state.

## Notes for reviewers

- `ValidatedCustomSelectControl` is included even though it is not currently exported anywhere — it is the third delegate-based control and the issue names it explicitly.
- The description **moves** rather than being duplicated: the delegate is `tabIndex={-1}` and visually hidden, so nothing reads its `aria-describedby`.
- The `it.skip` in `test/toggle-group-control.tsx` is intentionally left skipped. It covers a *different* pre-existing bug — `BaseControl` not associating the `help` prop — which this PR does not address.
- Two existing test comments asserted the old behavior and are updated.

## Testing instructions

1. `npm run test:unit -- packages/components/src/validated-form-controls`
2. In Storybook, open any of the three controls, submit the enclosing form with the field empty, and confirm with a screen reader (or the accessibility inspector) that the error is announced as the description of the combobox / radiogroup rather than of the hidden delegate.