### PR TITLE
DataViews:  Fix `array` field type validation for empty values

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,7 +20,7 @@
 -   DataViews: Pass only the eligible items to a bulk action's `callback`. A bulk action is offered when any one selected item is eligible for it, so the callback could run against items it had declared, through `isEligible`, that it could not handle. [#81198](https://github.com/WordPress/gutenberg/pull/81198)
 -   DataViews: Fix the `between` date filter discarding a manually entered `From`/`To` date on blur. The control now commits an incomplete range with an unfilled bound — which neither filters nor renders a chip — instead of waiting for both dates, so a typed date survives tabbing away and a range can be entered manually at all. [#81150](https://github.com/WordPress/gutenberg/pull/81150)
 -   DataViews: Render the filter chip for an incomplete `between` range as if no value were set — matching how the filter itself does not apply — instead of showing a dangling bound or the literal string "undefined". A `null` bound, produced when an unfilled bound round-trips through JSON persistence, is now treated as unfilled too. [#80830](https://github.com/WordPress/gutenberg/pull/80830)
--   DataViews: Treat an empty value as valid in the `array` field type's built-in validation, matching the other field types — use the `required` rule to enforce non-empty values. [#](https://github.com/WordPress/gutenberg/pull/)
+-   DataViews: Treat an empty value as valid in the `array` field type's built-in validation, matching the other field types — use the `required` rule to enforce non-empty values. [#81378](https://github.com/WordPress/gutenberg/pull/81378)
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,7 +20,7 @@
 -   DataViews: Pass only the eligible items to a bulk action's `callback`. A bulk action is offered when any one selected item is eligible for it, so the callback could run against items it had declared, through `isEligible`, that it could not handle. [#81198](https://github.com/WordPress/gutenberg/pull/81198)
 -   DataViews: Fix the `between` date filter discarding a manually entered `From`/`To` date on blur. The control now commits an incomplete range with an unfilled bound — which neither filters nor renders a chip — instead of waiting for both dates, so a typed date survives tabbing away and a range can be entered manually at all. [#81150](https://github.com/WordPress/gutenberg/pull/81150)
 -   DataViews: Render the filter chip for an incomplete `between` range as if no value were set — matching how the filter itself does not apply — instead of showing a dangling bound or the literal string "undefined". A `null` bound, produced when an unfilled bound round-trips through JSON persistence, is now treated as unfilled too. [#80830](https://github.com/WordPress/gutenberg/pull/80830)
--   DataViews: Treat an empty value as valid in the `array` field type's built-in validation, matching the other field types — use the `required` rule to enforce non-empty values. [#81378](https://github.com/WordPress/gutenberg/pull/81378)
+-   DataViews: Treat an empty value as valid in the `array` field type's built-in validation, matching the other field types — use the `required` rule to enforce non-empty values. Fields declaring `elements` still reject empty values. [#81378](https://github.com/WordPress/gutenberg/pull/81378)
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   DataViews: Pass only the eligible items to a bulk action's `callback`. A bulk action is offered when any one selected item is eligible for it, so the callback could run against items it had declared, through `isEligible`, that it could not handle. [#81198](https://github.com/WordPress/gutenberg/pull/81198)
 -   DataViews: Fix the `between` date filter discarding a manually entered `From`/`To` date on blur. The control now commits an incomplete range with an unfilled bound — which neither filters nor renders a chip — instead of waiting for both dates, so a typed date survives tabbing away and a range can be entered manually at all. [#81150](https://github.com/WordPress/gutenberg/pull/81150)
 -   DataViews: Render the filter chip for an incomplete `between` range as if no value were set — matching how the filter itself does not apply — instead of showing a dangling bound or the literal string "undefined". A `null` bound, produced when an unfilled bound round-trips through JSON persistence, is now treated as unfilled too. [#80830](https://github.com/WordPress/gutenberg/pull/80830)
+-   DataViews: Treat an empty value as valid in the `array` field type's built-in validation, matching the other field types — use the `required` rule to enforce non-empty values. [#](https://github.com/WordPress/gutenberg/pull/)
 
 ### Internal
 

--- a/packages/dataviews/src/field-types/array.tsx
+++ b/packages/dataviews/src/field-types/array.tsx
@@ -33,10 +33,12 @@ function render( { item, field }: DataViewRenderFieldProps< any > ) {
 function isValidCustom< Item >( item: Item, field: NormalizedField< Item > ) {
 	const value = field.getValue( { item } );
 
-	if (
-		! [ undefined, '', null ].includes( value ) &&
-		! Array.isArray( value )
-	) {
+	// Allow empty values; use the `required` rule to enforce non-empty ones.
+	if ( [ undefined, '', null ].includes( value ) ) {
+		return null;
+	}
+
+	if ( ! Array.isArray( value ) ) {
 		return __( 'Value must be an array.' );
 	}
 

--- a/packages/dataviews/src/hooks/test/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.ts
@@ -2263,6 +2263,47 @@ describe( 'useFormValidity', () => {
 			expect( isValid ).toBe( false );
 		} );
 
+		it( 'array is valid if value is empty', () => {
+			const item = { id: 1, tags: undefined };
+			const fields: Field< {} >[] = [
+				{
+					id: 'tags',
+					type: 'array',
+				},
+			];
+			const form = { fields: [ 'tags' ] };
+			const {
+				result: {
+					current: { validity, isValid },
+				},
+			} = renderHook( () => useFormValidity( item, fields, form ) );
+			expect( validity ).toEqual( undefined );
+			expect( isValid ).toBe( true );
+		} );
+
+		it( 'array is invalid if values are not strings when not empty', () => {
+			const item = { id: 1, tags: [ 'valid', 42 ] };
+			const fields: Field< {} >[] = [
+				{
+					id: 'tags',
+					type: 'array',
+				},
+			];
+			const form = { fields: [ 'tags' ] };
+			const {
+				result: {
+					current: { validity, isValid },
+				},
+			} = renderHook( () => useFormValidity( item, fields, form ) );
+			expect( validity?.tags ).toEqual( {
+				custom: {
+					type: 'invalid',
+					message: 'Every value must be a string.',
+				},
+			} );
+			expect( isValid ).toBe( false );
+		} );
+
 		it( 'should return early on custom sync validation failure', async () => {
 			const item = { status: 'draft' };
 			const fields: Field< any >[] = [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Extracted from https://github.com/WordPress/gutenberg/pull/81377

The built-in validation of the `array` field type crashed on empty values (`undefined`, `''`, `null`) and the exception surfaced as a validation error, making forms with an empty optional array field invalid. This was also inconsistent with the other field types, whose built-in validation lets empty values pass. This PR allows empty values — non-empty values should be enforced with the `required` rule instead.

Note: as pointed out in [review](https://github.com/WordPress/gutenberg/pull/81378#pullrequestreview-4898066609), this doesn't cover fields that declare `elements` — the `elements` rule is enabled by default and `isValidElements` does `[].concat( value )`, so an empty value still fails as `[ undefined ]`. That behavior predates this PR and is shared by all field types, so I'd rather handle it in a follow-up. This fix applies to array fields without `elements` (or with `isValid.elements: false`).

## Testing Instructions

There are unit tests for both the empty (valid) and the non-string values (invalid) cases. You can also test in the validation story, where the `Array` field is empty on load, by disabling the other fields' validation: http://localhost:50240/?path=/story/dataviews-dataform--validation&args=required:!false;elements:none;custom:none

1. `npm run storybook:dev` and open the above link.
2. In trunk the `Submit` button is disabled on load. With this PR it's enabled.

### Use of AI Tools
Generated with Fable 5 and adjusted/reviewed manually.
