### PR TITLE
Docs: Fix broken link to the Node.js debugging guide.

### DIFF
--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -478,7 +478,7 @@ In that case, you might see test failures and `TypeError` reported by Jest in th
 
 ### Debugging Jest unit tests
 
-Running `npm run test:unit:debug` will start the tests in debug mode so a [node inspector client](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients) can connect to the process and inspect the execution. Instructions for using Google Chrome or Visual Studio Code as an inspector client can be found in the [wp-scripts documentation](/packages/scripts/README.md#debugging-jest-unit-tests).
+Running `npm run test:unit:debug` will start the tests in debug mode so a [node inspector client](https://nodejs.org/en/learn/getting-started/debugging#inspector-clients) can connect to the process and inspect the execution. Instructions for using Google Chrome or Visual Studio Code as an inspector client can be found in the [wp-scripts documentation](/packages/scripts/README.md#debugging-jest-unit-tests).
 
 ## End-to-end testing
 


### PR DESCRIPTION
The Node.js debugging guide moved to https://nodejs.org/en/learn/getting-started/debugging, so the link on the testing overview page (https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients) returns a 404. This PR updates the link to the new destination, which still has the `#inspector-clients` anchor.

## Testing Instructions

Verify the link updated on this PR loads the "Inspector Clients" section of the Node.js debugging guide, while the previous link returns a 404.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
