### PR TITLE
Block Library: Restore 7.14.16 release metadata

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 7.14.16 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 7.14.0 (2022-09-13)
 
 ### New Feature

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "7.14.15",
+	"version": "7.14.16",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.1` to match version `7.14.16`, which is already published to npm.

## Why?

The manual package publication did not update this branch's package manifest, lockfile where applicable, or changelog.

## How?

Bumps `packages/block-library/package.json` and adds the `7.14.16` release entry for the Post Date output fix. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `7.14.16`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `7.14.16 (2026-08-06)` release with the Post Date entry.
3. Confirm the diff contains only those two metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.