### PR TITLE
Block Library: Restore 9.19.7 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50058,7 +50058,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "9.19.6",
+			"version": "9.19.7",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 -   Query Loop Block: Enable custom order or `menu_order` ordering option for post types that support it. ([#68781](https://github.com/WordPress/gutenberg/pull/68781))
 
+## 9.19.7 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 9.19.0 (2025-02-28)
 
 ## 9.18.0 (2025-02-12)

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ## Unreleased
 
-### Enhancements
-
--   Query Loop Block: Enable custom order or `menu_order` ordering option for post types that support it. ([#68781](https://github.com/WordPress/gutenberg/pull/68781))
-
 ## 9.19.7 (2026-08-06)
 
 ### Bug Fixes
 
 -   Post Date: Escape date values and link URLs before rendering the block.
+
+## 9.19.1 (2025-03-10)
+
+### Enhancements
+
+-   Query Loop Block: Enable custom order or `menu_order` ordering option for post types that support it. ([#68781](https://github.com/WordPress/gutenberg/pull/68781))
 
 ## 9.19.0 (2025-02-28)
 

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "9.19.6",
+	"version": "9.19.7",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.8` to match version `9.19.7`, which is already published to npm.

It also moves the Query Loop custom ordering enhancement from `Unreleased` into `9.19.1`, the first published package version that contained the change.

## Why?

The manual package publication did not update this branch's package manifest, lockfile, or changelog. The Query Loop entry was also still marked as unreleased even though it had shipped in `9.19.1`.

## How?

Updates the package manifest and lockfile, adds the `9.19.7` release entry for the Post Date output fix, and records the older Query Loop enhancement under `9.19.1`. This PR does not publish the package again.

## Testing Instructions

1. Confirm the package manifest and lockfile report version `9.19.7`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `9.19.7 (2026-08-06)` release with the Post Date entry.
3. Confirm the Query Loop entry is under `9.19.1 (2025-03-10)` and `Unreleased` is empty.
4. Confirm the diff contains only the package manifest, lockfile, and changelog.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.