### PR TITLE
Validated form controls: stabilize as public API

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Internal
 
+-   Import the validated form controls from the public `@wordpress/components` API instead of unlocking them ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). No behavior change.
 -   `ListView`: Reimplement the Firefox description-recomputation workaround in `AriaReferencedText` by keying the element on its text, so React replaces it instead of updating the existing text node in place ([#80929](https://github.com/WordPress/gutenberg/pull/80929).
 -   Gate the inherited Global Styles treatment in the block inspector on the `gutenberg-global-styles-inheritance-ui` Gutenberg experiment, so `useResolvedStyle` resolves nothing and the block-supports panels render without the inheritance affordances until the experiment is turned on ([#80555](https://github.com/WordPress/gutenberg/pull/80555), [#80815](https://github.com/WordPress/gutenberg/pull/80815)).
 -   `URLInput`: Convert the class component to a function component with hooks, replacing the `compose( withSafeTimeout, withSpokenMessages, withInstanceId, withSelect )` wrapper. The unused `setTimeout` prop injected by `withSafeTimeout` is dropped, and the block editor settings are now read on demand rather than subscribed to ([#80721](https://github.com/WordPress/gutenberg/pull/80721)).

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import clsx from 'clsx';
-
-/**
- * WordPress dependencies
- */
 import { speak } from '@wordpress/a11y';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -16,19 +9,12 @@ import {
 	__experimentalInputControl as InputControl,
 	Spinner,
 	Popover,
-	privateApis as componentsPrivateApis,
+	ValidatedInputControl,
 } from '@wordpress/components';
 import { useDebounce, useEvent, useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
 import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
-
-const { ValidatedInputControl } = unlock( componentsPrivateApis );
 
 const noop = () => {};
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 
+-   Import the validated form controls from the public `@wordpress/components` API instead of unlocking them ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). No behavior change.
 -   Update `memize` to 2.1.1 ([#80764](https://github.com/WordPress/gutenberg/pull/80764)).
 -   Image: Check only `window.__clientSideMediaProcessing` for sideloading status, following the removal of the redundant `window.__heicUploadSupport` flag ([#80452](https://github.com/WordPress/gutenberg/pull/80452)).
 

--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -1,24 +1,11 @@
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	Popover,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Popover, ValidatedTextareaControl } from '@wordpress/components';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-const { ValidatedTextareaControl } = unlock( componentsPrivateApis );
 
 export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 	const { latex, mathML } = attributes;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Enhancements
 
+-   Validated form controls: Stabilize `ValidatedCheckboxControl`, `ValidatedComboboxControl`, `ValidatedFormTokenField`, `ValidatedInputControl`, `ValidatedNumberControl`, `ValidatedRadioControl`, `ValidatedSelectControl`, `ValidatedTextControl`, `ValidatedTextareaControl`, `ValidatedToggleControl`, and `ValidatedToggleGroupControl` as public exports, along with the `ValidatedControlProps` type, and remove them from private APIs ([#81230](https://github.com/WordPress/gutenberg/issues/81230)).
+-   `ValidatedSelectControl`: Support multiple selection, mirroring `SelectControl`'s own single/multiple props union ([#81230](https://github.com/WordPress/gutenberg/issues/81230)).
 -   `GradientPicker`: Add `selectedSlug` prop for slug-based selection and pass the selected preset's slug to `onChange`, so two presets sharing a gradient keep their identity ([#80554](https://github.com/WordPress/gutenberg/pull/80554)).
 -   `SandBox`: Add `allowPopups` prop to opt into `allow-popups` in the iframe's sandbox attribute ([#69617](https://github.com/WordPress/gutenberg/pull/69617)).
 -   `SandBox`: Add `allowForms` prop to opt into `allow-forms` in the iframe's sandbox attribute ([#76471](https://github.com/WordPress/gutenberg/pull/76471)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug Fixes
 
+-   Validated form controls: Attach validation messages to the interactive element rather than the hidden validation delegate, so screen reader users hear the error on the control they focus. Affects `ValidatedFormTokenField`, `ValidatedToggleGroupControl`, and `ValidatedCustomSelectControl` ([#76741](https://github.com/WordPress/gutenberg/issues/76741)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -200,6 +200,20 @@ export {
 	useCustomUnits as __experimentalUseCustomUnits,
 	parseQuantityAndUnitFromRawValue as __experimentalParseQuantityAndUnitFromRawValue,
 } from './unit-control';
+export {
+	ValidatedCheckboxControl,
+	ValidatedComboboxControl,
+	ValidatedFormTokenField,
+	ValidatedInputControl,
+	ValidatedNumberControl,
+	ValidatedRadioControl,
+	ValidatedSelectControl,
+	ValidatedTextControl,
+	ValidatedTextareaControl,
+	ValidatedToggleControl,
+	ValidatedToggleGroupControl,
+} from './validated-form-controls/components';
+export type { ValidatedControlProps } from './validated-form-controls/components/types';
 export { View as __experimentalView } from './view';
 export { VisuallyHidden } from './visually-hidden';
 export { VStack as __experimentalVStack } from './v-stack';

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 import { useDrag } from '@use-gesture/react';
-
-/**
- * Internal dependencies
- */
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
@@ -14,22 +7,8 @@ import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
 import Badge from './badge';
-
 import { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
-import {
-	ValidatedCheckboxControl,
-	ValidatedComboboxControl,
-	ValidatedInputControl,
-	ValidatedNumberControl,
-	ValidatedSelectControl,
-	ValidatedRadioControl,
-	ValidatedContentEditableControl,
-	ValidatedTextControl,
-	ValidatedTextareaControl,
-	ValidatedToggleControl,
-	ValidatedToggleGroupControl,
-} from './validated-form-controls';
-import { ValidatedFormTokenField } from './validated-form-controls/components/form-token-field';
+import { ValidatedContentEditableControl } from './validated-form-controls';
 import ContentEditableControl from './content-editable-control';
 
 export const privateApis = {};
@@ -47,16 +26,5 @@ lock( privateApis, {
 	DateRangeCalendar,
 	TZDate,
 	useDrag,
-	ValidatedInputControl,
-	ValidatedCheckboxControl,
-	ValidatedComboboxControl,
-	ValidatedNumberControl,
-	ValidatedSelectControl,
-	ValidatedRadioControl,
 	ValidatedContentEditableControl,
-	ValidatedTextControl,
-	ValidatedTextareaControl,
-	ValidatedToggleControl,
-	ValidatedToggleGroupControl,
-	ValidatedFormTokenField,
 } );

--- a/packages/components/src/validated-form-controls/components/custom-select-control.tsx
+++ b/packages/components/src/validated-form-controls/components/custom-select-control.tsx
@@ -1,14 +1,14 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import type { ValidatedControlProps } from './types';
 import CustomSelectControl from '../../custom-select-control';
+
+/**
+ * The element the user actually interacts with. `ValidatedCustomSelectControl`
+ * validates through a hidden delegate `<select>`, so this has to be resolved
+ * from the DOM — both to delegate focus and to attach the validity message.
+ */
+const INTERACTIVE_TARGET_SELECTOR = '[role="combobox"]';
 
 const UnforwardedValidatedCustomSelectControl = (
 	{
@@ -22,6 +22,11 @@ const UnforwardedValidatedCustomSelectControl = (
 ) => {
 	const validityTargetRef = useRef< HTMLSelectElement >( null );
 
+	const getInteractiveTarget = () =>
+		validityTargetRef.current?.previousElementSibling?.querySelector(
+			INTERACTIVE_TARGET_SELECTOR
+		);
+
 	return (
 		<div
 			className="components-validated-control__wrapper-with-error-delegate"
@@ -32,6 +37,7 @@ const UnforwardedValidatedCustomSelectControl = (
 				markWhenOptional={ markWhenOptional }
 				customValidity={ customValidity }
 				getValidityTarget={ () => validityTargetRef.current }
+				getInteractiveTarget={ getInteractiveTarget }
 			>
 				<CustomSelectControl
 					// TODO: Upstream limitation - Required isn't passed down correctly,
@@ -49,7 +55,7 @@ const UnforwardedValidatedCustomSelectControl = (
 				onFocus={ ( e ) => {
 					e.target.previousElementSibling
 						?.querySelector< HTMLButtonElement >(
-							'[role="combobox"]'
+							INTERACTIVE_TARGET_SELECTOR
 						)
 						?.focus();
 				} }

--- a/packages/components/src/validated-form-controls/components/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/components/form-token-field.tsx
@@ -1,14 +1,16 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import type { ValidatedControlProps } from './types';
 import { FormTokenField } from '../../form-token-field';
+
+/**
+ * The element the user actually interacts with. `ValidatedFormTokenField`
+ * validates through a hidden delegate input, so this has to be resolved from
+ * the DOM — both to delegate focus and to attach the validity message.
+ *
+ * This input also carries `role="combobox"`.
+ */
+const INTERACTIVE_TARGET_SELECTOR = 'input[type="text"]';
 
 const UnforwardedValidatedFormTokenField = (
 	{
@@ -21,6 +23,11 @@ const UnforwardedValidatedFormTokenField = (
 ) => {
 	const validityTargetRef = useRef< HTMLInputElement >( null );
 
+	const getInteractiveTarget = () =>
+		validityTargetRef.current?.previousElementSibling?.querySelector(
+			INTERACTIVE_TARGET_SELECTOR
+		);
+
 	return (
 		<div
 			className="components-validated-control__wrapper-with-error-delegate"
@@ -31,6 +38,7 @@ const UnforwardedValidatedFormTokenField = (
 				markWhenOptional={ markWhenOptional }
 				customValidity={ customValidity }
 				getValidityTarget={ () => validityTargetRef.current }
+				getInteractiveTarget={ getInteractiveTarget }
 			>
 				<FormTokenField { ...restProps } />
 			</ControlWithError>
@@ -49,7 +57,7 @@ const UnforwardedValidatedFormTokenField = (
 				onFocus={ ( e ) => {
 					e.target.previousElementSibling
 						?.querySelector< HTMLInputElement >(
-							'input[type="text"]'
+							INTERACTIVE_TARGET_SELECTOR
 						)
 						?.focus();
 				} }

--- a/packages/components/src/validated-form-controls/components/select-control.tsx
+++ b/packages/components/src/validated-form-controls/components/select-control.tsx
@@ -1,15 +1,50 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useRef } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import SelectControl from '../../select-control';
+import type { WordPressComponentProps } from '../../context';
+import type {
+	SelectControlSingleSelectionProps,
+	SelectControlMultipleSelectionProps,
+} from '../../select-control/types';
 import type { ValidatedControlProps } from './types';
+
+/**
+ * `onChange` is redeclared as required — a validated control is always
+ * controlled — and without `SelectControl`'s optional `extra` argument, which
+ * consumers of this wrapper have no use for.
+ */
+export type ValidatedSelectControlSingleSelectionProps = Omit<
+	WordPressComponentProps<
+		SelectControlSingleSelectionProps< string >,
+		'select',
+		false
+	>,
+	'onChange'
+> &
+	ValidatedControlProps & {
+		onChange: ( value: string ) => void;
+	};
+
+export type ValidatedSelectControlMultipleSelectionProps = Omit<
+	WordPressComponentProps<
+		SelectControlMultipleSelectionProps< string >,
+		'select',
+		false
+	>,
+	'onChange'
+> &
+	ValidatedControlProps & {
+		onChange: ( value: string[] ) => void;
+	};
+
+/**
+ * Mirrors `SelectControl`'s own single/multiple discriminated union, so that
+ * `multiple` selects are typed with an array `value` and an array `onChange`.
+ */
+export type ValidatedSelectControlProps =
+	| ValidatedSelectControlSingleSelectionProps
+	| ValidatedSelectControlMultipleSelectionProps;
 
 const UnforwardedValidatedSelectControl = (
 	{
@@ -17,13 +52,7 @@ const UnforwardedValidatedSelectControl = (
 		customValidity,
 		markWhenOptional,
 		...restProps
-	}: Omit<
-		React.ComponentProps< typeof SelectControl >,
-		'multiple' | 'onChange' | 'value'
-	> & {
-		value?: string;
-		onChange: ( value: string ) => void;
-	} & ValidatedControlProps,
+	}: ValidatedSelectControlProps,
 	forwardedRef: React.ForwardedRef< HTMLSelectElement >
 ) => {
 	const validityTargetRef = useRef< HTMLSelectElement >( null );

--- a/packages/components/src/validated-form-controls/components/stories/checkbox-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/checkbox-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { ValidatedCheckboxControl } from '../checkbox-control';
 import { formDecorator } from './story-utils';
 
@@ -18,7 +7,6 @@ const meta: Meta< typeof ValidatedCheckboxControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedCheckboxControl',
 	id: 'components-validatedcheckboxcontrol',
 	component: ValidatedCheckboxControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/combobox-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/combobox-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { ValidatedComboboxControl } from '../combobox-control';
 import { formDecorator } from './story-utils';
 
@@ -18,7 +7,6 @@ const meta: Meta< typeof ValidatedComboboxControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedComboboxControl',
 	id: 'components-validatedcomboboxcontrol',
 	component: ValidatedComboboxControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/form-token-field.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/form-token-field.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { ValidatedFormTokenField } from '../form-token-field';
 import { formDecorator } from './story-utils';
 import type { TokenItem } from '../../../form-token-field/types';
@@ -19,7 +8,6 @@ const meta: Meta< typeof ValidatedFormTokenField > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedFormTokenField',
 	id: 'components-validatedformtokenfield',
 	component: ValidatedFormTokenField,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/input-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/input-control.story.tsx
@@ -1,21 +1,6 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * WordPress dependencies
- */
 import { seen, unseen } from '@wordpress/icons';
-
-/**
- * Internal dependencies
- */
 import { ValidatedInputControl } from '../input-control';
 import { formDecorator } from './story-utils';
 import InputControlSuffixWrapper from '../../../input-control/input-suffix-wrapper';
@@ -25,7 +10,6 @@ const meta: Meta< typeof ValidatedInputControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedInputControl',
 	id: 'components-validatedinputcontrol',
 	component: ValidatedInputControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/number-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/number-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { ValidatedNumberControl } from '../number-control';
 import { formDecorator } from './story-utils';
 
@@ -18,7 +7,6 @@ const meta: Meta< typeof ValidatedNumberControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedNumberControl',
 	id: 'components-validatednumbercontrol',
 	component: ValidatedNumberControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/overview.mdx
+++ b/packages/components/src/validated-form-controls/components/stories/overview.mdx
@@ -8,9 +8,9 @@ import { ValidatedInputControl } from '..';
 
 This section contains form control components that extend [WordPress components](https://wordpress.github.io/gutenberg/) with additional validation capabilities.
 
-## Status: Beta
+## Status: Stable
 
-We are still gathering feedback and iterating. Please get in touch with `@WordPress/gutenberg-components`  if you are interested in trying them out in the Gutenberg app.
+These components are part of the public `@wordpress/components` API.
 
 ## Usage
 

--- a/packages/components/src/validated-form-controls/components/stories/radio-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/radio-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { ValidatedRadioControl } from '../radio-control';
 import { formDecorator } from './story-utils';
 
@@ -18,7 +7,6 @@ const meta: Meta< typeof ValidatedRadioControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedRadioControl',
 	id: 'components-validatedradiocontrol',
 	component: ValidatedRadioControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/select-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/select-control.story.tsx
@@ -11,7 +11,6 @@ const meta: Meta< ValidatedSelectControlSingleSelectionProps > = {
 	id: 'components-validatedselectcontrol',
 	component:
 		ValidatedSelectControl as React.ComponentType< ValidatedSelectControlSingleSelectionProps >,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/select-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/select-control.story.tsx
@@ -1,23 +1,16 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { ValidatedSelectControl } from '../select-control';
+import type { ValidatedSelectControlSingleSelectionProps } from '../select-control';
 import { formDecorator } from './story-utils';
 
-const meta: Meta< typeof ValidatedSelectControl > = {
+// Pinned to the single-selection half of the props union: Storybook's `args`
+// spread cannot round-trip a discriminated union.
+const meta: Meta< ValidatedSelectControlSingleSelectionProps > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedSelectControl',
 	id: 'components-validatedselectcontrol',
-	component: ValidatedSelectControl,
+	component:
+		ValidatedSelectControl as React.ComponentType< ValidatedSelectControlSingleSelectionProps >,
 	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
@@ -27,7 +20,7 @@ const meta: Meta< typeof ValidatedSelectControl > = {
 };
 export default meta;
 
-export const Default: StoryObj< typeof ValidatedSelectControl > = {
+export const Default: StoryObj< ValidatedSelectControlSingleSelectionProps > = {
 	render: function Template( { onChange, ...args } ) {
 		const [ value, setValue ] = useState< string | undefined >( '' );
 

--- a/packages/components/src/validated-form-controls/components/stories/text-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/text-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { formDecorator } from './story-utils';
 import { ValidatedTextControl } from '../text-control';
 
@@ -18,7 +7,6 @@ const meta: Meta< typeof ValidatedTextControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedTextControl',
 	id: 'components-validatedtextcontrol',
 	component: ValidatedTextControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/textarea-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/textarea-control.story.tsx
@@ -1,15 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-/**
- * Internal dependencies
- */
 import { formDecorator } from './story-utils';
 import { ValidatedTextareaControl } from '../textarea-control';
 
@@ -17,7 +7,6 @@ const meta: Meta< typeof ValidatedTextareaControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedTextareaControl',
 	id: 'components-validatedtextareacontrol',
 	component: ValidatedTextareaControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: { value: { control: false } },

--- a/packages/components/src/validated-form-controls/components/stories/toggle-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/toggle-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { formDecorator } from './story-utils';
 import { ValidatedToggleControl } from '../toggle-control';
 
@@ -18,7 +7,6 @@ const meta: Meta< typeof ValidatedToggleControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedToggleControl',
 	id: 'components-validatedtogglecontrol',
 	component: ValidatedToggleControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/stories/toggle-group-control.story.tsx
+++ b/packages/components/src/validated-form-controls/components/stories/toggle-group-control.story.tsx
@@ -1,16 +1,5 @@
-/**
- * WordPress dependencies
- */
 import { useState } from '@wordpress/element';
-
-/**
- * External dependencies
- */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-
-/**
- * Internal dependencies
- */
 import { formDecorator } from './story-utils';
 import { ValidatedToggleGroupControl } from '../toggle-group-control';
 import { ToggleGroupControlOption } from '../../../toggle-group-control';
@@ -19,7 +8,6 @@ const meta: Meta< typeof ValidatedToggleGroupControl > = {
 	title: 'Components/Selection & Input/Validated Form Controls/ValidatedToggleGroupControl',
 	id: 'components-validatedtogglegroupcontrol',
 	component: ValidatedToggleGroupControl,
-	tags: [ 'status-private' ],
 	decorators: formDecorator,
 	args: { onChange: () => {} },
 	argTypes: {

--- a/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
@@ -1,14 +1,24 @@
-/**
- * WordPress dependencies
- */
 import { forwardRef, useId, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import { ControlWithError } from '../control-with-error';
 import type { ValidatedControlProps } from './types';
 import { ToggleGroupControl } from '../../toggle-group-control';
+
+/**
+ * The option currently holding the roving tabindex. Focus on the hidden
+ * delegate is redirected here.
+ */
+const ACTIVE_ITEM_SELECTOR = '[data-active-item="true"]';
+
+/**
+ * The group container. A group-level description is what a screen reader
+ * announces on entering the group, so the validity message goes here rather
+ * than on an individual option — and unlike the active item, this element is
+ * always present.
+ *
+ * `ToggleGroupControl` renders a `radiogroup` by default and a `group` in its
+ * deselectable mode.
+ */
+const GROUP_SELECTOR = '[role="radiogroup"],[role="group"]';
 
 const UnforwardedValidatedToggleGroupControl = (
 	{
@@ -24,6 +34,11 @@ const UnforwardedValidatedToggleGroupControl = (
 
 	const nameAttr = useId();
 
+	const getInteractiveTarget = () =>
+		validityTargetRef.current?.previousElementSibling?.querySelector(
+			GROUP_SELECTOR
+		);
+
 	return (
 		<div className="components-validated-control__wrapper-with-error-delegate">
 			<ControlWithError
@@ -31,6 +46,7 @@ const UnforwardedValidatedToggleGroupControl = (
 				markWhenOptional={ markWhenOptional }
 				customValidity={ customValidity }
 				getValidityTarget={ () => validityTargetRef.current }
+				getInteractiveTarget={ getInteractiveTarget }
 			>
 				<ToggleGroupControl ref={ forwardedRef } { ...restProps } />
 			</ControlWithError>
@@ -47,7 +63,7 @@ const UnforwardedValidatedToggleGroupControl = (
 				onFocus={ ( e ) => {
 					e.target.previousElementSibling
 						?.querySelector< HTMLButtonElement | HTMLInputElement >(
-							'[data-active-item="true"]'
+							ACTIVE_ITEM_SELECTOR
 						)
 						?.focus();
 				} }

--- a/packages/components/src/validated-form-controls/control-with-error.tsx
+++ b/packages/components/src/validated-form-controls/control-with-error.tsx
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import {
 	cloneElement,
@@ -9,10 +6,6 @@ import {
 	useId,
 	useState,
 } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { ValidatedControlProps } from './components/types';
 import { ValidityIndicator } from './validity-indicator';
 
@@ -66,6 +59,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		markWhenOptional,
 		customValidity,
 		getValidityTarget,
+		getInteractiveTarget,
 		children,
 	}: {
 		/**
@@ -81,6 +75,15 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		 * A function that returns the actual element on which the validity data should be applied.
 		 */
 		getValidityTarget: () => ValidityTarget | null | undefined;
+		/**
+		 * A function that returns the element that the validity message should
+		 * describe. Defaults to the validity target.
+		 *
+		 * Controls that validate through a visually hidden delegate element must
+		 * provide this, so the message reaches the element the user actually
+		 * focuses rather than the delegate.
+		 */
+		getInteractiveTarget?: () => Element | null | undefined;
 		/**
 		 * The control component to apply validation to.
 		 *
@@ -279,11 +282,11 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 
 	const visibleMessage = showMessage ? message : null;
 
-	// Imperatively manage `aria-describedby` on the validity target so we
+	// Imperatively manage `aria-describedby` on the described element so we
 	// merge with any value the child control sets internally (e.g. from a
 	// `help` prop), rather than competing with it at the props level.
 	useEffect( () => {
-		const target = getValidityTarget();
+		const target = getInteractiveTarget?.() ?? getValidityTarget();
 		if ( ! target ) {
 			return;
 		}
@@ -307,7 +310,7 @@ function UnforwardedControlWithError< C extends React.ReactElement >(
 		setDescribedBy( target, !! visibleMessage );
 
 		return () => setDescribedBy( target, false );
-	}, [ visibleMessage, messageId, getValidityTarget ] );
+	}, [ visibleMessage, messageId, getValidityTarget, getInteractiveTarget ] );
 
 	return (
 		<div className={ className } ref={ forwardedRef } onBlur={ onBlur }>

--- a/packages/components/src/validated-form-controls/test/custom-select-control.tsx
+++ b/packages/components/src/validated-form-controls/test/custom-select-control.tsx
@@ -57,4 +57,32 @@ describe( 'ValidatedCustomSelectControl', () => {
 			);
 		} );
 	} );
+
+	it( 'should connect the validation error to the interactive combobox', async () => {
+		const user = userEvent.setup();
+		render(
+			<form onSubmit={ ( e ) => e.preventDefault() }>
+				<ValidatedCustomSelectControl
+					label="Font Size"
+					options={ options }
+					value={ undefined }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const combobox = await screen.findByRole( 'combobox', {
+			name: /^Font Size/,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( combobox ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
+	} );
 } );

--- a/packages/components/src/validated-form-controls/test/form-token-field.tsx
+++ b/packages/components/src/validated-form-controls/test/form-token-field.tsx
@@ -37,9 +37,8 @@ describe( 'ValidatedFormTokenField', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
 
-		// The validation error targets the hidden delegate input, not the
-		// interactive combobox. The combobox's built-in description should
-		// be unaffected.
+		// The validation error is attached to the interactive combobox, and
+		// merges with — rather than replaces — the built-in description.
 		await waitFor( () => {
 			expect(
 				screen.getByText( 'Constraints not satisfied' )
@@ -48,5 +47,30 @@ describe( 'ValidatedFormTokenField', () => {
 		expect( input ).toHaveAccessibleDescription(
 			expect.stringContaining( 'Separate with commas or the Enter key.' )
 		);
+	} );
+
+	it( 'should connect the validation error to the interactive combobox', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedFormTokenField
+					label="Tags"
+					value={ [] }
+					onChange={ () => {} }
+					required
+				/>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const input = screen.getByRole( 'combobox', { name: /^Tags/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( input ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
 	} );
 } );

--- a/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/test/toggle-group-control.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ValidatedToggleGroupControl } from '../components';
 import { ToggleGroupControlOption } from '../../toggle-group-control';
 
@@ -24,5 +25,33 @@ describe( 'ValidatedToggleGroupControl', () => {
 		expect(
 			screen.getByRole( 'radiogroup', { name: 'Alignment' } )
 		).toHaveAccessibleDescription( 'Choose text alignment.' );
+	} );
+
+	it( 'should connect the validation error to the toggle group', async () => {
+		const user = userEvent.setup();
+		render(
+			<form>
+				<ValidatedToggleGroupControl
+					label="Alignment"
+					value={ undefined }
+					onChange={ () => {} }
+					required
+				>
+					<ToggleGroupControlOption label="Left" value="left" />
+					<ToggleGroupControlOption label="Center" value="center" />
+				</ValidatedToggleGroupControl>
+				<button type="submit">Submit</button>
+			</form>
+		);
+
+		const group = screen.getByRole( 'radiogroup', { name: /^Alignment/ } );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		await waitFor( () => {
+			expect( group ).toHaveAccessibleDescription(
+				expect.stringContaining( 'Constraints not satisfied' )
+			);
+		} );
 	} );
 } );

--- a/packages/content-types/CHANGELOG.md
+++ b/packages/content-types/CHANGELOG.md
@@ -12,4 +12,5 @@
 
 ### Internal
 
+-   Import the validated form controls from the public `@wordpress/components` API instead of unlocking them ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). No behavior change.
 -   Update `exports` to use subpath patterns instead of deprecated trailing `/` folder mappings ([#80270](https://github.com/WordPress/gutenberg/pull/80270)).

--- a/packages/content-types/src/utils/fields.tsx
+++ b/packages/content-types/src/utils/fields.tsx
@@ -1,7 +1,8 @@
-/**
- * WordPress dependencies
- */
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import {
+	ValidatedInputControl,
+	ValidatedToggleControl,
+} from '@wordpress/components';
+import type { ValidatedControlProps } from '@wordpress/components';
 import type {
 	DataFormControlProps,
 	Field,
@@ -9,26 +10,21 @@ import type {
 	NormalizedRules,
 } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-
 import { Badge } from '@wordpress/ui';
 import { cleanForSlug } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
 import type { ContentType } from '../types';
-
-const { ValidatedInputControl, ValidatedToggleControl } = unlock(
-	componentsPrivateApis
-);
 
 // Surface field-level validity messages in priority order: structural rules
 // (required, pattern, maxLength) first, async/custom last. `required` only
 // overrides the native browser message when our rule supplies one of its own.
-export function getCustomValidity( validity?: FieldValidity ) {
-	if ( validity?.required?.message ) {
-		return validity.required;
+export function getCustomValidity(
+	validity?: FieldValidity
+): ValidatedControlProps[ 'customValidity' ] {
+	// `FieldValidity.required.message` is optional, unlike every other rule, so
+	// it has to be narrowed rather than passed straight through.
+	const required = validity?.required;
+	if ( required?.message ) {
+		return { ...required, message: required.message };
 	}
 	if ( validity?.pattern ) {
 		return validity.pattern;
@@ -235,8 +231,11 @@ export function SlugEdit< T extends ContentType >( {
 	const { label, description, getValue, setValue } = field;
 	const isValid = field.isValid as SlugFieldRules< T >;
 	const value = ( getValue( { item: data } ) as string | undefined ) ?? '';
-	const handleChange = ( newValue: string ) =>
-		onChange( setValue( { item: data, value: newValue } ) );
+	// `InputControl` reports `undefined` when the field is cleared. The control
+	// renders `value ?? ''`, so normalise here to keep what is stored in step
+	// with what is displayed.
+	const handleChange = ( newValue: string | undefined ) =>
+		onChange( setValue( { item: data, value: newValue ?? '' } ) );
 	const onFocus = () => {
 		if ( data.id !== undefined || data.slug ) {
 			return;

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Internal
 
+-   DataViews: Import the validated form controls from the public `@wordpress/components` API instead of unlocking them, as part of removing the package's reliance on private cross-package APIs ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). Type-checking the migrated call sites also fixed a handful of latent type errors that the private `unlock()` helper's `any` return had hidden; no behavior change.
 -   DataViews: Inline a verbatim copy of the `kebabCase` utility instead of unlocking the private one from `@wordpress/components`, as part of removing the package's reliance on private cross-package APIs ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). Adds a direct `change-case` dependency; no behavior change. ([#81284](https://github.com/WordPress/gutenberg/pull/81284))
 -   Update `date-fns` to 4.4.0 ([#80763](https://github.com/WordPress/gutenberg/pull/80763)).
 -   Update Jest type definitions to v30 ([#80767](https://github.com/WordPress/gutenberg/pull/80767)).

--- a/packages/dataviews/src/components/dataform-controls/array.tsx
+++ b/packages/dataviews/src/components/dataform-controls/array.tsx
@@ -1,18 +1,8 @@
-/**
- * WordPress dependencies
- */
-import { privateApis, Spinner } from '@wordpress/components';
+import { Spinner, ValidatedFormTokenField } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
 import useElements from '../../hooks/use-elements';
-
-const { ValidatedFormTokenField } = unlock( privateApis );
 
 export default function ArrayControl< Item >( {
 	data,

--- a/packages/dataviews/src/components/dataform-controls/checkbox.tsx
+++ b/packages/dataviews/src/components/dataform-controls/checkbox.tsx
@@ -1,17 +1,7 @@
-/**
- * WordPress dependencies
- */
-import { privateApis } from '@wordpress/components';
+import { ValidatedCheckboxControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedCheckboxControl } = unlock( privateApis );
 
 export default function Checkbox< Item >( {
 	field,

--- a/packages/dataviews/src/components/dataform-controls/color.tsx
+++ b/packages/dataviews/src/components/dataform-controls/color.tsx
@@ -1,31 +1,17 @@
-/**
- * External dependencies
- */
 import { colord } from 'colord';
-
-/**
- * WordPress dependencies
- */
 import {
 	Button,
 	ColorIndicator,
 	ColorPicker,
 	Dropdown,
-	privateApis,
+	ValidatedInputControl,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedInputControl } = unlock( privateApis );
 
 const ColorPickerDropdown = ( {
 	color,

--- a/packages/dataviews/src/components/dataform-controls/combobox.tsx
+++ b/packages/dataviews/src/components/dataform-controls/combobox.tsx
@@ -1,18 +1,8 @@
-/**
- * WordPress dependencies
- */
-import { privateApis, Spinner } from '@wordpress/components';
+import { Spinner, ValidatedComboboxControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
 import useElements from '../../hooks/use-elements';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedComboboxControl } = unlock( privateApis );
 
 export default function Combobox< Item >( {
 	data,
@@ -26,7 +16,9 @@ export default function Combobox< Item >( {
 	const value = getValue( { item: data } ) ?? '';
 
 	const onChangeControl = useCallback(
-		( newValue: string | null ) =>
+		// `ComboboxControl` reports `null` on reset and `undefined` when the
+		// selection is cleared; both mean "no value" here.
+		( newValue: string | null | undefined ) =>
 			onChange( setValue( { item: data, value: newValue ?? '' } ) ),
 		[ data, onChange, setValue ]
 	);

--- a/packages/dataviews/src/components/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/components/dataform-controls/datetime.tsx
@@ -1,18 +1,12 @@
-/**
- * WordPress dependencies
- */
 import {
 	BaseControl,
+	ValidatedInputControl,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { Stack } from '@wordpress/ui';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps, FormatDatetime } from '../../types';
 import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../../constants';
 import RelativeDateControl from './utils/relative-date-control';
@@ -21,7 +15,7 @@ import getCustomValidity from './utils/get-custom-validity';
 import parseDateTime from '../../field-types/utils/parse-date-time';
 import { unlock } from '../../lock-unlock';
 
-const { DateCalendar, ValidatedInputControl } = unlock( componentsPrivateApis );
+const { DateCalendar } = unlock( componentsPrivateApis );
 
 const formatDateTime = ( value?: string ): string => {
 	if ( ! value ) {

--- a/packages/dataviews/src/components/dataform-controls/radio.tsx
+++ b/packages/dataviews/src/components/dataform-controls/radio.tsx
@@ -1,18 +1,8 @@
-/**
- * WordPress dependencies
- */
-import { privateApis, Spinner } from '@wordpress/components';
+import { Spinner, ValidatedRadioControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
 import useElements from '../../hooks/use-elements';
-
-const { ValidatedRadioControl } = unlock( privateApis );
 
 export default function Radio< Item >( {
 	data,

--- a/packages/dataviews/src/components/dataform-controls/select.tsx
+++ b/packages/dataviews/src/components/dataform-controls/select.tsx
@@ -1,18 +1,8 @@
-/**
- * WordPress dependencies
- */
-import { privateApis, Spinner } from '@wordpress/components';
+import { Spinner, ValidatedSelectControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
 import useElements from '../../hooks/use-elements';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedSelectControl } = unlock( privateApis );
 
 export default function Select< Item >( {
 	data,

--- a/packages/dataviews/src/components/dataform-controls/textarea.tsx
+++ b/packages/dataviews/src/components/dataform-controls/textarea.tsx
@@ -1,17 +1,7 @@
-/**
- * WordPress dependencies
- */
-import { privateApis } from '@wordpress/components';
+import { ValidatedTextareaControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedTextareaControl } = unlock( privateApis );
 
 export default function Textarea< Item >( {
 	data,

--- a/packages/dataviews/src/components/dataform-controls/time.tsx
+++ b/packages/dataviews/src/components/dataform-controls/time.tsx
@@ -1,24 +1,11 @@
-/**
- * WordPress dependencies
- */
-import {
-	BaseControl,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { BaseControl, ValidatedInputControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps, FormatTime } from '../../types';
 import { OPERATOR_BETWEEN } from '../../constants';
-import { unlock } from '../../lock-unlock';
 import parseTime from '../../field-types/utils/parse-time';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedInputControl } = unlock( componentsPrivateApis );
 
 type TimeBetween = [ string, string ];
 

--- a/packages/dataviews/src/components/dataform-controls/toggle-group.tsx
+++ b/packages/dataviews/src/components/dataform-controls/toggle-group.tsx
@@ -1,22 +1,12 @@
-/**
- * WordPress dependencies
- */
 import {
-	privateApis,
+	ValidatedToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Spinner,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
 import useElements from '../../hooks/use-elements';
-
-const { ValidatedToggleGroupControl } = unlock( privateApis );
 
 export default function ToggleGroup< Item >( {
 	data,

--- a/packages/dataviews/src/components/dataform-controls/toggle.tsx
+++ b/packages/dataviews/src/components/dataform-controls/toggle.tsx
@@ -1,17 +1,7 @@
-/**
- * WordPress dependencies
- */
-import { privateApis } from '@wordpress/components';
+import { ValidatedToggleControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../types';
-import { unlock } from '../../lock-unlock';
 import getCustomValidity from './utils/get-custom-validity';
-
-const { ValidatedToggleControl } = unlock( privateApis );
 
 export default function Toggle< Item >( {
 	field,

--- a/packages/dataviews/src/components/dataform-controls/utils/get-custom-validity.ts
+++ b/packages/dataviews/src/components/dataform-controls/utils/get-custom-validity.ts
@@ -1,18 +1,19 @@
-/**
- * Internal dependencies
- */
+import type { ValidatedControlProps } from '@wordpress/components';
 import type { NormalizedRules, FieldValidity } from '../../../types';
 
 export default function getCustomValidity< Item >(
 	isValid: NormalizedRules< Item >,
 	validity: FieldValidity | undefined
-) {
-	let customValidity;
+): ValidatedControlProps[ 'customValidity' ] {
+	let customValidity: ValidatedControlProps[ 'customValidity' ];
 	if ( isValid?.required && validity?.required ) {
 		// If the consumer provides a message for required,
 		// use it instead of the native built-in message.
-		customValidity = validity?.required?.message
-			? validity.required
+		// `FieldValidity.required.message` is optional, unlike every other
+		// rule, so it has to be narrowed rather than passed straight through.
+		const { message } = validity.required;
+		customValidity = message
+			? { ...validity.required, message }
 			: undefined;
 	} else if ( isValid?.pattern && validity?.pattern ) {
 		customValidity = validity.pattern;

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-input.tsx
@@ -1,17 +1,7 @@
-/**
- * WordPress dependencies
- */
-import { privateApis } from '@wordpress/components';
+import { ValidatedInputControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import type { DataFormControlProps } from '../../../types';
-import { unlock } from '../../../lock-unlock';
 import getCustomValidity from './get-custom-validity';
-
-const { ValidatedInputControl } = unlock( privateApis );
 
 export type DataFormValidatedTextControlProps< Item > =
 	DataFormControlProps< Item > & {
@@ -46,11 +36,14 @@ export default function ValidatedText< Item >( {
 	const disabled = field.isDisabled( { item: data, field } );
 
 	const onChangeControl = useCallback(
-		( newValue: string ) =>
+		// `InputControl` reports `undefined` when the field is cleared. The
+		// control renders `value ?? ''`, so normalise here to keep what is
+		// stored in step with what is displayed.
+		( newValue: string | undefined ) =>
 			onChange(
 				setValue( {
 					item: data,
-					value: newValue,
+					value: newValue ?? '',
 				} )
 			),
 		[ data, setValue, onChange ]

--- a/packages/dataviews/src/components/dataform-controls/utils/validated-number.tsx
+++ b/packages/dataviews/src/components/dataform-controls/utils/validated-number.tsx
@@ -1,24 +1,14 @@
-/**
- * WordPress dependencies
- */
 import {
 	Flex,
 	BaseControl,
+	ValidatedNumberControl,
 	__experimentalNumberControl as NumberControl,
-	privateApis,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
 import { OPERATOR_BETWEEN } from '../../../constants';
 import type { DataFormControlProps, FormatNumber } from '../../../types';
-import { unlock } from '../../../lock-unlock';
 import getCustomValidity from './get-custom-validity';
-
-const { ValidatedNumberControl } = unlock( privateApis );
 
 type NumberBetween = [ number | string, number | string ];
 
@@ -157,8 +147,11 @@ export default function ValidatedNumber< Item >( {
 			onChange={ onChangeControl }
 			hideLabelFromVision={ hideLabelFromVision }
 			step={ step }
-			min={ isValid.min ? isValid.min.constraint : undefined }
-			max={ isValid.max ? isValid.max.constraint : undefined }
+			// `min`/`max` constraints are typed `number | string` because the
+			// same rules describe dates and times. On a number field they are
+			// always numeric.
+			min={ isValid.min ? Number( isValid.min.constraint ) : undefined }
+			max={ isValid.max ? Number( isValid.max.constraint ) : undefined }
 			disabled={ disabled }
 		/>
 	);

--- a/packages/dataviews/src/dataform/stories/validation.tsx
+++ b/packages/dataviews/src/dataform/stories/validation.tsx
@@ -1,13 +1,7 @@
-/**
- * WordPress dependencies
- */
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { Button, privateApis } from '@wordpress/components';
+import type { ValidatedControlProps } from '@wordpress/components';
+import { Button, ValidatedTextControl } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-
-/**
- * Internal dependencies
- */
 import DataForm from '../index';
 import useFormValidity from '../../hooks/use-form-validity';
 import type {
@@ -17,20 +11,18 @@ import type {
 	NormalizedRules,
 } from '../../types';
 import DateControl from '../../components/dataform-controls/date';
-import { unlock } from '../../lock-unlock';
-
-const { ValidatedTextControl } = unlock( privateApis );
 
 function getCustomValidity< Item >(
 	isValid: NormalizedRules< Item >,
 	validity: FieldValidity | undefined
 ) {
-	let customValidity;
+	let customValidity: ValidatedControlProps[ 'customValidity' ];
 	if ( isValid?.required && validity?.required ) {
 		// If the consumer provides a message for required,
 		// use it instead of the native built-in message.
-		customValidity = validity?.required?.message
-			? validity.required
+		const { message } = validity.required;
+		customValidity = message
+			? { ...validity.required, message }
 			: undefined;
 	} else if ( isValid?.elements && validity?.elements ) {
 		customValidity = validity.elements;

--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Import the validated form controls from the public `@wordpress/components` API instead of unlocking them ([#81230](https://github.com/WordPress/gutenberg/issues/81230)). No behavior change.
+
 ## 5.51.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/format-library/src/math/index.js
+++ b/packages/format-library/src/math/index.js
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import {
@@ -11,18 +8,8 @@ import {
 	useAnchor,
 } from '@wordpress/rich-text';
 import { RichTextToolbarButton } from '@wordpress/block-editor';
-import {
-	Popover,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Popover, ValidatedTextControl } from '@wordpress/components';
 import { math as icon } from '@wordpress/icons';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-const { ValidatedTextControl } = unlock( componentsPrivateApis );
 
 const name = 'core/math';
 const title = __( 'Math' );


### PR DESCRIPTION
## What

Promotes eleven `Validated*` components from `@wordpress/components` private APIs to public exports, migrates all five in-repo consumers, and removes the private entries.

Part of #81230 (the `Validated*` item). Takes `@wordpress/dataviews` from 26 `unlock()` call sites to 13.

> [!IMPORTANT]
> Depends on #81305, which fixes #76741. This branch contains those commits; review only the ones from `Components: Export the validated form controls publicly` onward. Will rebase once #81305 lands.

## Why now

`@wordpress/dataviews` is a **bundled** package — it declares neither `wpScript` nor `wpModuleExports`. In `@wordpress/private-apis`, `lockedData` is a module-scoped `WeakMap` and `__private` is a plain `Symbol()` rather than `Symbol.for()`. Two copies in one runtime therefore cannot unlock each other's objects, so a plugin that loads `wp.components` from the WordPress global alongside a bundled DataViews throws `Cannot unlock an object that was not locked before` at module-eval time — before anything renders.

## Why `@wordpress/components` rather than `@wordpress/ui`

The obvious objection is that this commits public API in a package being superseded. `packages/eslint-plugin/rules/use-recommended-components.js` says otherwise: its `DENYLIST` for `@wordpress/components` contains no form controls at all (every entry is a layout primitive, `Text`/`Heading`, `Card*`, `Tabs`, `Tooltip`, or `VisuallyHidden`), and its `ALLOWLIST` for `@wordpress/ui` contains none either. `@wordpress/ui`'s form module has `Field`, `Input` and `Select` primitives but no validation layer of any kind, so migrating there is not currently an option.

## On the open issues

The layer was documented as "Status: Beta". Stabilization gates on API-shape finality, and the public surface is three props:

```ts
required?: boolean;
markWhenOptional?: boolean;
customValidity?: { type: 'validating' | 'valid' | 'invalid'; message: string };
```

- **#76741** (errors don't reach the interactive element) is fixed by the prerequisite PR #81305.
- **#71310** (async refinements) has two remaining items, neither of which changes that shape. *"Delay form submission on async validation"* is additive, and unreachable from DataViews — there is no `<form>`, no `onSubmit` and no `reportValidity()` anywhere in the package; `hooks/use-reveal-validity.ts` dispatches synthetic `invalid` events instead. *"Both sync and async errors on first blur"* is behavioral, and DataViews already resolves that precedence in `dataform-controls/utils/get-custom-validity.ts`.

## Latent bugs this surfaced

`unlock()` is typed `<T = any>( object: unknown ): T`, so every migrated call site was unchecked by TypeScript until now. Type-checking them turned up real problems, all fixed here:

- **`ValidatedSelectControl` excluded `multiple` from its props** while DataViews passes it for `type: 'array'` fields — and multi-select works at runtime, because `multiple` fell into `...restProps` and reached the inner `SelectControl`. The component now mirrors `SelectControl`'s own single/multiple discriminated union, so the public type matches the behavior. Doing this before stabilizing avoids a later type change to a stable API.
- **`onChange` handlers declared a non-optional `string`** where `InputControl`/`ComboboxControl` report `undefined` on clear — three independent instances (`dataform-controls/utils/validated-input.tsx`, `combobox.tsx`, `content-types/utils/fields.tsx`). Widened and normalised to match the `value ?? ''` the controls already render, so behavior is unchanged.
- **`getCustomValidity` never narrowed `required.message`.** `FieldValidity.required.message` is optional, unlike every other rule; the guard tests a property but returns the whole object. Three copies fixed, and the return type is now pinned to `ValidatedControlProps[ 'customValidity' ]`.
- **`min`/`max` are typed `number | string`** because the same rules describe dates; on a number field they are coerced.

## Scope

**Public (11):** `ValidatedCheckboxControl`, `ValidatedComboboxControl`, `ValidatedFormTokenField`, `ValidatedInputControl`, `ValidatedNumberControl`, `ValidatedRadioControl`, `ValidatedSelectControl`, `ValidatedTextControl`, `ValidatedTextareaControl`, `ValidatedToggleControl`, `ValidatedToggleGroupControl`, plus the `ValidatedControlProps` type.

**Still private:** `ValidatedContentEditableControl` — its base `ContentEditableControl` is itself private, and its only consumer (`dataform-controls/richtext/control.tsx`) is blocked on five `@wordpress/rich-text` private APIs regardless.

**Still internal:** `ValidatedCustomSelectControl` and `ValidatedRangeControl` were never locked into `privateApis` and have no consumers.

## Notes for reviewers

- The exports are an explicit named list rather than `export *`, so the two internal controls above don't leak.
- Names go out unprefixed even though `InputControl`, `NumberControl` and `ToggleGroupControl` are only public as `__experimental*`. The coding guidelines forbid adding new `__experimental` APIs, and it is the wrapper's own three-prop surface being stabilized.
- The `status-private` Storybook tag is removed from the eleven stabilized controls and kept on the three that stay internal. `storybook/badges.js` has no "stable" badge — stable is the absence of a tag.
- **No generated README.** `tools/docs/gen-components-docs/` resolves stories at `<manifest-dir>/stories/index.story.tsx`, which this folder's layout (per-control stories one level deeper) doesn't match. Documentation lives in the Storybook `overview.mdx`, whose status is updated from Beta to Stable. Happy to restructure if the components team would rather have a generated README.
- Files touched by this PR also lose their `/** WordPress dependencies */` comment blocks, as the `eslint.config.strict.cjs` used by lint-staged requires (`@wordpress/dependency-group: never`).

## Testing instructions

1. `npm run build` — the substantive gate; type generation is what checks the previously-`any` call sites. Passes with zero errors.
2. `npm run test:unit -- packages/components packages/dataviews`
3. `npm run docs:build && git status` — clean.
4. In Storybook, exercise the DataForm validation story and the validated-control stories.