### PR TITLE
Block Library: Restore 6.0.32 release metadata

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 6.0.32 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 6.0.0 (2021-09-09)
 
 ### Breaking Change

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "6.0.31",
+	"version": "6.0.32",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/5.9` to match version `6.0.32`, which is already published to npm.

## Why?

The manual package publication did not update this branch's package manifest, lockfile where applicable, or changelog.

## How?

Bumps `packages/block-library/package.json` and adds the `6.0.32` release entry for the Post Date output fix. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `6.0.32`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `6.0.32 (2026-08-06)` release with the Post Date entry.
3. Confirm the diff contains only those two metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.