### PR TITLE
Dashboard Widgets: split action icons into wire and resolved forms

### DIFF
--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Internal
 
+-   Widget actions menu: render the action icon directly; the widget types
+    contract guarantees a renderable element ([#81381](https://github.com/WordPress/gutenberg/pull/81381)).
 -   Remove obsolete dependency grouping comments as part of the repository-wide separator-free import migration. ([#81248](https://github.com/WordPress/gutenberg/pull/81248))
 
 ## 0.4.0 (2026-07-29)

--- a/packages/widget-dashboard/src/components/widget-actions/widget-actions.tsx
+++ b/packages/widget-dashboard/src/components/widget-actions/widget-actions.tsx
@@ -1,5 +1,4 @@
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/use-recommended-components
@@ -60,7 +59,7 @@ export function WidgetActions( {
 							<Menu.Item
 								key={ action.id }
 								prefix={
-									isValidElement( action.icon ) ? (
+									action.icon ? (
 										<Icon icon={ action.icon } />
 									) : undefined
 								}

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -13,6 +13,12 @@
     `WidgetType.icon` always reaches hosts renderable
     ([#80969](https://github.com/WordPress/gutenberg/pull/80969)).
 
+### Enhancements
+
+-   Name the two forms of an action icon: `WidgetActionRecord` carries the
+    registered icon name on the wire, and `WidgetAction.icon` narrows to the
+    rendered element hosts receive ([#81381](https://github.com/WordPress/gutenberg/pull/81381)).
+
 ### Documentation
 
 -   Simplify the actions doc: the accepted `href` forms in one statement and

--- a/packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
+++ b/packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
@@ -30,6 +30,14 @@ jest.mock(
 				},
 				{ id: 'label', label: 'Label', type: 'text' },
 			],
+			actions: [
+				{
+					id: 'module-action',
+					label: 'Module action',
+					href: 'https://example.com/module',
+					icon: mockModuleIcon,
+				},
+			],
 		},
 	} ),
 	{ virtual: true }
@@ -42,6 +50,14 @@ jest.mock(
 		default: {
 			title: 'String icon',
 			icon: 'wordpress',
+			actions: [
+				{
+					id: 'module-docs',
+					label: 'Docs',
+					href: 'https://example.com/docs',
+					icon: 'wordpress',
+				},
+			],
 		},
 	} ),
 	{ virtual: true }
@@ -212,7 +228,7 @@ describe( 'useWidgetTypes', () => {
 		);
 	} );
 
-	it( 'clears an action icon reference that does not resolve', async () => {
+	it( 'leaves an action without an icon when the reference does not resolve', async () => {
 		const { result } = renderHook( () =>
 			useWidgetTypes( actionIconRecords )
 		);
@@ -223,5 +239,46 @@ describe( 'useWidgetTypes', () => {
 				result.current[ 0 ][ 0 ].actions?.[ 0 ].icon
 			).toBeUndefined()
 		);
+	} );
+
+	it( 'emits record actions without their icon while the reference resolves', async () => {
+		registerIconResolver(
+			() => new Promise< WidgetIcon | null >( () => {} )
+		);
+
+		const { result } = renderHook( () =>
+			useWidgetTypes( actionIconRecords )
+		);
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+
+		expect( result.current[ 0 ][ 0 ].actions?.[ 0 ] ).toMatchObject( {
+			id: 'report',
+			relevance: 'high',
+		} );
+		expect( result.current[ 0 ][ 0 ].actions?.[ 0 ].icon ).toBeUndefined();
+	} );
+
+	it( "keeps a module action's element icon", async () => {
+		const { result } = renderHook( () => useWidgetTypes( records ) );
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+
+		expect( result.current[ 0 ][ 0 ].actions?.[ 0 ].icon ).toBe(
+			mockModuleIcon
+		);
+	} );
+
+	it( 'drops a module action icon that is not an element', async () => {
+		const { result } = renderHook( () =>
+			useWidgetTypes( stringIconRecords )
+		);
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+
+		expect( result.current[ 0 ][ 0 ].actions?.[ 0 ] ).toMatchObject( {
+			id: 'module-docs',
+		} );
+		expect( result.current[ 0 ][ 0 ].actions?.[ 0 ].icon ).toBeUndefined();
 	} );
 } );

--- a/packages/widget-primitives/src/hooks/use-widget-types.ts
+++ b/packages/widget-primitives/src/hooks/use-widget-types.ts
@@ -7,6 +7,8 @@ import {
 import { resolveFields } from '../field-types';
 import { resolveIcon } from '../icon-resolver';
 import type {
+	WidgetAction,
+	WidgetActionRecord,
 	WidgetIcon,
 	WidgetModuleRecord,
 	WidgetName,
@@ -20,6 +22,21 @@ import type {
 const pendingIcon: WidgetIcon = createElement( 'svg', {
 	viewBox: '0 0 24 24',
 } );
+
+/**
+ * Emitted actions carry only renderable icons: a wire reference resolves
+ * after the gate and patches in; anything else non-renderable drops.
+ *
+ * @param actions Declared actions, from the record or the module.
+ */
+function withRenderableIcons(
+	actions: ( WidgetAction | WidgetActionRecord )[]
+): WidgetAction[] {
+	return actions.map( ( { icon, ...action } ) => ( {
+		...action,
+		...( isValidElement( icon ) ? { icon: icon as WidgetIcon } : {} ),
+	} ) );
+}
 
 /* `true` while records or their metadata imports are still resolving; hosts
    must not treat a widget instance as missing until it is `false`. */
@@ -89,6 +106,8 @@ export function useWidgetTypes(
 					const icon =
 						moduleIcon ?? ( record.icon ? pendingIcon : undefined );
 
+					const actions = record.actions ?? metadata.actions;
+
 					return {
 						...metadata,
 						...( metadata.attributes
@@ -121,8 +140,8 @@ export function useWidgetTypes(
 						...( record.keywords
 							? { keywords: record.keywords }
 							: {} ),
-						...( record.actions
-							? { actions: record.actions }
+						...( actions
+							? { actions: withRenderableIcons( actions ) }
 							: {} ),
 					} as WidgetType;
 				} catch {
@@ -173,37 +192,32 @@ export function useWidgetTypes(
 			}
 
 			/*
-			 * Each action icon reference resolves off the gate and patches
-			 * into the emitted type; an unresolvable reference clears, so
-			 * hosts only render elements.
+			 * Each record action's icon reference resolves off the gate
+			 * and patches into the emitted action; an unresolvable
+			 * reference leaves the action without an icon.
 			 */
-			for ( const widgetType of results ) {
-				for ( const action of widgetType?.actions ?? [] ) {
+			for ( const record of records ) {
+				for ( const action of record.actions ?? [] ) {
 					if ( typeof action.icon !== 'string' ) {
 						continue;
 					}
 
-					const reference = action.icon;
-					void resolveIcon( reference ).then( ( resolved ) => {
-						if ( cancelled ) {
+					void resolveIcon( action.icon ).then( ( resolved ) => {
+						if ( cancelled || ! resolved ) {
 							return;
 						}
 
 						setWidgetTypes( ( prev ) =>
 							prev.map( ( type ) => {
-								if ( type.name !== widgetType?.name ) {
+								if ( type.name !== record.name ) {
 									return type;
 								}
 
 								return {
 									...type,
 									actions: type.actions?.map( ( entry ) =>
-										entry.id === action.id &&
-										entry.icon === reference
-											? {
-													...entry,
-													icon: resolved ?? undefined,
-											  }
+										entry.id === action.id
+											? { ...entry, icon: resolved }
 											: entry
 									),
 								};

--- a/packages/widget-primitives/src/index.ts
+++ b/packages/widget-primitives/src/index.ts
@@ -28,6 +28,7 @@ export type {
 	WidgetRelevance,
 	WidgetType,
 	WidgetAction,
+	WidgetActionRecord,
 	WidgetAttributeField,
 	WidgetRenderProps,
 	ResolveWidgetModule,

--- a/packages/widget-primitives/src/types.ts
+++ b/packages/widget-primitives/src/types.ts
@@ -91,12 +91,12 @@ export interface WidgetAction {
 	label: string;
 
 	/**
-	 * Icon for the action. Declared as a registered icon name
-	 * (`collection/icon-name`); `useWidgetTypes` resolves references, so
-	 * hosts receive a renderable element, or nothing when the reference
-	 * does not resolve.
+	 * Icon for the action, a rendered element. On the wire an action
+	 * declares a registered icon name instead (`WidgetActionRecord`);
+	 * `useWidgetTypes` resolves it, so hosts only receive renderable
+	 * elements.
 	 */
-	icon?: WidgetIconReference | WidgetIcon;
+	icon?: WidgetIcon;
 
 	/**
 	 * How relevant the action is among the widget's actions. Hosts may
@@ -121,6 +121,18 @@ export interface WidgetAction {
 	 * Link only. Whether the destination opens in a new browser tab.
 	 */
 	openInNewTab?: boolean;
+}
+
+/**
+ * Wire form of a `WidgetAction`, as carried by a `WidgetModuleRecord`:
+ * the same envelope and fulfillment, with `icon` as a registered icon
+ * name rather than a rendered element.
+ */
+export interface WidgetActionRecord extends Omit< WidgetAction, 'icon' > {
+	/**
+	 * Registered icon name (`collection/icon-name`); never an element.
+	 */
+	icon?: WidgetIconReference;
 }
 
 /**
@@ -312,7 +324,6 @@ type WidgetModuleRecordOverrides = {
 		| 'category'
 		| 'presentation'
 		| 'keywords'
-		| 'actions'
 	> ]?: WidgetTypeMetadata[ K ] | null;
 };
 
@@ -342,4 +353,10 @@ export interface WidgetModuleRecord extends WidgetModuleRecordOverrides {
 	 * `null`/absent means the module's icon stands.
 	 */
 	icon?: WidgetIconReference | null;
+
+	/**
+	 * Declarative actions in wire form, icons as registered icon names.
+	 * `null`/absent means the module's actions stand.
+	 */
+	actions?: WidgetActionRecord[] | null;
 }


### PR DESCRIPTION
## What

`WidgetAction.icon` narrows to the rendered element (`WidgetIcon`). The wire form gets its own name: `WidgetActionRecord`, the same envelope and fulfillment with `icon` as a registered icon name, carried by `WidgetModuleRecord.actions`.

`useWidgetTypes` is the single boundary between the two forms: emitted actions only carry renderable icons. A record action's reference resolves off the loading gate and patches into the emitted action; an unresolvable reference leaves the action without an icon.

A module-declared action now behaves like the module's own `icon`: only a rendered element enters, and anything else drops. A reference belongs in `widget.json`.

The wire itself is untouched: no `widget.json`, wp-build, PHP, or REST changes.

Follow-up to #81275, from [this review suggestion](https://github.com/WordPress/gutenberg/pull/81275#discussion_r3746468651).

## Why

`icon` was `WidgetIconReference | WidgetIcon`, so every host had to check which form it received, and the union reflected a transient state: the emitted type held the reference until resolution patched it.

Naming the forms separately encodes the boundary in the types and matches the widget type icon, where `WidgetModuleRecord.icon` is a reference and `WidgetTypeMetadata.icon` is an element.

## How

- `WidgetActionRecord` extends `Omit< WidgetAction, 'icon' >` with `icon?: WidgetIconReference`; `WidgetModuleRecord` carries `actions?: WidgetActionRecord[] | null`, and the record overrides map no longer includes `actions`.
- `useWidgetTypes` strips non-renderable icons when emitting actions, then resolves each record action's reference off the gate and patches the element in by action `id`.
- The dashboard "More" menu renders `action.icon` directly; the runtime `isValidElement` check is gone because the type guarantees an element.

## Testing

```
npx jest --config test/unit/jest.config.js packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
```

1. Enable the Dashboard Widgets experiment, build, and open the dashboard: Hello Dolly's "More" menu still shows the external-link icon, and Site Health's menu shows Status and Info with their icons.
2. Check `/wp/v2/widget-modules`: action `icon` values are still registered icon names; the endpoint output is identical to trunk.
