### PR TITLE
Social Icons: Allow gradient icon backgrounds

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -985,7 +985,7 @@ Display icons linking to your social profiles or sites.
 -	**Category:** [widgets](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-widgets/)
 -	**Allowed Blocks:** core/social-link
 -	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), contentRole, interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), listView, spacing (blockGap, margin, padding, units), ~~html~~
--	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
+-	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconBackgroundGradient, iconBackgroundGradientValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Gallery: Rename the dynamic variation's "Convert to images" action to "Detach", and confirm it in a dialog explaining that the gallery will keep its current images but stop updating automatically ([#80727](https://github.com/WordPress/gutenberg/pull/80727)).
 -   Page List: Rename the "Edit" action to "Detach", and confirm it in a dialog explaining that the list will keep its current pages but stop adding new ones automatically, matching the Gallery block ([#80847](https://github.com/WordPress/gutenberg/pull/80847)).
 -   Tabs: Start new tabs with an empty label showing a "Tab title" placeholder instead of a generic "Tab" ([#81009](https://github.com/WordPress/gutenberg/pull/81009)).
+-   Social Icons: Allow a gradient to be applied as the icon background, alongside the existing solid colour option ([#64252](https://github.com/WordPress/gutenberg/issues/64252)).
 
 ### Bug Fixes
 

--- a/packages/block-library/src/social-link/README.md
+++ b/packages/block-library/src/social-link/README.md
@@ -69,6 +69,8 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `iconColorValue`
 - `iconBackgroundColor`
 - `iconBackgroundColorValue`
+- `iconBackgroundGradient`
+- `iconBackgroundGradientValue`
 
 ## Block Markup
 

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -29,7 +29,9 @@
 		"iconColor",
 		"iconColorValue",
 		"iconBackgroundColor",
-		"iconBackgroundColorValue"
+		"iconBackgroundColorValue",
+		"iconBackgroundGradient",
+		"iconBackgroundGradientValue"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -120,6 +120,8 @@ const SocialLinkEdit = ( {
 		iconColorValue,
 		iconBackgroundColor,
 		iconBackgroundColorValue,
+		iconBackgroundGradient,
+		iconBackgroundGradientValue,
 	} = context;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const wrapperClasses = clsx(
@@ -133,6 +135,8 @@ const SocialLinkEdit = ( {
 			[ `has-${ iconColor }-color` ]: iconColor,
 			[ `has-${ iconBackgroundColor }-background-color` ]:
 				iconBackgroundColor,
+			[ `has-${ iconBackgroundGradient }-gradient-background` ]:
+				iconBackgroundGradient,
 		}
 	);
 
@@ -263,7 +267,11 @@ const SocialLinkEdit = ( {
 				className={ wrapperClasses }
 				style={ {
 					color: iconColorValue,
-					backgroundColor: iconBackgroundColorValue,
+					// A gradient replaces the background colour rather than
+					// layering on top of it, so only one of the two is set.
+					...( iconBackgroundGradientValue
+						? { background: iconBackgroundGradientValue }
+						: { backgroundColor: iconBackgroundColorValue } ),
 				} }
 			>
 				{ /*

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -387,7 +387,13 @@ function block_core_social_link_get_color_styles( $context ) {
 		$styles[] = 'color:' . $context['iconColorValue'] . ';';
 	}
 
-	if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
+	/*
+	 * A gradient replaces the background color rather than layering on top of
+	 * it, so only one of the two is ever emitted.
+	 */
+	if ( ! empty( $context['iconBackgroundGradientValue'] ) ) {
+		$styles[] = 'background:' . $context['iconBackgroundGradientValue'] . ';';
+	} elseif ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
 		$styles[] = 'background-color:' . $context['iconBackgroundColorValue'] . ';';
 	}
 
@@ -412,6 +418,10 @@ function block_core_social_link_get_color_classes( $context ) {
 
 	if ( array_key_exists( 'iconBackgroundColor', $context ) ) {
 		$classes[] = 'has-' . $context['iconBackgroundColor'] . '-background-color';
+	}
+
+	if ( ! empty( $context['iconBackgroundGradient'] ) ) {
+		$classes[] = 'has-' . $context['iconBackgroundGradient'] . '-gradient-background';
 	}
 
 	return ' ' . implode( ' ', $classes );

--- a/packages/block-library/src/social-links/README.md
+++ b/packages/block-library/src/social-links/README.md
@@ -26,6 +26,8 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `iconBackgroundColor` | `string` | — | — |
 | `customIconBackgroundColor` | `string` | — | — |
 | `iconBackgroundColorValue` | `string` | — | — |
+| `iconBackgroundGradient` | `string` | — | — |
+| `iconBackgroundGradientValue` | `string` | — | — |
 | `openInNewTab` | `boolean` | `false` | — |
 | `showLabels` | `boolean` | `false` | — |
 | `size` | `string` | — | — |
@@ -69,6 +71,8 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `iconColorValue` → attribute `iconColorValue`
 - `iconBackgroundColor` → attribute `iconBackgroundColor`
 - `iconBackgroundColorValue` → attribute `iconBackgroundColorValue`
+- `iconBackgroundGradient` → attribute `iconBackgroundGradient`
+- `iconBackgroundGradientValue` → attribute `iconBackgroundGradientValue`
 
 ## Block Styles
 

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -27,6 +27,12 @@
 		"iconBackgroundColorValue": {
 			"type": "string"
 		},
+		"iconBackgroundGradient": {
+			"type": "string"
+		},
+		"iconBackgroundGradientValue": {
+			"type": "string"
+		},
 		"openInNewTab": {
 			"type": "boolean",
 			"default": false
@@ -45,7 +51,9 @@
 		"iconColor": "iconColor",
 		"iconColorValue": "iconColorValue",
 		"iconBackgroundColor": "iconBackgroundColor",
-		"iconBackgroundColorValue": "iconBackgroundColorValue"
+		"iconBackgroundColorValue": "iconBackgroundColorValue",
+		"iconBackgroundGradient": "iconBackgroundGradient",
+		"iconBackgroundGradientValue": "iconBackgroundGradientValue"
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -55,6 +55,8 @@ export function SocialLinksEdit( props ) {
 
 	const {
 		iconBackgroundColorValue,
+		iconBackgroundGradient,
+		iconBackgroundGradientValue,
 		iconColorValue,
 		openInNewTab,
 		showLabels,
@@ -95,11 +97,16 @@ export function SocialLinksEdit( props ) {
 					iconBackgroundColor: prev.iconBackgroundColor,
 					iconBackgroundColorValue: prev.iconBackgroundColorValue,
 					customIconBackgroundColor: prev.customIconBackgroundColor,
+					iconBackgroundGradient: prev.iconBackgroundGradient,
+					iconBackgroundGradientValue:
+						prev.iconBackgroundGradientValue,
 				};
 				return {
 					iconBackgroundColor: undefined,
 					iconBackgroundColorValue: undefined,
 					customIconBackgroundColor: undefined,
+					iconBackgroundGradient: undefined,
+					iconBackgroundGradientValue: undefined,
 				};
 			} );
 
@@ -114,6 +121,7 @@ export function SocialLinksEdit( props ) {
 		'has-icon-color': iconColor.color || iconColorValue,
 		'has-icon-background-color':
 			iconBackgroundColor.color || iconBackgroundColorValue,
+		'has-icon-background-gradient': iconBackgroundGradientValue,
 	} );
 
 	const blockProps = useBlockProps( { className } );
@@ -155,10 +163,25 @@ export function SocialLinksEdit( props ) {
 					iconBackgroundColorValue: colorValue,
 				} );
 			},
+			// As with the colors above, the resolved value is stored alongside
+			// the named slug so the selection survives a theme switch to a
+			// theme without a matching named gradient.
+			gradientValue: iconBackgroundGradientValue,
+			gradientSlug: iconBackgroundGradient,
+			onGradientChange: ( gradientValue, gradientSlug ) => {
+				setAttributes( {
+					iconBackgroundGradient: gradientSlug,
+					iconBackgroundGradientValue: gradientValue,
+				} );
+			},
 			label: __( 'Icon background' ),
 			resetAllFilter: () => {
 				setIconBackgroundColor( undefined );
-				setAttributes( { iconBackgroundColorValue: undefined } );
+				setAttributes( {
+					iconBackgroundColorValue: undefined,
+					iconBackgroundGradient: undefined,
+					iconBackgroundGradientValue: undefined,
+				} );
 			},
 		} );
 	}
@@ -239,15 +262,26 @@ export function SocialLinksEdit( props ) {
 			{ showColorControls && (
 				<InspectorControls group="color">
 					{ colorSettings.map(
-						( { onChange, label, value, resetAllFilter } ) => (
+						( {
+							onChange,
+							onGradientChange,
+							label,
+							value,
+							gradientValue,
+							gradientSlug,
+							resetAllFilter,
+						} ) => (
 							<ColorGradientSettingsDropdown
 								key={ `social-links-color-${ label }` }
 								__experimentalIsRenderedInSidebar
 								settings={ [
 									{
 										colorValue: value,
+										gradientValue,
+										gradientSlug,
 										label,
 										onColorChange: onChange,
+										onGradientChange,
 										isShownByDefault: true,
 										resetAllFilter,
 										enableAlpha: true,
@@ -259,7 +293,7 @@ export function SocialLinksEdit( props ) {
 							/>
 						)
 					) }
-					{ ! logosOnly && (
+					{ ! logosOnly && ! iconBackgroundGradientValue && (
 						<ContrastChecker
 							{ ...{
 								textColor: iconColorValue,

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -12,6 +12,7 @@ export default function save( props ) {
 	const {
 		attributes: {
 			iconBackgroundColorValue,
+			iconBackgroundGradientValue,
 			iconColorValue,
 			showLabels,
 			size,
@@ -22,6 +23,7 @@ export default function save( props ) {
 		'has-visible-labels': showLabels,
 		'has-icon-color': iconColorValue,
 		'has-icon-background-color': iconBackgroundColorValue,
+		'has-icon-background-gradient': iconBackgroundGradientValue,
 	} );
 	const blockProps = useBlockProps.save( { className } );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -155,7 +155,7 @@
 
 // Ensure the Snapchat label is visible when no custom
 // icon color or background color is set.
-.wp-block-social-links:not(.has-icon-color):not(.has-icon-background-color) {
+.wp-block-social-links:not(.has-icon-color):not(.has-icon-background-color):not(.has-icon-background-gradient) {
 	.wp-social-link-snapchat {
 		.wp-block-social-link-label {
 			color: #000;


### PR DESCRIPTION
## What?
Closes #64252

Adds gradient support to the **Icon background** control in the Social Icons block, so icon backgrounds can use a preset or custom gradient in addition to a solid colour.

## Why?
The Social Icons block only accepted a solid colour for icon backgrounds. Gradients are supported by the block's own background (via the `color.gradients` block support) and by most other blocks that expose a background control, so the icon background was an inconsistent gap that limited design options.

## Testing Instructions
1. Open a post or page and insert a **Social Icons** block.
2. Add two or three icons (e.g. WordPress, Mail, Bluesky).
3. Open the sidebar, expand the **Styles** tab, and open the **Icon background** control.
4. Switch to the **Gradient** tab and pick a preset gradient. The icon backgrounds should update in the editor immediately.
5. Save and view on the front end, the gradient should render identically.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/967480a8-4b30-48a7-b713-994a2a0ac320

