### PR TITLE
Global styles: stop sanitize keeping breakpoints set on an element

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1287,10 +1287,12 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 
-			// Add responsive breakpoint states for elements.
-			foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
-				$schema_styles_elements[ $element ][ $breakpoint_state ] = $styles_non_top_level;
-			}
+			/*
+			 * Breakpoint states are not added here. A responsive element is
+			 * written as a block breakpoint containing elements, the third
+			 * structure listed above, which is assembled further down from
+			 * this same element schema.
+			 */
 		}
 
 		$schema_styles_blocks   = array();

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -3613,7 +3613,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
 	 */
-	public function test_remove_insecure_properties_preserves_responsive_block_element_styles() {
+	public function test_remove_insecure_properties_strips_breakpoints_set_on_a_block_element() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -3643,6 +3643,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
+		// The breakpoints are dropped. Only the element's own styles remain.
 		$expected = array(
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
@@ -3650,20 +3651,50 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'elements' => array(
 							'link' => array(
-								'color'   => array(
+								'color' => array(
 									'text' => 'var(--wp--preset--color--dark-gray)',
 								),
-								'@mobile' => array(
-									'color' => array(
-										'text' => 'var(--wp--preset--color--dark-pink)',
-									),
-								),
-								'@tablet' => array(
-									'color' => array(
-										'text' => 'var(--wp--preset--color--dark-red)',
-									),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Gutenberg::remove_insecure_properties
+	 */
+	public function test_remove_insecure_properties_strips_breakpoints_set_on_a_top_level_element() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'color'   => array(
+								'text' => 'var:preset|color|dark-gray',
+							),
+							'@mobile' => array(
+								'color' => array(
+									'text' => 'var:preset|color|dark-pink',
 								),
 							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'elements' => array(
+					'link' => array(
+						'color' => array(
+							'text' => 'var(--wp--preset--color--dark-gray)',
 						),
 					),
 				),


### PR DESCRIPTION
## What?
Low priority, data hygiene only. **CSS output does not change.**

`sanitize()` adds a breakpoint state to every element, so an element can carry `@mobile` or `@tablet` directly:

```json
{
	"version": 3,
	"styles": {
		"elements": {
			"link": {
				"color": { "text": "black" },
				"@mobile": {
					"color": { "text": "orange" }
				}
			}
		},
		"blocks": {
			"core/group": {
				"elements": {
					"link": {
						"color": { "text": "blue" },
						"@mobile": {
							"color": { "text": "green" }
						}
					}
				},
				"@mobile": {
					"elements": {
						"link": {
							"color": { "text": "red" }
						}
					}
				}
			}
		}
	}
}
```

Orange and green are kept by the sanitizer and never rendered. Only red produces a media query, which is correct and stays that way.

## Why?
The target structures are listed at `lib/class-wp-theme-json-gutenberg.php:1277-1279`, four lines above the loop this PR removes:

```
- top level elements:        styles.elements.link[':hover']
- block level elements:      styles.blocks['core/button'].elements.link[':hover']
- block responsive elements: styles.blocks['core/button']['@tablet'].elements.link[':hover']
```

A responsive element is a block breakpoint containing `elements`. An element carrying its own breakpoint is not one of the three, and node discovery never looks for it.

Because `remove_insecure_properties()` builds the same schema, the shape also survives untrusted input, so it can reach the database through user global styles and come back out of the REST API, while producing nothing.

The loop is not load-bearing for the shape that does work: `blocks.<block>["@mobile"].elements` is assembled at `:1320` from the same element schema and does not need breakpoints nested inside each element.

## How?
Delete the loop, leaving a comment in its place explaining where responsive elements are actually assembled.


## Testing Instructions

Use this theme.json

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"styles": {
		"elements": {
			"link": {
				"color": { "text": "#0000ff" },
				":hover": {
					"color": { "text": "#000088" }
				},
				"@mobile": {
					"color": { "text": "#ff9900" }
				}
			}
		},
		"blocks": {
			"core/group": {
				"elements": {
					"link": {
						"color": { "text": "#008800" },
						"@mobile": {
							"color": { "text": "#ff9900" }
						}
					}
				},
				"@mobile": {
					"elements": {
						"link": {
							"color": { "text": "#ff0000" }
						}
					}
				}
			},
			"core/button": {
				":hover": {
					"color": { "background": "#333333" }
				},
				"@mobile": {
					":hover": {
						"color": { "background": "#666666" }
					}
				}
			}
		}
	}
}
```

Both #ff9900 declarations are the dead shapes and they should be marked "invalid" by the local schema. The CSS shouldn't appear, but they're included just to make sure!

Here's some example HTML

```html
<!-- wp:paragraph -->
<p>Paragraph with <a href="https://wordpress.org">link</a></p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Paragraph with <a href="https://wordpress.org" data-type="link" data-id="https://wordpress.org">link</a> in a Group block</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

Check:

1. In the editor and frontend, check the hover/device states and ensure they match the valid theme.json entries
2. Site Editor → Styles → Elements → Link: the colour control shows blue, and the panel loads without error.
3. Save a change in the above Site Editor Styles, reload, confirm they persist

https://github.com/user-attachments/assets/795be676-c237-46cc-ba75-99072625a1d8




## Related

#81253 makes the schema reject the same two paths, so the editor flags them while typing.

