### PR TITLE
Block editor: Surface responsive style status

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Show responsive style overrides in List View and the block inspector, including when responsive editing is turned off.
 -   Creating a new block next to a sibling of the same type now inherits the sibling's attributes consistently, whether it is created by the appender, the inserter, or Enter at the edge of the text. Everything except the sibling's content (attributes with the `content` role) and its `metadata` is copied. The `attributesToCopy` list of a default block is removed: the copied attributes derive from the block's attribute roles.
 
 ### Enhancements

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -33,6 +33,7 @@ import { useBorderPanelLabel } from '../../hooks/border';
 import { BlockStateBadges, BlockStatesControl } from '../../hooks/states';
 import ContentTab from '../inspector-controls-tabs/content-tab';
 import ViewportVisibilityInfo from '../block-visibility/viewport-visibility-info';
+import ResponsiveStylesInfo from './responsive-styles-info';
 import { unlock } from '../../lock-unlock';
 import {
 	BlockStyleStateProvider,
@@ -492,6 +493,7 @@ const BlockInspectorSingleBlock = ( {
 				</Spacer>
 			) }
 			<ViewportVisibilityInfo clientId={ renderedBlockClientId } />
+			<ResponsiveStylesInfo clientId={ renderedBlockClientId } />
 			<EditContents clientId={ renderedBlockClientId } />
 			{ ! isEditingStyleState && (
 				<BlockVariationTransforms

--- a/packages/block-editor/src/components/block-inspector/responsive-styles-info.js
+++ b/packages/block-editor/src/components/block-inspector/responsive-styles-info.js
@@ -1,0 +1,38 @@
+import {
+	Icon as WCIcon,
+	__experimentalText as WCText,
+	__experimentalHStack as HStack,
+	privateApis as componentsPrivateApis,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { mobile } from '@wordpress/icons';
+import { unlock } from '../../lock-unlock';
+import { store as blockEditorStore } from '../../store';
+import { getResponsiveStylesLabel } from '../../hooks/block-style-state';
+
+const { Badge: WCBadge } = unlock( componentsPrivateApis );
+
+export default function ResponsiveStylesInfo( { clientId } ) {
+	const responsiveStylesLabel = useSelect(
+		( select ) => {
+			const { getBlockAttributes } = unlock( select( blockEditorStore ) );
+			return getResponsiveStylesLabel(
+				getBlockAttributes( clientId )?.style
+			);
+		},
+		[ clientId ]
+	);
+
+	if ( ! responsiveStylesLabel ) {
+		return null;
+	}
+
+	return (
+		<WCBadge className="block-editor-block-inspector__responsive-styles-info">
+			<HStack spacing={ 2 } justify="start">
+				<WCIcon icon={ mobile } />
+				<WCText>{ responsiveStylesLabel }</WCText>
+			</HStack>
+		</WCBadge>
+	);
+}

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -62,3 +62,12 @@
 		justify-content: center;
 	}
 }
+
+.block-editor-block-inspector__responsive-styles-info {
+	padding-top: $grid-unit-05;
+	padding-bottom: $grid-unit-05;
+	margin: 0 $grid-unit-20 $grid-unit-20;
+	display: flex;
+	align-items: center;
+	justify-content: start;
+}

--- a/packages/block-editor/src/components/block-inspector/test/responsive-styles-info.js
+++ b/packages/block-editor/src/components/block-inspector/test/responsive-styles-info.js
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import ResponsiveStylesInfo from '../responsive-styles-info';
+
+let mockAttributes;
+let mockResponsiveStylesLabel;
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: ( callback ) =>
+		callback( () => ( {
+			getBlockAttributes: () => mockAttributes,
+		} ) ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Icon: () => <span />,
+	__experimentalText: ( { children } ) => <span>{ children }</span>,
+	__experimentalHStack: ( { children } ) => <div>{ children }</div>,
+	privateApis: {
+		Badge: ( { children } ) => <div>{ children }</div>,
+	},
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	mobile: 'mobile',
+} ) );
+
+jest.mock( '../../../lock-unlock', () => ( {
+	unlock: ( value ) => value,
+} ) );
+
+jest.mock( '../../../store', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+jest.mock( '../../../hooks/block-style-state', () => ( {
+	getResponsiveStylesLabel: () => mockResponsiveStylesLabel,
+} ) );
+
+describe( 'ResponsiveStylesInfo', () => {
+	it( 'shows no status when the block has no responsive styles', () => {
+		mockAttributes = { style: { color: { text: '#000000' } } };
+		mockResponsiveStylesLabel = null;
+
+		const { container } = render(
+			<ResponsiveStylesInfo clientId="block-1" />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows the viewports with responsive styles', () => {
+		mockAttributes = {
+			style: {
+				'@tablet': { spacing: { padding: { top: '20px' } } },
+				'@mobile': { color: { text: '#ff0000' } },
+			},
+		};
+		mockResponsiveStylesLabel =
+			'Block has responsive styles for Tablet, Mobile.';
+
+		render( <ResponsiveStylesInfo clientId="block-1" /> );
+
+		expect(
+			screen.getByText(
+				'Block has responsive styles for Tablet, Mobile.'
+			)
+		).toBeVisible();
+	} );
+} );

--- a/packages/block-editor/src/components/list-view/README.md
+++ b/packages/block-editor/src/components/list-view/README.md
@@ -8,6 +8,8 @@ Blocks that have child blocks (such as group or column blocks) are presented wit
 
 In addition to presenting the structure of the blocks in the editor, the ListView component lets users navigate to each block by clicking on its line in the hierarchy tree. Multiple blocks at the same level of nesting can be selected by holding down the `SHIFT` key and clicking blocks within the list.
 
+Block rows use a single status affordance for block-level conditions such as visibility and responsive style overrides. Its tooltip describes every applicable status, and the same description is available to assistive technology through the row.
+
 ![List view](https://make.wordpress.org/core/files/2020/08/block-navigation.png)
 ![View of a group list view](https://make.wordpress.org/core/files/2020/08/view-of-group-block-navigation.png)
 

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -3,13 +3,7 @@ import { __experimentalTruncate as Truncate } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
-import {
-	Icon,
-	lockSmall as lock,
-	pinSmall,
-	symbol,
-	unseen,
-} from '@wordpress/icons';
+import { Icon, lockSmall as lock, pinSmall, symbol } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 import { Stack, Tooltip } from '@wordpress/ui';
 import BlockIcon from '../block-icon';
@@ -34,7 +28,8 @@ function ListViewBlockSelectButton(
 		draggable,
 		isExpanded,
 		ariaDescribedBy,
-		visibilityLabel,
+		statusLabel,
+		statusIcon,
 		isDisabled = false,
 	},
 	ref
@@ -168,10 +163,10 @@ function ListViewBlockSelectButton(
 						) ) }
 					</span>
 				) : null }
