### PR TITLE
Docs: Fix dead link in the dynamic blocks tutorial

### DIFF
--- a/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md
@@ -107,7 +107,7 @@ There are a few things to notice:
 -   The built-in `save` function just returns `null` because the rendering is performed server-side.
 -   The server-side rendering is a function taking the block and the block inner content as arguments, and returning the markup (quite similar to shortcodes)
 
-**Note :** For common customization settings including color, border, spacing customization and more, we will see on the [next chapter](/docs/how-to-guides/block-tutorial/block-supports-in-dynamic-blocks.md) how you can rely on block supports to provide such functionality in an efficient way.
+**Note :** For common customization settings including color, border, spacing customization and more, you can rely on [block supports](/docs/reference-guides/block-api/block-supports.md) to provide such functionality in an efficient way.
 
 ## Live rendering in the block editor
 


### PR DESCRIPTION
Fixes a dead link in the \"Creating dynamic blocks\" tutorial. The note at the end of the \"Creating dynamic blocks\" section linked to `block-supports-in-dynamic-blocks.md` as the \"next chapter\", but that file was removed, so the link is broken. The note now links to the [Block Supports reference](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/) instead, and the \"we will see on the next chapter\" wording was updated since the target is no longer a chapter of the tutorial.

## Testing Instructions

1. Open `docs/how-to-guides/block-tutorial/creating-dynamic-blocks.md` and verify the note under \"There are a few things to notice\" links to `/docs/reference-guides/block-api/block-supports.md`.
2. Verify that file exists in the repository.

*Note: This PR was created with AI assistance.*