### PR TITLE
Notes: Opt the note form out of the editor undo

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note-form.js
+++ b/packages/editor/src/components/collab-sidebar/note-form.js
@@ -8,13 +8,10 @@ import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { unlock } from '../../lock-unlock';
 import { sanitizeNoteContent } from './utils';
 import noteMentionCompleter from './note-mention-completer';
-/*
- * The rich text form field wires `@wordpress/rich-text` into the presentational
- * `ContentEditableControl` shell from `@wordpress/components`. The notes
- * sidebar is its only consumer, so it lives next to it.
- */
 import RichTextControl from './rich-text-control';
 
 /*
@@ -29,8 +26,9 @@ const ALLOWED_NOTE_FORMATS = [
 	'core/link',
 	'core/code',
 ];
-
 const NOTE_COMPLETERS = [ noteMentionCompleter ];
+
+const { useNativeUndo } = unlock( blockEditorPrivateApis );
 
 export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 	const [ inputComment, setInputComment ] = useState(
@@ -38,6 +36,9 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 	);
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
+	// Editor undo here would revert an unrelated edit and pull focus away from
+	// the note being typed.
+	const nativeUndoRef = useNativeUndo();
 	const inputId = useInstanceId( NoteForm, 'comment-input' );
 	const trimmedPlainText = sanitizeNoteContent( stripHTML( inputComment ) );
 	const isDisabled =
@@ -74,6 +75,7 @@ export function NoteForm( { onSubmit, onCancel, note, labels } ) {
 
 	return (
 		<Stack
+			ref={ nativeUndoRef }
 			className="editor-collab-sidebar-panel__note-form"
 			direction="column"
 			gap="lg"

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -72,6 +72,45 @@ test.describe( 'Block Notes', () => {
 		await expect( thread ).toBeFocused();
 	} );
 
+	test( 'undo in the note form undoes the note, not the editor', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Testing block comments' },
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		const form = page.getByRole( 'textbox', {
+			name: 'New note',
+			exact: true,
+		} );
+		await form.pressSequentially( 'Note' );
+		await expect( form ).toHaveText( 'Note' );
+
+		// The browser may split typing into several undo steps, so undo more
+		// than once rather than assuming a single step.
+		for ( let i = 0; i < 4; i++ ) {
+			await pageUtils.pressKeys( 'primary+z' );
+		}
+
+		/*
+		 * Undo acts on the field. It cannot clear it entirely: rich text
+		 * replaces the text node the browser typed into when it strips the
+		 * empty-state padding, which drops that first undo step, so the first
+		 * character survives.
+		 */
+		await expect( form ).not.toHaveText( 'Note' );
+		// The block edit is left alone.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Testing block comments' },
+			},
+		] );
+	} );
+
 	test( 'can reply to a block note', async ( { page, blockNoteUtils } ) => {
 		await blockNoteUtils.addBlockWithNote( {
 			type: 'core/paragraph',


### PR DESCRIPTION
## What?
Related #80768.

PR opts out of the note form from editor undo. It now uses `useNativeUndo`, so Cmd+Z and Cmd+Shift+Z inside the form fall through to the browser instead of the editor history.

Without this, undoing a typo while writing a note reverts an unrelated editor edit and can cause the focus to move, interrupting the note submission.

**Note:** Marking this as a draft, because there's a small bug in RichText, which prevents undoing the first character.

## Testing Instructions
1. Open a post or page.
2. Add a paragraph and some text.
3. Try adding a new note.
4. Undo the form text.
5. Confirm that it doesn't undo paragraph block text changes.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2e7fd2a3-1191-4eb4-84f2-c4f65a037e21

## Use of AI Tools

Assisted by Claude
