### PR TITLE
Document editEntityRecord's options.isCached param

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -841,6 +841,7 @@ _Parameters_
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
+-   _options.isCached_ `[boolean]`: Whether the edit is transient (e.g. typing). Transient edits are staged and eventually merged into the preceding undo level instead of creating a new one.
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -214,6 +214,7 @@ _Parameters_
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
+-   _options.isCached_ `[boolean]`: Whether the edit is transient (e.g. typing). Transient edits are staged and eventually merged into the preceding undo level instead of creating a new one.
 
 _Returns_
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1,19 +1,8 @@
-/**
- * External dependencies
- */
 import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 import { v4 as uuid } from 'uuid';
-
-/**
- * WordPress dependencies
- */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
-
-/**
- * Internal dependencies
- */
 import { clearUnchangedEdits, getNestedValue, setNestedValue } from './utils';
 import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
@@ -445,6 +434,9 @@ export const deleteEntityRecord =
  * @param {Object}        edits                The edits.
  * @param {Object}        options              Options for the edit.
  * @param {boolean}       [options.undoIgnore] Whether to ignore the edit in undo history or not.
+ * @param {boolean}       [options.isCached]   Whether the edit is transient (e.g. typing). Transient
+ *                                             edits are staged and eventually merged into the
+ *                                             preceding undo level instead of creating a new one.
  *
  * @return {Object} Action object.
  */


### PR DESCRIPTION
## What?

`options.isCached` was added in 2023 in #51644, but never added to the docblock.