### PR TITLE
UI: Add initial agents guidance mapping to contributing guidelines

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,28 +1,11 @@
-## Status
+## About this package
 
-`@wordpress/ui` is the home for design system components. The package includes many common UI components, though equivalents may still live in `@wordpress/components`; see the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for which to use.
+This directory is [`@wordpress/ui`](./README.md), the WordPress Design System's library of low-level React UI components built on the [`@wordpress/theme`](../theme/) foundation with token-driven styling and consistent patterns.
 
-Full guidance lives in [CONTRIBUTING.md](./CONTRIBUTING.md). The points below summarize how code in this package should be written.
+The WordPress Design System is a collection of reusable components, design tokens, and guidelines that work together across multiple packages for building the WordPress administrative dashboard. For how foundational packages (`@wordpress/theme`, `@wordpress/ui`, `@wordpress/icons`) and compositional packages (including `@wordpress/dataviews`, `@wordpress/admin-ui`) relate to one another, see [Design System/Introduction](../../../storybook/stories/design-system/introduction.mdx).
 
-## Scope
+[`@wordpress/components`](../components/) is a separate collection of UI components that grew organically over time. It is not the design system, though it remains maintained and contains components which either have no stable alternatives in `@wordpress/ui` yet or serve a niche use-case of the WordPress editors and aren't broadly reusable for building administrative interfaces. See the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for the canonical source of component status.
 
--   Add a component here only when it is generic and reusable in building admin interfaces. If it can live in a higher-level package or one scoped to a particular feature (`admin-ui`, `block-editor`, `dataviews`, etc.), it should.
--   Prefer composing existing `@wordpress/ui` components over bespoke markup and styles.
+## Guidance
 
