### PR TITLE
Block Library: Restore 8.28.13 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53807,7 +53807,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "8.28.12",
+			"version": "8.28.13",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 8.28.13 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 8.28.0 (2024-02-09)
 
 ## 8.27.0 (2024-01-24)

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "8.28.12",
+	"version": "8.28.13",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.5` to match version `8.28.13`, which is already published to npm.

## Why?

The manual package publication did not update this branch's package manifest, lockfile where applicable, or changelog.

## How?

Bumps `packages/block-library/package.json`, updates the matching workspace version in `package-lock.json`, and adds the `8.28.13` release entry for the Post Date output fix. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `8.28.13`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `8.28.13 (2026-08-06)` release with the Post Date entry.
3. Confirm `package-lock.json` reports `8.28.13` for the `packages/block-library` workspace.
4. Confirm the diff contains only those three metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.