### PR TITLE
Try: Set post navigation link icon to next.

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { next as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
@@ -9,6 +10,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
+	icon,
 	edit,
 	variations,
 	deprecated,


### PR DESCRIPTION
## What?

Closes #49630. The Post Navigation Link block exists only for usage in Global Styles, in templates you'd use Next Post and Previous Post blocks instead, which are variations of the same. 

This PR simply sets the icon for this block to "next", to give some recognisability between the two contexts.

Before:

<img width="402" height="384" alt="image" src="https://github.com/user-attachments/assets/18125cf5-875e-4c30-b1d8-7d360a438bf1" />

After:

<img width="401" height="329" alt="image" src="https://github.com/user-attachments/assets/2f24c7c2-f635-4cf9-b353-d281de8f551a" />

Inserter for context:

<img width="349" height="480" alt="image" src="https://github.com/user-attachments/assets/bc564fb9-9f24-46da-9325-86c3f46d889d" />

## Why?

This is the simplest possible solution, and avoids adding new icons that may not have broad value.

## Testing Instructions

Open Global Styles > Blocks, search for "Post Navigation Link", observe the double chevron icon instead of the LEGO brick.

## Use of AI Tools

No.