### PR TITLE
Global styles: render breakpoints set on an element

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3262,6 +3262,8 @@ class WP_Theme_JSON_Gutenberg {
 		);
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
+			$responsive_media_queries = static::get_viewport_media_queries( $theme_json['settings']['viewport'] ?? null );
+
 			foreach ( self::ELEMENTS as $element => $selector ) {
 				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || ! array_key_exists( $element, static::ELEMENTS ) ) {
 					continue;
@@ -3272,6 +3274,21 @@ class WP_Theme_JSON_Gutenberg {
 					'path'     => array( 'styles', 'elements', $element ),
 					'selector' => static::ELEMENTS[ $element ],
 				);
+
+				/*
+				 * Responsive element nodes: one node per breakpoint the element
+				 * sets styles for. Emitted after the default so the breakpoint
+				 * rule wins without needing extra specificity.
+				 */
+				foreach ( array_keys( $responsive_media_queries ) as $breakpoint ) {
+					if ( isset( $theme_json['styles']['elements'][ $element ][ $breakpoint ] ) ) {
+						$nodes[] = array(
+							'path'        => array( 'styles', 'elements', $element, $breakpoint ),
+							'selector'    => static::ELEMENTS[ $element ],
+							'media_query' => $responsive_media_queries[ $breakpoint ],
+						);
+					}
+				}
 
 				// Handle any pseudo selectors for the element.
 				if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] ) ) {
@@ -3741,6 +3758,21 @@ class WP_Theme_JSON_Gutenberg {
 							'path'     => $element_path,
 							'selector' => $element_selector,
 						);
+
+						/*
+						 * Breakpoints set on the element itself, as opposed to
+						 * elements set inside a block's breakpoint, which are
+						 * handled below.
+						 */
+						foreach ( array_keys( $responsive_media_queries ) as $breakpoint ) {
+							if ( isset( $block_node['elements'][ $element ][ $breakpoint ] ) ) {
+								$nodes[] = array(
+									'path'        => array( 'styles', 'blocks', $name, 'elements', $element, $breakpoint ),
+									'selector'    => $element_selector,
+									'media_query' => $responsive_media_queries[ $breakpoint ],
+								);
+							}
+						}
 					}
 
 					// Responsive element nodes: one node per breakpoint that has
@@ -3984,7 +4016,21 @@ class WP_Theme_JSON_Gutenberg {
 		 */
 		$is_processing_element = in_array( 'elements', $block_metadata['path'], true );
 
-		$current_element = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : null;
+		/*
+		 * An element's responsive node ends in the breakpoint rather than the
+		 * element, e.g. [ 'styles', 'elements', 'link', '@mobile' ], so step
+		 * back over it to find the element the node is for.
+		 */
+		$element_path_index = count( $block_metadata['path'] ) - 1;
+		if (
+			$is_processing_element &&
+			$element_path_index > 0 &&
+			str_starts_with( (string) $block_metadata['path'][ $element_path_index ], '@' )
+		) {
+			--$element_path_index;
+		}
+
+		$current_element = $is_processing_element ? $block_metadata['path'][ $element_path_index ] : null;
 
 		$element_pseudo_allowed = array();
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1462,6 +1462,98 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_stylesheet_renders_breakpoints_set_on_a_top_level_element() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'color'   => array(
+								'text' => 'blue',
+							),
+							'@mobile' => array(
+								'color' => array(
+									'text' => 'red',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$link_selector = 'a:where(:not(.wp-element-button))';
+		$expected      = $link_selector . '{color: blue;}' .
+			'@media (width <= 480px){' . $link_selector . '{color: red;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
+	public function test_get_stylesheet_renders_breakpoints_set_on_a_block_element() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									'color'   => array(
+										'text' => 'blue',
+									),
+									'@mobile' => array(
+										'color' => array(
+											'text' => 'red',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$link_selector = ':root :where(.wp-block-group a:where(:not(.wp-element-button)))';
+		$expected      = $link_selector . '{color: blue;}' .
+			'@media (width <= 480px){' . $link_selector . '{color: red;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
+	public function test_get_stylesheet_renders_a_top_level_element_breakpoint_without_default_styles() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'@tablet' => array(
+								'color' => array(
+									'text' => 'red',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = '@media (480px < width <= 782px){a:where(:not(.wp-element-button)){color: red;}}';
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
 	public function test_get_stylesheet_renders_element_styles_defined_only_in_a_breakpoint() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
## What?
Preliminary. Makes these two produce CSS, where today they produce none:

```
styles.elements.<element>["@mobile"]
styles.blocks.<block>.elements.<element>["@mobile"]
```

## Open question, please read before reviewing
There is a view that the nested-inside-the-element spelling isn't the intended one, and that responsive element styles should only be written as `blocks.<block>["@mobile"].elements.<element>`, which #81265 fixed.

If that's the decision, this PR should be closed and replaced by a schema change that rejects both paths, since the schema has accepted them for years.

Three things point the other way, which is why it's worth deciding rather than assuming:

1. Sanitization deliberately adds breakpoint states to every element (`class-wp-theme-json-gutenberg.php:1292`). The data is kept, then dropped at node discovery.
2. There is no alternative spelling for a **top-level** element. `styles` has no breakpoint key, so `styles.elements.link["@mobile"]` is the only way to make a site-wide link colour responsive. Without it, that is only possible block by block.
3. `docs/how-to-guides/themes/global-settings-and-styles.md:1113` tells theme authors responsive overrides "can also be placed on element nodes within a block", which reads like this spelling.

## Why?
Both paths survive sanitization and reach node discovery, which never looks for them.

## How?
Emit a node per breakpoint an element sets styles for, after the default node so the breakpoint rule wins without extra specificity.

One subtlety: `get_styles_for_block()` derives the element name from the last segment of a node's path, which for these nodes is the breakpoint rather than the element. Without stepping back over it, a top-level element's responsive rule gets wrapped in `:root :where()` while its default rule is not, changing specificity between the two rules. Fixed here, and pinned by a test.

## Testing Instructions
```
npm run test:unit:php
```

Three new cases in `phpunit/class-wp-theme-json-test.php`. All three fail on trunk.

Front end and editor, with this in an active theme:

```json
{
	"version": 3,
	"styles": {
		"elements": {
			"link": {
				"color": { "text": "blue" },
				"@mobile": {
					"color": { "text": "red" }
				}
			}
		}
	}
}
```

Before: only the blue rule. After:

```css
a:where(:not(.wp-element-button)){color: blue;}
@media (width <= 480px){a:where(:not(.wp-element-button)){color: red;}}
```

Links are blue, and red at 480px or narrower. Use the device toolbar, or the editor's Mobile preview, since `@mobile` is `width <= 480px` in CSS pixels and a resized desktop window rarely gets there.

Editor parity is covered: the rules appear in `gutenberg_get_block_editor_settings()`, so the canvas gets them from the same stylesheet as the front end.
