### PR TITLE
Scope breakpoint media queries to screen so printing does not look like a resize

### DIFF
--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `useFixedWindowList`: Remove a duplicate `resize` listener registration, and page by the measured viewport height rather than the initial window size ([#80935](https://github.com/WordPress/gutenberg/pull/80935)).
+-   `useViewportMatch`: Scope the generated media query to `screen`, so that printing does not report the viewport as having become narrower ([#81367](https://github.com/WordPress/gutenberg/pull/81367)).
 
 ## 8.5.0 (2026-07-29)
 

--- a/packages/compose/src/hooks/use-viewport-match/index.ts
+++ b/packages/compose/src/hooks/use-viewport-match/index.ts
@@ -76,9 +76,11 @@ const useViewportMatch = (
 		: undefined
 ): boolean => {
 	const simulatedWidth = useContext( ViewportMatchWidthContext );
+	// Scoped to `screen` so printing, which matches against the page box,
+	// does not read as a narrower viewport.
 	const mediaQuery =
 		! simulatedWidth &&
-		`(${ CONDITIONS[ operator ] }: ${ BREAKPOINTS[ breakpoint ] }px)`;
+		`screen and (${ CONDITIONS[ operator ] }: ${ BREAKPOINTS[ breakpoint ] }px)`;
 	const mediaQueryResult = useMediaQuery( mediaQuery || undefined, view );
 
 	if ( simulatedWidth ) {

--- a/packages/compose/src/hooks/use-viewport-match/test/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/test/index.js
@@ -35,17 +35,17 @@ describe( 'useViewportMatch', () => {
 		expect( useMediaQueryMock ).toHaveBeenCalledTimes( 3 );
 		expect( useMediaQueryMock ).toHaveBeenNthCalledWith(
 			1,
-			'(max-width: 1280px)',
+			'screen and (max-width: 1280px)',
 			window
 		);
 		expect( useMediaQueryMock ).toHaveBeenNthCalledWith(
 			2,
-			'(min-width: 782px)',
+			'screen and (min-width: 782px)',
 			window
 		);
 		expect( useMediaQueryMock ).toHaveBeenNthCalledWith(
 			3,
-			'(min-width: 600px)',
+			'screen and (min-width: 600px)',
 			window
 		);
 	} );
@@ -70,17 +70,17 @@ describe( 'useViewportMatch', () => {
 		expect( useMediaQueryMock ).toHaveBeenCalledTimes( 3 );
 		expect( useMediaQueryMock ).toHaveBeenNthCalledWith(
 			1,
-			'(min-width: 1440px)',
+			'screen and (min-width: 1440px)',
 			window
 		);
 		expect( useMediaQueryMock ).toHaveBeenNthCalledWith(
 			2,
-			'(max-width: 960px)',
+			'screen and (max-width: 960px)',
 			window
 		);
 		expect( useMediaQueryMock ).toHaveBeenNthCalledWith(
 			3,
-			'(max-width: 480px)',
+			'screen and (max-width: 480px)',
 			window
 		);
 	} );

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Scope the breakpoint media queries to `screen`, so that printing does not report the viewport as having become narrower ([#81367](https://github.com/WordPress/gutenberg/pull/81367)).
 
 ## 6.52.0 (2026-07-29)
 

--- a/packages/viewport/src/listener.ts
+++ b/packages/viewport/src/listener.ts
@@ -34,8 +34,10 @@ const addDimensionsEventListener = (
 		( [ name, width ] ) => {
 			return operatorEntries.map(
 				( [ operator, condition ] ): [ string, MediaQueryList ] => {
+					// Scoped to `screen` so printing, which matches against
+					// the page box, does not read as a narrower viewport.
 					const list = window.matchMedia(
-						`(${ condition }: ${ width }px)`
+						`screen and (${ condition }: ${ width }px)`
 					);
 					list.addEventListener( 'change', setIsMatching );
 					return [ `${ operator } ${ name }`, list ];


### PR DESCRIPTION
## What?
PR fixes an unusual bug that I discovered by accident. Printing currently closes and reopens the editor's complementary area. Scoping breakpoint media queries to `screen` prevents the print pass from being interpreted as a switch to a mobile viewport.

## Why?

Opening the browser print dialog re-evaluates the width media features against the page box rather than the window. Letter or A4 minus default margins is roughly 720 to 740 CSS px, which is under the 782px `medium` breakpoint, so `(max-width: 782px)` flips to true and back. `window.innerWidth` never changes and no `resize` event fires, so nothing else signals that anything happened.

Both breakpoint query builders omit the media type, so they match paged media too. That means printing runs the editor's big-to-small path. `useAdjustComplementaryListener` sees `isSmall` become true, calls `disableComplementaryArea`, then reopens the area afterward. Printing mutates the editor state, and the reopen animation is the visible symptom. Anything else keyed on viewport matching gets the same spurious event.

## How?

Build the queries as `screen and (min-width: Npx)` in both places where they are generated. `@wordpress/viewport`'s listener is the one that closed the sidebar, since `isSmall` reads from that store. `useViewportMatch` has the same flaw and the same fix.

## Testing Instructions

1. Open the post editor with the Settings sidebar open.
2. Open the browser print dialog.
3. The sidebar shouldn't re-animate in the background.
4. Resize the window across 782px in both directions. The sidebar should still close on the way down and reopen on the way up, as before.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/598637c6-d606-4da1-8e31-8f984967e577

## Use of AI Tools

Assisted by Claude.
