### PR TITLE
ESLint: Remove legacy import suppressions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,3 +21,6 @@ c56e8a1910ed74f405b74bbb12fe81dea974e5c3
 
 # ESLint: Enable react/jsx-curly-brace-presence
 5d4baa9ab5f57d207cc3a048003216a8574574d9
+
+# Remove dependency import separators.
+7f43eafccea3691044eabf94e94b978435d25bd3

--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -82,6 +82,8 @@ In the Gutenberg project, we use [the ES2015 import syntax](https://developer.mo
 
 Imports can reference third-party packages, WordPress packages, or local files.
 
+Write imports as one contiguous block. Do not separate dependency types with comments or blank lines.
+
 #### External dependencies
 
 An external dependency is third-party code that is not maintained by WordPress contributors, but instead [included in WordPress as a default script](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress) or referenced from an outside package manager like [npm](https://www.npmjs.com/).

--- a/docs/how-to-guides/platform/custom-block-editor.md
+++ b/docs/how-to-guides/platform/custom-block-editor.md
@@ -199,15 +199,9 @@ Begin by opening the main `src/index.js` file. Then pull in the required JavaScr
 
 ```js
 // File: src/index.js
-
-// External dependencies.
 import { createRoot } from 'react-dom';
-
-// WordPress dependencies.
 import domReady from '@wordpress/dom-ready';
 import { registerCoreBlocks } from '@wordpress/block-library';
-
-// Internal dependencies.
 import Editor from './editor';
 import './styles.scss';
 ```

--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -38,9 +38,6 @@ With the exception of [MainDashboardButton](/docs/reference-guides/slotfills/mai
 A fill can be restricted to the Post Editor by checking to see if the current post type object property `viewable` is set to `true`. Any post type not set to `viewable`, does not have an associated edit post screen and is a good indicator that the user is not in the Post Editor. The example below will render its content on the edit post screen for any registered post type.
 
 ```js
-/**
- * WordPress dependencies
- */
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	PluginDocumentSettingPanel,
@@ -87,9 +84,6 @@ registerPlugin( 'example-post-edit-only', {
 The following example expands on the example above by creating an allow list of post types where the fill should be rendered. In this case, the fill is only rendered when editing pages.
 
 ```js
-/**
- * WordPress dependencies
- */
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	PluginDocumentSettingPanel,
@@ -149,9 +143,6 @@ registerPlugin( 'example-restrict-post-types', {
 To restrict fills to the Site Editor, the reverse logic is true. If the post type object's `viewable` property is set to `true`, then the fill should not be rendered. The example below will render its content on any Site Editor screen.
 
 ```js
-/**
- * WordPress dependencies
- */
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	PluginDocumentSettingPanel,
@@ -200,9 +191,6 @@ registerPlugin( 'example-site-editor', {
 This example builds on the example above by providing an allow list to control which screens a fill can be rendered within the Site Editor.
 
 ```js
-/**
- * WordPress dependencies
- */
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	PluginDocumentSettingPanel,
@@ -271,10 +259,6 @@ SlotFills are created using `createSlotFill`. This creates two components, `Slot
 ```js
 /**
  * Defines as extensibility slot for the Summary panel.
- */
-
-/**
- * WordPress dependencies
  */
 import { createSlotFill, PanelRow } from '@wordpress/components';
 

--- a/packages/babel-preset-default/bin/index.js
+++ b/packages/babel-preset-default/bin/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
+const { writeFile } = require( 'fs' ).promises;
 const builder = require( 'core-js-builder' );
 const { minify } = require( 'terser' );
-const { writeFile } = require( 'fs' ).promises;
 const exclusions = require( '../polyfill-exclusions' );
 
 builder( {

--- a/packages/block-editor/src/components/block-context/README.md
+++ b/packages/block-editor/src/components/block-context/README.md
@@ -24,7 +24,6 @@ Internal to the `@wordpress/block-editor` module, a component can access the [fu
 
 ```js
 import { useContext } from 'react';
-
 // Only available internally within `@wordpress/block-editor`!
 import BlockContext from '../block-context';
 

--- a/packages/block-editor/src/components/block-controls/README.md
+++ b/packages/block-editor/src/components/block-controls/README.md
@@ -9,9 +9,6 @@ With `BlockControls`, you can customize the toolbar to include controls specific
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import {
 	BlockControls,
 	__experimentalBlockAlignmentMatrixControl as BlockAlignmentMatrixControl,

--- a/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
+++ b/packages/block-editor/src/components/block-visibility/test/use-block-visibility.js
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react';
 import { useMediaQuery } from '@wordpress/compose';
-
 // Mock WordPress dependencies before importing the hook
 jest.mock( '@wordpress/compose', () => ( {
 	...jest.requireActual( '@wordpress/compose' ),

--- a/packages/block-editor/src/components/border-radius-control/README.md
+++ b/packages/block-editor/src/components/border-radius-control/README.md
@@ -5,9 +5,6 @@
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { __experimentalBorderRadiusControl as BorderRadiusControl } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -24,9 +24,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { unlock } from '../../lock-unlock';
 import { ViewerSlot } from './viewer-slot';
-
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
-
 import useRichUrlData from './use-rich-url-data';
 
 export default function LinkPreview( {

--- a/packages/block-editor/src/components/panel-color-settings/README.md
+++ b/packages/block-editor/src/components/panel-color-settings/README.md
@@ -6,14 +6,7 @@ It is essentially a wrapper around the `PanelColorGradientSettings` component, b
 ## Usage
 
 ```jsx
-/**
- * External dependencies
- */
 import { useState } from 'react';
-
-/**
- * WordPress dependencies
- */
 import { PanelColorSettings } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 

--- a/packages/block-editor/src/components/recursion-provider/README.md
+++ b/packages/block-editor/src/components/recursion-provider/README.md
@@ -7,9 +7,6 @@ To help with detecting infinite loops on the client, the `RecursionProvider` com
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import {
 	RecursionProvider,
 	useHasRecursion,

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -23,7 +23,6 @@ const { fieldsKey, formKey } = unlock( blocksPrivateApis );
 import FieldsDropdownMenu from './fields-dropdown-menu';
 import { PrivateBlockContext } from '../../components/block-list/private-block-context';
 import InspectorControls from '../../components/inspector-controls/fill';
-
 // controls
 import RichText from './rich-text';
 import Media from './media';

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -8,7 +8,6 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
-
 const EMPTY_OBJECT = {};
 const MIN_FONT_SIZE_FOR_WARNING = 12;
 import { optimizeFitText } from '../utils/fit-text-utils';

--- a/packages/block-library/README.md
+++ b/packages/block-library/README.md
@@ -88,9 +88,6 @@ To find out more about contributing to this package or Gutenberg as a whole, ple
 3.  Add `init.js` file to the directory of the new block:
 
     ```js
-    /**
-     * Internal dependencies
-     */
     import { init } from './';
 
     export default init();

--- a/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js
@@ -1,12 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import { useEnableLinkStatusValidation } from '../use-enable-link-status-validation';
-
 // Mock useSelect directly at the implementation level to avoid loading complex dependencies
 jest.mock( '@wordpress/data/src/components/use-select', () => {
 	const mock = jest.fn();
 	return mock;
 } );
-
 const { useSelect } = require( '@wordpress/data' );
 
 describe( 'useEnableLinkStatusValidation', () => {

--- a/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js
@@ -1,15 +1,12 @@
 import { renderHook } from '@testing-library/react';
-
 // Mock the entire @wordpress/block-editor module
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: {},
 } ) );
-
 // Mock the entire @wordpress/core-data module
 jest.mock( '@wordpress/core-data', () => ( {
 	store: {},
 } ) );
-
 // Mock useDispatch specifically to avoid needing to set up full data store
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn(),

--- a/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js
@@ -1,14 +1,11 @@
 import { renderHook } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
-
 // Mock useRemoteUrlData from block-editor
 const mockUseRemoteUrlData = jest.fn();
-
 jest.mock( '@wordpress/block-editor', () => ( {
 	privateApis: {},
 	store: {},
 } ) );
-
 // Mock the unlock function to return useRemoteUrlData, isHashLink, and isRelativePath
 jest.mock( '../../../lock-unlock', () => ( {
 	unlock: jest.fn( () => ( {

--- a/packages/blocks/src/api/index.ts
+++ b/packages/blocks/src/api/index.ts
@@ -1,6 +1,5 @@
 import { lock } from '../lock-unlock';
 import { isContentBlock } from './utils';
-
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
 // and `save`. The transforms specification allows converting one blocktype to
@@ -19,7 +18,6 @@ export {
 	findTransform,
 	getBlockFromExample,
 } from './factory';
-
 // The block tree is composed of a collection of block nodes. Blocks contained
 // within other blocks are called inner blocks. An important design
 // consideration is that inner blocks are -- conceptually -- not part of the
@@ -43,7 +41,6 @@ export {
 	getBlockAttributes,
 	parseWithAttributeSchema,
 } from './parser/get-block-attributes';
-
 // While block transformations account for a specific surface of the API, there
 // are also raw transformations which handle arbitrary sources not made out of
 // blocks but producing block basaed on various heuristics. This includes
@@ -53,7 +50,6 @@ export {
 	rawHandler,
 	deprecatedGetPhrasingContentSchema as getPhrasingContentSchema,
 } from './raw-handling';
-
 // The process of serialization aims to deflate the internal memory of the block
 // editor and its state representation back into an HTML valid string. This
 // process restores the document integrity and inserts invisible delimiters
@@ -70,7 +66,6 @@ export {
 	getInnerBlocksProps as __unstableGetInnerBlocksProps,
 	__unstableSerializeAndClean,
 } from './serializer';
-
 // Validation is the process of comparing a block source with its output before
 // there is any user input or interaction with a block. When this operation
 // fails -- for whatever reason -- the block is to be considered invalid. As
@@ -95,7 +90,6 @@ export {
 // adequate to spend more time determining validity before throwing a conflict.
 export { isValidBlockContent, validateBlock } from './validation';
 export { getCategories, setCategories, updateCategory } from './categories';
-
 // Blocks are inherently indifferent about where the data they operate with ends
 // up being saved. For example, all blocks can have a static and dynamic aspect
 // to them depending on the needs. The static nature of a block is the `save()`
@@ -156,7 +150,6 @@ export {
 	getBlockAttributesNamesByRole,
 	__experimentalGetBlockAttributesNamesByRole,
 } from './utils';
-
 // Templates are, in a general sense, a basic collection of block nodes with any
 // given set of predefined attributes that are supplied as the initial state of
 // an inner blocks group. These nodes can, in turn, contain any number of nested
@@ -174,19 +167,16 @@ export {
 	__EXPERIMENTAL_ELEMENTS,
 	__EXPERIMENTAL_PATHS_WITH_OVERRIDE,
 } from './constants';
-
 // Allows blocks to declare private keys (fields form)
 // that we can use to generate UI controls for them via DataForm.
 const fieldsKey = Symbol( 'fields' );
 const formKey = Symbol( 'form' );
-
 // A private block setting, opted into by core text blocks, that makes the
 // editor canvas the contentEditable editing host (see `useEditableRoot`). It's
 // a Symbol rather than a `supports` key so it stays private for now: it can't
 // be set from `block.json` and third-party blocks can't opt in yet. It may
 // become a public support once the feature has settled.
 const editableRootKey = Symbol( 'editableRoot' );
-
 import { parseRawBlock as _parseRawBlock } from './parser';
 
 export const privateApis = {};

--- a/packages/boot/src/components/navigation/use-sidebar-parent.ts
+++ b/packages/boot/src/components/navigation/use-sidebar-parent.ts
@@ -2,7 +2,6 @@ import { privateApis as routePrivateApis } from '@wordpress/route';
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { unlock } from '../../lock-unlock';
-
 const { useRouter, useMatches } = unlock( routePrivateApis );
 import { STORE_NAME } from '../../store';
 import {

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -33,9 +33,6 @@ The RTL version of the stylesheet is available at `@wordpress/components/build-s
 Within Gutenberg, these components can be accessed by importing from the `components` root directory:
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { Button } from '@wordpress/components';
 
 export default function MyButton() {
@@ -53,14 +50,7 @@ The following example illustrates how you can wrap a component using a
 `Popover` and have those popovers render to a single location in the DOM.
 
 ```jsx
-/**
- * External dependencies
- */
 import { Popover, SlotFillProvider } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { MyComponentWithPopover } from './my-component';
 
 const Example = () => {

--- a/packages/components/src/menu/stories/best-practices.mdx
+++ b/packages/components/src/menu/stories/best-practices.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-
 import * as MenuStories from './index.story';
 
 <Meta of={ MenuStories } name="Best Practices" />

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -51,21 +51,18 @@ import type {
 } from './types';
 import { overlayMiddlewares } from './overlay-middlewares';
 import { StyleProvider } from '../style-provider';
-
 /**
  * Name of slot in which popover should fill.
  *
  * @type {string}
  */
 export const SLOT_NAME = 'Popover';
-
 /**
  * Virtual padding to account for overflow boundaries.
  *
  * @type {number}
  */
 const OVERFLOW_PADDING = 8;
-
 // An SVG displaying a triangle facing down, filled with a solid
 // color and bordered in such a way to create an arrow-like effect.
 // Keeping the SVG's viewbox squared simplify the arrow positioning
@@ -88,7 +85,6 @@ const ArrowTriangle = () => (
 		/>
 	</SVG>
 );
-
 import { slotNameContext } from './context';
 
 const fallbackContainerClassname = 'components-popover__fallback-container';

--- a/packages/components/src/slot-fill/index.tsx
+++ b/packages/components/src/slot-fill/index.tsx
@@ -6,7 +6,6 @@ import BubblesVirtuallySlot from './bubbles-virtually/slot';
 import SlotFillProvider from './provider';
 import SlotFillContext from './context';
 import type { WordPressComponentProps } from '../context';
-
 export { default as useSlot } from './bubbles-virtually/use-slot';
 export { default as useSlotFills } from './bubbles-virtually/use-slot-fills';
 import type {

--- a/packages/components/src/tabs/stories/best-practices.mdx
+++ b/packages/components/src/tabs/stories/best-practices.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-
 import * as TabsStories from './index.story';
 
 <Meta of={ TabsStories } name="Best Practices" />

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -49,14 +49,7 @@ both columns.
 ## Usage
 
 ```jsx
-/**
- * External dependencies
- */
 import styled from '@emotion/styled';
-
-/**
- * WordPress dependencies
- */
 import {
 	BoxControl,
 	__experimentalToolsPanel as ToolsPanel,

--- a/packages/compose/src/higher-order/with-instance-id/README.md
+++ b/packages/compose/src/higher-order/with-instance-id/README.md
@@ -6,9 +6,6 @@ Wrapping a component with `withInstanceId` provides a unique `instanceId` to ser
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { withInstanceId } from '@wordpress/compose';
 
 function MyCustomElement( { instanceId } ) {

--- a/packages/compose/src/higher-order/with-safe-timeout/README.md
+++ b/packages/compose/src/higher-order/with-safe-timeout/README.md
@@ -5,9 +5,6 @@
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { withSafeTimeout } from '@wordpress/compose';
 
 function MyEffectfulComponent( { setTimeout } ) {

--- a/packages/compose/src/higher-order/with-state/README.md
+++ b/packages/compose/src/higher-order/with-state/README.md
@@ -9,9 +9,6 @@ Wrapping a component with `withState` provides state as props to the wrapped com
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { withState } from '@wordpress/compose';
 
 function MyCounter( { count, setState } ) {

--- a/packages/compose/src/hooks/use-dragging/README.md
+++ b/packages/compose/src/hooks/use-dragging/README.md
@@ -54,9 +54,6 @@ A boolean value, when true it means dragging is currently taking place; when fal
 The following example allows us to drag & drop a red square around the entire viewport.
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { useState, useCallback } from 'react';
 import { __experimentalUseDragging as useDragging } from '@wordpress/compose';
 

--- a/packages/compose/src/hooks/use-instance-id/README.md
+++ b/packages/compose/src/hooks/use-instance-id/README.md
@@ -5,9 +5,6 @@ Some components need to generate a unique id for each instance. This could serve
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { useInstanceId } from '@wordpress/compose';
 
 function MyCustomElement() {

--- a/packages/compose/src/hooks/use-previous/README.md
+++ b/packages/compose/src/hooks/use-previous/README.md
@@ -5,9 +5,6 @@ Sometimes you need to get the value something had on the previous render. `usePr
 ## Usage
 
 ```jsx
-/**
- * WordPress dependencies
- */
 import { useEffect, useState } from 'react';
 import { usePrevious } from '@wordpress/compose';
 

--- a/packages/compose/src/hooks/use-viewport-match/test/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/test/index.js
@@ -1,10 +1,8 @@
 import { render } from '@testing-library/react';
 import useViewportMatch from '../';
-
 jest.mock( '../../use-media-query', () => {
 	return jest.fn();
 } );
-
 import useMediaQueryMock from '../../use-media-query';
 
 describe( 'useViewportMatch', () => {

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -1,6 +1,5 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
-
 jest.mock( '@wordpress/api-fetch' );
 import { act, render, waitFor } from '@testing-library/react';
 import { store as coreDataStore } from '../../index';

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -1,6 +1,5 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
-
 jest.mock( '@wordpress/api-fetch' );
 import { render, waitFor } from '@testing-library/react';
 import { store as coreDataStore } from '../../index';

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -1,6 +1,5 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
-
 jest.mock( '@wordpress/api-fetch' );
 import { render, waitFor } from '@testing-library/react';
 import { store as coreDataStore } from '../../index';

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,5 +1,4 @@
 import apiFetch from '@wordpress/api-fetch';
-
 jest.mock( '@wordpress/api-fetch' );
 import {
 	editEntityRecord,

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -1,5 +1,4 @@
 import apiFetch from '@wordpress/api-fetch';
-
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../sync', () => ( {
 	...jest.requireActual( '../sync' ),

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,6 +1,5 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { getSyncManager } from '../sync';
-
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../sync', () => ( {
 	getSyncManager: jest.fn(),

--- a/packages/core-data/src/test/rtc-rich-text-offset-space.test.js
+++ b/packages/core-data/src/test/rtc-rich-text-offset-space.test.js
@@ -15,7 +15,6 @@ import {
 import { RichText } from '@wordpress/block-editor';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 import { Y } from '@wordpress/sync';
-
 /**
  * Mock sync manager accessor.
  */

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -7,14 +7,12 @@ import {
 	beforeEach,
 	afterEach,
 } from '@jest/globals';
-
 /**
  * Mock uuid module
  */
 jest.mock( 'uuid', () => ( {
 	v4: () => 'mocked-uuid-' + Math.random(),
 } ) );
-
 /**
  * Mock @wordpress/blocks module
  */

--- a/packages/core-data/src/utils/test/crdt-user-selections.ts
+++ b/packages/core-data/src/utils/test/crdt-user-selections.ts
@@ -6,7 +6,6 @@ import {
 	SelectionType,
 } from '../crdt-user-selections';
 import { CRDT_RECORD_MAP_KEY } from '../../sync';
-
 jest.mock( '@wordpress/data', () => ( {
 	select: jest.fn(),
 	// Needed because @wordpress/rich-text initialises its store at import time.
@@ -15,7 +14,6 @@ jest.mock( '@wordpress/data', () => ( {
 	register: jest.fn(),
 	createSelector: ( selector: Function ) => selector,
 } ) );
-
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: 'core/block-editor',
 } ) );

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -1,6 +1,5 @@
 import { Y } from '@wordpress/sync';
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-
 /**
  * Mock getBlockTypes so CRDT merging can identify rich-text attributes.
  * Also stub __unstableSerializeAndClean so we can assert how it's invoked

--- a/packages/core-data/src/utils/test/rtc-rich-text-cursor-scope.test.js
+++ b/packages/core-data/src/utils/test/rtc-rich-text-cursor-scope.test.js
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Y } from '@wordpress/sync';
-
 /**
  * Mock block schemas and sync providers.
  */
 jest.mock( '@wordpress/blocks', () => {
 	const actual = jest.requireActual( '@wordpress/blocks' );
-
 	return {
 		...actual,
 		getBlockTypes: () => [
@@ -20,7 +18,6 @@ jest.mock( '@wordpress/blocks', () => {
 		],
 	};
 } );
-
 jest.mock( '../../../../sync/src/providers', () => ( {
 	getProviderCreators: jest.fn(),
 } ) );

--- a/packages/core-data/src/utils/test/rtc-rich-text-offset-space.test.js
+++ b/packages/core-data/src/utils/test/rtc-rich-text-offset-space.test.js
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Y } from '@wordpress/sync';
-
 /**
  * Mock block schemas and sync providers.
  */
 jest.mock( '@wordpress/blocks', () => {
 	const actual = jest.requireActual( '@wordpress/blocks' );
-
 	return {
 		...actual,
 		getBlockTypes: () => [
@@ -19,7 +17,6 @@ jest.mock( '@wordpress/blocks', () => {
 		],
 	};
 } );
-
 jest.mock( '../../../../sync/src/providers', () => ( {
 	getProviderCreators: jest.fn(),
 } ) );

--- a/packages/create-block-interactive-template/block-templates-client-side-navigation/edit.js.mustache
+++ b/packages/create-block-interactive-template/block-templates-client-side-navigation/edit.js.mustache
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 

--- a/packages/create-block-interactive-template/block-templates-client-side-navigation/index.js.mustache
+++ b/packages/create-block-interactive-template/block-templates-client-side-navigation/index.js.mustache
@@ -15,10 +15,6 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './style.scss';
 import './editor.scss';
-
-/**
- * Internal dependencies
- */
 import Edit from './edit';
 import metadata from './block.json';
 

--- a/packages/create-block-interactive-template/block-templates-client-side-navigation/index.js.mustache
+++ b/packages/create-block-interactive-template/block-templates-client-side-navigation/index.js.mustache
@@ -4,7 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
  */
 import { registerBlockType } from '@wordpress/blocks';
-
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
  * All files containing `style` keyword are bundled together. The code used

--- a/packages/create-block-interactive-template/block-templates-client-side-navigation/view.js.mustache
+++ b/packages/create-block-interactive-template/block-templates-client-side-navigation/view.js.mustache
@@ -1,6 +1,3 @@
-/**
- * WordPress dependencies
- */
 import { getElement, store, withSyncEvent } from '@wordpress/interactivity';
 
 const { state } = store( '{{namespace}}', {

--- a/packages/create-block-interactive-template/block-templates/edit.js.mustache
+++ b/packages/create-block-interactive-template/block-templates/edit.js.mustache
@@ -4,7 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
  */
 import { __ } from '@wordpress/i18n';
-
 /**
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.

--- a/packages/create-block-interactive-template/block-templates/index.js.mustache
+++ b/packages/create-block-interactive-template/block-templates/index.js.mustache
@@ -15,10 +15,6 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './style.scss';
 import './editor.scss';
-
-/**
- * Internal dependencies
- */
 import Edit from './edit';
 import metadata from './block.json';
 

--- a/packages/create-block-interactive-template/block-templates/index.js.mustache
+++ b/packages/create-block-interactive-template/block-templates/index.js.mustache
@@ -4,7 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
  */
 import { registerBlockType } from '@wordpress/blocks';
-
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
  * All files containing `style` keyword are bundled together. The code used

--- a/packages/create-block-interactive-template/block-templates/view.js.mustache
+++ b/packages/create-block-interactive-template/block-templates/view.js.mustache
@@ -1,7 +1,4 @@
 {{#isDefaultVariant}}
-/**
- * WordPress dependencies
- */
 import { store, getContext } from '@wordpress/interactivity';
 
 const { state } = store( '{{namespace}}', {

--- a/packages/create-block-interactive-template/block-templates/view.ts.mustache
+++ b/packages/create-block-interactive-template/block-templates/view.ts.mustache
@@ -1,7 +1,4 @@
 {{#isTypescriptVariant}}
-/**
- * WordPress dependencies
- */
 import { store, getContext } from '@wordpress/interactivity';
 
 type ServerState = {

--- a/packages/create-block-tutorial-template/block-templates/edit.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/edit.js.mustache
@@ -4,7 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
  */
 import { __ } from '@wordpress/i18n';
-
 /**
  * Imports the InspectorControls component, which is used to wrap
  * the block's custom controls that will appear in in the Settings
@@ -17,7 +16,6 @@ import { __ } from '@wordpress/i18n';
  * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-
 /**
  * Imports the necessary components that will be used to create
  * the user interface for the block's settings.
@@ -27,7 +25,6 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
  * @see https://developer.wordpress.org/block-editor/reference-guides/components/toggle-control/
  */
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
-
 /**
  * Imports the useEffect React Hook. This is used to set an attribute when the
  * block is loaded in the Editor.

--- a/packages/create-block-tutorial-template/block-templates/index.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/index.js.mustache
@@ -4,10 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
  */
 import { registerBlockType } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
 import Edit from './edit';
 import save from './save';
 import metadata from './block.json';

--- a/packages/create-block/lib/init-block.js
+++ b/packages/create-block/lib/init-block.js
@@ -1,6 +1,6 @@
 const { join } = require( 'path' );
-const makeDir = require( 'make-dir' );
 const { writeFile } = require( 'fs' ).promises;
+const makeDir = require( 'make-dir' );
 const { info } = require( './log' );
 const { writeOutputTemplate } = require( './output' );
 

--- a/packages/create-block/lib/init-wp-env.js
+++ b/packages/create-block/lib/init-wp-env.js
@@ -1,6 +1,6 @@
-const { command } = require( 'execa' );
 const { join } = require( 'path' );
 const { writeFile } = require( 'fs' ).promises;
+const { command } = require( 'execa' );
 const { info } = require( './log' );
 
 module.exports = async ( { rootDirectory } ) => {

--- a/packages/create-block/lib/output.js
+++ b/packages/create-block/lib/output.js
@@ -1,7 +1,7 @@
 const { dirname, join } = require( 'path' );
+const { writeFile } = require( 'fs' ).promises;
 const makeDir = require( 'make-dir' );
 const { render } = require( 'mustache' );
-const { writeFile } = require( 'fs' ).promises;
 
 const writeOutputAsset = async ( inputFile, outputFile, view ) => {
 	const outputFilePath = join( view.rootDirectory, 'assets', outputFile );

--- a/packages/create-block/lib/templates/block/edit.js.mustache
+++ b/packages/create-block/lib/templates/block/edit.js.mustache
@@ -4,7 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
  */
 import { __ } from '@wordpress/i18n';
-
 /**
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
@@ -12,7 +11,6 @@ import { __ } from '@wordpress/i18n';
  * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
 import { useBlockProps } from '@wordpress/block-editor';
-
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
  * Those files can contain any CSS code that gets applied to the editor.

--- a/packages/create-block/lib/templates/block/index.js.mustache
+++ b/packages/create-block/lib/templates/block/index.js.mustache
@@ -13,10 +13,6 @@ import { registerBlockType } from '@wordpress/blocks';
  * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
  */
 import './style.scss';
-
-/**
- * Internal dependencies
- */
 import Edit from './edit';
 {{#isStaticVariant}}
 import save from './save';

--- a/packages/create-block/lib/templates/block/index.js.mustache
+++ b/packages/create-block/lib/templates/block/index.js.mustache
@@ -4,7 +4,6 @@
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
 import { registerBlockType } from '@wordpress/blocks';
-
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
  * All files containing `style` keyword are bundled together. The code used

--- a/packages/data-controls/README.md
+++ b/packages/data-controls/README.md
@@ -52,11 +52,8 @@ The default export is what you use to register the controls with your custom sto
 _Usage_
 
 ```js
-// WordPress dependencies
 import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
-
-// Internal dependencies
 import reducer from './reducer';
 import * as selectors from './selectors';
 import * as actions from './actions';

--- a/packages/data-controls/src/index.ts
+++ b/packages/data-controls/src/index.ts
@@ -129,11 +129,8 @@ export const __unstableAwaitPromise = function < T >( promise: Promise< T > ) {
  *
  * @example
  * ```js
- * // WordPress dependencies
  * import { controls } from '@wordpress/data-controls';
  * import { registerStore } from '@wordpress/data';
- *
- * // Internal dependencies
  * import reducer from './reducer';
  * import * as selectors from './selectors';
  * import * as actions from './actions';

--- a/packages/data-controls/src/test/index.js
+++ b/packages/data-controls/src/test/index.js
@@ -1,5 +1,4 @@
 import triggerFetch from '@wordpress/api-fetch';
-
 jest.mock( '@wordpress/api-fetch' );
 import { controls } from '../index';
 

--- a/packages/dataviews/src/components/dataform-controls/test/richtext.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/richtext.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
 // The rich-text assembly (`./control`) wires `@wordpress/rich-text`'s
 // useRichText hook (format types, event listeners, etc.) into the
 // presentational `RichTextControl` shell from `@wordpress/components`, which is
@@ -12,7 +11,6 @@ jest.mock( '../richtext/control', () => ( {
 	default( props: any ) {
 		const handleChange = ( event: any ) =>
 			props.onChange( event.target.value );
-
 		return (
 			<textarea
 				aria-label={ props.label }

--- a/packages/dataviews/src/dataviews/stories/best-practices.story.mdx
+++ b/packages/dataviews/src/dataviews/stories/best-practices.story.mdx
@@ -1,18 +1,17 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-
 import * as DataViewsStories from './index.story';
 
 <Meta of={ DataViewsStories } name="Best practices" />
 
 # Data Views
 
-Data Views allow users to display and interact with information through different layouts such as table or grid. It includes features like search, filtering, sorting, pagination, and customization options to adjust column order, items per page, and hide columns, enhancing data exploration and flexibility. 
+Data Views allow users to display and interact with information through different layouts such as table or grid. It includes features like search, filtering, sorting, pagination, and customization options to adjust column order, items per page, and hide columns, enhancing data exploration and flexibility.
 
 A typical flow might be:
 
-- Use search and filters to narrow down a large collection.
-- Adjust the layout and visible fields to match the task (compare, skim, or visually scan).
-- Take inline actions on item metadata, or open an editing interface when more detail is needed.
+-   Use search and filters to narrow down a large collection.
+-   Adjust the layout and visible fields to match the task (compare, skim, or visually scan).
+-   Take inline actions on item metadata, or open an editing interface when more detail is needed.
 
 ## Choosing a layout
 
@@ -20,9 +19,9 @@ A typical flow might be:
 
 Use the **List** layout when:
 
-- **Content needs the most compact layout**, whether because it's used in a constrained context, or if paired with a preview surface.
-- Default information density allows for a reduced set of secondary metadata.
-- The view needs to work well in **narrow spaces**.
+-   **Content needs the most compact layout**, whether because it's used in a constrained context, or if paired with a preview surface.
+-   Default information density allows for a reduced set of secondary metadata.
+-   The view needs to work well in **narrow spaces**.
 
 List is a good fit for items like Pages that benefit from a live preview next to the list.
 
@@ -50,6 +49,5 @@ Table is ideal for dense, structured information where sorting and scanning down
 
 Data Views are designed for **browsing and managing collections**. In other situations, consider other components in the `@wordpress/dataviews` package:
 
-- **Use `DataForm`** when the primary workflow primarily relates to **creating or editing a single item** at a level that doesn't require a full editor.
-- **Use `DataViewsPicker`** when the goal is **selecting one or more items** and returning that selection to another part of the UI. This is a better fit for dialogs and sidebars where the outcome is a selection, not ongoing management of a collection, e.g. inserting from a media library.
-
+-   **Use `DataForm`** when the primary workflow primarily relates to **creating or editing a single item** at a level that doesn't require a full editor.
+-   **Use `DataViewsPicker`** when the goal is **selecting one or more items** and returning that selection to another part of the UI. This is a better fit for dialogs and sidebars where the outcome is a selection, not ongoing management of a collection, e.g. inserting from a media library.

--- a/packages/docgen/bin/cli.js
+++ b/packages/docgen/bin/cli.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const docgen = require( '../lib' );
 const optionator = require( 'optionator' )( {
 	prepend: 'Usage: node <path-to-docgen> <relative-path-to-entry-point>',
 	options: [
@@ -50,6 +49,7 @@ const optionator = require( 'optionator' )( {
 		},
 	],
 } );
+const docgen = require( '../lib' );
 
 const options = optionator.parseArgv( process.argv );
 process.exit( docgen( options._[ 0 ], options ) );

--- a/packages/docgen/test/get-export-entries.js
+++ b/packages/docgen/test/get-export-entries.js
@@ -111,9 +111,6 @@ describe( 'Export entries', () => {
 	it( 'default import (named)', () => {
 		const testCode = firstExport(
 			`
-			/**
-			 * Internal dependencies
-			 */
 			import { functionDeclaration as fnDeclaration } from './module-code';
 
 			export default fnDeclaration;
@@ -140,9 +137,6 @@ describe( 'Export entries', () => {
 		expect(
 			firstExport(
 				`
-				/**
-				 * Internal dependencies
-				 */
 				import fnDeclaration from './module-code';
 
 				export default fnDeclaration;
@@ -403,9 +397,6 @@ describe( 'Export entries', () => {
 		expect(
 			firstExport(
 				`
-				/**
-				 * Internal dependencies
-				 */
 				import * as variables from './module-code';
 
 				export { variables };

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -723,9 +723,6 @@ describe( 'Intermediate Representation', () => {
 				expect(
 					parse(
 						`
-						/**
-						 * Internal dependencies
-						 */
 						import fnDeclaration from './module-code';
 
 						export default fnDeclaration;
@@ -751,9 +748,6 @@ describe( 'Intermediate Representation', () => {
 				expect(
 					parse(
 						`
-						/**
-						 * Internal dependencies
-						 */
 						import { functionDeclaration as fnDeclaration } from './module-code';
 
 						export default fnDeclaration;
@@ -794,9 +788,6 @@ describe( 'Intermediate Representation', () => {
 					engine(
 						'test-code.ts',
 						`
-						/**
-						 * Internal dependencies
-						 */
 						import * as variables from './named-import-namespace-module';
 
 						export { variables };

--- a/packages/edit-site/README.md
+++ b/packages/edit-site/README.md
@@ -13,14 +13,7 @@ npm install @wordpress/edit-site
 ## Usage
 
 ```js
-/**
- * WordPress dependencies
- */
 import { initialize } from '@wordpress/edit-site';
-
-/**
- * Internal dependencies
- */
 import blockEditorSettings from './block-editor-settings';
 
 initialize( '#editor-root', blockEditorSettings );

--- a/packages/edit-site/src/components/page-patterns/search-items.js
+++ b/packages/edit-site/src/components/page-patterns/search-items.js
@@ -1,6 +1,5 @@
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { unlock } from '../../lock-unlock';
-
 const { extractWords, getNormalizedSearchTerms, normalizeString } = unlock(
 	blockEditorPrivateApis
 );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js
@@ -5,7 +5,6 @@ import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -11,11 +11,8 @@ import {
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-
 const SIDEBAR_ACTIVE_BY_DEFAULT = true;
-
 const BLOCK_INSPECTOR_IDENTIFIER = 'edit-widgets/block-inspector';
-
 // Widget areas were once called block areas, so use 'edit-widgets/block-areas'
 // for backwards compatibility.
 const WIDGET_AREAS_IDENTIFIER = 'edit-widgets/block-areas';

--- a/packages/editor/src/components/collaborators-presence/avatar/component.tsx
+++ b/packages/editor/src/components/collaborators-presence/avatar/component.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { colord, extend } from 'colord';
 import a11yPlugin from 'colord/plugins/a11y';
-
 extend( [ a11yPlugin ] );
 import { Icon as WCIcon } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';

--- a/packages/editor/src/components/post-visibility/test/check.js
+++ b/packages/editor/src/components/post-visibility/test/check.js
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
-
 jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
 import PostVisibilityCheck from '../check';
 

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -5,7 +5,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { createRegistry } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
-
 jest.mock( '@wordpress/a11y', () => ( {
 	speak: jest.fn(),
 } ) );

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -2,14 +2,10 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const util = require( 'util' );
+const pipeline = util.promisify( require( 'stream' ).pipeline );
 const got = require( 'got' );
 const AdmZip = require( 'adm-zip' );
 const SimpleGit = require( 'simple-git' );
-
-/**
- * Promisified dependencies
- */
-const pipeline = util.promisify( require( 'stream' ).pipeline );
 const { rimraf } = require( 'rimraf' );
 
 /**

--- a/packages/env/lib/runtime/docker/index.js
+++ b/packages/env/lib/runtime/docker/index.js
@@ -2,13 +2,9 @@
 const { spawn, execSync } = require( 'child_process' );
 const path = require( 'path' );
 const util = require( 'util' );
+const exec = util.promisify( require( 'child_process' ).exec );
 const { v2: dockerCompose } = require( 'docker-compose' );
 const { rimraf } = require( 'rimraf' );
-
-/**
- * Promisified dependencies
- */
-const exec = util.promisify( require( 'child_process' ).exec );
 const {
 	writeDockerFiles,
 	ensureDockerInitialized,

--- a/packages/env/lib/runtime/docker/wordpress.js
+++ b/packages/env/lib/runtime/docker/wordpress.js
@@ -1,10 +1,6 @@
 'use strict';
 const util = require( 'util' );
 const { v2: dockerCompose } = require( 'docker-compose' );
-
-/**
- * Promisified dependencies
- */
 const copyDir = util.promisify( require( 'copy-dir' ) );
 const { readWordPressVersion } = require( '../../wordpress' );
 

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -1,10 +1,6 @@
 # Enforce dependencies docblocks formatting (dependency-group)
 
-Ensures that all top-level package imports adhere to the dependencies grouping conventions as outlined in the [Coding Guidelines](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/coding-guidelines.md#imports).
-
-Specifically, this ensures that:
-
--   An import is preceded by "External dependencies", "WordPress dependencies", or "Internal dependencies" as appropriate by the import source.
+Requires or forbids dependency group comments for top-level package imports. The Gutenberg [Coding Guidelines](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/coding-guidelines.md#imports) use one contiguous import block without dependency group comments.
 
 ## Options
 

--- a/packages/eslint-plugin/docs/rules/use-import-as.md
+++ b/packages/eslint-plugin/docs/rules/use-import-as.md
@@ -29,9 +29,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 import { VisuallyHidden } from '@wordpress/components';
-
 import { Button, VisuallyHidden as Hidden } from '@wordpress/components';
-
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
 
@@ -42,9 +40,10 @@ Examples of **correct** code for this rule:
 
 ```js
 import { VisuallyHidden as WCVisuallyHidden } from '@wordpress/components';
-
-import { Button, VisuallyHidden as WCVisuallyHidden } from '@wordpress/components';
-
+import {
+	Button,
+	VisuallyHidden as WCVisuallyHidden,
+} from '@wordpress/components';
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
 

--- a/packages/eslint-plugin/docs/rules/use-recommended-components.md
+++ b/packages/eslint-plugin/docs/rules/use-recommended-components.md
@@ -11,10 +11,8 @@ Examples of **incorrect** code for this rule:
 ```js
 // @wordpress/ui — this component isn't recommended yet.
 import { SomeComponent } from '@wordpress/ui';
-
 // @wordpress/components — a newer alternative is available.
 import { Tabs } from '@wordpress/components';
-
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
 
@@ -26,12 +24,9 @@ Examples of **correct** code for this rule:
 ```js
 // Packages not covered by the rule are unaffected.
 import { Button } from '@wordpress/components';
-
 // Default and namespace imports are not checked.
 import UI from '@wordpress/ui';
-
 import { Tabs } from '@wordpress/ui';
-
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
 

--- a/packages/eslint-plugin/rules/no-unknown-ds-tokens.js
+++ b/packages/eslint-plugin/rules/no-unknown-ds-tokens.js
@@ -1,6 +1,5 @@
 const tokenListModule = require( '@wordpress/theme/design-tokens.js' );
 const tokenList = tokenListModule.default || tokenListModule;
-
 const {
 	DS_TOKEN_PREFIX,
 	collectTokenOccurrences,

--- a/packages/fields/src/stories/index.story.tsx
+++ b/packages/fields/src/stories/index.story.tsx
@@ -11,7 +11,6 @@ import {
 	statusField,
 	titleField,
 } from '../fields';
-
 // Fields not yet covered:
 // featuredImageField,
 // pageTitleField,
@@ -19,7 +18,6 @@ import {
 // patternTitleField,
 // templateField,
 // templateTitleField,
-
 import type { BasePost, BasePostWithEmbeddedAuthor } from '../types';
 
 // Mock users for the story.

--- a/packages/global-styles-ui/src/test/use-presets.js
+++ b/packages/global-styles-ui/src/test/use-presets.js
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-
 jest.mock( '../hooks', () => ( {
 	useSetting: jest.fn(),
 } ) );

--- a/packages/global-styles-ui/src/variations/test/variations-panel.js
+++ b/packages/global-styles-ui/src/variations/test/variations-panel.js
@@ -1,12 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
-
 // Only mock the internal hooks - let the real blocks store work
 jest.mock( '../../hooks', () => ( {
 	useStyle: jest.fn(),
 } ) );
-
 jest.mock( '@wordpress/components', () => ( {
 	__experimentalItemGroup: jest.fn( ( { children } ) => children ),
 } ) );

--- a/packages/icons/lib/generate-library.cjs
+++ b/packages/icons/lib/generate-library.cjs
@@ -298,10 +298,7 @@ function svgToTsx( svgContent ) {
 		.map( ( line ) => '\t' + line )
 		.join( '\n' );
 
-	return `/**
- * WordPress dependencies
- */
-import { ${ Array.from( usedPrimitives )
+	return `import { ${ Array.from( usedPrimitives )
 		.sort()
 		.join( ', ' ) } } from '@wordpress/primitives';
 

--- a/packages/readable-js-assets-webpack-plugin/test/build.js
+++ b/packages/readable-js-assets-webpack-plugin/test/build.js
@@ -1,7 +1,7 @@
 const fs = require( 'fs' );
+const path = require( 'path' );
 const glob = require( 'glob' ).sync;
 const mkdirp = require( 'mkdirp' ).mkdirp.sync;
-const path = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
 const webpack = require( 'webpack' );
 

--- a/packages/scripts/config/babel-transform.js
+++ b/packages/scripts/config/babel-transform.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const babelJest = require( 'babel-jest' );
 
 // Remove this workaround when https://github.com/facebook/jest/issues/11444 gets resolved in Jest.

--- a/packages/scripts/config/eslint.config.cjs
+++ b/packages/scripts/config/eslint.config.cjs
@@ -5,7 +5,6 @@
  * eslint.config.* will use this config automatically.
  */
 const { hasBabelConfig } = require( '../utils' );
-
 const wpPlugin = require( '@wordpress/eslint-plugin' );
 
 const config = [

--- a/packages/scripts/config/eslint.config.cjs
+++ b/packages/scripts/config/eslint.config.cjs
@@ -4,10 +4,6 @@
  * Projects using `wp-scripts lint-js` that do not provide their own
  * eslint.config.* will use this config automatically.
  */
-
-/**
- * Internal dependencies
- */
 const { hasBabelConfig } = require( '../utils' );
 
 const wpPlugin = require( '@wordpress/eslint-plugin' );

--- a/packages/scripts/config/jest-unit.config.js
+++ b/packages/scripts/config/jest-unit.config.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 const path = require( 'path' );
-
-/**
- * Internal dependencies
- */
 const { hasBabelConfig } = require( '../utils' );
 
 const jestUnitConfig = {

--- a/packages/scripts/config/playwright.config.js
+++ b/packages/scripts/config/playwright.config.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const path = require( 'path' );
 const { defineConfig, devices } = require( '@playwright/test' );
 

--- a/packages/scripts/config/playwright/global-setup.js
+++ b/packages/scripts/config/playwright/global-setup.js
@@ -1,11 +1,4 @@
-/**
- * External dependencies
- */
 const { request } = require( '@playwright/test' );
-
-/**
- * WordPress dependencies
- */
 const { RequestUtils } = require( '@wordpress/e2e-test-utils-playwright' );
 
 /**

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 const { basename, dirname, relative, resolve, sep } = require( 'path' );
 const { realpathSync } = require( 'fs' );
 const { exec } = require( 'child_process' );
@@ -12,16 +9,8 @@ const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
 const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { sync: glob } = require( 'fast-glob' );
-
-/**
- * WordPress dependencies
- */
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
-
-/**
- * Internal dependencies
- */
 const PhpFilePathsPlugin = require( '../plugins/php-file-paths-plugin' );
 const RtlCssPlugin = require( '../plugins/rtlcss-webpack-plugin' );
 const {

--- a/packages/sync/src/providers/http-polling/test/utils.test.ts
+++ b/packages/sync/src/providers/http-polling/test/utils.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-
 // Mock @wordpress/api-fetch
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,

--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { createRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-
 type WPDataRegistry = ReturnType< typeof createRegistry >;
 import type {
 	AdditionalData,

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -3,14 +3,12 @@ type WPDataRegistry = ReturnType< typeof createRegistry >;
 import { store as uploadStore } from '..';
 import { ItemStatus, OperationType } from '../types';
 import { unlock } from '../../lock-unlock';
-
 jest.mock( '@wordpress/blob', () => ( {
 	__esModule: true,
 	createBlobURL: jest.fn( () => 'blob:foo' ),
 	isBlobURL: jest.fn( ( str: string ) => str.startsWith( 'blob:' ) ),
 	revokeBlobURL: jest.fn(),
 } ) );
-
 jest.mock( '../utils', () => ( {
 	vipsCancelOperations: jest.fn( () => Promise.resolve( true ) ),
 	vipsResizeImage: jest.fn( () =>
@@ -25,7 +23,6 @@ jest.mock( '../utils', () => ( {
 	vipsConvertImageFormat: jest.fn(),
 	terminateVipsWorker: jest.fn(),
 } ) );
-
 /*
  * actions.ts transitively imports private-actions, which also pulls in
  * convertGifToVideo / isUnsupportedConversionError, so the mock must cover the
@@ -40,7 +37,6 @@ jest.mock( '../utils/video-conversion', () => {
 		isUnsupportedConversionError: actual.isUnsupportedConversionError,
 	};
 } );
-
 // Import the mocked modules to access the mock functions.
 import { vipsCancelOperations } from '../utils';
 import { cancelGifToVideoOperations } from '../utils/video-conversion';

--- a/packages/upload-media/src/store/test/vips.ts
+++ b/packages/upload-media/src/store/test/vips.ts
@@ -13,7 +13,6 @@ jest.mock( '@wordpress/vips/worker', () => ( {
 import * as vipsWorker from '@wordpress/vips/worker';
 import { ImageFile } from '../../image-file';
 import type { ImageSizeCrop } from '../types';
-
 // Import after mock is set up.
 import {
 	vipsConvertImageFormat,

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,8 +1,6 @@
 import Vips from 'wasm-vips';
-
 // @ts-expect-error - WASM files are inlined as Uint8Array at build time.
 import VipsModule from 'wasm-vips/vips.wasm';
-
 // @ts-expect-error - WASM files are inlined as Uint8Array at build time.
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
 import type {

--- a/packages/vips/src/test/highbitdepth-avif.ts
+++ b/packages/vips/src/test/highbitdepth-avif.ts
@@ -3,7 +3,6 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-
 /**
  * Loads the real `wasm-vips` build to exercise the actual AVIF decoder.
  *

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -17,7 +17,6 @@ import cssnano from 'cssnano';
 import babel from 'esbuild-plugin-babel';
 import { camelCase } from 'change-case';
 import { NodePackageImporter } from 'sass-embedded';
-
 // Optional dependency: @wordpress/theme provides plugins that inject fallback
 // values for design system tokens. Fails gracefully when the package is not
 // installed (it is an optional peerDependency).

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -26,12 +26,10 @@ import { patternStatusField } from './fields/sync-status';
 import { usePatternCategoryField } from './fields/category';
 import usePatterns, { useAugmentPatternsWithPermissions } from './use-patterns';
 import type { NormalizedPattern } from './use-patterns';
-
 // Unlock WordPress private APIs
 const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
 const { PATTERN_TYPES, CreatePatternModal } = unlock( patternPrivateApis );
-
 /**
  * Style dependencies
  */

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -32,12 +32,10 @@ import {
 	viewToQuery,
 } from './view-utils';
 import { QuickEditModal } from './quick-edit-modal';
-
 // Unlock WordPress private APIs
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
-
 /**
  * Style dependencies
  */

--- a/routes/template-list/stage-activation.tsx
+++ b/routes/template-list/stage-activation.tsx
@@ -32,11 +32,9 @@ import { slugField } from './fields/slug';
 import { useTemplates } from './use-templates';
 import { useSetActiveTemplateAction } from './actions/set-active-template';
 import AddNewTemplate from './add-new-template';
-
 // Unlock WordPress private APIs
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
-
 /**
  * Style dependencies
  */

--- a/routes/template-list/stage-legacy.tsx
+++ b/routes/template-list/stage-legacy.tsx
@@ -26,11 +26,9 @@ import { authorField } from './fields/author';
 import { descriptionField } from './fields/description';
 import { useTemplatesLegacy } from './use-templates-legacy';
 import AddNewTemplate from './add-new-template';
-
 // Unlock WordPress private APIs
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
-
 /**
  * Style dependencies
  */

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -30,12 +30,10 @@ import {
 	viewToQuery,
 } from './view-utils';
 import { previewField } from './fields/preview';
-
 // Unlock WordPress private APIs
 const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
-
 /**
  * Style dependencies
  */

--- a/test/e2e/bin/gen-ultrahdr-fixture.mjs
+++ b/test/e2e/bin/gen-ultrahdr-fixture.mjs
@@ -14,7 +14,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-
 // `wasm-vips` is a dependency of `@wordpress/vips` and is installed under that
 // package's `node_modules` (it no longer hoists to the repo root as of 0.0.18),
 // so resolve it from there, mirroring test/performance/specs/media-processing.

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -2,7 +2,6 @@ const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
 const { randomUUID } = require( 'crypto' );
-
 /** @typedef {import('@playwright/test').Page} Page */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -2,7 +2,6 @@ const path = require( 'path' );
 const fs = require( 'fs/promises' );
 const os = require( 'os' );
 const { randomUUID } = require( 'crypto' );
-
 /** @typedef {import('@playwright/test').Page} Page */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 

--- a/test/e2e/specs/editor/various/client-side-media-processing.spec.js
+++ b/test/e2e/specs/editor/various/client-side-media-processing.spec.js
@@ -4,7 +4,6 @@ const os = require( 'os' );
 const { randomUUID } = require( 'crypto' );
 const { createRequire } = require( 'node:module' );
 const { pathToFileURL } = require( 'node:url' );
-
 /**
  * Resolves the `wasm-vips` entry point from the `@wordpress/vips` package,
  * which declares it as a direct dependency. This works whether or not

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1,9 +1,4 @@
 {
-	"packages/babel-preset-default/bin/index.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/block-directory/src/components/downloadable-blocks-panel/no-results.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -115,11 +110,6 @@
 	"packages/block-editor/src/components/block-visibility/modal.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
-		}
-	},
-	"packages/block-editor/src/components/block-visibility/test/use-block-visibility.js": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/block-editor/src/components/block-visibility/viewport-toolbar.js": {
@@ -248,9 +238,6 @@
 	"packages/block-editor/src/components/link-control/link-preview.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
-		},
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/block-editor/src/components/link-control/use-create-page.js": {
@@ -324,9 +311,6 @@
 	"packages/block-editor/src/hooks/block-fields/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		},
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/block-editor/src/hooks/block-fields/link/index.js": {
@@ -336,11 +320,6 @@
 	},
 	"packages/block-editor/src/hooks/block-fields/media/index.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/block-editor/src/hooks/fit-text.js": {
-		"import/order": {
 			"count": 1
 		}
 	},
@@ -428,21 +407,6 @@
 	"packages/block-library/src/navigation-link/link-ui/page-creator.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
-		}
-	},
-	"packages/block-library/src/navigation-link/shared/test/use-enable-link-status-validation.test.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/block-library/src/navigation-link/shared/test/use-handle-link-change.test.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/block-library/src/navigation-link/shared/test/use-link-preview.test.js": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/block-library/src/navigation/edit/index.js": {
@@ -570,11 +534,6 @@
 			"count": 3
 		}
 	},
-	"packages/blocks/src/api/index.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/boot/src/components/navigation/drilldown-item/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
@@ -602,11 +561,6 @@
 		},
 		"@wordpress/use-recommended-components": {
 			"count": 2
-		}
-	},
-	"packages/boot/src/components/navigation/use-sidebar-parent.ts": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/boot/src/components/root/index.tsx": {
@@ -843,9 +797,6 @@
 		}
 	},
 	"packages/components/src/popover/index.tsx": {
-		"import/order": {
-			"count": 1
-		},
 		"react-hooks/refs": {
 			"count": 1
 		}
@@ -881,11 +832,6 @@
 	"packages/components/src/select-control/styles/select-control-styles.ts": {
 		"no-restricted-imports": {
 			"count": 2
-		}
-	},
-	"packages/components/src/slot-fill/index.tsx": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/components/src/slot-fill/slot.tsx": {
@@ -1008,11 +954,6 @@
 			"count": 1
 		}
 	},
-	"packages/compose/src/hooks/use-viewport-match/test/index.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/connectors/src/connector-item.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 5
@@ -1028,99 +969,14 @@
 			"count": 2
 		}
 	},
-	"packages/core-data/src/hooks/test/use-entity-record.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/hooks/test/use-entity-records.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/hooks/test/use-resource-permissions.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/test/actions.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/test/entities.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/test/resolvers.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/test/rtc-rich-text-offset-space.test.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/utils/test/crdt-blocks.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/utils/test/crdt-user-selections.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/utils/test/crdt.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/utils/test/rtc-rich-text-cursor-scope.test.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/utils/test/rtc-rich-text-offset-space.test.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/create-block/lib/init-block.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/create-block/lib/init-wp-env.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/create-block/lib/output.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/customize-widgets/src/components/welcome-guide/index.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/data-controls/src/test/index.js": {
-		"import/order": {
 			"count": 1
 		}
 	},
 	"packages/data/src/components/use-select/index.ts": {
 		"react-hooks/refs": {
 			"count": 2
-		}
-	},
-	"packages/dataviews/src/components/dataform-controls/test/richtext.tsx": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/dataviews/src/components/dataform-controls/utils/validated-number.tsx": {
@@ -1223,11 +1079,6 @@
 			"count": 2
 		}
 	},
-	"packages/docgen/bin/cli.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/edit-post/src/components/welcome-guide/default.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1278,11 +1129,6 @@
 			"count": 2
 		}
 	},
-	"packages/edit-site/src/components/page-patterns/search-items.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/edit-site/src/components/page-templates/fields.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1323,11 +1169,6 @@
 			"count": 2
 		}
 	},
-	"packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/leaf-more-menu.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/edit-site/src/components/sidebar-navigation-screen-unsupported/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1346,9 +1187,6 @@
 	"packages/edit-widgets/src/components/sidebar/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		},
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/edit-widgets/src/components/welcome-guide/index.js": {
@@ -1358,11 +1196,6 @@
 	},
 	"packages/editor/src/components/collab-sidebar/note-card.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/collaborators-presence/avatar/component.tsx": {
-		"import/order": {
 			"count": 1
 		}
 	},
@@ -1519,11 +1352,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/post-visibility/test/check.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/sidebar/post-revision-summary.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
@@ -1572,31 +1400,6 @@
 	"packages/editor/src/components/visual-editor/index.js": {
 		"react-hooks/refs": {
 			"count": 2
-		}
-	},
-	"packages/editor/src/store/test/actions.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/env/lib/download-sources.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/env/lib/runtime/docker/index.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/env/lib/runtime/docker/wordpress.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/eslint-plugin/rules/no-unknown-ds-tokens.js": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/fields/src/actions/delete-post.tsx": {
@@ -1702,11 +1505,6 @@
 	},
 	"packages/fields/src/fields/title/view.tsx": {
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/fields/src/stories/index.story.tsx": {
-		"import/order": {
 			"count": 1
 		}
 	},
@@ -1965,19 +1763,9 @@
 			"count": 1
 		}
 	},
-	"packages/global-styles-ui/src/test/use-presets.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/global-styles-ui/src/typography-elements.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
-		}
-	},
-	"packages/global-styles-ui/src/variations/test/variations-panel.js": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/variations/variations-color.tsx": {
@@ -2056,11 +1844,6 @@
 			"count": 7
 		}
 	},
-	"packages/readable-js-assets-webpack-plugin/test/build.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
@@ -2069,11 +1852,6 @@
 	"packages/rich-text/src/hook/index.js": {
 		"react-hooks/refs": {
 			"count": 12
-		}
-	},
-	"packages/sync/src/providers/http-polling/test/utils.test.ts": {
-		"import/order": {
-			"count": 1
 		}
 	},
 	"packages/ui/src/alert-dialog/root.tsx": {
@@ -2091,31 +1869,6 @@
 			"count": 1
 		}
 	},
-	"packages/upload-media/src/store/actions.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/upload-media/src/store/test/actions.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/upload-media/src/store/test/vips.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"packages/vips/src/index.ts": {
-		"import/order": {
-			"count": 2
-		}
-	},
-	"packages/vips/src/test/highbitdepth-avif.ts": {
-		"import/order": {
-			"count": 1
-		}
-	},
 	"packages/widgets/src/blocks/legacy-widget/edit/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
@@ -2126,11 +1879,6 @@
 			"count": 1
 		},
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
-	"packages/wp-build/lib/build.mjs": {
-		"import/order": {
 			"count": 1
 		}
 	},
@@ -2241,9 +1989,6 @@
 		},
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		},
-		"import/order": {
-			"count": 1
 		}
 	},
 	"routes/post-list/quick-edit-modal.tsx": {
@@ -2256,9 +2001,6 @@
 			"count": 1
 		},
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		},
-		"import/order": {
 			"count": 1
 		}
 	},
@@ -2316,9 +2058,6 @@
 		},
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		},
-		"import/order": {
-			"count": 1
 		}
 	},
 	"routes/template-list/stage-legacy.tsx": {
@@ -2327,9 +2066,6 @@
 		},
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		},
-		"import/order": {
-			"count": 1
 		}
 	},
 	"routes/template-part-list/stage.tsx": {
@@ -2337,9 +2073,6 @@
 			"count": 1
 		},
 		"@wordpress/use-recommended-components": {
-			"count": 1
-		},
-		"import/order": {
 			"count": 1
 		}
 	},
@@ -2350,26 +2083,6 @@
 	},
 	"storybook/stories/playground/with-undo-redo/index.jsx": {
 		"@wordpress/no-non-module-stylesheet-imports": {
-			"count": 1
-		}
-	},
-	"test/e2e/bin/gen-ultrahdr-fixture.mjs": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"test/e2e/specs/editor/blocks/cover.spec.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"test/e2e/specs/editor/blocks/image.spec.js": {
-		"import/order": {
-			"count": 1
-		}
-	},
-	"test/e2e/specs/editor/various/client-side-media-processing.spec.js": {
-		"import/order": {
 			"count": 1
 		}
 	},


### PR DESCRIPTION
Closes #81188.

## What?

Completes the dependency-import lint migration by fixing the remaining 62 `import/order` violations and removing their bulk suppressions. It also removes stale dependency-group comments from documentation, generators, templates, and excluded configuration files.

## Why?

The rules now run globally, but the remaining suppressions and unlinted examples still allowed the retired import style to persist or be generated again.

## How?

- Makes the remaining import blocks contiguous and orders built-in dependencies before external and internal dependencies.
- Prunes every `import/order` entry from `tools/eslint/suppressions.json`.
- Updates contributor guidance and removes stale comments from documentation and scaffolding generators.
- Adds the merged bulk-cleanup commit to `.git-blame-ignore-revs`.
- Keeps dependency-group comments only in the lint rule's tests and documentation.

## Testing Instructions

1. Run `npm run lint:js -- --format compact --quiet --prune-suppressions`.
2. Run `npm run test:unit -- packages/eslint-plugin/rules/__tests__/dependency-group.js --runInBand`.
3. Run `npm run test:unit -- packages/docgen/test packages/readable-js-assets-webpack-plugin/test packages/env/lib/test --runInBand`.
4. Run `npm run -w packages/icons build` and confirm it creates no additional tracked changes.

### Testing Instructions for Keyboard

Not applicable. This PR has no user interface changes.

## Use of AI Tools

This PR was authored with Codex and reviewed by the author.