### PR TITLE
Block Mover: Add the keyboard shortcut to the buttons' spoken description

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -5,8 +5,8 @@ import { VisuallyHidden } from '@wordpress/ui';
 import { useInstanceId, useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef, useMemo } from '@wordpress/element';
-import { __, isRTL } from '@wordpress/i18n';
-import { displayShortcut } from '@wordpress/keycodes';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 import {
 	chevronLeft,
 	chevronRight,
@@ -115,6 +115,7 @@ const BlockMoverButton = forwardRef(
 		};
 
 		const descriptionId = `block-editor-block-mover-button__description-${ instanceId }`;
+		const keyCharacter = direction === 'up' ? 't' : 'y';
 
 		return (
 			<>
@@ -142,21 +143,22 @@ const BlockMoverButton = forwardRef(
 					onClick={ isDisabled ? null : onClick }
 					disabled={ isDisabled }
 					accessibleWhenDisabled
-					shortcut={
-						direction === 'up'
-							? displayShortcut.secondary( 't' )
-							: displayShortcut.secondary( 'y' )
-					}
+					shortcut={ displayShortcut.secondary( keyCharacter ) }
 				/>
 				<VisuallyHidden id={ descriptionId }>
-					{ getBlockMoverDescription(
-						blocksCount,
-						blockType && blockType.title,
-						firstIndex,
-						isFirst,
-						isLast,
-						direction === 'up' ? -1 : 1,
-						orientation
+					{ sprintf(
+						// translators: 1: Description of the block movement. 2: Keyboard shortcut.
+						__( '%1$s (%2$s)' ),
+						getBlockMoverDescription(
+							blocksCount,
+							blockType && blockType.title,
+							firstIndex,
+							isFirst,
+							isLast,
+							direction === 'up' ? -1 : 1,
+							orientation
+						),
+						shortcutAriaLabel.secondary( keyCharacter )
 					) }
 				</VisuallyHidden>
 			</>


### PR DESCRIPTION

## What?

Resolves: https://github.com/WordPress/gutenberg/issues/51647

For a11y reasons it was [suggested](https://github.com/WordPress/gutenberg/issues/51647#issuecomment-5219970223) to also add the shortcut to the block mover's spoken description.

This PR does that.   

I didn't wrap the tooltip shortcut in parentheses as also suggested in the comment, because I didn't find any other tooltip shortcut in the editor that uses them. I think this should be discussed separately if needed and is not limited to the block mover tooltip.

## Testing Instructions
1. Select a block focus the `Move up` or `Move down` button in the block toolbar with a screen reader (e.g. VoiceOver).
2. The description should now end with the shortcut, e.g. "Move Paragraph block from position 2 up to position 1 (Shift + Option + Command + T)".

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8113002c-db1f-44f1-bb49-9a6b06ee182d


## Use of AI Tools
Generated with Fable 5 and adjusted/reviewed manually.