### PR TITLE
Block Editor: Fix Escape from the block toolbar and stop redundant last focus dispatches

### DIFF
--- a/packages/block-editor/src/components/navigable-toolbar/index.js
+++ b/packages/block-editor/src/components/navigable-toolbar/index.js
@@ -2,6 +2,7 @@ import { NavigableMenu, Toolbar } from '@wordpress/components';
 import {
 	useState,
 	useRef,
+	useContext,
 	useLayoutEffect,
 	useEffect,
 	useCallback,
@@ -12,6 +13,7 @@ import { focus } from '@wordpress/dom';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { ESCAPE } from '@wordpress/keycodes';
 import { store as blockEditorStore } from '../../store';
+import { BlockRefs } from '../provider/block-refs-provider';
 import { unlock } from '../../lock-unlock';
 
 function hasOnlyToolbarItem( elements ) {
@@ -108,6 +110,11 @@ function useToolbarFocus( {
 	const [ initialFocusOnMount ] = useState( focusOnMount );
 	const [ initialIndex ] = useState( defaultIndex );
 
+	const { getLastFocus, getSelectedBlockClientId } = unlock(
+		useSelect( blockEditorStore )
+	);
+	const { refsMap } = useContext( BlockRefs );
+
 	const focusToolbar = useCallback( () => {
 		focusFirstTabbableIn( toolbarRef.current );
 	}, [ toolbarRef ] );
@@ -169,31 +176,42 @@ function useToolbarFocus( {
 		};
 	}, [ initialIndex, initialFocusOnMount, onIndexChange, toolbarRef ] );
 
-	const { getLastFocus } = unlock( useSelect( blockEditorStore ) );
 	/**
 	 * Handles returning focus to the block editor canvas when pressing escape.
 	 */
 	useEffect( () => {
-		const navigableToolbarRef = toolbarRef.current;
-
-		if ( focusEditorOnEscape ) {
-			const handleKeyDown = ( event ) => {
-				const lastFocus = getLastFocus();
-				if ( event.keyCode === ESCAPE && lastFocus?.current ) {
-					// Focus the last focused element when pressing escape.
-					event.preventDefault();
-					lastFocus.current.focus();
-				}
-			};
-			navigableToolbarRef.addEventListener( 'keydown', handleKeyDown );
-			return () => {
-				navigableToolbarRef.removeEventListener(
-					'keydown',
-					handleKeyDown
-				);
-			};
+		if ( ! focusEditorOnEscape ) {
+			return;
 		}
-	}, [ focusEditorOnEscape, getLastFocus, toolbarRef ] );
+
+		const navigableToolbar = toolbarRef.current;
+		const handleKeyDown = ( event ) => {
+			if ( event.keyCode !== ESCAPE ) {
+				return;
+			}
+			// The last focused element is only recorded once focus has left
+			// the canvas, so fall back to the selected block. Without it
+			// escape leaves focus stranded in the toolbar, with no way back
+			// to the canvas by keyboard.
+			const target =
+				getLastFocus()?.current ??
+				refsMap.get( getSelectedBlockClientId() );
+			if ( target ) {
+				event.preventDefault();
+				target.focus();
+			}
+		};
+		navigableToolbar.addEventListener( 'keydown', handleKeyDown );
+		return () => {
+			navigableToolbar.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [
+		focusEditorOnEscape,
+		getLastFocus,
+		getSelectedBlockClientId,
+		refsMap,
+		toolbarRef,
+	] );
 }
 
 export default function NavigableToolbar( {

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -169,7 +169,13 @@ export default function useTabNav() {
 		}
 
 		function onFocusOut( event ) {
-			setLastFocus( { ...getLastFocus(), current: event.target } );
+			// `focusout` also fires when focus moves between elements within the
+			// canvas, but only the element focus left the canvas from is of
+			// interest. `contains` is false for a null `relatedTarget`, which is
+			// what focus moving to another document reports.
+			if ( ! node.contains( event.relatedTarget ) ) {
+				setLastFocus( { current: event.target } );
+			}
 
 			const { ownerDocument } = node;
 

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -168,16 +168,11 @@ test.describe( 'Block Toolbar', () => {
 		// Inserting from the global inserter leaves focus in the inserter, so the
 		// canvas has never been focused and there is no last focused element to
 		// return to. See https://github.com/WordPress/gutenberg/pull/61472.
-		// Escape currently does nothing in that state, leaving no way back to
-		// the canvas, because the toolbar has no fallback for an unset last
-		// focus.
 		test( 'returns focus to the block when the canvas has never been focused', async ( {
 			editor,
 			page,
 			pageUtils,
 		} ) => {
-			test.fail();
-
 			// The contextual toolbar is only rendered once the canvas has been
 			// interacted with, so use the fixed toolbar to reach it.
 			await editor.setIsFixedToolbar( true );

--- a/test/e2e/specs/editor/various/navigable-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/navigable-toolbar.spec.js
@@ -1,11 +1,5 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.use( {
-	BlockToolbarUtils: async ( { editor, page, pageUtils }, use ) => {
-		await use( new BlockToolbarUtils( { editor, page, pageUtils } ) );
-	},
-} );
-
 test.describe( 'Block Toolbar', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -55,7 +49,6 @@ test.describe( 'Block Toolbar', () => {
 		} );
 
 		test( 'can navigate to the block toolbar and back to block using the keyboard', async ( {
-			BlockToolbarUtils,
 			editor,
 			page,
 			pageUtils,
@@ -63,7 +56,7 @@ test.describe( 'Block Toolbar', () => {
 			// Test navigating to block toolbar
 			await editor.insertBlock( { name: 'core/paragraph' } );
 			await page.keyboard.type( 'Paragraph' );
-			await BlockToolbarUtils.focusBlockToolbar();
+			await pageUtils.pressKeys( 'alt+F10' );
 			await expect(
 				page.getByRole( 'button', { name: 'Paragraph', exact: true } )
 			).toBeFocused();
@@ -93,7 +86,7 @@ test.describe( 'Block Toolbar', () => {
 				page.getByRole( 'button', { name: 'Bold', exact: true } )
 			).toBeFocused();
 
-			await BlockToolbarUtils.focusBlock();
+			await pageUtils.pressKeys( 'Escape' );
 			await expect
 				.poll( () =>
 					editor.ownsSelection(
@@ -104,12 +97,12 @@ test.describe( 'Block Toolbar', () => {
 				)
 				.toBe( true );
 
-			await BlockToolbarUtils.focusBlockToolbar();
+			await pageUtils.pressKeys( 'alt+F10' );
 			await expect(
 				page.getByRole( 'button', { name: 'Bold', exact: true } )
 			).toBeFocused();
 
-			await BlockToolbarUtils.focusBlock();
+			await pageUtils.pressKeys( 'Escape' );
 
 			// Try selecting text and navigating to block toolbar
 			await pageUtils.pressKeys( 'Shift+ArrowLeft', {
@@ -123,7 +116,7 @@ test.describe( 'Block Toolbar', () => {
 			).toBe( 'raph' );
 
 			// Go back to the toolbar and apply a formatting option
-			await BlockToolbarUtils.focusBlockToolbar();
+			await pageUtils.pressKeys( 'alt+F10' );
 			await expect(
 				page.getByRole( 'button', { name: 'Bold', exact: true } )
 			).toBeFocused();
@@ -134,6 +127,95 @@ test.describe( 'Block Toolbar', () => {
 					.locator( ':root' )
 					.evaluate( () => window.getSelection().toString() )
 			).toBe( 'raph' );
+		} );
+
+		// The image placeholder focuses its Upload button, so the block wrapper
+		// and the element that last had focus are two different elements.
+		test( 'returns focus to the element within the block that had it, not the block wrapper', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( { name: 'core/image' } );
+			await expect.poll( editor.getFocusOwnerLabel ).toBe( 'Upload' );
+
+			await pageUtils.pressKeys( 'alt+F10' );
+			await expect(
+				page.getByRole( 'button', { name: 'Image', exact: true } )
+			).toBeFocused();
+
+			await pageUtils.pressKeys( 'Escape' );
+			await expect.poll( editor.getFocusOwnerLabel ).toBe( 'Upload' );
+		} );
+
+		test( 'returns focus to the element within the block that had it when tabbing back into the canvas', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await editor.insertBlock( { name: 'core/image' } );
+			await expect.poll( editor.getFocusOwnerLabel ).toBe( 'Upload' );
+
+			await pageUtils.pressKeys( 'alt+F10' );
+			await expect(
+				page.getByRole( 'button', { name: 'Image', exact: true } )
+			).toBeFocused();
+
+			await pageUtils.pressKeys( 'Tab' );
+			await expect.poll( editor.getFocusOwnerLabel ).toBe( 'Upload' );
+		} );
+
+		// Inserting from the global inserter leaves focus in the inserter, so the
+		// canvas has never been focused and there is no last focused element to
+		// return to. See https://github.com/WordPress/gutenberg/pull/61472.
+		// Escape currently does nothing in that state, leaving no way back to
+		// the canvas, because the toolbar has no fallback for an unset last
+		// focus.
+		test( 'returns focus to the block when the canvas has never been focused', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			test.fail();
+
+			// The contextual toolbar is only rendered once the canvas has been
+			// interacted with, so use the fixed toolbar to reach it.
+			await editor.setIsFixedToolbar( true );
+
+			const inserterToggle = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Block Inserter' } );
+
+			await inserterToggle.click();
+			await page
+				.getByRole( 'region', { name: 'Block Library' } )
+				.getByRole( 'searchbox', { name: 'Search' } )
+				.fill( 'Separator' );
+			await page
+				.getByRole( 'listbox', { name: 'Blocks' } )
+				.getByRole( 'option', { name: 'Separator', exact: true } )
+				.click();
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Separator',
+				} )
+			).toBeVisible();
+
+			// Closing the inserter keeps focus on its toggle, so the canvas is
+			// still unfocused.
+			await inserterToggle.click();
+
+			await pageUtils.pressKeys( 'alt+F10' );
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block Tools' } )
+					.getByRole( 'button', { name: 'Separator', exact: true } )
+			).toBeFocused();
+
+			await pageUtils.pressKeys( 'Escape' );
+			await expect
+				.poll( editor.getFocusOwnerLabel )
+				.toBe( 'Block: Separator' );
 		} );
 	} );
 
@@ -156,43 +238,48 @@ test.describe( 'Block Toolbar', () => {
 	// overflow-x property set to allow the block toolbar to scroll.
 	test( 'Block toolbar will scroll to reveal hidden buttons with fixed toolbar', async ( {
 		editor,
-		BlockToolbarUtils,
 		page,
 		pageUtils,
 	} ) => {
-		// Set the fixed toolbar
 		await editor.setIsFixedToolbar( true );
-		// Insert a block with a lot of tool buttons
+		// A block with more tools than fit in a narrow toolbar.
 		await editor.insertBlock( { name: 'core/buttons' } );
-		// Set the locators we'll need to check for visibility
-		const blockButton = page.getByRole( 'button', {
-			name: 'Button',
-			exact: true,
-		} );
 
 		const blockToolbar = page.getByRole( 'toolbar', {
 			name: 'Block tools',
 		} );
+		// The last tool in the toolbar, so it is the one the overflow hides.
+		const lastTool = blockToolbar.getByRole( 'button', {
+			name: 'Options',
+			exact: true,
+		} );
 
-		// Test: Top Toolbar can scroll to reveal hidden block tools.
-		await pageUtils.setBrowserViewport( { width: 960, height: 700 } );
+		// The top toolbar at a narrow viewport, then the toolbar fixed to the
+		// bottom of the screen.
+		for ( const width of [ 960, 400 ] ) {
+			await pageUtils.setBrowserViewport( { width, height: 700 } );
+			await expect( lastTool ).not.toBeInViewport();
 
-		// Test: Block toolbar can scroll on top toolbar mode
-		await BlockToolbarUtils.testScrollable( blockToolbar, blockButton );
+			// The toolbar has to be scrolled by wheel rather than
+			// programmatically, which would scroll it even if it were not
+			// scrollable.
+			await blockToolbar.hover();
+			await page.mouse.wheel( 200, 0 );
+			await expect( lastTool ).toBeInViewport();
 
-		// Test: Fixed toolbar can scroll.
+			await page.mouse.wheel( -200, 0 );
+			await expect( lastTool ).not.toBeInViewport();
+		}
 
-		// Make the viewport very small to force the fixed to bottom toolbar overflow
-		await pageUtils.setBrowserViewport( { width: 400, height: 700 } );
-
-		await BlockToolbarUtils.testScrollable( blockToolbar, blockButton );
-
+		// Preferences are saved on a debounce, so a fast test can outrun its own
+		// save and have it land after the reset in `afterEach`. Put the setting
+		// back instead of relying on that reset.
+		await editor.setIsFixedToolbar( false );
 		await pageUtils.setBrowserViewport( 'large' );
 	} );
 
 	test( 'Tab order of the block toolbar aligns with visual order', async ( {
 		editor,
-		BlockToolbarUtils,
 		page,
 		pageUtils,
 	} ) => {
@@ -210,10 +297,15 @@ test.describe( 'Block Toolbar', () => {
 		await expect( blockToolbarParagraphButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Tab' );
 		// check focus is on the block
-		await BlockToolbarUtils.expectLabelToHaveFocus( 'Block: Paragraph' );
+		await expect
+			.poll( editor.getFocusOwnerLabel )
+			.toBe( 'Block: Paragraph' );
 
 		// set the screen size to mobile
 		await pageUtils.setBrowserViewport( 'small' );
+		// The toolbar remounts when the viewport changes, so wait for it before
+		// tabbing. A key press that lands mid-remount moves focus elsewhere.
+		await expect( blockToolbarParagraphButton ).toBeVisible();
 
 		// TEST: Small screen toolbar without fixed toolbar setting should be the first tabstop before the editor
 		await pageUtils.pressKeys( 'shift+Tab' );
@@ -221,7 +313,9 @@ test.describe( 'Block Toolbar', () => {
 		await expect( blockToolbarParagraphButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Tab' );
 		// check focus is on the block
-		await BlockToolbarUtils.expectLabelToHaveFocus( 'Block: Paragraph' );
+		await expect
+			.poll( editor.getFocusOwnerLabel )
+			.toBe( 'Block: Paragraph' );
 		// TEST: Fixed toolbar should be within the header dom
 		// Changed to Fixed top toolbar setting and large viewport to test fixed toolbar
 		await pageUtils.setBrowserViewport( 'large' );
@@ -230,11 +324,13 @@ test.describe( 'Block Toolbar', () => {
 		await pageUtils.pressKeys( 'shift+Tab' );
 
 		// Options button is the last one in the top toolbar, the first item outside of the editor canvas, so it should get focused.
-		await BlockToolbarUtils.expectLabelToHaveFocus( 'Options' );
+		await expect.poll( editor.getFocusOwnerLabel ).toBe( 'Options' );
 
 		await pageUtils.pressKeys( 'Tab' );
 		// check focus is on the block
-		await BlockToolbarUtils.expectLabelToHaveFocus( 'Block: Paragraph' );
+		await expect
+			.poll( editor.getFocusOwnerLabel )
+			.toBe( 'Block: Paragraph' );
 		// Move to block, alt + f10
 		await pageUtils.pressKeys( 'alt+F10' );
 		// check focus in block toolbar
@@ -242,7 +338,9 @@ test.describe( 'Block Toolbar', () => {
 		// escape back to block
 		await pageUtils.pressKeys( 'Escape' );
 		// check block focus
-		await BlockToolbarUtils.expectLabelToHaveFocus( 'Block: Paragraph' );
+		await expect
+			.poll( editor.getFocusOwnerLabel )
+			.toBe( 'Block: Paragraph' );
 
 		// TEST: Small screen toolbar with fixed toolbar setting should be the first tabstop before the editor. Even though the fixed toolbar setting is on, it should not render within the header since it's visually after it.
 		await pageUtils.setBrowserViewport( 'small' );
@@ -251,7 +349,9 @@ test.describe( 'Block Toolbar', () => {
 		await expect( blockToolbarParagraphButton ).toBeFocused();
 		await pageUtils.pressKeys( 'Tab' );
 		// check focus is on the block
-		await BlockToolbarUtils.expectLabelToHaveFocus( 'Block: Paragraph' );
+		await expect
+			.poll( editor.getFocusOwnerLabel )
+			.toBe( 'Block: Paragraph' );
 
 		await pageUtils.setBrowserViewport( 'large' );
 	} );
@@ -312,56 +412,3 @@ test.describe( 'Block Toolbar', () => {
 		await expect( blockToolbarMoveUpButton ).toBeFocused();
 	} );
 } );
-
-class BlockToolbarUtils {
-	constructor( { editor, page, pageUtils } ) {
-		this.editor = editor;
-		this.page = page;
-		this.pageUtils = pageUtils;
-	}
-
-	async focusBlockToolbar() {
-		await this.pageUtils.pressKeys( 'alt+F10' );
-	}
-
-	async focusBlock() {
-		await this.pageUtils.pressKeys( 'Escape' );
-	}
-
-	async expectLabelToHaveFocus( label ) {
-		// Poll: the focused element and its label may settle asynchronously
-		// (selection changes sync to the store on `selectionchange`). When a
-		// focused editing host owns the selection, the editable element
-		// containing the selection owns the focus.
-		await expect.poll( this.editor.getFocusOwnerLabel ).toBe( label );
-	}
-
-	async testScrollable( scrollableElement, elementToTest ) {
-		// We can't use `not.toBeVisible()` here since Playwright's definition of visible or not visible is not the same
-		// as being human visible. It will pass if the element is off screen, but not human visible. Instead, we check the x
-		// position of the element. It should change as we scroll. But we also can't programmatically use scroll, as it will
-		// allow a scroll even if the element is not scrollable. So we use the mouse wheel event to scroll the element.
-		const initialBox = await elementToTest.boundingBox();
-
-		// Scroll the block toolbar to the right to reveal the hidden block tools
-		await scrollableElement.hover();
-		await this.page.mouse.wheel( 60, 0 );
-		// Wait for the scroll to complete. Playwright doesn't wait for the scroll from the mouse event to complete before returning.
-		await this.editor.page.waitForTimeout( 500 );
-
-		let currentBox = await elementToTest.boundingBox();
-
-		// The x position of the button should now be 60px lower.
-		expect( currentBox.x ).toEqual( initialBox.x - 60 );
-
-		// Scroll the block toolbar back to the left to hide the block tools again
-		await this.page.mouse.wheel( -60, 0 );
-		// Wait for the scroll to complete. Playwright doesn't wait for the scroll from the mouse event to complete before returning.
-		await this.editor.page.waitForTimeout( 500 );
-
-		currentBox = await elementToTest.boundingBox();
-
-		// The x positions should return to their initial values
-		expect( initialBox.x ).toEqual( currentBox.x );
-	}
-}


### PR DESCRIPTION
## What?

Two related fixes to how the block toolbar returns focus to the canvas, plus e2e coverage for the untested cases.

## Why?

`lastFocus` records the element that the focus left the editor canvas from, so Escape and Shift+Tab can put focus back where the user was. Two problems:

1. Escape has no fallback when nothing has been recorded yet. Insert a block from the global inserter, which leaves focus in the inserter, then press Alt+F10 and Escape. Nothing happens, and there is no way back to the canvas by keyboard. #61472 fixed this for the Shift+Tab path but left Escape unguarded.

2. `lastFocus` was written on every `focusout` in the canvas, including focus moves between blocks. Nothing reads it reactively, but each dispatch produced a new root state and notified every subscriber of the block editor store, so every `useSelect` in the editor re-ran.

## How?

Escape now falls back to the selected block's element. It is read from the `BlockRefs` map inside the keydown handler, so the toolbar keeps the non-reactive selection access introduced in #57140, and the lookup works across the iframe boundary. Escape also only prevents default when it has somewhere to move focus to. `onFocusOut` now records only when focus actually leaves the canvas, as the action's docblock already described.

## Testing Instructions

1. Open a new post without clicking into the canvas.
2. Insert a block from the top bar inserter.
3. Press Alt+F10 to reach the block toolbar, then Escape.
4. Focus should move to the inserted block. On trunk, it stays in the toolbar.

Then check the existing behavior still holds. Insert an Image block, press Alt+F10, then Escape. Focus should return to the Upload button rather than the block wrapper. Same via Shift+Tab and Tab.


## Use of AI Tools

Assisted by Claude.