### PR TITLE
Cover: Avoid passing null as the featured image size

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 -   Footnotes: Treat unreadable `footnotes` post meta as no footnotes instead of throwing, so the block shows its placeholder rather than the block crash warning ([#81201](https://github.com/WordPress/gutenberg/pull/81201)).
 -   Playlist: Improve handling of declarative waveform player configuration ([#81342](https://github.com/WordPress/gutenberg/pull/81342)).
+-   Cover: Pass `'full'` instead of `null` as the featured image size for parallax and repeated backgrounds, so a null array offset is no longer reached on PHP 8.5 ([#81444](https://github.com/WordPress/gutenberg/pull/81444)).
 
 ### Internal
 

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -161,7 +161,7 @@ function render_block_core_cover( $attributes, $content ) {
 		if ( in_the_loop() ) {
 			update_post_thumbnail_cache();
 		}
-		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['sizeSlug'] ?? null );
+		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['sizeSlug'] ?? 'full' );
 		if ( ! $current_featured_image ) {
 			return $content;
 		}


### PR DESCRIPTION
## What?

The Cover block asks WordPress for the featured image using `null` as the image size. This PR passes `'full'` instead, which is what the code already ends up using anyway.

This fixes the PHP 8.5 CI failures on `trunk`.

## Why?

Passing `null` as an image size was never valid — `get_the_post_thumbnail_url()` expects a size name or a width/height array.

[PHP 8.5 now deprecates using `null` as an array key](https://www.php.net/manual/en/migration85.deprecated.php#:~:text=Using%20null%20as%20an%20array%20offset%20%C2%B6), and a recent WordPress change — [r63177](https://core.trac.wordpress.org/changeset/63177) — made `image_constrain_size_for_editor()` do exactly that kind of lookup with whatever size it is handed. The previous code never reached the lookup; the new one does. So our invalid `null` started producing a deprecation notice, which PHPUnit reports as a test error:

```
Tests_Blocks_Render_Cover::test_gutenberg_render_block_core_cover
Using null as an array offset is deprecated, use an empty string instead
```

Whatever Core decides to do about r63177, passing `null` here is our bug, so this is worth fixing on its own.

## How?

`'full'` was chosen over `'post-thumbnail'` because it keeps the output identical — passing `null` today always resolves to the full-size image URL, and `'full'` does the same.

The `<img>` branch just above already uses `'post-thumbnail'` and is intentionally left alone — that one is a responsive image, not a CSS background.

## Testing Instructions

The failing test `Tests_Blocks_Render_Cover::test_gutenberg_render_block_core_cover` already covers this path, so green CI is the main check.

To confirm nothing changed visually:

1. Set a featured image on a post.
2. Add a Cover block, enable **Use featured image**, and turn on **Fixed background** or **Repeated background**.
3. Leave the image size unset in the sidebar.
4. On the front end, inspect the `background-image` URL on `.wp-block-cover__image-background`. It should be the full-size image, the same as before this change.

## Use of AI Tools

Claude Code was used to track down the cause of the CI failure and to draft this description. The one-line change and the choice of `'full'` were reviewed and accepted by me.
