### PR TITLE
Global Styles: report border, shadow, outline, filter and dimension changes

### DIFF
--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Report changes to border, shadow, outline, filter and dimensions in the global styles changelist. These are rendered by the styles engine but were not compared, so a revision or a pending save that changed only one of them said nothing had changed.
 -   Render block element styles defined only inside responsive viewport states.
 
 ## 1.19.0 (2026-07-29)

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Report changes to border, shadow, outline, filter and dimensions in the global styles changelist. These are rendered by the styles engine but were not compared, so a revision or a pending save that changed only one of them said nothing had changed.
+-   Report changes to site-wide border, shadow, outline, filter and dimensions in the global styles changelist. These are rendered by the styles engine but were not compared, so changing only one of them was reported as no change at all ([#81407](https://github.com/WordPress/gutenberg/pull/81407)).
 -   Render block element styles defined only inside responsive viewport states.
 
 ## 1.19.0 (2026-07-29)

--- a/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
+++ b/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
@@ -54,6 +54,19 @@ describe( 'getGlobalStylesChanges and utils', () => {
 			color: {
 				text: 'var(--wp--preset--color--tomato)',
 			},
+			border: {
+				width: '2px',
+			},
+			shadow: 'var(--wp--preset--shadow--natural)',
+			outline: {
+				style: 'dotted',
+			},
+			filter: {
+				opacity: '40',
+			},
+			dimensions: {
+				minHeight: '10px',
+			},
 			blocks: {
 				'core/test-fiori-di-zucca': {
 					color: {
@@ -205,7 +218,7 @@ describe( 'getGlobalStylesChanges and utils', () => {
 		it( 'returns a list of changes', () => {
 			const result = getGlobalStylesChanges( next, previous );
 			expect( result ).toEqual( [
-				'Background, Colors, Typography styles.',
+				'Background, Colors, Typography, Border, Shadow, Outline, Filter, Dimensions styles.',
 				'Test pumpkin flowers block.',
 				'H3, Caption, H6, Link elements.',
 				'Color, Typography settings.',
@@ -217,8 +230,7 @@ describe( 'getGlobalStylesChanges and utils', () => {
 				maxResults: 4,
 			} );
 			expect( resultA ).toEqual( [
-				'Background, Colors, Typography styles.',
-				'Test pumpkin flowers block.',
+				'Background, Colors, Typography, Border styles.',
 			] );
 		} );
 
@@ -267,6 +279,11 @@ describe( 'getGlobalStylesChanges and utils', () => {
 				[ 'styles', 'Background' ],
 				[ 'styles', 'Colors' ],
 				[ 'styles', 'Typography' ],
+				[ 'styles', 'Border' ],
+				[ 'styles', 'Shadow' ],
+				[ 'styles', 'Outline' ],
+				[ 'styles', 'Filter' ],
+				[ 'styles', 'Dimensions' ],
 				[ 'blocks', 'Test pumpkin flowers' ],
 				[ 'elements', 'H3' ],
 				[ 'elements', 'Caption' ],
@@ -279,49 +296,6 @@ describe( 'getGlobalStylesChanges and utils', () => {
 			const resultB = getGlobalStylesChangelist( next, previous );
 
 			expect( resultB ).toEqual( resultA );
-		} );
-
-		/*
-		 * These properties are rendered by the styles engine but were not
-		 * compared, so changing only one of them reported no change at all.
-		 */
-		it.each( [
-			[ 'border', { border: { width: '2px' } }, 'Border' ],
-			[
-				'shadow',
-				{ shadow: 'var(--wp--preset--shadow--natural)' },
-				'Shadow',
-			],
-			[ 'outline', { outline: { style: 'dotted' } }, 'Outline' ],
-			[ 'filter', { filter: { opacity: '40' } }, 'Filter' ],
-			[
-				'dimensions',
-				{ dimensions: { minHeight: '10px' } },
-				'Dimensions',
-			],
-		] )( 'reports a change to %s', ( _name, styles, label ) => {
-			expect(
-				getGlobalStylesChangelist( { styles }, { styles: {} } )
-			).toEqual( [ [ 'styles', label ] ] );
-		} );
-
-		it( 'reports the newly compared properties alongside the existing ones', () => {
-			expect(
-				getGlobalStylesChangelist(
-					{
-						styles: {
-							color: { text: 'red' },
-							border: { radius: '4px' },
-							dimensions: { maxWidth: '20px' },
-						},
-					},
-					{ styles: {} }
-				)
-			).toEqual( [
-				[ 'styles', 'Colors' ],
-				[ 'styles', 'Border' ],
-				[ 'styles', 'Dimensions' ],
-			] );
 		} );
 	} );
 } );

--- a/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
+++ b/packages/global-styles-engine/src/test/get-global-styles-changes.test.ts
@@ -280,5 +280,48 @@ describe( 'getGlobalStylesChanges and utils', () => {
 
 			expect( resultB ).toEqual( resultA );
 		} );
+
+		/*
+		 * These properties are rendered by the styles engine but were not
+		 * compared, so changing only one of them reported no change at all.
+		 */
+		it.each( [
+			[ 'border', { border: { width: '2px' } }, 'Border' ],
+			[
+				'shadow',
+				{ shadow: 'var(--wp--preset--shadow--natural)' },
+				'Shadow',
+			],
+			[ 'outline', { outline: { style: 'dotted' } }, 'Outline' ],
+			[ 'filter', { filter: { opacity: '40' } }, 'Filter' ],
+			[
+				'dimensions',
+				{ dimensions: { minHeight: '10px' } },
+				'Dimensions',
+			],
+		] )( 'reports a change to %s', ( _name, styles, label ) => {
+			expect(
+				getGlobalStylesChangelist( { styles }, { styles: {} } )
+			).toEqual( [ [ 'styles', label ] ] );
+		} );
+
+		it( 'reports the newly compared properties alongside the existing ones', () => {
+			expect(
+				getGlobalStylesChangelist(
+					{
+						styles: {
+							color: { text: 'red' },
+							border: { radius: '4px' },
+							dimensions: { maxWidth: '20px' },
+						},
+					},
+					{ styles: {} }
+				)
+			).toEqual( [
+				[ 'styles', 'Colors' ],
+				[ 'styles', 'Border' ],
+				[ 'styles', 'Dimensions' ],
+			] );
+		} );
 	} );
 } );

--- a/packages/global-styles-engine/src/utils/get-global-styles-changes.ts
+++ b/packages/global-styles-engine/src/utils/get-global-styles-changes.ts
@@ -31,6 +31,11 @@ const translationMap: TranslationMap = {
 	'styles.spacing': __( 'Spacing' ),
 	'styles.background': __( 'Background' ),
 	'styles.typography': __( 'Typography' ),
+	'styles.border': __( 'Border' ),
+	'styles.shadow': __( 'Shadow' ),
+	'styles.outline': __( 'Outline' ),
+	'styles.filter': __( 'Filter' ),
+	'styles.dimensions': __( 'Dimensions' ),
 };
 const getBlockNames = memoize(
 	(): BlockNamesMap =>
@@ -125,6 +130,40 @@ function deepCompare(
 	return diffs;
 }
 
+/*
+ * The top-level style properties reported as changes, in the order they appear
+ * in the results. These are the properties the styles engine renders, minus
+ * `blocks` and `elements`, which are compared separately because their changes
+ * are named after the block or element rather than the property.
+ *
+ * Keep in step with `STYLE_KEYS` in `core/render.tsx`: a property the engine
+ * renders but that is missing here is a real change the user is never told
+ * about.
+ */
+const COMPARED_STYLE_KEYS = [
+	'background',
+	'color',
+	'typography',
+	'spacing',
+	'border',
+	'shadow',
+	'outline',
+	'filter',
+	'dimensions',
+] as const;
+
+/**
+ * Picks the style properties that are compared for changes.
+ *
+ * @param config A global styles config.
+ * @return The subset of `config.styles` that is compared.
+ */
+function pickComparedStyles( config: any ): Record< string, any > {
+	return Object.fromEntries(
+		COMPARED_STYLE_KEYS.map( ( key ) => [ key, config?.styles?.[ key ] ] )
+	);
+}
+
 /**
  * Returns an array of translated summarized global styles changes.
  * Results are cached using a Map() key of `JSON.stringify( { next, previous } )`.
@@ -150,23 +189,13 @@ export function getGlobalStylesChangelist(
 	 */
 	const changedValueTree = deepCompare(
 		{
-			styles: {
-				background: next?.styles?.background,
-				color: next?.styles?.color,
-				typography: next?.styles?.typography,
-				spacing: next?.styles?.spacing,
-			},
+			styles: pickComparedStyles( next ),
 			blocks: next?.styles?.blocks,
 			elements: next?.styles?.elements,
 			settings: next?.settings,
 		},
 		{
-			styles: {
-				background: previous?.styles?.background,
-				color: previous?.styles?.color,
-				typography: previous?.styles?.typography,
-				spacing: previous?.styles?.spacing,
-			},
+			styles: pickComparedStyles( previous ),
 			blocks: previous?.styles?.blocks,
 			elements: previous?.styles?.elements,
 			settings: previous?.settings,

--- a/packages/global-styles-engine/src/utils/get-global-styles-changes.ts
+++ b/packages/global-styles-engine/src/utils/get-global-styles-changes.ts
@@ -131,14 +131,19 @@ function deepCompare(
 }
 
 /*
- * The top-level style properties reported as changes, in the order they appear
- * in the results. These are the properties the styles engine renders, minus
- * `blocks` and `elements`, which are compared separately because their changes
- * are named after the block or element rather than the property.
+ * The top-level style properties reported as changes. These are the properties
+ * the styles engine renders, minus `blocks` and `elements`, which are compared
+ * separately because their changes are named after the block or element rather
+ * than the property.
  *
- * Keep in step with `STYLE_KEYS` in `core/render.tsx`: a property the engine
- * renders but that is missing here is a real change the user is never told
- * about.
+ * Deliberately a separate list rather than a reuse of `STYLE_KEYS` in
+ * `core/render.tsx`, because the order here is the order the changes are read
+ * in, so it is sorted by what a person is most likely to have changed. The
+ * engine's list is ordered for rendering and sorting it for prose would be the
+ * wrong trade.
+ *
+ * Keep the two in step all the same: a property the engine renders but that is
+ * missing here is a real change the user is never told about.
  */
 const COMPARED_STYLE_KEYS = [
 	'background',

--- a/packages/global-styles-engine/src/utils/get-global-styles-changes.ts
+++ b/packages/global-styles-engine/src/utils/get-global-styles-changes.ts
@@ -131,19 +131,13 @@ function deepCompare(
 }
 
 /*
- * The top-level style properties reported as changes. These are the properties
- * the styles engine renders, minus `blocks` and `elements`, which are compared
- * separately because their changes are named after the block or element rather
+ * The top-level style properties reported as changes.
+ * `blocks` and `elements` changes are named after the block or element rather
  * than the property.
  *
  * Deliberately a separate list rather than a reuse of `STYLE_KEYS` in
  * `core/render.tsx`, because the order here is the order the changes are read
- * in, so it is sorted by what a person is most likely to have changed. The
- * engine's list is ordered for rendering and sorting it for prose would be the
- * wrong trade.
- *
- * Keep the two in step all the same: a property the engine renders but that is
- * missing here is a real change the user is never told about.
+ * in, so it is sorted by what a person is most likely to have changed.
  */
 const COMPARED_STYLE_KEYS = [
 	'background',


### PR DESCRIPTION
## What?

Report changes to `border`, `shadow`, `outline`, `filter` and `dimensions` in the global styles changelist.

## Why?

The changelist compared four top-level style properties by name; the styles engine renders nine. Changing only one of the missing five was reported as no change at all.

This affects site-wide styles only. A change inside `styles.blocks` is named after the block rather than the property, so block-level changes were already covered.

## How?

Take the compared properties from the same set the engine renders (`STYLE_KEYS` in `core/render.tsx`) and add a `translationMap` label for each. A property without a label is dropped, so both halves are required.

Follow up to #81373, which calls the changelist per block and so relies on this list for every block summary.

## Testing Instructions

1. Open the Site Editor -> Styles -> Shadows, and set a shadow on the site.
2. Click Save. The panel lists the pending change as "Shadow styles." On trunk it is absent from the list.
3. Save, then open Styles -> Revisions. The latest revision names Shadow too.
4. Repeat with a site-wide outline, filter or dimension change.

### Testing Instructions for Keyboard

No UI was added. The strings appear in the existing save panel and revisions list, which are reachable and readable as before.

## Screenshots or screencast

<img width="257" height="253" alt="Screenshot 2026-08-11 at 1 57 49 pm" src="https://github.com/user-attachments/assets/f5af5fed-57ef-48a8-b1a0-39183ceb0c31" />
<img width="399" height="328" alt="Screenshot 2026-08-11 at 2 00 26 pm" src="https://github.com/user-attachments/assets/8c9e48c2-6bde-4c4e-8dfd-6f8fc60423a3" />
<img width="439" height="386" alt="Screenshot 2026-08-11 at 1 59 14 pm" src="https://github.com/user-attachments/assets/c8694bc2-bf32-441d-8d2e-1ecbf94d0f9c" />