### PR TITLE
Core Data: Fix post staying dirty after saving edited post meta with RTC enabled

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing. Malformed JSON, or valid JSON that is not an array, threw inside a store subscriber where no error boundary catches it, so the edit was dropped and the post silently stopped saving ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
+-   `saveEntityRecord`: Reset persisted edits using the original edits instead of the `__unstablePrePersist`-augmented request payload. With collaborative editing enabled, the injected CRDT snapshot made the post-save comparison against the state edits fail, leaving the record dirty after a successful save whenever `meta` was edited.
 -   Ensure revision resolvers finish after fetched revisions are stored.
 
 ### Internal

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -862,13 +862,19 @@ export const saveEntityRecord =
 						method: recordId ? 'PUT' : 'POST',
 						data: edits,
 					} );
+					// Pass the pre-`__unstablePrePersist` edits so the reducer
+					// can clear the persisted edits from state. The values
+					// added by `__unstablePrePersist` (e.g. a fresh CRDT
+					// snapshot in `meta`) never exist in the state edits, so
+					// comparing against them would fail to match and leave the
+					// record dirty after a successful save.
 					dispatch.receiveEntityRecords(
 						kind,
 						name,
 						updatedRecord,
 						undefined,
 						true,
-						edits
+						record
 					);
 					if ( entityConfig.syncConfig ) {
 						let syncChanges;

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1180,6 +1180,91 @@ describe( 'saveEntityRecord', () => {
 		expect( result ).toBe( updatedRecord );
 	} );
 
+	it( 'resets persisted edits using the pre-prePersist edits so the record is clean after saving', async () => {
+		const persistedRecord = {
+			id: 10,
+			meta: {
+				plugin_value: 'persisted',
+				_crdt_document: 'old-doc',
+			},
+		};
+		// Mirrors a store meta edit: `mergedEdits` snapshots the full edited
+		// meta, including the load-time CRDT document.
+		const edits = {
+			id: 10,
+			meta: {
+				plugin_value: 'edited',
+				_crdt_document: 'old-doc',
+			},
+		};
+		const configs = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				syncConfig: {},
+				// Mirrors prePersistPostType, which injects a freshly
+				// serialized CRDT snapshot into the request meta.
+				__unstablePrePersist: async ( _persisted, saveEdits ) => ( {
+					meta: {
+						...saveEdits.meta,
+						_crdt_document: 'new-doc',
+					},
+				} ),
+			},
+		];
+		const syncManager = {
+			update: jest.fn(),
+		};
+		const select = {
+			getRawEntityRecord: () => persistedRecord,
+		};
+		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+		const updatedRecord = {
+			id: 10,
+			meta: {
+				plugin_value: 'edited',
+				// The server may also mutate meta on save (e.g. a plugin
+				// normalizing a value in a save hook).
+				server_value: 'server-mutated',
+				_crdt_document: 'new-doc',
+			},
+		};
+		apiFetch.mockImplementation( () => updatedRecord );
+		getSyncManager.mockReturnValue( syncManager );
+
+		await saveEntityRecord(
+			'postType',
+			'post',
+			edits
+		)( { select, dispatch, resolveSelect } );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/posts/10',
+			method: 'PUT',
+			data: {
+				...edits,
+				meta: {
+					plugin_value: 'edited',
+					_crdt_document: 'new-doc',
+				},
+			},
+		} );
+
+		// The persisted edits passed to the reducer must be the original
+		// edits, not the prePersist-augmented request payload. Otherwise the
+		// injected CRDT snapshot makes the comparison against the state edits
+		// fail and the record stays dirty after a successful save.
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			updatedRecord,
+			undefined,
+			true,
+			edits
+		);
+	} );
+
 	it( 'syncs direct save changes before pre-persisting the record', async () => {
 		const persistedRecord = {
 			id: 10,

--- a/test/e2e/specs/editor/collaboration/collaboration-save-clean-state.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-save-clean-state.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from './fixtures';
+
+test.describe( 'Collaboration - Clean state after saving meta edits', () => {
+	// Regression test: with collaboration enabled, every real post save
+	// injects a fresh CRDT snapshot into `meta._crdt_document` via
+	// `prePersistPostType`. Post meta edits snapshot the full edited meta
+	// (including the load-time `_crdt_document`), so the persisted-edits
+	// comparison that clears edits after a save must use the original edits,
+	// not the augmented request payload — otherwise the meta edit survives
+	// the save and the post stays permanently dirty.
+	test( 'post is not dirty after saving a meta edit', async ( {
+		collaborationUtils,
+		requestUtils,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Meta edit save test',
+			content: '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+			status: 'draft',
+			date_gmt: new Date().toISOString(),
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		// Edit and save once so the post record carries a persisted CRDT
+		// document in its meta, mirroring an existing post opened in a later
+		// session. (An unedited post shows no "Save draft" button.)
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/editor' ).editPost( {
+				title: 'Meta edit save test (edited)',
+			} );
+		} );
+		await editor.saveDraft();
+
+		// A meta change before save. Footnotes live in post meta, so this
+		// stands in for any plugin writing post meta from the editor.
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/editor' ).editPost( {
+				meta: {
+					footnotes: JSON.stringify( [
+						{ id: 'e2e-note', content: 'A footnote' },
+					] ),
+				},
+			} );
+		} );
+
+		// Sanity check: the meta edit marks the post dirty.
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data.select( 'core/editor' ).isEditedPostDirty()
+				)
+			)
+			.toBe( true );
+
+		// Arm a save-completion watcher, then save with the keyboard rather
+		// than `editor.saveDraft()`: that helper waits for the saved
+		// indicator, which the buggy behavior never reaches, and the failure
+		// should land on the assertions below instead.
+		await page.evaluate( () => {
+			( window as any ).__e2eSaveSettled = new Promise( ( resolve ) => {
+				const { select, subscribe } = window.wp.data;
+				let sawSaving = false;
+				const unsubscribe = subscribe( () => {
+					if ( select( 'core/editor' ).isSavingPost() ) {
+						sawSaving = true;
+					} else if ( sawSaving ) {
+						unsubscribe();
+						resolve( true );
+					}
+				} );
+			} );
+		} );
+		await pageUtils.pressKeys( 'primary+s' );
+		await page.evaluate( () => ( window as any ).__e2eSaveSettled );
+
+		// The saved meta edit must be cleared once the save response arrives.
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data.select( 'core/editor' ).isEditedPostDirty()
+				)
+			)
+			.toBe( false );
+
+		// And the UI reflects the clean state.
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Saved' } )
+		).toBeVisible();
+
+		// The saved meta value round-tripped.
+		await expect
+			.poll( () =>
+				page.evaluate( () => {
+					const postId = window.wp.data
+						.select( 'core/editor' )
+						.getCurrentPostId();
+					return window.wp.data
+						.select( 'core' )
+						.getEditedEntityRecord( 'postType', 'post', postId )
+						?.meta?.footnotes;
+				} )
+			)
+			.toContain( 'e2e-note' );
+	} );
+} );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/77610.

