### PR TITLE
Normalize block gap values in layout

### DIFF
--- a/backport-changelog/7.2/13011.md
+++ b/backport-changelog/7.2/13011.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13011
+
+* https://github.com/WordPress/gutenberg/pull/81460

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -284,15 +284,35 @@ function gutenberg_get_layout_container_values( $layout ) {
  * Regex for CSS value borrowed from `safecss_filter_attr`, used here to only match
  * against the value, not the CSS attribute.
  *
- * @param string|array|null $gap_value Block gap value.
- * @return string|array|null Sanitized block gap value.
+ * Numeric zero is converted to a string because it is valid CSS without a unit.
+ * Other non-string values are rejected.
+ *
+ * @param mixed $gap_value Block gap value.
+ * @return string|string[]|null Sanitized block gap value.
  */
 function gutenberg_sanitize_block_gap_value( $gap_value ) {
 	if ( is_array( $gap_value ) ) {
 		foreach ( $gap_value as $key => $value ) {
-			$gap_value[ $key ] = ! is_scalar( $value ) || ( $value && preg_match( '%[\\\(&=}]|/\*%', (string) $value ) ) ? null : $value;
+			$sanitized_value = gutenberg_sanitize_block_gap_value( $value );
+			if ( ! is_string( $sanitized_value ) ) {
+				unset( $gap_value[ $key ] );
+				continue;
+			}
+			$gap_value[ $key ] = $sanitized_value;
 		}
-		return $gap_value;
+		return $gap_value ?: null;
+	}
+
+	if ( ( is_int( $gap_value ) || is_float( $gap_value ) ) && 0.0 === (float) $gap_value ) {
+		return '0';
+	}
+
+	if ( ! is_string( $gap_value ) ) {
+		return null;
+	}
+
+	if ( '' === trim( $gap_value ) ) {
+		return null;
 	}
 
 	return $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
@@ -461,18 +481,25 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 /**
  * Generates the CSS corresponding to the provided layout.
  *
- * @param string               $selector                      CSS selector.
- * @param array                $layout                        Layout object. The one that is passed has already checked
- *                                                            the existence of default block layout.
- * @param bool                 $has_block_gap_support         Optional. Whether the theme has support for the block gap. Default false.
- * @param string|string[]|null $gap_value                     Optional. The block gap value to apply. Default null.
- * @param bool                 $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the editor. Default false.
- * @param string|array         $fallback_gap_value            Optional. The block gap value to apply. If it's an array expected properties are "top" and/or "left". Default '0.5em'.
- * @param array|null           $block_spacing                 Optional. Custom spacing set on the block. Default null.
- * @param array                $options                       Optional. Extra options for internal callers. Default empty array.
+ * @param string                         $selector                      CSS selector.
+ * @param array                          $layout                        Layout object. The one that is passed has already checked
+ *                                                                       the existence of default block layout.
+ * @param bool                           $has_block_gap_support         Optional. Whether the theme has support for the block gap. Default false.
+ * @param string|string[]|int|float|null $gap_value                     Optional. The block gap value to apply. Only zero is accepted as a
+ *                                                                       numeric value. Default null.
+ * @param bool                           $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the
+ *                                                                       editor. Default false.
+ * @param string|string[]|int|float|null $fallback_gap_value            Optional. The fallback block gap value to apply. Only zero is accepted
+ *                                                                       as a numeric value. Default '0.5em'.
+ * @param array|null                     $block_spacing                 Optional. Custom spacing set on the block. Default null.
+ * @param array                          $options                       Optional. Extra options for internal callers. Default empty array.
  * @return string CSS styles, or empty string.
  */
 function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null, $options = array() ) {
+	// Normalize here as well as at external data boundaries because this function has direct callers.
+	$gap_value          = gutenberg_sanitize_block_gap_value( $gap_value );
+	$fallback_gap_value = gutenberg_sanitize_block_gap_value( $fallback_gap_value ) ?? '0.5em';
+
 	$base_layout             = is_array( $layout ) ? $layout : array();
 	$viewport_overrides      = $options['viewport_overrides'] ?? null;
 	$layout_for_styles       = null === $viewport_overrides ? $base_layout : array_replace( $base_layout, $viewport_overrides );
@@ -739,7 +766,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 			$gap_value = trim( $combined_gap_value );
 
-			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
+			if ( '' !== $gap_value && ! $should_skip_gap_serialization ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'gap' => $gap_value ),
@@ -1164,7 +1191,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		$gap_value = gutenberg_sanitize_block_gap_value( $block['attrs']['style']['spacing']['blockGap'] ?? null );
 
-		$fallback_gap_value = $block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? '0.5em';
+		$fallback_gap_value = gutenberg_sanitize_block_gap_value(
+			$block_type->supports['spacing']['blockGap']['__experimentalDefault'] ?? null
+		) ?? '0.5em';
 		$block_spacing      = $block['attrs']['style']['spacing'] ?? null;
 
 		/*
@@ -1198,7 +1227,19 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			}
 		}
 
-		$global_block_gap_value = $variation_block_gap_value ?? $global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? $global_styles['spacing']['blockGap'] ?? null;
+		$global_block_gap_candidates = array(
+			$variation_block_gap_value,
+			$global_styles['blocks'][ $block_name ]['spacing']['blockGap'] ?? null,
+			$global_styles['spacing']['blockGap'] ?? null,
+		);
+		$global_block_gap_value      = null;
+		foreach ( $global_block_gap_candidates as $candidate_gap_value ) {
+			$candidate_gap_value = gutenberg_sanitize_block_gap_value( $candidate_gap_value );
+			if ( null !== $candidate_gap_value ) {
+				$global_block_gap_value = $candidate_gap_value;
+				break;
+			}
+		}
 
 		if ( null !== $global_block_gap_value ) {
 			$fallback_gap_value = $global_block_gap_value;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -300,7 +300,7 @@ function gutenberg_sanitize_block_gap_value( $gap_value ) {
 			}
 			$gap_value[ $key ] = $sanitized_value;
 		}
-		return $gap_value ?: null;
+		return empty( $gap_value ) ? null : $gap_value;
 	}
 
 	if ( ( is_int( $gap_value ) || is_float( $gap_value ) ) && 0.0 === (float) $gap_value ) {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -437,7 +437,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout{gap:0.5em 2rem;}',
 			),
-			'flex layout ignores an empty block gap'        => array(
+			'flex layout ignores an empty block gap'       => array(
 				'args'            => array(
 					'selector'              => '.wp-layout',
 					'layout'                => array( 'type' => 'flex' ),

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -73,20 +73,37 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider data_sanitize_block_gap_value
+	 *
 	 * @covers ::gutenberg_sanitize_block_gap_value
 	 */
-	public function test_sanitize_block_gap_value_rejects_nested_array_values() {
-		$this->assertSame(
-			array(
-				'top'  => null,
-				'left' => '2rem',
-			),
-			gutenberg_sanitize_block_gap_value(
+	public function test_sanitize_block_gap_value_normalizes_zero_and_rejects_other_non_string_values( $gap_value, $expected ) {
+		$this->assertSame( $expected, gutenberg_sanitize_block_gap_value( $gap_value ) );
+	}
+
+	/**
+	 * Data provider for test_sanitize_block_gap_value_normalizes_zero_and_rejects_other_non_string_values().
+	 *
+	 * @return array[] Test data.
+	 */
+	public function data_sanitize_block_gap_value() {
+		return array(
+			'string value'           => array( '1rem', '1rem' ),
+			'empty string'           => array( '', null ),
+			'whitespace-only string' => array( " \t\n", null ),
+			'integer zero'           => array( 0, '0' ),
+			'floating-point zero'    => array( 0.0, '0' ),
+			'non-zero integer'       => array( 1, null ),
+			'boolean value'          => array( true, null ),
+			'object value'           => array( new stdClass(), null ),
+			'nested array value'     => array(
 				array(
 					'top'  => array( '1rem' ),
 					'left' => '2rem',
-				)
-			)
+				),
+				array( 'left' => '2rem' ),
+			),
+			'empty sanitized array'  => array( array( array( '1rem' ) ), null ),
 		);
 	}
 
@@ -407,6 +424,28 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;gap:11px var(--wp--preset--spacing--40);justify-content:flex-start;align-items:flex-end;}',
 			),
+			'flex layout uses the default for malformed gap values' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array( 'type' => 'flex' ),
+					'has_block_gap_support' => true,
+					'gap_value'             => array( 'left' => '2rem' ),
+					'fallback_gap_value'    => array(
+						'top'  => array( '1rem' ),
+						'left' => new stdClass(),
+					),
+				),
+				'expected_output' => '.wp-layout{gap:0.5em 2rem;}',
+			),
+			'flex layout ignores an empty block gap'        => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array( 'type' => 'flex' ),
+					'has_block_gap_support' => true,
+					'gap_value'             => '',
+				),
+				'expected_output' => '',
+			),
 			'vertical flex layout with properties'         => array(
 				'args'            => array(
 					'selector' => '.wp-layout',
@@ -428,6 +467,19 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					),
 				),
 				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
+			),
+			'grid layout uses the default for malformed gap values' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array( 'type' => 'grid' ),
+					'has_block_gap_support' => true,
+					'gap_value'             => array( 'left' => '2rem' ),
+					'fallback_gap_value'    => array(
+						'top'  => array( '1rem' ),
+						'left' => new stdClass(),
+					),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;gap:0.5em 2rem;}',
 			),
 			'grid layout with columnCount'                 => array(
 				'args'            => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #52099.

A little overdue cleanup to ensure block gap values are either strings or numeric zero (if gap is an array, the array should also have only those values). This will hopefully prevent PHP warnings or fatals from incorrect values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Check a few different blocks: Columns is a good one because it has axial support, and Group in its various layout types.
2. Set different block gap values on them: units like `px`, `vw`... and numeric `0` should all work correctly in the front end.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Used codex/gpt 5.6 sol