### PR TITLE
components/Menu: Restore Modal focus return when menu items close (#81164)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+-   `Modal`: Prevent background page scrolling without relying on WordPress global styles when using the default `bodyOpenClassName` ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
+-   `Menu`: Return focus to the root trigger after closing a legacy `Modal` opened from a menu item, while preserving the menu-to-Modal scroll-lock handoff ([#81164](https://github.com/WordPress/gutenberg/pull/81164)).
 -   `Button`: Suppress the browser focus ring when keyboard-focused and pressed ([#81113](https://github.com/WordPress/gutenberg/pull/81113)).
 -   `ToolsPanel`: Migrate styles from Emotion to an SCSS Module and restore the header heading typography after the `View` migration. ([#80445](https://github.com/WordPress/gutenberg/pull/80445)).
 -   `Autocomplete`: Expose the suggestions list to assistive technology with `aria-controls` and `aria-haspopup`, both required alongside `aria-autocomplete="list"` ([#80403](https://github.com/WordPress/gutenberg/pull/80403)).

--- a/packages/components/src/menu/checkbox-item.tsx
+++ b/packages/components/src/menu/checkbox-item.tsx
@@ -16,6 +16,7 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { CheckboxItemProps } from './types';
 import * as Styled from './styles';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 export const CheckboxItem = forwardRef<
 	HTMLDivElement,
@@ -25,24 +26,25 @@ export const CheckboxItem = forwardRef<
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const store = menuContext?.store;
+	const computedHideOnClick = useMenuItemHideOnClick( store, hideOnClick );
 
-	if ( ! menuContext?.store ) {
+	if ( ! store ) {
 		throw new Error(
 			'Menu.CheckboxItem can only be rendered inside a Menu component'
 		);
 	}
-
 	return (
 		<Styled.CheckboxItem
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
-			hideOnClick={ hideOnClick }
-			store={ menuContext.store }
+			store={ store }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Ariakit.MenuItemCheck
-				store={ menuContext.store }
+				store={ store }
 				render={ <Styled.ItemPrefixWrapper /> }
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }

--- a/packages/components/src/menu/item.tsx
+++ b/packages/components/src/menu/item.tsx
@@ -10,6 +10,7 @@ import type { WordPressComponentProps } from '../context';
 import type { ItemProps } from './types';
 import * as Styled from './styles';
 import { Context } from './context';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 export const Item = forwardRef<
 	HTMLDivElement,
@@ -27,8 +28,13 @@ export const Item = forwardRef<
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const computedStore = store ?? menuContext?.store;
+	const computedHideOnClick = useMenuItemHideOnClick(
+		computedStore,
+		hideOnClick
+	);
 
-	if ( ! menuContext?.store ) {
+	if ( ! menuContext?.store || ! computedStore ) {
 		throw new Error(
 			'Menu.Item can only be rendered inside a Menu component'
 		);
@@ -38,16 +44,14 @@ export const Item = forwardRef<
 	// created by the top-level menu component). But in rare cases (ie.
 	// `Menu.SubmenuTriggerItem`), the context store wouldn't be correct. This is
 	// why the component accepts a `store` prop to override the context store.
-	const computedStore = store ?? menuContext.store;
-
 	return (
 		<Styled.Item
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
-			hideOnClick={ hideOnClick }
 			store={ computedStore }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
 

--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -17,6 +17,7 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { RadioItemProps } from './types';
 import * as Styled from './styles';
+import { useMenuItemHideOnClick } from './use-menu-item-hide-on-click';
 
 const radioCheck = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -32,24 +33,25 @@ export const RadioItem = forwardRef<
 	ref
 ) {
 	const menuContext = useContext( Context );
+	const store = menuContext?.store;
+	const computedHideOnClick = useMenuItemHideOnClick( store, hideOnClick );
 
-	if ( ! menuContext?.store ) {
+	if ( ! store ) {
 		throw new Error(
 			'Menu.RadioItem can only be rendered inside a Menu component'
 		);
 	}
-
 	return (
 		<Styled.RadioItem
 			ref={ ref }
 			{ ...props }
 			accessibleWhenDisabled
 			disabled={ disabled }
-			hideOnClick={ hideOnClick }
-			store={ menuContext.store }
+			store={ store }
+			hideOnClick={ computedHideOnClick }
 		>
 			<Ariakit.MenuItemCheck
-				store={ menuContext.store }
+				store={ store }
 				render={ <Styled.ItemPrefixWrapper /> }
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { StoryObj, Meta } from '@storybook/react-vite';
-import { css } from '@emotion/react';
 import { fn } from 'storybook/test';
 
 /**
@@ -14,7 +13,6 @@ import { useState, useMemo, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useCx } from '../../utils';
 import { Menu } from '..';
 import Icon from '../../icon';
 import Button from '../../button';
@@ -401,19 +399,9 @@ export const WithRadios: StoryObj< typeof Menu > = {
 	},
 };
 
-const modalOnTopOfMenuPopover = css`
-	&& {
-		z-index: 1000000;
-	}
-`;
-
-export const WithModals: StoryObj< typeof Menu > = {
-	render: function WithModals( props: Props ) {
-		const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
-		const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
-
-		const cx = useCx();
-		const modalOverlayClassName = cx( modalOnTopOfMenuPopover );
+export const WithModal: StoryObj< typeof Menu > = {
+	render: function WithModal( props: Props ) {
+		const [ isModalOpen, setModalOpen ] = useState( false );
 
 		return (
 			<>
@@ -426,42 +414,15 @@ export const WithModals: StoryObj< typeof Menu > = {
 						Open menu
 					</Menu.TriggerButton>
 					<Menu.Popover>
-						<Menu.Item
-							onClick={ () => setOuterModalOpen( true ) }
-							hideOnClick={ false }
-						>
-							<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
+						<Menu.Item onClick={ () => setModalOpen( true ) }>
+							<Menu.ItemLabel>Open modal</Menu.ItemLabel>
 						</Menu.Item>
-						<Menu.Item
-							onClick={ () => setInnerModalOpen( true ) }
-							hideOnClick={ false }
-						>
-							<Menu.ItemLabel>Open inner modal</Menu.ItemLabel>
-						</Menu.Item>
-						{ isInnerModalOpen && (
-							<Modal
-								onRequestClose={ () =>
-									setInnerModalOpen( false )
-								}
-								overlayClassName={ modalOverlayClassName }
-							>
-								Modal&apos;s contents
-								<button
-									onClick={ () => setInnerModalOpen( false ) }
-								>
-									Close
-								</button>
-							</Modal>
-						) }
 					</Menu.Popover>
 				</Menu>
-				{ isOuterModalOpen && (
-					<Modal
-						onRequestClose={ () => setOuterModalOpen( false ) }
-						overlayClassName={ modalOverlayClassName }
-					>
+				{ isModalOpen && (
+					<Modal onRequestClose={ () => setModalOpen( false ) }>
 						Modal&apos;s contents
-						<button onClick={ () => setOuterModalOpen( false ) }>
+						<button onClick={ () => setModalOpen( false ) }>
 							Close
 						</button>
 					</Modal>

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -13,6 +13,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { Menu } from '..';
+import Modal from '../../modal';
 
 const waitForFocusedMenu = () =>
 	waitFor( () => expect( screen.getByRole( 'menu' ) ).toHaveFocus() );
@@ -22,8 +23,64 @@ const waitForFocusedMenuItem = ( name: string ) =>
 		expect( screen.getByRole( 'menuitem', { name } ) ).toHaveFocus()
 	);
 
+const waitForClosedMenu = () =>
+	waitFor( () =>
+		expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
+	);
+
+const openMenu = async ( user: ReturnType< typeof userEvent.setup > ) => {
+	await user.click( screen.getByRole( 'button', { name: 'Open dropdown' } ) );
+	await waitForFocusedMenu();
+};
+
+// TODO: Add browser coverage for the computed overflow once component stories
+// use interaction tests. Jest mocks stylesheet imports, so this only verifies
+// the handoff between Ariakit's inline lock and Modal's body class.
+const isBodyScrollLocked = () =>
+	document.body.style.overflow === 'hidden' ||
+	document.body.classList.contains( 'modal-open' );
+
 const resetTypeahead = () => {
 	act( () => jest.advanceTimersByTime( 500 ) );
+};
+
+const MenuWithModal = ( { nested = false }: { nested?: boolean } ) => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const modalItem = (
+		<Menu.Item onClick={ () => setIsModalOpen( true ) }>
+			Open modal
+		</Menu.Item>
+	);
+
+	return (
+		<>
+			<Menu>
+				<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+				<Menu.Popover>
+					{ nested ? (
+						<Menu>
+							<Menu.SubmenuTriggerItem>
+								Open submenu
+							</Menu.SubmenuTriggerItem>
+							<Menu.Popover>{ modalItem }</Menu.Popover>
+						</Menu>
+					) : (
+						modalItem
+					) }
+				</Menu.Popover>
+			</Menu>
+			{ isModalOpen && (
+				<Modal
+					title="Modal"
+					onRequestClose={ () => setIsModalOpen( false ) }
+				>
+					<button onClick={ () => setIsModalOpen( false ) }>
+						Close modal
+					</button>
+				</Modal>
+			) }
+		</>
+	);
 };
 
 // Open dropdown => open menu
@@ -248,9 +305,31 @@ describe( 'Menu', () => {
 			// Click on the body (ie. outside of the dropdown menu)
 			await user.click( document.body );
 
-			await waitFor( () =>
-				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
+			await waitForClosedMenu();
+		} );
+
+		it( 'should retain outside focus when outside interaction closes a non-modal menu', async () => {
+			render(
+				<>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item>Menu item</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+					<button>Outside destination</button>
+				</>
 			);
+
+			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
+			const outsideDestination = screen.getByRole( 'button', {
+				name: 'Outside destination',
+			} );
+
+			await user.click( outsideDestination );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
 		} );
 
 		it( 'should close when clicking on a menu item', async () => {
@@ -273,7 +352,91 @@ describe( 'Menu', () => {
 			);
 		} );
 
-		it( 'should not close when clicking on a menu item when the `hideOnClick` prop is set to `false`', async () => {
+		it( 'should return focus to the root trigger after a modal opened by pointer closes', async () => {
+			render( <MenuWithModal /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+
+			await user.click( trigger );
+			await waitForFocusedMenu();
+			await user.click(
+				screen.getByRole( 'menuitem', { name: 'Open modal' } )
+			);
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should return focus after Enter opens a modal', async () => {
+			render( <MenuWithModal /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+			await openMenu( user );
+			await user.keyboard( '{ArrowDown}' );
+			await waitForFocusedMenuItem( 'Open modal' );
+
+			await user.keyboard( '{Enter}' );
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should return focus to the root trigger after a nested menu opens a modal', async () => {
+			render( <MenuWithModal nested /> );
+
+			const trigger = screen.getByRole( 'button', {
+				name: 'Open dropdown',
+			} );
+			await openMenu( user );
+			await user.keyboard( '{ArrowDown}' );
+			await waitForFocusedMenuItem( 'Open submenu' );
+			await user.keyboard( '{ArrowRight}' );
+			await waitForFocusedMenuItem( 'Open modal' );
+			await user.keyboard( '{Enter}' );
+			await waitForClosedMenu();
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+
+			await waitFor( () => expect( trigger ).toHaveFocus() );
+		} );
+
+		it( 'should keep body scroll locked while handing off to a modal', async () => {
+			render( <MenuWithModal /> );
+
+			expect( isBodyScrollLocked() ).toBe( false );
+			await openMenu( user );
+			expect( isBodyScrollLocked() ).toBe( true );
+
+			await user.click(
+				screen.getByRole( 'menuitem', { name: 'Open modal' } )
+			);
+			await waitForClosedMenu();
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			expect( isBodyScrollLocked() ).toBe( true );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Close modal' } )
+			);
+			await waitFor( () =>
+				expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+			);
+			await waitFor( () => expect( isBodyScrollLocked() ).toBe( false ) );
+		} );
+
+		it( 'should stay open when `hideOnClick` is `false`', async () => {
 			render(
 				<Menu defaultOpen>
 					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
@@ -285,7 +448,164 @@ describe( 'Menu', () => {
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
 
-			// Clicking a menu item will close the menu
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			expect( screen.getByRole( 'menu' ) ).toBeVisible();
+		} );
+
+		it( 'should use a `hideOnClick` callback to decide whether to close', async () => {
+			const hideOnClick = jest.fn( () => false );
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item hideOnClick={ hideOnClick }>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			expect( screen.getByRole( 'menu' ) ).toBeVisible();
+			expect( hideOnClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should close when a `hideOnClick` callback returns `true`', async () => {
+			const hideOnClick = jest.fn( () => true );
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item hideOnClick={ hideOnClick }>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( hideOnClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it.each( [ 'checkbox', 'radio' ] )(
+			'should close a %s item when `hideOnClick` is `true`',
+			async ( itemType ) => {
+				render(
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover>
+							{ itemType === 'checkbox' ? (
+								<Menu.CheckboxItem
+									name="checkbox"
+									value="checkbox"
+									hideOnClick
+								>
+									Checkbox item
+								</Menu.CheckboxItem>
+							) : (
+								<Menu.RadioItem
+									name="radio"
+									value="radio"
+									hideOnClick
+								>
+									Radio item
+								</Menu.RadioItem>
+							) }
+						</Menu.Popover>
+					</Menu>
+				);
+
+				await user.click( screen.getByRole( `menuitem${ itemType }` ) );
+
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'menu' )
+					).not.toBeInTheDocument()
+				);
+			}
+		);
+
+		it( 'should retain focus moved outside by an item click handler', async () => {
+			let outsideDestination: HTMLButtonElement | null = null;
+			render(
+				<>
+					<button
+						ref={ ( element ) => {
+							outsideDestination = element;
+						} }
+					>
+						Outside destination
+					</button>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item
+								onClick={ () => outsideDestination?.focus() }
+							>
+								Menu item
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
+		} );
+
+		it( 'should retain focus moved outside by a `hideOnClick` callback', async () => {
+			let outsideDestination: HTMLButtonElement | null = null;
+			render(
+				<>
+					<button
+						ref={ ( element ) => {
+							outsideDestination = element;
+						} }
+					>
+						Outside destination
+					</button>
+					<Menu defaultOpen>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal={ false }>
+							<Menu.Item
+								hideOnClick={ () => {
+									outsideDestination?.focus();
+									return true;
+								} }
+							>
+								Menu item
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</>
+			);
+
+			await user.click( screen.getByRole( 'menuitem' ) );
+
+			await waitForClosedMenu();
+			expect( outsideDestination ).toHaveFocus();
+		} );
+
+		it( 'should not close when item activation is prevented', async () => {
+			render(
+				<Menu defaultOpen>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item
+							onClick={ ( event ) => event.preventDefault() }
+						>
+							Menu item
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
 			await user.click( screen.getByRole( 'menuitem' ) );
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
@@ -516,7 +836,6 @@ describe( 'Menu', () => {
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			).not.toBeChecked();
 
-			// Click second radio item, make sure that the callback fires
 			await user.click(
 				screen.getByRole( 'menuitemradio', { name: 'Radio item two' } )
 			);
@@ -858,7 +1177,7 @@ describe( 'Menu', () => {
 				true
 			);
 
-			// Make sure that second checkbox is unselected
+			// Make sure that second checkbox is selected
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
 					name: 'Checkbox item two',
@@ -931,7 +1250,7 @@ describe( 'Menu', () => {
 			// The outer button can be focused by pressing tab. Doing so will cause
 			// the Menu to close.
 			await user.tab();
-			expect( outerButton ).toBeVisible();
+			expect( outerButton ).toHaveFocus();
 			await waitFor( () =>
 				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
 			);

--- a/packages/components/src/menu/use-menu-item-hide-on-click.ts
+++ b/packages/components/src/menu/use-menu-item-hide-on-click.ts
@@ -1,0 +1,67 @@
+import type * as Ariakit from '@ariakit/react';
+import { useCallback } from '@wordpress/element';
+
+function focusDisclosureElement( disclosureElement: HTMLElement ) {
+	disclosureElement.focus();
+
+	if ( disclosureElement.ownerDocument.activeElement === disclosureElement ) {
+		return;
+	}
+
+	// A modal Ariakit menu disables the document tree outside the menu. Modern
+	// browsers use `inert`; Ariakit's fallback replaces each element's `focus`
+	// method. Ariakit restores either mechanism as soon as the menu hides.
+	const inertAncestor = disclosureElement.closest< HTMLElement >( '[inert]' );
+	if ( inertAncestor ) {
+		inertAncestor.inert = false;
+	}
+
+	disclosureElement.ownerDocument.defaultView?.HTMLElement.prototype.focus.call(
+		disclosureElement
+	);
+}
+
+export function useMenuItemHideOnClick(
+	store: Ariakit.MenuItemProps[ 'store' ],
+	hideOnClick: Ariakit.MenuItemProps[ 'hideOnClick' ]
+) {
+	return useCallback(
+		( event: React.MouseEvent< HTMLElement > ) => {
+			const shouldHide =
+				typeof hideOnClick === 'function'
+					? hideOnClick( event )
+					: hideOnClick;
+
+			if ( ! shouldHide ) {
+				return false;
+			}
+
+			if ( ! store || ! ( 'hideAll' in store ) ) {
+				return true;
+			}
+
+			const menuElement = store.getState().contentElement;
+			const activeElement = menuElement?.ownerDocument.activeElement;
+
+			if ( menuElement?.contains( activeElement ?? null ) ) {
+				let rootStore = store;
+				while ( rootStore.parent ) {
+					rootStore = rootStore.parent;
+				}
+
+				const disclosureElement =
+					rootStore.getState().disclosureElement;
+
+				// Ariakit calls this immediately before it hides and unmounts the
+				// menu. Move focus first so an overlay opened by the item's onClick
+				// captures the root trigger as its focus return target.
+				if ( disclosureElement ) {
+					focusDisclosureElement( disclosureElement );
+				}
+			}
+
+			return true;
+		},
+		[ hideOnClick, store ]
+	);
+}

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -163,6 +163,7 @@ Titles are required for accessibility reasons, see `contentLabel` and `title` fo
 #### `bodyOpenClassName`: `string`
 
 Class name added to the body element when the modal is open.
+If you use a custom class name, its styles must set `overflow: hidden` to preserve the Modal's scroll lock.
 
 -   Required: No
 -   Default: `modal-open`

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,6 +5,10 @@
 @use "@wordpress/base-styles/z-index" as *;
 @use "../utils/theme-variables" as *;
 
+body.modal-open {
+	overflow: hidden;
+}
+
 // The scrim behind the modal window.
 .components-modal__screen-overlay {
 	position: fixed;

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -23,6 +23,8 @@ export type ModalProps = {
 	};
 	/**
 	 * Class name added to the body element when the modal is open.
+	 * If you use a custom class name, its styles must set `overflow: hidden`
+	 * to preserve the Modal's scroll lock.
 	 *
 	 * @default 'modal-open'
 	 */

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -736,11 +736,6 @@
 			"count": 1
 		}
 	},
-	"packages/components/src/menu/stories/index.story.tsx": {
-		"no-restricted-imports": {
-			"count": 1
-		}
-	},
 	"packages/components/src/menu/styles.ts": {
 		"no-restricted-imports": {
 			"count": 2


### PR DESCRIPTION
## What?

Backports #81164 to the `wp/7.1` branch.

## Why?

The cherry-pick did not apply cleanly, so it needs a dedicated PR rather than an automated backport.

## How?

Cherry-picked `13a0338a03a` and resolved the conflicts. Only the following three files conflicted, and none of the component logic changed:

-   `packages/components/CHANGELOG.md`
-   `packages/components/src/menu/stories/index.story.tsx`
-   `tools/eslint/suppressions.json`

## Testing Instructions

1. Open **Components / Actions / Menu / With Modal** in Storybook with **Global CSS: Font only**.
2. Open the menu and select **Open modal**.
3. Confirm that the menu closes and scrolling stays locked.
4. Close the Modal.
5. Confirm that scrolling is restored and focus returns to **Open menu**.

### Testing Instructions for Keyboard

Repeat using Enter to select **Open modal**.

## Use of AI Tools

Claude Code was used to resolve the cherry-pick conflicts and draft this description. The resulting diff was reviewed locally.
