### PR TITLE
Tools: Make agent setup a workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17168,6 +17168,10 @@
 			"resolved": "packages/admin-ui",
 			"link": true
 		},
+		"node_modules/@wordpress/agent-tools": {
+			"resolved": "tools/agents",
+			"link": true
+		},
 		"node_modules/@wordpress/annotations": {
 			"resolved": "packages/annotations",
 			"link": true
@@ -55355,6 +55359,11 @@
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
+		},
+		"tools/agents": {
+			"name": "@wordpress/agent-tools",
+			"version": "0.0.0",
+			"license": "GPL-2.0-or-later"
 		},
 		"tools/build-scripts": {
 			"name": "@wordpress/build-scripts",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"jsdom": "26.1.0"
 	},
 	"scripts": {
-		"agents:setup": "node ./tools/agents/setup-skills.mjs",
+		"agents:setup": "npm run --workspace @wordpress/agent-tools setup --",
 		"build": "npm run --workspace @wordpress/build-scripts build:all --",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"clean:package-types": "npm run --workspace @wordpress/build-scripts clean:package-types --",

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -1,0 +1,7 @@
+# @wordpress/agent-tools
+
+Tools for configuring AI coding agents in the Gutenberg repository. This is a private workspace package and is not published to npm.
+
+## Setup
+
+Run `npm run agents:setup` from the repository root to generate compatibility views of the canonical `.agents/skills` catalog for supported agents.

--- a/tools/agents/package.json
+++ b/tools/agents/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@wordpress/agent-tools",
+	"version": "0.0.0",
+	"description": "Tools for configuring AI coding agents in the Gutenberg repository.",
+	"private": true,
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"agents",
+		"skills"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/tools/agents",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/WordPress/gutenberg.git",
+		"directory": "tools/agents"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"setup": "node ./setup-skills.mjs"
+	}
+}

--- a/tools/agents/setup-skills.mjs
+++ b/tools/agents/setup-skills.mjs
@@ -1,7 +1,7 @@
 import { cp, mkdir, readdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { createInterface } from 'node:readline/promises';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SOURCE_SKILLS_DIRECTORY = '.agents/skills';
 const TARGET_SKILLS_DIRECTORY = '.claude/skills';
@@ -85,7 +85,10 @@ async function confirmReplacement( unmatchedEntries ) {
 async function runSetupSkills() {
 	const ifSafe = process.argv.includes( '--if-safe' );
 	const generated = await setupSkills( {
-		repositoryRoot: process.cwd(),
+		repositoryRoot: path.resolve(
+			path.dirname( fileURLToPath( import.meta.url ) ),
+			'../..'
+		),
 		confirm: confirmReplacement,
 		ifSafe,
 	} );

--- a/tools/agents/test/setup-skills.test.js
+++ b/tools/agents/test/setup-skills.test.js
@@ -1,5 +1,13 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+	copyFile,
+	mkdtemp,
+	mkdir,
+	readFile,
+	realpath,
+	rm,
+	writeFile,
+} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -7,7 +15,7 @@ import { promisify } from 'node:util';
 import { setupSkills } from '../setup-skills.mjs';
 
 const execFileAsync = promisify( execFile );
-const setupScript = path.join( __dirname, '../setup-skills.mjs' );
+const setupScriptSource = path.join( __dirname, '../setup-skills.mjs' );
 const temporaryRoots = [];
 
 afterEach( async () => {
@@ -17,8 +25,8 @@ afterEach( async () => {
 } );
 
 async function createRepository( skillNames = [ 'testing' ] ) {
-	const repositoryRoot = await mkdtemp(
-		path.join( os.tmpdir(), 'gutenberg-agent-skills-' )
+	const repositoryRoot = await realpath(
+		await mkdtemp( path.join( os.tmpdir(), 'gutenberg-agent-skills-' ) )
 	);
 	temporaryRoots.push( repositoryRoot );
 
@@ -26,7 +34,15 @@ async function createRepository( skillNames = [ 'testing' ] ) {
 		await createSkill( repositoryRoot, skillName );
 	}
 
+	const setupScript = getSetupScript( repositoryRoot );
+	await mkdir( path.dirname( setupScript ), { recursive: true } );
+	await copyFile( setupScriptSource, setupScript );
+
 	return repositoryRoot;
+}
+
+function getSetupScript( repositoryRoot ) {
+	return path.join( repositoryRoot, 'tools/agents/setup-skills.mjs' );
 }
 
 async function createSkill( repositoryRoot, skillName ) {
@@ -207,6 +223,7 @@ describe( 'setupSkills', () => {
 
 	test( 'runs the setup command when executed directly', async () => {
 		const repositoryRoot = await createRepository();
+		const setupScript = getSetupScript( repositoryRoot );
 
 		const { stdout } = await execFileAsync(
 			process.execPath,
@@ -219,6 +236,7 @@ describe( 'setupSkills', () => {
 
 	test( 'skips unmatched Claude skills when run with --if-safe', async () => {
 		const repositoryRoot = await createRepository();
+		const setupScript = getSetupScript( repositoryRoot );
 		await createFloatingSkill( repositoryRoot, 'private' );
 
 		const { stdout } = await execFileAsync(
@@ -240,6 +258,7 @@ describe( 'setupSkills', () => {
 
 	test( 'fails safely when unmatched skills need non-interactive confirmation', async () => {
 		const repositoryRoot = await createRepository();
+		const setupScript = getSetupScript( repositoryRoot );
 		await createFloatingSkill( repositoryRoot, 'private' );
 
 		await expect(
@@ -264,7 +283,7 @@ describe( 'setupSkills', () => {
 				'--input-type=module',
 				'--eval',
 				`await import( ${ JSON.stringify(
-					pathToFileURL( setupScript ).href
+					pathToFileURL( setupScriptSource ).href
 				) } );`,
 			] )
 		).resolves.toEqual( expect.objectContaining( { stdout: '' } ) );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/80811#pullrequestreview-4904389660

## What?

Makes `tools/agents` a private npm workspace and keeps `npm run agents:setup` as the repository-level entry point.

## Why?

Gutenberg's workspace guide defines `tools/*` as internal workspaces. Giving the agent setup tool its own package metadata makes its ownership and scripts consistent with the other tools in that directory.

## How?

- Adds the `@wordpress/agent-tools` workspace metadata and README.
- Forwards the root `agents:setup` script to the workspace.
- Resolves the repository root from the workspace location so setup behavior remains unchanged.
- Runs direct-execution tests from a temporary `tools/agents` workspace layout.

## Testing Instructions

1. Run `npm run agents:setup -- --if-safe`.
2. Confirm the command runs through `@wordpress/agent-tools` and generates `.claude/skills`.
3. Run `npm run test:unit -- tools/agents/test/setup-skills.test.js --runInBand`.

### Testing Instructions for Keyboard

Not applicable; this changes repository tooling only.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to assess the review suggestion, implement the workspace conversion, run verification, and draft this pull request.