### PR TITLE
Autop: add the missing double line break after hr tags

### DIFF
--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
-## 4.53.0 (2026-08-12)
+### Bug Fixes
 
+-   `autop` no longer leaves an unbalanced `</p>` when an `<hr>` is not followed by a blank line, matching `wpautop()` ([#81356](https://github.com/WordPress/gutenberg/pull/81356)).
+
+## 4.53.0 (2026-08-12)
 
 ## 4.52.0 (2026-07-29)
 

--- a/packages/autop/src/index.ts
+++ b/packages/autop/src/index.ts
@@ -191,6 +191,9 @@ export function autop( text: string, br: boolean = true ): string {
 		'$1\n\n'
 	);
 
+	// Add a double line break after hr tags, which are self closing.
+	text = text.replace( /(<hr\s*?\/?>)/g, '$1\n\n' );
+
 	// Standardize newline characters to "\n".
 	text = text.replace( /\r\n|\r/g, '\n' );
 

--- a/packages/autop/src/test/index.test.ts
+++ b/packages/autop/src/test/index.test.ts
@@ -326,7 +326,9 @@ test( 'that_autop_treats_block_level_elements_as_blocks', () => {
 		'h4',
 		'h5',
 		'h6',
-		'hr',
+		// `hr` is void, so `<hr>foo</hr>` is not a meaningful fixture here. It is
+		// covered by the dedicated tests below, and core's equivalent PHPUnit test
+		// omits it for the same reason.
 		'fieldset',
 		'legend',
 		'section',
@@ -537,6 +539,36 @@ test( 'that autop correctly adds a start and end tag when followed by a div', ()
 		'Testing autop with a div\n<div class="wp-some-class">content</div>';
 	const expected =
 		'<p>Testing autop with a div</p>\n<div class="wp-some-class">content</div>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test( 'that autop closes the paragraph before an hr', () => {
+	const content = 'before\n<hr>\nafter';
+	const expected = '<p>before</p>\n<hr>\n<p>after</p>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test( 'that autop closes the paragraph before self-closing hr variants', () => {
+	expect( autop( 'before\n<hr />\nafter' ).trim() ).toBe(
+		'<p>before</p>\n<hr />\n<p>after</p>'
+	);
+	expect( autop( 'before\n<hr/>\nafter' ).trim() ).toBe(
+		'<p>before</p>\n<hr/>\n<p>after</p>'
+	);
+} );
+
+test( 'that autop starts a new paragraph after every hr', () => {
+	const content = 'a\n<hr>\nb\n<hr>\nc';
+	const expected = '<p>a</p>\n<hr>\n<p>b</p>\n<hr>\n<p>c</p>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test( 'that autop closes the paragraph after an hr preceded by a blank line', () => {
+	const content = 'before\n\n<hr>\nafter';
+	const expected = '<p>before</p>\n<hr>\n<p>after</p>';
 
 	expect( autop( content ).trim() ).toBe( expected );
 } );


### PR DESCRIPTION
## What?

Fixes #81355.

Ports the one rule in core's `wpautop()` that the JavaScript version is missing: the double line break after `<hr>`.

## Why?

`<hr>` is void, so it never matches the closing block tag rule that gives every other block element its trailing blank line. `wp-includes/formatting.php` compensates with a dedicated step immediately after:

```php
// Add a double line break below block-level closing tags.
$text = preg_replace( '!(</' . $allblocks . '>)!', "$1\n\n", $text );

// Add a double line break after hr tags, which are self closing.
$text = preg_replace( '!(<hr\s*?/?>)!', "$1\n\n", $text );
```

`packages/autop/src/index.ts` has the first and not the second, so any `<hr>` that is not followed by a blank line leaves a `</p>` with no matching `<p>`:

```js
autop( 'before\n<hr>\nafter' );
// trunk: <p>before</p>\n<hr>\nafter</p>\n
// core:  <p>before</p>\n<hr>\n<p>after</p>\n
```

## How?

Adds the missing rule, transcribed from core so the two stay in step.

The existing `that_autop_treats_block_level_elements_as_blocks` test builds `<TAG>foo</TAG>` for every block tag, which is not a meaningful fixture for a void element: `</hr>` is not a tag. With the rule in place both implementations now agree on `<hr>foo</hr>` and return `<hr>\n<p>foo</hr>`, so the old assertion no longer holds. Core's equivalent PHPUnit test, `test_that_wpautop_treats_block_level_elements_as_blocks`, does not list `hr` for the same reason, so this drops it there and adds four dedicated `hr` tests instead.

### On `<hr>` with attributes

Core's regex allows no attributes, so `<hr class="wp-block-separator">` misses the rule in PHP too and stays unbalanced on both sides. That is the markup the Separator block emits, so it is worth knowing about, but widening the pattern here would make the package disagree with core in the other direction. This ports the rule as written. I will raise the attribute case on Trac against core.

## Testing Instructions

1. `npm run test:unit -- packages/autop/src/test/index.test.ts`
2. Confirm 22 tests pass, including the four new `hr` cases.
3. Check out `trunk` for `packages/autop/src/index.ts` alone and rerun: the four new tests fail, which confirms they cover the reported behaviour rather than restating it.
4. `npx eslint packages/autop/src/index.ts packages/autop/src/test/index.test.ts`
5. `npx tsc --noEmit --project packages/autop/tsconfig.json`

To check the result against core directly:

```php
wpautop( "before\n<hr>\nafter" ); // <p>before</p>\n<hr>\n<p>after</p>\n
```

```js
autop( 'before\n<hr>\nafter' );   // <p>before</p>\n<hr>\n<p>after</p>\n
```

### Testing Instructions for Keyboard

Not applicable, this does not change any UI.

## Verification

Both implementations were run over the same inputs, with PHP 8.4.24 against `src/wp-includes/formatting.php` from `wordpress-develop` `trunk`.

| | cases | diverge from core |
| --- | --- | --- |
| hand written set | 31 | 10 before, 0 after |
| generated documents | 4000 | 260 before, 17 after |

The generated set combines block elements, inline elements, comments, scripts, styles and every separator variant, with `br` toggled.

No input without an `<hr>` changes behaviour, so the change is confined to the reported case. The 17 that still differ are one separate pre-existing defect with no `<hr>` involved: `text.replace( /\n<\/p>$/g, '</p>' )` never fires, because PHP's `$` matches before a trailing newline and JavaScript's does not, and the output always ends in one. That is out of scope here and I will report it on its own.
