### PR TITLE
wp-build: Render the no-JS fallback in the generated page templates

### DIFF
--- a/backport-changelog/7.2/12946.md
+++ b/backport-changelog/7.2/12946.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12946
+
+* https://github.com/WordPress/gutenberg/pull/81365

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 -   Widgets: carry a widget's declarative `icon` reference from `widget.json`
     into the generated PHP registry ([#80969](https://github.com/WordPress/gutenberg/pull/80969)).
--   Render a no-JavaScript heading and notice from the generated page templates, so every page gets the fallback without duplicating it per page ([#81365](https://github.com/WordPress/gutenberg/pull/81365)).
--   Add the `no-js` body class and the `no-js`/`js` swap script from `admin-header.php` to the generated standalone page template, so `.hide-if-js` and `.hide-if-no-js` work on those pages ([#81365](https://github.com/WordPress/gutenberg/pull/81365)).
+-   Render a no-JavaScript heading and notice from the generated page templates ([#81365](https://github.com/WordPress/gutenberg/pull/81365)).
 
 ### Bug Fixes
 

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   Widgets: carry a widget's declarative `icon` reference from `widget.json`
     into the generated PHP registry ([#80969](https://github.com/WordPress/gutenberg/pull/80969)).
+-   Render a no-JavaScript heading and notice from the generated page templates, so every page gets the fallback without duplicating it per page ([#81365](https://github.com/WordPress/gutenberg/pull/81365)).
+-   Add the `no-js` body class and the `no-js`/`js` swap script from `admin-header.php` to the generated standalone page template, so `.hide-if-js` and `.hide-if-no-js` work on those pages ([#81365](https://github.com/WordPress/gutenberg/pull/81365)).
 
 ### Bug Fixes
 

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -315,6 +315,15 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 			}
 		}
 	</style>
+	<div class="wrap hide-if-js">
+		<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1>
+		<?php
+		wp_admin_notice(
+			__( 'This screen requires JavaScript. Enable JavaScript in your browser settings and reload the page.' ),
+			array( 'type' => 'error' )
+		);
+		?>
+	</div>
 	<div id="{{PAGE_SLUG}}-wp-admin-app" class="boot-layout-container"></div>
 	<?php
 }

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -278,7 +278,25 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	// END see wp-admin/admin-header.php
 	?>
 	</head>
-	<body class="{{PAGE_SLUG}}">
+	<body class="{{PAGE_SLUG}} no-js">
+	<?php
+	// BEGIN see wp-admin/admin-header.php
+	?>
+	<script type="text/javascript">
+		document.body.className = document.body.className.replace( 'no-js', 'js' );
+	</script>
+	<?php
+	// END see wp-admin/admin-header.php
+	?>
+		<div class="wrap hide-if-js" style="margin: 20px;">
+			<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<?php
+			wp_admin_notice(
+				__( 'This screen requires JavaScript. Enable JavaScript in your browser settings and reload the page.' ),
+				array( 'type' => 'error' )
+			);
+			?>
+		</div>
 		<div id="{{PAGE_SLUG}}-app" style="height: 100vh; box-sizing: border-box;"></div>
 	<?php
 	// BEGIN see wp-admin/admin-footer.php


### PR DESCRIPTION
## What?

- Follow up to #80628
- See https://core.trac.wordpress.org/ticket/65840

Renders the heading and the "requires JavaScript" notice from the generated page templates, so every wp-build page gets the no-JS fallback automatically.

## Why?

[Trac #65690](https://core.trac.wordpress.org/ticket/65690) added the notice to the Connectors and Font Library pages individually. More wp-build based pages will be added over time, and each one would have to repeat the same markup. Defining it in the template itself removes that duplication.

## How?

Both page templates now render a `.wrap.hide-if-js` block with the page heading and an error notice, right before the app mount point.

`page.php.template` needed one extra fix. It only ports the `<head>` part of `admin-header.php`, so `<body>` never received the `no-js` class or the script that swaps it for `js`. Without them `.hide-if-js` and `.hide-if-no-js` never worked on those pages.

No text domain is passed. These files are bundled into Core, where the default domain is correct. Strings in that directory are extracted: `wp-includes/build/` [already has 110 translatable strings on GlotPress](https://translate.wordpress.org/projects/wp/dev/en-gb/default/?filters%5Bterm%5D=wp-includes%2Fbuild&filters%5Bterm_scope%5D=scope_references).

## Testing Instructions

1. Disable JavaScript in your browser.
2. Go to **Appearance → Fonts** and **Settings → Connectors**. Each shows a heading and an error notice instead of a blank page.
3. Re-enable JavaScript and reload. The fallback is gone and the app renders as before.

## Screenshots or screencast

### Before

<img width="1274" height="570" alt="image" src="https://github.com/user-attachments/assets/b3bd779b-862d-4f1c-bc9d-afa13fee455f" />

### After

<img width="1274" height="558" alt="image" src="https://github.com/user-attachments/assets/4bdde81a-2ee5-4470-a05b-27b7880e7caa" />


## Use of AI Tools

Authored with Claude Code. The code, this description, and the GlotPress and Core references above were produced by the tool and reviewed by me.
