### PR TITLE
Fix: flaky autosave shareable URL revisions e2e test

### DIFF
--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -959,6 +959,13 @@ test.describe( 'Post autosave shareable URLs with revisions disabled', () => {
 		page,
 		requestUtils,
 	} ) => {
+		// The post must be published: when the post author autosaves their
+		// own draft, WordPress updates the draft in place instead of storing
+		// an autosave revision, so no autosave would exist to open. It must
+		// also be backdated because the editor deletes an autosave that is
+		// not strictly newer than the post on load, and the post and the
+		// autosave can otherwise be created within the same second.
+		// See https://github.com/WordPress/gutenberg/issues/81157.
 		const post = await requestUtils.rest( {
 			method: 'POST',
 			path: '/wp/v2/posts',
@@ -966,7 +973,8 @@ test.describe( 'Post autosave shareable URLs with revisions disabled', () => {
 				title: 'Autosave URL Test',
 				content:
 					'<!-- wp:paragraph --><p>Saved content</p><!-- /wp:paragraph -->',
-				status: 'draft',
+				status: 'publish',
+				date: '2024-01-01T00:00:00',
 			},
 		} );
 		const autosave = await requestUtils.rest( {


### PR DESCRIPTION
Fixes #81157

Fixes the flaky "should render an autosave that is absent from the revisions collection" e2e test in `revisions.spec.js`.

The test creates a draft and posts an autosave for it via the REST API, both as the admin user, and then opens the autosave's shareable URL. Whether that autosave exists as a revision depends on the real-time collaboration setting: with RTC enabled, draft autosaves are stored as autosave revisions, but with RTC disabled WordPress core applies an autosave from the post author directly to the draft and returns the post's own ID instead of a revision ID. The e2e environment starts with RTC enabled, but the collaboration fixture teardown leaves `wp_collaboration_enabled` set to `0`, so every test that runs after a collaboration spec in the same shard runs with RTC disabled. The trace of the failed run in the issue shows exactly that: the autosave request returned the post's own ID, the test deep-linked `revision=<post id>`, and the direct revision fetch 404'd, resetting revisions mode with the "Invalid revision ID." notice before the Restore button was asserted.

The test still passes on fast machines even in that state because the Restore button renders as soon as revisions mode is entered and is usually observed before the 404 response resets it, which is why the failures only show up on busy CI runners and can also hard-fail all three attempts on a persistently slow shard.

To fix this, the test now creates a published post instead of a draft, which makes core store the autosave as a real autosave revision regardless of the RTC setting. The post is also backdated, because the editor deletes an autosave that is not strictly newer than the post on load, and revision timestamps have one-second precision, so a post and an autosave created back to back can otherwise land in the same second. The test's premise is unchanged: revisions are disabled, so the revisions collection stays empty and the autosave revision is only reachable through the direct-fetch fallback the test covers.

The collaboration fixtures restoring the option to "disabled" rather than to its previous value affects the whole suite and is left for a separate discussion.

## Testing Instructions

1. Run `npm run test:e2e -- test/e2e/specs/editor/various/revisions.spec.js --grep "should render an autosave" --repeat-each=3` and verify it passes.
2. To reproduce the flake's mechanism on trunk, disable RTC first with `npm run wp-env-test -- run cli -- wp option update wp_collaboration_enabled 0` and run the same command without this PR's change: the output logs two `Failed to load resource: ... 404` errors (the direct revision fetch failing), and the test only passes by observing the Restore button before the failed fetch exits revisions mode with the "Invalid revision ID." notice. With this PR's change the 404s are gone under both values of the option.
3. Re-enable the option afterwards with `npm run wp-env-test -- run cli -- wp option update wp_collaboration_enabled 1`.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
