### PR TITLE
Playlist: Add ZIP upload support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51319,6 +51319,7 @@
 				"@wordpress/url": "file:../url",
 				"@wordpress/viewport": "file:../viewport",
 				"@wordpress/wordcount": "file:../wordcount",
+				"@zip.js/zip.js": "^2.7.57",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.9.3",

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Playlist: Populate tracks, album details, artist details, and cover artwork from uploaded ZIP files.
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -133,6 +133,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/wordcount": "file:../wordcount",
+		"@zip.js/zip.js": "^2.7.57",
 		"change-case": "^4.1.2",
 		"clsx": "^2.1.1",
 		"colord": "^2.9.3",

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -30,7 +30,12 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
 import { PlaylistContext } from './context';
 import { getTrackAttributes, getTrackImageAttributes } from './utils';
-import { getPlaylistMediaFromZip, isZipFile } from './zip-utils';
+import {
+	debugPlaylistZip,
+	getPlaylistMediaFromZip,
+	getPlaylistZipDebugMediaInfo,
+	isZipFile,
+} from './zip-utils';
 
 const ALLOWED_PLAYLIST_MEDIA_TYPES = [
 	'audio',
@@ -120,23 +125,47 @@ function getZipFileName( media ) {
 
 async function getZipFile( media ) {
 	if ( isFile( media ) ) {
+		debugPlaylistZip(
+			'using selected ZIP file object',
+			getPlaylistZipDebugMediaInfo( media )
+		);
 		return media;
 	}
 
 	const mediaUrl = getMediaUrl( media );
 	if ( ! mediaUrl ) {
+		debugPlaylistZip( 'selected ZIP attachment is missing a URL', {
+			media: getPlaylistZipDebugMediaInfo( media ),
+		} );
 		throw new Error( __( 'The ZIP file is missing a URL.' ) );
 	}
 
+	debugPlaylistZip( 'fetching selected ZIP attachment', {
+		media: getPlaylistZipDebugMediaInfo( media ),
+	} );
 	const response = await window.fetch( mediaUrl );
 	if ( ! response.ok ) {
+		debugPlaylistZip( 'selected ZIP attachment fetch failed', {
+			status: response.status,
+			statusText: response.statusText,
+			media: getPlaylistZipDebugMediaInfo( media ),
+		} );
 		throw new Error( response.statusText );
 	}
 
 	const blob = await response.blob();
-	return new File( [ blob ], getZipFileName( media ).split( /[/\\]/ ).pop(), {
-		type: blob.type || getMediaMimeType( media ) || 'application/zip',
+	const file = new File(
+		[ blob ],
+		getZipFileName( media ).split( /[/\\]/ ).pop(),
+		{
+			type: blob.type || getMediaMimeType( media ) || 'application/zip',
+		}
+	);
+	debugPlaylistZip( 'fetched selected ZIP attachment', {
+		media: getPlaylistZipDebugMediaInfo( media ),
+		file: getPlaylistZipDebugMediaInfo( file ),
 	} );
+	return file;
 }
 
 const PlaylistEdit = ( {
@@ -291,7 +320,13 @@ const PlaylistEdit = ( {
 	const uploadZipMediaFile = useCallback(
 		( file ) =>
 			new Promise( ( resolve, reject ) => {
+				debugPlaylistZip( 'uploading extracted ZIP file', {
+					file: getPlaylistZipDebugMediaInfo( file ),
+				} );
 				if ( ! mediaUpload ) {
+					debugPlaylistZip( 'extracted ZIP file upload unavailable', {
+						file: getPlaylistZipDebugMediaInfo( file ),
+					} );
 					reject(
 						__(
 							'The ZIP file could not be uploaded because media uploads are unavailable.'
@@ -302,6 +337,12 @@ const PlaylistEdit = ( {
 
 				let isComplete = false;
 				const resolveWhenComplete = ( attachments ) => {
+					debugPlaylistZip( 'extracted ZIP file upload changed', {
+						file: getPlaylistZipDebugMediaInfo( file ),
+						attachments: Array.isArray( attachments )
+							? attachments.map( getPlaylistZipDebugMediaInfo )
+							: attachments,
+					} );
 					if ( isComplete ) {
 						return;
 					}
@@ -313,6 +354,14 @@ const PlaylistEdit = ( {
 					const attachment = attachments.find( ( item ) => item?.id );
 					if ( attachment ) {
 						isComplete = true;
+						debugPlaylistZip(
+							'extracted ZIP file upload resolved',
+							{
+								file: getPlaylistZipDebugMediaInfo( file ),
+								attachment:
+									getPlaylistZipDebugMediaInfo( attachment ),
+							}
+						);
 						resolve( attachment );
 					}
 				};
@@ -323,11 +372,16 @@ const PlaylistEdit = ( {
 					multiple: false,
 					onFileChange: resolveWhenComplete,
 					onSuccess: resolveWhenComplete,
-					onError: ( message ) =>
+					onError: ( message ) => {
+						debugPlaylistZip( 'extracted ZIP file upload failed', {
+							file: getPlaylistZipDebugMediaInfo( file ),
+							message,
+						} );
 						reject(
 							message ||
 								__( 'The ZIP file could not be uploaded.' )
-						),
+						);
+					},
 				} );
 			} ),
 		[ mediaUpload ]
@@ -350,6 +404,15 @@ const PlaylistEdit = ( {
 				}
 			}
 
+			debugPlaylistZip( 'extracted ZIP file upload batch complete', {
+				fileCount: filesList.length,
+				uploadedCount: attachments.filter( Boolean ).length,
+				errors: errors.map( ( error ) => ( {
+					file: getPlaylistZipDebugMediaInfo( error.file ),
+					message: error.message,
+				} ) ),
+			} );
+
 			return { attachments, errors };
 		},
 		[ uploadZipMediaFile ]
@@ -359,11 +422,28 @@ const PlaylistEdit = ( {
 		async ( zipFile ) => {
 			let zipMedia;
 			try {
+				debugPlaylistZip( 'creating playlist tracks from ZIP', {
+					zip: getPlaylistZipDebugMediaInfo( zipFile ),
+				} );
 				zipMedia = await getPlaylistMediaFromZip(
 					await getZipFile( zipFile )
 				);
+				debugPlaylistZip( 'parsed ZIP playlist media', {
+					trackCount: zipMedia.tracks.length,
+					tracks: zipMedia.tracks.map( ( track ) => ( {
+						file: getPlaylistZipDebugMediaInfo( track.file ),
+						details: track.details,
+					} ) ),
+					imageFile: getPlaylistZipDebugMediaInfo(
+						zipMedia.imageFile
+					),
+				} );
 			} catch ( error ) {
 				const message = getErrorMessage( error );
+				debugPlaylistZip( 'reading ZIP failed', {
+					zip: getPlaylistZipDebugMediaInfo( zipFile ),
+					message,
+				} );
 				onUploadError(
 					message
 						? sprintf(
@@ -377,6 +457,9 @@ const PlaylistEdit = ( {
 			}
 
 			if ( zipMedia.tracks.length === 0 ) {
+				debugPlaylistZip( 'ZIP contained no audio tracks', {
+					zip: getPlaylistZipDebugMediaInfo( zipFile ),
+				} );
 				onUploadError(
 					__( 'The ZIP file does not contain any audio files.' )
 				);
@@ -420,8 +503,20 @@ const PlaylistEdit = ( {
 					coverImage = getTrackImageAttributes(
 						await uploadZipMediaFile( zipMedia.imageFile )
 					);
+					debugPlaylistZip( 'uploaded ZIP cover image', {
+						imageFile: getPlaylistZipDebugMediaInfo(
+							zipMedia.imageFile
+						),
+						coverImage,
+					} );
 				} catch ( error ) {
 					const message = getErrorMessage( error );
+					debugPlaylistZip( 'ZIP cover image upload failed', {
+						imageFile: getPlaylistZipDebugMediaInfo(
+							zipMedia.imageFile
+						),
+						message,
+					} );
 					onUploadError(
 						message
 							? sprintf(
@@ -442,6 +537,17 @@ const PlaylistEdit = ( {
 				.map( ( track, index ) => {
 					const attachment = attachments[ index ];
 					if ( ! attachment ) {
+						debugPlaylistZip(
+							'skipped ZIP track without uploaded attachment',
+							{
+								track: {
+									file: getPlaylistZipDebugMediaInfo(
+										track.file
+									),
+									details: track.details,
+								},
+							}
+						);
 						return null;
 					}
 
@@ -461,12 +567,32 @@ const PlaylistEdit = ( {
 	const createTrackBlocksFromMedia = useCallback(
 		async ( media ) => {
 			const mediaItems = getMediaItems( media );
+			const mediaItemsWithType = mediaItems.map( ( mediaItem ) => ( {
+				mediaItem,
+				isZip: isZipFile( mediaItem ),
+			} ) );
+			debugPlaylistZip( 'selected playlist media', {
+				items: mediaItemsWithType.map( ( { mediaItem, isZip } ) => ( {
+					media: getPlaylistZipDebugMediaInfo( mediaItem ),
+					isZip,
+					isAudio: isFile( mediaItem )
+						? isAudioFile( mediaItem )
+						: isAudioMediaItem( mediaItem ),
+				} ) ),
+			} );
 			const blocks = createTrackBlocks(
-				mediaItems.filter( ( mediaItem ) => ! isZipFile( mediaItem ) )
+				mediaItemsWithType
+					.filter( ( { isZip } ) => ! isZip )
+					.map( ( { mediaItem } ) => mediaItem )
 			);
-			const zipFiles = mediaItems.filter( isZipFile );
+			const zipFiles = mediaItemsWithType
+				.filter( ( { isZip } ) => isZip )
+				.map( ( { mediaItem } ) => mediaItem );
 
 			if ( zipFiles.length === 0 ) {
+				debugPlaylistZip( 'selected media had no ZIP files', {
+					blockCount: blocks.length,
+				} );
 				return blocks;
 			}
 
@@ -474,7 +600,13 @@ const PlaylistEdit = ( {
 				zipFiles.map( createTrackBlocksFromZip )
 			);
 
-			return [ ...blocks, ...zipBlocks.flat() ];
+			const newBlocks = [ ...blocks, ...zipBlocks.flat() ];
+			debugPlaylistZip( 'created playlist blocks from selected media', {
+				blockCount: newBlocks.length,
+				zipBlockCount: zipBlocks.flat().length,
+				regularBlockCount: blocks.length,
+			} );
+			return newBlocks;
 		},
 		[ createTrackBlocks, createTrackBlocksFromZip ]
 	);

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -21,7 +21,7 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { playlist as icon } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 import { createBlobURL } from '@wordpress/blob';
@@ -29,11 +29,15 @@ import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
 import { PlaylistContext } from './context';
-import { getTrackAttributes } from './utils';
+import { getTrackAttributes, getTrackImageAttributes } from './utils';
+import { getPlaylistMediaFromZip, isZipFile } from './zip-utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+const ZIP_UPLOAD_MEDIA_TYPES = [ 'audio', 'image' ];
 const AUDIO_FILE_EXTENSION =
 	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
+const AUDIO_AND_ZIP_ACCEPT =
+	'audio/*,.zip,application/zip,application/x-zip-compressed';
 const DEFAULT_WAVEFORM_STYLE = 'bars';
 const FILE_LIST_OBJECT_NAME = '[object FileList]';
 const WAVEFORM_STYLE_OPTIONS = [
@@ -60,6 +64,18 @@ function isAudioFile( file ) {
 
 function getTrackIdentifier( track ) {
 	return track.id ?? track.src ?? track.blob;
+}
+
+function getMediaItems( media ) {
+	if ( ! media ) {
+		return [];
+	}
+
+	if ( Object.prototype.toString.call( media ) === FILE_LIST_OBJECT_NAME ) {
+		return Array.from( media );
+	}
+
+	return Array.isArray( media ) ? media : [ media ];
 }
 
 const PlaylistEdit = ( {
@@ -120,11 +136,14 @@ const PlaylistEdit = ( {
 	);
 	const [ currentTrackClientId, setCurrentTrackClientId ] = useState( null );
 
-	const { innerBlockTracks } = useSelect(
+	const { innerBlockTracks, mediaUpload } = useSelect(
 		( select ) => {
 			const { getBlock: _getBlock } = select( blockEditorStore );
+			const { mediaUpload: _mediaUpload } =
+				select( blockEditorStore ).getSettings();
 			return {
 				innerBlockTracks: _getBlock( clientId )?.innerBlocks ?? [],
+				mediaUpload: _mediaUpload,
 			};
 		},
 		[ clientId ]
@@ -166,19 +185,7 @@ const PlaylistEdit = ( {
 
 	const createTrackBlocks = useCallback(
 		( media ) => {
-			if ( ! media ) {
-				return [];
-			}
-
-			let mediaItems = [ media ];
-			if (
-				Object.prototype.toString.call( media ) ===
-				FILE_LIST_OBJECT_NAME
-			) {
-				mediaItems = Array.from( media );
-			} else if ( Array.isArray( media ) ) {
-				mediaItems = media;
-			}
+			const mediaItems = getMediaItems( media );
 			let hasInvalidFile = false;
 
 			const blocks = mediaItems
@@ -214,9 +221,139 @@ const PlaylistEdit = ( {
 		[ onUploadError ]
 	);
 
+	const uploadZipMedia = useCallback(
+		( filesList ) =>
+			new Promise( ( resolve, reject ) => {
+				if ( ! mediaUpload ) {
+					reject(
+						__(
+							'The ZIP file could not be uploaded because media uploads are unavailable.'
+						)
+					);
+					return;
+				}
+
+				const resolveWhenComplete = ( attachments ) => {
+					if ( ! Array.isArray( attachments ) ) {
+						return;
+					}
+
+					if (
+						attachments.length === filesList.length &&
+						attachments.every( ( attachment ) => attachment.id )
+					) {
+						resolve( attachments );
+					}
+				};
+
+				mediaUpload( {
+					allowedTypes: ZIP_UPLOAD_MEDIA_TYPES,
+					filesList,
+					multiple: true,
+					onFileChange: resolveWhenComplete,
+					onSuccess: resolveWhenComplete,
+					onError: ( message ) =>
+						reject(
+							message ||
+								__( 'The ZIP file could not be uploaded.' )
+						),
+				} );
+			} ),
+		[ mediaUpload ]
+	);
+
+	const createTrackBlocksFromZip = useCallback(
+		async ( zipFile ) => {
+			let zipMedia;
+			try {
+				zipMedia = await getPlaylistMediaFromZip( zipFile );
+			} catch ( error ) {
+				const message =
+					typeof error === 'string' ? error : error?.message;
+				onUploadError(
+					message
+						? sprintf(
+								// translators: %s: Error message.
+								__( 'The ZIP file could not be read: %s' ),
+								message
+						  )
+						: __( 'The ZIP file could not be read.' )
+				);
+				return [];
+			}
+
+			if ( zipMedia.tracks.length === 0 ) {
+				onUploadError(
+					__( 'The ZIP file does not contain any audio files.' )
+				);
+				return [];
+			}
+
+			const filesList = [
+				...zipMedia.tracks.map( ( track ) => track.file ),
+				...( zipMedia.imageFile ? [ zipMedia.imageFile ] : [] ),
+			];
+			let attachments;
+			try {
+				attachments = await uploadZipMedia( filesList );
+			} catch ( error ) {
+				const message =
+					typeof error === 'string' ? error : error?.message;
+				onUploadError(
+					message
+						? sprintf(
+								// translators: %s: Error message.
+								__( 'The ZIP file could not be uploaded: %s' ),
+								message
+						  )
+						: __( 'The ZIP file could not be uploaded.' )
+				);
+				return [];
+			}
+
+			const coverImage = zipMedia.imageFile
+				? getTrackImageAttributes(
+						attachments[ zipMedia.tracks.length ]
+				  )
+				: {};
+
+			return zipMedia.tracks.map( ( track, index ) => {
+				const { trackNumber, ...trackDetails } = track.details;
+
+				return createBlock( 'core/playlist-track', {
+					...getTrackAttributes( attachments[ index ] ),
+					...trackDetails,
+					...coverImage,
+				} );
+			} );
+		},
+		[ onUploadError, uploadZipMedia ]
+	);
+
+	const createTrackBlocksFromMedia = useCallback(
+		async ( media ) => {
+			const mediaItems = getMediaItems( media );
+			const blocks = createTrackBlocks(
+				mediaItems.filter( ( mediaItem ) => ! isZipFile( mediaItem ) )
+			);
+			const zipFiles = mediaItems.filter( isZipFile );
+
+			if ( zipFiles.length === 0 ) {
+				return blocks;
+			}
+
+			const zipBlocks = await Promise.all(
+				zipFiles.map( createTrackBlocksFromZip )
+			);
+
+			return [ ...blocks, ...zipBlocks.flat() ];
+		},
+		[ createTrackBlocks, createTrackBlocksFromZip ]
+	);
+
 	const onSelectTracks = useCallback(
-		( media ) => {
-			const newBlocks = createTrackBlocks( media );
+		async ( media ) => {
+			const newBlocks = await createTrackBlocksFromMedia( media );
 			if ( newBlocks.length === 0 ) {
 				return;
 			}
@@ -227,20 +364,22 @@ const PlaylistEdit = ( {
 		},
 		[
 			clientId,
-			createTrackBlocks,
+			createTrackBlocksFromMedia,
 			replaceInnerBlocks,
 			setCurrentTrackClientId,
 		]
 	);
 
 	const onAddTracks = useCallback(
-		( media ) => {
+		async ( media ) => {
 			const existingIds = new Set(
 				validTracks
 					.map( ( block ) => getTrackIdentifier( block.attributes ) )
 					.filter( Boolean )
 			);
-			const newBlocks = createTrackBlocks( media ).filter(
+			const newBlocks = (
+				await createTrackBlocksFromMedia( media )
+			).filter(
 				( block ) =>
 					! existingIds.has( getTrackIdentifier( block.attributes ) )
 			);
@@ -255,7 +394,7 @@ const PlaylistEdit = ( {
 		},
 		[
 			clientId,
-			createTrackBlocks,
+			createTrackBlocksFromMedia,
 			replaceInnerBlocks,
 			selectBlock,
 			setCurrentTrackClientId,
@@ -459,7 +598,7 @@ const PlaylistEdit = ( {
 						),
 					} }
 					onSelect={ onSelectTracks }
-					accept="audio/*"
+					accept={ AUDIO_AND_ZIP_ACCEPT }
 					multiple="add"
 					handleUpload={ false }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
@@ -475,7 +614,7 @@ const PlaylistEdit = ( {
 				<MediaReplaceFlow
 					name={ __( 'Add track' ) }
 					onSelect={ onAddTracks }
-					accept="audio/*"
+					accept={ AUDIO_AND_ZIP_ACCEPT }
 					multiple="add"
 					handleUpload={ false }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
@@ -670,7 +809,7 @@ const PlaylistEdit = ( {
 			<figure { ...blockProps }>
 				<MediaPlaceholder
 					onSelect={ onAddTracks }
-					accept="audio/*"
+					accept={ AUDIO_AND_ZIP_ACCEPT }
 					multiple="add"
 					handleUpload={ false }
 					disableMediaButtons

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -32,12 +32,17 @@ import { PlaylistContext } from './context';
 import { getTrackAttributes, getTrackImageAttributes } from './utils';
 import { getPlaylistMediaFromZip, isZipFile } from './zip-utils';
 
-const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+const ALLOWED_PLAYLIST_MEDIA_TYPES = [
+	'audio',
+	'application/zip',
+	'application/x-zip',
+	'application/x-zip-compressed',
+];
 const ZIP_UPLOAD_MEDIA_TYPES = [ 'audio', 'image' ];
 const AUDIO_FILE_EXTENSION =
 	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
 const AUDIO_AND_ZIP_ACCEPT =
-	'audio/*,.zip,application/zip,application/x-zip-compressed';
+	'audio/*,.zip,application/zip,application/x-zip,application/x-zip-compressed';
 const DEFAULT_WAVEFORM_STYLE = 'bars';
 const FILE_LIST_OBJECT_NAME = '[object FileList]';
 const WAVEFORM_STYLE_OPTIONS = [
@@ -66,6 +71,31 @@ function getTrackIdentifier( track ) {
 	return track.id ?? track.src ?? track.blob;
 }
 
+function getErrorMessage( error ) {
+	return typeof error === 'string' ? error : error?.message;
+}
+
+function getMediaUrl( media ) {
+	return media?.url ?? media?.source_url;
+}
+
+function getMediaMimeType( media ) {
+	return media?.mime_type ?? media?.mime ?? media?.type;
+}
+
+function isAudioMediaItem( media ) {
+	const mimeType = getMediaMimeType( media );
+	const mediaUrl = getMediaUrl( media );
+
+	return (
+		mimeType === 'audio' ||
+		mimeType?.startsWith( 'audio/' ) ||
+		AUDIO_FILE_EXTENSION.test( media?.filename ?? '' ) ||
+		AUDIO_FILE_EXTENSION.test( media?.file ?? '' ) ||
+		AUDIO_FILE_EXTENSION.test( mediaUrl ?? '' )
+	);
+}
+
 function getMediaItems( media ) {
 	if ( ! media ) {
 		return [];
@@ -76,6 +106,37 @@ function getMediaItems( media ) {
 	}
 
 	return Array.isArray( media ) ? media : [ media ];
+}
+
+function getZipFileName( media ) {
+	return (
+		media?.filename ||
+		media?.file ||
+		media?.name ||
+		getMediaUrl( media )?.split( /[/\\]/ ).pop() ||
+		'playlist.zip'
+	);
+}
+
+async function getZipFile( media ) {
+	if ( isFile( media ) ) {
+		return media;
+	}
+
+	const mediaUrl = getMediaUrl( media );
+	if ( ! mediaUrl ) {
+		throw new Error( __( 'The ZIP file is missing a URL.' ) );
+	}
+
+	const response = await window.fetch( mediaUrl );
+	if ( ! response.ok ) {
+		throw new Error( response.statusText );
+	}
+
+	const blob = await response.blob();
+	return new File( [ blob ], getZipFileName( media ).split( /[/\\]/ ).pop(), {
+		type: blob.type || getMediaMimeType( media ) || 'application/zip',
+	} );
 }
 
 const PlaylistEdit = ( {
@@ -202,8 +263,12 @@ const PlaylistEdit = ( {
 						} );
 					}
 
-					const track = getTrackAttributes( mediaItem );
+					if ( ! isAudioMediaItem( mediaItem ) ) {
+						hasInvalidFile = true;
+						return null;
+					}
 
+					const track = getTrackAttributes( mediaItem );
 					return track.src
 						? createBlock( 'core/playlist-track', track )
 						: null;
@@ -212,7 +277,9 @@ const PlaylistEdit = ( {
 
 			if ( hasInvalidFile ) {
 				onUploadError(
-					__( 'Only audio files can be added to a playlist.' )
+					__(
+						'Only audio files and ZIP files can be added to a playlist.'
+					)
 				);
 			}
 
@@ -221,8 +288,8 @@ const PlaylistEdit = ( {
 		[ onUploadError ]
 	);
 
-	const uploadZipMedia = useCallback(
-		( filesList ) =>
+	const uploadZipMediaFile = useCallback(
+		( file ) =>
 			new Promise( ( resolve, reject ) => {
 				if ( ! mediaUpload ) {
 					reject(
@@ -233,23 +300,27 @@ const PlaylistEdit = ( {
 					return;
 				}
 
+				let isComplete = false;
 				const resolveWhenComplete = ( attachments ) => {
+					if ( isComplete ) {
+						return;
+					}
+
 					if ( ! Array.isArray( attachments ) ) {
 						return;
 					}
 
-					if (
-						attachments.length === filesList.length &&
-						attachments.every( ( attachment ) => attachment.id )
-					) {
-						resolve( attachments );
+					const attachment = attachments.find( ( item ) => item?.id );
+					if ( attachment ) {
+						isComplete = true;
+						resolve( attachment );
 					}
 				};
 
 				mediaUpload( {
 					allowedTypes: ZIP_UPLOAD_MEDIA_TYPES,
-					filesList,
-					multiple: true,
+					filesList: [ file ],
+					multiple: false,
 					onFileChange: resolveWhenComplete,
 					onSuccess: resolveWhenComplete,
 					onError: ( message ) =>
@@ -262,14 +333,37 @@ const PlaylistEdit = ( {
 		[ mediaUpload ]
 	);
 
+	const uploadZipMedia = useCallback(
+		async ( filesList ) => {
+			const attachments = [];
+			const errors = [];
+
+			for ( const file of filesList ) {
+				try {
+					attachments.push( await uploadZipMediaFile( file ) );
+				} catch ( error ) {
+					attachments.push( null );
+					errors.push( {
+						file,
+						message: getErrorMessage( error ),
+					} );
+				}
+			}
+
+			return { attachments, errors };
+		},
+		[ uploadZipMediaFile ]
+	);
+
 	const createTrackBlocksFromZip = useCallback(
 		async ( zipFile ) => {
 			let zipMedia;
 			try {
-				zipMedia = await getPlaylistMediaFromZip( zipFile );
+				zipMedia = await getPlaylistMediaFromZip(
+					await getZipFile( zipFile )
+				);
 			} catch ( error ) {
-				const message =
-					typeof error === 'string' ? error : error?.message;
+				const message = getErrorMessage( error );
 				onUploadError(
 					message
 						? sprintf(
@@ -289,16 +383,13 @@ const PlaylistEdit = ( {
 				return [];
 			}
 
-			const filesList = [
-				...zipMedia.tracks.map( ( track ) => track.file ),
-				...( zipMedia.imageFile ? [ zipMedia.imageFile ] : [] ),
-			];
-			let attachments;
-			try {
-				attachments = await uploadZipMedia( filesList );
-			} catch ( error ) {
-				const message =
-					typeof error === 'string' ? error : error?.message;
+			const { attachments, errors } = await uploadZipMedia(
+				zipMedia.tracks.map( ( track ) => track.file )
+			);
+			const uploadedTrackCount = attachments.filter( Boolean ).length;
+
+			if ( uploadedTrackCount === 0 ) {
+				const message = errors[ 0 ]?.message;
 				onUploadError(
 					message
 						? sprintf(
@@ -311,23 +402,60 @@ const PlaylistEdit = ( {
 				return [];
 			}
 
-			const coverImage = zipMedia.imageFile
-				? getTrackImageAttributes(
-						attachments[ zipMedia.tracks.length ]
-				  )
-				: {};
+			if ( errors.length > 0 ) {
+				onUploadError(
+					sprintf(
+						// translators: %s: Error message.
+						__(
+							'Some tracks from the ZIP file could not be uploaded: %s'
+						),
+						errors[ 0 ].message || errors[ 0 ].file.name
+					)
+				);
+			}
 
-			return zipMedia.tracks.map( ( track, index ) => {
-				const { trackNumber, ...trackDetails } = track.details;
+			let coverImage = {};
+			if ( zipMedia.imageFile ) {
+				try {
+					coverImage = getTrackImageAttributes(
+						await uploadZipMediaFile( zipMedia.imageFile )
+					);
+				} catch ( error ) {
+					const message = getErrorMessage( error );
+					onUploadError(
+						message
+							? sprintf(
+									// translators: %s: Error message.
+									__(
+										'The cover image from the ZIP file could not be uploaded: %s'
+									),
+									message
+							  )
+							: __(
+									'The cover image from the ZIP file could not be uploaded.'
+							  )
+					);
+				}
+			}
 
-				return createBlock( 'core/playlist-track', {
-					...getTrackAttributes( attachments[ index ] ),
-					...trackDetails,
-					...coverImage,
-				} );
-			} );
+			return zipMedia.tracks
+				.map( ( track, index ) => {
+					const attachment = attachments[ index ];
+					if ( ! attachment ) {
+						return null;
+					}
+
+					const { trackNumber, ...trackDetails } = track.details;
+
+					return createBlock( 'core/playlist-track', {
+						...getTrackAttributes( attachment ),
+						...trackDetails,
+						...coverImage,
+					} );
+				} )
+				.filter( Boolean );
 		},
-		[ onUploadError, uploadZipMedia ]
+		[ onUploadError, uploadZipMedia, uploadZipMediaFile ]
 	);
 
 	const createTrackBlocksFromMedia = useCallback(
@@ -601,7 +729,7 @@ const PlaylistEdit = ( {
 					accept={ AUDIO_AND_ZIP_ACCEPT }
 					multiple="add"
 					handleUpload={ false }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					allowedTypes={ ALLOWED_PLAYLIST_MEDIA_TYPES }
 					onError={ onUploadError }
 				/>
 			</div>
@@ -617,7 +745,7 @@ const PlaylistEdit = ( {
 					accept={ AUDIO_AND_ZIP_ACCEPT }
 					multiple="add"
 					handleUpload={ false }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					allowedTypes={ ALLOWED_PLAYLIST_MEDIA_TYPES }
 					onError={ onUploadError }
 				/>
 			</BlockControls>
@@ -813,7 +941,7 @@ const PlaylistEdit = ( {
 					multiple="add"
 					handleUpload={ false }
 					disableMediaButtons
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					allowedTypes={ ALLOWED_PLAYLIST_MEDIA_TYPES }
 					onError={ onUploadError }
 				/>
 				<Disabled isDisabled={ ! isSelected }>

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -30,12 +30,7 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
 import { PlaylistContext } from './context';
 import { getTrackAttributes, getTrackImageAttributes } from './utils';
-import {
-	debugPlaylistZip,
-	getPlaylistMediaFromZip,
-	getPlaylistZipDebugMediaInfo,
-	isZipFile,
-} from './zip-utils';
+import { getPlaylistMediaFromZip, isZipFile } from './zip-utils';
 
 const ALLOWED_PLAYLIST_MEDIA_TYPES = [
 	'audio',
@@ -125,31 +120,16 @@ function getZipFileName( media ) {
 
 async function getZipFile( media ) {
 	if ( isFile( media ) ) {
-		debugPlaylistZip(
-			'using selected ZIP file object',
-			getPlaylistZipDebugMediaInfo( media )
-		);
 		return media;
 	}
 
 	const mediaUrl = getMediaUrl( media );
 	if ( ! mediaUrl ) {
-		debugPlaylistZip( 'selected ZIP attachment is missing a URL', {
-			media: getPlaylistZipDebugMediaInfo( media ),
-		} );
 		throw new Error( __( 'The ZIP file is missing a URL.' ) );
 	}
 
-	debugPlaylistZip( 'fetching selected ZIP attachment', {
-		media: getPlaylistZipDebugMediaInfo( media ),
-	} );
 	const response = await window.fetch( mediaUrl );
 	if ( ! response.ok ) {
-		debugPlaylistZip( 'selected ZIP attachment fetch failed', {
-			status: response.status,
-			statusText: response.statusText,
-			media: getPlaylistZipDebugMediaInfo( media ),
-		} );
 		throw new Error( response.statusText );
 	}
 
@@ -161,10 +141,6 @@ async function getZipFile( media ) {
 			type: blob.type || getMediaMimeType( media ) || 'application/zip',
 		}
 	);
-	debugPlaylistZip( 'fetched selected ZIP attachment', {
-		media: getPlaylistZipDebugMediaInfo( media ),
-		file: getPlaylistZipDebugMediaInfo( file ),
-	} );
 	return file;
 }
 
@@ -320,13 +296,7 @@ const PlaylistEdit = ( {
 	const uploadZipMediaFile = useCallback(
 		( file ) =>
 			new Promise( ( resolve, reject ) => {
-				debugPlaylistZip( 'uploading extracted ZIP file', {
-					file: getPlaylistZipDebugMediaInfo( file ),
-				} );
 				if ( ! mediaUpload ) {
-					debugPlaylistZip( 'extracted ZIP file upload unavailable', {
-						file: getPlaylistZipDebugMediaInfo( file ),
-					} );
 					reject(
 						__(
 							'The ZIP file could not be uploaded because media uploads are unavailable.'
@@ -337,12 +307,6 @@ const PlaylistEdit = ( {
 
 				let isComplete = false;
 				const resolveWhenComplete = ( attachments ) => {
-					debugPlaylistZip( 'extracted ZIP file upload changed', {
-						file: getPlaylistZipDebugMediaInfo( file ),
-						attachments: Array.isArray( attachments )
-							? attachments.map( getPlaylistZipDebugMediaInfo )
-							: attachments,
-					} );
 					if ( isComplete ) {
 						return;
 					}
@@ -354,14 +318,6 @@ const PlaylistEdit = ( {
 					const attachment = attachments.find( ( item ) => item?.id );
 					if ( attachment ) {
 						isComplete = true;
-						debugPlaylistZip(
-							'extracted ZIP file upload resolved',
-							{
-								file: getPlaylistZipDebugMediaInfo( file ),
-								attachment:
-									getPlaylistZipDebugMediaInfo( attachment ),
-							}
-						);
 						resolve( attachment );
 					}
 				};
@@ -373,10 +329,6 @@ const PlaylistEdit = ( {
 					onFileChange: resolveWhenComplete,
 					onSuccess: resolveWhenComplete,
 					onError: ( message ) => {
-						debugPlaylistZip( 'extracted ZIP file upload failed', {
-							file: getPlaylistZipDebugMediaInfo( file ),
-							message,
-						} );
 						reject(
 							message ||
 								__( 'The ZIP file could not be uploaded.' )
@@ -404,15 +356,6 @@ const PlaylistEdit = ( {
 				}
 			}
 
-			debugPlaylistZip( 'extracted ZIP file upload batch complete', {
-				fileCount: filesList.length,
-				uploadedCount: attachments.filter( Boolean ).length,
-				errors: errors.map( ( error ) => ( {
-					file: getPlaylistZipDebugMediaInfo( error.file ),
-					message: error.message,
-				} ) ),
-			} );
-
 			return { attachments, errors };
 		},
 		[ uploadZipMediaFile ]
@@ -422,28 +365,11 @@ const PlaylistEdit = ( {
 		async ( zipFile ) => {
 			let zipMedia;
 			try {
-				debugPlaylistZip( 'creating playlist tracks from ZIP', {
-					zip: getPlaylistZipDebugMediaInfo( zipFile ),
-				} );
 				zipMedia = await getPlaylistMediaFromZip(
 					await getZipFile( zipFile )
 				);
-				debugPlaylistZip( 'parsed ZIP playlist media', {
-					trackCount: zipMedia.tracks.length,
-					tracks: zipMedia.tracks.map( ( track ) => ( {
-						file: getPlaylistZipDebugMediaInfo( track.file ),
-						details: track.details,
-					} ) ),
-					imageFile: getPlaylistZipDebugMediaInfo(
-						zipMedia.imageFile
-					),
-				} );
 			} catch ( error ) {
 				const message = getErrorMessage( error );
-				debugPlaylistZip( 'reading ZIP failed', {
-					zip: getPlaylistZipDebugMediaInfo( zipFile ),
-					message,
-				} );
 				onUploadError(
 					message
 						? sprintf(
@@ -457,9 +383,6 @@ const PlaylistEdit = ( {
 			}
 
 			if ( zipMedia.tracks.length === 0 ) {
-				debugPlaylistZip( 'ZIP contained no audio tracks', {
-					zip: getPlaylistZipDebugMediaInfo( zipFile ),
-				} );
 				onUploadError(
 					__( 'The ZIP file does not contain any audio files.' )
 				);
@@ -503,20 +426,8 @@ const PlaylistEdit = ( {
 					coverImage = getTrackImageAttributes(
 						await uploadZipMediaFile( zipMedia.imageFile )
 					);
-					debugPlaylistZip( 'uploaded ZIP cover image', {
-						imageFile: getPlaylistZipDebugMediaInfo(
-							zipMedia.imageFile
-						),
-						coverImage,
-					} );
 				} catch ( error ) {
 					const message = getErrorMessage( error );
-					debugPlaylistZip( 'ZIP cover image upload failed', {
-						imageFile: getPlaylistZipDebugMediaInfo(
-							zipMedia.imageFile
-						),
-						message,
-					} );
 					onUploadError(
 						message
 							? sprintf(
@@ -537,17 +448,6 @@ const PlaylistEdit = ( {
 				.map( ( track, index ) => {
 					const attachment = attachments[ index ];
 					if ( ! attachment ) {
-						debugPlaylistZip(
-							'skipped ZIP track without uploaded attachment',
-							{
-								track: {
-									file: getPlaylistZipDebugMediaInfo(
-										track.file
-									),
-									details: track.details,
-								},
-							}
-						);
 						return null;
 					}
 
@@ -571,15 +471,6 @@ const PlaylistEdit = ( {
 				mediaItem,
 				isZip: isZipFile( mediaItem ),
 			} ) );
-			debugPlaylistZip( 'selected playlist media', {
-				items: mediaItemsWithType.map( ( { mediaItem, isZip } ) => ( {
-					media: getPlaylistZipDebugMediaInfo( mediaItem ),
-					isZip,
-					isAudio: isFile( mediaItem )
-						? isAudioFile( mediaItem )
-						: isAudioMediaItem( mediaItem ),
-				} ) ),
-			} );
 			const blocks = createTrackBlocks(
 				mediaItemsWithType
 					.filter( ( { isZip } ) => ! isZip )
@@ -590,9 +481,6 @@ const PlaylistEdit = ( {
 				.map( ( { mediaItem } ) => mediaItem );
 
 			if ( zipFiles.length === 0 ) {
-				debugPlaylistZip( 'selected media had no ZIP files', {
-					blockCount: blocks.length,
-				} );
 				return blocks;
 			}
 
@@ -600,13 +488,7 @@ const PlaylistEdit = ( {
 				zipFiles.map( createTrackBlocksFromZip )
 			);
 
-			const newBlocks = [ ...blocks, ...zipBlocks.flat() ];
-			debugPlaylistZip( 'created playlist blocks from selected media', {
-				blockCount: newBlocks.length,
-				zipBlockCount: zipBlocks.flat().length,
-				regularBlockCount: blocks.length,
-			} );
-			return newBlocks;
+			return [ ...blocks, ...zipBlocks.flat() ];
 		},
 		[ createTrackBlocks, createTrackBlocksFromZip ]
 	);

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -65,7 +65,7 @@ jest.mock( '@wordpress/blob', () => ( {
 
 jest.mock( '@zip.js/zip.js/lib/zip-no-worker-inflate.js', () => ( {
 	BlobReader: jest.fn(),
-	BlobWriter: jest.fn( function ( type ) {
+	Uint8ArrayWriter: jest.fn( function ( type ) {
 		this.type = type;
 	} ),
 	ZipReader: jest.fn( function () {
@@ -141,11 +141,7 @@ describe( 'PlaylistEdit', () => {
 			filename,
 			directory: false,
 			lastModDate: new Date( '2026-08-11T00:00:00Z' ),
-			getData: jest.fn( ( writer ) =>
-				Promise.resolve(
-					new Blob( [ filename ], { type: writer.type } )
-				)
-			),
+			getData: jest.fn( () => Promise.resolve( new Uint8Array() ) ),
 		};
 	}
 

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -90,6 +90,7 @@ jest.mock( '@wordpress/data', () => ( {
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( text ) => text,
 	_x: ( text ) => text,
+	sprintf: ( text, replacement ) => text.replace( '%s', replacement ),
 } ) );
 
 jest.mock( '@wordpress/icons', () => ( {
@@ -127,6 +128,7 @@ describe( 'PlaylistEdit', () => {
 	let selectBlock;
 	let createErrorNotice;
 	let mediaUpload;
+	let uploadedFileCount;
 
 	function createZipFile() {
 		return new File( [ 'playlist' ], 'album.zip', {
@@ -158,14 +160,28 @@ describe( 'PlaylistEdit', () => {
 		replaceInnerBlocks = jest.fn();
 		selectBlock = jest.fn();
 		createErrorNotice = jest.fn();
-		mediaUpload = jest.fn( ( { filesList, onFileChange } ) =>
-			onFileChange(
-				Array.from( filesList ).map( ( file, index ) => ( {
-					id: index + 10,
+		uploadedFileCount = 0;
+		mediaUpload = jest.fn( ( { filesList, onFileChange } ) => {
+			const attachments = Array.from( filesList ).map(
+				( file, index ) => ( {
+					id: uploadedFileCount + index + 10,
 					url: `https://example.com/${ file.name }`,
 					title: file.name.replace( /\.[^.]+$/, '' ),
-				} ) )
-			)
+				} )
+			);
+			uploadedFileCount += attachments.length;
+			onFileChange( attachments );
+		} );
+		window.fetch = jest.fn( () =>
+			Promise.resolve( {
+				ok: true,
+				blob: () =>
+					Promise.resolve(
+						new Blob( [ 'playlist' ], {
+							type: 'application/zip',
+						} )
+					),
+			} )
 		);
 		useDispatch.mockReturnValue( {
 			createErrorNotice,
@@ -203,6 +219,12 @@ describe( 'PlaylistEdit', () => {
 		);
 
 		expect( mediaPlaceholderProps.multiple ).toBe( 'add' );
+		expect( mediaPlaceholderProps.allowedTypes ).toEqual( [
+			'audio',
+			'application/zip',
+			'application/x-zip',
+			'application/x-zip-compressed',
+		] );
 	} );
 
 	it( 'lets users select additional audio tracks individually from the Media Library', () => {
@@ -296,21 +318,38 @@ describe( 'PlaylistEdit', () => {
 		} );
 
 		expect( mediaPlaceholderProps.accept ).toBe(
-			'audio/*,.zip,application/zip,application/x-zip-compressed'
+			'audio/*,.zip,application/zip,application/x-zip,application/x-zip-compressed'
 		);
-		expect( mediaUpload ).toHaveBeenCalledWith(
+		expect( mediaUpload ).toHaveBeenNthCalledWith(
+			1,
 			expect.objectContaining( {
 				allowedTypes: [ 'audio', 'image' ],
 				filesList: [
 					expect.objectContaining( {
 						name: 'scruffian - Relics - 01 Curing.mp3',
 					} ),
+				],
+				multiple: false,
+			} )
+		);
+		expect( mediaUpload ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( {
+				allowedTypes: [ 'audio', 'image' ],
+				filesList: [
 					expect.objectContaining( {
 						name: 'scruffian - Relics - 02 Bramblers Relic.mp3',
 					} ),
-					expect.objectContaining( { name: 'cover.png' } ),
 				],
-				multiple: true,
+				multiple: false,
+			} )
+		);
+		expect( mediaUpload ).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining( {
+				allowedTypes: [ 'audio', 'image' ],
+				filesList: [ expect.objectContaining( { name: 'cover.png' } ) ],
+				multiple: false,
 			} )
 		);
 		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
@@ -340,6 +379,147 @@ describe( 'PlaylistEdit', () => {
 		expect(
 			replaceInnerBlocks.mock.calls[ 0 ][ 1 ][ 0 ].attributes
 		).not.toHaveProperty( 'trackNumber' );
+	} );
+
+	it( 'fills playlist tracks from a ZIP attachment selected in the Media Library', async () => {
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaPlaceholderProps.onSelect( {
+				id: 20,
+				filename: 'album.zip',
+				mime_type: 'application/zip',
+				url: 'https://example.com/album.zip',
+			} );
+		} );
+
+		expect( window.fetch ).toHaveBeenCalledWith(
+			'https://example.com/album.zip'
+		);
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					title: 'Curing',
+					artist: 'scruffian',
+					album: 'Relics',
+				} ),
+			} ),
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					title: 'Bramblers Relic',
+					artist: 'scruffian',
+					album: 'Relics',
+				} ),
+			} ),
+		] );
+	} );
+
+	it( 'shows an error when a non-audio media item is selected', async () => {
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaPlaceholderProps.onSelect( {
+				id: 20,
+				mime_type: 'image/png',
+				url: 'https://example.com/image.png',
+			} );
+		} );
+
+		expect( createErrorNotice ).toHaveBeenCalledWith(
+			'Only audio files and ZIP files can be added to a playlist.',
+			{ type: 'snackbar' }
+		);
+		expect( replaceInnerBlocks ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fills playlist tracks when the ZIP cover image upload fails', async () => {
+		mediaUpload = jest.fn( ( { filesList, onFileChange, onError } ) => {
+			const [ file ] = filesList;
+			if ( file.name === 'cover.png' ) {
+				onError( 'The cover image could not be uploaded.' );
+				return;
+			}
+
+			const attachment = {
+				id: uploadedFileCount + 10,
+				url: `https://example.com/${ file.name }`,
+				title: file.name.replace( /\.[^.]+$/, '' ),
+			};
+			uploadedFileCount += 1;
+			onFileChange( [ attachment ] );
+		} );
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaPlaceholderProps.onSelect( createZipFile() );
+		} );
+
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					title: 'Curing',
+					artist: 'scruffian',
+					album: 'Relics',
+				} ),
+			} ),
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					title: 'Bramblers Relic',
+					artist: 'scruffian',
+					album: 'Relics',
+				} ),
+			} ),
+		] );
+		expect(
+			replaceInnerBlocks.mock.calls[ 0 ][ 1 ][ 0 ].attributes
+		).toHaveProperty( 'image', undefined );
+		expect( createErrorNotice ).toHaveBeenCalledWith(
+			'The cover image from the ZIP file could not be uploaded: The cover image could not be uploaded.',
+			{ type: 'snackbar' }
+		);
 	} );
 
 	it( 'adds ZIP tracks to an existing playlist', async () => {

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -332,6 +332,9 @@ describe( 'PlaylistEdit', () => {
 				multiple: false,
 			} )
 		);
+		expect( mediaUpload.mock.calls[ 0 ][ 0 ].filesList[ 0 ].type ).toBe(
+			''
+		);
 		expect( mediaUpload ).toHaveBeenNthCalledWith(
 			2,
 			expect.objectContaining( {
@@ -408,6 +411,54 @@ describe( 'PlaylistEdit', () => {
 
 		expect( window.fetch ).toHaveBeenCalledWith(
 			'https://example.com/album.zip'
+		);
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					title: 'Curing',
+					artist: 'scruffian',
+					album: 'Relics',
+				} ),
+			} ),
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					title: 'Bramblers Relic',
+					artist: 'scruffian',
+					album: 'Relics',
+				} ),
+			} ),
+		] );
+	} );
+
+	it( 'fills playlist tracks from a legacy ZIP attachment selected in the Media Library', async () => {
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaPlaceholderProps.onSelect( {
+				id: 20,
+				type: 'application',
+				mime: 'application/zip',
+				url: 'https://example.com/download?id=20',
+			} );
+		} );
+
+		expect( window.fetch ).toHaveBeenCalledWith(
+			'https://example.com/download?id=20'
 		);
 		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
 			expect.objectContaining( {

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -64,7 +64,7 @@ jest.mock( '@wordpress/blob', () => ( {
 } ) );
 
 jest.mock( '@zip.js/zip.js/lib/zip-no-worker-inflate.js', () => ( {
-	BlobReader: jest.fn(),
+	Uint8ArrayReader: jest.fn(),
 	Uint8ArrayWriter: jest.fn( function ( type ) {
 		this.type = type;
 	} ),

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -1,9 +1,16 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import PlaylistEdit from '../edit';
 
 let mediaPlaceholderProps;
 let mediaReplaceFlowProps;
+let mockZipEntries;
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: {},
@@ -54,6 +61,17 @@ jest.mock( '@wordpress/blocks', () => ( {
 
 jest.mock( '@wordpress/blob', () => ( {
 	createBlobURL: jest.fn( () => 'blob:track' ),
+} ) );
+
+jest.mock( '@zip.js/zip.js/lib/zip-no-worker-inflate.js', () => ( {
+	BlobReader: jest.fn(),
+	BlobWriter: jest.fn( function ( type ) {
+		this.type = type;
+	} ),
+	ZipReader: jest.fn( function () {
+		this.getEntries = jest.fn( () => Promise.resolve( mockZipEntries ) );
+		this.close = jest.fn( () => Promise.resolve() );
+	} ),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -107,18 +125,55 @@ const defaultAttributes = {
 describe( 'PlaylistEdit', () => {
 	let replaceInnerBlocks;
 	let selectBlock;
+	let createErrorNotice;
+	let mediaUpload;
+
+	function createZipFile() {
+		return new File( [ 'playlist' ], 'album.zip', {
+			type: 'application/zip',
+		} );
+	}
+
+	function createZipEntry( filename ) {
+		return {
+			filename,
+			directory: false,
+			lastModDate: new Date( '2026-08-11T00:00:00Z' ),
+			getData: jest.fn( ( writer ) =>
+				Promise.resolve(
+					new Blob( [ filename ], { type: writer.type } )
+				)
+			),
+		};
+	}
 
 	beforeEach( () => {
 		mediaPlaceholderProps = undefined;
 		mediaReplaceFlowProps = undefined;
+		mockZipEntries = [
+			createZipEntry( 'scruffian - Relics - 02 Bramblers Relic.mp3' ),
+			createZipEntry( 'scruffian - Relics - 01 Curing.mp3' ),
+			createZipEntry( 'cover.png' ),
+		];
 		replaceInnerBlocks = jest.fn();
 		selectBlock = jest.fn();
+		createErrorNotice = jest.fn();
+		mediaUpload = jest.fn( ( { filesList, onFileChange } ) =>
+			onFileChange(
+				Array.from( filesList ).map( ( file, index ) => ( {
+					id: index + 10,
+					url: `https://example.com/${ file.name }`,
+					title: file.name.replace( /\.[^.]+$/, '' ),
+				} ) )
+			)
+		);
 		useDispatch.mockReturnValue( {
-			createErrorNotice: jest.fn(),
+			createErrorNotice,
 			replaceInnerBlocks,
 			selectBlock,
 		} );
 		useSelect.mockReturnValue( {
+			mediaUpload,
 			innerBlockTracks: [
 				{
 					clientId: 'track-1',
@@ -186,7 +241,7 @@ describe( 'PlaylistEdit', () => {
 		expect( screen.getByTestId( 'playlist-track' ) ).toBeInTheDocument();
 	} );
 
-	it( 'adds tracks from the add track control', () => {
+	it( 'adds tracks from the add track control', async () => {
 		render(
 			<PlaylistEdit
 				attributes={ defaultAttributes }
@@ -203,18 +258,158 @@ describe( 'PlaylistEdit', () => {
 			} )
 		);
 
+		await waitFor( () => {
+			expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
+				expect.objectContaining( { clientId: 'track-1' } ),
+				expect.objectContaining( {
+					clientId: 'new-track',
+					name: 'core/playlist-track',
+					attributes: expect.objectContaining( {
+						id: 2,
+						src: 'https://example.com/second-track.mp3',
+						title: 'Second track',
+					} ),
+				} ),
+			] );
+		} );
+		expect( selectBlock ).toHaveBeenCalledWith( 'new-track' );
+	} );
+
+	it( 'fills playlist tracks from an uploaded ZIP file', async () => {
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaPlaceholderProps.onSelect( createZipFile() );
+		} );
+
+		expect( mediaPlaceholderProps.accept ).toBe(
+			'audio/*,.zip,application/zip,application/x-zip-compressed'
+		);
+		expect( mediaUpload ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				allowedTypes: [ 'audio', 'image' ],
+				filesList: [
+					expect.objectContaining( {
+						name: 'scruffian - Relics - 01 Curing.mp3',
+					} ),
+					expect.objectContaining( {
+						name: 'scruffian - Relics - 02 Bramblers Relic.mp3',
+					} ),
+					expect.objectContaining( { name: 'cover.png' } ),
+				],
+				multiple: true,
+			} )
+		);
+		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					id: 10,
+					src: 'https://example.com/scruffian - Relics - 01 Curing.mp3',
+					title: 'Curing',
+					artist: 'scruffian',
+					album: 'Relics',
+					image: 'https://example.com/cover.png',
+				} ),
+			} ),
+			expect.objectContaining( {
+				name: 'core/playlist-track',
+				attributes: expect.objectContaining( {
+					id: 11,
+					src: 'https://example.com/scruffian - Relics - 02 Bramblers Relic.mp3',
+					title: 'Bramblers Relic',
+					artist: 'scruffian',
+					album: 'Relics',
+					image: 'https://example.com/cover.png',
+				} ),
+			} ),
+		] );
+		expect(
+			replaceInnerBlocks.mock.calls[ 0 ][ 1 ][ 0 ].attributes
+		).not.toHaveProperty( 'trackNumber' );
+	} );
+
+	it( 'adds ZIP tracks to an existing playlist', async () => {
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [
+				{
+					clientId: 'track-1',
+					attributes: {
+						id: 10,
+						src: 'https://example.com/Curing.mp3',
+						title: 'Curing',
+					},
+				},
+			],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaReplaceFlowProps.onSelect( createZipFile() );
+		} );
+
 		expect( replaceInnerBlocks ).toHaveBeenCalledWith( 'playlist-1', [
 			expect.objectContaining( { clientId: 'track-1' } ),
 			expect.objectContaining( {
-				clientId: 'new-track',
 				name: 'core/playlist-track',
 				attributes: expect.objectContaining( {
-					id: 2,
-					src: 'https://example.com/second-track.mp3',
-					title: 'Second track',
+					id: 11,
+					title: 'Bramblers Relic',
 				} ),
 			} ),
 		] );
 		expect( selectBlock ).toHaveBeenCalledWith( 'new-track' );
+	} );
+
+	it( 'shows an error when an uploaded ZIP file does not contain audio files', async () => {
+		mockZipEntries = [ createZipEntry( 'cover.png' ) ];
+		useSelect.mockReturnValue( {
+			mediaUpload,
+			innerBlockTracks: [],
+		} );
+
+		render(
+			<PlaylistEdit
+				attributes={ defaultAttributes }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		await act( async () => {
+			await mediaPlaceholderProps.onSelect( createZipFile() );
+		} );
+
+		expect( createErrorNotice ).toHaveBeenCalledWith(
+			'The ZIP file does not contain any audio files.',
+			{ type: 'snackbar' }
+		);
+		expect( mediaUpload ).not.toHaveBeenCalled();
+		expect( replaceInnerBlocks ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -130,8 +130,47 @@ describe( 'PlaylistEdit', () => {
 	let mediaUpload;
 	let uploadedFileCount;
 
+	function createBytes( value ) {
+		return new Uint8Array(
+			Array.from( value ).map( ( character ) =>
+				character.charCodeAt( 0 )
+			)
+		);
+	}
+
+	function createStoredZipData( entries ) {
+		const chunks = [];
+		let offset = 0;
+
+		for ( const entry of entries ) {
+			const filename = createBytes( entry.filename );
+			const data = createBytes( entry.filename );
+			const header = new Uint8Array( 30 + filename.length );
+			const headerView = new DataView( header.buffer );
+
+			headerView.setUint32( 0, 0x04034b50, true );
+			headerView.setUint16( 8, 0, true );
+			headerView.setUint32( 18, data.length, true );
+			headerView.setUint32( 22, data.length, true );
+			headerView.setUint16( 26, filename.length, true );
+			header.set( filename, 30 );
+
+			Object.assign( entry, {
+				offset,
+				compressedSize: data.length,
+				uncompressedSize: data.length,
+				compressionMethod: 0,
+			} );
+
+			chunks.push( header, data );
+			offset += header.length + data.length;
+		}
+
+		return chunks;
+	}
+
 	function createZipFile() {
-		return new File( [ 'playlist' ], 'album.zip', {
+		return new File( createStoredZipData( mockZipEntries ), 'album.zip', {
 			type: 'application/zip',
 		} );
 	}
@@ -378,6 +417,7 @@ describe( 'PlaylistEdit', () => {
 		expect(
 			replaceInnerBlocks.mock.calls[ 0 ][ 1 ][ 0 ].attributes
 		).not.toHaveProperty( 'trackNumber' );
+		expect( mockZipEntries[ 0 ].getData ).not.toHaveBeenCalled();
 	} );
 
 	it( 'fills playlist tracks from a ZIP attachment selected in the Media Library', async () => {

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -30,10 +30,17 @@ const MIME_TYPES = {
 };
 
 export function isZipFile( file ) {
+	const mimeType = file?.type || file?.mime_type || file?.mime;
+
 	return (
 		!! file?.name?.match( /\.zip$/i ) ||
-		file?.type === 'application/zip' ||
-		file?.type === 'application/x-zip-compressed'
+		!! file?.filename?.match( /\.zip$/i ) ||
+		!! file?.file?.match( /\.zip$/i ) ||
+		!! file?.url?.match( /\.zip(?:[?#].*)?$/i ) ||
+		!! file?.source_url?.match( /\.zip(?:[?#].*)?$/i ) ||
+		mimeType === 'application/zip' ||
+		mimeType === 'application/x-zip' ||
+		mimeType === 'application/x-zip-compressed'
 	);
 }
 

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -9,6 +9,9 @@ const AUDIO_FILE_EXTENSION =
 const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|gif|webp)$/i;
 const COVER_FILE_NAME = /^(cover|folder|album|albumart|artwork)\./i;
 const DEBUG_STORAGE_KEY = 'wpPlaylistZipDebug';
+const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const ZIP_LOCAL_FILE_HEADER_LENGTH = 30;
+const ZIP_COMPRESSION_METHOD_STORE = 0;
 
 function getSafeUrlDetails( url ) {
 	if ( typeof url !== 'string' ) {
@@ -80,6 +83,7 @@ function getZipEntryDebugInfo( entry ) {
 		compressedSize: entry?.compressedSize,
 		uncompressedSize: entry?.uncompressedSize,
 		encrypted: entry?.encrypted,
+		offset: entry?.offset,
 		zip64: entry?.zip64,
 		compressionMethod: entry?.compressionMethod,
 		hasGetData: typeof entry?.getData === 'function',
@@ -121,6 +125,83 @@ function getZipEntryReadDebugOptions( entryInfo ) {
 			} );
 		},
 	};
+}
+
+function getStoredZipEntryData( entry, zipData ) {
+	if (
+		entry?.encrypted ||
+		entry?.compressionMethod !== ZIP_COMPRESSION_METHOD_STORE
+	) {
+		return undefined;
+	}
+
+	const entryInfo = getZipEntryDebugInfo( entry );
+	const headerOffset = entry.offset;
+	const dataSize = entry.uncompressedSize;
+
+	if (
+		! Number.isSafeInteger( headerOffset ) ||
+		headerOffset < 0 ||
+		! Number.isSafeInteger( dataSize ) ||
+		dataSize < 0 ||
+		entry.compressedSize !== dataSize
+	) {
+		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
+			entry: entryInfo,
+			reason: 'invalid direct read metadata',
+		} );
+		return undefined;
+	}
+
+	if ( headerOffset + ZIP_LOCAL_FILE_HEADER_LENGTH > zipData.byteLength ) {
+		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
+			entry: entryInfo,
+			reason: 'local header outside ZIP data',
+		} );
+		return undefined;
+	}
+
+	const headerView = new DataView(
+		zipData.buffer,
+		zipData.byteOffset + headerOffset,
+		ZIP_LOCAL_FILE_HEADER_LENGTH
+	);
+
+	if ( headerView.getUint32( 0, true ) !== ZIP_LOCAL_FILE_HEADER_SIGNATURE ) {
+		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
+			entry: entryInfo,
+			reason: 'invalid local header signature',
+		} );
+		return undefined;
+	}
+
+	const fileNameLength = headerView.getUint16( 26, true );
+	const extraFieldLength = headerView.getUint16( 28, true );
+	const dataOffset =
+		headerOffset +
+		ZIP_LOCAL_FILE_HEADER_LENGTH +
+		fileNameLength +
+		extraFieldLength;
+	const dataEnd = dataOffset + dataSize;
+
+	if ( dataEnd > zipData.byteLength ) {
+		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
+			entry: entryInfo,
+			reason: 'entry data outside ZIP data',
+			dataOffset,
+			dataEnd,
+			byteLength: zipData.byteLength,
+		} );
+		return undefined;
+	}
+
+	debugPlaylistZip( 'read stored ZIP entry directly', {
+		entry: entryInfo,
+		dataOffset,
+		dataSize,
+	} );
+
+	return zipData.slice( dataOffset, dataEnd );
 }
 
 export function isZipFile( file ) {
@@ -207,7 +288,7 @@ function sortTracksByNumber( tracks ) {
 	} );
 }
 
-async function getEntryFile( entry ) {
+async function getEntryFile( entry, zipData ) {
 	const fileName = getFileName( entry.filename );
 	const entryInfo = getZipEntryDebugInfo( entry );
 	// Keep the MIME type unset so WordPress validates the upload by extension
@@ -218,10 +299,13 @@ async function getEntryFile( entry ) {
 	} );
 
 	try {
-		const data = await entry.getData(
-			new Uint8ArrayWriter(),
-			getZipEntryReadDebugOptions( entryInfo )
-		);
+		let data = getStoredZipEntryData( entry, zipData );
+		if ( data === undefined ) {
+			data = await entry.getData(
+				new Uint8ArrayWriter(),
+				getZipEntryReadDebugOptions( entryInfo )
+			);
+		}
 		const options = {};
 
 		if ( entry.lastModDate ) {
@@ -255,7 +339,10 @@ async function getZipReader( zipFile ) {
 		byteLength: zipData.byteLength,
 	} );
 
-	return new ZipReader( new Uint8ArrayReader( zipData ) );
+	return {
+		zipData,
+		zipReader: new ZipReader( new Uint8ArrayReader( zipData ) ),
+	};
 }
 
 /**
@@ -265,7 +352,7 @@ async function getZipReader( zipFile ) {
  * @return {Promise<Object>} Extracted audio files, cover image, and track details.
  */
 export async function getPlaylistMediaFromZip( zipFile ) {
-	const zipReader = await getZipReader( zipFile );
+	const { zipData, zipReader } = await getZipReader( zipFile );
 	debugPlaylistZip(
 		'opening ZIP file',
 		getPlaylistZipDebugMediaInfo( zipFile )
@@ -305,7 +392,7 @@ export async function getPlaylistMediaFromZip( zipFile ) {
 
 			if ( isAudio ) {
 				const details = getTrackDetails( fileName );
-				const file = await getEntryFile( entry );
+				const file = await getEntryFile( entry, zipData );
 				tracks.push( {
 					file,
 					details,
@@ -319,7 +406,7 @@ export async function getPlaylistMediaFromZip( zipFile ) {
 			}
 
 			if ( isCoverImage ) {
-				imageFile = await getEntryFile( entry );
+				imageFile = await getEntryFile( entry, zipData );
 				debugPlaylistZip( 'added ZIP cover image', {
 					entry: entryInfo,
 					file: getPlaylistZipDebugMediaInfo( imageFile ),

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -1,0 +1,159 @@
+import {
+	BlobReader,
+	BlobWriter,
+	ZipReader,
+} from '@zip.js/zip.js/lib/zip-no-worker-inflate.js';
+
+const AUDIO_FILE_EXTENSION =
+	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
+const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|gif|webp)$/i;
+const COVER_FILE_NAME = /^(cover|folder|album|albumart|artwork)\./i;
+
+const MIME_TYPES = {
+	aac: 'audio/aac',
+	aif: 'audio/aiff',
+	aiff: 'audio/aiff',
+	flac: 'audio/flac',
+	gif: 'image/gif',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	m4a: 'audio/mp4',
+	m4b: 'audio/mp4',
+	mp3: 'audio/mpeg',
+	oga: 'audio/ogg',
+	ogg: 'audio/ogg',
+	opus: 'audio/ogg',
+	png: 'image/png',
+	wav: 'audio/wav',
+	weba: 'audio/webm',
+	webp: 'image/webp',
+};
+
+export function isZipFile( file ) {
+	return (
+		!! file?.name?.match( /\.zip$/i ) ||
+		file?.type === 'application/zip' ||
+		file?.type === 'application/x-zip-compressed'
+	);
+}
+
+function getFileName( path = '' ) {
+	return path.split( /[/\\]/ ).pop() || path;
+}
+
+function getFileExtension( fileName ) {
+	return fileName.split( '.' ).pop()?.toLowerCase();
+}
+
+function getMimeType( fileName ) {
+	return MIME_TYPES[ getFileExtension( fileName ) ] || '';
+}
+
+function stripFileExtension( fileName ) {
+	return fileName.replace( /\.[^.]+$/, '' );
+}
+
+function getTrackDetails( fileName ) {
+	const name = stripFileExtension( fileName );
+	const matchedDetails = name.match(
+		/^(?<artist>.+?)\s+-\s+(?<album>.+?)\s+-\s+(?<trackNumber>\d+)\s+(?<title>.+)$/
+	);
+
+	if ( matchedDetails?.groups ) {
+		return {
+			artist: matchedDetails.groups.artist,
+			album: matchedDetails.groups.album,
+			title: matchedDetails.groups.title,
+			trackNumber: Number( matchedDetails.groups.trackNumber ),
+		};
+	}
+
+	const numberedTitle = name.match(
+		/^(?<trackNumber>\d+)[\s._-]+(?<title>.+)$/
+	);
+
+	return {
+		title: numberedTitle?.groups?.title || name,
+		trackNumber: numberedTitle?.groups
+			? Number( numberedTitle.groups.trackNumber )
+			: undefined,
+	};
+}
+
+function sortTracksByNumber( tracks ) {
+	return [ ...tracks ].sort( ( a, b ) => {
+		const aNumber = a.details.trackNumber;
+		const bNumber = b.details.trackNumber;
+
+		if ( aNumber === undefined && bNumber === undefined ) {
+			return 0;
+		}
+		if ( aNumber === undefined ) {
+			return 1;
+		}
+		if ( bNumber === undefined ) {
+			return -1;
+		}
+
+		return aNumber - bNumber;
+	} );
+}
+
+async function getEntryFile( entry ) {
+	const fileName = getFileName( entry.filename );
+	const type = getMimeType( fileName );
+	const blob = await entry.getData( new BlobWriter( type ) );
+	const options = { type: blob.type || type };
+
+	if ( entry.lastModDate ) {
+		options.lastModified = entry.lastModDate.getTime();
+	}
+
+	return new File( [ blob ], fileName, options );
+}
+
+/**
+ * Extract playlist media files and inferred track details from a ZIP archive.
+ *
+ * @param {File} zipFile ZIP archive selected by the user.
+ * @return {Promise<Object>} Extracted audio files, cover image, and track details.
+ */
+export async function getPlaylistMediaFromZip( zipFile ) {
+	const zipReader = new ZipReader( new BlobReader( zipFile ) );
+
+	try {
+		const entries = await zipReader.getEntries();
+		const tracks = [];
+		let imageFile;
+
+		for ( const entry of entries ) {
+			if ( entry.directory ) {
+				continue;
+			}
+
+			const fileName = getFileName( entry.filename );
+			if ( AUDIO_FILE_EXTENSION.test( fileName ) ) {
+				tracks.push( {
+					file: await getEntryFile( entry ),
+					details: getTrackDetails( fileName ),
+				} );
+				continue;
+			}
+
+			if (
+				! imageFile &&
+				IMAGE_FILE_EXTENSION.test( fileName ) &&
+				COVER_FILE_NAME.test( fileName )
+			) {
+				imageFile = await getEntryFile( entry );
+			}
+		}
+
+		return {
+			tracks: sortTracksByNumber( tracks ),
+			imageFile,
+		};
+	} finally {
+		await zipReader.close();
+	}
+}

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -1,5 +1,5 @@
 import {
-	BlobReader,
+	Uint8ArrayReader,
 	Uint8ArrayWriter,
 	ZipReader,
 } from '@zip.js/zip.js/lib/zip-no-worker-inflate.js';
@@ -244,6 +244,20 @@ async function getEntryFile( entry ) {
 	}
 }
 
+async function getZipReader( zipFile ) {
+	debugPlaylistZip( 'loading ZIP file data', {
+		zip: getPlaylistZipDebugMediaInfo( zipFile ),
+	} );
+
+	const zipData = new Uint8Array( await zipFile.arrayBuffer() );
+	debugPlaylistZip( 'loaded ZIP file data', {
+		zip: getPlaylistZipDebugMediaInfo( zipFile ),
+		byteLength: zipData.byteLength,
+	} );
+
+	return new ZipReader( new Uint8ArrayReader( zipData ) );
+}
+
 /**
  * Extract playlist media files and inferred track details from a ZIP archive.
  *
@@ -251,7 +265,7 @@ async function getEntryFile( entry ) {
  * @return {Promise<Object>} Extracted audio files, cover image, and track details.
  */
 export async function getPlaylistMediaFromZip( zipFile ) {
-	const zipReader = new ZipReader( new BlobReader( zipFile ) );
+	const zipReader = await getZipReader( zipFile );
 	debugPlaylistZip(
 		'opening ZIP file',
 		getPlaylistZipDebugMediaInfo( zipFile )

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -8,201 +8,9 @@ const AUDIO_FILE_EXTENSION =
 	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
 const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|gif|webp)$/i;
 const COVER_FILE_NAME = /^(cover|folder|album|albumart|artwork)\./i;
-const DEBUG_STORAGE_KEY = 'wpPlaylistZipDebug';
 const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const ZIP_LOCAL_FILE_HEADER_LENGTH = 30;
 const ZIP_COMPRESSION_METHOD_STORE = 0;
-
-function getSafeUrlDetails( url ) {
-	if ( typeof url !== 'string' ) {
-		return undefined;
-	}
-
-	try {
-		const parsedUrl = new URL( url, 'https://example.invalid' );
-		return {
-			pathname: parsedUrl.pathname,
-			hasSearch: parsedUrl.search !== '',
-			hasHash: parsedUrl.hash !== '',
-		};
-	} catch {
-		return { value: url.replace( /[?#].*$/, '' ) };
-	}
-}
-
-function isPlaylistZipDebugEnabled() {
-	if ( typeof window === 'undefined' ) {
-		return false;
-	}
-
-	if ( window.__wpPlaylistZipDebug === true ) {
-		return true;
-	}
-
-	try {
-		return window.localStorage?.getItem( DEBUG_STORAGE_KEY ) === '1';
-	} catch {
-		return false;
-	}
-}
-
-export function getPlaylistZipDebugMediaInfo( media ) {
-	const mediaUrl = media?.url ?? media?.source_url;
-
-	return {
-		name: media?.name,
-		filename: media?.filename,
-		file: typeof media?.file === 'string' ? media.file : undefined,
-		type: media?.type,
-		mime: media?.mime,
-		mimeType: media?.mime_type,
-		subtype: media?.subtype,
-		size: media?.size,
-		hasUrl: !! mediaUrl,
-		url: getSafeUrlDetails( mediaUrl ),
-	};
-}
-
-export function debugPlaylistZip( message, details ) {
-	if ( ! isPlaylistZipDebugEnabled() ) {
-		return;
-	}
-
-	// eslint-disable-next-line no-console
-	console.debug( '[Playlist ZIP]', message, details );
-}
-
-function getDebugErrorMessage( error ) {
-	return typeof error === 'string' ? error : error?.message;
-}
-
-function getZipEntryDebugInfo( entry ) {
-	return {
-		filename: entry?.filename,
-		directory: entry?.directory,
-		compressedSize: entry?.compressedSize,
-		uncompressedSize: entry?.uncompressedSize,
-		encrypted: entry?.encrypted,
-		offset: entry?.offset,
-		zip64: entry?.zip64,
-		compressionMethod: entry?.compressionMethod,
-		hasGetData: typeof entry?.getData === 'function',
-	};
-}
-
-function getZipEntryReadDebugOptions( entryInfo ) {
-	let lastProgressBucket;
-
-	return {
-		onstart( total ) {
-			debugPlaylistZip( 'started reading ZIP entry file', {
-				entry: entryInfo,
-				total,
-			} );
-		},
-		onprogress( progress, total ) {
-			const percent =
-				total > 0 ? Math.floor( ( progress / total ) * 100 ) : null;
-			const progressBucket =
-				percent === null ? progress : Math.floor( percent / 25 );
-
-			if ( progressBucket === lastProgressBucket ) {
-				return;
-			}
-			lastProgressBucket = progressBucket;
-
-			debugPlaylistZip( 'reading ZIP entry file progress', {
-				entry: entryInfo,
-				progress,
-				total,
-				percent,
-			} );
-		},
-		onend( computedSize ) {
-			debugPlaylistZip( 'finished reading ZIP entry file', {
-				entry: entryInfo,
-				computedSize,
-			} );
-		},
-	};
-}
-
-function getStoredZipEntryData( entry, zipData ) {
-	if (
-		entry?.encrypted ||
-		entry?.compressionMethod !== ZIP_COMPRESSION_METHOD_STORE
-	) {
-		return undefined;
-	}
-
-	const entryInfo = getZipEntryDebugInfo( entry );
-	const headerOffset = entry.offset;
-	const dataSize = entry.uncompressedSize;
-
-	if (
-		! Number.isSafeInteger( headerOffset ) ||
-		headerOffset < 0 ||
-		! Number.isSafeInteger( dataSize ) ||
-		dataSize < 0 ||
-		entry.compressedSize !== dataSize
-	) {
-		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
-			entry: entryInfo,
-			reason: 'invalid direct read metadata',
-		} );
-		return undefined;
-	}
-
-	if ( headerOffset + ZIP_LOCAL_FILE_HEADER_LENGTH > zipData.byteLength ) {
-		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
-			entry: entryInfo,
-			reason: 'local header outside ZIP data',
-		} );
-		return undefined;
-	}
-
-	const headerView = new DataView(
-		zipData.buffer,
-		zipData.byteOffset + headerOffset,
-		ZIP_LOCAL_FILE_HEADER_LENGTH
-	);
-
-	if ( headerView.getUint32( 0, true ) !== ZIP_LOCAL_FILE_HEADER_SIGNATURE ) {
-		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
-			entry: entryInfo,
-			reason: 'invalid local header signature',
-		} );
-		return undefined;
-	}
-
-	const fileNameLength = headerView.getUint16( 26, true );
-	const extraFieldLength = headerView.getUint16( 28, true );
-	const dataOffset =
-		headerOffset +
-		ZIP_LOCAL_FILE_HEADER_LENGTH +
-		fileNameLength +
-		extraFieldLength;
-	const dataEnd = dataOffset + dataSize;
-
-	if ( dataEnd > zipData.byteLength ) {
-		debugPlaylistZip( 'stored ZIP entry needs zip.js reader', {
-			entry: entryInfo,
-			reason: 'entry data outside ZIP data',
-			dataOffset,
-			dataEnd,
-			byteLength: zipData.byteLength,
-		} );
-		return undefined;
-	}
-
-	debugPlaylistZip( 'read stored ZIP entry directly', {
-		entry: entryInfo,
-		dataOffset,
-		dataSize,
-	} );
-
-	return zipData.slice( dataOffset, dataEnd );
-}
 
 export function isZipFile( file ) {
 	const mimeTypes = [ file?.mime_type, file?.mime, file?.type ].filter(
@@ -211,7 +19,7 @@ export function isZipFile( file ) {
 	const hasZipFileExtension = ( value ) =>
 		typeof value === 'string' && /\.zip(?:[?#].*)?$/i.test( value );
 
-	const isZip =
+	return (
 		hasZipFileExtension( file?.name ) ||
 		hasZipFileExtension( file?.filename ) ||
 		hasZipFileExtension( file?.file ) ||
@@ -223,15 +31,8 @@ export function isZipFile( file ) {
 				mimeType === 'application/zip' ||
 				mimeType === 'application/x-zip' ||
 				mimeType === 'application/x-zip-compressed'
-		);
-
-	debugPlaylistZip( 'checked ZIP file candidate', {
-		media: getPlaylistZipDebugMediaInfo( file ),
-		mimeTypes,
-		isZip,
-	} );
-
-	return isZip;
+		)
+	);
 }
 
 function getFileName( path = '' ) {
@@ -288,56 +89,73 @@ function sortTracksByNumber( tracks ) {
 	} );
 }
 
+function getStoredZipEntryData( entry, zipData ) {
+	if (
+		entry?.encrypted ||
+		entry?.compressionMethod !== ZIP_COMPRESSION_METHOD_STORE
+	) {
+		return undefined;
+	}
+
+	const headerOffset = entry.offset;
+	const dataSize = entry.uncompressedSize;
+
+	if (
+		! Number.isSafeInteger( headerOffset ) ||
+		headerOffset < 0 ||
+		! Number.isSafeInteger( dataSize ) ||
+		dataSize < 0 ||
+		entry.compressedSize !== dataSize ||
+		headerOffset + ZIP_LOCAL_FILE_HEADER_LENGTH > zipData.byteLength
+	) {
+		return undefined;
+	}
+
+	const headerView = new DataView(
+		zipData.buffer,
+		zipData.byteOffset + headerOffset,
+		ZIP_LOCAL_FILE_HEADER_LENGTH
+	);
+
+	if ( headerView.getUint32( 0, true ) !== ZIP_LOCAL_FILE_HEADER_SIGNATURE ) {
+		return undefined;
+	}
+
+	const fileNameLength = headerView.getUint16( 26, true );
+	const extraFieldLength = headerView.getUint16( 28, true );
+	const dataOffset =
+		headerOffset +
+		ZIP_LOCAL_FILE_HEADER_LENGTH +
+		fileNameLength +
+		extraFieldLength;
+	const dataEnd = dataOffset + dataSize;
+
+	if ( dataEnd > zipData.byteLength ) {
+		return undefined;
+	}
+
+	return zipData.slice( dataOffset, dataEnd );
+}
+
 async function getEntryFile( entry, zipData ) {
 	const fileName = getFileName( entry.filename );
-	const entryInfo = getZipEntryDebugInfo( entry );
 	// Keep the MIME type unset so WordPress validates the upload by extension
 	// instead of by a browser-dependent guess for extracted ZIP entries.
-	debugPlaylistZip( 'reading ZIP entry file', {
-		entry: entryInfo,
-		fileName,
-	} );
-
-	try {
-		let data = getStoredZipEntryData( entry, zipData );
-		if ( data === undefined ) {
-			data = await entry.getData(
-				new Uint8ArrayWriter(),
-				getZipEntryReadDebugOptions( entryInfo )
-			);
-		}
-		const options = {};
-
-		if ( entry.lastModDate ) {
-			options.lastModified = entry.lastModDate.getTime();
-		}
-
-		const file = new File( [ data ], fileName, options );
-		debugPlaylistZip( 'created ZIP entry file', {
-			entry: entryInfo,
-			file: getPlaylistZipDebugMediaInfo( file ),
-		} );
-
-		return file;
-	} catch ( error ) {
-		debugPlaylistZip( 'reading ZIP entry file failed', {
-			entry: entryInfo,
-			message: getDebugErrorMessage( error ),
-		} );
-		throw error;
+	let data = getStoredZipEntryData( entry, zipData );
+	if ( data === undefined ) {
+		data = await entry.getData( new Uint8ArrayWriter() );
 	}
+	const options = {};
+
+	if ( entry.lastModDate ) {
+		options.lastModified = entry.lastModDate.getTime();
+	}
+
+	return new File( [ data ], fileName, options );
 }
 
 async function getZipReader( zipFile ) {
-	debugPlaylistZip( 'loading ZIP file data', {
-		zip: getPlaylistZipDebugMediaInfo( zipFile ),
-	} );
-
 	const zipData = new Uint8Array( await zipFile.arrayBuffer() );
-	debugPlaylistZip( 'loaded ZIP file data', {
-		zip: getPlaylistZipDebugMediaInfo( zipFile ),
-		byteLength: zipData.byteLength,
-	} );
 
 	return {
 		zipData,
@@ -353,26 +171,14 @@ async function getZipReader( zipFile ) {
  */
 export async function getPlaylistMediaFromZip( zipFile ) {
 	const { zipData, zipReader } = await getZipReader( zipFile );
-	debugPlaylistZip(
-		'opening ZIP file',
-		getPlaylistZipDebugMediaInfo( zipFile )
-	);
 
 	try {
 		const entries = await zipReader.getEntries();
 		const tracks = [];
 		let imageFile;
-		debugPlaylistZip( 'read ZIP entries', {
-			count: entries.length,
-			entries: entries.map( getZipEntryDebugInfo ),
-		} );
 
 		for ( const entry of entries ) {
-			const entryInfo = getZipEntryDebugInfo( entry );
 			if ( entry.directory ) {
-				debugPlaylistZip( 'skipped ZIP directory entry', {
-					entry: entryInfo,
-				} );
 				continue;
 			}
 
@@ -383,34 +189,16 @@ export async function getPlaylistMediaFromZip( zipFile ) {
 				IMAGE_FILE_EXTENSION.test( fileName ) &&
 				COVER_FILE_NAME.test( fileName );
 
-			debugPlaylistZip( 'classified ZIP entry', {
-				entry: entryInfo,
-				fileName,
-				isAudio,
-				isCoverImage,
-			} );
-
 			if ( isAudio ) {
-				const details = getTrackDetails( fileName );
-				const file = await getEntryFile( entry, zipData );
 				tracks.push( {
-					file,
-					details,
-				} );
-				debugPlaylistZip( 'added ZIP audio track', {
-					entry: entryInfo,
-					file: getPlaylistZipDebugMediaInfo( file ),
-					details,
+					file: await getEntryFile( entry, zipData ),
+					details: getTrackDetails( fileName ),
 				} );
 				continue;
 			}
 
 			if ( isCoverImage ) {
 				imageFile = await getEntryFile( entry, zipData );
-				debugPlaylistZip( 'added ZIP cover image', {
-					entry: entryInfo,
-					file: getPlaylistZipDebugMediaInfo( imageFile ),
-				} );
 			}
 		}
 
@@ -419,7 +207,6 @@ export async function getPlaylistMediaFromZip( zipFile ) {
 			imageFile,
 		};
 	} finally {
-		debugPlaylistZip( 'closing ZIP file' );
 		await zipReader.close();
 	}
 }

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -9,51 +9,31 @@ const AUDIO_FILE_EXTENSION =
 const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|gif|webp)$/i;
 const COVER_FILE_NAME = /^(cover|folder|album|albumart|artwork)\./i;
 
-const MIME_TYPES = {
-	aac: 'audio/aac',
-	aif: 'audio/aiff',
-	aiff: 'audio/aiff',
-	flac: 'audio/flac',
-	gif: 'image/gif',
-	jpg: 'image/jpeg',
-	jpeg: 'image/jpeg',
-	m4a: 'audio/mp4',
-	m4b: 'audio/mp4',
-	mp3: 'audio/mpeg',
-	oga: 'audio/ogg',
-	ogg: 'audio/ogg',
-	opus: 'audio/ogg',
-	png: 'image/png',
-	wav: 'audio/wav',
-	weba: 'audio/webm',
-	webp: 'image/webp',
-};
-
 export function isZipFile( file ) {
-	const mimeType = file?.type || file?.mime_type || file?.mime;
+	const mimeTypes = [ file?.mime_type, file?.mime, file?.type ].filter(
+		Boolean
+	);
+	const hasZipFileExtension = ( value ) =>
+		typeof value === 'string' && /\.zip(?:[?#].*)?$/i.test( value );
 
 	return (
-		!! file?.name?.match( /\.zip$/i ) ||
-		!! file?.filename?.match( /\.zip$/i ) ||
-		!! file?.file?.match( /\.zip$/i ) ||
-		!! file?.url?.match( /\.zip(?:[?#].*)?$/i ) ||
-		!! file?.source_url?.match( /\.zip(?:[?#].*)?$/i ) ||
-		mimeType === 'application/zip' ||
-		mimeType === 'application/x-zip' ||
-		mimeType === 'application/x-zip-compressed'
+		hasZipFileExtension( file?.name ) ||
+		hasZipFileExtension( file?.filename ) ||
+		hasZipFileExtension( file?.file ) ||
+		hasZipFileExtension( file?.url ) ||
+		hasZipFileExtension( file?.source_url ) ||
+		file?.subtype === 'zip' ||
+		mimeTypes.some(
+			( mimeType ) =>
+				mimeType === 'application/zip' ||
+				mimeType === 'application/x-zip' ||
+				mimeType === 'application/x-zip-compressed'
+		)
 	);
 }
 
 function getFileName( path = '' ) {
 	return path.split( /[/\\]/ ).pop() || path;
-}
-
-function getFileExtension( fileName ) {
-	return fileName.split( '.' ).pop()?.toLowerCase();
-}
-
-function getMimeType( fileName ) {
-	return MIME_TYPES[ getFileExtension( fileName ) ] || '';
 }
 
 function stripFileExtension( fileName ) {
@@ -108,9 +88,10 @@ function sortTracksByNumber( tracks ) {
 
 async function getEntryFile( entry ) {
 	const fileName = getFileName( entry.filename );
-	const type = getMimeType( fileName );
-	const blob = await entry.getData( new BlobWriter( type ) );
-	const options = { type: blob.type || type };
+	// Keep the MIME type unset so WordPress validates the upload by extension
+	// instead of by a browser-dependent guess for extracted ZIP entries.
+	const blob = await entry.getData( new BlobWriter() );
+	const options = {};
 
 	if ( entry.lastModDate ) {
 		options.lastModified = entry.lastModDate.getTime();

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -69,6 +69,60 @@ export function debugPlaylistZip( message, details ) {
 	console.debug( '[Playlist ZIP]', message, details );
 }
 
+function getDebugErrorMessage( error ) {
+	return typeof error === 'string' ? error : error?.message;
+}
+
+function getZipEntryDebugInfo( entry ) {
+	return {
+		filename: entry?.filename,
+		directory: entry?.directory,
+		compressedSize: entry?.compressedSize,
+		uncompressedSize: entry?.uncompressedSize,
+		encrypted: entry?.encrypted,
+		zip64: entry?.zip64,
+		compressionMethod: entry?.compressionMethod,
+		hasGetData: typeof entry?.getData === 'function',
+	};
+}
+
+function getZipEntryReadDebugOptions( entryInfo ) {
+	let lastProgressBucket;
+
+	return {
+		onstart( total ) {
+			debugPlaylistZip( 'started reading ZIP entry file', {
+				entry: entryInfo,
+				total,
+			} );
+		},
+		onprogress( progress, total ) {
+			const percent =
+				total > 0 ? Math.floor( ( progress / total ) * 100 ) : null;
+			const progressBucket =
+				percent === null ? progress : Math.floor( percent / 25 );
+
+			if ( progressBucket === lastProgressBucket ) {
+				return;
+			}
+			lastProgressBucket = progressBucket;
+
+			debugPlaylistZip( 'reading ZIP entry file progress', {
+				entry: entryInfo,
+				progress,
+				total,
+				percent,
+			} );
+		},
+		onend( computedSize ) {
+			debugPlaylistZip( 'finished reading ZIP entry file', {
+				entry: entryInfo,
+				computedSize,
+			} );
+		},
+	};
+}
+
 export function isZipFile( file ) {
 	const mimeTypes = [ file?.mime_type, file?.mime, file?.type ].filter(
 		Boolean
@@ -155,16 +209,39 @@ function sortTracksByNumber( tracks ) {
 
 async function getEntryFile( entry ) {
 	const fileName = getFileName( entry.filename );
+	const entryInfo = getZipEntryDebugInfo( entry );
 	// Keep the MIME type unset so WordPress validates the upload by extension
 	// instead of by a browser-dependent guess for extracted ZIP entries.
-	const blob = await entry.getData( new BlobWriter() );
-	const options = {};
+	debugPlaylistZip( 'reading ZIP entry file', {
+		entry: entryInfo,
+		fileName,
+	} );
 
-	if ( entry.lastModDate ) {
-		options.lastModified = entry.lastModDate.getTime();
+	try {
+		const blob = await entry.getData(
+			new BlobWriter(),
+			getZipEntryReadDebugOptions( entryInfo )
+		);
+		const options = {};
+
+		if ( entry.lastModDate ) {
+			options.lastModified = entry.lastModDate.getTime();
+		}
+
+		const file = new File( [ blob ], fileName, options );
+		debugPlaylistZip( 'created ZIP entry file', {
+			entry: entryInfo,
+			file: getPlaylistZipDebugMediaInfo( file ),
+		} );
+
+		return file;
+	} catch ( error ) {
+		debugPlaylistZip( 'reading ZIP entry file failed', {
+			entry: entryInfo,
+			message: getDebugErrorMessage( error ),
+		} );
+		throw error;
 	}
-
-	return new File( [ blob ], fileName, options );
 }
 
 /**
@@ -186,32 +263,53 @@ export async function getPlaylistMediaFromZip( zipFile ) {
 		let imageFile;
 		debugPlaylistZip( 'read ZIP entries', {
 			count: entries.length,
-			entries: entries.map( ( entry ) => ( {
-				filename: entry.filename,
-				directory: entry.directory,
-			} ) ),
+			entries: entries.map( getZipEntryDebugInfo ),
 		} );
 
 		for ( const entry of entries ) {
+			const entryInfo = getZipEntryDebugInfo( entry );
 			if ( entry.directory ) {
-				continue;
-			}
-
-			const fileName = getFileName( entry.filename );
-			if ( AUDIO_FILE_EXTENSION.test( fileName ) ) {
-				tracks.push( {
-					file: await getEntryFile( entry ),
-					details: getTrackDetails( fileName ),
+				debugPlaylistZip( 'skipped ZIP directory entry', {
+					entry: entryInfo,
 				} );
 				continue;
 			}
 
-			if (
+			const fileName = getFileName( entry.filename );
+			const isAudio = AUDIO_FILE_EXTENSION.test( fileName );
+			const isCoverImage =
 				! imageFile &&
 				IMAGE_FILE_EXTENSION.test( fileName ) &&
-				COVER_FILE_NAME.test( fileName )
-			) {
+				COVER_FILE_NAME.test( fileName );
+
+			debugPlaylistZip( 'classified ZIP entry', {
+				entry: entryInfo,
+				fileName,
+				isAudio,
+				isCoverImage,
+			} );
+
+			if ( isAudio ) {
+				const details = getTrackDetails( fileName );
+				const file = await getEntryFile( entry );
+				tracks.push( {
+					file,
+					details,
+				} );
+				debugPlaylistZip( 'added ZIP audio track', {
+					entry: entryInfo,
+					file: getPlaylistZipDebugMediaInfo( file ),
+					details,
+				} );
+				continue;
+			}
+
+			if ( isCoverImage ) {
 				imageFile = await getEntryFile( entry );
+				debugPlaylistZip( 'added ZIP cover image', {
+					entry: entryInfo,
+					file: getPlaylistZipDebugMediaInfo( imageFile ),
+				} );
 			}
 		}
 

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -1,6 +1,6 @@
 import {
 	BlobReader,
-	BlobWriter,
+	Uint8ArrayWriter,
 	ZipReader,
 } from '@zip.js/zip.js/lib/zip-no-worker-inflate.js';
 
@@ -218,8 +218,8 @@ async function getEntryFile( entry ) {
 	} );
 
 	try {
-		const blob = await entry.getData(
-			new BlobWriter(),
+		const data = await entry.getData(
+			new Uint8ArrayWriter(),
 			getZipEntryReadDebugOptions( entryInfo )
 		);
 		const options = {};
@@ -228,7 +228,7 @@ async function getEntryFile( entry ) {
 			options.lastModified = entry.lastModDate.getTime();
 		}
 
-		const file = new File( [ blob ], fileName, options );
+		const file = new File( [ data ], fileName, options );
 		debugPlaylistZip( 'created ZIP entry file', {
 			entry: entryInfo,
 			file: getPlaylistZipDebugMediaInfo( file ),

--- a/packages/block-library/src/playlist/zip-utils.js
+++ b/packages/block-library/src/playlist/zip-utils.js
@@ -8,6 +8,66 @@ const AUDIO_FILE_EXTENSION =
 	/\.(aac|aif|aiff|flac|m4a|m4b|mp3|oga|ogg|opus|wav|weba)$/i;
 const IMAGE_FILE_EXTENSION = /\.(jpe?g|png|gif|webp)$/i;
 const COVER_FILE_NAME = /^(cover|folder|album|albumart|artwork)\./i;
+const DEBUG_STORAGE_KEY = 'wpPlaylistZipDebug';
+
+function getSafeUrlDetails( url ) {
+	if ( typeof url !== 'string' ) {
+		return undefined;
+	}
+
+	try {
+		const parsedUrl = new URL( url, 'https://example.invalid' );
+		return {
+			pathname: parsedUrl.pathname,
+			hasSearch: parsedUrl.search !== '',
+			hasHash: parsedUrl.hash !== '',
+		};
+	} catch {
+		return { value: url.replace( /[?#].*$/, '' ) };
+	}
+}
+
+function isPlaylistZipDebugEnabled() {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	if ( window.__wpPlaylistZipDebug === true ) {
+		return true;
+	}
+
+	try {
+		return window.localStorage?.getItem( DEBUG_STORAGE_KEY ) === '1';
+	} catch {
+		return false;
+	}
+}
+
+export function getPlaylistZipDebugMediaInfo( media ) {
+	const mediaUrl = media?.url ?? media?.source_url;
+
+	return {
+		name: media?.name,
+		filename: media?.filename,
+		file: typeof media?.file === 'string' ? media.file : undefined,
+		type: media?.type,
+		mime: media?.mime,
+		mimeType: media?.mime_type,
+		subtype: media?.subtype,
+		size: media?.size,
+		hasUrl: !! mediaUrl,
+		url: getSafeUrlDetails( mediaUrl ),
+	};
+}
+
+export function debugPlaylistZip( message, details ) {
+	if ( ! isPlaylistZipDebugEnabled() ) {
+		return;
+	}
+
+	// eslint-disable-next-line no-console
+	console.debug( '[Playlist ZIP]', message, details );
+}
 
 export function isZipFile( file ) {
 	const mimeTypes = [ file?.mime_type, file?.mime, file?.type ].filter(
@@ -16,7 +76,7 @@ export function isZipFile( file ) {
 	const hasZipFileExtension = ( value ) =>
 		typeof value === 'string' && /\.zip(?:[?#].*)?$/i.test( value );
 
-	return (
+	const isZip =
 		hasZipFileExtension( file?.name ) ||
 		hasZipFileExtension( file?.filename ) ||
 		hasZipFileExtension( file?.file ) ||
@@ -28,8 +88,15 @@ export function isZipFile( file ) {
 				mimeType === 'application/zip' ||
 				mimeType === 'application/x-zip' ||
 				mimeType === 'application/x-zip-compressed'
-		)
-	);
+		);
+
+	debugPlaylistZip( 'checked ZIP file candidate', {
+		media: getPlaylistZipDebugMediaInfo( file ),
+		mimeTypes,
+		isZip,
+	} );
+
+	return isZip;
 }
 
 function getFileName( path = '' ) {
@@ -108,11 +175,22 @@ async function getEntryFile( entry ) {
  */
 export async function getPlaylistMediaFromZip( zipFile ) {
 	const zipReader = new ZipReader( new BlobReader( zipFile ) );
+	debugPlaylistZip(
+		'opening ZIP file',
+		getPlaylistZipDebugMediaInfo( zipFile )
+	);
 
 	try {
 		const entries = await zipReader.getEntries();
 		const tracks = [];
 		let imageFile;
+		debugPlaylistZip( 'read ZIP entries', {
+			count: entries.length,
+			entries: entries.map( ( entry ) => ( {
+				filename: entry.filename,
+				directory: entry.directory,
+			} ) ),
+		} );
 
 		for ( const entry of entries ) {
 			if ( entry.directory ) {
@@ -142,6 +220,7 @@ export async function getPlaylistMediaFromZip( zipFile ) {
 			imageFile,
 		};
 	} finally {
+		debugPlaylistZip( 'closing ZIP file' );
 		await zipReader.close();
 	}
 }


### PR DESCRIPTION
## What?
Adds support for ZIP uploads in the Playlist block, extracting audio entries into tracks with inferred artist, album, title, ordering, and cover artwork.

## Why?
This lets users create a playlist from an album archive without adding every track and artwork file manually.

## How?
The block now accepts ZIP files, reads them with zip.js, uploads extracted audio and cover media through `mediaUpload`, and creates Playlist Track inner blocks.

## Testing Instructions
Run `npm run test:unit packages/block-library/src/playlist/test/edit-component.js`; manually insert a Playlist block, upload a ZIP with numbered audio files and `cover.png`, then verify ordered tracks, metadata, artwork, and the no-audio ZIP error.

### Testing Instructions for Keyboard
Same as manual testing, using keyboard focus and file picker navigation.

## Screenshots or screencast
Not applicable.

## Use of AI Tools
Codex was used to prepare the PR, inspect the diff, and run focused checks.
