### PR TITLE
CollapsibleCard: Scope the header focus ring to its own trigger

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   `CollapsibleCard`: Only show the header's focus ring when its own trigger is keyboard-focused ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   `Button`, `Link`, `Combobox`, `Select`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
--   `CollapsibleCard`: Only show the header's focus ring when its own trigger is keyboard-focused ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `CollapsibleCard`: Only show the header's focus ring when its own trigger is keyboard-focused ([#81314](https://github.com/WordPress/gutenberg/pull/81314)).
 -   `Button`, `Link`, `Combobox`, `Select`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   Keep overlays in the compat overlay slot available to assistive technologies when used alongside `@wordpress/components` Modal ([#80310](https://github.com/WordPress/gutenberg/pull/80310)).
 

--- a/packages/ui/src/collapsible-card/header.tsx
+++ b/packages/ui/src/collapsible-card/header.tsx
@@ -53,7 +53,10 @@ export const Header = forwardRef< HTMLDivElement, HeaderProps >(
 				children: (
 					<HeaderDescriptionIdContext.Provider value={ contextValue }>
 						<Collapsible.Trigger
-							className={ styles.header }
+							className={ clsx(
+								styles.header,
+								focusStyles[ 'outset-ring-parent' ]
+							) }
 							render={ <Card.Header /> }
 							nativeButton={ false }
 							aria-describedby={ descriptionId }

--- a/packages/ui/src/utils/css/focus.module.scss
+++ b/packages/ui/src/utils/css/focus.module.scss
@@ -8,7 +8,7 @@
 		.outset-ring--focus-visible:focus-visible,
 		.outset-ring--focus-within:focus-within,
 		.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
-		:focus-visible .outset-ring--focus-parent-visible {
+		.outset-ring-parent:focus-visible .outset-ring--focus-parent-visible {
 			@include mixins.focus-ring();
 		}
 


### PR DESCRIPTION
## What?

Prevents `CollapsibleCard` from showing a focus ring on every header toggle inside it when an ancestor element receives focus.

I ran into this while refactoring my own plugin's UI with `CollapsibleCard`. It reproduces easily by placing several `CollapsibleCard`s inside a `Tabs.Panel`, since `Tabs.Panel` is focusable by default.

## Why?

The `outset-ring--focus-parent-visible` utility was matched by a bare `:focus-visible` descendant selector, so any focus-visible ancestor lit up every target inside it.

## How?

Requires an `outset-ring-parent` class on the focusable ancestor, and applies it to `Collapsible.Trigger` in the card header.

## Testing Instructions

Apply this change to the Stacked story: http://localhost:50240/?path=/story/design-system-components-collapsiblecard--stacked

```diff
diff --git a/packages/ui/src/collapsible-card/stories/index.story.tsx b/packages/ui/src/collapsible-card/stories/index.story.tsx
index e6a056150b4..4809c23c452 100644
--- a/packages/ui/src/collapsible-card/stories/index.story.tsx
+++ b/packages/ui/src/collapsible-card/stories/index.story.tsx
@@ -120,6 +120,7 @@ export const Stacked: Story = {
 				flexDirection: 'column',
 				gap: 'var(--wpds-dimension-gap-lg)',
 			} }
+			tabIndex={ 0 }
 		>
 			{ [
 				'General',
```

Confirm that focusing the container `div` no longer shows a focus ring on the header triggers inside it.

## Screenshots

| Before | After |
|--------|--------|
| <img width="991" height="635" alt="image" src="https://github.com/user-attachments/assets/5d056d0b-c296-4cb5-b8d6-9bc0c91597a1" />| <img width="988" height="625" alt="image" src="https://github.com/user-attachments/assets/7e72fdde-a23d-4ec1-ac15-f389a81a0dd8" /> |

## Use of AI Tools

Claude Code was used to locate the offending selector and apply the fix. I reviewed and adjusted the result.
