### PR TITLE
Block Library: Restore 3.2.22 release metadata

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 ## Unreleased
 
-## Breaking Changes
-
--   Removes the `core/legacy-widget` block. This is now in `@wordpress/widgets`
-	via `registerLegacyWidgetBlock()`.
-
 ## 3.2.22 (2026-08-06)
 
 ### Bug Fixes
 
 -   Post Date: Escape date values and link URLs before rendering the block.
+
+## 3.2.5 (2021-06-14)
+
+### Breaking Changes
+
+-   Removes the `core/legacy-widget` block. This is now in `@wordpress/widgets`
+	via `registerLegacyWidgetBlock()`.
 
 ## 3.2.0 (2021-05-24)
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -7,6 +7,12 @@
 -   Removes the `core/legacy-widget` block. This is now in `@wordpress/widgets`
 	via `registerLegacyWidgetBlock()`.
 
+## 3.2.22 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 3.2.0 (2021-05-24)
 
 ### New Features

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "3.2.21",
+	"version": "3.2.22",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/5.8` to match version `3.2.22`, which is already published to npm.

It also moves the Legacy Widget removal entry from `Unreleased` into `3.2.5`, the first published package version that contained the change.

## Why?

The manual package publication did not update this branch's package manifest or changelog. The Legacy Widget entry was also still marked as unreleased even though it had shipped in `3.2.5`.

## How?

Bumps `packages/block-library/package.json`, adds the `3.2.22` release entry for the Post Date output fix, and records the older Legacy Widget change under `3.2.5`. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `3.2.22`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `3.2.22 (2026-08-06)` release with the Post Date entry.
3. Confirm the Legacy Widget entry is under `3.2.5 (2021-06-14)` and `Unreleased` is empty.
4. Confirm the diff contains only those two metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.