### PR TITLE
Add the captureControls block support and opt in the quote block

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -892,7 +892,7 @@ Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Ju
 
 -	**Name:** [core/quote](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/core-block-quote/)
 -	**Category:** [text](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-text/)
--	**Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize, gradient), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, left, right, wide), allowedBlocks, anchor, background (backgroundImage, backgroundSize, gradient), captureControls, color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** citation, textAlign, value
 
 ## Read More

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+-   Added the `captureControls` block support: a block that opts in keeps showing its own toolbar and inspector while its inner blocks are selected, with the selection reduced to a tile at the end of the toolbar that temporarily expands the selection's own controls ([#81464](https://github.com/WordPress/gutenberg/pull/81464)).
+
 ### Internal
 
 -   Use the new `@wordpress/kebab-case` package instead of unlocking the `kebabCase` utility from the `@wordpress/components` private APIs ([#81294](https://github.com/WordPress/gutenberg/pull/81294)).

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -158,6 +158,7 @@ function StyleStateInspectorSlots( {
 function BlockInspector() {
 	const {
 		selectedBlockCount,
+		isCapturedSelection,
 		renderedBlockName,
 		renderedBlockClientId,
 		blockType,
@@ -178,6 +179,7 @@ function BlockInspector() {
 			getSelectedBlockCount,
 			getBlockName,
 			getParentSectionBlock,
+			getControlsCapturingParent,
 			isSectionBlock: _isSectionBlock,
 			getEditedContentOnlySection,
 			isWithinEditedContentOnlySection,
@@ -191,9 +193,19 @@ function BlockInspector() {
 		const isWithinEditedSection = isWithinEditedContentOnlySection(
 			_selectedBlockClientId
 		);
+		// Selection (single or multi) within a collapsed controls-capturing
+		// block renders the capturing block's inspector instead.
+		// Content-locked sections take precedence over controls capture.
+		const _firstSelectedClientId = getSelectedBlockClientIds()[ 0 ];
+		const _controlsCapturingParent =
+			isWithinEditedSection ||
+			getParentSectionBlock( _firstSelectedClientId )
+				? undefined
+				: getControlsCapturingParent( _firstSelectedClientId );
 		const _renderedBlockClientId = isWithinEditedSection
 			? _selectedBlockClientId
 			: getParentSectionBlock( _selectedBlockClientId ) ||
+			  _controlsCapturingParent ||
 			  _selectedBlockClientId;
 		const _renderedBlockName =
 			_renderedBlockClientId && getBlockName( _renderedBlockClientId );
@@ -209,6 +221,7 @@ function BlockInspector() {
 
 		return {
 			selectedBlockCount: getSelectedBlockCount(),
+			isCapturedSelection: !! _controlsCapturingParent,
 			renderedBlockClientId: _renderedBlockClientId,
 			renderedBlockName: _renderedBlockName,
 			blockType: _blockType,
@@ -290,7 +303,11 @@ function BlockInspector() {
 		selectedBlockStyleState
 	);
 
-	if ( hasSelectedBlocks && ! isSectionBlockInSelection ) {
+	if (
+		hasSelectedBlocks &&
+		! isSectionBlockInSelection &&
+		! isCapturedSelection
+	) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
@@ -308,7 +325,11 @@ function BlockInspector() {
 		);
 	}
 
-	if ( hasSelectedBlocks && isSectionBlockInSelection ) {
+	if (
+		hasSelectedBlocks &&
+		isSectionBlockInSelection &&
+		! isCapturedSelection
+	) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -598,6 +598,8 @@ function BlockListBlockProvider( props ) {
 				getMultiSelectedBlockClientIds,
 				hasSelectedInnerBlock,
 				getBlocksByName,
+				getBlockSelectionStart,
+				getControlsCapturingParent,
 
 				getBlockIndex,
 				isBlockMultiSelected,
@@ -701,6 +703,20 @@ function BlockListBlockProvider( props ) {
 				( !! sectionBlockClientId &&
 					hasSelectedInnerBlock( sectionBlockClientId, checkDeep ) );
 
+			// A collapsed controls-capturing ancestor renders its own
+			// controls in place of the selected block's; the selected
+			// block's controls are suppressed until expanded. Content-locked
+			// sections take precedence over controls capture.
+			const controlsCapturingParent = sectionBlockClientId
+				? undefined
+				: getControlsCapturingParent( clientId );
+			const capturesSelectionControls =
+				! sectionBlockClientId &&
+				_hasBlockSupport( blockName, 'captureControls', false ) &&
+				isAncestorOfSelectedBlock &&
+				getControlsCapturingParent( getBlockSelectionStart() ) ===
+					clientId;
+
 			const multiple = hasBlockSupport( blockName, 'multiple', true );
 
 			// For block types with `multiple` support, there is no "original
@@ -728,11 +744,13 @@ function BlockListBlockProvider( props ) {
 					getEditedContentOnlySection() === clientId,
 				blockEditingMode,
 				mayDisplayControls:
-					_isSelected ||
-					( isFirstMultiSelectedBlock( clientId ) &&
-						getMultiSelectedBlockClientIds().every(
-							( id ) => getBlockName( id ) === blockName
-						) ),
+					capturesSelectionControls ||
+					( ! controlsCapturingParent &&
+						( _isSelected ||
+							( isFirstMultiSelectedBlock( clientId ) &&
+								getMultiSelectedBlockClientIds().every(
+									( id ) => getBlockName( id ) === blockName
+								) ) ) ),
 				mayDisplayParentControls:
 					_hasBlockSupport(
 						getBlockName( clientId ),

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -41,12 +41,14 @@ function Root( { className, ...settings } ) {
 		isFocusMode,
 		isPreviewMode,
 		editedContentOnlySection,
+		expandedControlsBlock,
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
 			isTyping,
 			hasBlockSpotlight,
 			getEditedContentOnlySection,
+			getExpandedControlsBlock,
 		} = unlock( select( blockEditorStore ) );
 		const {
 			outlineMode,
@@ -58,6 +60,7 @@ function Root( { className, ...settings } ) {
 			isFocusMode: focusMode || hasBlockSpotlight(),
 			isPreviewMode: _isPreviewMode,
 			editedContentOnlySection: getEditedContentOnlySection(),
+			expandedControlsBlock: getExpandedControlsBlock(),
 		};
 	}, [] );
 	const registry = useRegistry();
@@ -118,6 +121,11 @@ function Root( { className, ...settings } ) {
 					clientId={ editedContentOnlySection }
 				/>
 			) }
+			{ !! expandedControlsBlock && (
+				<CollapseExpandedControlsOnOutsideSelect
+					clientId={ expandedControlsBlock }
+				/>
+			) }
 		</IntersectionObserver.Provider>
 	);
 }
@@ -147,6 +155,32 @@ function StopEditingContentOnlySectionOnOutsideSelect( { clientId } ) {
 			stopEditingContentOnlySection();
 		}
 	}, [ isBlockOrDescendantSelected, stopEditingContentOnlySection ] );
+
+	return null;
+}
+
+function CollapseExpandedControlsOnOutsideSelect( { clientId } ) {
+	const { collapseBlockControls } = unlock( useDispatch( blockEditorStore ) );
+	// Unlike an edited contentOnly section, selecting the capturing block
+	// itself also collapses; only a selection within its inner blocks keeps
+	// the controls expanded.
+	const isDescendantSelected = useSelect(
+		( select ) => {
+			const { hasSelectedInnerBlock, getBlockSelectionStart } =
+				select( blockEditorStore );
+			return (
+				! getBlockSelectionStart() ||
+				hasSelectedInnerBlock( clientId, true )
+			);
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		if ( ! isDescendantSelected ) {
+			collapseBlockControls();
+		}
+	}, [ isDescendantSelected, collapseBlockControls ] );
 
 	return null;
 }

--- a/packages/block-editor/src/components/block-toolbar/captured-block-selector.js
+++ b/packages/block-editor/src/components/block-toolbar/captured-block-selector.js
@@ -1,0 +1,62 @@
+import { ToolbarButton } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { copy } from '@wordpress/icons';
+import BlockIcon from '../block-icon';
+import useBlockDisplayInformation from '../use-block-display-information';
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+/**
+ * Tile shown at the end of a controls-capturing block's toolbar, displaying
+ * the deepest selected inner block. Activating it temporarily expands the
+ * selection's own toolbar and inspector controls.
+ *
+ * @param {Object}   props
+ * @param {string[]} props.clientIds      The selected inner block client IDs.
+ * @param {string}   props.parentClientId The controls-capturing block.
+ *
+ * @return {Component} Captured block selector.
+ */
+export default function CapturedBlockSelector( { clientIds, parentClientId } ) {
+	const { expandBlockControls } = unlock( useDispatch( blockEditorStore ) );
+	const blockInformation = useBlockDisplayInformation( clientIds[ 0 ] );
+	const isSingle = clientIds.length === 1;
+
+	const label = isSingle
+		? sprintf(
+				/* translators: %s: Name of the selected block. */
+				__( 'Show block tools: %s' ),
+				blockInformation?.title
+		  )
+		: sprintf(
+				/* translators: %d: Number of selected blocks. */
+				_n(
+					'Show block tools: %d block',
+					'Show block tools: %d blocks',
+					clientIds.length
+				),
+				clientIds.length
+		  );
+
+	return (
+		<div
+			className="block-editor-captured-block-selector"
+			key={ clientIds[ 0 ] }
+		>
+			<ToolbarButton
+				className="block-editor-captured-block-selector__button"
+				onClick={ () => expandBlockControls( parentClientId ) }
+				label={ label }
+				showTooltip
+				icon={
+					isSingle ? (
+						<BlockIcon icon={ blockInformation?.icon } />
+					) : (
+						copy
+					)
+				}
+			/>
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -29,6 +29,7 @@ import EditSectionButton from './edit-section-button';
 import { unlock } from '../../lock-unlock';
 import { deviceTypeKey } from '../../store/private-keys';
 import BlockToolbarIcon from './block-toolbar-icon';
+import CapturedBlockSelector from './captured-block-selector';
 import { hasViewportBlockStyleState } from '../../hooks/block-style-state';
 
 /**
@@ -53,6 +54,7 @@ export function PrivateBlockToolbar( {
 	const {
 		blockClientId,
 		blockClientIds,
+		capturedClientIds,
 		isDefaultEditingMode,
 		blockType,
 		toolbarKey,
@@ -83,6 +85,7 @@ export function PrivateBlockToolbar( {
 			getSettings,
 			getTemplateLock,
 			getParentSectionBlock,
+			getControlsCapturingParent,
 			isZoomOut,
 			isSectionBlock,
 			isBlockHiddenAtViewport,
@@ -91,57 +94,72 @@ export function PrivateBlockToolbar( {
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
-		const parents = getBlockParents( selectedBlockClientId );
-		const parentSection = getParentSectionBlock( selectedBlockClientId );
+		const _isZoomOut = isZoomOut();
+		// A collapsed controls-capturing ancestor's toolbar is shown in
+		// place of the selection's own, with the selection reduced to a
+		// tile at the end of the toolbar. Section blocks take precedence.
+		const controlsCapturingParent =
+			! _isZoomOut && ! getParentSectionBlock( selectedBlockClientId )
+				? getControlsCapturingParent( selectedBlockClientId )
+				: undefined;
+		const displayedClientIds = controlsCapturingParent
+			? [ controlsCapturingParent ]
+			: selectedBlockClientIds;
+		const displayedClientId = displayedClientIds[ 0 ];
+		const parents = getBlockParents( displayedClientId );
+		const parentSection = getParentSectionBlock( displayedClientId );
 		const parentClientId = parentSection ?? parents[ parents.length - 1 ];
 		const parentBlockName = getBlockName( parentClientId );
 		const parentBlockType = getBlockType( parentBlockName );
-		const editingMode = getBlockEditingMode( selectedBlockClientId );
+		const editingMode = getBlockEditingMode( displayedClientId );
 		const _isDefaultEditingMode = editingMode === 'default';
-		const _blockName = getBlockName( selectedBlockClientId );
-		const isValid = selectedBlockClientIds.every( ( id ) =>
+		const _blockName = getBlockName( displayedClientId );
+		const isValid = displayedClientIds.every( ( id ) =>
 			isBlockValid( id )
 		);
-		const isVisual = selectedBlockClientIds.every(
+		const isVisual = displayedClientIds.every(
 			( id ) => getBlockMode( id ) === 'visual'
 		);
-		const _isUsingBindings = selectedBlockClientIds.every(
+		const _isUsingBindings = displayedClientIds.every(
 			( clientId ) =>
 				!! getBlockAttributes( clientId )?.metadata?.bindings
 		);
 
 		// If one or more selected blocks are locked, do not show the BlockGroupToolbar.
-		const _hasTemplateLock = selectedBlockClientIds.some(
+		const _hasTemplateLock = displayedClientIds.some(
 			( id ) => getTemplateLock( id ) === 'contentOnly'
 		);
 
-		const _isZoomOut = isZoomOut();
-		const _isSectionBlock = isSectionBlock( selectedBlockClientId );
-		const _canEditBlock = canEditBlock( selectedBlockClientId );
+		const _isSectionBlock = isSectionBlock( displayedClientId );
+		const _canEditBlock = canEditBlock( displayedClientId );
 		const _showSwitchSectionStyleButton =
 			_canEditBlock && ( _isZoomOut || _isSectionBlock );
 
 		const _currentDeviceType =
 			getSettings()?.[ deviceTypeKey ]?.toLowerCase() || 'desktop';
 		const _areSelectedBlocksHiddenOnViewport =
-			selectedBlockClientIds.length > 0 &&
-			selectedBlockClientIds.every( ( id ) =>
+			displayedClientIds.length > 0 &&
+			displayedClientIds.every( ( id ) =>
 				isBlockHiddenAtViewport( id, _currentDeviceType )
 			);
 		const _isEditingResponsiveStyleState =
 			isResponsiveEditing() &&
 			hasViewportBlockStyleState(
-				getSelectedBlockStyleState( selectedBlockClientId )
+				getSelectedBlockStyleState( displayedClientId )
 			);
 
 		return {
-			blockClientId: selectedBlockClientId,
-			blockClientIds: selectedBlockClientIds,
+			blockClientId: displayedClientId,
+			blockClientIds: displayedClientIds,
+			capturedClientIds: controlsCapturingParent
+				? selectedBlockClientIds
+				: null,
 			isDefaultEditingMode: _isDefaultEditingMode,
-			blockType: selectedBlockClientId && getBlockType( _blockName ),
+			blockType: displayedClientId && getBlockType( _blockName ),
 			shouldShowVisualToolbar: isValid && isVisual,
-			toolbarKey: `${ selectedBlockClientId }${ parentClientId }`,
+			toolbarKey: `${ displayedClientId }${ parentClientId }`,
 			showParentSelector:
+				! controlsCapturingParent &&
 				! _isZoomOut &&
 				parentBlockType &&
 				editingMode !== 'contentOnly' &&
@@ -151,7 +169,7 @@ export function PrivateBlockToolbar( {
 					'__experimentalParentSelector',
 					true
 				) &&
-				selectedBlockClientIds.length === 1,
+				displayedClientIds.length === 1,
 			isUsingBindings: _isUsingBindings,
 			isSectionContainer: _isSectionBlock,
 			hasContentOnlyLocking: _hasTemplateLock,
@@ -302,6 +320,12 @@ export function PrivateBlockToolbar( {
 					) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
+				{ capturedClientIds && isLargeViewport && (
+					<CapturedBlockSelector
+						clientIds={ capturedClientIds }
+						parentClientId={ blockClientId }
+					/>
+				) }
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -74,7 +74,12 @@
 	// we need to remove the double border from the penultimate one.
 	&:has(> :last-child:empty) > :nth-last-child(2),
 	&:has(> :last-child:empty) > :nth-last-child(2) .components-toolbar-group,
-	&:has(> :last-child:empty) > :nth-last-child(2) .components-toolbar {
+	&:has(> :last-child:empty) > :nth-last-child(2) .components-toolbar,
+	// The captured block selector renders detached at the end of the
+	// toolbar, so the group before it is the visual last child.
+	& > :has(+ .block-editor-captured-block-selector),
+	& > :has(+ .block-editor-captured-block-selector) .components-toolbar-group,
+	& > :has(+ .block-editor-captured-block-selector) .components-toolbar {
 		border-right: none;
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -118,11 +118,27 @@
 				display: none;
 			}
 		}
+
+		// The captured block selector renders detached at the end of the
+		// toolbar, so the group before it is the visual last child.
+		> :has(+ .block-editor-captured-block-selector),
+		> :has(+ .block-editor-captured-block-selector) .components-toolbar-group,
+		> :has(+ .block-editor-captured-block-selector) .components-toolbar {
+			&::after {
+				display: none;
+			}
+		}
 	}
 
 	& > .block-editor-block-toolbar {
 		flex-grow: initial;
 		width: initial;
+	}
+
+	.block-editor-captured-block-selector {
+		position: relative;
+		margin-top: -$border-width;
+		margin-bottom: -$border-width;
 	}
 
 	.block-editor-block-parent-selector {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -171,6 +171,19 @@
 		}
 	}
 
+	.block-editor-captured-block-selector {
+		position: absolute;
+		right: calc(-#{$grid-unit-60} - #{$grid-unit-10} - #{$border-width});
+
+		.block-editor-captured-block-selector__button {
+			border: $border-width solid $gray-900;
+			border-radius: $radius-small;
+			padding-right: 6px;
+			padding-left: 6px;
+			background-color: $white;
+		}
+	}
+
 	// Show Icon Label Styles
 	.show-icon-labels & {
 
@@ -178,6 +191,12 @@
 			position: relative;
 			left: auto;
 			margin-left: -$border-width;
+		}
+
+		.block-editor-captured-block-selector {
+			position: relative;
+			right: auto;
+			margin-right: -$border-width;
 		}
 
 		.block-editor-block-mover__move-button-container,

--- a/packages/block-editor/src/components/block-tools/use-selected-block-tool-props.js
+++ b/packages/block-editor/src/components/block-tools/use-selected-block-tool-props.js
@@ -1,5 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Returns props for the selected block tools and empty block inserter.
@@ -18,7 +19,9 @@ export default function useSelectedBlockToolProps( clientId ) {
 				getBlockOrder,
 				hasMultiSelection,
 				getLastMultiSelectedBlockClientId,
-			} = select( blockEditorStore );
+				getControlsCapturingParent,
+				getParentSectionBlock,
+			} = unlock( select( blockEditorStore ) );
 
 			const blockParentsClientIds = getBlockParents( clientId );
 
@@ -28,12 +31,18 @@ export default function useSelectedBlockToolProps( clientId ) {
 					blockParentsClientIds
 				);
 
-			// Get the clientId of the topmost parent with the capture toolbars setting.
-			const capturingClientId = blockParentsClientIds.find(
-				( parentClientId ) =>
-					parentBlockListSettings[ parentClientId ]
-						?.__experimentalCaptureToolbars
-			);
+			// Get the clientId of the topmost parent with the capture
+			// toolbars setting, or of a collapsed controls-capturing block.
+			// Content-locked sections take precedence over controls capture.
+			const capturingClientId =
+				( getParentSectionBlock( clientId )
+					? undefined
+					: getControlsCapturingParent( clientId ) ) ??
+				blockParentsClientIds.find(
+					( parentClientId ) =>
+						parentBlockListSettings[ parentClientId ]
+							?.__experimentalCaptureToolbars
+				);
 
 			let isInsertionPointVisible = false;
 			if ( isBlockInsertionPointVisible() ) {

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -369,6 +369,29 @@ export function stopEditingContentOnlySection() {
 }
 
 /**
+ * Temporarily expand the inner blocks of a controls-capturing block so the
+ * selected inner block shows its own toolbar and inspector controls.
+ *
+ * @param {string} clientId The client id of the controls-capturing block.
+ */
+export function expandBlockControls( clientId ) {
+	return {
+		type: 'EXPAND_BLOCK_CONTROLS',
+		clientId,
+	};
+}
+
+/**
+ * Action that collapses the inner blocks of a controls-capturing block back
+ * into the capturing block's controls.
+ */
+export function collapseBlockControls() {
+	return {
+		type: 'EXPAND_BLOCK_CONTROLS',
+	};
+}
+
+/**
  * Sets the zoom level.
  *
  * @param {number} zoom the new zoom level

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -894,6 +894,56 @@ export function isWithinEditedContentOnlySection( state, clientId ) {
 }
 
 /**
+ * Retrieves the client ID of the closest-to-the-root ancestor block that
+ * captures the controls (toolbar and inspector) of the block with the
+ * provided client ID, via the `captureControls` block support.
+ *
+ * Returns undefined while the capturing block's inner blocks are temporarily
+ * expanded to show their own controls.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client Id of the block.
+ *
+ * @return {?string} Client ID of the controls-capturing ancestor block.
+ */
+export function getControlsCapturingParent( state, clientId ) {
+	if ( ! clientId ) {
+		return undefined;
+	}
+
+	let current = clientId;
+	let result;
+	// If capturing blocks are nested, the topmost one captures the controls.
+	while ( ( current = state.blocks.parents.get( current ) ) ) {
+		const blockName = getBlockName( state, current );
+		if (
+			blockName &&
+			hasBlockSupport( blockName, 'captureControls', false )
+		) {
+			result = current;
+		}
+	}
+
+	if ( ! result || state.expandedControlsBlock === result ) {
+		return undefined;
+	}
+
+	return result;
+}
+
+/**
+ * Retrieves the client ID of the controls-capturing block whose inner blocks
+ * are temporarily expanded to show their own controls.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {?string} The client ID of the expanded controls-capturing block.
+ */
+export function getExpandedControlsBlock( state ) {
+	return state.expandedControlsBlock;
+}
+
+/**
  * Returns the style attributes of multiple blocks.
  *
  * @param {Object}   state     Global application state.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2066,6 +2066,47 @@ export function editedContentOnlySection( state, action ) {
 }
 
 /**
+ * Reducer returning the clientId of the controls-capturing block whose inner
+ * blocks temporarily show their own controls instead of the capturing
+ * block's.
+ *
+ * @param {string|undefined} state  Current state.
+ * @param {Object}           action Dispatched action.
+ *
+ * @return {string|undefined} Updated state.
+ */
+export function expandedControlsBlock( state, action ) {
+	if ( action.type === 'EXPAND_BLOCK_CONTROLS' ) {
+		return action.clientId;
+	}
+
+	if ( ! state ) {
+		return state;
+	}
+
+	switch ( action.type ) {
+		case 'REMOVE_BLOCKS':
+		case 'REPLACE_BLOCKS':
+			// Clear if the expanded block is directly among the removed or
+			// replaced blocks. A removed ancestor is not caught here since
+			// action.clientIds only contains the top-level IDs; that edge
+			// case is handled by the CollapseExpandedControlsOnOutsideSelect
+			// component in block-list/index.js.
+			if ( action.clientIds.includes( state ) ) {
+				return undefined;
+			}
+			break;
+		case 'RESET_BLOCKS':
+			if ( ! getFlattenedClientIds( action.blocks )[ state ] ) {
+				return undefined;
+			}
+			break;
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning a map of style IDs to style overrides.
  *
  * @param {Map}    state  Current state.
@@ -2442,6 +2483,7 @@ const combinedReducers = combineReducers( {
 	highlightedBlock,
 	lastBlockInserted,
 	editedContentOnlySection,
+	expandedControlsBlock,
 	blockVisibility,
 	viewportModalClientIds,
 	styleOverrides,

--- a/packages/block-library/src/quote/README.md
+++ b/packages/block-library/src/quote/README.md
@@ -24,6 +24,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 _Defined via the [`supports`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/) property in block.json._
 
 - [`anchor`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#anchor): `true`
+- `captureControls`: `true`
 - [`align`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#align): `"left"`, `"right"`, `"wide"`, `"full"`
 - [`html`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#html): `false`
 - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#background):

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -28,6 +28,7 @@
 	},
 	"supports": {
 		"anchor": true,
+		"captureControls": true,
 		"align": [ "left", "right", "wide", "full" ],
 		"html": false,
 		"background": {

--- a/test/e2e/specs/editor/various/captured-block-controls.spec.js
+++ b/test/e2e/specs/editor/various/captured-block-controls.spec.js
@@ -1,0 +1,178 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Captured block controls', () => {
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/quote',
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'first line' },
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'second line' },
+				},
+			],
+		} );
+	} );
+
+	test( 'shows the quote toolbar and inspector for a selected inner paragraph', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas.getByText( 'first line' ).click();
+		await editor.showBlockToolbar();
+
+		const toolbar = page.getByRole( 'toolbar', { name: 'Block tools' } );
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Quote', exact: true } )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', {
+				name: 'Show block tools: Paragraph',
+			} )
+		).toBeVisible();
+		// The parent toolbar replaces the parent selector.
+		await expect(
+			toolbar.getByRole( 'button', { name: /Select parent block/ } )
+		).toBeHidden();
+
+		// The actual selection stays on the paragraph.
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectedBlock().name
+				)
+			)
+			.toBe( 'core/paragraph' );
+
+		await editor.openDocumentSettingsSidebar();
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'heading', { name: 'Quote', exact: true } )
+		).toBeVisible();
+	} );
+
+	test( 'expands the paragraph controls from the tile and keeps them expanded within the quote', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas.getByText( 'first line' ).click();
+		await editor.showBlockToolbar();
+
+		const toolbar = page.getByRole( 'toolbar', { name: 'Block tools' } );
+		await toolbar
+			.getByRole( 'button', { name: 'Show block tools: Paragraph' } )
+			.click();
+
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Paragraph', exact: true } )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', {
+				name: 'Select parent block: Quote',
+			} )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', { name: /Show block tools/ } )
+		).toBeHidden();
+
+		// Moving to a sibling inside the quote keeps the controls expanded.
+		await editor.canvas.getByText( 'second line' ).click();
+		await editor.showBlockToolbar();
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Paragraph', exact: true } )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', { name: /Show block tools/ } )
+		).toBeHidden();
+	} );
+
+	test( 'collapses the expanded controls when selection leaves the quote', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'outside' },
+		} );
+		await editor.canvas.getByText( 'first line' ).click();
+		await editor.showBlockToolbar();
+
+		const toolbar = page.getByRole( 'toolbar', { name: 'Block tools' } );
+		await toolbar
+			.getByRole( 'button', { name: 'Show block tools: Paragraph' } )
+			.click();
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Paragraph', exact: true } )
+		).toBeVisible();
+
+		// Leave the quote, then come back: collapsed again.
+		await editor.canvas.getByText( 'outside' ).click();
+		await editor.canvas.getByText( 'first line' ).click();
+		await editor.showBlockToolbar();
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Quote', exact: true } )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', {
+				name: 'Show block tools: Paragraph',
+			} )
+		).toBeVisible();
+	} );
+
+	test( 'selecting the quote itself collapses the expanded controls', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas.getByText( 'first line' ).click();
+		await editor.showBlockToolbar();
+
+		const toolbar = page.getByRole( 'toolbar', { name: 'Block tools' } );
+		await toolbar
+			.getByRole( 'button', { name: 'Show block tools: Paragraph' } )
+			.click();
+		await toolbar
+			.getByRole( 'button', { name: 'Select parent block: Quote' } )
+			.click();
+
+		// The quote's own toolbar, without a captured tile.
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Quote', exact: true } )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', { name: /Show block tools/ } )
+		).toBeHidden();
+	} );
+
+	test( 'shows a multi-selection tile for a multi-selection within the quote', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.canvas.getByText( 'first line' ).click();
+		// Select all text, then all blocks within the quote.
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+a' );
+		await editor.showBlockToolbar();
+
+		const toolbar = page.getByRole( 'toolbar', { name: 'Block tools' } );
+		await expect(
+			toolbar.getByRole( 'button', { name: 'Quote', exact: true } )
+		).toBeVisible();
+		await expect(
+			toolbar.getByRole( 'button', {
+				name: 'Show block tools: 2 blocks',
+			} )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
## What?

See #61209. Adds a `captureControls` block support: while an inner block is selected, the toolbar and inspector keep showing the opted-in ancestor's controls, and the selection shrinks to a tile at the end of the toolbar. Activating the tile expands the selection's own controls. The quote block opts in.

## Why?

Selecting a paragraph inside a quote hides the quote's controls, notably the citation toggle. This keeps them in view without changing the selection or locking anything.

## How?

1. **`getControlsCapturingParent`** (private selector): topmost `captureControls` ancestor of the selection; content-locked sections take precedence.
2. **`mayDisplayControls`** mounts the capturing block's fills and suppresses the selection's.
3. **Toolbar, popover anchor, and inspector** render the capturing block; a `CapturedBlockSelector` tile shows the deepest selected block, or the count for a multi-selection.
4. **`expandedControlsBlock`** (ephemeral state) disables the capture after the tile is clicked, until the selection leaves the block or lands on it.

## Testing Instructions

1. Insert a quote with two paragraphs and click into one: quote toolbar and inspector show, with a paragraph tile at the toolbar's end.
2. Click the tile: paragraph toolbar and inspector show; the sibling paragraph keeps them; selecting the quote or leaving it collapses back.
3. Multi-select both paragraphs: quote toolbar with a "2 blocks" tile.
4. `npm run test:e2e -- --project=chromium editor/various/captured-block-controls.spec.js`

### Testing Instructions for Keyboard

Alt+F10, arrow to the last toolbar item, Enter to expand. Known gap: focus is not moved into the re-rendered toolbar after expanding.

## Screenshots or screencast

| Collapsed (paragraph selected) | Expanded (after activating the tile) |
|-|-|
| ![The quote toolbar with the paragraph tile at its end](https://github.com/user-attachments/assets/16358544-f483-40fb-a1dc-8b2a9629f915) | ![The paragraph toolbar after activating the tile](https://github.com/user-attachments/assets/e2034548-9f2c-4305-b41a-27b676b574df) |

## Use of AI Tools

Authored by Claude (Fable 5) in collaboration with @ellatrix.
