### PR TITLE
Image: Include the Add toolbar button from the Gallery block when nested within a Gallery

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Gallery: Show the gallery's "Add" toolbar control on a selected child Image block, so an image can be added without first selecting the Gallery ([#47200](https://github.com/WordPress/gutenberg/issues/47200)).
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Gallery: Show the gallery's "Add" toolbar control on a selected child Image block, so an image can be added without first selecting the Gallery ([#47200](https://github.com/WordPress/gutenberg/issues/47200)).
+-   Gallery: Show the gallery's "Add" toolbar control on a selected child Image block, so an image can be added without first selecting the Gallery ([#81469](https://github.com/WordPress/gutenberg/pull/81469)).
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))

--- a/packages/block-library/src/gallery/add-images-toolbar-control.js
+++ b/packages/block-library/src/gallery/add-images-toolbar-control.js
@@ -1,0 +1,66 @@
+import {
+	BlockControls,
+	MediaReplaceFlow,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { ALLOWED_MEDIA_TYPES } from './constants';
+import useUpdateImages from './use-update-images';
+
+/**
+ * The gallery's "Add" toolbar control.
+ *
+ * Rendered both by the gallery itself and by a selected child image block, so
+ * an image can be added without first having to select the gallery. See
+ * https://github.com/WordPress/gutenberg/issues/47200.
+ *
+ * It sits in the `other` group rather than being shared through the
+ * `__experimentalExposeControlsToChildren` support, which would also share the
+ * gallery's alignment control — duplicating the image block's own — and move
+ * the selected image's whole toolbar to the top of the gallery.
+ *
+ * @param {Object} props
+ * @param {string} props.clientId Client ID of the gallery block.
+ */
+export default function AddImagesToolbarControl( { clientId } ) {
+	const updateImages = useUpdateImages( clientId );
+
+	const { canAddImages, mediaIds } = useSelect(
+		( select ) => {
+			const { getBlock, canInsertBlockType } = select( blockEditorStore );
+
+			return {
+				// The same check the inserter makes, so the control is hidden
+				// wherever an image could not actually be added: a template
+				// lock on the gallery, a disabled editing mode, a section or
+				// synced pattern ancestor, an `allowedBlocks` restriction (as
+				// dynamic galleries set), or preview mode.
+				canAddImages: canInsertBlockType( 'core/image', clientId ),
+				mediaIds: ( getBlock( clientId )?.innerBlocks ?? [] )
+					.map( ( block ) => block.attributes.id )
+					.filter( ( id ) => !! id ),
+			};
+		},
+		[ clientId ]
+	);
+
+	if ( ! canAddImages ) {
+		return null;
+	}
+
+	return (
+		<BlockControls group="other">
+			<MediaReplaceFlow
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				handleUpload={ false }
+				onSelect={ updateImages }
+				name={ __( 'Add' ) }
+				multiple
+				mediaIds={ mediaIds }
+				addToGallery={ mediaIds.length > 0 }
+				variant="toolbar"
+			/>
+		</BlockControls>
+	);
+}

--- a/packages/block-library/src/gallery/constants.js
+++ b/packages/block-library/src/gallery/constants.js
@@ -5,3 +5,4 @@ export const LINK_DESTINATION_ATTACHMENT = 'attachment';
 export const LINK_DESTINATION_MEDIA_WP_CORE = 'file';
 export const LINK_DESTINATION_ATTACHMENT_WP_CORE = 'post';
 export const DEFAULT_MEDIA_SIZE_SLUG = 'large';
+export const ALLOWED_MEDIA_TYPES = [ 'image' ];

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -20,14 +20,11 @@ import {
 	useInnerBlocksProps,
 	useBlockEditingMode,
 	BlockControls,
-	MediaReplaceFlow,
 	useSettings,
 } from '@wordpress/block-editor';
 import { useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
-import { createBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	link as linkIcon,
@@ -51,7 +48,10 @@ import {
 	LINK_DESTINATION_NONE,
 	LINK_DESTINATION_LIGHTBOX,
 	DEFAULT_MEDIA_SIZE_SLUG,
+	ALLOWED_MEDIA_TYPES,
 } from './constants';
+import AddImagesToolbarControl from './add-images-toolbar-control';
+import useUpdateImages from './use-update-images';
 import useImageSizes from './use-image-sizes';
 import useGetNewImages from './use-get-new-images';
 import useGetMedia from './use-get-media';
@@ -102,8 +102,6 @@ const NAVIGATION_BUTTON_TYPE_OPTIONS = [
 		value: 'both',
 	},
 ];
-const ALLOWED_MEDIA_TYPES = [ 'image' ];
-
 const PLACEHOLDER_TEXT = __(
 	'Drag and drop images, upload, or choose from your library.'
 );
@@ -160,12 +158,8 @@ export default function GalleryEdit( props ) {
 		aspectRatio,
 	} = attributes;
 
-	const {
-		__unstableMarkNextChangeAsNotPersistent,
-		replaceInnerBlocks,
-		updateBlockAttributes,
-		selectBlock,
-	} = useDispatch( blockEditorStore );
+	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
+		useDispatch( blockEditorStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
@@ -345,105 +339,7 @@ export default function GalleryEdit( props ) {
 		};
 	}
 
-	function isValidFileType( file ) {
-		const mediaTypeSelector = file.type;
-
-		return (
-			ALLOWED_MEDIA_TYPES.some(
-				( mediaType ) => mediaTypeSelector?.indexOf( mediaType ) === 0
-			) || file.blob
-		);
-	}
-
-	function updateImages( selectedImages ) {
-		const newFileUploads =
-			Object.prototype.toString.call( selectedImages ) ===
-			'[object FileList]';
-
-		const imageArray = newFileUploads
-			? Array.from( selectedImages ).map( ( file ) => {
-					if ( ! file.url ) {
-						return {
-							blob: createBlobURL( file ),
-						};
-					}
-
-					return file;
-			  } )
-			: selectedImages;
-
-		if ( ! imageArray.every( isValidFileType ) ) {
-			createErrorNotice(
-				__(
-					'If uploading to a gallery all files need to be image formats'
-				),
-				{ id: 'gallery-upload-invalid-file', type: 'snackbar' }
-			);
-		}
-
-		const processedImages = imageArray
-			.filter( ( file ) => file.url || isValidFileType( file ) )
-			.map( ( file ) => {
-				if ( ! file.url ) {
-					return {
-						blob: file.blob || createBlobURL( file ),
-					};
-				}
-
-				return file;
-			} );
-
-		// Because we are reusing existing innerImage blocks any reordering
-		// done in the media library will be lost so we need to reapply that ordering
-		// once the new image blocks are merged in with existing.
-		const newOrderMap = processedImages.reduce(
-			( result, image, index ) => (
-				( result[ image.id ] = index ), result
-			),
-			{}
-		);
-
-		const existingImageBlocks = ! newFileUploads
-			? innerBlockImages.filter( ( block ) =>
-					processedImages.find(
-						( img ) => img.id === block.attributes.id
-					)
-			  )
-			: innerBlockImages;
-
-		const newImageList = processedImages.filter(
-			( img ) =>
-				! existingImageBlocks.find(
-					( existingImg ) => img.id === existingImg.attributes.id
-				)
-		);
-
-		const newBlocks = newImageList.map( ( image ) => {
-			return createBlock( 'core/image', {
-				id: image.id,
-				blob: image.blob,
-				url: image.url,
-				caption: image.caption,
-				alt: image.alt,
-			} );
-		} );
-
-		replaceInnerBlocks(
-			clientId,
-			existingImageBlocks
-				.concat( newBlocks )
-				.sort(
-					( a, b ) =>
-						newOrderMap[ a.attributes.id ] -
-						newOrderMap[ b.attributes.id ]
-				)
-		);
-
-		// Select the first block to scroll into view when new blocks are added.
-		if ( newBlocks?.length > 0 ) {
-			selectBlock( newBlocks[ 0 ].clientId );
-		}
-	}
+	const updateImages = useUpdateImages( clientId );
 
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
@@ -602,7 +498,6 @@ export default function GalleryEdit( props ) {
 		}
 	}, [ linkTo ] );
 
