### PR TITLE
ESLint Plugin: Fix `no-unused-vars-before-return` advising a change that breaks code

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   The `no-unused-vars-before-return` rule no longer reports variables assigned from a method which mutates the object it is called on (`push`, `pop`, `shift`, `unshift`, `splice`, `sort`, `reverse`), since following its advice would move the mutation past the return and change behavior. ([#71568](https://github.com/WordPress/gutenberg/issues/71568))
+
 ### Enhancements
 
 -   The `dependency-group` rule's `"never"` mode now recognizes dependency comments regardless of capitalization or a trailing period while preserving other comments. ([#81246](https://github.com/WordPress/gutenberg/pull/81246))

--- a/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
@@ -30,6 +30,21 @@ function example( number ) {
 }
 ```
 
+Variables assigned from a method which mutates the object it is called on (`push`, `pop`, `shift`, `unshift`, `splice`, `sort`, `reverse`) are never reported, since deferring the assignment would also defer the mutation and change behavior:
+
+```js
+function example( queue ) {
+	// Not reported: moving this past the return would also move the mutation
+	// of `queue`, so `queue.length` below would be evaluated differently.
+	const next = queue.shift();
+	if ( ! queue.length ) {
+		return null;
+	}
+
+	return next;
+}
+```
+
 ## Options
 
 This rule accepts a single options argument:

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -50,6 +50,39 @@ function example() {
 		},
 		{
 			code: `
+function example( queue ) {
+	const next = queue.shift();
+	if ( ! queue.length ) {
+		return null;
+	}
+
+	return next;
+}`,
+		},
+		{
+			code: `
+function example( queue ) {
+	const next = queue[ 'shift' ]();
+	if ( ! queue.length ) {
+		return null;
+	}
+
+	return next;
+}`,
+		},
+		{
+			code: `
+function example( items ) {
+	const sorted = items.sort();
+	if ( ! items.length ) {
+		return null;
+	}
+
+	return sorted;
+}`,
+		},
+		{
+			code: `
 function MyComponent() {
 	const Foo = getSomeComponent();
 	return <Foo />;
@@ -121,6 +154,23 @@ function example() {
 	return number + foo + bar;
 }`,
 			options: [ { excludePattern: '^do' } ],
+			errors: [
+				{
+					message:
+						'Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused.',
+				},
+			],
+		},
+		{
+			code: `
+function example( items ) {
+	const foo = items.map( doSomeCostlyOperation );
+	if ( ! items.length ) {
+		return null;
+	}
+
+	return foo;
+}`,
 			errors: [
 				{
 					message:

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -11,6 +11,23 @@
 const FUNCTION_SCOPE_JSX_IDENTIFIERS = new WeakMap();
 
 /**
+ * Set of method names which mutate the object they are called on. A variable
+ * assigned from one of these cannot be safely moved past an early return,
+ * since doing so would also move the mutation and change behavior.
+ *
+ * @type {Set<string>}
+ */
+const MUTATING_METHODS = new Set( [
+	'push',
+	'pop',
+	'shift',
+	'unshift',
+	'splice',
+	'sort',
+	'reverse',
+] );
+
+/**
  * Returns the closest function scope for the given node, or undefined if it
  * cannot be determined.
  *
@@ -68,6 +85,31 @@ module.exports = /** @type {import('eslint').Rule} */ ( {
 			);
 		}
 
+		/**
+		 * Given an Espree CallExpression node, returns true if the call mutates
+		 * the object it is called on, or false otherwise. Such a call cannot be
+		 * deferred past a return statement without altering behavior, since the
+		 * mutation would be deferred along with it.
+		 *
+		 * @param {Object} node Node to test.
+		 *
+		 * @return {boolean} Whether the call mutates its callee object.
+		 */
+		function isMutatingMethodCall( node ) {
+			const { callee } = node;
+
+			if ( callee.type !== 'MemberExpression' ) {
+				return false;
+			}
+
+			// Account for both `foo.shift()` and `foo[ 'shift' ]()`.
+			const name = callee.computed
+				? callee.property.value
+				: callee.property.name;
+
+			return MUTATING_METHODS.has( name );
+		}
+
 		return {
 			JSXIdentifier( node ) {
 				// Currently, a scope's variable references does not include JSX
@@ -104,6 +146,10 @@ module.exports = /** @type {import('eslint').Rule} */ ( {
 							def.node.init.type === 'CallExpression' &&
 							// Allow unused if part of an object destructuring.
 							! isExemptObjectDestructureDeclarator( def.node ) &&
+							// Allow calls which mutate the object they are
+							// called on, since deferring the assignment would
+							// also defer the mutation.
+							! isMutatingMethodCall( def.node.init ) &&
 							// Only target assignments preceding `return`.
 							def.node.range[ 1 ] < node.range[ 1 ]
 						);


### PR DESCRIPTION
## What?
Closes #71568

Exempts variables assigned from mutating methods from the `no-unused-vars-before-return` ESLint rule.

## Why?

The rule currently reports code like this:

```js
function example( queue ) {
      const next = queue.shift();
      if ( ! queue.length ) {
              return null;
      }

      return next;
}
```
`next` is only referenced after the early return, so the rule asks you to move the assignment below it. Doing so is a behavior change, not a refactor: `shift()` mutates queue in place, so moving the call also moves the mutation, and `queue.length` in the condition is then evaluated against a different array. The rule's advice silently breaks the code.

The rule's candidate filter treated every CallExpression as an equally deferrable "expensive" operation, with no notion of side effects.

The excludePattern option is not a usable workaround here, for two separate reasons. It is opt-in, so every consumer hits the bad advice by default; and it is also currently unable to match method calls at all. That second problem is a distinct defect that I'm filing and fixing separately, to keep this PR to one conceptual change.

## How?
Adds a `MUTATING_METHODS` set (`push`, `pop`, `shift`, `unshift`, `splice`, `sort`, `reverse` — the list from the issue) and an `isMutatingMethodCall()` helper, wired into the existing declarator filter alongside the object-destructuring exemption. Both dot access (`queue.shift()`) and computed access (`queue[ 'shift' ]()`) are handled.

## Testing Instructions

No WordPress install needed.

1. npm run test:unit packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js — 12 tests pass.
2. To confirm it fixes the report, git stash the change to rules/no-unused-vars-before-return.js and re-run: the three new valid cases (`queue.shift()`, `queue[ 'shift' ]()`, `items.sort()`) fail with "Variables should not be assigned until just prior its first reference."
3. A new invalid case (items.map( … )) asserts non-mutating method calls are still reported, so the exemption isn't over-broad.

### Testing Instructions for Keyboard
N/A — lint rule, no UI.

## Screenshots or screencast
N/A — lint rule, no UI.

## Use of AI Tools

Assisted by Opus 5.
