### PR TITLE
Editor: Speed up the hierarchical term selector for large taxonomies

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -50,40 +50,27 @@ const EMPTY_ARRAY = [];
  * @return {Object[]} Sorted array of terms.
  */
 export function sortBySelected( termsTree, terms ) {
+	const selectedTerms = new Set( terms );
 	const treeHasSelection = ( termTree ) => {
-		if ( terms.indexOf( termTree.id ) !== -1 ) {
+		if ( selectedTerms.has( termTree.id ) ) {
 			return true;
 		}
-		if ( undefined === termTree.children ) {
-			return false;
-		}
-		return (
-			termTree.children
-				.map( treeHasSelection )
-				.filter( ( child ) => child ).length > 0
-		);
+		return !! termTree.children?.some( treeHasSelection );
 	};
-	const termOrChildIsSelected = ( termA, termB ) => {
-		const termASelected = treeHasSelection( termA );
-		const termBSelected = treeHasSelection( termB );
 
-		if ( termASelected === termBSelected ) {
-			return 0;
+	// Partition rather than sort, so each subtree is walked once instead of
+	// once per comparison. Terms keep their relative order within each group.
+	const selected = [];
+	const unselected = [];
+	for ( const termTree of termsTree ) {
+		if ( treeHasSelection( termTree ) ) {
+			selected.push( termTree );
+		} else {
+			unselected.push( termTree );
 		}
+	}
 
-		if ( termASelected && ! termBSelected ) {
-			return -1;
-		}
-
-		if ( ! termASelected && termBSelected ) {
-			return 1;
-		}
-
-		return 0;
-	};
-	const newTermTree = [ ...termsTree ];
-	newTermTree.sort( termOrChildIsSelected );
-	return newTermTree;
+	return [ ...selected, ...unselected ];
 }
 
 /**

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -1,5 +1,5 @@
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
+import { memo, useMemo, useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	Button,
@@ -13,7 +13,7 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useDebounce } from '@wordpress/compose';
+import { useDebounce, useEvent } from '@wordpress/compose';
 import {
 	store as coreStore,
 	privateApis as coreDataPrivateApis,
@@ -41,6 +41,48 @@ const DEFAULT_QUERY = {
 const MIN_TERMS_COUNT_FOR_FILTER = 8;
 const EMPTY_ARRAY = [];
 
+// Memoized on primitive props, so toggling one term does not re-render every
+// checkbox in the list.
+const TermCheckbox = memo( function Checkbox( {
+	id,
+	name,
+	checked,
+	onToggle,
+} ) {
+	return (
+		<CheckboxControl
+			checked={ checked }
+			onChange={ () => onToggle( id ) }
+			label={ decodeEntities( name ) }
+		/>
+	);
+} );
+
+function TermRow( { term, selectedTerms, onToggle } ) {
+	return (
+		<div className="editor-post-taxonomies__hierarchical-terms-choice">
+			<TermCheckbox
+				id={ term.id }
+				name={ term.name }
+				checked={ selectedTerms.has( term.id ) }
+				onToggle={ onToggle }
+			/>
+			{ !! term.children.length && (
+				<div className="editor-post-taxonomies__hierarchical-terms-subchoices">
+					{ term.children.map( ( child ) => (
+						<TermRow
+							key={ child.id }
+							term={ child }
+							selectedTerms={ selectedTerms }
+							onToggle={ onToggle }
+						/>
+					) ) }
+				</div>
+			) }
+		</div>
+	);
+}
+
 /**
  * Sort Terms by Selected.
  *
@@ -58,8 +100,8 @@ export function sortBySelected( termsTree, terms ) {
 		return !! termTree.children?.some( treeHasSelection );
 	};
 
-	// Partition rather than sort, so each subtree is walked once instead of
-	// once per comparison. Terms keep their relative order within each group.
+	// Partition rather than sort: each subtree is walked once, and terms keep
+	// their relative order within each group.
 	const selected = [];
 	const unselected = [];
 	for ( const termTree of termsTree ) {
@@ -98,6 +140,8 @@ export function findTerm( terms, parent, name ) {
  * @return {(function(Object): (Object|boolean))} Matcher function.
  */
 export function getFilterMatcher( filterValue ) {
+	// Normalize once rather than per visited term.
+	const normalizedFilterValue = normalizeTextString( filterValue );
 	const matchTermsForFilter = ( originalTerm ) => {
 		if ( '' === filterValue ) {
 			return originalTerm;
@@ -120,7 +164,7 @@ export function getFilterMatcher( filterValue ) {
 		if (
 			-1 !==
 				normalizeTextString( term.name ).indexOf(
-					normalizeTextString( filterValue )
+					normalizedFilterValue
 				) ||
 			term.children.length > 0
 		) {
@@ -200,12 +244,35 @@ export function HierarchicalTermSelector( { slug } ) {
 	const { editPost } = useDispatch( editorStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 
+	const selectedTerms = useMemo( () => new Set( terms ), [ terms ] );
 	const availableTermsTree = useMemo(
 		() => sortBySelected( buildTermsTree( availableTerms ), terms ),
 		// Remove `terms` from the dependency list to avoid reordering every time
 		// checking or unchecking a term.
 		[ availableTerms ]
 	);
+
+	/**
+	 * Update terms for post.
+	 *
+	 * @param {number[]} termIds Term ids.
+	 */
+	const onUpdateTerms = ( termIds ) => {
+		editPost( { [ taxonomy.rest_base ]: termIds } );
+	};
+
+	// Stable, so unchanged checkboxes can bail out of re-rendering.
+	const onToggleTerm = useEvent( ( termId ) => {
+		const id = parseInt( termId, 10 );
+		onUpdateTerms(
+			selectedTerms.has( id )
+				? terms.filter( ( term ) => term !== id )
+				: [ ...terms, id ]
+		);
+	} );
+
+	const shownTerms =
+		'' !== filterValue ? filteredTermsTree : availableTermsTree;
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 
@@ -223,28 +290,6 @@ export function HierarchicalTermSelector( { slug } ) {
 		return saveEntityRecord( 'taxonomy', slug, term, {
 			throwOnError: true,
 		} );
-	};
-
-	/**
-	 * Update terms for post.
-	 *
-	 * @param {number[]} termIds Term ids.
-	 */
-	const onUpdateTerms = ( termIds ) => {
-		editPost( { [ taxonomy.rest_base ]: termIds } );
-	};
-
-	/**
-	 * Handler for checking term.
-	 *
-	 * @param {number} termId
-	 */
-	const onChange = ( termId ) => {
-		const hasTerm = terms.includes( termId );
-		const newTerms = hasTerm
-			? terms.filter( ( id ) => id !== termId )
-			: [ ...terms, termId ];
-		onUpdateTerms( newTerms );
 	};
 
 	const onChangeFormName = ( value ) => {
@@ -338,31 +383,6 @@ export function HierarchicalTermSelector( { slug } ) {
 		debouncedSpeak( resultsFoundMessage, 'assertive' );
 	};
 
-	const renderTerms = ( renderedTerms ) => {
-		return renderedTerms.map( ( term ) => {
-			return (
-				<div
-					key={ term.id }
-					className="editor-post-taxonomies__hierarchical-terms-choice"
-				>
-					<CheckboxControl
-						checked={ terms.indexOf( term.id ) !== -1 }
-						onChange={ () => {
-							const termId = parseInt( term.id, 10 );
-							onChange( termId );
-						} }
-						label={ decodeEntities( term.name ) }
-					/>
-					{ !! term.children.length && (
-						<div className="editor-post-taxonomies__hierarchical-terms-subchoices">
-							{ renderTerms( term.children ) }
-						</div>
-					) }
-				</div>
-			);
-		} );
-	};
-
 	const labelWithFallback = (
 		labelProperty,
 		fallbackIsCategory,
@@ -419,9 +439,14 @@ export function HierarchicalTermSelector( { slug } ) {
 				role="group"
 				aria-label={ groupLabel }
 			>
-				{ renderTerms(
-					'' !== filterValue ? filteredTermsTree : availableTermsTree
-				) }
+				{ shownTerms.map( ( term ) => (
+					<TermRow
+						key={ term.id }
+						term={ term }
+						selectedTerms={ selectedTerms }
+						onToggle={ onToggleTerm }
+					/>
+				) ) }
 			</div>
 			{ ! loading && hasCreateAction && (
 				<FlexItem>

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -25,32 +25,26 @@ export function buildTermsTree( flatTerms ) {
 		return flatTermsWithParentAndChildren;
 	}
 
-	const termsByParent = flatTermsWithParentAndChildren.reduce(
-		( acc, term ) => {
-			const { parent } = term;
-			if ( ! acc[ parent ] ) {
-				acc[ parent ] = [];
-			}
-			acc[ parent ].push( term );
-			return acc;
-		},
-		{}
-	);
+	const termsById = Object.create( null );
+	for ( const term of flatTermsWithParentAndChildren ) {
+		// The tree owns `children`, so drop whatever the input carried.
+		term.children = [];
+		termsById[ term.id ] = term;
+	}
 
-	const fillWithChildren = ( terms ) => {
-		return terms.map( ( term ) => {
-			const children = termsByParent[ term.id ];
-			return {
-				...term,
-				children:
-					children && children.length
-						? fillWithChildren( children )
-						: [],
-			};
-		} );
-	};
+	// Link each term into its parent instead of cloning the tree a second time.
+	// Terms whose parent is missing are dropped, as they are unreachable.
+	const tree = [];
+	for ( const term of flatTermsWithParentAndChildren ) {
+		const parent = termsById[ term.parent ];
+		if ( parent ) {
+			parent.children.push( term );
+		} else if ( `${ term.parent }` === '0' ) {
+			tree.push( term );
+		}
+	}
 
-	return fillWithChildren( termsByParent[ '0' ] || [] );
+	return tree;
 }
 
 export const unescapeString = ( arg ) => {

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -32,8 +32,7 @@ export function buildTermsTree( flatTerms ) {
 		termsById[ term.id ] = term;
 	}
 
-	// Link each term into its parent instead of cloning the tree a second time.
-	// Terms whose parent is missing are dropped, as they are unreachable.
+	// Terms whose parent is missing are unreachable, so they are dropped.
 	const tree = [];
 	for ( const term of flatTermsWithParentAndChildren ) {
 		const parent = termsById[ term.parent ];


### PR DESCRIPTION
## What
PR tries to speed up the Categories panel on sites with thousands of terms. With 5,000 categories, ticking a checkbox blocked the main thread for about 157ms.

## How

~~Each row now uses content-visibility, so the browser skips layout for rows that are off-screen.~~ This was dropped fro this branch and will try to handled separately.

Alongside that, in the same component:

- `buildTermsTree` builds the tree in a single pass instead of cloning it twice
- `sortBySelected` partitions the list instead of sorting with a comparator that rewalks each subtree on every comparison
- each checkbox is memoized on primitive props, so ticking one term does not rerender the rest

## Testing Instructions
1. Create test data - `wp term generate category --count=5000 --max_depth=3`.
2. Open a post.
3. Try interacting with the Categories panel.
4. Selection and filtering should feel faster.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/b99f54a2-97f9-4efc-afcb-739663899904

**After**

https://github.com/user-attachments/assets/2912d37c-5b18-4f9e-875d-1bd9db6f824b

## Use of AI Tools

Assisted by Claude.