### PR TITLE
Interface: Let CSS own the ComplementaryArea width and use AnimatePresence custom for exit

### DIFF
--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Internal
 
+-   `ComplementaryArea`: Take the panel width from the stylesheet instead of a hardcoded inline style, and resolve the exit transition through `AnimatePresence`'s `custom` prop instead of a forced re-render ([#81363](https://github.com/WordPress/gutenberg/pull/81363)).
 -   Remove obsolete dependency grouping comments as part of the repository-wide separator-free import migration. ([#81248](https://github.com/WordPress/gutenberg/pull/81248))
 
 ## 9.37.0 (2026-07-29)

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -37,11 +37,14 @@ function ComplementaryAreaSlot( { scope, ...props } ) {
 	return <Slot name={ `ComplementaryArea/${ scope }` } { ...props } />;
 }
 
-const SIDEBAR_WIDTH = 280;
 const variants = {
-	open: { width: SIDEBAR_WIDTH },
-	closed: { width: 0 },
-	mobileOpen: { width: '100vw' },
+	// `auto` leaves the width to the area's own stylesheet, so it stays in one
+	// place. framer-motion measures the element to animate, then restores
+	// `auto`.
+	open: { width: 'auto' },
+	// Resolved with the `custom` value passed to `AnimatePresence`, which is
+	// the only way an already removed element can be given a fresh transition.
+	closed: ( transition ) => ( { width: 0, transition } ),
 };
 
 /**
@@ -77,24 +80,16 @@ function ComplementaryAreaFill( {
 } ) {
 	const disableMotion = useReducedMotion();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-	// This is used to delay the exit animation to the next tick.
-	// The reason this is done is to allow us to apply the right transition properties
-	// When we switch from an open sidebar to another open sidebar.
-	// we don't want to animate in this case.
+	// Swapping one open area straight for another should not animate.
 	const previousActiveArea = usePrevious( activeArea );
-	const previousIsActive = usePrevious( isActive );
-	const [ , setState ] = useState( {} );
-	useEffect( () => {
-		setState( {} );
-	}, [ isActive ] );
+	const isSwitchingAreas =
+		!! previousActiveArea &&
+		!! activeArea &&
+		activeArea !== previousActiveArea;
 	const transition = {
 		type: 'tween',
 		duration:
-			disableMotion ||
-			isMobileViewport ||
-			( !! previousActiveArea &&
-				!! activeArea &&
-				activeArea !== previousActiveArea )
+			disableMotion || isMobileViewport || isSwitchingAreas
 				? 0
 				: ANIMATION_DURATION,
 		ease: [ 0.6, 0, 0.4, 1 ],
@@ -102,12 +97,12 @@ function ComplementaryAreaFill( {
 
 	return (
 		<Fill name={ `ComplementaryArea/${ scope }` }>
-			<AnimatePresence initial={ false }>
-				{ ( previousIsActive || isActive ) && (
+			<AnimatePresence initial={ false } custom={ transition }>
+				{ isActive && (
 					<motion.div
 						variants={ variants }
 						initial="closed"
-						animate={ isMobileViewport ? 'mobileOpen' : 'open' }
+						animate="open"
 						exit="closed"
 						transition={ transition }
 						className="interface-complementary-area__fill"
@@ -115,11 +110,6 @@ function ComplementaryAreaFill( {
 						{ renderContainer( render, {
 							id,
 							className,
-							style: {
-								width: isMobileViewport
-									? '100vw'
-									: SIDEBAR_WIDTH,
-							},
 							children,
 						} ) }
 					</motion.div>

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -7,6 +7,7 @@
 	color: $gray-900;
 	height: 100%;
 	overflow: auto;
+	width: 100vw;
 
 	@include break-medium() {
 		width: $sidebar-width;


### PR DESCRIPTION
## What?
Related #81362.

Cleanup of `ComplementaryAreaFill` animation logic. No behavior change intended. Replaces two pieces of hand-rolled logic with the equivalent CSS and framer-motion APIs.

## Why?

`SIDEBAR_WIDTH = 280` was a JavaScript copy of `$sidebar-width: 280px`. It was applied as an inline style to the container, so it silently overrode the stylesheet, and the number ended up in three places.

Separately, the exit animation was delayed by a render on purpose. `usePrevious( isActive )` kept the element mounted one extra render, and a `useState({})` plus `useEffect` pair forced that render. This was needed because `AnimatePresence` keeps the last rendered element for an exiting child, so the exiting area carried a `transition` prop computed before `activeArea` changed, and swapping one open area for another animated when it should not.

## How?

Animate the open state to `width: 'auto'` so the area's own stylesheet owns the width. framer-motion measures the element to run the animation and then restores `auto`. The `mobileOpen` variant and the `isMobileViewport` branch on the container are no longer needed, since `auto` resolves to whatever CSS says at that breakpoint. The mobile width is set to SCSS as `width: 100vw`, matching the inline style.

Pass the transition through `AnimatePresence`'s `custom` prop and resolve the `closed` variant from it. This is what the prop is documented for: "When a component is removed, there's no longer a chance to update its props. So if a component's exit prop is defined as a dynamic variant and you want to pass a new custom prop, you can do so via AnimatePresence. This will ensure all leaving components animate using the latest data."

That removes one state, one effect, one `usePrevious`, one variant, and the duplicated width constant.

One consequence worth noting: the width is no longer forced from JavaScript, so a stylesheet targeting `.interface-complementary-area` can now actually change it.

## Testing Instructions

1. Open and close the Settings sidebar in the post editor. It animates as before.
2. With the Settings sidebar open, open a plugin sidebar so one area swaps straight for another. It should switch with no animation.
3. Check the sidebar is 280px wide on a desktop viewport and full width on a small one.
4. Repeat in the site editor.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
