### PR TITLE
Media blocks: Stop other page media when playback starts

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Bug Fixes
 
 -   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing, so the block shows its placeholder rather than the block crash warning ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
+-   Media blocks: Stop other page media when Playlist, Audio, and Video blocks start playback ([#81389](https://github.com/WordPress/gutenberg/pull/81389)).
 -   Playlist: Improve handling of declarative waveform player configuration ([#81342](https://github.com/WordPress/gutenberg/pull/81342)).
 
 ### Internal

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -47,6 +47,7 @@
 		"./file/view": "./build-module/file/view.mjs",
 		"./form/view": "./build-module/form/view.mjs",
 		"./image/view": "./build-module/image/view.mjs",
+		"./media-playback": "./build-module/utils/media-playback.mjs",
 		"./navigation/view": "./build-module/navigation/view.mjs",
 		"./playlist/view": "./build-module/playlist/view.mjs",
 		"./query/view": "./build-module/query/view.mjs",

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -64,5 +64,6 @@
 		}
 	},
 	"editorStyle": "wp-block-audio-editor",
-	"style": "wp-block-audio"
+	"style": "wp-block-audio",
+	"viewScriptModule": "@wordpress/block-library/media-playback"
 }

--- a/packages/block-library/src/playlist/test/view.js
+++ b/packages/block-library/src/playlist/test/view.js
@@ -1,0 +1,86 @@
+let mockContext;
+let mockElement;
+let mockRegisteredStore;
+let mockPlayer;
+
+jest.mock( '@wordpress/interactivity', () => ( {
+	store: ( name, config ) => {
+		mockRegisteredStore = config;
+		return config;
+	},
+	getContext: () => mockContext,
+	getElement: () => mockElement,
+} ) );
+
+jest.mock( '../../utils/waveform-utils', () => ( {
+	initWaveformPlayer: jest.fn( () => mockPlayer ),
+	logPlayError: jest.fn(),
+	setupPlayButtonArtwork: jest.fn(),
+	updateSeekControlLabel: jest.fn(),
+} ) );
+
+jest.mock( '../../utils/media-playback', () => ( {
+	notifyMediaPlayback: jest.fn(),
+	registerPlaylistPlayer: jest.fn( () => jest.fn() ),
+} ) );
+
+describe( 'Playlist view script', () => {
+	beforeEach( async () => {
+		jest.resetModules();
+
+		mockContext = {
+			currentId: 'track-1',
+			isPlaying: false,
+			playlistId: 'playlist-1',
+			showPlayButtonArtwork: false,
+			tracks: [ 'track-1' ],
+		};
+		mockElement = {
+			ref: document.createElement( 'div' ),
+		};
+		mockPlayer = {
+			instance: {
+				destroy: jest.fn(),
+				isPlaying: true,
+				pause: jest.fn(),
+			},
+			container: document.createElement( 'div' ),
+			destroy: jest.fn(),
+		};
+		mockRegisteredStore = null;
+
+		await import( '../view' );
+		mockRegisteredStore.state.playlists = {
+			'playlist-1': {
+				tracks: {
+					'track-1': {
+						url: 'https://example.com/song.mp3',
+						title: 'Song title',
+						artist: 'Artist',
+					},
+				},
+			},
+		};
+	} );
+
+	afterEach( () => {
+		document.body.replaceChildren();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'notifies media playback when the current playlist starts playing', async () => {
+		const { notifyMediaPlayback, registerPlaylistPlayer } = await import(
+			'../../utils/media-playback'
+		);
+
+		mockRegisteredStore.callbacks.initWaveformPlayer();
+		mockPlayer.container.dispatchEvent(
+			new CustomEvent( 'waveformplayer:play' )
+		);
+
+		const registeredPlayer = registerPlaylistPlayer.mock.calls[ 0 ][ 0 ];
+
+		expect( mockContext.isPlaying ).toBe( true );
+		expect( notifyMediaPlayback ).toHaveBeenCalledWith( registeredPlayer );
+	} );
+} );

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -5,6 +5,10 @@ import {
 	setupPlayButtonArtwork,
 	updateSeekControlLabel,
 } from '../utils/waveform-utils';
+import {
+	notifyMediaPlayback,
+	registerPlaylistPlayer,
+} from '../utils/media-playback';
 
 /**
  * Store player state for each element.
@@ -174,28 +178,32 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 			}
 		},
 	} );
-	const setIsPlaying = ( isPlaying ) => {
-		context.isPlaying = isPlaying;
-	};
-	const onPlay = () => setIsPlaying( true );
-	const onPause = () => setIsPlaying( false );
-	player.container.addEventListener( 'waveformplayer:play', onPlay );
-	player.container.addEventListener( 'waveformplayer:pause', onPause );
-	player.container.addEventListener( 'waveformplayer:ended', onPause );
-	const destroy = () => {
-		player.container.removeEventListener( 'waveformplayer:play', onPlay );
-		player.container.removeEventListener( 'waveformplayer:pause', onPause );
-		player.container.removeEventListener( 'waveformplayer:ended', onPause );
-		player.destroy();
-	};
-
-	// Store state for cleanup, including instance for loadTrack reuse.
 	const nextState = {
 		url: track.url,
 		instance: player.instance,
 		container: player.container,
 		destroy,
 	};
+	const unregisterPlaylistPlayer = registerPlaylistPlayer( nextState );
+	const setIsPlaying = ( isPlaying ) => {
+		context.isPlaying = isPlaying;
+	};
+	const onPlay = () => {
+		setIsPlaying( true );
+		notifyMediaPlayback( nextState );
+	};
+	const onPause = () => setIsPlaying( false );
+	player.container.addEventListener( 'waveformplayer:play', onPlay );
+	player.container.addEventListener( 'waveformplayer:pause', onPause );
+	player.container.addEventListener( 'waveformplayer:ended', onPause );
+	function destroy() {
+		unregisterPlaylistPlayer?.();
+		player.container.removeEventListener( 'waveformplayer:play', onPlay );
+		player.container.removeEventListener( 'waveformplayer:pause', onPause );
+		player.container.removeEventListener( 'waveformplayer:ended', onPause );
+		player.destroy();
+	}
+
 	playerState.set( ref, nextState );
 	playlistPlayerState.set( context.playlistId, nextState );
 }

--- a/packages/block-library/src/utils/media-playback.js
+++ b/packages/block-library/src/utils/media-playback.js
@@ -1,0 +1,101 @@
+const MEDIA_PLAY_EVENT = 'wp-block-library-media-play';
+const MEDIA_SELECTOR = 'audio, video';
+const COORDINATOR_KEY = '__wpBlockLibraryMediaPlayback';
+
+function getDocument() {
+	return typeof document === 'undefined' ? undefined : document;
+}
+
+function getCoordinator() {
+	const currentWindow = getDocument()?.defaultView;
+	if ( ! currentWindow ) {
+		return;
+	}
+
+	currentWindow[ COORDINATOR_KEY ] ??= {
+		isListening: false,
+		playlistPlayers: new Set(),
+	};
+
+	return currentWindow[ COORDINATOR_KEY ];
+}
+
+function pauseNativeMedia( source ) {
+	getDocument()
+		?.querySelectorAll( MEDIA_SELECTOR )
+		.forEach( ( media ) => {
+			if ( media !== source && ! media.paused ) {
+				media.pause();
+			}
+		} );
+}
+
+function pausePlaylistPlayers( source ) {
+	getCoordinator()?.playlistPlayers.forEach( ( player ) => {
+		if ( player !== source && player.instance?.isPlaying ) {
+			player.instance.pause();
+		}
+	} );
+}
+
+function pauseOtherMedia( source ) {
+	pauseNativeMedia( source );
+	pausePlaylistPlayers( source );
+}
+
+function isMediaElement( element ) {
+	return element?.matches?.( MEDIA_SELECTOR );
+}
+
+export function notifyMediaPlayback( source ) {
+	const currentDocument = getDocument();
+
+	if ( ! currentDocument ) {
+		return;
+	}
+
+	currentDocument.dispatchEvent(
+		new currentDocument.defaultView.CustomEvent( MEDIA_PLAY_EVENT, {
+			detail: { source },
+		} )
+	);
+}
+
+export function registerPlaylistPlayer( player ) {
+	const playlistPlayers = getCoordinator()?.playlistPlayers;
+
+	playlistPlayers?.add( player );
+
+	return () => {
+		playlistPlayers?.delete( player );
+	};
+}
+
+function setupMediaPlaybackListeners() {
+	const currentDocument = getDocument();
+	const coordinator = getCoordinator();
+
+	if ( ! currentDocument || ! coordinator || coordinator.isListening ) {
+		return;
+	}
+
+	currentDocument.addEventListener(
+		MEDIA_PLAY_EVENT,
+		( event ) => pauseOtherMedia( event.detail?.source ),
+		true
+	);
+
+	currentDocument.addEventListener(
+		'play',
+		( event ) => {
+			if ( isMediaElement( event.target ) ) {
+				notifyMediaPlayback( event.target );
+			}
+		},
+		true
+	);
+
+	coordinator.isListening = true;
+}
+
+setupMediaPlaybackListeners();

--- a/packages/block-library/src/utils/test/media-playback.js
+++ b/packages/block-library/src/utils/test/media-playback.js
@@ -1,0 +1,122 @@
+import { notifyMediaPlayback, registerPlaylistPlayer } from '../media-playback';
+
+function mockMediaPlaybackState( media, isPaused = false ) {
+	let paused = isPaused;
+
+	Object.defineProperty( media, 'paused', {
+		configurable: true,
+		get: () => paused,
+	} );
+
+	jest.spyOn( media, 'pause' ).mockImplementation( () => {
+		paused = true;
+	} );
+}
+
+describe( 'media playback coordination', () => {
+	afterEach( () => {
+		document.body.replaceChildren();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'stops other audio and video elements when native media starts playing', () => {
+		document.body.innerHTML = `
+			<audio></audio>
+			<audio></audio>
+			<video controls></video>
+			<video></video>
+		`;
+		const [ currentAudio, otherAudio ] =
+			document.querySelectorAll( 'audio' );
+		const [ controlledVideo, videoWithoutControls ] =
+			document.querySelectorAll( 'video' );
+
+		[
+			currentAudio,
+			otherAudio,
+			controlledVideo,
+			videoWithoutControls,
+		].forEach( ( media ) => mockMediaPlaybackState( media ) );
+
+		currentAudio.dispatchEvent( new Event( 'play' ) );
+
+		expect( currentAudio.pause ).not.toHaveBeenCalled();
+		expect( otherAudio.pause ).toHaveBeenCalledTimes( 1 );
+		expect( controlledVideo.pause ).toHaveBeenCalledTimes( 1 );
+		expect( videoWithoutControls.pause ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'stops audio and video elements when a playlist starts playing', () => {
+		document.body.innerHTML = `
+			<audio></audio>
+			<video></video>
+		`;
+		const mediaElements = document.querySelectorAll( 'audio, video' );
+		mediaElements.forEach( ( media ) => mockMediaPlaybackState( media ) );
+
+		const playlistPlayer = {
+			instance: {
+				isPlaying: true,
+				pause: jest.fn(),
+			},
+		};
+		const unregister = registerPlaylistPlayer( playlistPlayer );
+
+		notifyMediaPlayback( playlistPlayer );
+
+		mediaElements.forEach( ( media ) => {
+			expect( media.pause ).toHaveBeenCalledTimes( 1 );
+		} );
+		expect( playlistPlayer.instance.pause ).not.toHaveBeenCalled();
+
+		unregister();
+	} );
+
+	it( 'stops playlist players when audio or video starts playing', () => {
+		document.body.innerHTML = '<video></video>';
+		const video = document.querySelector( 'video' );
+		mockMediaPlaybackState( video );
+
+		const playlistPlayer = {
+			instance: {
+				isPlaying: true,
+				pause: jest.fn(),
+			},
+		};
+		const unregister = registerPlaylistPlayer( playlistPlayer );
+
+		video.dispatchEvent( new Event( 'play' ) );
+
+		expect( video.pause ).not.toHaveBeenCalled();
+		expect( playlistPlayer.instance.pause ).toHaveBeenCalledTimes( 1 );
+
+		unregister();
+	} );
+
+	it( 'stops other playlist players when a playlist starts playing', () => {
+		const currentPlaylistPlayer = {
+			instance: {
+				isPlaying: true,
+				pause: jest.fn(),
+			},
+		};
+		const otherPlaylistPlayer = {
+			instance: {
+				isPlaying: true,
+				pause: jest.fn(),
+			},
+		};
+		const unregisterCurrent = registerPlaylistPlayer(
+			currentPlaylistPlayer
+		);
+		const unregisterOther = registerPlaylistPlayer( otherPlaylistPlayer );
+
+		notifyMediaPlayback( currentPlaylistPlayer );
+
+		expect( currentPlaylistPlayer.instance.pause ).not.toHaveBeenCalled();
+		expect( otherPlaylistPlayer.instance.pause ).toHaveBeenCalledTimes( 1 );
+
+		unregisterCurrent();
+		unregisterOther();
+	} );
+} );

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -104,5 +104,6 @@
 		}
 	},
 	"editorStyle": "wp-block-video-editor",
-	"style": "wp-block-video"
+	"style": "wp-block-video",
+	"viewScriptModule": "@wordpress/block-library/media-playback"
 }


### PR DESCRIPTION
## What?
Alternative approach to #81387.

Stops other page media when a core Playlist, Audio, or Video block starts playback. Unlike #81387's core-block-only native media selector, this version coordinates with every document-level `audio` and `video` element once the media playback coordinator has loaded.

## Why?
Playlist blocks already avoid overlapping playlist tracks, but a Playlist block and standalone media could play together. This explores the broader behavior where starting one relevant media experience pauses other media on the page, including media outside core block wrappers.

## How?
Adds a small shared frontend media playback coordinator script module for Audio and Video blocks. The coordinator listens for captured native `play` events on any `audio` or `video` element and pauses the other native media elements on the page. Playlist waveform players still register with the coordinator because their underlying audio element is owned by the waveform library rather than discoverable in block markup.

## Testing Instructions
1. Add an Audio block, a Video block, and a Playlist block with at least one track.
2. Add another native audio or video element outside a core media block wrapper, if desired.
3. View the post or page on the front end.
4. Start playback in one media element.
5. Start playback in another media element and confirm the first one stops.
6. Repeat across Audio, Video, Playlist, and non-core native media combinations.

### Testing Instructions for Keyboard
1. Use Tab to focus a media control in an Audio, Video, or Playlist block.
2. Start playback with the keyboard.
3. Tab to another media block and start playback with the keyboard.
4. Confirm the previously playing media stops.

## Validation
- `npm run test:unit packages/block-library/src/utils/test/media-playback.js packages/block-library/src/playlist/test/view.js`
- `npm run lint:js -- packages/block-library/src/utils/media-playback.js packages/block-library/src/utils/test/media-playback.js packages/block-library/src/playlist/view.js packages/block-library/src/playlist/test/view.js`
- `npm run lint:pkg-json -- packages/block-library/package.json`
- `npm run build -- --skip-types --webpack-copy-php --webpack-bundle-analyzer=false --no-watch`