### PR TITLE
Block Library: Restore 9.33.11 release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51352,7 +51352,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "9.33.10",
+			"version": "9.33.11",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 9.33.11 (2026-08-06)
+
+### Bug Fixes
+
+-   Post Content: Restrict the wrapper tag to the supported values offered in the editor.
+-   Post Date: Escape date values and link URLs before rendering the block.
+
 ## 9.33.0 (2025-10-17)
 
 ### Enhancements

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "9.33.10",
+	"version": "9.33.11",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Related: #81295

## What?

Updates `@wordpress/block-library` metadata on `wp/6.9` to match version `9.33.11`, which is already published to npm.

## Why?

The manual package publication did not update this branch's package manifest, lockfile where applicable, or changelog.

## How?

Bumps `packages/block-library/package.json`, updates the matching workspace version in `package-lock.json`, and adds the `9.33.11` release entry for the Post Content and Post Date output fixes. This PR does not publish the package again.

## Testing Instructions

1. Confirm `packages/block-library/package.json` reports version `9.33.11`.
2. Confirm `packages/block-library/CHANGELOG.md` contains the `9.33.11 (2026-08-06)` release with the Post Content and Post Date entries.
3. Confirm `package-lock.json` reports `9.33.11` for the `packages/block-library` workspace.
4. Confirm the diff contains only those three metadata files.

## Use of AI Tools

Codex was used to prepare and verify these metadata-only changes and this pull request.