-	const hasImageIds = hasImages && images.some( ( image ) => !! image.id );
 	const imagesUploading = images.some(
 		( img ) => ! img.id && img.url?.indexOf( 'blob:' ) === 0
 	);
@@ -915,20 +810,7 @@ export default function GalleryEdit( props ) {
 			</BlockControls>
 			<>
 				{ ! multiGallerySelection && ! isDynamic && (
-					<BlockControls group="other">
-						<MediaReplaceFlow
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							handleUpload={ false }
-							onSelect={ updateImages }
-							name={ __( 'Add' ) }
-							multiple
-							mediaIds={ images
-								.filter( ( image ) => image.id )
-								.map( ( image ) => image.id ) }
-							addToGallery={ hasImageIds }
-							variant="toolbar"
-						/>
-					</BlockControls>
+					<AddImagesToolbarControl clientId={ clientId } />
 				) }
 				<GalleryGapCustomProperties
 					style={ attributes.style }

--- a/packages/block-library/src/gallery/use-update-images.js
+++ b/packages/block-library/src/gallery/use-update-images.js
@@ -1,0 +1,141 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlobURL } from '@wordpress/blob';
+import { createBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { ALLOWED_MEDIA_TYPES } from './constants';
+
+function isValidFileType( file ) {
+	const mediaTypeSelector = file.type;
+
+	return (
+		ALLOWED_MEDIA_TYPES.some(
+			( mediaType ) => mediaTypeSelector?.indexOf( mediaType ) === 0
+		) || file.blob
+	);
+}
+
+/**
+ * Returns a callback that merges a media selection (or a `FileList` from a
+ * direct upload) into a gallery's inner image blocks.
+ *
+ * Everything it needs is derived from the gallery's client ID at call time, so
+ * the "Add" control can be rendered either by the gallery itself or by a
+ * selected child image block.
+ *
+ * The new blocks are created with only the attributes the media selection
+ * carries. Gallery-wide attributes (`sizeSlug`, `linkTo`, `linkTarget`,
+ * `aspectRatio`) are applied afterwards by the gallery's own hydration effect,
+ * which runs whoever triggered the change.
+ *
+ * @param {string} clientId Client ID of the gallery block.
+ *
+ * @return {Function} `onSelect` handler for a media picker.
+ */
+export default function useUpdateImages( clientId ) {
+	const { getBlock } = useSelect( blockEditorStore );
+	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	return useCallback(
+		( selectedImages ) => {
+			const innerBlockImages = getBlock( clientId )?.innerBlocks ?? [];
+			const newFileUploads =
+				Object.prototype.toString.call( selectedImages ) ===
+				'[object FileList]';
+
+			const imageArray = newFileUploads
+				? Array.from( selectedImages ).map( ( file ) => {
+						if ( ! file.url ) {
+							return {
+								blob: createBlobURL( file ),
+							};
+						}
+
+						return file;
+				  } )
+				: selectedImages;
+
+			if ( ! imageArray.every( isValidFileType ) ) {
+				createErrorNotice(
+					__(
+						'If uploading to a gallery all files need to be image formats'
+					),
+					{ id: 'gallery-upload-invalid-file', type: 'snackbar' }
+				);
+			}
+
+			const processedImages = imageArray
+				.filter( ( file ) => file.url || isValidFileType( file ) )
+				.map( ( file ) => {
+					if ( ! file.url ) {
+						return {
+							blob: file.blob || createBlobURL( file ),
+						};
+					}
+
+					return file;
+				} );
+
+			// Because we are reusing existing innerImage blocks any reordering
+			// done in the media library will be lost so we need to reapply that ordering
+			// once the new image blocks are merged in with existing.
+			const newOrderMap = processedImages.reduce(
+				( result, image, index ) => (
+					( result[ image.id ] = index ), result
+				),
+				{}
+			);
+
+			const existingImageBlocks = ! newFileUploads
+				? innerBlockImages.filter( ( block ) =>
+						processedImages.find(
+							( img ) => img.id === block.attributes.id
+						)
+				  )
+				: innerBlockImages;
+
+			const newImageList = processedImages.filter(
+				( img ) =>
+					! existingImageBlocks.find(
+						( existingImg ) => img.id === existingImg.attributes.id
+					)
+			);
+
+			const newBlocks = newImageList.map( ( image ) => {
+				return createBlock( 'core/image', {
+					id: image.id,
+					blob: image.blob,
+					url: image.url,
+					caption: image.caption,
+					alt: image.alt,
+				} );
+			} );
+
+			replaceInnerBlocks(
+				clientId,
+				existingImageBlocks
+					.concat( newBlocks )
+					.sort(
+						( a, b ) =>
+							newOrderMap[ a.attributes.id ] -
+							newOrderMap[ b.attributes.id ]
+					)
+			);
+
+			// Select the first block to scroll into view when new blocks are added.
+			if ( newBlocks?.length > 0 ) {
+				selectBlock( newBlocks[ 0 ].clientId );
+			}
+		},
+		[
+			clientId,
+			getBlock,
+			replaceInnerBlocks,
+			selectBlock,
+			createErrorNotice,
+		]
+	);
+}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -20,6 +20,7 @@ import { useResizeObserver } from '@wordpress/compose';
 import { getProtocol, prependHTTPS } from '@wordpress/url';
 import { store as uploadStore } from '@wordpress/upload-media';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
+import AddImagesToolbarControl from '../gallery/add-images-toolbar-control';
 import Image from './image';
 import { isValidFileType } from './utils';
 import { useMaxWidthObserver } from './use-max-width-observer';
@@ -138,6 +139,25 @@ export function ImageEdit( {
 		canInsertBlockType,
 	} = useSelect( blockEditorStore );
 	const blockEditingMode = useBlockEditingMode();
+
+	// A gallery's "Add" control is only reachable by first selecting the gallery
+	// itself, which is hard to discover when the obvious thing to click is one
+	// of the images. Surface it on the selected image too, acting on the parent.
+	// See https://github.com/WordPress/gutenberg/issues/47200.
+	const galleryClientId = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId: _getBlockRootClientId,
+				getBlockName: _getBlockName,
+			} = select( blockEditorStore );
+			const rootClientId = _getBlockRootClientId( clientId );
+
+			return _getBlockName( rootClientId ) === 'core/gallery'
+				? rootClientId
+				: undefined;
+		},
+		[ clientId ]
+	);
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
@@ -460,6 +480,14 @@ export function ImageEdit( {
 
 	return (
 		<>
+			{ /*
+			 * Rendered ahead of the figure so that the gallery's "Add" fill
+			 * registers before the image's own "Replace" fill, placing the two
+			 * in that order within the toolbar's `other` group.
+			 */ }
+			{ isSingleSelected && !! galleryClientId && (
+				<AddImagesToolbarControl clientId={ galleryClientId } />
+			) }
 			<figure { ...blockProps }>
 				<Image
 					temporaryURL={ temporaryURL }

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -196,6 +196,48 @@ test.describe( 'Gallery', () => {
 			);
 	} );
 
+	test( "the gallery's Add control is shared with a selected child image", async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			innerBlocks: [
+				{
+					name: 'core/image',
+					attributes: {
+						id: uploadedMedia.id,
+						url: uploadedMedia.source_url,
+					},
+				},
+			],
+		} );
+
+		const galleryImage = editor.canvas.locator(
+			'role=document[name="Block: Gallery"i] >> role=document[name="Block: Image"i]'
+		);
+		await expect( galleryImage ).toBeVisible();
+		await galleryImage.click();
+
+		await editor.showBlockToolbar();
+		const blockToolbar = page.locator(
+			'role=toolbar[name="Block tools"i]'
+		);
+
+		// The toolbar is still the child image's own toolbar…
+		await expect(
+			blockToolbar.locator( 'role=button[name="Replace"i]' )
+		).toBeVisible();
+
+		// …but it also exposes the parent gallery's "Add" control, so an image
+		// can be added without first selecting the gallery.
+		await expect(
+			blockToolbar.locator( 'role=button[name="Add"i]' )
+		).toBeVisible();
+	} );
+
 	test( 'when initially added the media library shows the Create Gallery view', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
## What?

Fixes #47200

Share and "Add" toolbar button between the Gallery block and Image blocks that are nested within a Gallery block. That is, expose the gallery block's Add control to the child image block.

## Why?

As described in #47200 it can be hard to find where to add images to a gallery block just by selecting the gallery block as a first click onto an image within the gallery.

So, this PR tries a fairly naive approach of sharing the control between the image and gallery blocks. It intentionally _doesn't_ use the `"__experimentalExposeControlsToChildren"` support because:

* We only want to share the "Add" control
* And we want the "Add" control to line up right next to the Replace control so that things feel consistent

There's discussion elsewhere e.g. in https://github.com/WordPress/gutenberg/issues/61209#issuecomment-5262468501 for other options of exposing parent/child controls, but IMO I think Gallery -> Image might be kind of unique in this respect as it's just about exposing "Add" for now. That said, open to ideas here!

## How?

* Turn the Gallery block's "Add" button into a shared `AddImagesToolbarControl` component
* In the Image block, inject the `AddImagesToolbarControl` right next to the Replace control when the image is a child of a Gallery block

## Testing Instructions

* Add a Gallery block to a post or page
* Give it at least a single image
* Click the image within the Gallery block and see that there is now an "Add" button alongside the "Replace" button
* Check that clicking "Add" behaves just as it does on the Gallery block itself (allows you to add images to the gallery)
* Smoke-test that an image _not_ in a Gallery block doesn't show the Add button, and that a wrapper Gallery block _does_ show the Add button

## Screenshots or screencast <!-- if applicable -->

A quick video showing "Add" working at both the Image and Gallery block levels:

https://github.com/user-attachments/assets/12426577-0c56-4dce-8b21-a4759140a910

## Use of AI Tools

Claude Code Opus 5 to develop the change, and I've been reviewing and testing as I go