-				{ !! visibilityLabel && (
+				{ !! statusLabel && (
 					// The tooltip below is a sighted-hover affordance for
-					// the (decorative) visibility icon. The same
-					// `visibilityLabel` is exposed to assistive technology
+					// the decorative status icon. The same status is exposed
+					// to assistive technology
 					// via the row's `aria-describedby`, which references the
 					// hidden `AriaReferencedText` rendered by the parent
 					// `ListViewBlock`.
@@ -179,14 +174,14 @@ function ListViewBlockSelectButton(
 						<Tooltip.Trigger
 							render={
 								<span
-									className="block-editor-list-view-block-select-button__block-visibility"
+									className="block-editor-list-view-block-select-button__status"
 									aria-hidden="true"
 								>
-									<Icon icon={ unseen } />
+									<Icon icon={ statusIcon } />
 								</span>
 							}
 						/>
-						<Tooltip.Popup>{ visibilityLabel }</Tooltip.Popup>
+						<Tooltip.Popup>{ statusLabel }</Tooltip.Popup>
 					</Tooltip.Root>
 				) }
 				{ shouldShowLockIcon && (

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -5,7 +5,7 @@ import {
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { useInstanceId, useDebounce } from '@wordpress/compose';
-import { moreVertical } from '@wordpress/icons';
+import { mobile, moreVertical, unseen } from '@wordpress/icons';
 import {
 	useCallback,
 	useMemo,
@@ -40,6 +40,7 @@ import AriaReferencedText from './aria-referenced-text';
 import { unlock } from '../../lock-unlock';
 import usePasteStyles from '../use-paste-styles';
 import { getBlockVisibilityLabel } from '../block-visibility';
+import { getResponsiveStylesLabel } from '../../hooks/block-style-state';
 
 function ListViewBlock( {
 	clientId,
@@ -110,6 +111,7 @@ function ListViewBlock( {
 
 	const {
 		blockName,
+		blockStyle,
 		blockVisibility,
 		blockEditingMode,
 		allowRightClickOverrides,
@@ -135,6 +137,7 @@ function ListViewBlock( {
 
 			return {
 				blockName: getBlockName( clientId ),
+				blockStyle: attributes?.style,
 				blockVisibility: attributes?.metadata?.blockVisibility,
 				blockEditingMode: getBlockEditingModeForClientId( clientId ),
 				allowRightClickOverrides: settings.allowRightClickOverrides,
@@ -555,6 +558,14 @@ function ListViewBlock( {
 		blockVisibility,
 		viewportSettings
 	);
+	const responsiveStylesDescription = getResponsiveStylesLabel( blockStyle );
+	const blockStatusDescription = [
+		blockVisibilityDescription,
+		responsiveStylesDescription,
+	]
+		.filter( Boolean )
+		.join( ' ' );
+	const blockStatusIcon = blockVisibilityDescription ? unseen : mobile;
 
 	const hasSiblings = siblingBlockCount > 0;
 	const canShowBlockActions = showBlockActions && ! isDisabled;
@@ -657,14 +668,15 @@ function ListViewBlock( {
 							isExpanded={ canEditBlock ? isExpanded : undefined }
 							selectedClientIds={ selectedClientIds }
 							ariaDescribedBy={ descriptionId }
-							visibilityLabel={ blockVisibilityDescription }
+							statusLabel={ blockStatusDescription }
+							statusIcon={ blockStatusIcon }
 							isDisabled={ isDisabled }
 						/>
 						<AriaReferencedText id={ descriptionId }>
 							{ [
 								blockPositionDescription,
 								blockPropertiesDescription,
-								blockVisibilityDescription,
+								blockStatusDescription,
 							]
 								.filter( Boolean )
 								.join( ' ' ) }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -435,7 +435,7 @@
 		color: $white;
 	}
 
-	.block-editor-list-view-block-select-button__block-visibility,
+	.block-editor-list-view-block-select-button__status,
 	.block-editor-list-view-block-select-button__lock,
 	.block-editor-list-view-block-select-button__sticky {
 		line-height: 0;

--- a/packages/block-editor/src/hooks/block-style-state.js
+++ b/packages/block-editor/src/hooks/block-style-state.js
@@ -1,9 +1,15 @@
 import { createContext, useContext } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { cleanEmptyObject } from './utils';
 import { getValueFromObjectPath, setImmutably } from '../utils/object';
 
 const DEFAULT_STATE_VALUE = 'default';
 const VIEWPORT_STYLE_STATES = [ '@tablet', '@mobile' ];
+
+export const RESPONSIVE_STATE_LABELS = {
+	'@tablet': __( 'Tablet' ),
+	'@mobile': __( 'Mobile' ),
+};
 
 export const DEFAULT_BLOCK_STYLE_STATE = {
 	viewport: DEFAULT_STATE_VALUE,
@@ -99,6 +105,28 @@ export function getPopulatedViewportStyleStates( style ) {
 
 		return cleanEmptyObject( viewportStyle ) !== undefined;
 	} );
+}
+
+/**
+ * Returns a description of a block's responsive style overrides.
+ *
+ * @param {Object} style Block style attribute.
+ * @return {?string} Responsive style description, or null when none are set.
+ */
+export function getResponsiveStylesLabel( style ) {
+	const labels = getPopulatedViewportStyleStates( style ).map(
+		( viewport ) => RESPONSIVE_STATE_LABELS[ viewport ]
+	);
+
+	if ( ! labels.length ) {
+		return null;
+	}
+
+	return sprintf(
+		// translators: %s: comma-separated list of viewport names, for example "Tablet, Mobile".
+		__( 'Block has responsive styles for %s.' ),
+		labels.join( ', ' )
+	);
 }
 
 export function setStyleForState( style, selectedState, newStyle ) {

--- a/packages/block-editor/src/hooks/block-style-state.js
+++ b/packages/block-editor/src/hooks/block-style-state.js
@@ -3,6 +3,7 @@ import { cleanEmptyObject } from './utils';
 import { getValueFromObjectPath, setImmutably } from '../utils/object';
 
 const DEFAULT_STATE_VALUE = 'default';
+const VIEWPORT_STYLE_STATES = [ '@tablet', '@mobile' ];
 
 export const DEFAULT_BLOCK_STYLE_STATE = {
 	viewport: DEFAULT_STATE_VALUE,
@@ -77,6 +78,27 @@ export function getStyleForState( style, selectedState ) {
 		return style;
 	}
 	return getValueFromObjectPath( style, path );
+}
+
+/**
+ * Returns the viewport style states that contain block-level style overrides.
+ *
+ * @param {Object} style Block style attribute.
+ * @return {string[]} Populated viewport style state names.
+ */
+export function getPopulatedViewportStyleStates( style ) {
+	return VIEWPORT_STYLE_STATES.filter( ( viewport ) => {
+		const viewportStyle = style?.[ viewport ];
+		if (
+			! viewportStyle ||
+			typeof viewportStyle !== 'object' ||
+			Array.isArray( viewportStyle )
+		) {
+			return false;
+		}
+
+		return cleanEmptyObject( viewportStyle ) !== undefined;
+	} );
 }
 
 export function setStyleForState( style, selectedState, newStyle ) {

--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -6,6 +6,7 @@ import StateControlBadges from '../components/global-styles/state-control-badges
 import { useToolsPanelDropdownMenuProps } from '../components/global-styles/utils';
 import { useSettings } from '../components/use-settings';
 import { unlock } from '../lock-unlock';
+import { RESPONSIVE_STATE_LABELS } from './block-style-state';
 
 const { getViewportBreakpoints } = unlock( globalStylesEnginePrivateApis );
 
@@ -14,11 +15,6 @@ export const PSEUDO_STATE_LABELS = {
 	':focus': __( 'Focus' ),
 	':focus-visible': __( 'Focus-visible' ),
 	':active': __( 'Active' ),
-};
-
-export const RESPONSIVE_STATE_LABELS = {
-	'@tablet': __( 'Tablet' ),
-	'@mobile': __( 'Mobile' ),
 };
 
 // Viewport states are selected globally via the editor's device preview.

--- a/packages/block-editor/src/hooks/test/block-style-state.js
+++ b/packages/block-editor/src/hooks/test/block-style-state.js
@@ -1,8 +1,63 @@
 import {
+	getPopulatedViewportStyleStates,
 	getStyleForState,
 	scopeResetAllFilterToState,
 	setStyleForState,
 } from '../block-style-state';
+
+describe( 'getPopulatedViewportStyleStates', () => {
+	it( 'returns no viewport states when a block has no responsive style overrides', () => {
+		expect(
+			getPopulatedViewportStyleStates( {
+				color: { text: '#000000' },
+				':hover': { color: { text: '#ff0000' } },
+				'@current': { color: { text: '#00ff00' } },
+			} )
+		).toEqual( [] );
+	} );
+
+	it( 'returns populated viewport states in display order', () => {
+		expect(
+			getPopulatedViewportStyleStates( {
+				'@mobile': { color: { text: '#ff0000' } },
+				'@tablet': { spacing: { padding: { top: '20px' } } },
+			} )
+		).toEqual( [ '@tablet', '@mobile' ] );
+	} );
+
+	it( 'counts pseudo-state styles nested inside a viewport', () => {
+		expect(
+			getPopulatedViewportStyleStates( {
+				'@mobile': {
+					':hover': { color: { text: '#ff0000' } },
+				},
+			} )
+		).toEqual( [ '@mobile' ] );
+	} );
+
+	it( 'ignores empty and malformed viewport style slices', () => {
+		expect(
+			getPopulatedViewportStyleStates( {
+				'@tablet': { color: { text: undefined } },
+				'@mobile': null,
+			} )
+		).toEqual( [] );
+	} );
+
+	it( 'does not mutate the style attribute', () => {
+		const style = {
+			'@tablet': { color: { text: undefined } },
+			'@mobile': { color: { text: '#ff0000' } },
+		};
+
+		getPopulatedViewportStyleStates( style );
+
+		expect( style ).toEqual( {
+			'@tablet': { color: { text: undefined } },
+			'@mobile': { color: { text: '#ff0000' } },
+		} );
+	} );
+} );
 
 describe( 'getStyleForState', () => {
 	it( 'returns the root style for the default state', () => {

--- a/packages/block-editor/src/hooks/test/block-style-state.js
+++ b/packages/block-editor/src/hooks/test/block-style-state.js
@@ -1,5 +1,6 @@
 import {
 	getPopulatedViewportStyleStates,
+	getResponsiveStylesLabel,
 	getStyleForState,
 	scopeResetAllFilterToState,
 	setStyleForState,
@@ -56,6 +57,29 @@ describe( 'getPopulatedViewportStyleStates', () => {
 			'@tablet': { color: { text: undefined } },
 			'@mobile': { color: { text: '#ff0000' } },
 		} );
+	} );
+} );
+
+describe( 'getResponsiveStylesLabel', () => {
+	it( 'returns no description when a block has no responsive styles', () => {
+		expect( getResponsiveStylesLabel( {} ) ).toBeNull();
+	} );
+
+	it( 'describes a single responsive viewport', () => {
+		expect(
+			getResponsiveStylesLabel( {
+				'@mobile': { color: { text: '#ff0000' } },
+			} )
+		).toBe( 'Block has responsive styles for Mobile.' );
+	} );
+
+	it( 'describes all responsive viewports in display order', () => {
+		expect(
+			getResponsiveStylesLabel( {
+				'@mobile': { color: { text: '#ff0000' } },
+				'@tablet': { spacing: { padding: { top: '20px' } } },
+			} )
+		).toBe( 'Block has responsive styles for Tablet, Mobile.' );
 	} );
 } );
 


### PR DESCRIPTION
## What?

- Detect populated Tablet and Mobile block style overrides.
- Show responsive style status in List View, consolidated with existing visibility status.
- Show an informational responsive style badge in the block inspector.
- Add unit/component coverage and update List View documentation and the package changelog.

## Why?

When responsive editing is turned off, persisted per-viewport styles still affect the front end but are not visible in the editor. This makes responsive overrides difficult to discover and diagnose, especially when another person edits the site later.

The consolidated List View affordance avoids adding a separate permanent icon when a block has multiple statuses, while the inspector status keeps the information available when List View is closed.

Closes 81050.

## Testing Instructions

1. Add a block and enable Responsive styles.
2. Add Tablet and/or Mobile style overrides.
3. Turn Responsive styles off.
4. Open List View and confirm the block has a status icon whose tooltip names the configured viewports.
5. Select the block and confirm the block inspector shows the responsive style status.
6. Combine responsive styles with block visibility and confirm List View shows one status affordance with both descriptions.

## Automated testing

- `npm run test:unit packages/block-editor/src/hooks/test/block-style-state.js packages/block-editor/src/components/block-inspector/test/responsive-styles-info.js`
- Scoped JavaScript lint
- `npm run build -- --skip-types`
- `git diff --check`