Fixes a bug where a post stays dirty (Save button remains active) after a successful save when collaborative editing (RTC) is enabled and post meta was edited before saving.

`saveEntityRecord` now passes the original edits—rather than the `__unstablePrePersist`-augmented request payload—to `receiveEntityRecords` as the persisted edits used to clear state edits after a save.

## Why?

With RTC enabled, saving a post that has a meta edit leaves the record permanently dirty, and saving again never clears it. This is easy to reproduce with plugins that write post meta during the editor session or mutate meta server-side during save (e.g. ActivityPub with a published post older than one month), but any meta edit triggers it—including footnotes.

The cause is a mismatch between the edits held in state and the edits used to prune them after a save:

1. A meta edit snapshots the **full** edited meta object into state edits (`mergedEdits: { meta: true }`), including the load-time `meta._crdt_document` value.
2. On save, `prePersistPostType` injects a **freshly serialized** CRDT snapshot into `meta._crdt_document` in the request payload. This always differs from the load-time snapshot.
3. `saveEntityRecord` passed that augmented payload to `receiveEntityRecords` as `persistedEdits`. The post-save prune in the `edits` reducer compares `meta` as one atomic object: a state edit is cleared only if it deep-equals the response value or the persisted edits. The state's `edits.meta` (old snapshot) matches neither, so the meta edit survives every save.

The same mismatch also affected the auto-draft flow, where `prePersistPostType` rewrites an `Auto Draft` title to an empty string.

## How?

Pass the pre-`__unstablePrePersist` edits (`record`) as `persistedEdits`. Semantically, `persistedEdits` answers "has the user edited further since the save started?"—so it should be the edits captured at save time, not the transformed request payload. Values injected by `__unstablePrePersist` never exist in state edits, so they don't need to participate in the comparison; the response record (also part of the prune comparison) still reflects them.

## Testing Instructions

1. Enable the collaborative editing experiment.
2. Open an existing published post.
3. Make a meta change, e.g. add a footnote to a paragraph (footnotes are stored in post meta), or change a meta field exposed by a plugin sidebar (e.g. ActivityPub).
4. Save the post.
5. Confirm the Save button becomes inactive ("Saved") after the save completes. On trunk, it stays active and repeated saves never clear it.
6. Reload and confirm the meta change persisted.

Regression coverage: `npm run test:unit -- packages/core-data/src/test/actions.js` (new test: "resets persisted edits using the pre-prePersist edits so the record is clean after saving").

### Testing Instructions for Keyboard

Same as above; all steps are operable with the keyboard (navigate the editor and Save button with <kbd>Tab</kbd>, save with <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>S</kbd>). No UI changes.

## Use of AI Tools

This PR was investigated and drafted with assistance from Claude Code (Claude Fable 5); the root-cause analysis, code change, and tests were reviewed and verified by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
