### PR TITLE
ESLint: Rename root eslint.config.cjs to eslint.config.mjs

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -285,7 +285,7 @@ You can start with this workspace settings file:
 
 ### ESLint
 
-[ESLint](https://eslint.org/) statically analyzes the code to find problems. The lint rules are integrated in the continuous integration process and must pass to be able to commit. With an editor integration enabled, ESLint will use the [eslint.config.cjs](https://github.com/WordPress/gutenberg/blob/HEAD/eslint.config.cjs) file in the root of the Gutenberg repository to highlight issues as you develop.
+[ESLint](https://eslint.org/) statically analyzes the code to find problems. The lint rules are integrated in the continuous integration process and must pass to be able to commit. With an editor integration enabled, ESLint will use the [eslint.config.mjs](https://github.com/WordPress/gutenberg/blob/HEAD/eslint.config.mjs) file in the root of the Gutenberg repository to highlight issues as you develop.
 
 If you use Visual Studio Code, use the extension and settings listed in the [Visual Studio Code](#visual-studio-code) section above. For other editors, see the [ESLint editor integration docs](https://eslint.org/docs/user-guide/integrations).
 

--- a/docs/contributors/folder-structure.md
+++ b/docs/contributors/folder-structure.md
@@ -9,7 +9,7 @@ The following snippet explains how the Gutenberg repository is structured omitti
     ├── CONTRIBUTING.md
     │
     ├── .editorconfig
-    ├── eslint.config.cjs
+    ├── eslint.config.mjs
     ├── .jshintignore
     ├── prettier.config.mjs
     ├── .stylelintignore

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,3 +1,0 @@
-module.exports = import( './tools/eslint/config.mjs' ).then(
-	( m ) => m.default
-);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from './tools/eslint/config.mjs';

--- a/tools/eslint/README.md
+++ b/tools/eslint/README.md
@@ -4,7 +4,7 @@ Consolidated ESLint configuration for the Gutenberg monorepo. This is a **privat
 
 ## Files
 
--   **`config.mjs`** — Main ESLint flat config. The root `eslint.config.cjs` re-exports this so that ESLint, VS Code, and CI all resolve it transparently.
+-   **`config.mjs`** — Main ESLint flat config. The root `eslint.config.mjs` re-exports this so that ESLint, VS Code, and CI all resolve it transparently.
 -   **`import-resolver.cjs`** — Custom import resolver that maps `@wordpress/*` package imports to source files (`src/`) instead of built files (`build-module/`), so linting works without a build step.
 -   **`lint-js.cjs`** — Wrapper around `wp-scripts lint-js` used by `npm run lint:js`. Streams ESLint output through, detects the "stale suppressions" hint, and formats `suppressions.json` after `--prune-suppressions` runs.
 -   **`suppressions.json`** — ESLint suppressions file for pre-existing violations. Updated via `npm run lint:js:prune-suppressions`. CI enforces that this file is pruned and committed.


### PR DESCRIPTION
## What?

Follow up to #77215.

Renames the root `eslint.config.cjs` to `eslint.config.mjs` and replaces the dynamic `import()` re-export with a static `export { default }`.

## Why?

#77215 kept the root file as CommonJS only so git would detect the rename of the original `eslint.config.mjs` into [tools/eslint/config.mjs](tools/eslint/config.mjs). That history is now recorded, so the root file can go back to ESM and drop the promise-returning `import()` wrapper.

## How?

`git mv` to `.mjs` plus a one-line static re-export in [eslint.config.mjs](eslint.config.mjs). Docs referencing the old filename are updated.

## Testing Instructions

1. `npm run lint:js` passes.
2. Open a `.js` file in VS Code and confirm ESLint squiggles still appear.
3. Introduce `var x = 1;` in a package file and confirm it is reported.

### Testing Instructions for Keyboard

N/A, no UI changes.

## Use of AI Tools

Authored with assistance from Claude Code (Claude Opus 5). All changes were reviewed and verified manually.
