### PR TITLE
UI: Update Base UI to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2121,15 +2121,15 @@
 			}
 		},
 		"node_modules/@base-ui/react": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.3.1",
-				"@floating-ui/react-dom": "^2.1.8",
-				"@floating-ui/utils": "^0.2.11",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"engines": {
@@ -2159,13 +2159,13 @@
 			}
 		},
 		"node_modules/@base-ui/utils": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
-			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
-				"@floating-ui/utils": "^0.2.11",
+				"@floating-ui/utils": "^0.2.12",
 				"reselect": "^5.2.0",
 				"use-sync-external-store": "^1.6.0"
 			},
@@ -55117,7 +55117,7 @@
 			"version": "0.20.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@base-ui/react": "^1.6.0",
+				"@base-ui/react": "^1.7.0",
 				"@daypicker/react": "^10.0.1",
 				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/compose": "file:../compose",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 ### Internal
 
--   Update `@base-ui/react` from `1.6.0` to `1.7.0`.
+-   Update `@base-ui/react` from `1.6.0` to `1.7.0`. ([#81390](https://github.com/WordPress/gutenberg/pull/81390))
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Internal
 
+-   Update `@base-ui/react` from `1.6.0` to `1.7.0`.
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@base-ui/react": "^1.6.0",
+		"@base-ui/react": "^1.7.0",
 		"@daypicker/react": "^10.0.1",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -126,6 +126,11 @@ if ( typeof window !== 'undefined' ) {
 		global.HTMLElement.prototype.getAnimations = () => [];
 	}
 
+	// jsdom lacks PointerEvent (needed by Base UI keyboard activation ≥1.7).
+	if ( ! global.PointerEvent ) {
+		global.PointerEvent = global.MouseEvent;
+	}
+
 	// jsdom lacks CSS.supports (needed by Ariakit's modal scroll locking).
 	if ( ! global.CSS ) {
 		global.CSS = {};

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -128,7 +128,14 @@ if ( typeof window !== 'undefined' ) {
 
 	// jsdom lacks PointerEvent (needed by Base UI keyboard activation ≥1.7).
 	if ( ! global.PointerEvent ) {
-		global.PointerEvent = global.MouseEvent;
+		global.PointerEvent = class PointerEvent extends global.MouseEvent {
+			constructor( type, init = {} ) {
+				super( type, init );
+				this.pointerId = init.pointerId ?? 0;
+				this.pointerType = init.pointerType ?? '';
+				this.isPrimary = init.isPrimary ?? false;
+			}
+		};
 	}
 
 	// jsdom lacks CSS.supports (needed by Ariakit's modal scroll locking).


### PR DESCRIPTION
## What?

Updates the direct `@base-ui/react` dependency in `@wordpress/ui` from declared and resolved version `1.6.0` to `1.7.0`. It also adds the jsdom `PointerEvent` fallback required by Base UI 1.7 keyboard activation.

Upstream sources: [Base UI 1.7.0 release notes](https://base-ui.com/react/overview/releases/v1-7-0) and [GitHub release](https://github.com/mui/base-ui/releases/tag/v1.7.0).

### Impact on components we consume

- **Alert Dialog, Dialog, Popover, and Tooltip:** receive the reused-handle remount fix. Dialog also receives touch outside-dismissal and overlay scroll-lock handoff fixes. Gutenberg does not carry a matching lifecycle workaround, so no migration or cleanup is required.
- **Drawer:** receives the reused-handle fix plus swipe, snap-point, virtual-keyboard, iOS touch-slop, Shadow DOM gesture, and transition fixes. Its existing API remains compatible.
- **Menu:** receives VoiceOver and Android TalkBack submenu fixes, correct disabled-item behavior, improved submenu pointer handling, pinch-zoom support, and fixes for duplicate `onOpenChange` calls and checkbox-item exit animation. Gutenberg's local nested-overlay focus handoff serves a separate purpose and remains necessary.
- **Autocomplete:** receives locale-aware filtering, new additive event-detail reasons, filter scroll reset, listbox separator semantics, and internal cleanup. Existing callbacks do not exhaustively match the reason union, so no source change is required.
- **Combobox:** receives additive event-detail reasons; group-filtering, initial-highlight, clear, portalled-content, scroll, Safari hover, disabled-item inheritance, and pointer-tolerance fixes; and listbox separator semantics. Existing wrappers and tests remain compatible.
- **Select:** receives Safari hover, disabled-item inheritance, pointer-tolerance, programmatic-value, and listbox separator fixes. Existing wrappers and tests remain compatible.
- **Checkbox, Field, and Fieldset:** receive validation-input event handling, disabled-invalid state, null-value dirty tracking, ref, and bundle-size fixes. Their public contracts are unchanged.
- **Button:** keyboard activation now constructs a `PointerEvent`. Browsers provide this API, but jsdom does not. The shared Jest environment therefore defines a minimal `MouseEvent`-based fallback that preserves pointer ID, type, and primary-pointer metadata. This fixes the two Tabs keyboard regressions reproduced after the update while retaining media-editor touch-pointer behavior.
- **Tabs:** receives Suspense/prehydration indicator and bundle-size fixes. Existing keyboard and selection behavior remains compatible.
- **Shared internals:** popup focus restoration in Safari and Firefox, positioning, collision-padding, cleanup, canceled-exit unmounting, React 17 popup mounting, and generated declaration fixes apply across the wrappers above. Composite navigation also receives reordering, native-disabled, RTL scrolling, and keyboard-bookkeeping fixes.
- **`render`-based primitives:** Base UI now infers render-callback props from the rendered element. Gutenberg's `useRender` consumers, including layout and text primitives, pass the complete typecheck and build without migration.
- **Collapsible, Input, and DirectionProvider:** have no component-specific 1.7.0 release entry. They receive only applicable shared internal fixes.

Release-note sections for Base UI primitives that Gutenberg does not import from `@base-ui/react` do not affect `@wordpress/ui` directly.

### Compatibility and dependency assessment

- `1.7.0` is the current npm release.
- React, React DOM, React type, date-fns, and Node peer/engine ranges are unchanged.
- The lockfile moves `@base-ui/utils` from `0.3.1` to `0.3.2` and raises Base UI's Floating UI minimums. Gutenberg already resolves `@floating-ui/react-dom` `2.1.9` and `@floating-ui/utils` `0.2.12`, so both remain deduplicated.
- The updated Base UI and Floating UI dependency tree has no npm audit findings. The full local repository audit reports 80 existing findings elsewhere: 6 low, 41 moderate, 32 high, and 1 critical.
- No public API migration or local workaround removal is required.

## Why?

This keeps the UI package on the current Base UI release and brings in relevant focus, overlay, form-control, accessibility, type, and bundle fixes.

## How?

The UI manifest and root lockfile now resolve Base UI 1.7.0. The shared Jest setup defines `PointerEvent` only when the test environment does not provide it.

## Testing Instructions

1. Open Gutenberg Storybook and navigate to **Design System / Components / Tabs**. Use Tab to focus the tab list. Use Left Arrow and Right Arrow to move focus, then Space or Enter to activate a tab. Confirm the matching panel appears and focus remains visible.
2. Open **Design System / Components / AlertDialog**, **Dialog**, and **Drawer**. Open and close each overlay with the keyboard. Confirm focus returns to its trigger and the overlay can be reopened normally.
3. Open **Design System / Components / Menu**. Navigate items and submenus with the keyboard. Confirm disabled items cannot be selected and focus returns correctly when the menu closes.
4. Open **Design System / Components / Form / Primitives / Autocomplete**, **Combobox**, and **Select**. Filter where applicable, navigate items, and select a value. Confirm list scrolling, disabled items, and selection work as expected.
5. Open **Design System / Components / Tooltip**. Focus the trigger with the keyboard and confirm the tooltip opens, remains associated with the trigger, and closes without losing visible focus.

### Testing Instructions for Keyboard

Complete all steps above without a pointer. Expected behavior is unchanged: arrow-key navigation, Space/Enter activation, Escape dismissal, and focus return all work with a visible focus indicator.

<details>
<summary>Automated verification</summary>

- All 51 `@wordpress/ui` suites pass: 618 tests.
- The affected media-editor cropper and rectangle-stencil suites pass: 48 tests.
- The complete repository typecheck and typed build pass.
- The Storybook production build passes.
- Lockfile, package JSON, JavaScript, and published-dependency validation pass. The published-dependency audit checked 128 packages with zero findings.
- `npm ls` confirms Base UI 1.7.0 and the expected deduplicated Floating UI resolutions.

Manual Safari, Firefox, screen-reader, and browser end-to-end verification were not run.

</details>

## Screenshots or screencast

Not applicable; this dependency update is expected to preserve the current UI.

## Use of AI Tools

Codex performed the rebase, dependency and consumer analysis, conflict resolution, verification, and pull request description update. A human has not reviewed the result.
