### PR TITLE
Global Styles: Drop the tablet viewport breakpoint when its base differs from mobile

### DIFF
--- a/backport-changelog/7.1/12948.md
+++ b/backport-changelog/7.1/12948.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/12948
+
+* https://github.com/WordPress/gutenberg/pull/81388

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -760,6 +760,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * uses a single max-width media query. When `tablet` is not larger than
 	 * `mobile`, it is removed.
 	 *
+	 * `tablet` is also removed when the two breakpoints are measured against
+	 * different bases, since their order cannot be determined.
+	 *
 	 * @since 7.1.0
 	 *
 	 * @param mixed $viewport_settings Viewport settings from theme.json.
@@ -778,6 +781,7 @@ class WP_Theme_JSON_Gutenberg {
 				$breakpoints[ $breakpoint ] = array(
 					'value' => trim( $value ),
 					'px'    => $px,
+					'is_px' => str_ends_with( trim( $value ), 'px' ),
 				);
 			}
 		}
@@ -793,7 +797,10 @@ class WP_Theme_JSON_Gutenberg {
 
 		$sanitized = array( 'mobile' => $breakpoints['mobile']['value'] );
 
-		if ( isset( $breakpoints['tablet'] ) && $breakpoints['mobile']['px'] < $breakpoints['tablet']['px']
+		if (
+			isset( $breakpoints['tablet'] )
+			&& $breakpoints['mobile']['is_px'] === $breakpoints['tablet']['is_px']
+			&& $breakpoints['mobile']['px'] < $breakpoints['tablet']['px']
 		) {
 			$sanitized['tablet'] = $breakpoints['tablet']['value'];
 		}

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Render block element styles defined only inside responsive viewport states.
+-   Drop the tablet viewport breakpoint when it is measured against a different base than mobile (e.g. `30em` and `500px`), since their order cannot be determined in a media query.
 
 ## 1.19.0 (2026-07-29)
 

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   Render block element styles defined only inside responsive viewport states.
--   Drop the tablet viewport breakpoint when it is measured against a different base than mobile (e.g. `30em` and `500px`), since their order cannot be determined in a media query.
+-   Drop the tablet viewport breakpoint when it is measured against a different base than mobile (e.g. `30em` and `500px`), since their order cannot be determined in a media query ([#81388](https://github.com/WordPress/gutenberg/pull/81388)).
 
 ## 1.19.0 (2026-07-29)
 

--- a/packages/global-styles-engine/src/test/viewport-utils.test.ts
+++ b/packages/global-styles-engine/src/test/viewport-utils.test.ts
@@ -102,6 +102,52 @@ describe( 'viewport utils', () => {
 				mobile: '64rem',
 			} );
 		} );
+
+		it( 'omits tablet when mobile is font-relative and tablet is in pixels', () => {
+			expect(
+				getViewportBreakpoints( {
+					mobile: '30em',
+					tablet: '500px',
+				} )
+			).toEqual( {
+				mobile: '30em',
+			} );
+		} );
+
+		it( 'omits tablet when mobile is in pixels and tablet is font-relative', () => {
+			expect(
+				getViewportBreakpoints( {
+					mobile: '400px',
+					tablet: '30em',
+				} )
+			).toEqual( {
+				mobile: '400px',
+			} );
+		} );
+
+		it( 'keeps tablet when mobile is in em and tablet is in rem', () => {
+			expect(
+				getViewportBreakpoints( {
+					mobile: '30em',
+					tablet: '40rem',
+				} )
+			).toEqual( {
+				mobile: '30em',
+				tablet: '40rem',
+			} );
+		} );
+
+		it( 'keeps tablet when mobile is in rem and tablet is in em', () => {
+			expect(
+				getViewportBreakpoints( {
+					mobile: '30rem',
+					tablet: '40em',
+				} )
+			).toEqual( {
+				mobile: '30rem',
+				tablet: '40em',
+			} );
+		} );
 	} );
 
 	describe( 'getResponsiveMediaQueries', () => {
@@ -159,6 +205,38 @@ describe( 'viewport utils', () => {
 				} )
 			).toEqual( {
 				'@mobile': '@media (width <= 960px)',
+			} );
+		} );
+
+		it( 'omits the tablet media query when the breakpoints do not share a base', () => {
+			expect(
+				getResponsiveMediaQueries( {
+					mobile: '30em',
+					tablet: '500px',
+				} )
+			).toEqual( {
+				'@mobile': '@media (width <= 30em)',
+			} );
+
+			expect(
+				getResponsiveMediaQueries( {
+					mobile: '400px',
+					tablet: '30em',
+				} )
+			).toEqual( {
+				'@mobile': '@media (width <= 400px)',
+			} );
+		} );
+
+		it( 'returns a tablet media query when the breakpoints share a base', () => {
+			expect(
+				getResponsiveMediaQueries( {
+					mobile: '30em',
+					tablet: '40rem',
+				} )
+			).toEqual( {
+				'@mobile': '@media (width <= 30em)',
+				'@tablet': '@media (30em < width <= 40rem)',
 			} );
 		} );
 	} );

