### PR TITLE
Global Styles: Keep storing shadow presets as CSS variables when custom presets exist

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   `ListView`: Only move focus into the list when the new `focusOnMount` prop is set, so that a list mounted as a side effect of a selection no longer pulls focus out of the editor canvas ([#81659](https://github.com/WordPress/gutenberg/pull/81659)).
 -   `RichText`: Handle Enter using the current record, so pressing it right after moving the caret splits at the caret's new position instead of the previous one ([#81696](https://github.com/WordPress/gutenberg/pull/81696)).
 -   `useInnerBlocksProps`: Resolve the manual grid placement check that disables the standard drop zone against a layout passed through the options, when provided, instead of always using the block edit context layout ([#81120](https://github.com/WordPress/gutenberg/pull/81120)).
+-   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists ([#81346](https://github.com/WordPress/gutenberg/pull/81346)).
 
 ### Internal
 
@@ -58,7 +59,6 @@
 
 ### Bug Fixes
 
--   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists ([#81346](https://github.com/WordPress/gutenberg/pull/81346)).
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 ### Bug Fixes
 
--   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists.
+-   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists ([#81346](https://github.com/WordPress/gutenberg/pull/81346)).
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -58,6 +58,7 @@
 
 ### Bug Fixes
 
+-   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists.
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -273,19 +273,9 @@ export default function BorderPanel( {
 		// the most specific origin when more than one defines the same shadow
 		// value — a newly added custom preset starts out identical to the
 		// `natural` default one, and it is the custom slug the user means.
-		const preset = shadowPresets.findLast(
+		const slug = shadowPresets.findLast(
 			( { shadow: shadowName } ) => shadowName === newValue
-		);
-		// Only the most specific definition of a slug becomes a CSS variable.
-		// When another origin redefines this one with a different value,
-		// referencing it would render a shadow the user did not pick, so the
-		// value is kept as it is.
-		const isRedefined =
-			preset &&
-			shadowPresets.findLast(
-				( { slug: presetSlug } ) => presetSlug === preset.slug
-			) !== preset;
-		const slug = isRedefined ? undefined : preset?.slug;
+		)?.slug;
 
 		onChange(
 			setImmutably(

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -262,16 +262,30 @@ export default function BorderPanel( {
 		inheritedShadow !== undefined &&
 		inheritedShadow !== '';
 	const shadow = isShadowPlaceholder ? inheritedShadow : localShadow;
-	const shadowPresets = settings?.shadow?.presets ?? {};
-	const mergedShadowPresets =
-		shadowPresets.custom ??
-		shadowPresets.theme ??
-		shadowPresets.default ??
-		[];
+	// The presets the popover offers, from every origin. A preset the user
+	// picked has to be stored as a reference to its CSS variable rather than as
+	// the value it resolves to today, otherwise it stops tracking later edits
+	// to the preset. Reading the same list the popover renders is what keeps
+	// the two in step.
+	const shadowPresets = useShadowPresets( settings );
 	const setShadow = ( newValue ) => {
-		const slug = mergedShadowPresets?.find(
+		// The list runs default, theme, custom, so searching backwards picks
+		// the most specific origin when more than one defines the same shadow
+		// value — a newly added custom preset starts out identical to the
+		// `natural` default one, and it is the custom slug the user means.
+		const preset = shadowPresets.findLast(
 			( { shadow: shadowName } ) => shadowName === newValue
-		)?.slug;
+		);
+		// Only the most specific definition of a slug becomes a CSS variable.
+		// When another origin redefines this one with a different value,
+		// referencing it would render a shadow the user did not pick, so the
+		// value is kept as it is.
+		const isRedefined =
+			preset &&
+			shadowPresets.findLast(
+				( { slug: presetSlug } ) => presetSlug === preset.slug
+			) !== preset;
+		const slug = isRedefined ? undefined : preset?.slug;
 
 		onChange(
 			setImmutably(

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -25,13 +25,27 @@ const EMPTY_ARRAY = [];
 
 export function ShadowPopoverContainer( { shadow, onShadowChange, settings } ) {
 	const shadows = useShadowPresets( settings );
+	const presets = useMemo( () => {
+		if ( ! shadows.length ) {
+			return shadows;
+		}
+		// The entry that clears the shadow is a display-only affordance with no
+		// counterpart in `theme.json`. It is added here rather than in
+		// `useShadowPresets` so that callers mapping a value back to a preset
+		// never mistake it for one and persist a reference to a CSS variable
+		// that is never output.
+		return [
+			{ name: __( 'Unset' ), slug: 'unset', shadow: 'none' },
+			...shadows,
+		];
+	}, [ shadows ] );
 
 	return (
 		<div className="block-editor-global-styles__shadow-popover-container">
 			<VStack spacing={ 4 }>
 				<Heading level={ 5 }>{ __( 'Drop shadow' ) }</Heading>
 				<ShadowPresets
-					presets={ shadows }
+					presets={ presets }
 					activeShadow={ shadow }
 					onSelect={ onShadowChange }
 				/>
@@ -209,6 +223,18 @@ function renderShadowToggle( shadow, onShadowChange, resetConfig ) {
 	};
 }
 
+/**
+ * Returns the available shadow presets, from every origin, in the order they
+ * are presented to the user.
+ *
+ * This is the single source of truth for which presets exist: it backs both the
+ * popover's preset list and the mapping of a chosen shadow back to the preset
+ * it came from, so what is shown and what is stored cannot drift apart.
+ *
+ * @param {Object} settings Theme.json settings for the current context.
+ *
+ * @return {Array} The shadow presets.
+ */
 export function useShadowPresets( settings ) {
 	return useMemo( () => {
 		if ( ! settings?.shadow ) {
@@ -221,21 +247,13 @@ export function useShadowPresets( settings ) {
 			theme: themeShadows,
 			custom: customShadows,
 		} = settings?.shadow?.presets ?? {};
-		const unsetShadow = {
-			name: __( 'Unset' ),
-			slug: 'unset',
-			shadow: 'none',
-		};
 
 		const shadowPresets = [
 			...( ( defaultPresetsEnabled && defaultShadows ) || EMPTY_ARRAY ),
 			...( themeShadows || EMPTY_ARRAY ),
 			...( customShadows || EMPTY_ARRAY ),
 		];
-		if ( shadowPresets.length ) {
-			shadowPresets.unshift( unsetShadow );
-		}
 
-		return shadowPresets;
+		return shadowPresets.length ? shadowPresets : EMPTY_ARRAY;
 	}, [ settings ] );
 }

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -258,13 +258,11 @@ export function useShadowPresets( settings ) {
 		// specific definition is output as a CSS variable. Keeping the ones it
 		// overrides would offer swatches that apply a different shadow than
 		// the one they show.
-		const shadowPresets = allPresets.filter(
+		return allPresets.filter(
 			( preset, index ) =>
 				allPresets.findLastIndex(
 					( { slug } ) => slug === preset.slug
 				) === index
 		);
-
-		return shadowPresets.length ? shadowPresets : EMPTY_ARRAY;
 	}, [ settings ] );
 }

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -248,11 +248,22 @@ export function useShadowPresets( settings ) {
 			custom: customShadows,
 		} = settings?.shadow?.presets ?? {};
 
-		const shadowPresets = [
+		const allPresets = [
 			...( ( defaultPresetsEnabled && defaultShadows ) || EMPTY_ARRAY ),
 			...( themeShadows || EMPTY_ARRAY ),
 			...( customShadows || EMPTY_ARRAY ),
 		];
+
+		// More than one origin can define the same slug, but only the most
+		// specific definition is output as a CSS variable. Keeping the ones it
+		// overrides would offer swatches that apply a different shadow than
+		// the one they show.
+		const shadowPresets = allPresets.filter(
+			( preset, index ) =>
+				allPresets.findLastIndex(
+					( { slug } ) => slug === preset.slug
+				) === index
+		);
 
 		return shadowPresets.length ? shadowPresets : EMPTY_ARRAY;
 	}, [ settings ] );

--- a/packages/block-editor/src/components/global-styles/test/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.js
@@ -589,7 +589,7 @@ describe( 'BorderPanel — shadow preset persistence', () => {
 		} );
 	} );
 
-	it( 'keeps the value when another origin redefines the matching slug', async () => {
+	it( 'offers only the most specific preset when a slug is defined twice', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();
 
@@ -618,17 +618,21 @@ describe( 'BorderPanel — shadow preset persistence', () => {
 			/>
 		);
 
-		await selectShadowPreset( user, 'Theme shadow' );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Drop shadow' } )
+		);
 
 		// `--wp--preset--shadow--shadow-1` holds the custom preset's value, so
-		// referencing the slug would render the shadow the user did not click.
+		// offering the theme one would show a shadow it cannot apply.
+		expect(
+			screen.queryByRole( 'option', { name: 'Theme shadow' } )
+		).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'option', { name: 'Shadow 1' } ) );
+
 		expect( onChange ).toHaveBeenCalledWith( {
-			shadow: themeShadowOne.shadow,
+			shadow: 'var:preset|shadow|shadow-1',
 		} );
-		// `ShadowPresets` keys the list on the slug, so rendering both
-		// definitions warns. That is a separate, pre-existing problem with
-		// showing two indistinguishable swatches.
-		expect( console ).toHaveErrored();
 	} );
 
 	it( 'references the most specific origin when two presets share a value', async () => {

--- a/packages/block-editor/src/components/global-styles/test/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.js
@@ -432,3 +432,229 @@ describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 		} );
 	} );
 } );
+
+describe( 'BorderPanel — shadow preset persistence', () => {
+	const selectShadowPreset = async ( user, name ) => {
+		await user.click(
+			screen.getByRole( 'button', { name: 'Drop shadow' } )
+		);
+		await user.click( screen.getByRole( 'option', { name } ) );
+	};
+
+	const shadowSettings = ( presets, defaultPresets = true ) => ( {
+		shadow: { defaultPresets, presets },
+	} );
+
+	const defaultPreset = {
+		name: 'Natural',
+		slug: 'natural',
+		shadow: '6px 6px 9px rgba(0, 0, 0, 0.2)',
+	};
+	const themePreset = {
+		name: 'Outlined',
+		slug: 'outlined',
+		shadow: '6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)',
+	};
+	const customPreset = {
+		name: 'My shadow',
+		slug: 'my-shadow',
+		shadow: '0 0 10px rgba(255, 0, 0, 1)',
+	};
+
+	it( 'persists a theme preset as a preset reference when custom presets also exist', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings( {
+					default: [ defaultPreset ],
+					theme: [ themePreset ],
+					custom: [ customPreset ],
+				} ) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'Outlined' );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			shadow: 'var:preset|shadow|outlined',
+		} );
+	} );
+
+	it( 'persists a default preset as a preset reference when custom presets also exist', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings( {
+					default: [ defaultPreset ],
+					theme: [ themePreset ],
+					custom: [ customPreset ],
+				} ) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'Natural' );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			shadow: 'var:preset|shadow|natural',
+		} );
+	} );
+
+	it( 'persists a custom preset as a preset reference', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings( {
+					default: [ defaultPreset ],
+					theme: [ themePreset ],
+					custom: [ customPreset ],
+				} ) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'My shadow' );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			shadow: 'var:preset|shadow|my-shadow',
+		} );
+	} );
+
+	it( 'persists the unset entry as a literal value, not a preset reference', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings( {
+					theme: [ themePreset ],
+					custom: [ customPreset ],
+				} ) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'Unset' );
+
+		expect( onChange ).toHaveBeenCalledWith( { shadow: 'none' } );
+	} );
+
+	it( 'does not reference default presets the theme has opted out of', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings(
+					{
+						// Same shadow value as the theme preset below, so the
+						// lookup has to skip it rather than match it first.
+						default: [
+							{ ...defaultPreset, shadow: themePreset.shadow },
+						],
+						theme: [ themePreset ],
+					},
+					false
+				) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'Outlined' );
+
+		// The opted-out preset is not offered, so it is not something the
+		// user can have meant.
+		expect(
+			screen.queryByRole( 'option', { name: 'Natural' } )
+		).not.toBeInTheDocument();
+		expect( onChange ).toHaveBeenCalledWith( {
+			shadow: 'var:preset|shadow|outlined',
+		} );
+	} );
+
+	it( 'keeps the value when another origin redefines the matching slug', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		// Custom preset slugs are generated as `shadow-<n>` from the custom
+		// presets alone, so they can collide with a theme preset's slug.
+		const themeShadowOne = {
+			name: 'Theme shadow',
+			slug: 'shadow-1',
+			shadow: '0 0 10px rgba(0, 0, 255, 1)',
+		};
+		const customShadowOne = {
+			name: 'Shadow 1',
+			slug: 'shadow-1',
+			shadow: '0 0 10px rgba(255, 0, 0, 1)',
+		};
+
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings( {
+					theme: [ themeShadowOne ],
+					custom: [ customShadowOne ],
+				} ) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'Theme shadow' );
+
+		// `--wp--preset--shadow--shadow-1` holds the custom preset's value, so
+		// referencing the slug would render the shadow the user did not click.
+		expect( onChange ).toHaveBeenCalledWith( {
+			shadow: themeShadowOne.shadow,
+		} );
+		// `ShadowPresets` keys the list on the slug, so rendering both
+		// definitions warns. That is a separate, pre-existing problem with
+		// showing two indistinguishable swatches.
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'references the most specific origin when two presets share a value', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		// A custom preset starts out with the same value as the `natural`
+		// default one, so this is the state right after adding one.
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowSettings( {
+					default: [ defaultPreset ],
+					custom: [
+						{ ...customPreset, shadow: defaultPreset.shadow },
+					],
+				} ) }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+
+		await selectShadowPreset( user, 'My shadow' );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			shadow: 'var:preset|shadow|my-shadow',
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #71873

