### PR TITLE
Env: Update git to latest commit when `--update` passed

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Update git sources to the latest commit when `--update` is passed. Previously, a source pointing at a branch (such as `"core": "WordPress/WordPress"`) stayed at the commit it was first cloned at, no matter how many times it was updated.
 
 ## 11.12.0 (2026-07-29)
 

--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -79,6 +79,15 @@ async function downloadGitSource( source, { onProgress, spinner, debug } ) {
 	log( 'Checking out the specified ref.' );
 	await git.checkout( source.ref );
 
+	// Checking out a ref which already exists as a local branch doesn't advance
+	// that branch to the commit which was just fetched, so the branch has to be
+	// moved explicitly for updates to have any effect. `FETCH_HEAD` is used
+	// rather than the ref itself because `source.ref` is undefined when the
+	// source string has no `#ref` part, in which case the repository's default
+	// branch is the intended target.
+	log( 'Resetting to the fetched commit.' );
+	await git.reset( [ '--hard', 'FETCH_HEAD' ] );
+
 	onProgress( 1 );
 }
 


### PR DESCRIPTION
## What?

Updates `@wordpress/env` so that the local git copy of a source (e.g. `WordPress/WordPress`) is actually updated to the latest commit when passing `--update`.

Regression of #28848

## Why?

So that `--update` works as expected to... well, update. 

This has been the source of confusion when trying to troubleshoot issues causing test failures in `trunk` caused by upstream changes in WordPress Core ([example](https://wordpress.slack.com/archives/C02QB2JS7/p1786462498290599?thread_ts=1786461642.808129&cid=C02QB2JS7), [example](https://wordpress.slack.com/archives/C02QB2JS7/p1784896860424429?thread_ts=1784840773.034829&cid=C02QB2JS7)), since often the tests will pass locally because the local copy is out of date, and there is no way currently to force it up to date easily without manually updating local ephemeral git clones in `~/.wp-env`.

## How?

In the step after checking out the git ref, adds a command to hard-reset to the fetched head of the ref.

The issue is that if a git repository is already cloned, `git checkout` doesn't actually fast-forward to the latest version automatically. With how this function can receive `ref` as an explicit tag or as `undefined`, the approach here works relatively universally.

Worth noting that this code worked much like what's being proposed here prior to #28848, which [changed from a forced checkout of `FETCH_HEAD`](https://github.com/WordPress/gutenberg/pull/28848/files#diff-5a08defd70ab4f4a6f61d7c4acfe4b5d6609f294c4a0a8895dd98fc4703a04bcL150) to what we have today, thus regressing the expected behavior. This updated approach is argued to be slightly better because it doesn't leave the branch in a detached HEAD state, as was the case with the forced checkout previously.

## Testing Instructions

Assuming you already have a test environment set up locally (or set it up before changing to this branch) you can probably test this by observing that the following sequence of commands results in passing tests on `trunk` and failing tests on this branch, which highlights the issue being fixed in #81444.

```
WP_ENV_PHP_VERSION=8.5 npm run test:unit:php:setup -- --update
npm run test:unit:php:base -- --filter test_gutenberg_render_block_core_cover
```

The test failure is _expected_ until #81444. The goal of these changes is to make it so that test failures like this are reproduceable locally.

`WP_ENV_PHP_VERSION` is required because the issue only occurs on PHP 8.5, but we don't specify the PHP version in local environments, so it defaults to whatever comes through the Docker image (PHP 7.x).

## Use of AI Tools

Researched and implemented with Claude Code + Claude Opus 5, with manual review and prompted iterations.