### PR TITLE
InputControl: Vertically center date and time input values in Safari

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   `Modal`: Prevent background page scrolling without relying on WordPress global styles when using the default `bodyOpenClassName` ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Menu`: Return focus to the root trigger after closing a legacy `Modal` opened from a menu item, while preserving the menu-to-Modal scroll-lock handoff ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
+-   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 
 ### TypeScript
 

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -273,6 +273,18 @@ export const Input = styled.input< InputProps >`
 			color: ${ COLORS.ui.darkGrayPlaceholder };
 		}
 
+		&[type='date'],
+		&[type='datetime-local'],
+		&[type='month'],
+		&[type='time'],
+		&[type='week'] {
+			&::-webkit-datetime-edit {
+				display: flex;
+				align-items: center;
+				height: 100%;
+			}
+		}
+
 		&[type='email'],
 		&[type='url'] {
 			/* rtl:ignore */


### PR DESCRIPTION
## What?

Partially addresses #81344

## Why?

The cause is not in DataViews. The dataform controls render native inputs — [date.tsx#L434](https://github.com/WordPress/gutenberg/blob/fde0bda5330c199ab4b70141e78feabfa998a28e/packages/dataviews/src/components/dataform-controls/date.tsx#L434), [datetime.tsx#L174](https://github.com/WordPress/gutenberg/blob/fde0bda5330c199ab4b70141e78feabfa998a28e/packages/dataviews/src/components/dataform-controls/datetime.tsx#L174), [time.tsx#L90](https://github.com/WordPress/gutenberg/blob/fde0bda5330c199ab4b70141e78feabfa998a28e/packages/dataviews/src/components/dataform-controls/time.tsx#L90) — through `InputControl`, whose [Input sets an explicit height: 40](https://github.com/WordPress/gutenberg/blob/fde0bda5330c199ab4b70141e78feabfa998a28e/packages/components/src/input-control/styles/input-control-styles.tsx#L175). WebKit lays the value out in a shadow-DOM `::-webkit-datetime-edit` box that keeps its natural height at the top of the field; Chromium centers it. Any `InputControl` given one of these types is affected, so the fix belongs in the components layer.

## How?

Stretches `::-webkit-datetime-edit` to the full field height and centers its contents, in [`Input`](https://github.com/WordPress/gutenberg/blob/fde0bda5330c199ab4b70141e78feabfa998a28e/packages/components/src/input-control/styles/input-control-styles.tsx#L245). No-op in Chromium; dropped by engines without the pseudo-element. `month` and `week` are covered too, though currently unused.

### Audit other controls

a repo-wide search for native `date` / `time` / `datetime-local` / `month` / `week` inputs turns up only the three controls above, so this single change covers all of them. `TimePicker` uses `type="number"` and is unaffected. Out of scope: #81345, and Safari showing no native picker indicator (a UA difference, not a defect).

## Testing Instructions

The offset is a few pixels, so compare the value text inside the input box — not the calendar grid, which is fine in both browsers.

1. In **Safari**, open Storybook → `DataViews/DataForm` → **Layout Regular**.
2. At the **Date** and **Datetime** fields, compare the value against the plain text value in **Title** or **Author** above. On trunk the date value rides higher; with this change both sit on the same center line.
3. Confirm Chrome is unchanged before and after.

For `time`, use `DataViews/FieldTypes` → **time** and tick the row checkbox first — [the form renders only once a single item is selected](https://github.com/WordPress/gutenberg/blob/fde0bda5330c199ab4b70141e78feabfa998a28e/packages/dataviews/src/field-types/stories/index.story.tsx#L754-L790).

### Testing Instructions for Keyboard

No behavior change; purely visual CSS, no change to focus order or styles.

## Screenshots or screencast

| Before (Safari) | After (Safari) |
|-|-|
| <img width="1308" height="569" alt="image" src="https://github.com/user-attachments/assets/c01d1447-fe18-4743-98be-8090d6b2ebea" /> | <img width="1316" height="537" alt="image" src="https://github.com/user-attachments/assets/5628bd04-af8e-43cb-a745-41a77abda230" /> |
|<img width="1318" height="836" alt="image" src="https://github.com/user-attachments/assets/0e2ee307-41cd-48b9-9599-6e8d4f73569d" />|<img width="1322" height="779" alt="image" src="https://github.com/user-attachments/assets/efa85fc6-b149-443a-ad9c-982b99058594" />|
|<img width="1314" height="661" alt="image" src="https://github.com/user-attachments/assets/466c6b25-adaf-44dc-a693-bd99a8931704" />|<img width="1317" height="752" alt="image" src="https://github.com/user-attachments/assets/fc079bd3-d497-492c-9fb8-fe1c708dd5ed" />|
|<img width="937" height="892" alt="image" src="https://github.com/user-attachments/assets/78ef34fb-cb36-41e5-9c7a-da7ba2fce813" />|<img width="1111" height="891" alt="image" src="https://github.com/user-attachments/assets/1f1b9388-bdca-4c50-b645-aaf6b0814697" />|

## Use of AI

Claude Code Opus 5
Purpose - investigate bug, identify files, audit presence in other components