### PR TITLE
Block Library: Restore 8.19.19 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56387,7 +56387,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "8.19.18",
+			"version": "8.19.19",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ## 8.20.0 (2023-10-05)
 
+## 8.19.19 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 8.19.0 (2023-09-20)
 
 ## 8.18.0 (2023-08-31)

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-### Bug Fix
-
--   Fix Image block lightbox missing alt attribute and improve accessibility. ([#54608](https://github.com/WordPress/gutenberg/pull/55010))
-
-
 ## 8.20.0 (2023-10-05)
 
 ## 8.19.19 (2026-08-06)
@@ -14,6 +9,12 @@
 ### Bug Fixes
 
 -   Post Date: Escape date values and link URLs before rendering the block.
+
+## 8.19.4 (2023-10-09)
+
+### Bug Fixes
+
+-   Fix Image block lightbox missing alt attribute and improve accessibility. ([#54608](https://github.com/WordPress/gutenberg/pull/55010))
 
 ## 8.19.0 (2023-09-20)
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "8.19.18",
+	"version": "8.19.19",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.4` to match version `8.19.19`, which is already published to npm.

It also moves the Image block lightbox accessibility fix from `Unreleased` into `8.19.4`, the first published package version that contained the change.

## Why?

The manual package publication did not update this branch's package manifest, lockfile, or changelog. The Image block entry was also still marked as unreleased even though it had shipped in `8.19.4`.

## How?

Updates the package manifest and lockfile, adds the `8.19.19` release entry for the Post Date output fix, and records the older Image block fix under `8.19.4`. This PR does not publish the package again.

## Testing Instructions

1. Confirm the package manifest and lockfile report version `8.19.19`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `8.19.19 (2026-08-06)` release with the Post Date entry.
3. Confirm the Image block entry is under `8.19.4 (2023-10-09)` and `Unreleased` is empty.
4. Confirm the diff contains only the package manifest, lockfile, and changelog.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.