### PR TITLE
Block Library: Restore 7.3.20 release metadata

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 7.3.20 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 7.3.0 (2022-04-08)
 
 ## 7.2.0 (2022-03-23)

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "7.3.19",
+	"version": "7.3.20",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.0` to match version `7.3.20`, which is already published to npm.

## Why?

The manual package publication did not update this branch's package manifest, lockfile where applicable, or changelog.

## How?

Bumps `packages/block-library/package.json` and adds the `7.3.20` release entry for the Post Date output fix. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `7.3.20`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `7.3.20 (2026-08-06)` release with the Post Date entry.
3. Confirm the diff contains only those two metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.