--- a/packages/global-styles-engine/src/utils/viewport.ts
+++ b/packages/global-styles-engine/src/utils/viewport.ts
@@ -82,7 +82,9 @@ export function getViewportBreakpointValueInPixels(
  * mobile breakpoint is missing, a valid tablet breakpoint remains keyed as
  * tablet so the editor can present it as a tablet breakpoint. If the tablet
  * breakpoint is missing, invalid, or not larger than the mobile breakpoint, the
- * result only includes the mobile breakpoint.
+ * result only includes the mobile breakpoint. The tablet breakpoint is also
+ * dropped when the two breakpoints are measured against different bases, since
+ * their order cannot be determined.
  *
  * @param configOrSettings Global styles config or viewport settings.
  * @return Sanitized viewport breakpoints.
@@ -95,6 +97,8 @@ export function getViewportBreakpoints(
 	const breakpointValuesInPixels: Partial<
 		Record< ViewportBreakpoint, number >
 	> = {};
+	const breakpointsInPx: Partial< Record< ViewportBreakpoint, boolean > > =
+		{};
 
 	Object.keys( DEFAULT_VIEWPORT_BREAKPOINTS ).forEach( ( breakpoint ) => {
 		const key = breakpoint as ViewportBreakpoint;
@@ -103,6 +107,7 @@ export function getViewportBreakpoints(
 		if ( px !== undefined && isValidViewportSize( value ) ) {
 			breakpoints[ key ] = value.trim();
 			breakpointValuesInPixels[ key ] = px;
+			breakpointsInPx[ key ] = value.trim().endsWith( 'px' );
 		}
 	} );
 
@@ -118,6 +123,7 @@ export function getViewportBreakpoints(
 	const mobile = breakpoints.mobile!;
 	const tablet = breakpoints.tablet!;
 	if (
+		breakpointsInPx.mobile !== breakpointsInPx.tablet ||
 		breakpointValuesInPixels.mobile! >= breakpointValuesInPixels.tablet!
 	) {
 		return { mobile };

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1250,6 +1250,110 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * A `px` breakpoint cannot be ordered against a font-relative one, so the
+	 * tablet range is dropped rather than emitted unordered.
+	 *
+	 * @dataProvider data_viewport_breakpoints_without_a_shared_base
+	 *
+	 * @param array $viewport_settings Viewport settings to sanitize.
+	 * @param array $expected          Expected media queries.
+	 */
+	public function test_get_viewport_media_queries_omits_tablet_when_breakpoints_do_not_share_a_base( $viewport_settings, $expected ) {
+		$this->assertSame(
+			$expected,
+			WP_Theme_JSON_Gutenberg::get_viewport_media_queries(
+				$viewport_settings,
+				array(
+					'include_desktop' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_viewport_breakpoints_without_a_shared_base() {
+		return array(
+			'font-relative mobile, pixel tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '30em',
+					'tablet' => '500px',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 30em)',
+					'@desktop' => '@media (width > 30em)',
+				),
+			),
+			'pixel mobile, font-relative tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '400px',
+					'tablet' => '30em',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 400px)',
+					'@desktop' => '@media (width > 400px)',
+				),
+			),
+		);
+	}
+
+	/**
+	 * `em` and `rem` resolve against the same base in a media query, so they can
+	 * be ordered against each other.
+	 *
+	 * @dataProvider data_viewport_breakpoints_with_a_shared_base
+	 *
+	 * @param array $viewport_settings Viewport settings to sanitize.
+	 * @param array $expected          Expected media queries.
+	 */
+	public function test_get_viewport_media_queries_keeps_tablet_when_breakpoints_share_a_base( $viewport_settings, $expected ) {
+		$this->assertSame(
+			$expected,
+			WP_Theme_JSON_Gutenberg::get_viewport_media_queries(
+				$viewport_settings,
+				array(
+					'include_desktop' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_viewport_breakpoints_with_a_shared_base() {
+		return array(
+			'em mobile, rem tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '30em',
+					'tablet' => '40rem',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 30em)',
+					'@tablet'  => '@media (30em < width <= 40rem)',
+					'@desktop' => '@media (width > 40rem)',
+				),
+			),
+			'rem mobile, em tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '30rem',
+					'tablet' => '40em',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 30rem)',
+					'@tablet'  => '@media (30rem < width <= 40em)',
+					'@desktop' => '@media (width > 40em)',
+				),
+			),
+		);
+	}
+
 	public function test_get_stylesheet_uses_custom_viewport_breakpoints_for_responsive_block_styles() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
## What?

- See https://core.trac.wordpress.org/ticket/65833
- Core backport PR: https://github.com/WordPress/wordpress-develop/pull/12948

Drops the `tablet` viewport breakpoint when it is measured against a different base than `mobile`, since the two cannot be ordered in a media query.

## Why?

Viewport breakpoints are ordered using values normalized at a hardcoded 16px, but the generated media queries keep the authored units. A media query resolves `em` and `rem` against the browser's initial font size rather than 16px, so the ordering proven at 16px does not transfer to the browser when the two breakpoints are measured against different bases.

## How?

`em` and `rem` share a base in a media query, so they can be ordered against each other. A `px` length and a font-relative one cannot, at any base. `tablet` is now kept only when both breakpoints are measured against the same base, and dropped in the mixed case exactly as it is already dropped when it is not larger than `mobile`.

The warning message suggested in the ticket is left as a follow-up, since it needs a translatable string: https://core.trac.wordpress.org/ticket/65841

## Testing Instructions

1. Add the following to a block theme's `theme.json`:

```json
{
	"version": 3,
	"settings": {
		"viewport": {
			"mobile": "30em",
			"tablet": "500px"
		}
	}
}
```

2. Add a paragraph, set block visibility to hide it on tablet, and view the post.
3. Before this change the page emits `@media (30em < width <= 500px)`. After it, `tablet` is not a configured breakpoint and only the mobile query is emitted. The editor's device preview no longer offers a tablet breakpoint either.
4. Change `tablet` to `40rem` and confirm both breakpoints are kept, since `em` and `rem` share a base.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Porting the change and the tests. I reviewed, tested and take responsibility for everything in this pull request.
