### PR TITLE
[WIP] Media Experiment: Try adding media folders support

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -36,6 +36,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaEditor = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-folders' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaFolders = true', 'before' );
+	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDashboardWidgets = true', 'before' );
 	}

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -55,6 +55,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-media-folders',
+					'label'       => __( 'Media folders', 'gutenberg' ),
+					'description' => __( 'Adds folders for organizing media. Folders can be created and filled from the inserter’s Media tab, and used as the source for a dynamic Gallery block.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/lib/experimental/media-folders.php
+++ b/lib/experimental/media-folders.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Media folders: a hierarchical taxonomy for organizing attachments.
+ *
+ * Experimental. Loaded from `lib/load.php` only when the `gutenberg-media-folders`
+ * experiment is enabled, so with the experiment off the taxonomy is never
+ * registered and every consumer degrades to the pre-existing behaviour.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the `wp_media_folder` taxonomy on attachments.
+ *
+ * Storing folders as a taxonomy (rather than a custom table or a custom post
+ * type) is what makes them interoperable: `show_in_rest` alone yields term CRUD
+ * via `WP_REST_Terms_Controller`, a `media-folders` collection parameter on
+ * `/wp/v2/media` for filtering, and a `media-folders` field on each attachment
+ * record for assignment — so the editor needs no bespoke endpoints.
+ *
+ * Registered as hierarchical even though the current UI only creates top-level
+ * folders: nesting is the expected direction, and changing `hierarchical` later
+ * would mean re-registering an already-populated taxonomy.
+ */
+function gutenberg_register_media_folder_taxonomy() {
+	register_taxonomy(
+		'wp_media_folder',
+		'attachment',
+		array(
+			'hierarchical'          => true,
+			// Folders are an admin-side organizational tool: they have no
+			// public archive, permalink or query var of their own.
+			'public'                => false,
+			'publicly_queryable'    => false,
+			'rewrite'               => false,
+			'query_var'             => false,
+			// Surfaces the taxonomy on the attachment edit screen, which is a
+			// useful way to inspect assignments while the feature is
+			// experimental.
+			'show_ui'               => true,
+			'show_in_menu'          => false,
+			'show_in_nav_menus'     => false,
+			'show_in_rest'          => true,
+			'rest_base'             => 'media-folders',
+			// The default `_update_post_term_count` bases an attachment's count
+			// on its *parent post's* status, and only counts attachments with
+			// `post_parent > 0`. Media in a folder is typically unattached, so
+			// the default would report every folder as empty. The generic
+			// callback simply counts term relationships, which is what a folder
+			// means here.
+			'update_count_callback' => '_update_generic_term_count',
+			'capabilities'          => array(
+				'manage_terms' => 'manage_categories',
+				'edit_terms'   => 'manage_categories',
+				'delete_terms' => 'manage_categories',
+				// Anyone who can upload media can file it into an existing
+				// folder; only editors and above can create or rename folders.
+				'assign_terms' => 'upload_files',
+			),
+			'labels'                => array(
+				'name'                       => _x( 'Folders', 'taxonomy general name', 'gutenberg' ),
+				'singular_name'              => _x( 'Folder', 'taxonomy singular name', 'gutenberg' ),
+				'menu_name'                  => __( 'Folders', 'gutenberg' ),
+				'all_items'                  => __( 'All folders', 'gutenberg' ),
+				'edit_item'                  => __( 'Edit folder', 'gutenberg' ),
+				'view_item'                  => __( 'View folder', 'gutenberg' ),
+				'update_item'                => __( 'Update folder', 'gutenberg' ),
+				'add_new_item'               => __( 'Add folder', 'gutenberg' ),
+				'new_item_name'              => __( 'New folder name', 'gutenberg' ),
+				'parent_item'                => __( 'Parent folder', 'gutenberg' ),
+				'parent_item_colon'          => __( 'Parent folder:', 'gutenberg' ),
+				'search_items'               => __( 'Search folders', 'gutenberg' ),
+				'not_found'                  => __( 'No folders found.', 'gutenberg' ),
+				'no_terms'                   => __( 'No folders', 'gutenberg' ),
+				'items_list'                 => __( 'Folders list', 'gutenberg' ),
+				'items_list_navigation'      => __( 'Folders list navigation', 'gutenberg' ),
+				'back_to_items'              => __( '&larr; Go to folders', 'gutenberg' ),
+				'item_link'                  => __( 'Folder Link', 'gutenberg' ),
+				'item_link_description'      => __( 'A link to a folder.', 'gutenberg' ),
+				'separate_items_with_commas' => __( 'Separate folders with commas', 'gutenberg' ),
+				'add_or_remove_items'        => __( 'Add or remove folders', 'gutenberg' ),
+				'choose_from_most_used'      => __( 'Choose from the most used folders', 'gutenberg' ),
+			),
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_media_folder_taxonomy' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -146,6 +146,9 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-dataform-inspector' ) ) {
 if ( gutenberg_is_experiment_enabled( 'gutenberg-media-editor' ) ) {
 	require __DIR__ . '/experimental/media-editor/load.php';
 }
+if ( gutenberg_is_experiment_enabled( 'gutenberg-media-folders' ) ) {
+	require __DIR__ . '/experimental/media-folders.php';
+}
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-workflow-palette' ) ) {
 	require __DIR__ . '/experimental/workflow-palette.php';

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Enhancements
 
+-   Inserter: Support media folders in the Media tab — folders are listed as media categories with an "Add images to folder" action, an "Add folder" button creates one, and attach/detach copy now travels with each media category instead of being hardcoded to the attached-images wording. Behind the `gutenberg-media-folders` experiment.
+-   Inserter: Skip the media category visibility probe for categories that supply an `emptyMessage`, since they are listed regardless of the result.
 -   Creating a new block next to a sibling of the same type now inherits the sibling's attributes consistently, whether it is created by the appender, the inserter, or Enter at the edge of the text. Everything except the sibling's content (attributes with the `content` role) and its `metadata` is copied. The `attributesToCopy` list of a default block is removed: the copied attributes derive from the block's attribute roles.
 
 ### Enhancements

--- a/packages/block-editor/src/components/inserter/media-tab/add-folder-button.js
+++ b/packages/block-editor/src/components/inserter/media-tab/add-folder-button.js
@@ -1,0 +1,163 @@
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { Stack } from '@wordpress/ui';
+import { store as blockEditorStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
+
+/**
+ * Turns a rejected folder creation into something worth showing a user.
+ *
+ * A rejected `apiFetch` isn't necessarily an `Error`: a REST error arrives as a
+ * plain `{ code, message }` object, and a custom fetch handler can reject with
+ * anything at all. So the shape is read defensively, and the one failure a user
+ * can actually act on — a folder by that name already existing — gets its own
+ * wording rather than the server's generic "term already exists" phrasing.
+ *
+ * @param {any} error The rejection value.
+ * @return {string} A message to show.
+ */
+function getCreateErrorMessage( error ) {
+	if ( error?.code === 'term_exists' ) {
+		return __( 'A folder with that name already exists.' );
+	}
+	return typeof error?.message === 'string' && error.message
+		? error.message
+		: __( 'Could not create the folder.' );
+}
+
+/**
+ * "Add folder" affordance for the inserter's Media tab: a button that opens a
+ * modal asking for a name, and creates a media folder.
+ *
+ * Rendered only when the host editor supplies the `inserterMediaFolders`
+ * capability (i.e. the media folders experiment is on) and the current user may
+ * create folders. Creating one is a write against a WordPress taxonomy, which
+ * this package can't do itself — hence the injected `create`.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onCreate Called with the new folder's term record.
+ */
+export default function AddFolderButton( { onCreate } ) {
+	const mediaFolders = useSelect(
+		( select ) =>
+			unlock( select( blockEditorStore ) ).getInserterMediaFolders(),
+		[]
+	);
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ name, setName ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+
+	const close = useCallback( () => {
+		setIsOpen( false );
+		setName( '' );
+	}, [] );
+
+	const trimmedName = name.trim();
+
+	const handleSubmit = useCallback(
+		async ( event ) => {
+			event.preventDefault();
+			if ( ! trimmedName || isSaving ) {
+				return;
+			}
+			setIsSaving( true );
+			try {
+				const folder = await mediaFolders.create( trimmedName );
+				close();
+				createSuccessNotice( __( 'Folder created.' ), {
+					type: 'snackbar',
+					id: 'inserter-notice',
+				} );
+				onCreate?.( folder );
+			} catch ( error ) {
+				// The modal stays open on failure so the name isn't lost and can
+				// be corrected — a duplicate name is the likely cause.
+				createErrorNotice( getCreateErrorMessage( error ), {
+					type: 'snackbar',
+					id: 'inserter-notice',
+				} );
+			} finally {
+				setIsSaving( false );
+			}
+		},
+		[
+			trimmedName,
+			isSaving,
+			mediaFolders,
+			close,
+			onCreate,
+			createSuccessNotice,
+			createErrorNotice,
+		]
+	);
+
+	if ( ! mediaFolders?.canCreate ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Button
+				__next40pxDefaultSize
+				className="block-editor-inserter__media-add-folder-button"
+				variant="secondary"
+				onClick={ () => setIsOpen( true ) }
+			>
+				{ __( 'Add folder' ) }
+			</Button>
+			{ isOpen && (
+				<Modal
+					title={ __( 'Add folder' ) }
+					onRequestClose={ close }
+					size="small"
+				>
+					<form onSubmit={ handleSubmit }>
+						<Stack direction="column" gap="md">
+							<TextControl
+								label={ __( 'Name' ) }
+								help={ __(
+									'Folders group media in the inserter. They are not shown on the site.'
+								) }
+								value={ name }
+								onChange={ setName }
+								autoComplete="off"
+							/>
+							<Stack
+								direction="row"
+								gap="sm"
+								justify="flex-end"
+								className="block-editor-inserter__media-add-folder-actions"
+							>
+								<Button
+									__next40pxDefaultSize
+									variant="tertiary"
+									onClick={ close }
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									type="submit"
+									isBusy={ isSaving }
+									// Nothing to create without a name, but keep
+									// the button reachable so the requirement is
+									// discoverable by keyboard and screen reader.
+									disabled={ ! trimmedName || isSaving }
+									accessibleWhenDisabled
+								>
+									{ __( 'Create' ) }
+								</Button>
+							</Stack>
+						</Stack>
+					</form>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/block-editor/src/components/inserter/media-tab/attach-copy.js
+++ b/packages/block-editor/src/components/inserter/media-tab/attach-copy.js
@@ -1,0 +1,39 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Copy for the media panel's attach/detach affordances.
+ *
+ * A media category that exposes `attach`/`detach` also supplies an `attachCopy`
+ * object wording them for what the source actually is — "Attach images" to a
+ * post, "Add images to folder" for a media folder. Those sources are defined in
+ * the `editor` package, which knows the post type or folder in question; this
+ * package stays generic and renders whatever copy it is handed.
+ *
+ * These defaults cover a source that opts into the capabilities without
+ * supplying copy, so the panel never renders an empty label.
+ */
+export const DEFAULT_ATTACH_COPY = {
+	attachButton: __( 'Attach images' ),
+	attachedNotice: () => __( 'Images attached.' ),
+	noneAttachedNotice: __( 'No images were attached.' ),
+	attachErrorNotice: __( 'Could not attach images.' ),
+	detachAction: __( 'Detach' ),
+	detachModalTitle: __( 'Detach image' ),
+	detachModalBody: __(
+		'Detach this image? The image will remain in the Media Library.'
+	),
+	detachConfirmButton: __( 'Detach' ),
+	detachedNotice: __( 'Image detached.' ),
+	detachErrorNotice: __( 'Could not detach image.' ),
+};
+
+/**
+ * Merges a category's `attachCopy` over the defaults, so a source can supply
+ * only the strings it cares to override.
+ *
+ * @param {Object} category The inserter media category.
+ * @return {Object} The resolved attach/detach copy.
+ */
+export function getAttachCopy( category ) {
+	return { ...DEFAULT_ATTACH_COPY, ...category?.attachCopy };
+}

--- a/packages/block-editor/src/components/inserter/media-tab/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/hooks.js
@@ -179,7 +179,14 @@ export function useMediaCategories( rootClientId ) {
 				await Promise.all(
 					inserterMediaCategories.map( async ( category ) => {
 						// Some sources are external and we don't need to make a request.
-						if ( category.isExternalResource ) {
+						// A source with an `emptyMessage` is always listed (see
+						// below), so probing it would only discard the result —
+						// skip the request entirely. This is what keeps the cost
+						// of listing N media folders at zero.
+						if (
+							category.isExternalResource ||
+							category.emptyMessage
+						) {
 							return [ category.name, true ];
 						}
 						let results = [];
@@ -200,7 +207,8 @@ export function useMediaCategories( rootClientId ) {
 			// whose corresponding block type is not allowed to be inserted, based
 			// on the category's `mediaType`. A category that provides an
 			// `emptyMessage` stays in the list even when empty, so it can show
-			// that message (e.g. Attachments, to expose its "Attach" action).
+			// that message and expose its "Attach"/"Add" action (e.g. Attachments,
+			// or an empty media folder) — those are never probed above.
 			const canInsertMediaType = {
 				image: canInsertImage,
 				video: canInsertVideo,

--- a/packages/block-editor/src/components/inserter/media-tab/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-panel.js
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { Button, Modal, Spinner, SearchControl } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	useCallback,
 	useEffect,
@@ -19,6 +19,7 @@ import MediaUploadCheck from '../../media-upload/check';
 import { useMediaResults, useDelayedLoading } from './hooks';
 import InserterNoResults from '../no-results';
 import BlockPatternsPaging from '../../block-patterns-paging';
+import { getAttachCopy } from './attach-copy';
 
 const MEDIA_ITEMS_PER_PAGE = 20;
 
@@ -26,25 +27,27 @@ const MEDIA_ITEMS_PER_PAGE = 20;
 const ATTACH_ALLOWED_TYPES = [ 'image' ];
 
 /**
- * Opens the Media Library to attach images to the current post. Only rendered
- * for media categories that expose an `attach` capability (i.e. the "Attached
- * images" source); other sources render the panel exactly as before.
+ * Opens the Media Library to add images to the panel's source. Only rendered for
+ * media categories that expose an `attach` capability (i.e. the "Attached
+ * images" source, or a media folder); other sources render the panel exactly as
+ * before.
  *
  * The picker opens fresh each time with no pre-selected value, so it is purely
- * additive: selecting images attaches them, and it does not imply that
- * deselecting would detach. Detaching is a separate, explicit per-item action.
+ * additive: selecting images adds them, and it does not imply that deselecting
+ * would remove them. Removing is a separate, explicit per-item action.
  *
  * @param {Object}   props
  * @param {Function} props.onSelect Called with the selected media items.
+ * @param {string}   props.label    Button label, also used as the picker's title.
  */
-function AttachImagesButton( { onSelect } ) {
+function AttachImagesButton( { onSelect, label } ) {
 	return (
 		<MediaUploadCheck>
 			<MediaUpload
 				multiple="add"
 				onSelect={ onSelect }
 				allowedTypes={ ATTACH_ALLOWED_TYPES }
-				title={ __( 'Attach images' ) }
+				title={ label }
 				render={ ( { open } ) => (
 					<Button
 						__next40pxDefaultSize
@@ -56,7 +59,7 @@ function AttachImagesButton( { onSelect } ) {
 						} }
 						variant="secondary"
 					>
-						{ __( 'Attach images' ) }
+						{ label }
 					</Button>
 				) }
 			/>
@@ -114,6 +117,10 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 	const attach = supportsAttachments ? category.attach : undefined;
 	const detach = supportsAttachments ? category.detach : undefined;
 	const subscribe = supportsAttachments ? category.subscribe : undefined;
+	// Each source words these affordances for what it actually is ("Attach
+	// images" to a post, "Add images to folder"), so the copy travels with the
+	// category. Merged over the defaults so a source can supply only some of it.
+	const attachCopy = useMemo( () => getAttachCopy( category ), [ category ] );
 
 	// Only show the pager for multi-page sources. Gating on the page count (not
 	// `mediaList.length`) keeps the footer mounted while paging, since the count
@@ -168,7 +175,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 					// This source only attaches images (the picker's "Upload
 					// files" tab otherwise accepts any file type), so a selection
 					// with no images attaches nothing.
-					createWarningNotice( __( 'No images were attached.' ), {
+					createWarningNotice( attachCopy.noneAttachedNotice, {
 						type: 'snackbar',
 						id: 'inserter-notice',
 					} );
@@ -177,30 +184,14 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 
 				refresh();
 				createSuccessNotice(
-					category.postTypeLabel
-						? sprintf(
-								/* translators: %1$d: Number of images attached. %2$s: Name of the post type e.g: "Page". */
-								_n(
-									'%1$d image attached to %2$s.',
-									'%1$d images attached to %2$s.',
-									attachedCount
-								),
-								attachedCount,
-								category.postTypeLabel
-						  )
-						: sprintf(
-								/* translators: %d: Number of images attached to the post. */
-								_n(
-									'%d image attached to post.',
-									'%d images attached to post.',
-									attachedCount
-								),
-								attachedCount
-						  ),
-					{ type: 'snackbar', id: 'inserter-notice' }
+					attachCopy.attachedNotice( attachedCount ),
+					{
+						type: 'snackbar',
+						id: 'inserter-notice',
+					}
 				);
 			} catch {
-				createErrorNotice( __( 'Could not attach images.' ), {
+				createErrorNotice( attachCopy.attachErrorNotice, {
 					type: 'snackbar',
 					id: 'inserter-notice',
 				} );
@@ -208,7 +199,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 		},
 		[
 			attach,
-			category,
+			attachCopy,
 			refresh,
 			createErrorNotice,
 			createSuccessNotice,
@@ -221,24 +212,18 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 			try {
 				await detach( media );
 				refresh();
-				createSuccessNotice(
-					category.postTypeLabel
-						? sprintf(
-								/* translators: %s: Name of the post type e.g: "Page". */
-								__( 'Image detached from %s.' ),
-								category.postTypeLabel
-						  )
-						: __( 'Image detached from post.' ),
-					{ type: 'snackbar', id: 'inserter-notice' }
-				);
+				createSuccessNotice( attachCopy.detachedNotice, {
+					type: 'snackbar',
+					id: 'inserter-notice',
+				} );
 			} catch {
-				createErrorNotice( __( 'Could not detach image.' ), {
+				createErrorNotice( attachCopy.detachErrorNotice, {
 					type: 'snackbar',
 					id: 'inserter-notice',
 				} );
 			}
 		},
-		[ detach, category, refresh, createErrorNotice, createSuccessNotice ]
+		[ detach, attachCopy, refresh, createErrorNotice, createSuccessNotice ]
 	);
 
 	// Detaching is confirmed first: the dropdown sets the pending item, which
@@ -325,7 +310,10 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 					{ attach && (
 						// Lines up with the "Open Media Library" button in the
 						// adjacent column.
-						<AttachImagesButton onSelect={ handleAttach } />
+						<AttachImagesButton
+							onSelect={ handleAttach }
+							label={ attachCopy.attachButton }
+						/>
 					) }
 				</Stack>
 			) }
@@ -334,23 +322,11 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 				// `overlayClassName` and stack it above the options dropdown that
 				// opened it (see the z-index entry in `_z-index.scss`).
 				<Modal
-					title={ __( 'Detach image' ) }
+					title={ attachCopy.detachModalTitle }
 					onRequestClose={ () => setMediaPendingDetach( undefined ) }
 					overlayClassName={ `${ baseCssClass }-detach-modal` }
 				>
-					<p>
-						{ category.postTypeLabel
-							? sprintf(
-									/* translators: %s: Name of the post type e.g: "Page". */
-									__(
-										'Detach this image from the current %s? The image will remain in the Media Library.'
-									),
-									category.postTypeLabel
-							  )
-							: __(
-									'Detach this image from the current post? The image will remain in the Media Library.'
-							  ) }
-					</p>
+					<p>{ attachCopy.detachModalBody }</p>
 					<div className={ `${ baseCssClass }-detach-actions` }>
 						<Button
 							__next40pxDefaultSize
@@ -364,7 +340,7 @@ export function MediaCategoryPanel( { rootClientId, onInsert, category } ) {
 							variant="primary"
 							onClick={ confirmDetach }
 						>
-							{ __( 'Detach' ) }
+							{ attachCopy.detachConfirmButton }
 						</Button>
 					</div>
 				</Modal>

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -22,6 +22,7 @@ import { getFilename } from '@wordpress/url';
 import { Tooltip } from '@wordpress/ui';
 import InserterDraggableBlocks from '../../inserter-draggable-blocks';
 import { getBlockAndPreviewFromMedia } from './utils';
+import { getAttachCopy } from './attach-copy';
 import { store as blockEditorStore } from '../../../store';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -64,13 +65,7 @@ function MediaPreviewOptions( { category, media, onDetach } ) {
 							onClick={ () => onDetach( media ) }
 							icon={ linkOff }
 						>
-							{ category.postTypeLabel
-								? sprintf(
-										/* translators: %s: Name of the post type e.g: "Page". */
-										__( 'Detach from %s' ),
-										category.postTypeLabel
-								  )
-								: __( 'Detach from post' ) }
+							{ getAttachCopy( category ).detachAction }
 						</MenuItem>
 					) }
 				</MenuGroup>

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -1,12 +1,14 @@
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
-import { useCallback, useEffect, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
 import { MediaCategoryPanel } from './media-panel';
 import MediaUploadCheck from '../../media-upload/check';
 import MediaUpload from '../../media-upload';
 import { useMediaCategories } from './hooks';
 import { getBlockAndPreviewFromMedia } from './utils';
+import AddFolderButton from './add-folder-button';
 import MobileTabNavigation from '../mobile-tab-navigation';
 import CategoryTabs from '../category-tabs';
 import InserterNoResults from '../no-results';
@@ -63,6 +65,25 @@ function MediaTab( {
 		}
 	}, [ categories, onSelectCategory, selectedCategory ] );
 
+	// A folder's category isn't available the moment the folder is created — it
+	// appears once the term list resolves again and the categories are re-derived.
+	// So the id is parked here and the category is selected when it turns up,
+	// putting the user straight into the empty folder they just made, next to its
+	// "Add images to folder" button.
+	const [ pendingFolderId, setPendingFolderId ] = useState();
+	useEffect( () => {
+		if ( pendingFolderId === undefined ) {
+			return;
+		}
+		const folderCategory = categories.find(
+			( category ) => category.folderId === pendingFolderId
+		);
+		if ( folderCategory ) {
+			setPendingFolderId( undefined );
+			onSelectCategory( folderCategory );
+		}
+	}, [ categories, pendingFolderId, onSelectCategory ] );
+
 	if ( ! categories.length ) {
 		return <InserterNoResults />;
 	}
@@ -78,33 +99,49 @@ function MediaTab( {
 					>
 						{ children }
 					</CategoryTabs>
-					<MediaUploadCheck>
-						<MediaUpload
-							multiple={ false }
-							onSelect={ onSelectMedia }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							render={ ( { open } ) => (
-								<Button
-									__next40pxDefaultSize
-									onClick={ ( event ) => {
-										// Safari doesn't emit a focus event on button elements when
-										// clicked and we need to manually focus the button here.
-										// The reason is that core's Media Library modal explicitly triggers a
-										// focus event and therefore a `blur` event is triggered on a different
-										// element, which doesn't contain the `data-unstable-ignore-focus-outside-for-relatedtarget`
-										// attribute making the Inserter dialog to close.
-										event.target.focus();
-										open();
-									} }
-									className="block-editor-inserter__media-library-button"
-									variant="secondary"
-									data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
-								>
-									{ __( 'Open Media Library' ) }
-								</Button>
-							) }
+					{ /*
+					 * The container distributes space between the tab list and
+					 * this footer, so the buttons share a single stack rather
+					 * than each becoming a distributed child.
+					 */ }
+					<Stack
+						direction="column"
+						gap="sm"
+						className="block-editor-inserter__media-tabs-footer"
+					>
+						<AddFolderButton
+							onCreate={ ( folder ) =>
+								setPendingFolderId( folder?.id )
+							}
 						/>
-					</MediaUploadCheck>
+						<MediaUploadCheck>
+							<MediaUpload
+								multiple={ false }
+								onSelect={ onSelectMedia }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								render={ ( { open } ) => (
+									<Button
+										__next40pxDefaultSize
+										onClick={ ( event ) => {
+											// Safari doesn't emit a focus event on button elements when
+											// clicked and we need to manually focus the button here.
+											// The reason is that core's Media Library modal explicitly triggers a
+											// focus event and therefore a `blur` event is triggered on a different
+											// element, which doesn't contain the `data-unstable-ignore-focus-outside-for-relatedtarget`
+											// attribute making the Inserter dialog to close.
+											event.target.focus();
+											open();
+										} }
+										className="block-editor-inserter__media-library-button"
+										variant="secondary"
+										data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
+									>
+										{ __( 'Open Media Library' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</Stack>
 				</div>
 			) }
 			{ isMobile && (

--- a/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/hooks.js
@@ -1,5 +1,22 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useDelayedLoading, useMediaResults } from '../hooks';
+import { useSelect } from '@wordpress/data';
+import {
+	useDelayedLoading,
+	useMediaResults,
+	useMediaCategories,
+} from '../hooks';
+
+// `useMediaCategories` reads the categories and the insertion capabilities from
+// the block editor store. Only `useSelect` is exercised here, so the store and
+// its unlock helper are stubbed rather than instantiated — the hook's own logic
+// (which sources get probed, and which survive) is what's under test.
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+jest.mock( '../../../../store', () => ( { store: 'core/block-editor' } ) );
+jest.mock( '../../../../lock-unlock', () => ( {
+	unlock: ( value ) => value,
+} ) );
 
 describe( 'useDelayedLoading', () => {
 	beforeEach( () => {
@@ -256,5 +273,82 @@ describe( 'useMediaResults', () => {
 
 		expect( fetch ).toHaveBeenCalledTimes( 1 );
 		expect( result.current.mediaList ).toEqual( [ { id: 1 } ] );
+	} );
+} );
+
+describe( 'useMediaCategories', () => {
+	// Run each `useSelect` callback against a stub store, rather than returning
+	// canned values per call — the hook makes two `useSelect` calls and they must
+	// keep answering correctly across re-renders.
+	const mockSelects = ( categories ) => {
+		const select = () => ( {
+			getInserterMediaCategories: () => categories,
+			canInsertBlockType: () => true,
+		} );
+		useSelect.mockImplementation( ( mapSelect ) => mapSelect( select ) );
+	};
+
+	beforeEach( () => {
+		useSelect.mockReset();
+	} );
+
+	it( 'lists a source with an empty message without probing it', async () => {
+		// A source that supplies an `emptyMessage` is listed whether or not it
+		// has media — so probing it would only throw the result away. Media
+		// folders rely on this: an empty folder still has to be reachable so
+		// images can be added to it, and N folders must not cost N requests.
+		const emptyFolder = {
+			name: 'media-folder-7',
+			mediaType: 'image',
+			emptyMessage: 'No images in this folder.',
+			fetch: jest.fn().mockResolvedValue( { mediaItems: [] } ),
+		};
+		mockSelects( [ emptyFolder ] );
+
+		const { result } = renderHook( () => useMediaCategories( '' ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ emptyFolder ] )
+		);
+		expect( emptyFolder.fetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'probes a source without an empty message and drops it when empty', async () => {
+		const populated = {
+			name: 'images',
+			mediaType: 'image',
+			fetch: jest.fn().mockResolvedValue( { mediaItems: [ { id: 1 } ] } ),
+		};
+		const empty = {
+			name: 'videos',
+			mediaType: 'video',
+			fetch: jest.fn().mockResolvedValue( { mediaItems: [] } ),
+		};
+		mockSelects( [ populated, empty ] );
+
+		const { result } = renderHook( () => useMediaCategories( '' ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ populated ] )
+		);
+		expect( populated.fetch ).toHaveBeenCalledWith( { per_page: 1 } );
+		expect( empty.fetch ).toHaveBeenCalledWith( { per_page: 1 } );
+	} );
+
+	it( 'does not probe an external source', async () => {
+		const openverse = {
+			name: 'openverse',
+			mediaType: 'image',
+			isExternalResource: true,
+			fetch: jest.fn(),
+		};
+		mockSelects( [ openverse ] );
+
+		const { result } = renderHook( () => useMediaCategories( '' ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ openverse ] )
+		);
+		expect( openverse.fetch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
+++ b/packages/block-editor/src/components/inserter/media-tab/test/media-panel.js
@@ -118,3 +118,31 @@ describe( 'MediaCategoryPanel subscription gating', () => {
 		expect( subscribe ).not.toHaveBeenCalled();
 	} );
 } );
+
+describe( 'MediaCategoryPanel attach copy', () => {
+	it( 'falls back to the default copy when the source supplies none', () => {
+		renderPanel( baseCategory );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Attach images' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'uses the copy the source supplies', () => {
+		// A media folder words the same affordance around the folder, so the
+		// panel renders whatever the source hands it rather than assuming the
+		// attached-images wording.
+		renderPanel( {
+			...baseCategory,
+			name: 'media-folder-7',
+			attachCopy: { attachButton: 'Add images to folder' },
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Add images to folder' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Attach images' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -460,11 +460,18 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__patterns-explore-button,
-.block-editor-inserter__media-library-button {
+// Sits at the bottom of the media tab column, below the category list. The
+// wrapper owns the separation from the list so the buttons inside it are spaced
+// only by the stack's own gap.
+.block-editor-inserter__media-tabs-footer {
+	margin-top: $grid-unit-20;
+}
+
+.block-editor-inserter__media-library-button,
+.block-editor-inserter__media-add-folder-button {
 	&.components-button {
 		padding: $grid-unit-20;
 		justify-content: center;
-		margin-top: $grid-unit-20;
 		width: 100%;
 	}
 }

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -15,6 +15,7 @@ const castArray = ( maybeArray ) =>
  */
 const privateSettings = [
 	'inserterMediaCategories',
+	'inserterMediaFolders',
 	'blockInspectorAnimation',
 	'mediaSideload',
 ];

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -560,6 +560,22 @@ export const getInserterMediaCategories = createSelector(
 );
 
 /**
+ * Returns the media folders capability supplied by the host editor, or
+ * `undefined` when media folders aren't available.
+ *
+ * Creating a folder means writing a taxonomy term, which this WordPress-agnostic
+ * package can't do itself — so the capability is passed in as a setting by the
+ * `editor` package (which owns the folder media categories too).
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {?{canCreate: boolean, create: Function}} The media folders capability.
+ */
+export function getInserterMediaFolders( state ) {
+	return state.settings.inserterMediaFolders;
+}
+
+/**
  * Returns whether there is at least one allowed pattern for inner blocks children.
  * This is useful for deferring the parsing of all patterns until needed.
  *

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Gallery: Add a media folder source to dynamic mode, so a gallery can display the images in a folder rather than the images attached to the post. The Source panel now offers a choice of sources. Behind the `gutenberg-media-folders` experiment.
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))

--- a/packages/block-library/src/gallery/dynamic-gallery.js
+++ b/packages/block-library/src/gallery/dynamic-gallery.js
@@ -18,9 +18,18 @@ import {
 	useBlockEditingMode,
 	__experimentalUseBlockPreview as useBlockPreview,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 import { sharedIcon } from './shared-icon';
 import { Caption } from '../utils/caption';
-import { DEFAULT_ORDERBY, DEFAULT_ORDER, MAX_IMAGES } from './dynamic-source';
+import {
+	DEFAULT_ORDERBY,
+	DEFAULT_ORDER,
+	MAX_IMAGES,
+	MEDIA_FOLDER,
+	getDynamicSource,
+} from './dynamic-source';
 
 /**
  * Ordering options for a dynamic gallery source. Each value is a composite
@@ -64,6 +73,96 @@ function OrderControl( { orderby, order, onChange } ) {
 				onChange( { orderby: newOrderby, order: newOrder } );
 			} }
 		/>
+	);
+}
+
+/**
+ * Every media folder, alphabetically — the options for the folder chooser below.
+ * Matches the query the inserter's folder categories use, so both read from one
+ * resolved list rather than issuing separate requests.
+ */
+const MEDIA_FOLDERS_QUERY = {
+	per_page: -1,
+	hide_empty: false,
+	orderby: 'name',
+	order: 'asc',
+};
+
+/**
+ * "Folder" control for a media folder gallery: which folder's images to show.
+ *
+ * Unlike the ordering control this isn't an optional setting — a folder gallery
+ * with no folder resolves to nothing — so it renders as a plain control rather
+ * than a resettable `ToolsPanelItem`.
+ *
+ * @param {Object}   props
+ * @param {?number}  props.folderId  The currently selected folder id.
+ * @param {Function} props.onChange  Called with the new folder id (or `undefined`).
+ * @param {string}   props.label     The control's label.
+ * @param {string}   props.noneLabel Placeholder option copy for "no folder chosen".
+ */
+function FolderControl( { folderId, onChange, label, noneLabel } ) {
+	const folders = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecords(
+				'taxonomy',
+				'wp_media_folder',
+				MEDIA_FOLDERS_QUERY
+			),
+		[]
+	);
+
+	const options = [
+		// Keeps the control usable before a folder is chosen, and lets a chosen
+		// one be cleared again.
+		{ label: noneLabel, value: '' },
+		...( folders ?? [] ).map( ( folder ) => ( {
+			label: decodeEntities( folder.name ),
+			value: String( folder.id ),
+		} ) ),
+	];
+
+	// A folder that has since been deleted (or isn't readable) leaves an id with
+	// no matching option. Surface it rather than silently snapping the control
+	// back to "no folder", which would misrepresent what the block is set to.
+	const hasSelection = folderId !== undefined && folderId !== null;
+	const isMissing =
+		hasSelection &&
+		!! folders &&
+		! folders.some( ( folder ) => folder.id === folderId );
+
+	return (
+		<>
+			<SelectControl
+				label={ label }
+				value={ hasSelection ? String( folderId ) : '' }
+				options={
+					isMissing
+						? [
+								...options,
+								{
+									label: __( 'Folder not found' ),
+									value: String( folderId ),
+								},
+						  ]
+						: options
+				}
+				onChange={ ( value ) =>
+					onChange( value ? Number( value ) : undefined )
+				}
+			/>
+			{ isMissing && (
+				<Notice
+					className="wp-block-gallery__source-notice"
+					status="warning"
+					isDismissible={ false }
+				>
+					{ __(
+						'The selected folder no longer exists. Choose another folder to display images.'
+					) }
+				</Notice>
+			) }
+		</>
 	);
 }
 
@@ -119,10 +218,13 @@ export function GallerySourcePanel( {
 	const {
 		dynamicContent,
 		canUseDynamicSource,
+		availableSources,
 		sourceDescriptor,
 		sourceOrderby,
 		sourceOrder,
 		setSourceOrder,
+		sourceFolderId,
+		setSourceFolderId,
 		convertToStatic,
 		enableDynamicMode,
 		resetSource,
@@ -132,16 +234,17 @@ export function GallerySourcePanel( {
 	} = dynamic;
 	const isDynamic = !! dynamicContent;
 
-	const [ isConfirming, setIsConfirming ] = useState( false );
+	// The source awaiting confirmation, set only while the dialog is open.
+	const [ sourcePendingConfirm, setSourcePendingConfirm ] = useState();
 	const [ isConfirmingDetach, setIsConfirmingDetach ] = useState( false );
 
 	// Entering dynamic mode discards any hand-added images, so confirm first
 	// when there are images to lose; otherwise switch straight away.
-	function requestEnableDynamicMode() {
+	function requestEnableDynamicMode( source ) {
 		if ( hasImages ) {
-			setIsConfirming( true );
+			setSourcePendingConfirm( source );
 		} else {
-			enableDynamicMode();
+			enableDynamicMode( source );
 		}
 	}
 
@@ -170,6 +273,14 @@ export function GallerySourcePanel( {
 						>
 							{ __( 'Detach Gallery' ) }
 						</Button>
+						{ dynamicContent.source === MEDIA_FOLDER && (
+							<FolderControl
+								folderId={ sourceFolderId }
+								onChange={ setSourceFolderId }
+								label={ sourceDescriptor.selectFolderLabel }
+								noneLabel={ sourceDescriptor.noFolderMessage }
+							/>
+						) }
 					</div>
 					{ hasMoreImagesThanCap && (
 						<Notice
@@ -228,37 +339,45 @@ export function GallerySourcePanel( {
 		return null;
 	}
 
+	const pendingDescriptor = sourcePendingConfirm
+		? getDynamicSource( sourcePendingConfirm )
+		: undefined;
+
 	return (
 		<>
 			<PanelBody title={ __( 'Source' ) }>
 				<div className="wp-block-gallery__source-settings">
 					{ /*
-					 * Hardcoded on purpose: this single-source entry button (and
-					 * its confirm dialog below) is temporary. Once more sources
-					 * exist it becomes a "Choose source" select whose options read
-					 * from each source descriptor's `title`, with help text
-					 * carrying the per-source explanation this string does today.
+					 * One entry button per available source, each labelled with
+					 * that source's own `title`. A list rather than a select:
+					 * choosing a source is a one-way change that replaces the
+					 * gallery's contents, so it reads better as an action than as
+					 * a setting, and it keeps the confirmation attached to the
+					 * thing being confirmed.
 					 */ }
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						onClick={ requestEnableDynamicMode }
-					>
-						{ __( 'Use images attached to the post' ) }
-					</Button>
+					{ availableSources.map( ( [ source, descriptor ] ) => (
+						<Button
+							key={ source }
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => requestEnableDynamicMode( source ) }
+						>
+							{ descriptor.title }
+						</Button>
+					) ) }
 				</div>
 			</PanelBody>
-			{ isConfirming && (
+			{ pendingDescriptor && (
 				<ConfirmDialog
 					isOpen
-					title={ __( 'Use images attached to the post?' ) }
+					title={ pendingDescriptor.title }
 					__experimentalHideHeader={ false }
-					confirmButtonText={ __( 'Use attached images' ) }
+					confirmButtonText={ __( 'Replace images' ) }
 					onConfirm={ () => {
-						enableDynamicMode();
-						setIsConfirming( false );
+						enableDynamicMode( sourcePendingConfirm );
+						setSourcePendingConfirm( undefined );
 					} }
-					onCancel={ () => setIsConfirming( false ) }
+					onCancel={ () => setSourcePendingConfirm( undefined ) }
 					size="medium"
 				>
 					{ __(
@@ -337,12 +456,19 @@ export function GalleryDynamicView( {
 	multiGallerySelection,
 } ) {
 	const {
+		dynamicContent,
 		sourceDescriptor,
+		sourceFolderId,
 		dynamicImageBlocks,
 		galleryContext,
 		isResolvingDynamic,
 		convertToStatic,
 	} = dynamic;
+
+	// A folder gallery with no folder chosen yet isn't "empty" so much as
+	// unconfigured, so it says what to do rather than what will appear.
+	const needsFolder =
+		dynamicContent?.source === MEDIA_FOLDER && ! sourceFolderId;
 
 	// Detaching the gallery materializes editable inner blocks, which is a
 	// structural change. Only offer it when the block is fully editable:
@@ -358,10 +484,16 @@ export function GalleryDynamicView( {
 	// post with no matching images and a template with no post in context yet —
 	// in either case the source simply resolves to nothing right now. The per-
 	// source wording comes from the source descriptor.
-	const emptyInstructions = isResolvingDynamic
-		? __( 'Loading images…' )
-		: sourceDescriptor?.emptyMessage ??
-		  __( 'Dynamic images will appear here.' );
+	let emptyInstructions;
+	if ( needsFolder ) {
+		emptyInstructions = sourceDescriptor.noFolderMessage;
+	} else if ( isResolvingDynamic ) {
+		emptyInstructions = __( 'Loading images…' );
+	} else {
+		emptyInstructions =
+			sourceDescriptor?.emptyMessage ??
+			__( 'Dynamic images will appear here.' );
+	}
 
 	return (
 		<>

--- a/packages/block-library/src/gallery/dynamic-source.js
+++ b/packages/block-library/src/gallery/dynamic-source.js
@@ -9,6 +9,24 @@ import { __ } from '@wordpress/i18n';
 export const ATTACHED_MEDIA = 'core/attached-media';
 
 /**
+ * Source discriminator for "images in a media folder". Unlike
+ * `core/attached-media` this source is not relative to the rendered post — its
+ * folder is named outright in `args.folderId` — so it resolves anywhere,
+ * including in templates and patterns.
+ *
+ * Only meaningful while the media folders experiment is on; without it the
+ * `wp_media_folder` taxonomy isn't registered, so the source resolves to nothing
+ * on both sides and the gallery renders empty.
+ */
+export const MEDIA_FOLDER = 'core/media-folder';
+
+/**
+ * The media folders taxonomy's REST base, which names the `/wp/v2/media`
+ * collection parameter used to filter attachments by folder.
+ */
+export const MEDIA_FOLDER_REST_BASE = 'media-folders';
+
+/**
  * Default ordering for a dynamic source. `menu_order` (the manual media-library
  * order) is intentionally not used: it isn't a valid `orderby` value on the
  * media REST endpoint, so the editor preview couldn't reproduce it. Both the
@@ -28,13 +46,32 @@ export const DEFAULT_ORDER = 'desc';
  */
 const DYNAMIC_SOURCES = {
 	[ ATTACHED_MEDIA ]: {
-		// Short label for the entry affordance / future source chooser. Mirrors
-		// the "Attached images" media inserter category name.
+		// Short label for the entry affordance / source chooser. Mirrors the
+		// "Attached images" media inserter category name.
 		title: __( 'Use attached images' ),
 		// Help text shown beneath the Source controls.
 		description: __( 'Images attached to the post.' ),
 		// Empty-state copy for the canvas preview.
 		emptyMessage: __( 'Images attached to the post will appear here.' ),
+		// This source is relative to the post being rendered, so it can only be
+		// offered where there will be one. A source without this flag resolves
+		// anywhere, including template parts and patterns.
+		requiresPost: true,
+	},
+	[ MEDIA_FOLDER ]: {
+		// Mirrors the folder categories in the media inserter, which is where a
+		// folder's images are put together in the first place.
+		title: __( 'Use a folder' ),
+		description: __( 'Images in a media folder.' ),
+		emptyMessage: __( 'Images in the selected folder will appear here.' ),
+		// Copy for the source's own configuration, which the Source panel renders
+		// alongside the shared ordering control.
+		selectFolderLabel: __( 'Folder' ),
+		noFolderMessage: __( 'Select a folder to display its images.' ),
+		// Media folders are experimental: without the experiment the taxonomy
+		// isn't registered, so there is nothing to point a gallery at and the
+		// source isn't offered.
+		isAvailable: () => !! window.__experimentalMediaFolders,
 	},
 };
 
@@ -47,6 +84,16 @@ const DYNAMIC_SOURCES = {
  */
 export function getDynamicSource( source ) {
 	return DYNAMIC_SOURCES[ source ];
+}
+
+/**
+ * Returns every dynamic source as `[ name, descriptor ]` pairs, for building the
+ * "Source" chooser. Order here is the order they are offered in.
+ *
+ * @return {Array<[string, Object]>} The source entries.
+ */
+export function getDynamicSources() {
+	return Object.entries( DYNAMIC_SOURCES );
 }
 
 /**
@@ -80,33 +127,47 @@ export const MAX_IMAGES = 100;
 export function getSourceQuery( dynamicContent, { postId } ) {
 	const { source, args = {} } = dynamicContent ?? {};
 
+	// Query params shared by every source. Unexpected `args` values (only
+	// reachable via hand-edited markup) are coerced back to the defaults —
+	// mirroring the server resolver's allow list — so the editor preview stays in
+	// step with the frontend instead of issuing an invalid REST query.
+	const baseQuery = {
+		per_page: MAX_IMAGES,
+		// The gallery only accepts images, so constrain the source to image
+		// media (matching the server resolver). This keeps the editor preview in
+		// step with the rendered output for sources that also match other media.
+		media_type: 'image',
+		// Map the camelCase `args` to the REST-named media collection params.
+		orderby:
+			args.orderBy === 'date' || args.orderBy === 'title'
+				? args.orderBy
+				: DEFAULT_ORDERBY,
+		order:
+			args.order === 'asc' || args.order === 'desc'
+				? args.order
+				: DEFAULT_ORDER,
+	};
+
 	switch ( source ) {
 		case ATTACHED_MEDIA:
 			if ( ! postId ) {
 				return null;
 			}
+			return { ...baseQuery, parent: postId };
+
+		case MEDIA_FOLDER: {
+			// A folder gallery that hasn't been pointed at a folder yet: return
+			// no query rather than one matching every image, so the block shows
+			// its empty state instead of the whole media library.
+			const folderId = Number( args.folderId );
+			if ( ! Number.isInteger( folderId ) || folderId <= 0 ) {
+				return null;
+			}
 			return {
-				parent: postId,
-				per_page: MAX_IMAGES,
-				// The gallery only accepts images, so constrain the source to
-				// image media (matching the server resolver). This keeps the
-				// editor preview in step with the rendered output for posts
-				// that also have non-image attachments.
-				media_type: 'image',
-				// Map the camelCase `args` to the REST-named media collection
-				// params. Unexpected values (only reachable via hand-edited
-				// markup) are coerced back to the defaults — mirroring the server
-				// resolver's allow list — so the editor preview stays in step with
-				// the frontend instead of issuing an invalid REST query.
-				orderby:
-					args.orderBy === 'date' || args.orderBy === 'title'
-						? args.orderBy
-						: DEFAULT_ORDERBY,
-				order:
-					args.order === 'asc' || args.order === 'desc'
-						? args.order
-						: DEFAULT_ORDER,
+				...baseQuery,
+				[ MEDIA_FOLDER_REST_BASE ]: [ folderId ],
 			};
+		}
 	}
 
 	// Unknown or not-yet-implemented source.

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -58,7 +58,6 @@ import useGetMedia from './use-get-media';
 import GalleryGapCustomProperties from './gap-styles';
 import useDynamicGallery from './use-dynamic-gallery';
 import { GallerySourcePanel, GalleryDynamicView } from './dynamic-gallery';
-import { getDynamicSource, ATTACHED_MEDIA } from './dynamic-source';
 
 const MAX_COLUMNS = 8;
 const LINK_OPTIONS = [
@@ -673,24 +672,38 @@ export default function GalleryEdit( props ) {
 					{ ...mediaPlaceholderProps }
 				>
 					{ /*
-					 * Entry into dynamic mode. Gated on the editing mode so it's
-					 * hidden in content-only editing (where this structural change
-					 * isn't allowed), but intentionally not hidden by
-					 * `canUseDynamicSource` the way the inspector is (see
-					 * `dynamic-gallery.js`): even with no
-					 * post type to preview against, the source still resolves at
-					 * render time via `get_the_ID()` (see `index.php`) — e.g. in a
-					 * template part or pattern shown on a singular page.
+					 * Entry into dynamic mode, one button per source. An empty
+					 * gallery renders only this placeholder (no inspector), so
+					 * these are the sole way to reach dynamic mode on a fresh
+					 * block — every source has to be offered here, not just the
+					 * first one.
+					 *
+					 * Gated on the editing mode so they're hidden in content-only
+					 * editing, where this structural change isn't allowed. They
+					 * are intentionally not gated by `canUseDynamicSource` the way
+					 * the inspector is (see `dynamic-gallery.js`): even with no
+					 * post type to preview against, a post-relative source still
+					 * resolves at render time via `get_the_ID()` (see `index.php`)
+					 * — e.g. in a template part or pattern shown on a singular
+					 * page. That's what `enterableSources` accounts for.
 					 */ }
-					{ blockEditingMode === 'default' && (
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							onClick={ dynamic.enableDynamicMode }
-						>
-							{ getDynamicSource( ATTACHED_MEDIA ).title }
-						</Button>
-					) }
+					{ blockEditingMode === 'default' &&
+						dynamic.enterableSources.map(
+							( [ source, descriptor ] ) => (
+								<Button
+									key={ source }
+									__next40pxDefaultSize
+									variant="secondary"
+									// Called through an arrow so the click event
+									// isn't passed as the source argument.
+									onClick={ () =>
+										dynamic.enableDynamicMode( source )
+									}
+								>
+									{ descriptor.title }
+								</Button>
+							)
+						) }
 				</MediaPlaceholder>
 			</div>
 		);

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -113,6 +113,34 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 	$source_name = $source['source'] ?? null;
 	$args        = isset( $source['args'] ) && is_array( $source['args'] ) ? $source['args'] : array();
 
+	// Query arguments shared by every source. Map the camelCase `args`
+	// (block-attribute convention) to WP_Query names, defaulting to the same
+	// order as the editor preview (see `dynamic-source.js`). Only REST-supported
+	// orderby values are allowed; `menu_order` is intentionally unsupported (it
+	// isn't a valid media REST `orderby`).
+	$orderby = $args['orderBy'] ?? 'date';
+	if ( ! in_array( $orderby, array( 'date', 'title' ), true ) ) {
+		$orderby = 'date';
+	}
+	$order = strtoupper( $args['order'] ?? 'desc' ) === 'ASC' ? 'ASC' : 'DESC';
+
+	// Bound the number of resolved images until the gallery supports
+	// pagination. Kept in sync with the editor query's `per_page` cap; a
+	// case-insensitive grep for `max_images` finds both this and
+	// `MAX_IMAGES` in `dynamic-source.js`.
+	$max_images = 100;
+
+	$base_query_args = array(
+		'post_type'      => 'attachment',
+		'post_status'    => 'inherit',
+		'post_mime_type' => 'image',
+		'orderby'        => $orderby,
+		'order'          => $order,
+		'posts_per_page' => $max_images,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	);
+
 	switch ( $source_name ) {
 		case 'core/attached-media':
 			// Prefer the post supplied via block context, falling back to the post
@@ -125,34 +153,42 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 				return array();
 			}
 
-			// Map the camelCase `args` (block-attribute convention) to WP_Query
-			// names, defaulting to the same order as the editor preview (see
-			// `dynamic-source.js`). Only REST-supported orderby values are
-			// allowed; `menu_order` is intentionally unsupported (it isn't a
-			// valid media REST `orderby`).
-			$orderby = $args['orderBy'] ?? 'date';
-			if ( ! in_array( $orderby, array( 'date', 'title' ), true ) ) {
-				$orderby = 'date';
-			}
-			$order = strtoupper( $args['order'] ?? 'desc' ) === 'ASC' ? 'ASC' : 'DESC';
+			$query = new WP_Query(
+				array_merge(
+					$base_query_args,
+					array( 'post_parent' => $post_id )
+				)
+			);
 
-			// Bound the number of resolved images until the gallery supports
-			// pagination. Kept in sync with the editor query's `per_page` cap; a
-			// case-insensitive grep for `max_images` finds both this and
-			// `MAX_IMAGES` in `dynamic-source.js`.
-			$max_images = 100;
+			return array_map( 'intval', $query->posts );
+
+		case 'core/media-folder':
+			$folder_id = isset( $args['folderId'] ) ? (int) $args['folderId'] : 0;
+
+			// No folder chosen, or the media folders experiment is off so the
+			// taxonomy doesn't exist. Either way there is nothing to resolve, so
+			// bail before running a query that can only come back empty.
+			if ( $folder_id <= 0 || ! taxonomy_exists( 'wp_media_folder' ) ) {
+				return array();
+			}
 
 			$query = new WP_Query(
-				array(
-					'post_parent'    => $post_id,
-					'post_type'      => 'attachment',
-					'post_status'    => 'inherit',
-					'post_mime_type' => 'image',
-					'orderby'        => $orderby,
-					'order'          => $order,
-					'posts_per_page' => $max_images,
-					'fields'         => 'ids',
-					'no_found_rows'  => true,
+				array_merge(
+					$base_query_args,
+					array(
+						'tax_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+							array(
+								'taxonomy'         => 'wp_media_folder',
+								'field'            => 'term_id',
+								'terms'            => array( $folder_id ),
+								// Folders are registered hierarchical, but the
+								// editor only creates a flat list and shows a
+								// folder's own images — so the frontend matches
+								// that rather than rolling up descendants.
+								'include_children' => false,
+							),
+						),
+					)
 				)
 			);
 

--- a/packages/block-library/src/gallery/use-dynamic-gallery.js
+++ b/packages/block-library/src/gallery/use-dynamic-gallery.js
@@ -9,6 +9,7 @@ import { getUpdatedLinkTargetSettings } from '../image/utils';
 import {
 	getSourceQuery,
 	getDynamicSource,
+	getDynamicSources,
 	ATTACHED_MEDIA,
 	DEFAULT_ORDERBY,
 	DEFAULT_ORDER,
@@ -98,13 +99,42 @@ export default function useDynamicGallery( {
 } ) {
 	const { dynamicContent } = attributes;
 
-	// Whether dynamic mode makes sense in the current editing context. A
-	// `postType` means the block will resolve against some post at render time —
-	// either a concrete post (post/page editor, Query Loop item) or a post-bound
-	// template (`single`, `page`) whose post is filled in by `get_the_ID()` on the
-	// frontend (see `index.php`). Without it (template part, pattern, generic
-	// template) there's no post to attach to, so the source can never resolve.
-	const canUseDynamicSource = !! postType;
+	// The sources that can be offered here, as `[ name, descriptor ]` pairs.
+	//
+	// A source flagged `requiresPost` resolves relative to the post being
+	// rendered, so it needs a `postType` — meaning the block will resolve against
+	// some post at render time, either a concrete post (post/page editor, Query
+	// Loop item) or a post-bound template (`single`, `page`) whose post is filled
+	// in by `get_the_ID()` on the frontend (see `index.php`). Without one
+	// (template part, pattern, generic template) there's nothing to attach to, so
+	// such a source can never resolve. Sources that name their own content —
+	// a media folder — are offered everywhere.
+	const availableSources = useMemo(
+		() =>
+			getDynamicSources().filter(
+				( [ , descriptor ] ) =>
+					( ! descriptor.requiresPost || !! postType ) &&
+					( descriptor.isAvailable?.() ?? true )
+			),
+		[ postType ]
+	);
+
+	// Whether dynamic mode makes sense in the current editing context at all.
+	const canUseDynamicSource = availableSources.length > 0;
+
+	// The sources offered as entry points on the block placeholder. Unlike
+	// `availableSources` this ignores `requiresPost`: with no post type to
+	// preview against, a post-relative source still resolves at render time via
+	// `get_the_ID()` (see `index.php`) — e.g. in a template part or pattern shown
+	// on a singular page. A source gated off by its own `isAvailable` is still
+	// excluded, since it could never resolve at all.
+	const enterableSources = useMemo(
+		() =>
+			getDynamicSources().filter(
+				( [ , descriptor ] ) => descriptor.isAvailable?.() ?? true
+			),
+		[]
+	);
 
 	// The descriptor for the configured source (its `title`/`description`/
 	// `emptyMessage`), resolved once here so consumers read the copy without
@@ -114,6 +144,8 @@ export default function useDynamicGallery( {
 	// Current source ordering, falling back to the shared defaults when unset.
 	const sourceOrderby = dynamicContent?.args?.orderBy ?? DEFAULT_ORDERBY;
 	const sourceOrder = dynamicContent?.args?.order ?? DEFAULT_ORDER;
+	// The folder a `core/media-folder` gallery points at, if any.
+	const sourceFolderId = dynamicContent?.args?.folderId;
 
 	const registry = useRegistry();
 	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
@@ -202,14 +234,14 @@ export default function useDynamicGallery( {
 	// legacy `images`/`ids` attributes aren't touched — they're back-compat shims
 	// for the pre-innerBlocks format (see `deprecated.js`/`transforms.js`), empty
 	// on any gallery reachable here.
-	function enableDynamicMode() {
+	function enableDynamicMode( source = ATTACHED_MEDIA ) {
 		// Batch the attribute change and the inner-block reset into a single
 		// undo level: they're two halves of one mode switch, so one undo should
 		// revert both. Marking the second dispatch non-persistent stops it from
 		// opening a second undo level, which would otherwise leave the gallery
 		// in a half-switched state (dynamic source set, images still present).
 		registry.batch( () => {
-			setAttributes( { dynamicContent: { source: ATTACHED_MEDIA } } );
+			setAttributes( { dynamicContent: { source } } );
 			__unstableMarkNextChangeAsNotPersistent();
 			replaceInnerBlocks( clientId, [] );
 		} );
@@ -233,20 +265,17 @@ export default function useDynamicGallery( {
 		} );
 	}
 
-	// Updates the source ordering within `dynamicContent.args`. Passing
-	// `undefined` (or the default order) strips the keys so they aren't
-	// persisted redundantly and the ToolsPanel item reads as unset.
-	function setSourceOrder( nextOrderby, nextOrder ) {
-		const nextArgs = { ...dynamicContent?.args };
-		delete nextArgs.orderBy;
-		delete nextArgs.order;
-		if (
-			nextOrderby !== undefined &&
-			( nextOrderby !== DEFAULT_ORDERBY || nextOrder !== DEFAULT_ORDER )
-		) {
-			nextArgs.orderBy = nextOrderby;
-			nextArgs.order = nextOrder;
-		}
+	// Merges updates into `dynamicContent.args`. A key set to `undefined` is
+	// removed rather than persisted, so an unset argument leaves no trace in the
+	// serialized attribute and the corresponding control reads as unset; `args`
+	// itself is dropped once it is empty.
+	function updateSourceArgs( updates ) {
+		const nextArgs = { ...dynamicContent?.args, ...updates };
+		Object.keys( updates ).forEach( ( key ) => {
+			if ( nextArgs[ key ] === undefined ) {
+				delete nextArgs[ key ];
+			}
+		} );
 		const nextSource = { ...dynamicContent };
 		if ( Object.keys( nextArgs ).length ) {
 			nextSource.args = nextArgs;
@@ -256,21 +285,44 @@ export default function useDynamicGallery( {
 		setAttributes( { dynamicContent: nextSource } );
 	}
 
-	// Resets the source to its bare form: keeps the source kind, drops its args.
+	// Updates the source ordering. Passing `undefined` (or the default order)
+	// strips the keys so they aren't persisted redundantly.
+	function setSourceOrder( nextOrderby, nextOrder ) {
+		const isDefault =
+			nextOrderby === undefined ||
+			( nextOrderby === DEFAULT_ORDERBY && nextOrder === DEFAULT_ORDER );
+		updateSourceArgs(
+			isDefault
+				? { orderBy: undefined, order: undefined }
+				: { orderBy: nextOrderby, order: nextOrder }
+		);
+	}
+
+	// Points a media folder gallery at a folder. A falsy id clears the selection,
+	// returning the block to its "choose a folder" empty state.
+	function setSourceFolderId( folderId ) {
+		updateSourceArgs( { folderId: folderId || undefined } );
+	}
+
+	// Resets the source's optional settings. Only the ordering is optional — the
+	// source kind and the folder it points at are what the gallery *is*, so
+	// clearing them would empty the block rather than reset a setting.
 	function resetSource() {
-		setAttributes( {
-			dynamicContent: { source: dynamicContent.source },
-		} );
+		setSourceOrder( undefined, undefined );
 	}
 
 	return {
 		dynamicContent,
 		canUseDynamicSource,
+		availableSources,
+		enterableSources,
 		sourceDescriptor,
 		hasMoreImagesThanCap,
 		dynamicMediaTotal,
 		sourceOrderby,
 		sourceOrder,
+		sourceFolderId,
+		setSourceFolderId,
 		dynamicMedia,
 		dynamicImageBlocks,
 		isResolvingDynamic,

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Enhancements
 
+-   Inserter: Add a media category per media folder, with pagination, and an injected folder-creation capability for the inserter's "Add folder" button. Behind the `gutenberg-media-folders` experiment.
 -   Add a read-only code diff to the revisions screen ([#80314](https://github.com/WordPress/gutenberg/pull/80314)).
 
 ### New Features

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -5,7 +5,7 @@
  * In the future we could consider creating an Openvese package that can be used in both `editor` and `site-editor`.
  * The rest of the settings would still need to be in sync though.
  */
-import { __, sprintf, _x } from '@wordpress/i18n';
+import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import { dispatch, resolveSelect, select, subscribe } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
@@ -265,6 +265,70 @@ const createCoreMediaCategory = ( { getQuery, ...category } ) => ( {
 } );
 
 /**
+ * Copy for the "Attached images" source's attach/detach affordances. The shared
+ * panel in `block-editor` renders whatever copy the source supplies, so the
+ * post-type-specific wording is built here, where the post type is known.
+ *
+ * @param {string|null} [typeLabel] The post type's singular label (e.g. "Page"),
+ *                                  or null to fall back to the generic "post".
+ * @return {Object} The source's `attachCopy`.
+ */
+const getAttachedImagesCopy = ( typeLabel ) => ( {
+	attachButton: __( 'Attach images' ),
+	attachedNotice: ( count ) =>
+		typeLabel
+			? sprintf(
+					/* translators: %1$d: Number of images attached. %2$s: Name of the post type e.g: "Page". */
+					_n(
+						'%1$d image attached to %2$s.',
+						'%1$d images attached to %2$s.',
+						count
+					),
+					count,
+					typeLabel
+			  )
+			: sprintf(
+					/* translators: %d: Number of images attached to the post. */
+					_n(
+						'%d image attached to post.',
+						'%d images attached to post.',
+						count
+					),
+					count
+			  ),
+	noneAttachedNotice: __( 'No images were attached.' ),
+	attachErrorNotice: __( 'Could not attach images.' ),
+	detachAction: typeLabel
+		? sprintf(
+				/* translators: %s: Name of the post type e.g: "Page". */
+				__( 'Detach from %s' ),
+				typeLabel
+		  )
+		: __( 'Detach from post' ),
+	detachModalTitle: __( 'Detach image' ),
+	detachModalBody: typeLabel
+		? sprintf(
+				/* translators: %s: Name of the post type e.g: "Page". */
+				__(
+					'Detach this image from the current %s? The image will remain in the Media Library.'
+				),
+				typeLabel
+		  )
+		: __(
+				'Detach this image from the current post? The image will remain in the Media Library.'
+		  ),
+	detachConfirmButton: __( 'Detach' ),
+	detachedNotice: typeLabel
+		? sprintf(
+				/* translators: %s: Name of the post type e.g: "Page". */
+				__( 'Image detached from %s.' ),
+				typeLabel
+		  )
+		: __( 'Image detached from post.' ),
+	detachErrorNotice: __( 'Could not detach image.' ),
+} );
+
+/**
  * Builds the "Attachments" media category for a given post. It behaves like
  * any other inserter media source (e.g. Openverse): it appears in the tab list
  * and renders through the shared media panel. In addition to `fetch`, it exposes
@@ -288,9 +352,7 @@ const getAttachedImagesCategory = ( postId, typeLabel ) =>
 		},
 		mediaType: 'image',
 		getQuery: ( query ) => getAttachedImagesQuery( postId, query ),
-		// The post type's singular label (e.g. "Page"), threaded through so the
-		// shared panel can word its attach/detach copy for the current post type.
-		postTypeLabel: typeLabel,
+		attachCopy: getAttachedImagesCopy( typeLabel ),
 		// Empty-state message. Providing this also keeps the source in the tab
 		// list when it has no items, so it stays discoverable and the first
 		// image can be attached even with none yet.
@@ -319,6 +381,169 @@ const getAttachedImagesCategory = ( postId, typeLabel ) =>
 			invalidateAttachedImagesQueries( postId, query );
 		},
 	} );
+
+/**
+ * The media folders taxonomy's REST base. It names both the `/wp/v2/media`
+ * collection parameter used to filter attachments by folder and the field on an
+ * attachment record holding its folder ids — `WP_REST_Posts_Controller` derives
+ * both from `rest_base`, so the hyphenated form is correct in a REST context
+ * even though the taxonomy itself is `wp_media_folder`.
+ */
+const MEDIA_FOLDER_REST_BASE = 'media-folders';
+
+const getMediaFolderQuery = ( folderId, query = {} ) => ( {
+	...query,
+	media_type: 'image',
+	[ MEDIA_FOLDER_REST_BASE ]: [ folderId ],
+} );
+
+/**
+ * Reads an attachment's current folder ids straight from the REST record.
+ *
+ * Folder assignment is many-to-many, and saving the taxonomy field *replaces*
+ * the whole set — so adding or removing one folder means reading the current set
+ * first and writing the union/difference. The record is read here rather than
+ * taken from the caller's media item because selections coming from the media
+ * picker are not guaranteed to carry the taxonomy field.
+ *
+ * @param {number} attachmentId The attachment id.
+ * @return {Promise<number[]>} The attachment's current folder ids.
+ */
+const getAttachmentFolderIds = async ( attachmentId ) => {
+	const record = await resolveSelect( coreStore ).getEntityRecord(
+		'postType',
+		'attachment',
+		attachmentId
+	);
+	const folderIds = record?.[ MEDIA_FOLDER_REST_BASE ];
+	return Array.isArray( folderIds ) ? folderIds : [];
+};
+
+const saveAttachmentFolderIds = ( attachmentId, folderIds ) =>
+	// `throwOnError` so a failed REST write rejects rather than being silently
+	// swallowed, letting the panel surface an error notice (see
+	// `saveAttachmentParent`).
+	dispatch( coreStore ).saveEntityRecord(
+		'postType',
+		'attachment',
+		{
+			id: attachmentId,
+			[ MEDIA_FOLDER_REST_BASE ]: folderIds,
+		},
+		{ throwOnError: true }
+	);
+
+/**
+ * Copy for a folder source's attach/detach affordances, worded around the
+ * folder's own name. Mirrors `getAttachedImagesCopy`.
+ *
+ * @param {string} folderName The folder's (decoded) name.
+ * @return {Object} The source's `attachCopy`.
+ */
+const getMediaFolderCopy = ( folderName ) => ( {
+	attachButton: __( 'Add images to folder' ),
+	attachedNotice: ( count ) =>
+		sprintf(
+			/* translators: %1$d: Number of images added. %2$s: Name of the folder. */
+			_n(
+				'%1$d image added to %2$s.',
+				'%1$d images added to %2$s.',
+				count
+			),
+			count,
+			folderName
+		),
+	noneAttachedNotice: __( 'No images were added.' ),
+	attachErrorNotice: __( 'Could not add images to the folder.' ),
+	detachAction: __( 'Remove from folder' ),
+	detachModalTitle: __( 'Remove image from folder' ),
+	detachModalBody: sprintf(
+		/* translators: %s: Name of the folder. */
+		__(
+			'Remove this image from %s? The image will remain in the Media Library.'
+		),
+		folderName
+	),
+	detachConfirmButton: __( 'Remove' ),
+	detachedNotice: sprintf(
+		/* translators: %s: Name of the folder. */
+		__( 'Image removed from %s.' ),
+		folderName
+	),
+	detachErrorNotice: __( 'Could not remove image from the folder.' ),
+} );
+
+/**
+ * Builds a media category for a single media folder (a `wp_media_folder` term).
+ *
+ * Structurally identical to the "Attached images" category — it renders through
+ * the same shared panel, gets pagination for free from `coreMediaFetch`, and
+ * exposes the same `attach`/`detach`/`invalidate`/`subscribe` capabilities — but
+ * membership is a taxonomy term rather than the attachment's parent post. That
+ * means a folder is not tied to the edited post, so these categories are offered
+ * everywhere the media tab appears.
+ *
+ * @param {Object} term The folder term record from `/wp/v2/media-folders`.
+ * @return {InserterMediaCategory} The folder's media category.
+ */
+const getMediaFolderCategory = ( term ) => {
+	const folderId = term.id;
+	const folderName = decodeEntities( term.name );
+
+	return createCoreMediaCategory( {
+		// Namespaced so a folder can never collide with a built-in source name.
+		name: `media-folder-${ folderId }`,
+		labels: {
+			name: folderName,
+			search_items: __( 'Search images' ),
+		},
+		mediaType: 'image',
+		getQuery: ( query ) => getMediaFolderQuery( folderId, query ),
+		folderId,
+		attachCopy: getMediaFolderCopy( folderName ),
+		// As with "Attached images", this both supplies the empty-state copy and
+		// keeps the folder in the tab list while it is empty — which is what
+		// makes a brand new folder reachable so images can be added to it.
+		emptyMessage: __( 'No images in this folder.' ),
+		async attach( mediaItems ) {
+			const attachmentIds = getImageAttachmentIds( mediaItems );
+
+			await Promise.all(
+				attachmentIds.map( async ( attachmentId ) => {
+					const folderIds =
+						await getAttachmentFolderIds( attachmentId );
+					// Already in this folder: skip the write rather than
+					// re-saving an unchanged set. The image still counts toward
+					// the notice below, which reports what the selection put in
+					// the folder, not how many rows changed.
+					if ( folderIds.includes( folderId ) ) {
+						return;
+					}
+					await saveAttachmentFolderIds( attachmentId, [
+						...folderIds,
+						folderId,
+					] );
+				} )
+			);
+
+			return attachmentIds.length;
+		},
+		async detach( mediaItem ) {
+			const folderIds = await getAttachmentFolderIds( mediaItem.id );
+			await saveAttachmentFolderIds(
+				mediaItem.id,
+				folderIds.filter( ( id ) => id !== folderId )
+			);
+		},
+		invalidate( query = {} ) {
+			dispatch( coreStore ).invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'attachment',
+				getCoreMediaQuery( getMediaFolderQuery( folderId, query ) ),
+			] );
+		},
+	} );
+};
 
 /** @type {InserterMediaCategory[]} */
 const inserterMediaCategories = [
@@ -412,14 +637,24 @@ const inserterMediaCategories = [
  * navigation menus and templates, which aren't the entity that actually gets
  * rendered, so attaching media to them is meaningless.
  *
+ * Media folders, in contrast, aren't tied to the edited entity, so a category is
+ * appended for each folder regardless of what is being edited. The list is empty
+ * unless the media folders experiment is on (the taxonomy is only registered
+ * then, so it resolves to nothing).
+ *
  * @param {number|string} postId                  The current post id.
  * @param {string}        [viewablePostTypeLabel] Singular label of the post type, set only when it is front-end viewable (post, page, public CPT).
+ * @param {Object[]}      [mediaFolders]          The `wp_media_folder` term records.
  * @return {InserterMediaCategory[]} The inserter media categories.
  */
 export default function getInserterMediaCategories(
 	postId,
-	viewablePostTypeLabel
+	viewablePostTypeLabel,
+	mediaFolders
 ) {
+	const folderCategories = ( mediaFolders ?? [] ).map(
+		getMediaFolderCategory
+	);
 	const currentPostId = normalizePostId( postId );
 
 	// A falsy label means either a non-viewable post type (synced pattern,
@@ -427,11 +662,12 @@ export default function getInserterMediaCategories(
 	// cases the category is omitted. A numeric id is also required since it
 	// backs the attachment `parent` query.
 	if ( ! currentPostId || ! viewablePostTypeLabel ) {
-		return inserterMediaCategories;
+		return [ ...inserterMediaCategories, ...folderCategories ];
 	}
 
 	return [
 		getAttachedImagesCategory( currentPostId, viewablePostTypeLabel ),
 		...inserterMediaCategories,
+		...folderCategories,
 	];
 }

--- a/packages/editor/src/components/media-categories/test/index.js
+++ b/packages/editor/src/components/media-categories/test/index.js
@@ -325,4 +325,162 @@ describe( 'getInserterMediaCategories', () => {
 			)
 		).toBe( false );
 	} );
+
+	describe( 'media folders', () => {
+		const getFolderCategory = ( folders, postId, typeLabel ) =>
+			getInserterMediaCategories( postId, typeLabel, folders ).find(
+				( category ) => category.name === 'media-folder-7'
+			);
+
+		it( 'adds a category per folder, independently of the edited post', () => {
+			const folders = [
+				{ id: 7, name: 'Holiday' },
+				{ id: 8, name: 'Product shots' },
+			];
+
+			// Folders are not relative to the edited entity, so they are offered
+			// even where "Attached images" is not (e.g. a template).
+			const categories = getInserterMediaCategories(
+				'wp_template//theme//home',
+				undefined,
+				folders
+			);
+
+			expect( categories.map( ( category ) => category.name ) ).toEqual( [
+				'images',
+				'videos',
+				'audio',
+				'openverse',
+				'media-folder-7',
+				'media-folder-8',
+			] );
+			expect( categories.at( -2 ).labels.name ).toBe( 'Holiday' );
+		} );
+
+		it( 'decodes entities in the folder name', () => {
+			const category = getFolderCategory( [
+				{ id: 7, name: 'Ben &amp; Jerry&#8217;s' },
+			] );
+
+			expect( category.labels.name ).toBe( 'Ben & Jerry’s' );
+			expect( category.attachCopy.detachedNotice ).toBe(
+				'Image removed from Ben & Jerry’s.'
+			);
+		} );
+
+		it( 'filters media by the folder term', async () => {
+			const getEntityRecords = jest.fn().mockResolvedValue( [] );
+			resolveSelect.mockReturnValue( { getEntityRecords } );
+			select.mockReturnValue( {
+				getEntityRecordsTotalItems: jest.fn().mockReturnValue( 0 ),
+				getEntityRecordsTotalPages: jest.fn().mockReturnValue( 0 ),
+			} );
+
+			const category = getFolderCategory( [
+				{ id: 7, name: 'Holiday' },
+			] );
+			await category.fetch( { per_page: 20 } );
+
+			expect( getEntityRecords ).toHaveBeenCalledWith(
+				'postType',
+				'attachment',
+				{
+					per_page: 20,
+					media_type: 'image',
+					'media-folders': [ 7 ],
+					orderBy: 'date',
+				}
+			);
+		} );
+
+		it( 'adds a folder without dropping the ones an image is already in', async () => {
+			const saveEntityRecord = jest.fn().mockResolvedValue( {} );
+			dispatch.mockReturnValue( { saveEntityRecord } );
+			// Image 10 is already filed under folder 3; image 11 is in none.
+			const getEntityRecord = jest.fn( ( kind, name, id ) =>
+				Promise.resolve(
+					id === 10 ? { id, 'media-folders': [ 3 ] } : { id }
+				)
+			);
+			resolveSelect.mockReturnValue( { getEntityRecord } );
+
+			const category = getFolderCategory( [
+				{ id: 7, name: 'Holiday' },
+			] );
+			const attachedCount = await category.attach( [
+				{ id: 10, type: 'image' },
+				{ id: 11, type: 'image' },
+				// Non-images are gated out, as for attached images.
+				{ id: 12, type: 'application' },
+			] );
+
+			expect( attachedCount ).toBe( 2 );
+			expect( saveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'attachment',
+				{ id: 10, 'media-folders': [ 3, 7 ] },
+				{ throwOnError: true }
+			);
+			expect( saveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'attachment',
+				{ id: 11, 'media-folders': [ 7 ] },
+				{ throwOnError: true }
+			);
+			expect( saveEntityRecord ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'skips the write for an image already in the folder', async () => {
+			const saveEntityRecord = jest.fn().mockResolvedValue( {} );
+			dispatch.mockReturnValue( { saveEntityRecord } );
+			resolveSelect.mockReturnValue( {
+				getEntityRecord: jest
+					.fn()
+					.mockResolvedValue( { id: 10, 'media-folders': [ 7 ] } ),
+			} );
+
+			const category = getFolderCategory( [
+				{ id: 7, name: 'Holiday' },
+			] );
+			const attachedCount = await category.attach( [
+				{ id: 10, type: 'image' },
+			] );
+
+			// Still reported as in the folder, but nothing was re-saved.
+			expect( attachedCount ).toBe( 1 );
+			expect( saveEntityRecord ).not.toHaveBeenCalled();
+		} );
+
+		it( 'removes only this folder on detach', async () => {
+			const saveEntityRecord = jest.fn().mockResolvedValue( {} );
+			dispatch.mockReturnValue( { saveEntityRecord } );
+			resolveSelect.mockReturnValue( {
+				getEntityRecord: jest
+					.fn()
+					.mockResolvedValue( { id: 10, 'media-folders': [ 3, 7 ] } ),
+			} );
+
+			const category = getFolderCategory( [
+				{ id: 7, name: 'Holiday' },
+			] );
+			await category.detach( { id: 10 } );
+
+			expect( saveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'attachment',
+				{ id: 10, 'media-folders': [ 3 ] },
+				{ throwOnError: true }
+			);
+		} );
+
+		it( 'stays listed while empty so images can be added to it', () => {
+			const category = getFolderCategory( [
+				{ id: 7, name: 'Holiday' },
+			] );
+
+			// `emptyMessage` is what keeps a category in the tab list when it has
+			// no items — and what tells `useMediaCategories` not to probe it.
+			expect( category.emptyMessage ).toBe( 'No images in this folder.' );
+		} );
+	} );
 } );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -30,6 +30,81 @@ const { store: mediaEditorStore } = unlock( mediaEditorPrivateApis );
 
 const EMPTY_OBJECT = {};
 
+/**
+ * Every folder, alphabetically. Folders are a small, hand-curated set, so they
+ * are fetched in one page rather than paginated, and empty ones are kept: a new
+ * folder has to be listed in the inserter before anything can be put in it.
+ */
+const MEDIA_FOLDERS_QUERY = {
+	per_page: -1,
+	hide_empty: false,
+	orderby: 'name',
+	order: 'asc',
+};
+
+/**
+ * The `wp_media_folder` terms backing the inserter's folder media categories.
+ *
+ * Returns `undefined` when the media folders experiment is off — the taxonomy
+ * isn't registered then, so nothing is requested and the inserter is unchanged.
+ *
+ * @return {Object[]|undefined} The folder term records, or `undefined`.
+ */
+function useMediaFolders() {
+	return useSelect(
+		( select ) =>
+			window.__experimentalMediaFolders
+				? select( coreStore ).getEntityRecords(
+						'taxonomy',
+						'wp_media_folder',
+						MEDIA_FOLDERS_QUERY
+				  )
+				: undefined,
+		[]
+	);
+}
+
+/**
+ * The folder-creation capability handed to the inserter's "Add folder" button.
+ *
+ * `block-editor` is WordPress-agnostic and can't write a taxonomy term itself,
+ * so the capability is injected as a setting from here. `undefined` when the
+ * experiment is off, which is what hides the button.
+ *
+ * @return {?{canCreate: boolean, create: Function}} The media folders capability.
+ */
+function useInserterMediaFolders() {
+	const canCreateMediaFolders = useSelect(
+		( select ) =>
+			window.__experimentalMediaFolders
+				? select( coreStore ).canUser( 'create', {
+						kind: 'taxonomy',
+						name: 'wp_media_folder',
+				  } )
+				: false,
+		[]
+	);
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	return useMemo( () => {
+		if ( ! window.__experimentalMediaFolders ) {
+			return undefined;
+		}
+		return {
+			canCreate: !! canCreateMediaFolders,
+			// `throwOnError` so a rejected write (e.g. a duplicate name) reaches
+			// the caller and can be reported, rather than failing silently.
+			create: ( name ) =>
+				saveEntityRecord(
+					'taxonomy',
+					'wp_media_folder',
+					{ name },
+					{ throwOnError: true }
+				),
+		};
+	}, [ canCreateMediaFolders, saveEntityRecord ] );
+}
+
 function __experimentalReusableBlocksSelect( select ) {
 	const { RECEIVE_INTERMEDIATE_RESULTS } = unlock( coreDataPrivateApis );
 	const { getEntityRecords } = select( coreStore );
@@ -348,12 +423,20 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	const forceDisableFocusMode = settings.focusMode === false;
 
 	// The "Attachments" media category depends on the edited post and its post
-	// type label (which gates whether it's offered and words its copy), so the
-	// categories are derived rather than being a static list.
+	// type label (which gates whether it's offered and words its copy), and one
+	// category is derived per media folder, so the categories are derived rather
+	// than being a static list. Re-deriving when the folders resolve is what
+	// makes a newly created folder appear in the tab list.
+	const mediaFolders = useMediaFolders();
+	const inserterMediaFolders = useInserterMediaFolders();
 	const inserterMediaCategories = useMemo(
 		() =>
-			getInserterMediaCategories( currentPostId, viewablePostTypeLabel ),
-		[ currentPostId, viewablePostTypeLabel ]
+			getInserterMediaCategories(
+				currentPostId,
+				viewablePostTypeLabel,
+				mediaFolders
+			),
+		[ currentPostId, viewablePostTypeLabel, mediaFolders ]
 	);
 
 	return useMemo( () => {
@@ -413,6 +496,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>
 				fetchLinkSuggestions( search, searchOptions, settings ),
 			inserterMediaCategories,
+			inserterMediaFolders,
 			__experimentalFetchRichUrlData: fetchUrlData,
 			// Todo: This only checks the top level post, not the post within a template or any other entity that can be edited.
 			// This might be better as a generic "canUser" selector.
@@ -476,6 +560,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		blockPatterns,
 		blockPatternCategories,
 		inserterMediaCategories,
+		inserterMediaFolders,
 		canUseUnfilteredHTML,
 		undo,
 		createPageEntity,

--- a/phpunit/blocks/render-block-gallery-media-folder-test.php
+++ b/phpunit/blocks/render-block-gallery-media-folder-test.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Gallery block media folder source rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests the Gallery block's `core/media-folder` dynamic source, which resolves a
+ * gallery's images from a `wp_media_folder` term rather than from the post the
+ * gallery is rendered within.
+ *
+ * The taxonomy is registered by an experiment (see
+ * `lib/experimental/media-folders.php`), which is off in the test environment —
+ * so these tests register it themselves. The one test that matters for the
+ * experiment being off is `test_folder_source_renders_nothing_without_taxonomy`,
+ * which deliberately runs without it.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Gallery_Media_Folder extends WP_UnitTestCase {
+
+	/**
+	 * Image attachment IDs filed under the folder, in creation order.
+	 *
+	 * @var int[]
+	 */
+	private $attachment_ids = array();
+
+	/**
+	 * The folder the gallery points at.
+	 *
+	 * @var int
+	 */
+	private $folder_id;
+
+	/**
+	 * An image outside the folder, to prove the source actually filters.
+	 *
+	 * @var int
+	 */
+	private $unfiled_attachment_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->register_media_folder_taxonomy();
+
+		$folder          = wp_insert_term( 'Holiday', 'wp_media_folder' );
+		$this->folder_id = $folder['term_id'];
+
+		$file = DIR_TESTDATA . '/images/canola.jpg';
+
+		// Distinct titles and dates so both orderings are deterministic. Created
+		// back-to-back from one file the attachments would otherwise share a
+		// `post_date`, which MySQL tie-breaks by ID regardless of direction.
+		foreach ( array( 'Beach', 'Apple' ) as $index => $title ) {
+			$attachment_id          = self::factory()->attachment->create_upload_object( $file );
+			$this->attachment_ids[] = $attachment_id;
+
+			wp_update_post(
+				array(
+					'ID'            => $attachment_id,
+					'post_title'    => $title,
+					'post_date'     => sprintf( '2020-01-0%d 00:00:00', $index + 1 ),
+					'post_date_gmt' => sprintf( '2020-01-0%d 00:00:00', $index + 1 ),
+				)
+			);
+			wp_set_object_terms( $attachment_id, array( $this->folder_id ), 'wp_media_folder' );
+		}
+
+		$this->unfiled_attachment_id = self::factory()->attachment->create_upload_object( $file );
+	}
+
+	public function tear_down() {
+		foreach ( array_merge( $this->attachment_ids, array( $this->unfiled_attachment_id ) ) as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+		$this->attachment_ids = array();
+
+		unregister_taxonomy( 'wp_media_folder' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers the media folders taxonomy the way the experiment does.
+	 *
+	 * Loads the experiment's own registration rather than restating its
+	 * arguments, so the tests exercise the real configuration — in particular
+	 * `update_count_callback`, which the count assertion below depends on.
+	 */
+	private function register_media_folder_taxonomy() {
+		if ( ! function_exists( 'gutenberg_register_media_folder_taxonomy' ) ) {
+			require_once __DIR__ . '/../../lib/experimental/media-folders.php';
+		}
+		gutenberg_register_media_folder_taxonomy();
+	}
+
+	/**
+	 * Renders a gallery block outside any loop.
+	 *
+	 * Unlike `core/attached-media`, a folder source names its own content, so it
+	 * must resolve with no post in context — which is what lets a folder gallery
+	 * work in a template part or pattern.
+	 *
+	 * @param array $dynamic_content The gallery's `dynamicContent` attribute.
+	 * @return string Rendered HTML.
+	 */
+	private function render_folder_gallery( $dynamic_content ) {
+		return do_blocks(
+			'<!-- wp:gallery ' . wp_json_encode( array( 'dynamicContent' => $dynamic_content ) ) . ' /-->'
+		);
+	}
+
+	public function test_folder_source_renders_only_that_folders_images() {
+		$output = $this->render_folder_gallery(
+			array(
+				'source' => 'core/media-folder',
+				'args'   => array( 'folderId' => $this->folder_id ),
+			)
+		);
+
+		$this->assertSame(
+			count( $this->attachment_ids ),
+			substr_count( $output, 'wp-block-image' ),
+			'Should render one image block per image in the folder.'
+		);
+
+		foreach ( $this->attachment_ids as $attachment_id ) {
+			$this->assertStringContainsString(
+				'wp-image-' . $attachment_id,
+				$output,
+				"Rendered gallery should contain attachment $attachment_id."
+			);
+		}
+
+		$this->assertStringNotContainsString(
+			'wp-image-' . $this->unfiled_attachment_id,
+			$output,
+			'An image outside the folder should not be rendered.'
+		);
+	}
+
+	public function test_folder_source_honours_order() {
+		$by_title = $this->render_folder_gallery(
+			array(
+				'source' => 'core/media-folder',
+				'args'   => array(
+					'folderId' => $this->folder_id,
+					'orderBy'  => 'title',
+					'order'    => 'asc',
+				),
+			)
+		);
+
+		list( $beach, $apple ) = $this->attachment_ids;
+
+		// A → Z puts "Apple" before "Beach", the reverse of creation order — so
+		// this also proves the ordering args reach the query at all.
+		$this->assertLessThan(
+			strpos( $by_title, 'wp-image-' . $beach ),
+			strpos( $by_title, 'wp-image-' . $apple ),
+			'With orderBy=title and order=asc, "Apple" should render before "Beach".'
+		);
+	}
+
+	public function test_folder_source_counts_unattached_media() {
+		// The taxonomy's `update_count_callback` exists for exactly this: WordPress'
+		// default counts an attachment against its parent post's status and skips
+		// unattached media, which would report every folder as empty.
+		$folder = get_term( $this->folder_id, 'wp_media_folder' );
+
+		$this->assertSame(
+			count( $this->attachment_ids ),
+			$folder->count,
+			'A folder should count the unattached media filed under it.'
+		);
+	}
+
+	public function test_folder_source_renders_nothing_without_a_folder() {
+		foreach ( array(
+			'missing folder id' => array(),
+			'empty folder id'   => array( 'folderId' => 0 ),
+			'non-numeric id'    => array( 'folderId' => 'oops' ),
+			'unknown folder'    => array( 'folderId' => 999999 ),
+		) as $case => $args ) {
+			$output = $this->render_folder_gallery(
+				array(
+					'source' => 'core/media-folder',
+					'args'   => $args,
+				)
+			);
+
+			$this->assertSame(
+				'',
+				trim( $output ),
+				"A folder gallery with $case should render nothing at all."
+			);
+		}
+	}
+
+	public function test_folder_source_renders_nothing_without_taxonomy() {
+		// With the experiment off the taxonomy doesn't exist, so a gallery saved
+		// while it was on has to degrade to rendering nothing rather than erroring
+		// or falling back to some other set of images.
+		unregister_taxonomy( 'wp_media_folder' );
+
+		$output = $this->render_folder_gallery(
+			array(
+				'source' => 'core/media-folder',
+				'args'   => array( 'folderId' => $this->folder_id ),
+			)
+		);
+
+		$this->assertSame(
+			'',
+			trim( $output ),
+			'A folder gallery should render nothing when media folders are unavailable.'
+		);
+
+		// Re-registered so `tear_down` can unregister it symmetrically.
+		$this->register_media_folder_taxonomy();
+	}
+}

--- a/test/e2e/specs/editor/various/media-folders.spec.js
+++ b/test/e2e/specs/editor/various/media-folders.spec.js
@@ -1,0 +1,187 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * The media folders MVP end to end: create a folder from the inserter's Media
+ * tab, put images in it, and point a dynamic Gallery at it so those images
+ * render in the editor and on the front end.
+ *
+ * Behind the `gutenberg-media-folders` experiment, which registers the
+ * `wp_media_folder` taxonomy — with it off, none of this UI exists.
+ */
+test.describe( 'Media folders', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-media-folders',
+		] );
+		await Promise.all( [
+			requestUtils.deleteAllMedia(),
+			requestUtils.deleteAllPosts(),
+		] );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		// Folders persist across tests otherwise, and each one adds a tab to the
+		// Media list that later assertions would have to work around. The route
+		// only exists while the experiment is on, and a failing test can leave it
+		// off — so a missing route here means there is nothing to clean up.
+		let folders;
+		try {
+			folders = await requestUtils.rest( {
+				path: '/wp/v2/media-folders',
+				params: { per_page: 100 },
+			} );
+		} catch {
+			return;
+		}
+		await Promise.all(
+			folders.map( ( folder ) =>
+				requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/media-folders/${ folder.id }`,
+					params: { force: true },
+				} )
+			)
+		);
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllMedia(),
+			requestUtils.deleteAllPosts(),
+		] );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'creates a folder, adds an image to it, and shows it in a Gallery', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const media = await requestUtils.uploadMedia(
+			'./assets/10x10_e2e_test_image_z9T8jK.png'
+		);
+
+		await admin.createNewPost();
+
+		// 1. Create a folder from the Media tab.
+		await page.getByLabel( 'Block Inserter' ).click();
+		await page.getByRole( 'tab', { name: 'Media' } ).click();
+		await page.getByRole( 'button', { name: 'Add folder' } ).click();
+
+		const addFolderDialog = page.getByRole( 'dialog', {
+			name: 'Add folder',
+		} );
+		await addFolderDialog.getByLabel( 'Name' ).fill( 'Holiday' );
+		await addFolderDialog.getByRole( 'button', { name: 'Create' } ).click();
+
+		// The new folder is selected as soon as its category appears, so the
+		// user lands in the empty folder they just made.
+		const mediaPanel = page.locator(
+			'.block-editor-inserter__media-panel'
+		);
+		await expect(
+			page.getByRole( 'tab', { name: 'Holiday' } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+		await expect(
+			mediaPanel.getByText( 'No images in this folder.' )
+		).toBeVisible();
+
+		// 2. Add an image to the folder, through the same Media Library picker
+		// the "Attach images" flow uses. It opens on "Upload files", so switch
+		// to the library and pick the existing image; the picker's own confirm
+		// button is core's "Select" (only the modal title is ours).
+		await mediaPanel
+			.getByRole( 'button', { name: 'Add images to folder' } )
+			.click();
+		const mediaLibrary = page.getByRole( 'dialog', {
+			name: 'Add images to folder',
+		} );
+		await mediaLibrary
+			.getByRole( 'tab', { name: 'Media Library' } )
+			.click();
+		await mediaLibrary
+			.getByRole( 'checkbox', { name: media.title.raw } )
+			.click();
+		// `exact` so this is the modal's confirm button, not the selected item's
+		// own "Select"/"Deselect" toggle.
+		await mediaLibrary
+			.getByRole( 'button', { name: 'Select', exact: true } )
+			.click();
+
+		await expect(
+			page
+				.locator( '.components-snackbar__content' )
+				.filter( { hasText: 'added to Holiday' } )
+		).toBeVisible();
+		await expect(
+			mediaPanel.getByRole( 'option', { name: media.title.raw } )
+		).toBeVisible();
+
+		await page.getByLabel( 'Close Block Inserter' ).click();
+
+		// 3. Point a Gallery at the folder. An empty gallery renders only its
+		// placeholder, so the source is chosen there; the folder itself is then
+		// picked in the Source panel.
+		await editor.insertBlock( { name: 'core/gallery' } );
+		await editor.canvas
+			.getByRole( 'button', { name: 'Use a folder' } )
+			.click();
+
+		await editor.openDocumentSettingsSidebar();
+		const settings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settings.getByRole( 'tab', { name: 'Settings' } ).click();
+		await settings
+			.getByRole( 'combobox', { name: 'Folder' } )
+			.selectOption( { label: 'Holiday' } );
+
+		// The canvas preview resolves the folder's images.
+		await expect(
+			editor.canvas.locator( `.wp-block-gallery img` )
+		).toHaveCount( 1 );
+
+		// 4. The same images render on the front end.
+		const postId = await editor.publishPost();
+		const previewPage = await page.context().newPage();
+		await previewPage.goto( `/?p=${ postId }` );
+
+		await expect(
+			previewPage.locator( '.wp-block-gallery img' )
+		).toHaveCount( 1 );
+		await expect(
+			previewPage.locator(
+				`.wp-block-gallery img.wp-image-${ media.id }`
+			)
+		).toBeVisible();
+
+		await previewPage.close();
+	} );
+
+	test( 'hides the folder affordances when the experiment is off', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+
+		await admin.createNewPost();
+		await page.getByLabel( 'Block Inserter' ).click();
+		await page.getByRole( 'tab', { name: 'Media' } ).click();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Add folder' } )
+		).toBeHidden();
+		// The rest of the Media tab is untouched. (The built-in sources are
+		// filtered out when the library is empty, so assert on the button that
+		// is always there rather than on a source tab.)
+		await expect(
+			page.getByRole( 'button', { name: 'Open Media Library' } )
+		).toBeVisible();
+
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-media-folders',
+		] );
+	} );
+} );


### PR DESCRIPTION
> [!NOTE]
> 🚧 This is a very early vibe-coded proof of concept, the code and approach will change considerably and this isn't intended to merge directly. Rather, I'm trying out some ideas that we could put behind an experiment and potentially land in smaller pieces

Part of:

* #81370
* #79779

## What?

Try adding basic support for media folders, behind an experiment, and hooking into media features that landed in WP 7.1:

* Add media folders as an additional source for the Dynamic Gallery block variation
* Expand categories in the media inserter to support adding folders, and from within a folder, adding images _to_ that folder (just like the UI for attaching images, that landed in 7.1)

## Why?

As described in #79779 and https://core.trac.wordpress.org/ticket/47839 the desire to use media folders is a very common one for folks running WP sites (and there's at least half a dozen popular and widely-used plugins that do this). The general idea behind this prototype is to see what an MVP / minimal version in core/Gutenberg might look like, and what the flows within the editor might be for working with media folders.

## How?

TBD but so far:

* Register a custom `wp_media_folder` taxonomy that's available via the REST API
* Add an "add folder" button to the media inserter in Gutenberg to allow users to create new folders
* Render all folders in the media inserter, even if they're empty
* Ensure there's an "Add image" button within each folder to allow folks to add images to a folder
* In the Dynamic Gallery block variation, add a new folders source to allow folks to link a gallery block to a media folder

## Testing Instructions

TBD, but for now you can play with this by switching on the experiment:

<img width="624" height="89" alt="image" src="https://github.com/user-attachments/assets/877ff880-5bb1-4f9b-8af2-e1a00902edc7" />

## To-do

* [ ] Update the Source panel to better allow switching between dynamic sources (between attached and a folder, for example)
* [ ] Improve the Gallery block placeholder state. I.e. should you be able to choose a particular folder _from_ the placeholder?
* [ ] In the media inserter, should you be able to delete a folder?

## Screenshots or screencast <!-- if applicable -->

Current state:

<img width="3348" height="1744" alt="image" src="https://github.com/user-attachments/assets/fac84d01-7e96-425c-b275-7aa41e57ba54" />

## Use of AI Tools

Claude Code Opus 5 for generating the code change — I have not done a human review of the code just yet as I'm still exploring how the feature might work.