### PR TITLE
Notes: Fix text wrapping for long usernames in collaboration sidebar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -89,6 +89,8 @@
 }
 
 .editor-collab-sidebar-panel__note-content {
+	overflow-wrap: break-word;
+
 	p:last-child {
 		margin-bottom: 0;
 	}
@@ -255,7 +257,7 @@ mark.wp-note {
 	background: var(--wpds-color-background-surface-brand);
 	color: var(--wpds-color-foreground-interactive-brand);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
-	white-space: nowrap;
+	overflow-wrap: anywhere;
 
 	// Keep the chip boundary visible when forced-colors drops the background tint.
 	@media (forced-colors: active) {

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -160,7 +160,7 @@
 	max-height: calc(20px * 20 + 18px); // 20 rows + vertical padding.
 	overflow-y: auto;
 	white-space: pre-wrap;
-	word-wrap: break-word;
+	overflow-wrap: break-word;
 
 	// Inline formats inherit the surrounding text styles but keep
 	// their semantic emphasis (RichText renders <strong>, <em>, etc.).

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -257,7 +257,6 @@ mark.wp-note {
 	background: var(--wpds-color-background-surface-brand);
 	color: var(--wpds-color-foreground-interactive-brand);
 	font-weight: var(--wpds-typography-font-weight-emphasis);
-	overflow-wrap: anywhere;
 
 	// Keep the chip boundary visible when forced-colors drops the background tint.
 	@media (forced-colors: active) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/81403

Tagging a user with a long handle in a note no longer breaks the text layout, in the reply field or in the published comment.

## Why?

The mention chip was set to never wrap (`white-space: nowrap`). The notes column is only ~214px wide, so a long handle makes the chip wider than the column. The note content clips its overflow, so the text isn't just squashed, it's cut off and unreadable.

## How?

Two CSS changes in the collab sidebar stylesheet:

- `.wp-note-mention` — dropped `white-space: nowrap` and allowed it to breakwith `overflow-wrap: anywhere`, so a handle too long for the column wraps instead of overflowing.
- `.editor-collab-sidebar-panel__note-content` — added `overflow-wrap: break-word`, matching what the reply field already does.


## Testing Instructions

1. Create a user with a long display name, e.g. `userwithaloooooooonghandle`.
2. Open a post that has a note on a block, and resolve that note.
3. Click the resolved note and choose "Reopen & Reply".
4. Type `@`, pick the long-handled user, then type some text after it,
   e.g. `hello`.
5. Submit the reply.

Before: the text is cut off at the right edge, both while typing and in the posted comment.
After: it wraps and stays fully visible.

Notes that were already saved in the broken state also display correctly again, without editing them.

### Testing Instructions for Keyboard

1. Open the notes sidebar and focus the reply field.
2. Type `@`, use the arrow keys to move through the suggestions, Enter to pick one.
3. Type text, then Tab to the submit button and press Enter.
4. Confirm the mention and the text after it wrap and stay visible.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/561504c3-9914-41e1-acd1-6c8a93cb4415

### After

https://github.com/user-attachments/assets/be761554-f9c4-429f-b44b-8f21e5bfa0ad

## Use of AI Tools

Used Claude Code to help track down the cause and test the fix locally. The change is two CSS lines, reviewed and tested by me.