-## Styling
-
--   Use semantic `--wpds-*` tokens for visual values; avoid hardcoded colors, spacing, and arbitrary consumer-facing value props. See [Design principles](./CONTRIBUTING.md#design-principles).
--   Match token families to semantics: `interactive` for clickable UI, `content` for static text; use state variants (`-active`, `-disabled`) rather than mixing tones across states.
--   Do not ship outer margins on component roots. Consumers should provide their own spacing.
--   Follow the [CSS layer pattern](./CONTRIBUTING.md#css-layers) and the [custom property / state rules](./CONTRIBUTING.md#custom-properties-and-state-styles).
--   Style disabled states with `[data-disabled]` for Base UI components. See [Disabled state styling](./CONTRIBUTING.md#disabled-state-styling).
--   Respect `prefers-reduced-motion` when adding motion animation. See [Design principles](./CONTRIBUTING.md#design-principles).
--   Apply [global CSS defense](./CONTRIBUTING.md#global-css-defense-wp-admin) classes when rendering native elements affected by wp-admin global styling.
-
-## Code conventions
-
--   Follow the [folder structure](./CONTRIBUTING.md#folder-structure) and [public API rules](./CONTRIBUTING.md#public-apis).
--   Use [compound components](./CONTRIBUTING.md#compound-components) and the [`render` prop patterns](./CONTRIBUTING.md#render-prop-and-ref-forwarding).
--   Use `ComponentProps` from `../utils/types` for wp-ui components; do not export prop types — use `React.ComponentProps< typeof Component >`.
--   Use `forwardRef`, named function expressions, and `displayName` on subcomponents.
--   Add Storybook stories under `Design System/Components/`.
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) before adding or changing code here. It is the canonical guidance for this package, including [design principles](./CONTRIBUTING.md#design-principles), folder structure, styling, and APIs.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,11 +1,3 @@
-## About this package
+# Guidance
 
-This directory is [`@wordpress/ui`](./README.md), the WordPress Design System's library of low-level React UI components built on the [`@wordpress/theme`](../theme/) foundation with token-driven styling and consistent patterns.
-
-The WordPress Design System is a collection of reusable components, design tokens, and guidelines that work together across multiple packages for building the WordPress administrative dashboard. For how foundational packages (`@wordpress/theme`, `@wordpress/ui`, `@wordpress/icons`) and compositional packages (including `@wordpress/dataviews`, `@wordpress/admin-ui`) relate to one another, see [Design System/Introduction](../../../storybook/stories/design-system/introduction.mdx).
-
-[`@wordpress/components`](../components/) is a separate collection of UI components that grew organically over time. It is not the design system, though it remains maintained and contains components which either have no stable alternatives in `@wordpress/ui` yet or serve a niche use-case of the WordPress editors and aren't broadly reusable for building administrative interfaces. See the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for the canonical source of component status.
-
-## Guidance
-
-Read [CONTRIBUTING.md](./CONTRIBUTING.md) before adding or changing code here. It is the canonical guidance for this package, including [design principles](./CONTRIBUTING.md#design-principles), folder structure, styling, and APIs.
+Before adding or changing code in this directory, read [CONTRIBUTING.md](./CONTRIBUTING.md). It is the canonical guidance for this package.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,3 +1,6 @@
 # Guidance
 
-Before adding or changing code in this directory, read [CONTRIBUTING.md](./CONTRIBUTING.md). It is the canonical guidance for this package.
+Before adding or changing code in this directory:
+
+-   Read [README.md](./README.md) for this package's role, its relationship to other Design System packages, and setup guidance.
+-   Read [CONTRIBUTING.md](./CONTRIBUTING.md) for the canonical design principles, implementation patterns, styling, and public API guidance.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,28 @@
+## Status
+
+`@wordpress/ui` is the home for design system components. The package includes many common UI components, though equivalents may still live in `@wordpress/components`; see the [`use-recommended-components` ESLint rule](../eslint-plugin/rules/use-recommended-components.js) for which to use.
+
+Full guidance lives in [CONTRIBUTING.md](./CONTRIBUTING.md). The points below summarize how code in this package should be written.
+
+## Scope
+
+-   Add a component here only when it is generic and reusable in building admin interfaces. If it can live in a higher-level package or one scoped to a particular feature (`admin-ui`, `block-editor`, `dataviews`, etc.), it should.
+-   Prefer composing existing `@wordpress/ui` components over bespoke markup and styles.
+
+## Styling
+
+-   Use semantic `--wpds-*` tokens for visual values; avoid hardcoded colors, spacing, and arbitrary consumer-facing value props. See [Design principles](./CONTRIBUTING.md#design-principles).
+-   Match token families to semantics: `interactive` for clickable UI, `content` for static text; use state variants (`-active`, `-disabled`) rather than mixing tones across states.
+-   Do not ship outer margins on component roots. Consumers should provide their own spacing.
+-   Follow the [CSS layer pattern](./CONTRIBUTING.md#css-layers) and the [custom property / state rules](./CONTRIBUTING.md#custom-properties-and-state-styles).
+-   Style disabled states with `[data-disabled]` for Base UI components. See [Disabled state styling](./CONTRIBUTING.md#disabled-state-styling).
+-   Respect `prefers-reduced-motion` when adding motion animation. See [Design principles](./CONTRIBUTING.md#design-principles).
+-   Apply [global CSS defense](./CONTRIBUTING.md#global-css-defense-wp-admin) classes when rendering native elements affected by wp-admin global styling.
+
+## Code conventions
+
+-   Follow the [folder structure](./CONTRIBUTING.md#folder-structure) and [public API rules](./CONTRIBUTING.md#public-apis).
+-   Use [compound components](./CONTRIBUTING.md#compound-components) and the [`render` prop patterns](./CONTRIBUTING.md#render-prop-and-ref-forwarding).
+-   Use `ComponentProps` from `../utils/types` for wp-ui components; do not export prop types — use `React.ComponentProps< typeof Component >`.
+-   Use `forwardRef`, named function expressions, and `displayName` on subcomponents.
+-   Add Storybook stories under `Design System/Components/`.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Documentation
 
--   Document design principles and route coding agents to the package's canonical contribution guidelines. ([#81400](https://github.com/WordPress/gutenberg/pull/81400))
+-   Document design principles and route coding agents to the package's canonical documentation. ([#81400](https://github.com/WordPress/gutenberg/pull/81400))
 
 ### Internal
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 -   `Card`: Use the normal neutral surface stroke for the default border. ([#81746](https://github.com/WordPress/gutenberg/pull/81746))
 
+### Documentation
+
+-   Document design principles and route coding agents to the package's canonical contribution guidelines. ([#81400](https://github.com/WordPress/gutenberg/pull/81400))
+
 ### Internal
 
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 The following guidance builds upon the existing [contribution guidelines for `@wordpress/components`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md), which should serve as a starting point for contribution. The documentation included here encodes decisions and technical approaches which are unique to this package.
 
+## Design principles
+
+-   **Scope**: Only add components that are generic and reusable in building admin interfaces. If it can live in a higher-level package or one scoped to a particular feature (`admin-ui`, `block-editor`, `dataviews`, etc.), it should.
+-   **Composition**: Prefer existing `@wordpress/ui` primitives over bespoke markup and styles when they fit.
+-   **Spacing**: Components should not ship with outer margins. Consumers should provide their own spacing via layout like `Stack` or `className` custom styling.
+-   **Tokens**: Visual values should use semantic `--wpds-*` design tokens, not hardcoded colors or spacing. Avoid props that accept arbitrary CSS values when a token or variant can express the intent.
+-   **Token semantics**: Use `interactive` tokens for clickable UI and `content` tokens for static text. Prefer state variants (`-active`, `-disabled`) over mixing tones (for example, neutral at rest and brand on hover).
+-   **Motion**: Animation should respect `prefers-reduced-motion`.
+
 ## Folder Structure
 
 Each component should be organized within its own folder under `src/` following this pattern:
@@ -107,15 +116,18 @@ For components that do **not** wrap a Base UI primitive, use `useRender` and `me
 import { useRender, mergeProps } from '@base-ui/react';
 import { forwardRef } from '@wordpress/element';
 
-export const Root = forwardRef( function MyComponent( { render, className, ...restProps }, ref ) {
-    const element = useRender( {
-        render,
-        defaultTagName: 'div',
-        ref,
-        props: mergeProps( { className: styles.root }, restProps ),
-    } );
+export const Root = forwardRef( function MyComponent(
+	{ render, className, ...restProps },
+	ref
+) {
+	const element = useRender( {
+		render,
+		defaultTagName: 'div',
+		ref,
+		props: mergeProps( { className: styles.root }, restProps ),
+	} );
 
-    return element;
+	return element;
 } );
 ```
 
@@ -130,7 +142,7 @@ import { Collapsible as _Collapsible } from '@base-ui/react/collapsible';
 import { forwardRef } from '@wordpress/element';
 
 export const Trigger = forwardRef( function MyTrigger( props, ref ) {
-    return <_Collapsible.Trigger ref={ ref } { ...props } />;
+	return <_Collapsible.Trigger ref={ ref } { ...props } />;
 } );
 ```
 
@@ -160,14 +172,19 @@ The default can be a **JSX element** or a **render function**, depending on what
 const DEFAULT_TAG = <div />;
 
 export const Title = forwardRef( function MyTitle(
-    { render = DEFAULT_TAG, className, children, ...props },
-    ref
+	{ render = DEFAULT_TAG, className, children, ...props },
+	ref
 ) {
-    return (
-        <Text ref={ ref } render={ render } className={ className } { ...props }>
-            { children }
-        </Text>
-    );
+	return (
+		<Text
+			ref={ ref }
+			render={ render }
+			className={ className }
+			{ ...props }
+		>
+			{ children }
+		</Text>
+	);
 } );
 ```
 
@@ -175,16 +192,21 @@ export const Title = forwardRef( function MyTitle(
 // Render function — useful when the default needs to compose
 // other components or add additional props.
 const DEFAULT_RENDER = ( props: React.ComponentProps< typeof Stack > ) => (
-    <Stack { ...props } direction="column" gap="sm" />
+	<Stack { ...props } direction="column" gap="sm" />
 );
 
 export const Root = forwardRef( function MyRoot(
-    { className, render = DEFAULT_RENDER, ...restProps },
-    ref
+	{ className, render = DEFAULT_RENDER, ...restProps },
+	ref
 ) {
-    return (
-        <_Field.Root ref={ ref } className={ className } render={ render } { ...restProps } />
-    );
+	return (
+		<_Field.Root
+			ref={ ref }
+			className={ className }
+			render={ render }
+			{ ...restProps }
+		/>
+	);
 } );
 ```
 
@@ -206,12 +228,12 @@ When `render` is provided by the consumer, `ref` and `...props` remain on the un
 ```tsx
 // BAD: destructure-and-pass-through with no interaction
 function MyComponent( { render, ...props }, ref ) {
-    return <Inner ref={ ref } render={ render } { ...props } />;
+	return <Inner ref={ ref } render={ render } { ...props } />;
 }
 
 // GOOD: let render flow through ...props
 function MyComponent( props, ref ) {
-    return <Inner ref={ ref } { ...props } />;
+	return <Inner ref={ ref } { ...props } />;
 }
 ```
 
@@ -315,10 +337,10 @@ Define a separate custom property per state, and use CSS property declarations i
 .button {
 	--button-bg: blue;
 	--button-bg-hover: darkblue;
-	background-color: var(--button-bg);
+	background-color: var( --button-bg );
 
 	&:hover {
-		background-color: var(--button-bg-hover);
+		background-color: var( --button-bg-hover );
 	}
 }
 ```
@@ -332,7 +354,7 @@ Do not reassign the same custom property in state selectors:
 ```css
 .button {
 	--button-bg: blue;
-	background-color: var(--button-bg);
+	background-color: var( --button-bg );
 
 	&:hover {
 		--button-bg: darkblue;

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -11,6 +11,10 @@ While similar in scope to `@wordpress/components`, there are a few key differenc
 -   `@wordpress/components` grew organically as a collection of unrelated UI elements for WordPress screens. In contrast, this package is an implementation of a design system that guarantees user- and developer-facing cohesion between components.
 -   Unlike `@wordpress/components`, this package is not bundled as a WordPress script available on the `window.wp` global and is instead distributed as an npm package that follows [semantic versioning](https://semver.org/) for release changes.
 
+`@wordpress/theme`, `@wordpress/ui`, and `@wordpress/icons` form the foundational layer of the Design System. Higher-level compositional packages, including `@wordpress/dataviews` and `@wordpress/admin-ui`, build common solutions from those foundations. See the version-matched [Design System introduction](../../storybook/stories/design-system/introduction.mdx) in a Gutenberg checkout, or the [latest copy on Gutenberg trunk](https://github.com/WordPress/gutenberg/blob/trunk/storybook/stories/design-system/introduction.mdx) when reading this package outside the monorepo.
+
+This package includes many common UI components, but equivalent components can still live in `@wordpress/components`. For current component-by-component guidance, including when an existing `@wordpress/components` component remains the recommended choice, see the version-matched [`use-recommended-components` rule documentation](../eslint-plugin/docs/rules/use-recommended-components.md) in a Gutenberg checkout, or the [latest copy on Gutenberg trunk](https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/docs/rules/use-recommended-components.md) when reading this package outside the monorepo.
+
 This is a companion to the `@wordpress/theme` package that provides:
 
 -   **Design Tokens**: A comprehensive system of design tokens for colors, spacing, typography, and more


### PR DESCRIPTION
Related: #80597

> [!NOTE]
> The current implementation keeps `packages/ui/AGENTS.md` as a minimal router to the local `README.md` and `CONTRIBUTING.md`, so the public package documentation remains the canonical, version-aligned source. The README states the package relationship and coexistence guidance directly, then links to version-matched monorepo documents with canonical trunk fallbacks for packaged copies. #80597 continues the complementary task-workflow guidance in parallel. The original rationale and source examples below are preserved; references to a "compacted snapshot" and to contributor guidelines not being readily accessible describe the initial iteration of this PR.

## What?

Adds an initial `packages/ui/AGENTS.md` agents context document as a compacted snapshot of existing [contributing guidelines](https://github.com/WordPress/gutenberg/blob/trunk/packages/ui/CONTRIBUTING.md), adding a new "Design Principles" section to the contributing guidelines in the process.

## Why?

Ultimately, the goal here is to try to reduce the amount of back-and-forth review that can happen for contributions to the design system based on basic tenets of building components, and reducing the up-front effort of the contributor in the process.

This also keeps us accountable to the principles around review feedback being documented somewhere, and not trapped within any one individual or group's personal knowledge.

We already have [contributing guidelines](https://github.com/WordPress/gutenberg/blob/trunk/packages/ui/CONTRIBUTING.md), but these aren't readily accessible to an AI agent. And even if they were, they're quite verbose and written for human readers to rationalize decisions.

## How?

First, I'll caveat to say this isn't meant to be exhaustive. It's a starting point.

But what was devised here was based on real-world observations on things that either come up in review or are flagged as intentional differences from how alternative equivalent components had been written (e.g. see #81358 "Differences from `@wordpress/components`").

* “Only add components when generic/reusable; if it can live in a higher-level package, it should.”
   * Examples: 
      * ["This component is essentially a pattern of existing components, and my instinct tells me it belongs to a higher level of abstraction."](https://github.com/WordPress/gutenberg/pull/74719#issuecomment-3848689716)
      * ["If it can live somewhere else, it should"](https://github.com/WordPress/gutenberg/pull/74719#issuecomment-3856137493)
* “Prefer composing existing @wordpress/ui components over bespoke markup and styles.”
   * Examples:
      * ["Use existing `@wordpress/ui` components [...] remove the need for custom markup/styles"](https://github.com/Automattic/wp-calypso/pull/111036#discussion_r3403425390)
* “Components should not ship with outer margins.”
   * Examples:
      * ["No default margin [...] callers can add spacing via className or style where needed."](https://github.com/WordPress/gutenberg/pull/81358)
* “Use semantic tokens; avoid hardcoded colors/spacing and arbitrary value props.”
   * Examples:
      * ["I'd try to replace these all with `@wordpress/theme` style tokens."](https://github.com/Automattic/wp-calypso/pull/111036#discussion_r3323981488)
      * ["Differences from `@wordpress/components` [...] WPDS tokens"](https://github.com/WordPress/gutenberg/pull/81358)
* "Use interactive for clickable UI, content for static text; use -active/-disabled, don’t mix tones across states.”
   * Examples:
      * ["Mixing and matching the tone (ie. neutral in the resting state, and brand in the hover state) should be avoided when using the tokens."](https://github.com/Automattic/wp-calypso/pull/111036#discussion_r3390052669)
      * ["We shouldn't mix and match these [states] categories"](https://github.com/WordPress/gutenberg/pull/81088#discussion_r3727769345)
      * ["Per WPDS token guidance, we shouldn't mix and match: [...] `content` and `interactive` elements [...] `neutral` and `brand` tones for different states of the same UI"](https://github.com/WordPress/gutenberg/pull/81337#discussion_r3749764712)
* “Animation should respect prefers-reduced-motion.”
   * Examples:
      * ["Differences from `@wordpress/components` [...] `prefers-reduced-motion`"](https://github.com/WordPress/gutenberg/pull/81358)

## Testing Instructions

Review documents for accuracy.

## Use of AI Tools

Research and implementation with Cursor IDE + Auto model, given related context for preexisting examples from pull requests and existing guidance. AI-produced content was reviewed for accuracy and manually edited accordingly.

Follow-up restructuring, changelog work, rebase verification, and this description update used Codex. The resulting changes were reviewed and verified before publication.
