### PR TITLE
Playlist: Convert multiple tracks to Audio blocks

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
+-   Playlist: Allow Playlist blocks with multiple tracks to transform into multiple Audio blocks.
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))
 -   Page List: Rename the "Edit" action to "Detach", and confirm it in a dialog explaining that the list will keep its current pages but stop adding new ones automatically, matching the Gallery block ([#80847](https://github.com/WordPress/gutenberg/pull/80847)).

--- a/packages/block-library/src/playlist/test/transforms.js
+++ b/packages/block-library/src/playlist/test/transforms.js
@@ -170,15 +170,62 @@ describe( 'Playlist transforms', () => {
 		);
 	} );
 
-	it( 'does not offer Playlist to Audio for multiple tracks', () => {
-		const playlist = createBlock( 'core/playlist', {}, [
-			createBlock( 'core/playlist-track', {
+	it( 'converts a multi-track Playlist into multiple Audio blocks', () => {
+		const playlist = createBlock(
+			'core/playlist',
+			{
+				align: 'wide',
+				anchor: 'my-playlist',
+				caption: 'A playlist caption',
+				style: { spacing: { margin: { top: '1rem' } } },
+			},
+			[
+				createBlock( 'core/playlist-track', {
+					blob: 'blob:https://example.com/first-track',
+					id: 123,
+					src: 'https://example.com/first-track.mp3',
+				} ),
+				createBlock( 'core/playlist-track', {
+					id: 456,
+					src: 'https://example.com/second-track.mp3',
+				} ),
+			]
+		);
+
+		expect( getPossibleBlockTransformations( [ playlist ] ) ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { name: 'core/audio' } ),
+			] )
+		);
+
+		const audioBlocks = switchToBlockType( playlist, 'core/audio' );
+
+		expect( audioBlocks ).toHaveLength( 2 );
+		expect( audioBlocks[ 0 ] ).toMatchObject( {
+			name: 'core/audio',
+			attributes: {
+				align: 'wide',
+				blob: 'blob:https://example.com/first-track',
+				id: 123,
 				src: 'https://example.com/first-track.mp3',
-			} ),
-			createBlock( 'core/playlist-track', {
+				style: { spacing: { margin: { top: '1rem' } } },
+			},
+		} );
+		expect( audioBlocks[ 0 ].attributes ).not.toHaveProperty( 'anchor' );
+		expect( audioBlocks[ 0 ].attributes.caption.toString() ).toBe( '' );
+		expect( audioBlocks[ 1 ] ).toMatchObject( {
+			name: 'core/audio',
+			attributes: {
+				align: 'wide',
+				id: 456,
 				src: 'https://example.com/second-track.mp3',
-			} ),
-		] );
+				style: { spacing: { margin: { top: '1rem' } } },
+			},
+		} );
+	} );
+
+	it( 'does not offer Playlist to Audio without tracks', () => {
+		const playlist = createBlock( 'core/playlist' );
 
 		expect( getPossibleBlockTransformations( [ playlist ] ) ).not.toEqual(
 			expect.arrayContaining( [

--- a/packages/block-library/src/playlist/transforms.js
+++ b/packages/block-library/src/playlist/transforms.js
@@ -27,18 +27,29 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/audio' ],
 			isMatch: ( {}, block ) =>
-				block.innerBlocks.length === 1 &&
-				block.innerBlocks[ 0 ].name === 'core/playlist-track',
-			transform: ( { style, ...attributes }, [ track ] ) =>
-				createBlock( 'core/audio', {
-					...attributes,
-					...( style?.spacing && {
-						style: { spacing: style.spacing },
-					} ),
-					blob: track.attributes.blob,
-					id: track.attributes.id,
-					src: track.attributes.src,
-				} ),
+				block.innerBlocks.length > 0 &&
+				block.innerBlocks.every(
+					( { name } ) => name === 'core/playlist-track'
+				),
+			transform: ( { style, ...attributes }, tracks ) => {
+				const { anchor, caption, ...attributesWithoutContent } =
+					attributes;
+				const hasMultipleTracks = tracks.length > 1;
+
+				return tracks.map( ( track ) =>
+					createBlock( 'core/audio', {
+						...( hasMultipleTracks
+							? attributesWithoutContent
+							: attributes ),
+						...( style?.spacing && {
+							style: { spacing: style.spacing },
+						} ),
+						blob: track.attributes.blob,
+						id: track.attributes.id,
+						src: track.attributes.src,
+					} )
+				);
+			},
 		},
 	],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/80926.

Allow Playlist blocks with multiple tracks to transform into multiple Audio blocks.

## Why?
Users can convert multiple Audio blocks into one Playlist, so they should also be able to convert a multi-track Playlist back into individual Audio blocks.

## How?
The Playlist to Audio transform now accepts any non-empty list of Playlist Track inner blocks and maps each track source into its own Audio block, while avoiding duplicated multi-block anchor and caption attributes.

## Testing Instructions
1. Add a Playlist block with multiple tracks.
2. Open the block toolbar's Transform menu and choose Audio.
3. Confirm the Playlist is replaced by one Audio block per track.

### Testing Instructions for Keyboard
Use keyboard navigation to select the Playlist block, open the block toolbar Transform menu, choose Audio, and confirm one Audio block is created per track.

## Screenshots or screencast

N/A.

## Use of AI Tools

AI tools helped implement and verify this change, with human review of the resulting diff.
