### PR TITLE
 Stylelint: extract the shared rule set into a reusable "project" preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55603,7 +55603,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/stylelint-config": "file:../../packages/stylelint-config",
-				"@wordpress/theme": "file:../../packages/theme",
 				"stylelint": "^16.26.1",
 				"stylelint-plugin-logical-css": "^1.2.3"
 			}

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added a `project` preset holding the rules shared by Gutenberg and WordPress Core, so both projects can extend a single source instead of duplicating the set ([#81349](https://github.com/WordPress/gutenberg/issues/81349)).
 
 ## 24.1.0 (2026-07-29)
 

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -30,7 +30,7 @@ If you've globally installed `@wordpress/stylelint-config` using the `-g` flag, 
 
 ## Presets
 
-In addition to the default preset, there is also a SCSS preset and 2 stylistic variant presets.
+In addition to the default preset, there is also a SCSS preset, 2 stylistic variant presets, and a preset for the WordPress projects themselves.
 
 ### SCSS
 
@@ -59,6 +59,18 @@ This preset extends`@wordpress/stylelint-config`, `@wordpress/stylelint-config/s
 ```json
 {
 	"extends": [ "@wordpress/stylelint-config/scss-stylistic" ]
+}
+```
+
+### Project
+
+This preset extends `@wordpress/stylelint-config/scss-stylistic` with the rules shared by the WordPress projects that lint their own stylesheets — Gutenberg and WordPress Core. Compared to `scss-stylistic` it turns off the stylistic and SCSS rules those codebases do not follow, adds accessibility rules for the `order` property and reversed `flex-direction` values, and relaxes `selector-class-pattern` to allow BEM-style class names.
+
+Use it if you want to match how WordPress itself is linted. If you are configuring a theme or plugin, one of the presets above is likely a better fit.
+
+```json
+{
+	"extends": [ "@wordpress/stylelint-config/project" ]
 }
 ```
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -28,6 +28,7 @@
 		"LICENSE",
 		"README.md",
 		"index.js",
+		"project.js",
 		"scss.js",
 		"scss-stylistic.js",
 		"stylistic.js"
@@ -36,6 +37,7 @@
 	"main": "index.js",
 	"exports": {
 		".": "./index.js",
+		"./project": "./project.js",
 		"./scss": "./scss.js",
 		"./scss-stylistic": "./scss-stylistic.js",
 		"./stylistic": "./stylistic.js",

--- a/packages/stylelint-config/project.js
+++ b/packages/stylelint-config/project.js
@@ -1,0 +1,71 @@
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The set of rules shared by the WordPress projects that lint their own
+ * stylesheets — Gutenberg and WordPress Core.
+ *
+ * It layers on top of `scss-stylistic` and mostly does three things:
+ *
+ * - Turns off the stylistic and SCSS rules that the existing WordPress
+ *   codebases do not follow, so the config can be adopted without a mass
+ *   reformat.
+ * - Adds the accessibility rules that keep visual, reading, and DOM order in
+ *   sync (`order`, reversed `flex-direction`).
+ * - Relaxes `selector-class-pattern` to allow BEM-style class names.
+ *
+ * Project-specific rules do not belong here. Extend this config and add them
+ * in the consuming project instead.
+ *
+ * @type {import('stylelint').Config}
+ */
+export default {
+	extends: [ './scss-stylistic' ].map( ( m ) =>
+		fileURLToPath( import.meta.resolve( m ) )
+	),
+	reportNeedlessDisables: true,
+	reportDescriptionlessDisables: true,
+	rules: {
+		'at-rule-empty-line-before': null,
+		'at-rule-no-unknown': null,
+		'comment-empty-line-before': null,
+		'declaration-property-value-allowed-list': [
+			{
+				'flex-direction': '/^(?!(row|column)-reverse).*$/',
+			},
+			{
+				message: ( property, value ) =>
+					`Avoid "${ value }" value for the "${ property }" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.`,
+			},
+		],
+		'font-weight-notation': null,
+		'@stylistic/max-line-length': null,
+		'no-descending-specificity': null,
+		'property-disallowed-list': [
+			[ 'order' ],
+			{
+				message:
+					'Avoid the order property. For accessibility reasons, visual, reading, and DOM order must match. Only use the order property when it does not affect reading order, meaning, and interaction.',
+			},
+		],
+		'rule-empty-line-before': null,
+		'selector-class-pattern': [
+			'^[a-z][a-z0-9]*(?:(?:__|--|-)[a-z0-9]+)*$',
+			{
+				message:
+					'Selector should use lowercase class segments separated with hyphens, double hyphens, or double underscores (selector-class-pattern)',
+			},
+		],
+		'value-keyword-case': null,
+		'scss/operator-no-unspaced': null,
+		'scss/selector-no-redundant-nesting-selector': null,
+		'scss/load-partial-extension': null,
+		'scss/no-global-function-names': null,
+		'scss/comment-no-empty': null,
+		'scss/at-extend-no-missing-placeholder': null,
+		'scss/operator-no-newline-after': null,
+		'scss/at-if-closing-brace-newline-after': null,
+		'scss/at-else-empty-line-before': null,
+		'scss/at-if-closing-brace-space-after': null,
+		'no-invalid-position-at-import-rule': null,
+	},
+};

--- a/packages/stylelint-config/test/.stylelintrc.project.tests.json
+++ b/packages/stylelint-config/test/.stylelintrc.project.tests.json
@@ -1,0 +1,3 @@
+{
+	"extends": "@wordpress/stylelint-config/project"
+}

--- a/packages/stylelint-config/test/__snapshots__/project.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/project.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`flags warnings with invalid project scss snapshot matches warnings 1`] = `
+[
+  {
+    "column": 18,
+    "endColumn": 29,
+    "endLine": 3,
+    "line": 3,
+    "rule": "declaration-property-value-allowed-list",
+    "severity": "error",
+    "text": "Avoid "row-reverse" value for the "flex-direction" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction. (declaration-property-value-allowed-list)",
+  },
+  {
+    "column": 2,
+    "endColumn": 7,
+    "endLine": 4,
+    "line": 4,
+    "rule": "property-disallowed-list",
+    "severity": "error",
+    "text": "Avoid the order property. For accessibility reasons, visual, reading, and DOM order must match. Only use the order property when it does not affect reading order, meaning, and interaction. (property-disallowed-list)",
+  },
+]
+`;

--- a/packages/stylelint-config/test/project-invalid.scss
+++ b/packages/stylelint-config/test/project-invalid.scss
@@ -1,0 +1,5 @@
+// Both declarations break the reading-order rules this preset adds.
+.block-editor__inserter-menu {
+	flex-direction: row-reverse;
+	order: 1;
+}

--- a/packages/stylelint-config/test/project-valid.scss
+++ b/packages/stylelint-config/test/project-valid.scss
@@ -1,0 +1,14 @@
+// BEM-style class segments are allowed by this preset.
+.block-editor__inserter-menu--open {
+	display: flex;
+	flex-direction: row;
+}
+
+// Rules this preset turns off relative to `scss-stylistic`.
+.block-editor-inserter {
+	@if $condition {
+		color: #fff;
+	} @else {
+		color: #000;
+	}
+}

--- a/packages/stylelint-config/test/project.js
+++ b/packages/stylelint-config/test/project.js
@@ -1,0 +1,46 @@
+const utils = require( './utils' );
+const getStylelintResult = utils.getStylelintResult;
+
+const CONFIG = './.stylelintrc.project.tests.json';
+
+describe( 'flags no warnings with valid project scss', () => {
+	let result;
+
+	beforeEach( () => {
+		result = getStylelintResult( './project-valid.scss', CONFIG );
+	} );
+
+	it( 'did not error', () => {
+		return result.then( ( data ) => expect( data.errored ).toBeFalsy() );
+	} );
+
+	it( 'flags no warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toHaveLength( 0 )
+		);
+	} );
+} );
+
+describe( 'flags warnings with invalid project scss', () => {
+	let result;
+
+	beforeEach( () => {
+		result = getStylelintResult( './project-invalid.scss', CONFIG );
+	} );
+
+	it( 'did error', () => {
+		return result.then( ( data ) => expect( data.errored ).toBeTruthy() );
+	} );
+
+	it( 'flags correct number of warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toHaveLength( 2 )
+		);
+	} );
+
+	it( 'snapshot matches warnings', () => {
+		return result.then( ( data ) =>
+			expect( data.results[ 0 ].warnings ).toMatchSnapshot()
+		);
+	} );
+} );

--- a/packages/stylelint-config/test/utils/index.js
+++ b/packages/stylelint-config/test/utils/index.js
@@ -14,20 +14,23 @@ const stylelintBin = path.join(
 	'bin/stylelint.mjs'
 );
 
-const generateStylelintCommand = ( filename ) =>
+const generateStylelintCommand = ( filename, configFile ) =>
 	'node ' +
 	stylelintBin +
 	' ' +
 	path.resolve( __dirname, '../', filename ) +
 	' -c' +
-	path.resolve( __dirname, '../', './.stylelintrc.tests.json' ) +
+	path.resolve( __dirname, '../', configFile ) +
 	' --formatter json' +
 	' --ignore-path ' +
 	path.resolve( __dirname, '../', './.stylelintignore' );
 
 module.exports = {
-	getStylelintResult: ( filename ) =>
-		execute( generateStylelintCommand( filename ) )
+	getStylelintResult: (
+		filename,
+		configFile = './.stylelintrc.tests.json'
+	) =>
+		execute( generateStylelintCommand( filename, configFile ) )
 			.then( ( { stderr } ) => {
 				return {
 					errored: false,

--- a/tools/stylelint/config.js
+++ b/tools/stylelint/config.js
@@ -3,25 +3,12 @@ const CSS_BASELINE_2024_FUNCTIONS = [ 'round', 'rem', 'mod' ];
 
 /** @type {import('stylelint').Config} */
 module.exports = {
-	extends: '@wordpress/stylelint-config/scss-stylistic',
-	plugins: [
-		'stylelint-plugin-logical-css',
-		'@wordpress/theme/stylelint-plugins/no-token-fallback-values',
-	],
-	reportNeedlessDisables: true,
+	// The rules shared with WordPress Core live in the published config so both
+	// projects have a single source for them. Only Gutenberg-specific
+	// configuration belongs below.
+	extends: '@wordpress/stylelint-config/project',
+	plugins: [ 'stylelint-plugin-logical-css' ],
 	rules: {
-		'at-rule-empty-line-before': null,
-		'at-rule-no-unknown': null,
-		'comment-empty-line-before': null,
-		'declaration-property-value-allowed-list': [
-			{
-				'flex-direction': '/^(?!(row|column)-reverse).*$/',
-			},
-			{
-				message: ( property, value ) =>
-					`Avoid "${ value }" value for the "${ property }" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.`,
-			},
-		],
 		'declaration-property-value-disallowed-list': [
 			{
 				'/.*/': [
@@ -51,37 +38,6 @@ module.exports = {
 				},
 			},
 		],
-		'font-weight-notation': null,
-		'@stylistic/max-line-length': null,
-		'no-descending-specificity': null,
-		'property-disallowed-list': [
-			[ 'order' ],
-			{
-				message:
-					'Avoid the order property. For accessibility reasons, visual, reading, and DOM order must match. Only use the order property when it does not affect reading order, meaning, and interaction.',
-			},
-		],
-		'rule-empty-line-before': null,
-		'selector-class-pattern': [
-			'^[a-z][a-z0-9]*(?:(?:__|--|-)[a-z0-9]+)*$',
-			{
-				message:
-					'Selector should use lowercase class segments separated with hyphens, double hyphens, or double underscores (selector-class-pattern)',
-			},
-		],
-		'value-keyword-case': null,
-		'scss/operator-no-unspaced': null,
-		'scss/selector-no-redundant-nesting-selector': null,
-		'scss/load-partial-extension': null,
-		'scss/no-global-function-names': null,
-		'scss/comment-no-empty': null,
-		'scss/at-extend-no-missing-placeholder': null,
-		'scss/operator-no-newline-after': null,
-		'scss/at-if-closing-brace-newline-after': null,
-		'scss/at-else-empty-line-before': null,
-		'scss/at-if-closing-brace-space-after': null,
-		'no-invalid-position-at-import-rule': null,
-		'plugin-wpds/no-token-fallback-values': true,
 	},
 	overrides: [
 		{
@@ -169,5 +125,4 @@ module.exports = {
 			},
 		},
 	],
-	reportDescriptionlessDisables: true,
 };

--- a/tools/stylelint/package.json
+++ b/tools/stylelint/package.json
@@ -24,7 +24,6 @@
 	},
 	"dependencies": {
 		"@wordpress/stylelint-config": "file:../../packages/stylelint-config",
-		"@wordpress/theme": "file:../../packages/theme",
 		"stylelint": "^16.26.1",
 		"stylelint-plugin-logical-css": "^1.2.3"
 	},


### PR DESCRIPTION
## What?

Closes #81349

Adds a `project` preset to `@wordpress/stylelint-config` holding the Stylelint rules Gutenberg and WordPress Core share, and switches `tools/stylelint/config.js` over to it so the set has a single source.

## Why?

[wordpress-develop#12934](https://github.com/WordPress/wordpress-develop/pull/12934) proposes adding Stylelint to Core, and its `.stylelintrc.js` is currently a copy of Gutenberg's config. The overlap is exact: Core's file is [tools/stylelint/config.js](https://github.com/WordPress/gutenberg/blob/c7cdb481578375c23863690bb07eab8f87c03762/tools/stylelint/config.js) minus [declaration-property-value-disallowed-list](https://github.com/WordPress/gutenberg/blob/c7cdb481578375c23863690bb07eab8f87c03762/tools/stylelint/config.js#L25-L53), [plugin-wpds/no-token-fallback-values](https://github.com/WordPress/gutenberg/blob/c7cdb481578375c23863690bb07eab8f87c03762/tools/stylelint/config.js#L84) and the [overrides section](https://github.com/WordPress/gutenberg/blob/c7cdb481578375c23863690bb07eab8f87c03762/tools/stylelint/config.js#L86-L171) — the other ~22 rules and both `report*Disables` options are identical. Keeping two copies in sync by hand is the maintenance problem the issue describes.

## How?

The shared set becomes a fourth preset in the already-published `@wordpress/stylelint-config`, alongside `scss` / `stylistic` / `scss-stylistic`, rather than a new package. It extends `scss-stylistic` and carries the shared rules plus `reportNeedlessDisables` and `reportDescriptionlessDisables`.

`tools/stylelint/config.js` drops from 173 to 122 lines and keeps only Gutenberg's own configuration:

```js
extends: '@wordpress/stylelint-config/project',
plugins: [ 'stylelint-plugin-logical-css' ],
rules: { /* wp-components-color / font-weight / cursor only */ },
overrides: [ /* CSS modules + routes/ */ ],
```

Core's config then becomes `extends: '@wordpress/stylelint-config/project'` plus its `ignorePath`.

Two incidental cleanups fall out: the file was re-registering the `no-token-fallback-values` plugin and re-enabling its rule, both already no-ops given the base config, and `tools/stylelint` no longer needs its `@wordpress/theme` dependency.

**Note for reviewers:** `plugin-wpds/no-token-fallback-values` is excluded from the extracted set per the issue, but that does not actually keep it out of Core — it is [enabled in the base index.js](https://github.com/WordPress/gutenberg/blob/c7cdb481578375c23863690bb07eab8f87c03762/packages/stylelint-config/index.js#L81-L83) that Core already extends, along with `no-unknown-ds-tokens` and `no-setting-wpds-custom-properties`. They are inert there (Core has no `--wpds-*` tokens), so this PR leaves the base preset alone; excluding WPDS rules from Core entirely would be a separate, more disruptive change.

## Testing Instructions

This is a no-op refactor for Gutenberg — the goal is proving the resolved config did not change.

1. `npm run lint:css`
2. `npm run test:unit packages/stylelint-config`
3. Optional, to confirm equivalence directly — compare `npx stylelint --print-config <file>` on this branch against `trunk` for each file shape in the repo:
   - `packages/components/src/button/style.scss` (plain SCSS)
   - `packages/components/src/angle-picker-control/style.module.scss` (CSS module, SCSS)
   - `widgets/hello-world/style.module.css` (CSS module, CSS)
   - `routes/template-list/style.scss` (`routes/`)

Output is semantically identical for all four; only key ordering shifts, so sort keys before diffing.

### Testing Instructions for Keyboard

N/A — build tooling only, no UI changes.

## Use of AI

Claude Code Opus 5
Purpose - compare configs, extract shared rules, verify equivalence, write tests