### PR TITLE
Scripts: Prevent a UTF-8 BOM in the middle of extracted CSS

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Set Sass's `charset` option to `false` so production builds no longer emit a UTF-8 BOM in the middle of the extracted CSS ([#81382](https://github.com/WordPress/gutenberg/issues/81382)).
+-   Set Sass's `charset` option to `false` so production builds no longer emit a UTF-8 BOM in the middle of the extracted CSS ([#81383](https://github.com/WordPress/gutenberg/pull/81383)).
 
 ## 34.0.0 (2026-07-29)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Set Sass's `charset` option to `false` so production builds no longer emit a UTF-8 BOM in the middle of the extracted CSS ([#81382](https://github.com/WordPress/gutenberg/issues/81382)).
 
 ## 34.0.0 (2026-07-29)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -202,6 +202,9 @@ const baseConfig = {
 						loader: require.resolve( 'sass-loader' ),
 						options: {
 							sourceMap: ! isProduction,
+							sassOptions: {
+								charset: false,
+							},
 						},
 					},
 				],


### PR DESCRIPTION
## What?

Closes #81382

## Why / How ?

See #81382 for the full cause chain and the alternatives considered. 

Short version: `sass-loader` compiles production builds `compressed`, so Sass prepends U+FEFF to every module containing non-ASCII characters; since postcss 8.5.24 that BOM survives and `MiniCSSExtractPlugin` concatenation leaves it mid-file, where it silently kills the next rule. 

Sass documents `charset: false` as the correct setting when output is concatenated - output stays UTF-8.

## Testing Instructions

```bash
mkdir wp-scripts-bom && cd wp-scripts-bom
npm init -y && npm i -D @wordpress/scripts
mkdir src
printf "import './a.css';\nimport './b.scss';\n" > src/index.js
printf '.first { color: red; }\n' > src/a.css
printf ':root { --brand: #037d96; }\n.quote::before { content: "\xe2\x80\x9c"; }\n' > src/b.scss
npx wp-scripts build
grep -oba $'\xef\xbb\xbf' build/index.css
```

- **trunk:** prints `18:` — `.first{color:red}\n<BOM>:root{…}`, so `--brand` is unreachable.
- **this PR:** no output, non-ASCII `content` value preserved.

Alternative fixes considered:

- webpack/css-loader#1679 strips the BOM before postcss. It targets css-loader 7.x while `@wordpress/scripts` pins `css-loader@^6.2.0`, so it would not reach wp-scripts users without a backport.
- https://github.com/postcss/postcss/pull/2119#issuecomment-5189995599 postcss will not revert — the maintainer's position is that a BOM belongs only at the start of a file and that concatenating tools are responsible for removing it.
- https://github.com/vercel/next.js/issues/96374  is the same fallout in another build tool (NextJS), fixed on their side.
