### PR TITLE
Site Editor: Decode HTML entities in Identity fields (#81269)

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Identity: Decode HTML entities in the Site Title and Site Tagline fields. ([#81269](https://github.com/WordPress/gutenberg/pull/81269))
+
 ## 7.0.0 (2026-07-14)
 
 ### Breaking Changes

--- a/packages/edit-site/src/components/sidebar-identity/index.js
+++ b/packages/edit-site/src/components/sidebar-identity/index.js
@@ -7,6 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { DataForm } from '@wordpress/dataviews';
 import { MediaEdit } from '@wordpress/fields';
+import { decodeEntities } from '@wordpress/html-entities';
 
 const fields = [
 	{
@@ -16,6 +17,7 @@ const fields = [
 		description: __(
 			"Displays in your site's layout via the Site Title block."
 		),
+		getValue: ( { item } ) => decodeEntities( item.title ?? '' ),
 	},
 	{
 		id: 'description',
@@ -24,6 +26,7 @@ const fields = [
 		description: __(
 			"In a few words, explain what this site is about. Displays in your site's layout via the Site Tagline block."
 		),
+		getValue: ( { item } ) => decodeEntities( item.description ?? '' ),
 	},
 	{
 		id: 'site_logo',

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `MediaEdit`: Decode HTML entities when displaying attachment titles. ([#81269](https://github.com/WordPress/gutenberg/pull/81269))
+
 ## 0.43.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -28,6 +28,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 import {
 	archive,
 	audio,
@@ -212,7 +213,7 @@ const archiveMimeTypes = [
 function MediaTitle( { attachment }: { attachment: Attachment< 'view' > } ) {
 	return (
 		<Truncate className="fields__media-edit-filename">
-			{ attachment.title.rendered }
+			{ decodeEntities( attachment.title.rendered ) }
 		</Truncate>
 	);
 }
@@ -356,9 +357,11 @@ function ExpandedMediaEditAttachments( {
 									? sprintf(
 											/* translators: %s: The title of the media item. */
 											__( 'Replace %s' ),
-											(
-												attachment as Attachment< 'view' >
-											 ).title.rendered
+											decodeEntities(
+												(
+													attachment as Attachment< 'view' >
+												 ).title.rendered
+											)
 									  )
 									: __( 'Replace' )
 							}


### PR DESCRIPTION
## What?

Manual backport of #81269 to `wp/7.1` after the automatic cherry-pick encountered changelog conflicts.

The two source changes match the merged commit `8323351f`. The manual resolution only keeps the `wp/7.1` package history while adding both bug-fix entries under `Unreleased`.

## Why?

Identity REST values can contain strings such as `Jordan&#039;s Test` or `Logo &amp; Mark`. Without local display-time decoding, the WordPress 7.1 Identity screen shows those entities literally.

## How?

- Decode Site Title and Site Tagline values in their local Identity field getters.
- Decode media attachment titles in the compact filename and accessible replacement label used by Site Logo and Site Icon.
- Leave source records, URLs, alt text, validation, and unrelated DataForm fields unchanged.

## Testing Instructions

Automated checks run locally:

- Cherry-picked only the final merged commit from #81269.
- The complete pre-commit hook passed.
- Targeted JavaScript/TypeScript lint passed for both source files.
- Focused source formatting checks passed; both added changelog entries match
  the repository format.
- `git diff --check` passed; the backport changes exactly four files.

No new tests or dependencies are introduced, following the review guidance on the original PR.

Manual verification:

1. Open the Site Editor and go to **Design → Identity**.
2. Save a Site Title and Site Tagline containing `&`, `'`, or angle brackets.
3. Reload Identity and confirm both text fields show readable characters rather than HTML entities.
4. Select a Site Logo and Site Icon whose attachment title contains `&`.
5. Confirm the selected media filename shows `&` rather than `&amp;`.
6. Save and reload, then confirm all four values remain readable and editable.

### Testing Instructions for Keyboard

1. Tab through the Site Title and Site Tagline inputs and edit the values.
2. Use the keyboard to choose or replace the Site Logo and Site Icon.
3. Confirm the media replacement control has a readable accessible name and the form remains fully operable.

## Screenshots or screencast

The verified before/after comparison is available in the [original approved PR](https://github.com/WordPress/gutenberg/pull/81269#pullrequestreview-4880621000).

## Use of AI Tools

OpenAI Codex assisted with the conflict review and validation. I reviewed the final four-file diff and take responsibility for the contribution.