Fixes theme and default shadow presets being stored as resolved CSS once a custom shadow preset exists.

Picking a drop shadow stores a reference to the preset, `var:preset|shadow|<slug>`, so the block follows the preset when it later changes. To find the slug, the border panel searched `presets.custom ?? presets.theme ?? presets.default`, which stops at the first origin that exists. Adding a single custom shadow in Styles → Shadows therefore hid every theme and default preset from the search, and picking one of them stored the value it happened to have at that moment. The popover still showed it as selected, but the block no longer tracked the preset.

To fix this the search now runs over the same list the popover renders, which already spreads all three origins, so what is offered and what is stored cannot drift apart. Two details are worth a look in review: a newly added custom preset starts out with the same value as the `natural` default one, so the most specific origin wins when two presets share a value; and where more than one origin defines the same slug, only the definition that wins stays in the list, since it is the only one with a CSS variable behind it. Dropping the overridden ones also stops the popover offering two identical-looking swatches, one of which applied a different shadow than it showed.

## Before

Both buttons use the same theme preset, the second one picked after adding a custom shadow. The theme then changed that preset's colour, and only the first button follows.

![Before](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/shadow-preset-css-vars/before.png)

## After

![After](https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/shadow-preset-css-vars/after.png)

## Testing Instructions

1. Use a block theme with shadow presets, e.g. Twenty Twenty-Five.
2. Add a Button block to a post. In the block inspector's Border & Shadow panel, enable Shadow from the panel's options menu (⋮ → Show Shadow) if it isn't shown, then pick a drop shadow, e.g. Outlined. Switch to the code editor and verify the block stores `"shadow":"var:preset|shadow|outlined"`.
3. Go to Appearance → Editor → Styles → Shadows, add a custom shadow, and save.
4. Back in the post, add a second Button and pick the same Outlined preset.
5. Verify it also stores `"shadow":"var:preset|shadow|outlined"` and not the resolved `6px 6px 0px -3px ...` value. On trunk it stores the resolved value.
6. In Styles → Shadows, change the Outlined preset's colour and save. Verify both buttons follow it.
7. Verify the Unset entry in the drop shadow popover still clears the shadow.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.

