### PR TITLE
Fix scroll lock over the in-between block inserter

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 
+-   `usePopoverScroll`: Prevent the default action on the wheel events it forwards into the canvas. Block popovers render outside the canvas iframe, in a document with no room to scroll, so the browser would start a mousewheel transaction against a target it could never scroll and drop subsequent wheel events until the pointer moved. Scrolling with the pointer over the in-between block inserter froze for several seconds as a result ([#81415](https://github.com/WordPress/gutenberg/pull/81415)).
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/src/components/block-popover/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-popover/use-popover-scroll.js
@@ -28,12 +28,20 @@ function usePopoverScroll( contentRef ) {
 				// Scrolls “through” the popover only if another contained scrollable area isn’t
 				// in front of it. This is to avoid scrolling both containers simultaneously.
 				if ( ! node.contains( eventScrollContainer ) ) {
+					// Prevent the browser from starting a mousewheel
+					// transaction against this popover's own scroll chain. The
+					// popover renders outside the canvas iframe, in a document
+					// that has no room to scroll, so the browser would latch
+					// onto a target it can never scroll and drop subsequent
+					// wheel events until the pointer moves or the transaction
+					// times out. See https://github.com/WordPress/gutenberg/issues/80712
+					event.preventDefault();
 					scrollContainer.scrollBy( deltaX, deltaY );
 				}
 			}
-			// Tell the browser that we do not call event.preventDefault
-			// See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners
-			const options = { passive: true };
+			// Not passive: the handler calls preventDefault to stop the
+			// browser latching a wheel transaction onto an unscrollable target.
+			const options = { passive: false };
 			node.addEventListener( 'wheel', onWheel, options );
 			return () => {
 				node.removeEventListener( 'wheel', onWheel, options );


### PR DESCRIPTION
## What?

Closes #80712

Stops the in-between block inserter locking up mouse-wheel scrolling in the editor canvas.

## Why?

Hovering the gap between two blocks until the blue insertion line appears, then scrolling with a physical mouse wheel, freezes scrolling for several seconds. Moving the pointer releases it immediately.

The cause is a browser **mousewheel transaction** (Chromium calls it scroll latching), not a browser bug — the linked Mozilla report ([2054425](https://bugzilla.mozilla.org/show_bug.cgi?id=2054425)) was closed as INVALID after investigation by a Gecko scrolling engineer. Once a wheel event picks a scroll target, the browser locks that target until the pointer moves or an idle timeout expires.

Block popovers render **outside** the canvas iframe, in a document whose `<html>` has no room to scroll (`scrollTopMax` is 0; all the scrollable range lives inside the iframe). When `.is-with-inserter` makes the full-gap overlay hit-testable, a wheel event lands there and the browser latches onto a target it can never scroll. Once the canvas moves and the pointer is no longer over the popover, `usePopoverScroll` stops running and nothing scrolls until the transaction lapses.

Full analysis and instrumented measurements: https://github.com/WordPress/gutenberg/issues/80712#issuecomment-5249644696

## How?

`usePopoverScroll` already forwards the wheel delta into the canvas, but registers its listener as `{ passive: true }`, which forbids `preventDefault()`. So the forwarded scroll happened *and* the browser was still free to open a transaction against the unscrollable parent document.

Making the listener non-passive and preventing the default when it forwards stops that transaction being established:

```diff
  if ( ! node.contains( eventScrollContainer ) ) {
+     event.preventDefault();
      scrollContainer.scrollBy( deltaX, deltaY );
  }
- const options = { passive: true };
+ const options = { passive: false };
```

The `preventDefault()` sits deliberately *inside* the `! node.contains( eventScrollContainer )` branch, so popovers with their own scrollable region keep native scrolling and the behaviour added in #71468 is preserved.

Also adds the corresponding `packages/block-editor/CHANGELOG.md` entry under Bug Fixes.

Worth reviewer attention: `usePopoverScroll` has four call sites — the block toolbar (×2), the generic block popover, and the in-between inserter — so this changes wheel handling for all block popovers, not only the reported case. They share the same out-of-iframe, zero-scroll-room document and the same exposure, so I believe this is correct, but it is wider than the bug report.

## Testing Instructions

Requires a **physical mouse wheel** — a trackpad cannot reproduce this, because continuous scrolling doesn't create the discrete transaction. Use Firefox or Chrome; WebKit latches differently.

1. Create a post with enough paragraph and heading blocks to scroll (~40).
2. Move the pointer into the vertical gap between two blocks until the blue insertion line and `+` button appear.
3. Keep the pointer completely still and scroll with the wheel.
4. On `trunk`: after one or two ticks the canvas freezes for several seconds, releasing when you move the pointer. With this PR: scrolling continues normally.

Also worth checking for regressions, since the hook is shared:

- [ ] Scrolling the canvas while hovering the block toolbar
- [ ] Scrolling over a popover that has its own scrollable list, which should still scroll internally rather than moving the canvas

### Testing Instructions for Keyboard

No UI or keyboard-reachable behaviour changes; the patch only affects `wheel` event handling.

## Screenshots or screencast

Instrumented wheel events on the same post, pointer held still throughout — each row is one wheel event, recording whether any scrolling actually resulted:

| | wheel events | events that scrolled |
|-|-|-|
| Before | 38 | 1 |
| After | 26 | 26 |

Before, the canvas stayed frozen for 6.7s while `deltaY` climbed from 16 to 112 as I scrolled harder. After, every event scrolls and `deltaY` stays in its normal range.

Verified on Gutenberg 23.7.1, WordPress 7.0.3, Twenty Twenty-Five 1.5, Firefox 153.0.3 on macOS 26.6, with no other plugins active. I have not verified in Chrome, and `usePopoverScroll` currently has no test coverage.

## Use of AI Tools

The root-cause analysis, the diagnostic instrumentation used to gather the wheel-event measurements above, and this patch were drafted with AI assistance (Claude Code). All reproduction and verification was performed by me on my own machine, and I have reviewed the change and take responsibility for it.
