### PR TITLE
Block Library: Restore 8.3.17 release metadata

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 8.3.17 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 8.3.0 (2023-02-01)
 
 ## 8.2.0 (2023-01-11)

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "8.3.16",
+	"version": "8.3.17",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.2` to match version `8.3.17`, which is already published to npm.

## Why?

The manual package publication did not update this branch's package manifest, lockfile where applicable, or changelog.

## How?

Bumps `packages/block-library/package.json` and adds the `8.3.17` release entry for the Post Date output fix. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `8.3.17`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `8.3.17 (2026-08-06)` release with the Post Date entry.
3. Confirm the diff contains only those two metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.