### PR TITLE
theme.json schema: allow responsive states on block style variations

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2913,6 +2913,9 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+				},
+				{
 					"type": "object",
 					"properties": {
 						"elements": {
@@ -2929,6 +2932,9 @@
 						"anyOf": [
 							{
 								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 							},
 							{
 								"enum": [ "elements", "blocks" ]
@@ -2952,6 +2958,9 @@
 					"$ref": "#/definitions/stylesProperties"
 				},
 				{
+					"$ref": "#/definitions/stylesBlocksResponsiveSelectorsProperties"
+				},
+				{
 					"type": "object",
 					"properties": {
 						"elements": {
@@ -2968,6 +2977,9 @@
 						"anyOf": [
 							{
 								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
 							},
 							{
 								"enum": [ "elements", "blocks" ]

--- a/test/integration/fixtures/schemas/stylesVariationPropertiesComplete_breakpoint.json
+++ b/test/integration/fixtures/schemas/stylesVariationPropertiesComplete_breakpoint.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"variations": {
+					"custom-variation": {
+						"@mobile": {
+							"blocks": {
+								"core/paragraph": {
+									"color": {
+										"text": "red"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesVariationProperties_breakpoint.json
+++ b/test/integration/fixtures/schemas/stylesVariationProperties_breakpoint.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"variations": {
+			"shared-variation": {
+				"@desktop": {
+					"color": {
+						"text": "red"
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/theme-json/variation-breakpoints/theme.json
+++ b/test/integration/fixtures/theme-json/variation-breakpoints/theme.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "../../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"variations": {
+					"custom-variation": {
+						"color": {
+							"text": "var(--wp--preset--color--primary)"
+						},
+						"@mobile": {
+							"typography": {
+								"fontSize": "1rem"
+							}
+						},
+						"@tablet": {
+							"typography": {
+								"fontSize": "1.25rem"
+							}
+						}
+					}
+				}
+			}
+		},
+		"variations": {
+			"shared-variation": {
+				"color": {
+					"text": "var(--wp--preset--color--primary)"
+				},
+				"@mobile": {
+					"spacing": {
+						"padding": {
+							"top": "1rem"
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What?
A block style variation can carry `@mobile` and `@tablet` states. The schema rejected them for every block except `core/button` and `core/navigation-link`, which picked up breakpoint support incidentally in #81209.

## Why?
WordPress renders them. Given this theme.json, using the `plain` style that `core/quote` registers by default:

```json
{
	"version": 3,
	"styles": {
		"blocks": {
			"core/quote": {
				"variations": {
					"plain": {
						"color": { "text": "blue" },
						"@mobile": {
							"color": { "text": "red" }
						}
					}
				}
			}
		}
	}
}
```

WordPress outputs:

```css
:root :where(.wp-block-quote.is-style-plain){color: blue;}
@media (width <= 480px){:root :where(.wp-block-quote.is-style-plain){color: red;}}
```

The schema on trunk flags `@mobile` as an unaccepted key.

## How?
Both variation definitions gain the breakpoint keys: `stylesVariationPropertiesComplete` (block level) and `stylesVariationProperties` (shared, used by `styles.variations`). The body is the shared `stylesBlocksResponsiveSelectorsProperties`, so variations track whatever a block breakpoint allows rather than repeating it.

Nested `blocks` stays rejected inside a breakpoint. Style properties and `elements` render there; a nested block does not, in the global stylesheet or in the per-instance styles from `gutenberg_render_block_style_variation_support_styles()`.

## Testing Instructions

### Automated

```
npm run test:unit -- test/integration/theme-schema.test.js
```

`test/integration/fixtures/theme-json/variation-breakpoints/theme.json` is rejected on trunk and accepted here. Two invalid fixtures keep `blocks` inside a variation breakpoint, and an unknown breakpoint name, rejected.

### Editor validation

1. Overwrite a registered variation by using this theme.json example:

```json
{
	"$schema": "../../schemas/json/theme.json"
	"version": 3,
	"styles": {
		"blocks": {
			"core/quote": {
				"variations": {
					"plain": {
						"color": { "text": "blue" },
						"@mobile": {
							"color": { "text": "red" }
						}
					}
				}
			}
		}
	}
}
```

2. Open it in VS Code, or any editor that reads `$schema`. No warning on `@mobile`.
3. Swap the `$schema` for `https://schemas.wp.org/trunk/theme.json` and confirm `@mobile` is flagged. That is the bug.
4. Back on this branch's schema, confirm these are still flagged, since none of them render:

```json
"plain": {
	"@mobile": {
		"blocks": {
			"core/paragraph": { "color": { "text": "red" } }
		}
	},
	"@desktop": {
		"color": { "text": "red" }
	}
}
```

### Front end

5. Put the first theme.json above in an active theme, without the `$schema` line.
6. Add a Quote block to a post, and in the block's Styles panel pick the **Plain** style.
7. View the post. The quote text is blue above 480px and red at or below it. Resize the window to check.

The schema change alone does not affect rendering. Step 7 confirms the behaviour the schema is being corrected to describe.

## Note
Independent of #81253, but they touch adjacent parts of the same file, so whichever lands second may need a trivial rebase. Once #81253 is in, `elements` inside a variation breakpoint is picked up automatically, since both point at the same breakpoint definition.
