### PR TITLE
Core Data: Add invalidateCache option to saveEntityRecord

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -953,8 +953,9 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
+-   _options.invalidateCache_ `[boolean]`: Whether to invalidate the query caches for the entity once the record is received.
 -   _options.throwOnError_ `[boolean]`: If false, this action suppresses all the exceptions. Defaults to false.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 
 ### undo
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Improve error reporting in private action `saveDirtyEntities` ([#81151](https://github.com/WordPress/gutenberg/pull/81151)).
+-   `saveEntityRecord`: Add an `invalidateCache` option (defaults to `true`) to let consumers opt out of query cache invalidation.
 
 ### Bug Fixes
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -326,8 +326,9 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 -   _options.isAutosave_ `[boolean]`: Whether this is an autosave.
--   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
+-   _options.invalidateCache_ `[boolean]`: Whether to invalidate the query caches for the entity once the record is received.
 -   _options.throwOnError_ `[boolean]`: If false, this action suppresses all the exceptions. Defaults to false.
+-   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
 
 ### undo
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -639,25 +639,28 @@ export const __unstableCreateUndoLevel =
 /**
  * Action triggered to save an entity record.
  *
- * @param {string}   kind                         Kind of the received entity.
- * @param {string}   name                         Name of the received entity.
- * @param {Object}   record                       Record to be saved.
- * @param {Object}   options                      Saving options.
- * @param {boolean}  [options.isAutosave=false]   Whether this is an autosave.
- * @param {Function} [options.__unstableFetch]    Internal use only. Function to
- *                                                call instead of `apiFetch()`.
- *                                                Must return a promise.
- * @param {boolean}  [options.throwOnError=false] If false, this action suppresses all
- *                                                the exceptions. Defaults to false.
+ * @param {string}   kind                           Kind of the received entity.
+ * @param {string}   name                           Name of the received entity.
+ * @param {Object}   record                         Record to be saved.
+ * @param {Object}   options                        Saving options.
+ * @param {boolean}  [options.isAutosave=false]     Whether this is an autosave.
+ * @param {boolean}  [options.invalidateCache=true] Whether to invalidate the query caches
+ *                                                  for the entity once the record is received.
+ * @param {boolean}  [options.throwOnError=false]   If false, this action suppresses all
+ *                                                  the exceptions. Defaults to false.
+ * @param {Function} [options.__unstableFetch]      Internal use only. Function to
+ *                                                  call instead of `apiFetch()`.
+ *                                                  Must return a promise.
  */
 export const saveEntityRecord =
 	( kind, name, record, options = {} ) =>
 	async ( { select, resolveSelect, dispatch } ) => {
 		const {
 			isAutosave = false,
+			invalidateCache = true,
+			throwOnError = false,
 			__unstableFetch = apiFetch,
 			__unstableSkipSyncUpdate = false,
-			throwOnError = false,
 		} = options;
 
 		logEntityDeprecation( kind, name, 'saveEntityRecord' );
@@ -846,7 +849,7 @@ export const saveEntityRecord =
 							name,
 							newRecord,
 							undefined,
-							true
+							invalidateCache
 						);
 					} else {
 						dispatch.receiveAutosaves(
@@ -875,7 +878,7 @@ export const saveEntityRecord =
 						name,
 						updatedRecord,
 						undefined,
-						true,
+						invalidateCache,
 						edits
 					);
 					if ( entityConfig.syncConfig ) {


### PR DESCRIPTION
## What?
**Note:** Mostly wanted to run the idea with folks. 

PR adds an `invalidateCache` option to `saveEntityRecord`, with a default of `true`. Existing behavior unchanged. This will allow consumers to opt out of cache invalidation if needed.

## Possible use case

* Creating an entity in the editor can invalidate the cache earlier than needed. Example: Creating a tag invalidates the cache, fetches for old term IDs, then fetches again for new term IDs. Ideally, it should only do the latter. Related #80623.
* Bulk saves. Saving N records fires N invalidation storms. Opt out on all but the last.
* Quick Edit. Editing a field in a data view via Quick Edit invalidates the whole list; depending on the case, the consumer might want to opt out.

## Testing Instructions

No behavior change by default; existing `core-data` action tests cover both paths.

## Use of AI Tools

Assisted by Claude.