### PR TITLE
Editor: Keep navigation sidebars at full height

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -49,6 +49,7 @@
 ### Bug Fixes
 
 -   Identity: Decode HTML entities in the Site Title and Site Tagline fields. ([#81269](https://github.com/WordPress/gutenberg/pull/81269))
+-   Keep the closed save panel control at the top of its full-height navigation region ([#48186](https://github.com/WordPress/gutenberg/issues/48186)).
 
 ## 7.1.0 (2026-07-29)
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Keep the closed save panel control at the top of its full-height navigation region ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 -   `WelcomeGuide`: Keep the modal close icon white on hover now that it is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `SidebarNavigationItem`: Stop forcing `style={ { fill: 'currentcolor' } }` on the icon. The explicit override was clobbering stroke-based icons' intrinsic styling. Colour is inherited via CSS `color` and the icon's own declared fills/strokes. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `AddNewTemplate`: Preserve the admin theme color on the Author template icon after it became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
@@ -49,7 +50,6 @@
 ### Bug Fixes
 
 -   Identity: Decode HTML entities in the Site Title and Site Tagline fields. ([#81269](https://github.com/WordPress/gutenberg/pull/81269))
--   Keep the closed save panel control at the top of its full-height navigation region ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 
 ## 7.1.0 (2026-07-29)
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -49,7 +49,7 @@
 ### Bug Fixes
 
 -   Identity: Decode HTML entities in the Site Title and Site Tagline fields. ([#81269](https://github.com/WordPress/gutenberg/pull/81269))
--   Keep the closed save panel control at the top of its full-height navigation region ([#48186](https://github.com/WordPress/gutenberg/issues/48186)).
+-   Keep the closed save panel control at the top of its full-height navigation region ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 
 ## 7.1.0 (2026-07-29)
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -190,15 +190,8 @@ html.canvas-mode-edit-transition::view-transition-group(toggle) {
 
 	&:focus,
 	&:focus-within {
-		top: auto;
+		top: var(--wp-admin--admin-bar--height, 0);
 		bottom: 0;
-	}
-
-	&.is-entity-save-view-open {
-		&:focus,
-		&:focus-within {
-			top: var(--wp-admin--admin-bar--height, 0);
-		}
 	}
 
 	@include break-medium {

--- a/packages/edit-site/src/components/save-panel/index.jsx
+++ b/packages/edit-site/src/components/save-panel/index.jsx
@@ -144,9 +144,7 @@ export default function SavePanel() {
 	const disabled = isSaving || ! activateSaveEnabled;
 	return (
 		<NavigableRegion
-			className={ clsx( 'edit-site-layout__actions', {
-				'is-entity-save-view-open': isSaveViewOpen,
-			} ) }
+			className="edit-site-layout__actions"
 			ariaLabel={ __( 'Save panel' ) }
 		>
 			<div

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -84,7 +84,7 @@
 
 -   Device Preview: Keep tablet and mobile iframe widths inside their responsive breakpoints so media queries remain accurate at browser zoom levels.
 -   Document tools: Fix icon button focus styles to use the design system `outset-ring__focus` mixin ([#81115](https://github.com/WordPress/gutenberg/pull/81115)).
--   Keep closed publish and save panel controls at the top of their full-height navigation regions ([#48186](https://github.com/WordPress/gutenberg/issues/48186)).
+-   Keep closed publish and save panel controls at the top of their full-height navigation regions ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 
 ## 14.52.0 (2026-07-29)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Bug Fixes
 
 -   More menu: Align SVG prefix icons with item labels using `Menu.PrefixIcon`, preserving Dashicon and custom component support. ([#82346](https://github.com/WordPress/gutenberg/pull/82346))
+-   Keep closed publish and save panel controls at the top of their full-height navigation regions ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 -   Attach media an Image or Gallery block displays to the post on save, when it is not already attached to another post, matching what uploading into that post has always done ([#81977](https://github.com/WordPress/gutenberg/pull/81977)).
 -   Color the welcome guide's hovered button icon with `color` rather than `fill`, so stroke-based icons follow it. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.
@@ -84,7 +85,6 @@
 
 -   Device Preview: Keep tablet and mobile iframe widths inside their responsive breakpoints so media queries remain accurate at browser zoom levels.
 -   Document tools: Fix icon button focus styles to use the design system `outset-ring__focus` mixin ([#81115](https://github.com/WordPress/gutenberg/pull/81115)).
--   Keep closed publish and save panel controls at the top of their full-height navigation regions ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 
 ## 14.52.0 (2026-07-29)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -84,6 +84,7 @@
 
 -   Device Preview: Keep tablet and mobile iframe widths inside their responsive breakpoints so media queries remain accurate at browser zoom levels.
 -   Document tools: Fix icon button focus styles to use the design system `outset-ring__focus` mixin ([#81115](https://github.com/WordPress/gutenberg/pull/81115)).
+-   Keep closed publish and save panel controls at the top of their full-height navigation regions ([#48186](https://github.com/WordPress/gutenberg/issues/48186)).
 
 ## 14.52.0 (2026-07-29)
 

--- a/packages/editor/src/components/editor-interface/index.jsx
+++ b/packages/editor/src/components/editor-interface/index.jsx
@@ -204,7 +204,6 @@ export default function EditorInterface( {
 		<InterfaceSkeleton
 			isDistractionFree={ isDistractionFree }
 			className={ clsx( 'editor-editor-interface', className, {
-				'is-entity-save-view-open': !! entitiesSavedStatesCallback,
 				'is-distraction-free': isDistractionFree && ! isPreviewMode,
 			} ) }
 			labels={ {

--- a/packages/editor/src/components/save-publish-panels/style.scss
+++ b/packages/editor/src/components/save-publish-panels/style.scss
@@ -1,32 +1,14 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
-@use "@wordpress/base-styles/z-index" as *;
-
 
 .editor-layout__toggle-publish-panel,
 .editor-layout__toggle-sidebar-panel,
 .editor-layout__toggle-entities-saved-states-panel {
-	z-index: z-index(".editor-layout__toggle-sidebar-panel");
-	position: fixed !important; // Necessary to override the default relative positioning.
-	top: -9999em;
-	bottom: auto;
-	left: auto;
-	right: 0;
 	box-sizing: border-box;
 	width: $sidebar-width;
 	background-color: $white;
 	border: $border-width dotted $gray-300;
-	height: auto !important; // Necessary to override the default sidebar positioning.
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;
-}
-
-.editor-layout__toggle-entities-saved-states-panel,
-.editor-layout__toggle-publish-panel {
-	.interface-interface-skeleton__actions:focus &,
-	.interface-interface-skeleton__actions:focus-within & {
-		top: auto;
-		bottom: 0;
-	}
 }

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).
 -   `InterfaceSkeleton`: Increase the footer height from 24px to 32px to prevent the focus ring from being clipped ([#81145](https://github.com/WordPress/gutenberg/pull/81145)).
 -   `InterfaceSkeleton`: Stop the secondary sidebar from animating itself into place on page load when it is already open, for example with the "Always open List View" preference enabled ([#81362](https://github.com/WordPress/gutenberg/pull/81362)).
+-   `InterfaceSkeleton`: Keep focused publish and save navigation regions at full height when their panels are closed ([#48186](https://github.com/WordPress/gutenberg/issues/48186)).
 
 ### Internal
 

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `InterfaceSkeleton`: Keep focused publish and save navigation regions at full height when their panels are closed ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
+
 ### Internal
 
 -   `ComplementaryAreaMoreMenuItem`: Stop passing a `selectedIcon`. The component the item renders as shows the selection ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
@@ -26,7 +30,6 @@
 -   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).
 -   `InterfaceSkeleton`: Increase the footer height from 24px to 32px to prevent the focus ring from being clipped ([#81145](https://github.com/WordPress/gutenberg/pull/81145)).
 -   `InterfaceSkeleton`: Stop the secondary sidebar from animating itself into place on page load when it is already open, for example with the "Always open List View" preference enabled ([#81362](https://github.com/WordPress/gutenberg/pull/81362)).
--   `InterfaceSkeleton`: Keep focused publish and save navigation regions at full height when their panels are closed ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 
 ### Internal
 

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -26,7 +26,7 @@
 -   `ComplementaryArea`: Remove incorrect `aria-expanded` attribute from the "Pin to toolbar" toggle button, which already exposes its state via `aria-pressed` ([#79874](https://github.com/WordPress/gutenberg/pull/79874)).
 -   `InterfaceSkeleton`: Increase the footer height from 24px to 32px to prevent the focus ring from being clipped ([#81145](https://github.com/WordPress/gutenberg/pull/81145)).
 -   `InterfaceSkeleton`: Stop the secondary sidebar from animating itself into place on page load when it is already open, for example with the "Always open List View" preference enabled ([#81362](https://github.com/WordPress/gutenberg/pull/81362)).
--   `InterfaceSkeleton`: Keep focused publish and save navigation regions at full height when their panels are closed ([#48186](https://github.com/WordPress/gutenberg/issues/48186)).
+-   `InterfaceSkeleton`: Keep focused publish and save navigation regions at full height when their panels are closed ([#81395](https://github.com/WordPress/gutenberg/pull/81395)).
 
 ### Internal
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -198,19 +198,15 @@ html.interface-interface-skeleton__html-container {
 
 	&:focus,
 	&:focus-within {
-		top: auto;
+		top: $admin-bar-height-big;
 		bottom: 0;
 
-		.is-entity-save-view-open & {
-			top: $admin-bar-height-big;
+		@include break-medium() {
+			border-left: $border-width solid $gray-300;
+			top: $admin-bar-height;
 
-			@include break-medium() {
-				border-left: $border-width solid $gray-300;
-				top: $admin-bar-height;
-
-				.is-fullscreen-mode & {
-					top: var(--wp-admin--admin-bar--height, 0);
-				}
+			.is-fullscreen-mode & {
+				top: var(--wp-admin--admin-bar--height, 0);
 			}
 		}
 	}

--- a/test/e2e/specs/editor/various/a11y-region-navigation.spec.js
+++ b/test/e2e/specs/editor/various/a11y-region-navigation.spec.js
@@ -1,5 +1,39 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+async function navigateToRegion( page, pageUtils, region ) {
+	const regionCount = await page
+		.locator( '[role="region"][tabindex="-1"]' )
+		.count();
+
+	for ( let index = 0; index < regionCount; index++ ) {
+		await pageUtils.pressKeys( 'ctrl+`' );
+		if (
+			await region.evaluate(
+				( element ) => element === document.activeElement
+			)
+		) {
+			return;
+		}
+	}
+}
+
+async function expectRegionToFillEditor( page, region, openPanelButton ) {
+	await expect( region ).toBeVisible();
+	const editor = page
+		.locator( '.interface-interface-skeleton' )
+		.filter( { has: region } )
+		.last();
+	const [ regionBox, editorBox, buttonBox ] = await Promise.all( [
+		region.boundingBox(),
+		editor.boundingBox(),
+		openPanelButton.boundingBox(),
+	] );
+
+	expect( regionBox.y ).toBe( editorBox.y );
+	expect( regionBox.height ).toBe( editorBox.height );
+	expect( buttonBox.y ).toBeLessThan( regionBox.y + regionBox.height / 2 );
+}
+
 test.describe( 'Region navigation (@firefox, @webkit)', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -58,5 +92,23 @@ test.describe( 'Region navigation (@firefox, @webkit)', () => {
 		}
 
 		await expect( editorTopBar ).toBeFocused();
+	} );
+
+	test( 'shows a closed publish region at full editor height', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		const publishRegion = page.getByRole( 'region', {
+			name: 'Editor publish',
+		} );
+
+		await navigateToRegion( page, pageUtils, publishRegion );
+
+		await expect( publishRegion ).toBeFocused();
+		const openPublishPanel = publishRegion.getByRole( 'button', {
+			name: 'Open publish panel',
+		} );
+		await expect( openPublishPanel ).toBeVisible();
+		await expectRegionToFillEditor( page, publishRegion, openPublishPanel );
 	} );
 } );

--- a/test/e2e/specs/editor/various/multi-entity-saving.spec.js
+++ b/test/e2e/specs/editor/various/multi-entity-saving.spec.js
@@ -135,7 +135,7 @@ test.describe( 'Editor - Multi-entity save flow', () => {
 		await expect( saveButton ).toBeEnabled();
 
 		// Verify multi-entity saving not enabled.
-		await expect( publishPanel ).toBeHidden();
+		await expect( publishPanel ).not.toBeInViewport();
 
 		await siteTitleField.fill( `${ originalSiteTitle }!` );
 

--- a/test/e2e/specs/site-editor/activate-theme.spec.js
+++ b/test/e2e/specs/site-editor/activate-theme.spec.js
@@ -6,6 +6,40 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 // redirects to the themes screen.
 const isSiteEditorV2 = !! process.env.GUTENBERG_E2E_SITE_EDITOR_V2;
 
+async function navigateToRegion( page, pageUtils, region ) {
+	const regionCount = await page
+		.locator( '[role="region"][tabindex="-1"]' )
+		.count();
+
+	for ( let index = 0; index < regionCount; index++ ) {
+		await pageUtils.pressKeys( 'ctrl+`' );
+		if (
+			await region.evaluate(
+				( element ) => element === document.activeElement
+			)
+		) {
+			return;
+		}
+	}
+}
+
+async function expectRegionToFillEditor( page, region, openPanelButton ) {
+	await expect( region ).toBeVisible();
+	const editor = page
+		.locator( '.interface-interface-skeleton' )
+		.filter( { has: region } )
+		.last();
+	const [ regionBox, editorBox, buttonBox ] = await Promise.all( [
+		region.boundingBox(),
+		editor.boundingBox(),
+		openPanelButton.boundingBox(),
+	] );
+
+	expect( regionBox.y ).toBe( editorBox.y );
+	expect( regionBox.height ).toBe( editorBox.height );
+	expect( buttonBox.y ).toBeLessThan( regionBox.y + regionBox.height / 2 );
+}
+
 test.describe( 'Activate theme', () => {
 	test.beforeEach( async ( { admin, page } ) => {
 		await admin.visitAdminPage( 'themes.php' );
@@ -76,5 +110,33 @@ test.describe( 'Activate theme', () => {
 		).toContainText( 'Theme activated.' );
 		await admin.visitAdminPage( 'themes.php' );
 		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
+	} );
+
+	// The extensible site editor does not expose the classic editor's keyboard
+	// region navigation order.
+	test( 'shows a closed save region at full editor height @site-editor-v1-only', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await expect(
+			page.getByRole( 'button', { name: 'Activate Emptytheme' } )
+		).toBeVisible();
+		await editor.setPreferences( 'core/edit-site', {
+			welcomeGuide: false,
+		} );
+		await editor.canvas.locator( 'body' ).click();
+
+		const saveRegion = page.getByRole( 'region', {
+			name: 'Save panel',
+		} );
+		await navigateToRegion( page, pageUtils, saveRegion );
+
+		await expect( saveRegion ).toBeFocused();
+		const openSavePanel = saveRegion.getByRole( 'button', {
+			name: 'Open save panel',
+		} );
+		await expect( openSavePanel ).toBeVisible();
+		await expectRegionToFillEditor( page, saveRegion, openSavePanel );
 	} );
 } );


### PR DESCRIPTION
Closes #48186.

## What?

Makes the closed publish and save navigation regions span the full editor height when they receive focus.

The controls for opening the publish or save panel remain near the top of the region.

## Why?

The closed regions currently collapse around their controls near the bottom-right corner of the editor. This makes the focused region appear disconnected from the full-height sidebar that opens from it.

Keeping the region at full editor height provides a consistent navigation target and clearer focus presentation.

## How?

- Extends the focused Post Editor action region from the admin bar to the bottom of the editor.
- Applies the same full-height behavior to the Site Editor save region.
- Removes the obsolete entity-save state class and the fixed, off-screen positioning previously used for the closed panel controls.
- Adds Playwright coverage that verifies:
  - The focused region matches the editor height.
  - The opening control remains in the upper half of the region.
  - The behavior works in both the Post Editor and Site Editor.

## Testing Instructions

### Post Editor

1. Open the Post Editor.
2. Move focus into the editor.
3. Press `Ctrl` + backtick repeatedly until the `Editor publish` region receives focus.
4. Confirm that the focused region spans the full editor height.
5. Confirm that the `Open publish panel` button appears near the top of the region.
6. Activate the button and confirm that the publish panel opens normally.

### Site Editor

1. Open the Site Editor.
2. Make a change so that saving is available.
3. Move focus into the editor canvas.
4. Press `Ctrl` + backtick repeatedly until the `Save panel` region receives focus.
5. Confirm that the focused region spans the full editor height.
6. Confirm that the `Open save panel` button appears near the top of the region.
7. Activate the button and confirm that the save panel opens normally.

### Automated verification

The following checks pass:

- `npm run build -- --skip-types`
- Focused JavaScript lint
- Repository CSS lint
- Gutenberg pre-commit checks
- Post Editor navigation test repeated three times across Chromium, WebKit, and Firefox: 18 tests passed
- Site Editor save-region test repeated three times across Chromium, WebKit, and Firefox: 9 tests passed

## Testing Instructions for Keyboard

1. Complete the Post Editor and Site Editor instructions without using a pointer.
2. Use `Ctrl` + backtick to navigate between editor regions.
3. Confirm that focus reaches the closed publish or save region.
4. Confirm that the opening button is visible and can be activated using the keyboard.

## Screenshots or screencast

Not included. This is a structural layout correction, and the regression tests verify the region and editor bounding boxes directly.

## Use of AI Tools

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard navigation for closed Save and Publish panels.
  - Focused navigation regions now remain visible at full editor height.
  - Panel controls stay correctly positioned at the top of the editor, including with the admin bar present.
  - Updated panel visibility behavior to keep closed panels out of view without affecting keyboard accessibility.

- **Tests**
  - Added end-to-end coverage for keyboard focus, region sizing, visibility, and panel control positioning in the Editor and Site Editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->