### PR TITLE
Media Editor: Add scale controls

### DIFF
--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-attachments-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-attachments-controller-7-1.php
@@ -5,6 +5,8 @@
  * @package gutenberg
  */
 
+require_once __DIR__ . '/../wordpress-7.2/class-gutenberg-rest-attachments-controller-7-2.php';
+
 /**
  * Controller which provides REST endpoint for retrieving attachments.
  * This overrides the core WP_REST_Attachments_Controller to provide
@@ -14,7 +16,7 @@
  *
  * @see WP_REST_Attachments_Controller
  */
-class Gutenberg_REST_Attachments_Controller_7_1 extends WP_REST_Attachments_Controller {
+class Gutenberg_REST_Attachments_Controller_7_1 extends Gutenberg_REST_Attachments_Controller_7_2 {
 
 	/**
 	 * Determines the allowed query_vars for a get_items() response and

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-attachments-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-attachments-controller-7-2.php
@@ -1,0 +1,404 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Attachments_Controller_7_2 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds a `resize` image modifier to the attachment `/edit` endpoint.
+ *
+ * Core's `edit_media_item()` understands three modifiers — `flip`, `rotate`
+ * and `crop`. There is no way to change the pixel dimensions of the saved
+ * image, which is what the classic Edit Image screen's "Scale Image" panel
+ * does. This class adds a fourth modifier that calls
+ * `WP_Image_Editor::resize()`.
+ *
+ * Core offers no hook inside the modifier loop, so `edit_media_item()` is
+ * copied here in full and one `case` is added to the switch. Requests that
+ * carry no `resize` modifier are handed straight back to core, so the copied
+ * body only runs for the new feature.
+ *
+ * Both of Gutenberg's attachment controllers extend this class, because which
+ * one serves the route depends on whether client-side media processing is
+ * enabled. See `lib/media/load.php` and `lib/compat/wordpress-7.1/rest-api.php`.
+ *
+ * @since 7.2.0
+ *
+ * @see WP_REST_Attachments_Controller
+ */
+class Gutenberg_REST_Attachments_Controller_7_2 extends WP_REST_Attachments_Controller {
+
+	/**
+	 * Applies edits to a media item and creates a new attachment record.
+	 *
+	 * Identical to the parent implementation apart from the `resize` case in
+	 * the modifier loop. Modifiers are applied in the order they arrive, so a
+	 * client that wants to scale before cropping sends `resize` first. Because
+	 * core expresses crop arguments as percentages, a preceding resize does not
+	 * change where a crop lands.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
+	 */
+	public function edit_media_item( $request ) {
+		// Nothing to add for the existing modifiers — let core handle it.
+		if ( ! $this->has_resize_modifier( $request ) ) {
+			return parent::edit_media_item( $request );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		$attachment_id = $request['id'];
+
+		// This also confirms the attachment is an image.
+		$image_file = wp_get_original_image_path( $attachment_id );
+		$image_meta = wp_get_attachment_metadata( $attachment_id );
+
+		if (
+			! $image_meta ||
+			! $image_file ||
+			! wp_image_file_matches_image_meta( $request['src'], $image_meta, $attachment_id )
+		) {
+			return new WP_Error(
+				'rest_unknown_attachment',
+				__( 'Unable to get meta information for file.' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$supported_types = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/heic' );
+		$mime_type       = get_post_mime_type( $attachment_id );
+		if ( ! in_array( $mime_type, $supported_types, true ) ) {
+			return new WP_Error(
+				'rest_cannot_edit_file_type',
+				__( 'This type of file cannot be edited.' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$modifiers = $request['modifiers'];
+
+		/*
+		 * If the file doesn't exist, attempt a URL fopen on the src link.
+		 * This can occur with certain file replication plugins.
+		 * Keep the original file path to get a modified name later.
+		 */
+		$image_file_to_edit = $image_file;
+		if ( ! file_exists( $image_file_to_edit ) ) {
+			$image_file_to_edit = _load_image_to_edit_path( $attachment_id );
+		}
+
+		$image_editor = wp_get_image_editor( $image_file_to_edit );
+
+		if ( is_wp_error( $image_editor ) ) {
+			return new WP_Error(
+				'rest_unknown_image_file_type',
+				__( 'Unable to edit this image.' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		// Apply any unapplied EXIF orientation so edits run in the upright frame the client previewed.
+		$image_editor->maybe_exif_rotate();
+
+		foreach ( $modifiers as $modifier ) {
+			$args = $modifier['args'];
+			switch ( $modifier['type'] ) {
+				case 'flip':
+					/*
+					 * Flips the current image.
+					 * The vertical flip is the first argument (flip along horizontal axis), the horizontal flip is the second argument (flip along vertical axis).
+					 * See: WP_Image_Editor::flip()
+					 */
+					$result = $image_editor->flip( $args['flip']['vertical'], $args['flip']['horizontal'] );
+					if ( is_wp_error( $result ) ) {
+						return new WP_Error(
+							'rest_image_flip_failed',
+							__( 'Unable to flip this image.' ),
+							array( 'status' => 500 )
+						);
+					}
+					break;
+				case 'rotate':
+					// Rotation direction: clockwise vs. counterclockwise.
+					$rotate = 0 - $args['angle'];
+
+					if ( 0 !== $rotate ) {
+						$result = $image_editor->rotate( $rotate );
+
+						if ( is_wp_error( $result ) ) {
+							return new WP_Error(
+								'rest_image_rotation_failed',
+								__( 'Unable to rotate this image.' ),
+								array( 'status' => 500 )
+							);
+						}
+					}
+
+					break;
+
+				case 'crop':
+					$size = $image_editor->get_size();
+
+					$crop_x = (int) round( ( $size['width'] * $args['left'] ) / 100.0 );
+					$crop_y = (int) round( ( $size['height'] * $args['top'] ) / 100.0 );
+					$width  = (int) round( ( $size['width'] * $args['width'] ) / 100.0 );
+					$height = (int) round( ( $size['height'] * $args['height'] ) / 100.0 );
+
+					if ( $size['width'] !== $width || $size['height'] !== $height ) {
+						$result = $image_editor->crop( $crop_x, $crop_y, $width, $height );
+
+						if ( is_wp_error( $result ) ) {
+							return new WP_Error(
+								'rest_image_crop_failed',
+								__( 'Unable to crop this image.' ),
+								array( 'status' => 500 )
+							);
+						}
+					}
+
+					break;
+
+				case 'resize':
+					$size = $image_editor->get_size();
+
+					$resize_width  = (int) $args['width'];
+					$resize_height = (int) $args['height'];
+
+					/*
+					 * Enlarging cannot add detail, so it is refused — the same
+					 * rule the classic Edit Image screen applies. The check runs
+					 * against the size at this point in the chain, which is the
+					 * upright original unless an earlier modifier already
+					 * changed it.
+					 */
+					if ( $resize_width > $size['width'] || $resize_height > $size['height'] ) {
+						return new WP_Error(
+							'rest_image_resize_too_large',
+							__( 'Images cannot be scaled to a size larger than the original.' ),
+							array( 'status' => 400 )
+						);
+					}
+
+					if ( $resize_width !== $size['width'] || $resize_height !== $size['height'] ) {
+						// `crop` is false, so this fits the image inside the
+						// box and keeps the source aspect ratio. Dimensions
+						// that don't match that ratio get the best fit rather
+						// than a stretched image.
+						$result = $image_editor->resize( $resize_width, $resize_height, false );
+
+						if ( is_wp_error( $result ) ) {
+							return new WP_Error(
+								'rest_image_resize_failed',
+								__( 'Unable to scale this image.' ),
+								array( 'status' => 500 )
+							);
+						}
+					}
+
+					break;
+
+			}
+		}
+
+		// Calculate the file name.
+		$image_ext  = pathinfo( $image_file, PATHINFO_EXTENSION );
+		$image_name = wp_basename( $image_file, ".{$image_ext}" );
+
+		/*
+		 * Do not append multiple `-edited` to the file name.
+		 * The user may be editing a previously edited image.
+		 */
+		if ( preg_match( '/-edited(-\d+)?$/', $image_name ) ) {
+			// Remove any `-1`, `-2`, etc. `wp_unique_filename()` will add the proper number.
+			$image_name = preg_replace( '/-edited(-\d+)?$/', '-edited', $image_name );
+		} else {
+			// Append `-edited` before the extension.
+			$image_name .= '-edited';
+		}
+
+		$filename = "{$image_name}.{$image_ext}";
+
+		// Create the uploads subdirectory if needed.
+		$uploads = wp_upload_dir();
+
+		// Make the file name unique in the (new) upload directory.
+		$filename = wp_unique_filename( $uploads['path'], $filename );
+
+		// Save to disk.
+		$saved = $image_editor->save( $uploads['path'] . "/$filename" );
+
+		if ( is_wp_error( $saved ) ) {
+			return $saved;
+		}
+
+		// Grab original attachment post so we can use it to set defaults.
+		$original_attachment_post = get_post( $attachment_id );
+
+		// Check request fields and assign default values.
+		$new_attachment_post                 = $this->prepare_item_for_database( $request );
+		$new_attachment_post->post_mime_type = $saved['mime-type'];
+		$new_attachment_post->guid           = $uploads['url'] . "/$filename";
+
+		// Unset ID so wp_insert_attachment generates a new ID.
+		unset( $new_attachment_post->ID );
+
+		// Set new attachment post title with fallbacks.
+		$new_attachment_post->post_title = $new_attachment_post->post_title ?? $original_attachment_post->post_title ?? $image_name;
+
+		// Set new attachment post caption (post_excerpt).
+		$new_attachment_post->post_excerpt = $new_attachment_post->post_excerpt ?? $original_attachment_post->post_excerpt ?? '';
+
+		// Set new attachment post description (post_content) with fallbacks.
+		$new_attachment_post->post_content = $new_attachment_post->post_content ?? $original_attachment_post->post_content ?? '';
+
+		// Set post parent if set in request, else the default of `0` (no parent).
+		$new_attachment_post->post_parent = $new_attachment_post->post_parent ?? 0;
+
+		// Insert the new attachment post.
+		$new_attachment_id = wp_insert_attachment( wp_slash( (array) $new_attachment_post ), $saved['path'], 0, true );
+
+		if ( is_wp_error( $new_attachment_id ) ) {
+			if ( 'db_update_error' === $new_attachment_id->get_error_code() ) {
+				$new_attachment_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$new_attachment_id->add_data( array( 'status' => 400 ) );
+			}
+
+			return $new_attachment_id;
+		}
+
+		// First, try to use the alt text from the request. If not set, copy the image alt text from the original attachment.
+		$image_alt = isset( $request['alt_text'] ) ? sanitize_text_field( $request['alt_text'] ) : get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		if ( ! empty( $image_alt ) ) {
+			// update_post_meta() expects slashed.
+			update_post_meta( $new_attachment_id, '_wp_attachment_image_alt', wp_slash( $image_alt ) );
+		}
+
+		if ( wp_is_serving_rest_request() ) {
+			/*
+			 * Set a custom header with the attachment_id.
+			 * Used by the browser/client to resume creating image sub-sizes after a PHP fatal error.
+			 */
+			header( 'X-WP-Upload-Attachment-ID: ' . $new_attachment_id );
+		}
+
+		// Generate image sub-sizes and meta.
+		$new_image_meta = wp_generate_attachment_metadata( $new_attachment_id, $saved['path'] );
+
+		// Copy the EXIF metadata from the original attachment if not generated for the edited image.
+		if ( isset( $image_meta['image_meta'] ) && isset( $new_image_meta['image_meta'] ) && is_array( $new_image_meta['image_meta'] ) ) {
+			// Merge but skip empty values.
+			foreach ( (array) $image_meta['image_meta'] as $key => $value ) {
+				if ( empty( $new_image_meta['image_meta'][ $key ] ) && ! empty( $value ) ) {
+					$new_image_meta['image_meta'][ $key ] = $value;
+				}
+			}
+		}
+
+		// Reset orientation. At this point the image is edited and orientation is correct.
+		if ( ! empty( $new_image_meta['image_meta']['orientation'] ) ) {
+			$new_image_meta['image_meta']['orientation'] = 1;
+		}
+
+		// The attachment_id may change if the site is exported and imported.
+		$new_image_meta['parent_image'] = array(
+			'attachment_id' => $attachment_id,
+			// Path to the originally uploaded image file relative to the uploads directory.
+			'file'          => _wp_relative_upload_path( $image_file ),
+		);
+
+		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php */
+		$new_image_meta = apply_filters( 'wp_edited_image_metadata', $new_image_meta, $new_attachment_id, $attachment_id );
+
+		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );
+
+		$response = $this->prepare_item_for_response( get_post( $new_attachment_id ), $request );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $new_attachment_id ) ) );
+
+		return $response;
+	}
+
+	/**
+	 * Reports whether the request carries a `resize` modifier.
+	 *
+	 * Only the `modifiers` array is inspected. The older top-level `rotation`,
+	 * `x`, `y`, `width` and `height` parameters have no resize equivalent, so a
+	 * request using that format always goes to core.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool Whether a `resize` modifier is present.
+	 */
+	private function has_resize_modifier( $request ) {
+		if ( ! isset( $request['modifiers'] ) || ! is_array( $request['modifiers'] ) ) {
+			return false;
+		}
+
+		foreach ( $request['modifiers'] as $modifier ) {
+			if ( isset( $modifier['type'] ) && 'resize' === $modifier['type'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retrieves the supported arguments for the `/edit` endpoint.
+	 *
+	 * Adds the `resize` modifier to the schema. Core validates `modifiers`
+	 * with a `oneOf` list, so an unknown type is rejected before the request
+	 * reaches `edit_media_item()`.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @return array Supported arguments.
+	 */
+	protected function get_edit_media_item_args() {
+		$args = parent::get_edit_media_item_args();
+
+		if ( ! isset( $args['modifiers']['items']['oneOf'] ) ) {
+			return $args;
+		}
+
+		$args['modifiers']['items']['oneOf'][] = array(
+			'title'      => __( 'Resize' ),
+			'properties' => array(
+				'type' => array(
+					'description' => __( 'Resize type.' ),
+					'type'        => 'string',
+					'enum'        => array( 'resize' ),
+				),
+				'args' => array(
+					'description' => __( 'Resize arguments.' ),
+					'type'        => 'object',
+					'required'    => array(
+						'width',
+						'height',
+					),
+					'properties'  => array(
+						'width'  => array(
+							'description' => __( 'New width in pixels. Cannot be larger than the current width.' ),
+							'type'        => 'integer',
+							'minimum'     => 1,
+						),
+						'height' => array(
+							'description' => __( 'New height in pixels. Cannot be larger than the current height.' ),
+							'type'        => 'integer',
+							'minimum'     => 1,
+						),
+					),
+				),
+			),
+		);
+
+		return $args;
+	}
+}

--- a/lib/media/class-gutenberg-rest-attachments-controller.php
+++ b/lib/media/class-gutenberg-rest-attachments-controller.php
@@ -5,13 +5,15 @@
  * @package gutenberg
  */
 
+require_once __DIR__ . '/../compat/wordpress-7.2/class-gutenberg-rest-attachments-controller-7-2.php';
+
 /**
  * REST API controller for media attachments.
  *
  * Extends the core attachments controller to add client-side media processing
  * functionality including sideload support and sub-size generation control.
  */
-class Gutenberg_REST_Attachments_Controller extends WP_REST_Attachments_Controller {
+class Gutenberg_REST_Attachments_Controller extends Gutenberg_REST_Attachments_Controller_7_2 {
 	/**
 	 * Image size token for the source-format original preserved alongside a
 	 * client-generated derivative (e.g. the HEIC file kept next to its JPEG).

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
 -   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play.
+-   Warn in the Crop panel when a scale value goes over the original dimensions, and add a Reset to original button.
 
 ### Bug Fixes
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Enhancements
 
--   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
--   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play.
--   Cap the Crop panel's scale fields at the original dimensions, and offer a Reset to original size link once the image has been scaled.
+-   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first ([#81461](https://github.com/WordPress/gutenberg/pull/81461)).
+-   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play ([#81461](https://github.com/WordPress/gutenberg/pull/81461)).
+-   Cap the Crop panel's scale fields at the original dimensions, and offer a Reset to original size link once the image has been scaled ([#81461](https://github.com/WordPress/gutenberg/pull/81461)).
 
 ### Bug Fixes
 
--   The undo shortcut now leaves the browser's own undo alone in any field you can type into, rather than only in fields outside a crop control region.
--   The crop handle tooltip now reports dimensions against the scaled image, matching the saved size shown in the Crop panel.
+-   The undo shortcut now leaves the browser's own undo alone in any field you can type into, rather than only in fields outside a crop control region ([#81461](https://github.com/WordPress/gutenberg/pull/81461)).
+-   The crop handle tooltip now reports dimensions against the scaled image, matching the saved size shown in the Crop panel ([#81461](https://github.com/WordPress/gutenberg/pull/81461)).
 
 ## 0.15.0 (2026-07-29)
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
+-   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play.
 
 ## 0.15.0 (2026-07-29)
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
 
 ## 0.15.0 (2026-07-29)
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
 -   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play.
--   Warn in the Crop panel when a scale value goes over the original dimensions, and add a Reset to original button.
+-   Cap the Crop panel's scale fields at the original dimensions, and add a Reset to original button.
 
 ### Bug Fixes
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -7,6 +7,11 @@
 -   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
 -   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play.
 
+### Bug Fixes
+
+-   The undo shortcut now leaves the browser's own undo alone in any field you can type into, rather than only in fields outside a crop control region.
+-   The crop handle tooltip now reports dimensions against the scaled image, matching the saved size shown in the Crop panel.
+
 ## 0.15.0 (2026-07-29)
 
 ## 0.14.0 (2026-07-14)

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Add `scaledSize` to the cropper state and a `setScaledSize` setter, for scaling the whole image down before a crop is taken. `buildModifiers` emits the matching `resize` modifier first.
 -   Add linked width and height fields to the Crop panel for scaling the image, with the resulting saved size shown when a crop is in play.
--   Cap the Crop panel's scale fields at the original dimensions, and add a Reset to original button.
+-   Cap the Crop panel's scale fields at the original dimensions, and offer a Reset to original size link once the image has been scaled.
 
 ### Bug Fixes
 

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -3,6 +3,7 @@ import { Stack, VisuallyHidden } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
 import MediaEditorImageControls from '../media-editor-image-controls';
+import MediaEditorScaleControl from '../media-editor-scale-control';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
 
 export interface MediaEditorCropPanelProps {
@@ -62,6 +63,7 @@ export default function MediaEditorCropPanel( {
 					value: preset.value.toString(),
 				} ) ) }
 			/>
+			<MediaEditorScaleControl />
 		</Stack>
 	);
 }

--- a/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
+++ b/packages/media-editor/src/components/media-editor-modal/build-modifiers.ts
@@ -26,7 +26,8 @@ export type Modifier =
 	| {
 			type: 'crop';
 			args: { left: number; top: number; width: number; height: number };
-	  };
+	  }
+	| { type: 'resize'; args: { width: number; height: number } };
 
 /**
  * Tolerance (percent) used to decide whether a crop rect is effectively
@@ -39,11 +40,12 @@ const CROP_TOLERANCE = 0.1;
 /**
  * Build a Core-compatible modifiers array from the cropper state.
  *
- * Emits `[flip, rotate, crop]` in that order. Identity operations are
- * pruned — an absent flip, a rotation that normalizes to 0°, and a crop
- * rect that covers (within tolerance) the full post-rotate AABB each
- * produce no modifier. An identity state (fresh image, no edits) returns
- * an empty array; callers can use that to skip the `/edit` call.
+ * Emits `[resize, flip, rotate, crop]` in that order. Identity operations
+ * are pruned — an unscaled image, an absent flip, a rotation that
+ * normalizes to 0°, and a crop rect that covers (within tolerance) the
+ * full post-rotate AABB each produce no modifier. An identity state
+ * (fresh image, no edits) returns an empty array; callers can use that to
+ * skip the `/edit` call.
  *
  * Frames and math:
  *
@@ -85,7 +87,20 @@ export function buildModifiers(
 		return modifiers;
 	}
 
-	const { cropRect, pan, zoom, flip } = state;
+	const { cropRect, pan, zoom, flip, scaledSize } = state;
+
+	// Resize goes first so the crop is taken from the scaled image, which
+	// is the order the sidebar's copy promises. The crop args below are
+	// percentages of the post-rotate bounding box, and scaling the source
+	// scales that box by the same factor, so none of the crop math below
+	// has to know a resize happened.
+	if ( scaledSize ) {
+		modifiers.push( {
+			type: 'resize',
+			args: { width: scaledSize.width, height: scaledSize.height },
+		} );
+	}
+
 	const hasFlipH = flip.horizontal;
 	const hasFlipV = flip.vertical;
 

--- a/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
+++ b/packages/media-editor/src/components/media-editor-modal/test/build-modifiers.test.ts
@@ -347,3 +347,62 @@ describe( 'buildModifiers ↔ Export-camera parity', () => {
 		expect( server.y ).toBeCloseTo( exported.y, 0 );
 	} );
 } );
+
+describe( 'buildModifiers — scaled images', () => {
+	const CROPPED = {
+		cropRect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+	};
+
+	it( 'emits no resize for an unscaled image', () => {
+		const modifiers = buildModifiers( makeState( CROPPED ), IMAGE );
+
+		expect(
+			modifiers.some( ( modifier ) => modifier.type === 'resize' )
+		).toBe( false );
+	} );
+
+	it( 'puts the resize first so the crop is taken from the scaled image', () => {
+		const modifiers = buildModifiers(
+			makeState( {
+				...CROPPED,
+				scaledSize: { width: 800, height: 450 },
+			} ),
+			IMAGE
+		);
+
+		expect( modifiers[ 0 ] ).toEqual( {
+			type: 'resize',
+			args: { width: 800, height: 450 },
+		} );
+		expect( modifiers[ modifiers.length - 1 ].type ).toBe( 'crop' );
+	} );
+
+	it( 'leaves the crop percentages unchanged when the image is scaled', () => {
+		// Crop args are percentages of the post-rotate bounding box, and a
+		// resize scales that box by the same factor, so the crop lands in
+		// the same place whether or not the image was scaled first.
+		const unscaled = buildModifiers( makeState( CROPPED ), IMAGE );
+		const scaled = buildModifiers(
+			makeState( {
+				...CROPPED,
+				scaledSize: { width: 800, height: 450 },
+			} ),
+			IMAGE
+		);
+
+		expect( scaled.filter( ( m ) => m.type === 'crop' ) ).toEqual(
+			unscaled.filter( ( m ) => m.type === 'crop' )
+		);
+	} );
+
+	it( 'emits a resize on its own when the image is only scaled', () => {
+		const modifiers = buildModifiers(
+			makeState( { scaledSize: { width: 800, height: 450 } } ),
+			IMAGE
+		);
+
+		expect( modifiers ).toEqual( [
+			{ type: 'resize', args: { width: 800, height: 450 } },
+		] );
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor-scale-control/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/index.tsx
@@ -189,21 +189,25 @@ export default function MediaEditorScaleControl() {
 					{ ...sharedFieldProps }
 				/>
 			</Stack>
-			<Button
-				className="media-editor-scale-control__reset"
-				variant="secondary"
-				size="compact"
-				disabled={ state.scaledSize === null }
-				accessibleWhenDisabled
-				onClick={ () => {
-					setDraft( null );
-					setScaledSize( null );
-				} }
-			>
-				{ __( 'Reset to original' ) }
-			</Button>
 			<Text variant="body-sm">
 				{ __( 'Scaling applies to the whole image, before any crop.' ) }
+				{ /* Only offered once there is a scale to undo, so the
+				     sentence reads plainly the rest of the time. */ }
+				{ state.scaledSize !== null && (
+					<>
+						{ ' ' }
+						<Button
+							className="media-editor-scale-control__reset"
+							variant="link"
+							onClick={ () => {
+								setDraft( null );
+								setScaledSize( null );
+							} }
+						>
+							{ __( 'Reset to original size' ) }
+						</Button>
+					</>
+				) }
 			</Text>
 			{ showSavedSize && (
 				<Text variant="body-sm">

--- a/packages/media-editor/src/components/media-editor-scale-control/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/index.tsx
@@ -5,7 +5,6 @@ import {
 import { Stack, Text } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useMediaEditor } from '../../state';
 import { getSourceRegion } from '../../image-editor';
@@ -37,10 +36,6 @@ interface ScaleDraft {
 export default function MediaEditorScaleControl() {
 	const { state, setScaledSize } = useMediaEditor();
 	const [ draft, setDraft ] = useState< ScaleDraft | null >( null );
-	const warningId = useInstanceId(
-		MediaEditorScaleControl,
-		'media-editor-scale-control__warning'
-	);
 
 	const image = state.image;
 	const naturalWidth = image?.naturalWidth ?? 0;
@@ -149,22 +144,17 @@ export default function MediaEditorScaleControl() {
 		height: String( committed.height ),
 	};
 
-	// Flagged while typing rather than on commit, so the message arrives on
-	// the keystroke that crosses the line instead of explaining a snap that
-	// already happened.
-	const exceedsOriginal =
-		parseInt( shown.width, 10 ) > naturalWidth ||
-		parseInt( shown.height, 10 ) > naturalHeight;
-
+	// `max` carries the "no scaling up" rule on its own. NumberControl only
+	// applies it on commit — Enter, blur, arrow keys and drag — never while
+	// typing, so a larger number can still be entered a digit at a time and
+	// snaps back when the field is left. It also caps the increment arrows
+	// and gives assistive tech the range for free.
 	// `spinControls` is left at its default of `native`. The `custom`
 	// variant renders real buttons, which take focus and blur the field, so
 	// every arrow click would commit the value from before the click.
 	const sharedFieldProps = {
 		step: 1,
-		// No min/max: the reducer is the single place that caps a request at
-		// the natural size and floors it, and clamping mid-keystroke would
-		// fight someone typing "1000" into a 640-wide image.
-		'aria-describedby': exceedsOriginal ? warningId : undefined,
+		min: 1,
 		onBlur: commit,
 		onKeyDown: handleKeyDown,
 	};
@@ -175,6 +165,7 @@ export default function MediaEditorScaleControl() {
 				<NumberControl
 					label={ __( 'Width' ) }
 					value={ shown.width }
+					max={ naturalWidth }
 					onChange={ ( next?: string ) =>
 						handleChange( 'width', next ?? '' )
 					}
@@ -183,6 +174,7 @@ export default function MediaEditorScaleControl() {
 				<NumberControl
 					label={ __( 'Height' ) }
 					value={ shown.height }
+					max={ naturalHeight }
 					onChange={ ( next?: string ) =>
 						handleChange( 'height', next ?? '' )
 					}
@@ -191,7 +183,7 @@ export default function MediaEditorScaleControl() {
 			</Stack>
 			<Button
 				variant="tertiary"
-				size="small"
+				size="compact"
 				disabled={ state.scaledSize === null }
 				accessibleWhenDisabled
 				onClick={ () => {
@@ -201,22 +193,6 @@ export default function MediaEditorScaleControl() {
 			>
 				{ __( 'Reset to original' ) }
 			</Button>
-			{ /* The live region is always mounted so the message is announced
-			     when it appears, rather than arriving with its container. */ }
-			<div role="status" id={ warningId }>
-				{ exceedsOriginal && (
-					<Text variant="body-sm">
-						{ sprintf(
-							/* translators: 1: original image width in pixels, 2: original image height in pixels. */
-							__(
-								'%1$d × %2$d is the original size. Anything larger scales back down.'
-							),
-							naturalWidth,
-							naturalHeight
-						) }
-					</Text>
-				) }
-			</div>
 			<Text variant="body-sm">
 				{ __( 'Scaling applies to the whole image, before any crop.' ) }
 			</Text>

--- a/packages/media-editor/src/components/media-editor-scale-control/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/index.tsx
@@ -1,0 +1,189 @@
+import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useMediaEditor } from '../../state';
+import { getSourceRegion } from '../../image-editor';
+
+/**
+ * The width and height being typed, before they are committed.
+ *
+ * Held locally so the fields stay put while someone edits them. Committing
+ * on every keystroke would push a history entry per character, and a
+ * half-typed width (`3` on the way to `320`) would scale the image to the
+ * minimum and then back out again.
+ */
+interface ScaleDraft {
+	width: string;
+	height: string;
+}
+
+/**
+ * Width and height fields for scaling the whole image before it is cropped.
+ *
+ * The two fields are linked: the image only scales as a whole, so editing one
+ * derives the other from the source's aspect ratio. Values commit on blur or
+ * Enter, producing a single undo entry per edit.
+ *
+ * The numbers are the size of the *image*, not of the file that gets saved.
+ * When a crop is in play the saved file is smaller, so the resulting size is
+ * spelled out underneath rather than left for the user to work out.
+ */
+export default function MediaEditorScaleControl() {
+	const { state, setScaledSize } = useMediaEditor();
+	const [ draft, setDraft ] = useState< ScaleDraft | null >( null );
+
+	const image = state.image;
+	const naturalWidth = image?.naturalWidth ?? 0;
+	const naturalHeight = image?.naturalHeight ?? 0;
+
+	// What the fields show when nobody is typing: the scaled size if one is
+	// set, otherwise the size the image came in at.
+	const committed = useMemo(
+		() =>
+			state.scaledSize ?? {
+				width: naturalWidth,
+				height: naturalHeight,
+			},
+		[ state.scaledSize, naturalWidth, naturalHeight ]
+	);
+
+	// The size the `/edit` request will actually produce: the crop applied to
+	// the scaled image. `getSourceRegion` scales linearly with the image size
+	// it is given, so passing the scaled size yields the saved dimensions.
+	const savedSize = useMemo( () => {
+		if ( ! image ) {
+			return null;
+		}
+		const region = getSourceRegion( state, committed );
+		return {
+			width: Math.round( region.width ),
+			height: Math.round( region.height ),
+		};
+	}, [ state, image, committed ] );
+
+	// Only worth showing when it differs from the size in the fields —
+	// otherwise it repeats the numbers directly above it.
+	const showSavedSize =
+		savedSize !== null &&
+		( savedSize.width !== committed.width ||
+			savedSize.height !== committed.height );
+
+	if ( ! image || naturalWidth <= 0 || naturalHeight <= 0 ) {
+		return null;
+	}
+
+	const handleChange = ( axis: 'width' | 'height', next: string ) => {
+		const current = draft ?? {
+			width: String( committed.width ),
+			height: String( committed.height ),
+		};
+		const parsed = parseInt( next, 10 );
+
+		// Leave the linked field alone until there's a number to derive it
+		// from, so clearing a field doesn't blank both.
+		if ( ! Number.isFinite( parsed ) || parsed <= 0 ) {
+			setDraft( { ...current, [ axis ]: next } );
+			return;
+		}
+
+		setDraft(
+			axis === 'width'
+				? {
+						width: next,
+						height: String(
+							Math.round(
+								( parsed * naturalHeight ) / naturalWidth
+							)
+						),
+				  }
+				: {
+						width: String(
+							Math.round(
+								( parsed * naturalWidth ) / naturalHeight
+							)
+						),
+						height: next,
+				  }
+		);
+	};
+
+	const commit = () => {
+		if ( ! draft ) {
+			return;
+		}
+		const width = parseInt( draft.width, 10 );
+		const height = parseInt( draft.height, 10 );
+
+		// An empty or nonsense entry reverts to the committed value rather
+		// than scaling to something the user didn't ask for.
+		if (
+			Number.isFinite( width ) &&
+			Number.isFinite( height ) &&
+			width > 0 &&
+			height > 0
+		) {
+			setScaledSize( { width, height } );
+		}
+		setDraft( null );
+	};
+
+	const handleKeyDown = ( event: ReactKeyboardEvent< HTMLInputElement > ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			commit();
+		}
+	};
+
+	const shown = draft ?? {
+		width: String( committed.width ),
+		height: String( committed.height ),
+	};
+
+	return (
+		<Stack direction="column" gap="xs">
+			<Stack direction="row" gap="sm">
+				{ /* No min/max here: the reducer is the single place that
+				     caps a request at the natural size and floors it, and
+				     clamping mid-keystroke would fight someone typing
+				     "1000" into a 640-wide image. */ }
+				<NumberControl
+					label={ __( 'Width' ) }
+					value={ shown.width }
+					step={ 1 }
+					spinControls="none"
+					onChange={ ( next?: string ) =>
+						handleChange( 'width', next ?? '' )
+					}
+					onBlur={ commit }
+					onKeyDown={ handleKeyDown }
+				/>
+				<NumberControl
+					label={ __( 'Height' ) }
+					value={ shown.height }
+					step={ 1 }
+					spinControls="none"
+					onChange={ ( next?: string ) =>
+						handleChange( 'height', next ?? '' )
+					}
+					onBlur={ commit }
+					onKeyDown={ handleKeyDown }
+				/>
+			</Stack>
+			<Text variant="body-sm">
+				{ __( 'Scaling applies to the whole image, before any crop.' ) }
+			</Text>
+			{ showSavedSize && (
+				<Text variant="body-sm">
+					{ sprintf(
+						/* translators: 1: image width in pixels, 2: image height in pixels. */
+						__( 'Saved size: %1$d × %2$d pixels.' ),
+						savedSize.width,
+						savedSize.height
+					) }
+				</Text>
+			) }
+		</Stack>
+	);
+}

--- a/packages/media-editor/src/components/media-editor-scale-control/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/index.tsx
@@ -160,8 +160,16 @@ export default function MediaEditorScaleControl() {
 	};
 
 	return (
-		<Stack direction="column" gap="xs">
-			<Stack direction="row" gap="sm">
+		<Stack
+			className="media-editor-scale-control"
+			direction="column"
+			gap="xs"
+		>
+			<Stack
+				className="media-editor-scale-control__fields"
+				direction="row"
+				gap="sm"
+			>
 				<NumberControl
 					label={ __( 'Width' ) }
 					value={ shown.width }
@@ -182,7 +190,8 @@ export default function MediaEditorScaleControl() {
 				/>
 			</Stack>
 			<Button
-				variant="tertiary"
+				className="media-editor-scale-control__reset"
+				variant="secondary"
 				size="compact"
 				disabled={ state.scaledSize === null }
 				accessibleWhenDisabled

--- a/packages/media-editor/src/components/media-editor-scale-control/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/index.tsx
@@ -1,7 +1,11 @@
-import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
+import {
+	Button,
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
 import { Stack, Text } from '@wordpress/ui';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useMediaEditor } from '../../state';
 import { getSourceRegion } from '../../image-editor';
@@ -33,6 +37,10 @@ interface ScaleDraft {
 export default function MediaEditorScaleControl() {
 	const { state, setScaledSize } = useMediaEditor();
 	const [ draft, setDraft ] = useState< ScaleDraft | null >( null );
+	const warningId = useInstanceId(
+		MediaEditorScaleControl,
+		'media-editor-scale-control__warning'
+	);
 
 	const image = state.image;
 	const naturalWidth = image?.naturalWidth ?? 0;
@@ -141,36 +149,74 @@ export default function MediaEditorScaleControl() {
 		height: String( committed.height ),
 	};
 
+	// Flagged while typing rather than on commit, so the message arrives on
+	// the keystroke that crosses the line instead of explaining a snap that
+	// already happened.
+	const exceedsOriginal =
+		parseInt( shown.width, 10 ) > naturalWidth ||
+		parseInt( shown.height, 10 ) > naturalHeight;
+
+	// `spinControls` is left at its default of `native`. The `custom`
+	// variant renders real buttons, which take focus and blur the field, so
+	// every arrow click would commit the value from before the click.
+	const sharedFieldProps = {
+		step: 1,
+		// No min/max: the reducer is the single place that caps a request at
+		// the natural size and floors it, and clamping mid-keystroke would
+		// fight someone typing "1000" into a 640-wide image.
+		'aria-describedby': exceedsOriginal ? warningId : undefined,
+		onBlur: commit,
+		onKeyDown: handleKeyDown,
+	};
+
 	return (
 		<Stack direction="column" gap="xs">
 			<Stack direction="row" gap="sm">
-				{ /* No min/max here: the reducer is the single place that
-				     caps a request at the natural size and floors it, and
-				     clamping mid-keystroke would fight someone typing
-				     "1000" into a 640-wide image. */ }
 				<NumberControl
 					label={ __( 'Width' ) }
 					value={ shown.width }
-					step={ 1 }
-					spinControls="none"
 					onChange={ ( next?: string ) =>
 						handleChange( 'width', next ?? '' )
 					}
-					onBlur={ commit }
-					onKeyDown={ handleKeyDown }
+					{ ...sharedFieldProps }
 				/>
 				<NumberControl
 					label={ __( 'Height' ) }
 					value={ shown.height }
-					step={ 1 }
-					spinControls="none"
 					onChange={ ( next?: string ) =>
 						handleChange( 'height', next ?? '' )
 					}
-					onBlur={ commit }
-					onKeyDown={ handleKeyDown }
+					{ ...sharedFieldProps }
 				/>
 			</Stack>
+			<Button
+				variant="tertiary"
+				size="small"
+				disabled={ state.scaledSize === null }
+				accessibleWhenDisabled
+				onClick={ () => {
+					setDraft( null );
+					setScaledSize( null );
+				} }
+			>
+				{ __( 'Reset to original' ) }
+			</Button>
+			{ /* The live region is always mounted so the message is announced
+			     when it appears, rather than arriving with its container. */ }
+			<div role="status" id={ warningId }>
+				{ exceedsOriginal && (
+					<Text variant="body-sm">
+						{ sprintf(
+							/* translators: 1: original image width in pixels, 2: original image height in pixels. */
+							__(
+								'%1$d × %2$d is the original size. Anything larger scales back down.'
+							),
+							naturalWidth,
+							naturalHeight
+						) }
+					</Text>
+				) }
+			</div>
 			<Text variant="body-sm">
 				{ __( 'Scaling applies to the whole image, before any crop.' ) }
 			</Text>

--- a/packages/media-editor/src/components/media-editor-scale-control/style.scss
+++ b/packages/media-editor/src/components/media-editor-scale-control/style.scss
@@ -1,0 +1,16 @@
+.media-editor-scale-control {
+	// Width and height carry equal weight, so they get equal room. The
+	// `0` basis makes the split independent of how many digits each value
+	// happens to have, and `min-width: 0` stops the inputs' intrinsic
+	// width from forcing one wider than the other in a narrow sidebar.
+	&__fields > * {
+		flex: 1 1 0;
+		min-width: 0;
+	}
+
+	// The column stack stretches its children, which would leave the reset
+	// spanning the whole sidebar.
+	&__reset {
+		align-self: flex-start;
+	}
+}

--- a/packages/media-editor/src/components/media-editor-scale-control/style.scss
+++ b/packages/media-editor/src/components/media-editor-scale-control/style.scss
@@ -8,9 +8,11 @@
 		min-width: 0;
 	}
 
-	// The column stack stretches its children, which would leave the reset
-	// spanning the whole sidebar.
+	// Sits inline at the end of the help sentence, so it takes the
+	// surrounding text's size rather than the Button default.
 	&__reset {
-		align-self: flex-start;
+		font-size: inherit;
+		line-height: inherit;
+		height: auto;
 	}
 }

--- a/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
@@ -35,8 +35,12 @@ function setupScaleControl( initialCropperState?: Partial< CropperState > ) {
 		width: screen.getByLabelText( 'Width' ) as HTMLInputElement,
 		height: screen.getByLabelText( 'Height' ) as HTMLInputElement,
 		undo: screen.getByRole( 'button', { name: 'undo' } ),
+		reset: screen.getByRole( 'button', { name: 'Reset to original' } ),
 	};
 }
+
+const OVER_ORIGINAL_WARNING =
+	'640 × 480 is the original size. Anything larger scales back down.';
 
 describe( 'MediaEditorScaleControl', () => {
 	it( 'renders nothing until an image is loaded', () => {
@@ -171,5 +175,121 @@ describe( 'MediaEditorScaleControl', () => {
 		expect(
 			screen.getByText( 'Saved size: 160 × 120 pixels.' )
 		).toBeInTheDocument();
+	} );
+	describe( 'when a value exceeds the original', () => {
+		it( 'warns while the value is still being typed', () => {
+			const { width } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '1280' } } );
+
+			expect(
+				screen.getByText( OVER_ORIGINAL_WARNING )
+			).toBeInTheDocument();
+		} );
+
+		it( 'stays quiet for a value within the original', () => {
+			const { width } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '320' } } );
+
+			expect(
+				screen.queryByText( OVER_ORIGINAL_WARNING )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'warns when the linked field is the one that overflows', () => {
+			const { height } = setupScaleControl();
+
+			// 481 is over the 480 height on its own.
+			fireEvent.change( height, { target: { value: '481' } } );
+
+			expect(
+				screen.getByText( OVER_ORIGINAL_WARNING )
+			).toBeInTheDocument();
+		} );
+
+		it( 'describes both fields with the warning for screen readers', () => {
+			const { width, height } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '1280' } } );
+
+			expect( width ).toHaveAccessibleDescription(
+				OVER_ORIGINAL_WARNING
+			);
+			expect( height ).toHaveAccessibleDescription(
+				OVER_ORIGINAL_WARNING
+			);
+		} );
+
+		it( 'clears the warning once the value is capped', () => {
+			const { width } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '1280' } } );
+			fireEvent.blur( width );
+
+			expect(
+				screen.queryByText( OVER_ORIGINAL_WARNING )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'reset to original', () => {
+		// The button stays focusable while unavailable (`accessibleWhenDisabled`)
+		// so it reports its state through `aria-disabled` rather than by
+		// dropping out of the tab order.
+		it( 'is unavailable when the image has not been scaled', () => {
+			const { reset } = setupScaleControl();
+
+			expect( reset ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'becomes available once the image is scaled', () => {
+			const { width, reset } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '320' } } );
+			fireEvent.blur( width );
+
+			expect( reset ).not.toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'puts the image back to its original size', () => {
+			const { width, height, reset } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '320' } } );
+			fireEvent.blur( width );
+
+			fireEvent.click( reset );
+
+			expect( width ).toHaveValue( 640 );
+			expect( height ).toHaveValue( 480 );
+			expect( reset ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'discards a value that was typed but not committed', () => {
+			const { width, height, reset } = setupScaleControl();
+
+			fireEvent.change( width, { target: { value: '320' } } );
+			fireEvent.blur( width );
+			fireEvent.change( width, { target: { value: '160' } } );
+
+			fireEvent.click( reset );
+
+			expect( width ).toHaveValue( 640 );
+			expect( height ).toHaveValue( 480 );
+		} );
+	} );
+
+	describe( 'increment arrows', () => {
+		it( 'offers native spin controls on both fields', () => {
+			const { width, height } = setupScaleControl();
+
+			// The `custom` variant would render Increment/Decrement buttons
+			// that steal focus from the field and commit on every click.
+			expect(
+				screen.queryByRole( 'button', { name: 'Increment' } )
+			).not.toBeInTheDocument();
+			expect( width ).toHaveAttribute( 'type', 'number' );
+			expect( height ).toHaveAttribute( 'type', 'number' );
+		} );
 	} );
 } );

--- a/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import MediaEditorScaleControl from '..';
+import { MediaEditorStateProvider, useMediaEditor } from '../../../state';
+import type { CropperState } from '../../../image-editor';
+
+const IMAGE = {
+	src: 'test.jpg',
+	naturalWidth: 640,
+	naturalHeight: 480,
+};
+
+/**
+ * Exposes undo so a test can check how many history entries an edit made.
+ */
+function UndoProbe() {
+	const { undo, hasUndo } = useMediaEditor();
+	return (
+		<button type="button" onClick={ undo } disabled={ ! hasUndo }>
+			undo
+		</button>
+	);
+}
+
+function setupScaleControl( initialCropperState?: Partial< CropperState > ) {
+	render(
+		<MediaEditorStateProvider
+			initialCropperState={ { image: IMAGE, ...initialCropperState } }
+		>
+			<MediaEditorScaleControl />
+			<UndoProbe />
+		</MediaEditorStateProvider>
+	);
+
+	return {
+		width: screen.getByLabelText( 'Width' ) as HTMLInputElement,
+		height: screen.getByLabelText( 'Height' ) as HTMLInputElement,
+		undo: screen.getByRole( 'button', { name: 'undo' } ),
+	};
+}
+
+describe( 'MediaEditorScaleControl', () => {
+	it( 'renders nothing until an image is loaded', () => {
+		render(
+			<MediaEditorStateProvider>
+				<MediaEditorScaleControl />
+			</MediaEditorStateProvider>
+		);
+
+		expect( screen.queryByLabelText( 'Width' ) ).not.toBeInTheDocument();
+	} );
+
+	it( "shows the image's natural size when nothing has been scaled", () => {
+		const { width, height } = setupScaleControl();
+
+		expect( width ).toHaveValue( 640 );
+		expect( height ).toHaveValue( 480 );
+	} );
+
+	it( 'fills in the height when a width is typed', () => {
+		const { width, height } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '320' } } );
+
+		expect( height ).toHaveValue( 240 );
+	} );
+
+	it( 'fills in the width when a height is typed', () => {
+		const { width, height } = setupScaleControl();
+
+		fireEvent.change( height, { target: { value: '240' } } );
+
+		expect( width ).toHaveValue( 320 );
+	} );
+
+	it( 'leaves the image alone until the field is left', () => {
+		const { width, undo } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '320' } } );
+
+		// Nothing committed yet, so there is nothing to undo.
+		expect( undo ).toBeDisabled();
+	} );
+
+	it( 'scales the image when the field is left', () => {
+		const { width, undo } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '320' } } );
+		fireEvent.blur( width );
+
+		expect( undo ).toBeEnabled();
+	} );
+
+	it( 'scales the image when Enter is pressed', () => {
+		const { width, undo } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '320' } } );
+		fireEvent.keyDown( width, { key: 'Enter' } );
+
+		expect( undo ).toBeEnabled();
+	} );
+
+	it( 'records one undo entry for one edit', () => {
+		const { width, height, undo } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '320' } } );
+		fireEvent.blur( width );
+
+		expect( width ).toHaveValue( 320 );
+
+		fireEvent.click( undo );
+
+		expect( width ).toHaveValue( 640 );
+		expect( height ).toHaveValue( 480 );
+		expect( undo ).toBeDisabled();
+	} );
+
+	it( 'caps a width larger than the image at its natural size', () => {
+		const { width, height } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '1280' } } );
+		fireEvent.blur( width );
+
+		expect( width ).toHaveValue( 640 );
+		expect( height ).toHaveValue( 480 );
+	} );
+
+	it( 'restores the previous size when the field is left empty', () => {
+		const { width, height } = setupScaleControl();
+
+		fireEvent.change( width, { target: { value: '' } } );
+		fireEvent.blur( width );
+
+		expect( width ).toHaveValue( 640 );
+		expect( height ).toHaveValue( 480 );
+	} );
+
+	it( 'says the scale applies to the whole image', () => {
+		setupScaleControl();
+
+		expect(
+			screen.getByText(
+				'Scaling applies to the whole image, before any crop.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not show a saved size when the whole image is kept', () => {
+		setupScaleControl();
+
+		expect( screen.queryByText( /Saved size/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the size the file will be saved at when a crop is in play', () => {
+		setupScaleControl( {
+			cropRect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+		} );
+
+		expect(
+			screen.getByText( 'Saved size: 320 × 240 pixels.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'reports the saved size against the scaled image, not the original', () => {
+		const { width } = setupScaleControl( {
+			cropRect: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+		} );
+
+		fireEvent.change( width, { target: { value: '320' } } );
+		fireEvent.blur( width );
+
+		expect(
+			screen.getByText( 'Saved size: 160 × 120 pixels.' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
@@ -39,9 +39,6 @@ function setupScaleControl( initialCropperState?: Partial< CropperState > ) {
 	};
 }
 
-const OVER_ORIGINAL_WARNING =
-	'640 × 480 is the original size. Anything larger scales back down.';
-
 describe( 'MediaEditorScaleControl', () => {
 	it( 'renders nothing until an image is loaded', () => {
 		render(
@@ -118,16 +115,6 @@ describe( 'MediaEditorScaleControl', () => {
 		expect( undo ).toBeDisabled();
 	} );
 
-	it( 'caps a width larger than the image at its natural size', () => {
-		const { width, height } = setupScaleControl();
-
-		fireEvent.change( width, { target: { value: '1280' } } );
-		fireEvent.blur( width );
-
-		expect( width ).toHaveValue( 640 );
-		expect( height ).toHaveValue( 480 );
-	} );
-
 	it( 'restores the previous size when the field is left empty', () => {
 		const { width, height } = setupScaleControl();
 
@@ -177,59 +164,31 @@ describe( 'MediaEditorScaleControl', () => {
 		).toBeInTheDocument();
 	} );
 	describe( 'when a value exceeds the original', () => {
-		it( 'warns while the value is still being typed', () => {
-			const { width } = setupScaleControl();
-
-			fireEvent.change( width, { target: { value: '1280' } } );
-
-			expect(
-				screen.getByText( OVER_ORIGINAL_WARNING )
-			).toBeInTheDocument();
-		} );
-
-		it( 'stays quiet for a value within the original', () => {
-			const { width } = setupScaleControl();
-
-			fireEvent.change( width, { target: { value: '320' } } );
-
-			expect(
-				screen.queryByText( OVER_ORIGINAL_WARNING )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'warns when the linked field is the one that overflows', () => {
-			const { height } = setupScaleControl();
-
-			// 481 is over the 480 height on its own.
-			fireEvent.change( height, { target: { value: '481' } } );
-
-			expect(
-				screen.getByText( OVER_ORIGINAL_WARNING )
-			).toBeInTheDocument();
-		} );
-
-		it( 'describes both fields with the warning for screen readers', () => {
+		it( 'caps each field at the original dimension', () => {
 			const { width, height } = setupScaleControl();
 
-			fireEvent.change( width, { target: { value: '1280' } } );
-
-			expect( width ).toHaveAccessibleDescription(
-				OVER_ORIGINAL_WARNING
-			);
-			expect( height ).toHaveAccessibleDescription(
-				OVER_ORIGINAL_WARNING
-			);
+			expect( width ).toHaveAttribute( 'max', '640' );
+			expect( height ).toHaveAttribute( 'max', '480' );
 		} );
 
-		it( 'clears the warning once the value is capped', () => {
+		it( 'still accepts a larger number being typed a digit at a time', () => {
 			const { width } = setupScaleControl();
+
+			// 1 and 12 are both under 640 on the way to 1280, so the field
+			// must not clamp mid-entry.
+			fireEvent.change( width, { target: { value: '1280' } } );
+
+			expect( width ).toHaveValue( 1280 );
+		} );
+
+		it( 'snaps back to the original once the field is left', () => {
+			const { width, height } = setupScaleControl();
 
 			fireEvent.change( width, { target: { value: '1280' } } );
 			fireEvent.blur( width );
 
-			expect(
-				screen.queryByText( OVER_ORIGINAL_WARNING )
-			).not.toBeInTheDocument();
+			expect( width ).toHaveValue( 640 );
+			expect( height ).toHaveValue( 480 );
 		} );
 	} );
 

--- a/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
+++ b/packages/media-editor/src/components/media-editor-scale-control/test/index.tsx
@@ -35,9 +35,11 @@ function setupScaleControl( initialCropperState?: Partial< CropperState > ) {
 		width: screen.getByLabelText( 'Width' ) as HTMLInputElement,
 		height: screen.getByLabelText( 'Height' ) as HTMLInputElement,
 		undo: screen.getByRole( 'button', { name: 'undo' } ),
-		reset: screen.getByRole( 'button', { name: 'Reset to original' } ),
 	};
 }
+
+const queryReset = () =>
+	screen.queryByRole( 'button', { name: 'Reset to original size' } );
 
 describe( 'MediaEditorScaleControl', () => {
 	it( 'renders nothing until an image is loaded', () => {
@@ -192,46 +194,46 @@ describe( 'MediaEditorScaleControl', () => {
 		} );
 	} );
 
-	describe( 'reset to original', () => {
-		// The button stays focusable while unavailable (`accessibleWhenDisabled`)
-		// so it reports its state through `aria-disabled` rather than by
-		// dropping out of the tab order.
-		it( 'is unavailable when the image has not been scaled', () => {
-			const { reset } = setupScaleControl();
+	describe( 'reset to original size', () => {
+		it( 'is not offered until the image is scaled', () => {
+			setupScaleControl();
 
-			expect( reset ).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( queryReset() ).not.toBeInTheDocument();
 		} );
 
-		it( 'becomes available once the image is scaled', () => {
-			const { width, reset } = setupScaleControl();
+		it( 'appears at the end of the help sentence once the image is scaled', () => {
+			const { width } = setupScaleControl();
 
 			fireEvent.change( width, { target: { value: '320' } } );
 			fireEvent.blur( width );
 
-			expect( reset ).not.toHaveAttribute( 'aria-disabled', 'true' );
+			expect( queryReset() ).toBeInTheDocument();
+			expect(
+				screen.getByText( /Scaling applies to the whole image/ )
+			).toContainElement( queryReset() );
 		} );
 
 		it( 'puts the image back to its original size', () => {
-			const { width, height, reset } = setupScaleControl();
+			const { width, height } = setupScaleControl();
 
 			fireEvent.change( width, { target: { value: '320' } } );
 			fireEvent.blur( width );
 
-			fireEvent.click( reset );
+			fireEvent.click( queryReset() as HTMLElement );
 
 			expect( width ).toHaveValue( 640 );
 			expect( height ).toHaveValue( 480 );
-			expect( reset ).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( queryReset() ).not.toBeInTheDocument();
 		} );
 
 		it( 'discards a value that was typed but not committed', () => {
-			const { width, height, reset } = setupScaleControl();
+			const { width, height } = setupScaleControl();
 
 			fireEvent.change( width, { target: { value: '320' } } );
 			fireEvent.blur( width );
 			fireEvent.change( width, { target: { value: '160' } } );
 
-			fireEvent.click( reset );
+			fireEvent.click( queryReset() as HTMLElement );
 
 			expect( width ).toHaveValue( 640 );
 			expect( height ).toHaveValue( 480 );

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -42,7 +42,7 @@ import MediaForm from '../media-form';
 import { getMediaTypeFromMimeType } from '../../utils';
 import { MediaEditorStateProvider, useMediaEditor } from '../../state';
 import type { AspectRatioPreset } from '../../image-editor/core/constants';
-import { CROP_CONTROL_ATTR } from '../../hooks/use-crop-gesture-handlers';
+import { isTextEntryField } from '../../hooks/use-crop-gesture-handlers';
 import MediaEditorKeyboardShortcutsModal from '../media-editor-keyboard-shortcuts-modal';
 import {
 	MEDIA_EDITOR_NOTICES_CONTEXT,
@@ -533,12 +533,7 @@ function MediaEditorContent( {
 			( ! isAppleOS() && isKeyboardEvent.primary( event, 'y' ) );
 		if ( ( isUndoShortcut || isRedoShortcut ) && isImage ) {
 			const target = event.target as HTMLElement;
-			const isMetadataField =
-				( target.tagName === 'INPUT' ||
-					target.tagName === 'TEXTAREA' ||
-					target.isContentEditable ) &&
-				! target.closest( `[${ CROP_CONTROL_ATTR }]` );
-			if ( ! isMetadataField ) {
+			if ( ! isTextEntryField( target ) ) {
 				event.preventDefault();
 				if ( isCropInteractionActive ) {
 					return;

--- a/packages/media-editor/src/hooks/test/use-crop-gesture-handlers.ts
+++ b/packages/media-editor/src/hooks/test/use-crop-gesture-handlers.ts
@@ -1,0 +1,59 @@
+import { isTextEntryField } from '../use-crop-gesture-handlers';
+
+function makeInput( type?: string ): HTMLElement {
+	const input = document.createElement( 'input' );
+	if ( type ) {
+		input.setAttribute( 'type', type );
+	}
+	return input;
+}
+
+describe( 'isTextEntryField', () => {
+	it( 'claims the shortcut for a text field', () => {
+		expect( isTextEntryField( makeInput( 'text' ) ) ).toBe( true );
+	} );
+
+	it( 'claims the shortcut for the scale fields', () => {
+		expect( isTextEntryField( makeInput( 'number' ) ) ).toBe( true );
+	} );
+
+	it( 'claims the shortcut for an input with no type, which defaults to text', () => {
+		expect( isTextEntryField( makeInput() ) ).toBe( true );
+	} );
+
+	it( 'claims the shortcut for a textarea', () => {
+		expect( isTextEntryField( document.createElement( 'textarea' ) ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'claims the shortcut for contenteditable content', () => {
+		const editable = document.createElement( 'div' );
+		// jsdom does not implement isContentEditable from the attribute.
+		Object.defineProperty( editable, 'isContentEditable', {
+			value: true,
+		} );
+
+		expect( isTextEntryField( editable ) ).toBe( true );
+	} );
+
+	it( 'leaves the shortcut to the image editor for the rotation slider', () => {
+		expect( isTextEntryField( makeInput( 'range' ) ) ).toBe( false );
+	} );
+
+	it( 'leaves the shortcut to the image editor for a checkbox', () => {
+		expect( isTextEntryField( makeInput( 'checkbox' ) ) ).toBe( false );
+	} );
+
+	it( 'leaves the shortcut to the image editor for the aspect ratio select', () => {
+		expect( isTextEntryField( document.createElement( 'select' ) ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'leaves the shortcut to the image editor for a button', () => {
+		expect( isTextEntryField( document.createElement( 'button' ) ) ).toBe(
+			false
+		);
+	} );
+} );

--- a/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
+++ b/packages/media-editor/src/hooks/use-crop-gesture-handlers.ts
@@ -2,12 +2,53 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useMediaEditor } from '../state';
 
 /**
- * Data attribute applied to crop control wrappers. The modal's keyboard
- * shortcut handler uses this to distinguish crop controls (where custom
- * undo/redo should fire) from metadata text fields (where the browser's
- * native undo should be preserved).
+ * Data attribute applied to crop control wrappers, marking the region a
+ * pointer or keyboard gesture belongs to so repeated input inside it
+ * coalesces into one history entry.
  */
 export const CROP_CONTROL_ATTR = 'data-crop-control';
+
+/**
+ * Input types the browser keeps its own undo stack for.
+ *
+ * A range slider is an `<input>` too, but there is no typed text to
+ * restore, so Ctrl/Cmd+Z on one should undo the image edit it drives.
+ */
+const TEXT_ENTRY_INPUT_TYPES = new Set( [
+	'email',
+	'number',
+	'password',
+	'search',
+	'tel',
+	'text',
+	'url',
+] );
+
+/**
+ * Whether Ctrl/Cmd+Z on this element means "undo my typing".
+ *
+ * The editor's undo shortcut moves through the image edit history, which
+ * is right everywhere except a field someone is typing into — there, the
+ * browser's own undo has to win, or a keystroke correction silently
+ * reverts a crop instead.
+ *
+ * Being inside a crop control region makes no difference: the Crop
+ * panel's scale fields are text entry and sit inside one, while the fine
+ * rotation slider is not text entry and also sits inside one. The
+ * element decides, not where it lives.
+ *
+ * @param target The element the key event fired on.
+ * @return Whether the browser's undo should handle the shortcut.
+ */
+export function isTextEntryField( target: HTMLElement ): boolean {
+	if ( target.isContentEditable || target.tagName === 'TEXTAREA' ) {
+		return true;
+	}
+	return (
+		target.tagName === 'INPUT' &&
+		TEXT_ENTRY_INPUT_TYPES.has( ( target as HTMLInputElement ).type )
+	);
+}
 
 /** Idle window used to group repeated keyboard input into one gesture. */
 const KEYBOARD_GESTURE_IDLE_MS = 300;

--- a/packages/media-editor/src/image-editor/core/constants.ts
+++ b/packages/media-editor/src/image-editor/core/constants.ts
@@ -24,6 +24,14 @@ export const MAX_ZOOM = 10;
 export const MIN_CROP_PIXELS = 16;
 
 /**
+ * Smallest dimension, in pixels, the whole image can be scaled down to.
+ * Keeps a typed-in value from collapsing the image to nothing, which would
+ * leave a subsequent crop with no pixels to take. Separate from
+ * `MIN_CROP_PIXELS`, which floors the crop rectangle during a handle drag.
+ */
+export const MIN_SCALED_PIXELS = 16;
+
+/**
  * Minimum on-screen crop rect dimension in CSS pixels. The source-pixel
  * floor (`MIN_CROP_PIXELS`) keeps crops from going sub-pixel, but on a large
  * image fit into a small canvas it can render only a few CSS pixels wide —
@@ -101,6 +109,7 @@ export const DEFAULT_STATE: CropperState = {
 	baseRotation: 0,
 	flip: { ...DEFAULT_FLIP },
 	cropRect: { ...DEFAULT_CROP_RECT },
+	scaledSize: null,
 };
 
 /**

--- a/packages/media-editor/src/image-editor/core/state.ts
+++ b/packages/media-editor/src/image-editor/core/state.ts
@@ -1,8 +1,14 @@
-import type { CropperAction, CropperState, TransformOperation } from './types';
+import type {
+	CropperAction,
+	CropperState,
+	Size,
+	TransformOperation,
+} from './types';
 import {
 	ABSOLUTE_MIN_ZOOM,
 	DEFAULT_STATE,
 	MAX_ZOOM,
+	MIN_SCALED_PIXELS,
 	MIN_ZOOM,
 } from './constants';
 import { normalizeRotation, degreesToRadians } from './math/rotation';
@@ -45,8 +51,66 @@ export function areCropperStatesEqual(
 		nearlyEqual( a.cropRect.x, b.cropRect.x ) &&
 		nearlyEqual( a.cropRect.y, b.cropRect.y ) &&
 		nearlyEqual( a.cropRect.width, b.cropRect.width ) &&
-		nearlyEqual( a.cropRect.height, b.cropRect.height )
+		nearlyEqual( a.cropRect.height, b.cropRect.height ) &&
+		a.scaledSize?.width === b.scaledSize?.width &&
+		a.scaledSize?.height === b.scaledSize?.height
 	);
+}
+
+/**
+ * Resolve a requested scaled size against the image it applies to.
+ *
+ * The request is treated as a target box rather than exact dimensions. The
+ * tighter of the two axes decides a single factor, which is applied to both,
+ * so the stored size always sits on the source's aspect ratio — scaling that
+ * changed the ratio would be distortion, not scaling.
+ *
+ * The factor is capped at 1 because enlarging cannot add detail, and floored
+ * so neither axis collapses. A request that resolves back to the natural size
+ * returns `null`, the same value as "never scaled", so history and dirty
+ * checks see no change.
+ *
+ * @param requested Requested size, or `null` to clear the scale.
+ * @param image     The loaded source image.
+ * @return The size to store, or `null` for no scaling.
+ */
+function resolveScaledSize(
+	requested: Size | null,
+	image: CropperState[ 'image' ]
+): Size | null {
+	if ( ! requested || ! image ) {
+		return null;
+	}
+
+	const { naturalWidth, naturalHeight } = image;
+	if ( naturalWidth <= 0 || naturalHeight <= 0 ) {
+		return null;
+	}
+
+	const requestedFactor = Math.min(
+		requested.width / naturalWidth,
+		requested.height / naturalHeight
+	);
+
+	// Never below the point where either axis would round away.
+	const minFactor = Math.min(
+		1,
+		Math.max(
+			MIN_SCALED_PIXELS / naturalWidth,
+			MIN_SCALED_PIXELS / naturalHeight
+		)
+	);
+
+	const factor = Math.min( 1, Math.max( minFactor, requestedFactor ) );
+
+	const width = Math.max( 1, Math.round( naturalWidth * factor ) );
+	const height = Math.max( 1, Math.round( naturalHeight * factor ) );
+
+	if ( width === naturalWidth && height === naturalHeight ) {
+		return null;
+	}
+
+	return { width, height };
 }
 
 function clampRequestedZoom( state: CropperState, zoom: number ): number {
@@ -226,6 +290,9 @@ export function cropperReducer(
 				enforceContainment( {
 					...state,
 					image: action.payload,
+					// A scaled size belongs to the image it was measured
+					// against, so a new image starts unscaled.
+					scaledSize: null,
 				} )
 			);
 
@@ -381,6 +448,19 @@ export function cropperReducer(
 				} )
 			);
 
+		case 'SET_SCALED_SIZE': {
+			const scaledSize = resolveScaledSize( action.payload, state.image );
+			if (
+				scaledSize?.width === state.scaledSize?.width &&
+				scaledSize?.height === state.scaledSize?.height
+			) {
+				return state;
+			}
+			// No containment pass: the camera works in normalized
+			// fractions, so the source's pixel size doesn't move it.
+			return { ...state, scaledSize };
+		}
+
 		case 'SETTLE_CROP': {
 			// After a resize drag ends: expand the crop to fill the
 			// available height (maintaining its aspect ratio), center it,
@@ -479,6 +559,8 @@ export function isStateDirty(
 		! nearlyEqual( current.cropRect.x, initial.cropRect.x ) ||
 		! nearlyEqual( current.cropRect.y, initial.cropRect.y ) ||
 		! nearlyEqual( current.cropRect.width, initial.cropRect.width ) ||
-		! nearlyEqual( current.cropRect.height, initial.cropRect.height )
+		! nearlyEqual( current.cropRect.height, initial.cropRect.height ) ||
+		current.scaledSize?.width !== initial.scaledSize?.width ||
+		current.scaledSize?.height !== initial.scaledSize?.height
 	);
 }

--- a/packages/media-editor/src/image-editor/core/test/state.ts
+++ b/packages/media-editor/src/image-editor/core/test/state.ts
@@ -1,6 +1,16 @@
 import type { CropperState, Size } from '../types';
-import { ABSOLUTE_MIN_ZOOM, DEFAULT_STATE, MAX_ZOOM } from '../constants';
-import { cropperReducer, enforceContainment, isStateDirty } from '../state';
+import {
+	ABSOLUTE_MIN_ZOOM,
+	DEFAULT_STATE,
+	MAX_ZOOM,
+	MIN_SCALED_PIXELS,
+} from '../constants';
+import {
+	areCropperStatesEqual,
+	cropperReducer,
+	enforceContainment,
+	isStateDirty,
+} from '../state';
 import {
 	createCamera,
 	screenToWorld,
@@ -871,5 +881,133 @@ describe( 'cropperReducer — SET_ROTATION', () => {
 		expect( result.pan.x ).toBeCloseTo( state.pan.x, 5 );
 		expect( result.pan.y ).toBeCloseTo( state.pan.y, 5 );
 		expect( result.zoom ).toBeCloseTo( state.zoom, 5 );
+	} );
+} );
+
+describe( 'cropperReducer — SET_SCALED_SIZE', () => {
+	it( 'scales the image to the requested size', () => {
+		const result = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 800, height: 450 },
+		} );
+
+		expect( result.scaledSize ).toEqual( { width: 800, height: 450 } );
+	} );
+
+	it( 'keeps the source aspect ratio when the requested size does not match it', () => {
+		// 800 is half the width; 900 is the full height. The tighter axis
+		// wins, so both are halved rather than the image being stretched.
+		const result = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 800, height: 900 },
+		} );
+
+		expect( result.scaledSize ).toEqual( { width: 800, height: 450 } );
+	} );
+
+	it( 'refuses to scale above the natural size', () => {
+		const result = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 3200, height: 1800 },
+		} );
+
+		expect( result.scaledSize ).toBeNull();
+	} );
+
+	it( 'records no scale when the requested size is the natural size', () => {
+		const result = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: IMAGE.width, height: IMAGE.height },
+		} );
+
+		expect( result.scaledSize ).toBeNull();
+	} );
+
+	it( 'clears the scale when set to null', () => {
+		const scaled = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 800, height: 450 },
+		} );
+
+		const cleared = cropperReducer( scaled, {
+			type: 'SET_SCALED_SIZE',
+			payload: null,
+		} );
+
+		expect( cleared.scaledSize ).toBeNull();
+	} );
+
+	it( 'keeps the shorter axis above the minimum', () => {
+		const result = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 1, height: 1 },
+		} );
+
+		expect( result.scaledSize?.height ).toBe( MIN_SCALED_PIXELS );
+		expect( result.scaledSize?.width ).toBe( 28 );
+	} );
+
+	it( 'leaves the camera and crop rect untouched', () => {
+		const state = makeState( {
+			zoom: 1.5,
+			rotation: 12,
+			pan: { x: 0.05, y: -0.03 },
+			cropRect: { x: 0.2, y: 0.1, width: 0.5, height: 0.4 },
+		} );
+
+		const result = cropperReducer( state, {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 800, height: 450 },
+		} );
+
+		expect( result.zoom ).toBe( state.zoom );
+		expect( result.rotation ).toBe( state.rotation );
+		expect( result.pan ).toEqual( state.pan );
+		expect( result.cropRect ).toEqual( state.cropRect );
+	} );
+
+	it( 'returns the same reference when the scale does not change', () => {
+		const state = makeState();
+
+		expect(
+			cropperReducer( state, {
+				type: 'SET_SCALED_SIZE',
+				payload: null,
+			} )
+		).toBe( state );
+	} );
+
+	it( 'starts unscaled when a new image is loaded', () => {
+		const scaled = cropperReducer( makeState(), {
+			type: 'SET_SCALED_SIZE',
+			payload: { width: 800, height: 450 },
+		} );
+
+		const result = cropperReducer( scaled, {
+			type: 'SET_IMAGE',
+			payload: {
+				src: 'other.jpg',
+				naturalWidth: 400,
+				naturalHeight: 300,
+			},
+		} );
+
+		expect( result.scaledSize ).toBeNull();
+	} );
+} );
+
+describe( 'scaled size and change detection', () => {
+	const unscaled = makeState();
+	const scaled = cropperReducer( unscaled, {
+		type: 'SET_SCALED_SIZE',
+		payload: { width: 800, height: 450 },
+	} );
+
+	it( 'counts a scaled image as dirty', () => {
+		expect( isStateDirty( scaled, unscaled ) ).toBe( true );
+	} );
+
+	it( 'does not treat a scaled image as equal to an unscaled one', () => {
+		expect( areCropperStatesEqual( scaled, unscaled ) ).toBe( false );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/core/types.ts
+++ b/packages/media-editor/src/image-editor/core/types.ts
@@ -102,6 +102,22 @@ export interface CropperState {
 	flip: Flip;
 	/** The crop rectangle in normalized coordinates. */
 	cropRect: NormalizedRect;
+	/**
+	 * Pixel size the whole source image is scaled to before any crop is
+	 * taken. `null` means no scaling — the image keeps its natural size.
+	 *
+	 * Always on the source's aspect ratio and never larger than the
+	 * natural size; `SET_SCALED_SIZE` enforces both.
+	 *
+	 * This is the size of the *whole image*, not of the saved file. With
+	 * a crop in play the saved file is smaller: scaling a 640x480 image
+	 * to 320x240 and then cropping half of it saves a 160x120 file.
+	 *
+	 * Independent of the camera. `pan`, `zoom` and `cropRect` are all
+	 * normalized fractions, so scaling the source doesn't move them and
+	 * containment has nothing to re-check.
+	 */
+	scaledSize: Size | null;
 }
 
 /**
@@ -136,6 +152,13 @@ export type CropperAction =
 	| { type: 'SET_FLIP'; payload: Flip }
 	/** Sets the crop rectangle. */
 	| { type: 'SET_CROP_RECT'; payload: NormalizedRect }
+	/**
+	 * Sets the pixel size the whole image is scaled to before cropping.
+	 * `null` clears the scale. The payload is a request, not the stored
+	 * value: it is rounded onto the source's aspect ratio, capped at the
+	 * natural size, and floored so neither axis collapses.
+	 */
+	| { type: 'SET_SCALED_SIZE'; payload: Size | null }
 	/** Settle animation after resize drag, recentering the crop rect. */
 	| { type: 'SETTLE_CROP' }
 	/** Applies a single pipeline transform via the reducer. */

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -776,10 +776,16 @@ function CropperInner(
 		if ( ! showDimensions || ! activeHandle || ! state.image ) {
 			return null;
 		}
-		const region = getSourceRegion( state, {
-			width: state.image.naturalWidth,
-			height: state.image.naturalHeight,
-		} );
+		// Measured against the scaled size when one is set, so the tooltip
+		// reports the size the file will be saved at rather than the size
+		// of an intermediate the user never receives.
+		const region = getSourceRegion(
+			state,
+			state.scaledSize ?? {
+				width: state.image.naturalWidth,
+				height: state.image.naturalHeight,
+			}
+		);
 		return { width: region.width, height: region.height };
 	}, [ showDimensions, activeHandle, state ] );
 

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.tsx
@@ -15,7 +15,9 @@ const GRID_INTERACTIVE_CLASS =
 	'wp-media-editor-image-editor__canvas--grid-interactive';
 const SHOW_GRID_CLASS = 'wp-media-editor-image-editor__canvas--show-grid';
 
-function createController(): CropperController {
+function createController(
+	stateOverrides: Partial< CropperController[ 'state' ] > = {}
+): CropperController {
 	return {
 		state: {
 			...DEFAULT_STATE,
@@ -24,7 +26,9 @@ function createController(): CropperController {
 				naturalWidth: 600,
 				naturalHeight: 400,
 			},
+			...stateOverrides,
 		},
+		setScaledSize: jest.fn(),
 		setImage: jest.fn(),
 		setPan: jest.fn(),
 		setZoom: jest.fn(),
@@ -1143,5 +1147,65 @@ describe( 'Cropper', () => {
 		render( <Cropper src="tall.jpg" controller={ controller } /> );
 
 		expect( imageRendering() ).not.toBe( 'pixelated' );
+	} );
+	describe( 'dimensions tooltip', () => {
+		/**
+		 * Render, grab a resize handle to make the tooltip appear, and read
+		 * the pixel dimensions out of it.
+		 *
+		 * @param controller Controller whose state drives the tooltip.
+		 */
+		async function readTooltipDimensions(
+			controller: CropperController
+		): Promise< { width: number; height: number; unmount: () => void } > {
+			const { unmount } = render(
+				<Cropper
+					src="test.jpg"
+					controller={ controller }
+					freeformCrop
+				/>
+			);
+
+			const handle = await screen.findByRole( 'button', {
+				name: 'Resize from top-left corner',
+			} );
+			fireEvent.pointerDown( handle, {
+				button: 0,
+				clientX: 0,
+				clientY: 0,
+				pointerId: 1,
+			} );
+
+			const tooltip = screen.getByTestId( 'cropper-dimensions-tooltip' );
+			const [ width, height ] = ( tooltip.textContent ?? '' )
+				.match( /\d+/g )!
+				.map( Number );
+
+			fireEvent.pointerUp( handle, { pointerId: 1 } );
+
+			return { width, height, unmount };
+		}
+
+		it( 'reports the crop against the scaled image, not the original', async () => {
+			const cropRect = { x: 0.25, y: 0.25, width: 0.5, height: 0.5 };
+
+			const unscaled = await readTooltipDimensions(
+				createController( { cropRect } )
+			);
+			unscaled.unmount();
+
+			// Half the source in each direction, so the same crop should
+			// report half the pixels.
+			const scaled = await readTooltipDimensions(
+				createController( {
+					cropRect,
+					scaledSize: { width: 300, height: 200 },
+				} )
+			);
+			scaled.unmount();
+
+			expect( scaled.width ).toBeCloseTo( unscaled.width / 2, 0 );
+			expect( scaled.height ).toBeCloseTo( unscaled.height / 2, 0 );
+		} );
 	} );
 } );

--- a/packages/media-editor/src/image-editor/react/hooks/build-cropper-setters.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/build-cropper-setters.ts
@@ -4,6 +4,7 @@ import type {
 	Flip,
 	NormalizedPoint,
 	NormalizedRect,
+	Size,
 	TransformOperation,
 } from '../../core/types';
 import { buildFocalPointZoomAction } from '../../core/setter-helpers';
@@ -28,6 +29,13 @@ export interface CropperSetters {
 	setCropRect: ( rect: NormalizedRect ) => void;
 	settleCrop: () => void;
 	applyOperation: ( op: TransformOperation ) => void;
+	/**
+	 * Scale the whole image to a pixel size before any crop is taken.
+	 * Pass `null` to go back to the natural size. The request is
+	 * resolved onto the source's aspect ratio and capped there — see
+	 * `SET_SCALED_SIZE`.
+	 */
+	setScaledSize: ( size: Size | null ) => void;
 }
 
 /**
@@ -97,6 +105,11 @@ export function buildCropperSetters(
 			dispatchCropperAction( {
 				type: 'APPLY_OPERATION',
 				payload: op,
+			} ),
+		setScaledSize: ( size ) =>
+			dispatchCropperAction( {
+				type: 'SET_SCALED_SIZE',
+				payload: size,
 			} ),
 	};
 }

--- a/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-reducer.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/test/use-cropper-reducer.ts
@@ -1017,6 +1017,9 @@ describe( 'useCropperReducer', () => {
 				'flip.vertical',
 				'rotation',
 				'zoom',
+				// Defaults to null, so it flattens to the bare key.
+				// `isStateDirty` compares its width and height.
+				'scaledSize',
 			].sort();
 
 			// 'image' is intentionally excluded — it's set once on load

--- a/packages/media-editor/src/style.scss
+++ b/packages/media-editor/src/style.scss
@@ -8,3 +8,4 @@
 @use "./components/media-editor-image-controls/style.scss" as *;
 @use "./components/media-editor-keyboard-shortcuts-modal/style.scss" as *;
 @use "./components/rotation-ruler/style.scss" as *;
+@use "./components/media-editor-scale-control/style.scss" as *;

--- a/phpunit/media/class-gutenberg-rest-attachments-controller-7-2-test.php
+++ b/phpunit/media/class-gutenberg-rest-attachments-controller-7-2-test.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Tests for the `resize` image modifier added by
+ * Gutenberg_REST_Attachments_Controller_7_2.
+ *
+ * These run real image processing rather than a mock editor, so they assert
+ * the dimensions actually written to disk and recorded in the new
+ * attachment's metadata.
+ *
+ * @coversDefaultClass \Gutenberg_REST_Attachments_Controller_7_2
+ */
+class Gutenberg_REST_Attachments_Controller_7_2_Test extends WP_Test_REST_TestCase {
+
+	/**
+	 * Administrator ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Source image. 640x480.
+	 *
+	 * @var string
+	 */
+	protected static $test_file;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$test_file = DIR_TESTDATA . '/images/canola.jpg';
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		$this->remove_added_uploads();
+		parent::tear_down();
+	}
+
+	/**
+	 * Posts modifiers to the `/edit` route for a freshly uploaded image.
+	 *
+	 * @param array $modifiers Modifiers to send.
+	 * @return WP_REST_Response|WP_Error The response.
+	 */
+	private function edit_test_image( $modifiers ) {
+		$attachment_id = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/edit" );
+		$request->set_body_params(
+			array(
+				'src'       => wp_get_attachment_image_url( $attachment_id, 'full' ),
+				'modifiers' => $modifiers,
+			)
+		);
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * Reads the width and height recorded for an edited attachment.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return array{0:int,1:int} Width and height.
+	 */
+	private function get_saved_dimensions( $attachment_id ) {
+		$meta = wp_get_attachment_metadata( $attachment_id );
+		return array( (int) $meta['width'], (int) $meta['height'] );
+	}
+
+	/**
+	 * The controller Gutenberg registers for the media route must inherit the
+	 * `resize` support, otherwise the modifier is silently unavailable.
+	 *
+	 * @covers ::edit_media_item
+	 */
+	public function test_registered_attachments_controller_supports_resize() {
+		$post_type = get_post_type_object( 'attachment' );
+
+		$this->assertTrue(
+			is_a( $post_type->rest_controller_class, 'Gutenberg_REST_Attachments_Controller_7_2', true ),
+			'The controller serving /wp/v2/media does not extend the 7.2 controller.'
+		);
+	}
+
+	/**
+	 * @covers ::edit_media_item
+	 */
+	public function test_resize_scales_the_saved_image_down() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'resize',
+					'args' => array(
+						'width'  => 320,
+						'height' => 240,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$this->assertSame(
+			array( 320, 240 ),
+			$this->get_saved_dimensions( $response->get_data()['id'] )
+		);
+	}
+
+	/**
+	 * A resize is an edit in its own right, so it must produce a new
+	 * attachment rather than being pruned as a no-op.
+	 *
+	 * @covers ::edit_media_item
+	 */
+	public function test_resize_alone_creates_a_new_attachment() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'resize',
+					'args' => array(
+						'width'  => 200,
+						'height' => 150,
+					),
+				),
+			)
+		);
+
+		$data = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertNotEmpty( $data['id'] );
+		$this->assertStringContainsString( '-edited', $data['media_details']['file'] );
+	}
+
+	/**
+	 * Enlarging cannot add detail, so it is refused. Matches the rule the
+	 * classic Edit Image screen applies.
+	 *
+	 * @covers ::edit_media_item
+	 */
+	public function test_resize_larger_than_the_source_is_rejected() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'resize',
+					'args' => array(
+						'width'  => 1280,
+						'height' => 960,
+					),
+				),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_image_resize_too_large', $response, 400 );
+	}
+
+	/**
+	 * Only one side needs to exceed the source for the request to be refused.
+	 *
+	 * @covers ::edit_media_item
+	 */
+	public function test_resize_larger_on_one_axis_is_rejected() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'resize',
+					'args' => array(
+						'width'  => 700,
+						'height' => 240,
+					),
+				),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_image_resize_too_large', $response, 400 );
+	}
+
+	/**
+	 * Crop arguments are percentages, so a preceding resize scales the source
+	 * without moving where the crop lands. 640x480 scaled to 320x240, then the
+	 * top-left quarter cropped, is 160x120.
+	 *
+	 * @covers ::edit_media_item
+	 */
+	public function test_resize_applies_before_a_following_crop() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'resize',
+					'args' => array(
+						'width'  => 320,
+						'height' => 240,
+					),
+				),
+				array(
+					'type' => 'crop',
+					'args' => array(
+						'left'   => 0,
+						'top'    => 0,
+						'width'  => 50,
+						'height' => 50,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$this->assertSame(
+			array( 160, 120 ),
+			$this->get_saved_dimensions( $response->get_data()['id'] )
+		);
+	}
+
+	/**
+	 * Requests without a resize modifier are handed to core untouched.
+	 *
+	 * @covers ::edit_media_item
+	 */
+	public function test_crop_without_resize_still_works() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'crop',
+					'args' => array(
+						'left'   => 0,
+						'top'    => 0,
+						'width'  => 50,
+						'height' => 50,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$this->assertSame(
+			array( 320, 240 ),
+			$this->get_saved_dimensions( $response->get_data()['id'] )
+		);
+	}
+
+	/**
+	 * @covers ::get_edit_media_item_args
+	 */
+	public function test_resize_modifier_is_advertised_in_the_schema() {
+		$routes = rest_get_server()->get_routes();
+		$route  = $routes['/wp/v2/media/(?P<id>[\d]+)/edit'][0];
+
+		$titles = wp_list_pluck( $route['args']['modifiers']['items']['oneOf'], 'title' );
+
+		$this->assertContains( 'Resize', $titles );
+	}
+
+	/**
+	 * An unknown modifier type is still rejected by schema validation.
+	 *
+	 * @covers ::get_edit_media_item_args
+	 */
+	public function test_unknown_modifier_type_is_rejected() {
+		$response = $this->edit_test_image(
+			array(
+				array(
+					'type' => 'sharpen',
+					'args' => array( 'amount' => 5 ),
+				),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+}


### PR DESCRIPTION
## What

POC: width and height fields in the media editor Crop panel for scaling an image before it is cropped.

Part of https://github.com/WordPress/gutenberg/issues/81413

## Why

The classic Edit Image screen has a Scale Image panel. The modal has no equivalent — nothing in the pipeline can change output dimensions.

## How

- New `resize` modifier on `/wp/v2/media/{id}/edit`, in `Gutenberg_REST_Attachments_Controller_7_2`. Core has no hook inside the modifier loop, so `edit_media_item()` is forked with one added `case`; requests without a resize go straight to `parent::`. Both existing Gutenberg attachment controllers now extend it, since which one serves the route depends on whether client-side media processing is enabled.
- `scaledSize` on `CropperState`. `buildModifiers` emits `[resize, flip, rotate, crop]`. Crop args are percentages, so a preceding resize doesn't move where the crop lands.
- Fields are linked and commit on blur or Enter — one undo entry per edit. `max` caps them at the original; no scaling up.

## Testing Instructions

1. Open an image in the media editor, Crop tab.
2. Set Width to half the original. Height follows.
3. Save. The new attachment should be half size.
4. Reopen, drag a crop, and scale. The "Saved size" line shows the resulting file size, and the crop handle tooltip agrees.
5. Type a value over the original — it snaps back on blur.
6. "Reset to original size" appears at the end of the help text once scaled.

## Known gaps

- Not yet run in a browser. Unit and PHPUnit coverage only.
- `exportCroppedImage` ignores `scaledSize`. Deliberate: the resize runs server-side through `WP_Image_Editor`, and resampling in canvas would produce different bytes for the same state.
- #79393 creates the same 7.2 controller file and will need to rebase onto this fork rather than adding a second.