### PR TITLE
Interface: Stop the secondary sidebar animating into place on page load

### DIFF
--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).
 -   `InterfaceSkeleton`: Increase the footer height from 24px to 32px to prevent the focus ring from being clipped ([#81145](https://github.com/WordPress/gutenberg/pull/81145)).
+-   `InterfaceSkeleton`: Stop the secondary sidebar from animating itself into place on page load when it is already open, for example with the "Always open List View" preference enabled ([#81362](https://github.com/WordPress/gutenberg/pull/81362)).
 
 ### Internal
 

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -6,11 +6,7 @@ import {
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import {
-	useReducedMotion,
-	useViewportMatch,
-	useResizeObserver,
-} from '@wordpress/compose';
+import { useReducedMotion, useViewportMatch } from '@wordpress/compose';
 
 const ANIMATION_DURATION = 0.25;
 const commonTransition = {
@@ -75,8 +71,6 @@ function InterfaceSkeleton(
 	},
 	ref
 ) {
-	const [ secondarySidebarResizeListener, secondarySidebarSize ] =
-		useResizeObserver();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const disableMotion = useReducedMotion();
 	const defaultTransition = {
@@ -161,20 +155,23 @@ function InterfaceSkeleton(
 								initial="closed"
 								animate="open"
 								exit="closed"
+								// `auto` leaves the open width to the panel, so a
+								// sidebar that is already open on page load is
+								// at its full width on the first paint instead
+								// of animating there. framer-motion measures
+								// the element to animate, then restores `auto`.
 								variants={ {
-									open: { width: secondarySidebarSize.width },
+									open: { width: 'auto' },
 									closed: { width: 0 },
 								} }
 								transition={ defaultTransition }
 							>
 								<motion.div
 									style={ {
-										position: 'absolute',
 										width: isMobileViewport
 											? '100vw'
-											: 'fit-content',
+											: 'max-content',
 										height: '100%',
-										left: 0,
 									} }
 									variants={ {
 										open: { x: 0 },
@@ -182,7 +179,6 @@ function InterfaceSkeleton(
 									} }
 									transition={ defaultTransition }
 								>
-									{ secondarySidebarResizeListener }
 									{ secondarySidebar }
 								</motion.div>
 							</NavigableRegion>


### PR DESCRIPTION
## What?
Closes #69240.
Related #60693.

The secondary sidebar no longer animates itself open when it is already open on page load, for example, with the "Always open List View" preference enabled.

## Why?

The sidebar's open width was measured with a `ResizeObserver`, so on the first render, the width was `null`. framer-motion committed a width of 0, and the measured width arrived a render later. The framer treated it as a value change and tweened it, sliding the canvas to the left by 250ms on every page load. The sidebar also sat at zero width until the measurement landed, painting the panel over the canvas for a few frames, longer on a slow load.

`AnimatePresence initial={ false }` was already correct. Only the late width broke it.

## How?

Animate the open state to `width: 'auto'` instead of a measured pixel value. framer-motion supports this. It measures the element to run the animation, then restores `auto` as the committed value, so the width goes back to being driven by CSS.

The panel had to move out of `position: absolute` for `auto` to resolve to anything, and `width: max-content` keeps it from squashing while the container animates.

This removes the `ResizeObserver` entirely. The sidebar is at its full width on the first paint rather than one render later.

> [!NOTE]
>  One behavior note. A panel that resizes while it is already open, such as the patterns inserter in the site editor, now resizes in one step instead of the canvas easing to the new width over 250ms. This was not deliberate before. It fell out of using a live measurement as the animation target, so any change to that measurement became something to animate. It was also only half animated: the panel itself is sized by CSS, so it jumped to its new width immediately while the canvas trailed behind it for a quarter second.

## Testing Instructions

1. Post editor > Options > Preferences, enable "Always open List View".
2. Leave the editor, then open any post from the Posts list.
3. The List View is present at full width as soon as the editor paints. Nothing slides.
4. Close and reopen the List View. It animates as before.
5. Open and close the block inserter. It animates as before.
6. Repeat on a small viewport and in the site editor.


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d32909f2-33a2-4639-b6a7-555ae5c8ad91

## Use of AI Tools

Assisted by Claude.
