### PR TITLE
Site editor: fix sidebar item hover color

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -8,14 +8,11 @@
 	border: none;
 	min-height: $grid-unit-50;
 
-	&:hover,
 	&:focus,
-	&[aria-current="true"] {
+	&[aria-current="true"],
+	// Bump the specificity above the <Item> component's own `:hover` color.
+	&#{&}:hover {
 		color: var(--wpds-color-foreground-interactive-neutral-weak-active);
-
-		.edit-site-sidebar-navigation-item__drilldown-indicator {
-			fill: var(--wpds-color-foreground-interactive-neutral-weak-active);
-		}
 	}
 
 	&[aria-current="true"] {
@@ -30,10 +27,6 @@
 		--wp-components-color-accent: var(--wpds-color-stroke-focus);
 
 		transform: translateZ(0);
-	}
-
-	.edit-site-sidebar-navigation-item__drilldown-indicator {
-		fill: var(--wpds-color-foreground-interactive-neutral-weak);
 	}
 
 	&.with-suffix {


### PR DESCRIPTION
## What?
Follow up to #80797

Fixes the text color of site editor sidebar menu items on hover.

| Before | After |
|--------|--------|
| <img width="319" height="306" alt="image" src="https://github.com/user-attachments/assets/8a590e92-4e07-4b33-8298-c3f7fb3bfe0b" /> | <img width="310" height="311" alt="image" src="https://github.com/user-attachments/assets/e0d5cd6d-2e45-40f7-9be5-ba8198e55c5b" />|
| <img width="315" height="310" alt="image" src="https://github.com/user-attachments/assets/5b7153e3-09bd-4f43-a458-cf52e00d448b" /> | <img width="305" height="300" alt="image" src="https://github.com/user-attachments/assets/e4963376-502f-4e25-ad38-9c7c54902ac2" />| 

## Why?

#80797 migrated `ItemGroup` from Emotion to SCSS modules. The `Item` hover rule went from a single Emotion class to a two-class selector, raising its specificity to exactly match the site editor's own rule. Component styles are injected at runtime, always after the enqueued `wp-edit-site` stylesheet, so the tie is broken by source order and `Item` now wins.

## How?

Bump the specificity of the site editor rule so the intended neutral hover color applies again. As far as I know, this is the only way to solve the problem without changing the `ItemGroup` component itself.

## Testing Instructions

1. Open the site editor.
2. Hover the sidebar items. The text color should be basically white.
3. Change the admin color scheme and test again.

## Use of AI Tools

Claude Code (Opus 5) was used to investigate the root cause and draft the patch. I reviewed the result and take responsibility for it.
