### PR TITLE
Post Revisions: Disable Restore on a revision matching the post

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 -   Device Preview: Keep tablet and mobile iframe widths inside their responsive breakpoints so media queries remain accurate at browser zoom levels.
 -   Document tools: Fix icon button focus styles to use the design system `outset-ring__focus` mixin ([#81115](https://github.com/WordPress/gutenberg/pull/81115)).
+-   Post Revisions: Disable the "Restore" button on a revision that already matches the saved post. The current version was offered as restorable and clicking it reported a successful restore without anything having changed.
 
 ## 14.52.0 (2026-07-29)
 

--- a/packages/editor/src/components/post-revisions-preview/revisions-header.js
+++ b/packages/editor/src/components/post-revisions-preview/revisions-header.js
@@ -1,3 +1,4 @@
+import fastDeepEqual from 'fast-deep-equal/es6/index.js';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -12,6 +13,65 @@ import { sidebars } from '../sidebar/constants';
 import { unlock } from '../../lock-unlock';
 
 /**
+ * Whether restoring a revision would actually change the post.
+ *
+ * `restoreRevision` writes the revision's content, title, excerpt and meta back
+ * onto the post, so a revision whose fields already match the saved post has
+ * nothing to restore. The newest revision is always in that state, because
+ * WordPress stores a copy of the post as a revision every time it is saved.
+ *
+ * The comparison is against the saved post rather than the last revision ID.
+ * An autosave becomes the post's latest revision while it exists, so comparing
+ * IDs would refuse to restore an autosave, which is the one revision users most
+ * often want back.
+ *
+ * @param {?Object} revision The revision being previewed.
+ * @param {Object}  post     The saved post, with raw attribute values.
+ * @return {boolean} Whether restoring the revision would change the post.
+ */
+export function hasChangesToRestore( revision, post ) {
+	if ( ! revision ) {
+		return false;
+	}
+
+	if ( revision.content?.raw !== post.content ) {
+		return true;
+	}
+
+	if (
+		revision.title?.raw !== undefined &&
+		revision.title.raw !== post.title
+	) {
+		return true;
+	}
+
+	if (
+		revision.excerpt?.raw !== undefined &&
+		revision.excerpt.raw !== post.excerpt
+	) {
+		return true;
+	}
+
+	// Revisions only carry meta registered with `revisions_enabled`, so compare
+	// the keys the revision actually has instead of the whole meta object.
+	//
+	// Protected keys are skipped. They hold internal bookkeeping rather than
+	// authored content, and revisions do not store it faithfully: the
+	// collaborative editing document (`_crdt_document`) is saved empty on every
+	// revision, so comparing it would report a difference against every single
+	// revision and never let the button settle.
+	if ( revision.meta ) {
+		return Object.keys( revision.meta ).some(
+			( key ) =>
+				! key.startsWith( '_' ) &&
+				! fastDeepEqual( revision.meta[ key ], post.meta?.[ key ] )
+		);
+	}
+
+	return false;
+}
+
+/**
  * Header component for revisions preview mode.
  *
  * @param {Object}   props              Component props.
@@ -20,17 +80,32 @@ import { unlock } from '../../lock-unlock';
  * @return {React.JSX.Element} The revisions header component.
  */
 function RevisionsHeader( { showDiff, onToggleDiff } ) {
-	const { currentRevisionId, sidebarIsOpened } = useSelect( ( select ) => {
-		return {
-			currentRevisionId: unlock(
+	const { currentRevisionId, canRestore, sidebarIsOpened } = useSelect(
+		( select ) => {
+			const { getCurrentRevisionId, getCurrentRevision } = unlock(
 				select( editorStore )
-			).getCurrentRevisionId(),
-			sidebarIsOpened:
-				!! select( interfaceStore ).getActiveComplementaryArea(
-					'core'
-				),
-		};
-	}, [] );
+			);
+			const { getCurrentPostAttribute } = select( editorStore );
+			const revisionId = getCurrentRevisionId();
+
+			return {
+				currentRevisionId: revisionId,
+				canRestore:
+					!! revisionId &&
+					hasChangesToRestore( getCurrentRevision(), {
+						content: getCurrentPostAttribute( 'content' ),
+						title: getCurrentPostAttribute( 'title' ),
+						excerpt: getCurrentPostAttribute( 'excerpt' ),
+						meta: getCurrentPostAttribute( 'meta' ),
+					} ),
+				sidebarIsOpened:
+					!! select( interfaceStore ).getActiveComplementaryArea(
+						'core'
+					),
+			};
+		},
+		[]
+	);
 
 	const { setCurrentRevisionId, restoreRevision } = unlock(
 		useDispatch( editorStore )
@@ -38,8 +113,6 @@ function RevisionsHeader( { showDiff, onToggleDiff } ) {
 
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
-
-	const canRestore = !! currentRevisionId;
 
 	const handleRestore = () => {
 		if ( currentRevisionId ) {

--- a/packages/editor/src/components/post-revisions-preview/test/revisions-header.js
+++ b/packages/editor/src/components/post-revisions-preview/test/revisions-header.js
@@ -1,0 +1,87 @@
+import { hasChangesToRestore } from '../revisions-header';
+
+const post = {
+	content: '<!-- wp:paragraph --><p>Saved</p><!-- /wp:paragraph -->',
+	title: 'Saved title',
+	excerpt: 'Saved excerpt',
+	meta: {
+		footnotes: '[]',
+		unrelated: 'value',
+		_crdt_document: '{"document":"AAAV46m","updateId":151275664}',
+	},
+};
+
+function getRevision( overrides = {} ) {
+	return {
+		id: 2,
+		content: { raw: post.content },
+		title: { raw: post.title },
+		excerpt: { raw: post.excerpt },
+		...overrides,
+	};
+}
+
+describe( 'hasChangesToRestore', () => {
+	it( 'returns false while the revision is still loading', () => {
+		expect( hasChangesToRestore( null, post ) ).toBe( false );
+	} );
+
+	it( 'returns false for a revision matching the saved post', () => {
+		expect( hasChangesToRestore( getRevision(), post ) ).toBe( false );
+	} );
+
+	it( 'returns true when the content differs', () => {
+		const revision = getRevision( { content: { raw: 'Something else' } } );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( true );
+	} );
+
+	it( 'returns true when the title differs', () => {
+		const revision = getRevision( { title: { raw: 'Older title' } } );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( true );
+	} );
+
+	it( 'returns true when the excerpt differs', () => {
+		const revision = getRevision( { excerpt: { raw: 'Older excerpt' } } );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( true );
+	} );
+
+	it( 'ignores title and excerpt the revision does not carry', () => {
+		const revision = getRevision( {
+			title: undefined,
+			excerpt: undefined,
+		} );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( false );
+	} );
+
+	it( 'returns true when meta the revision carries differs', () => {
+		const revision = getRevision( { meta: { footnotes: '[{"id":"a"}]' } } );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( true );
+	} );
+
+	it( 'returns false when meta the revision carries matches', () => {
+		const revision = getRevision( { meta: { footnotes: '[]' } } );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( false );
+	} );
+
+	it( 'ignores post meta the revision does not carry', () => {
+		const revision = getRevision( { meta: {} } );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( false );
+	} );
+
+	it( 'ignores protected meta the revision stores empty', () => {
+		// Revisions save `_crdt_document` empty, so it differs from the post on
+		// every revision and must not count as a change to restore.
+		const revision = getRevision( {
+			meta: { footnotes: '[]', _crdt_document: '' },
+		} );
+
+		expect( hasChangesToRestore( revision, post ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## What?

Closes #81401

Disables the "Restore" button in the Post Revisions view when the selected revision already matches the saved post, so the current version is no longer offered as restorable.

## Why?

The revisions view opens on the newest revision, which is a copy of the post as it was last saved. Restore was enabled there anyway, because the only condition was:

```js
const canRestore = !! currentRevisionId;
```

Clicking it ran a full `editPost` + `savePost` round-trip that changed nothing and then reported `Restored to revision from %s.` as if a restore had happened. As the reporter put it, "I expected the Restore button to be disabled or something since there is nothing to restore."

## How?

`hasChangesToRestore()` compares the fields `restoreRevision` writes back — `content`, `title` and `excerpt` raw values, plus the meta keys the revision carries — against the saved post, and the button is disabled when they all match.

Two details drove that shape, both established by measurement rather than assumption (full write-up in [the issue](https://github.com/WordPress/gutenberg/issues/81401#issuecomment-5263358724)):

**It does not compare revision IDs.** Disabling when the selection equals `getCurrentPostLastRevisionId()` looks like the obvious fix, but while an autosave exists it *is* the post's latest revision — verified through REST, where `predecessor-version` pointed at the autosave and the collection was `[60, 59]`. An ID comparison would refuse to restore an autosave, which is exactly what the "View the autosave" flow in `use-autosave-notice.js` enters revisions mode to do. Comparing content instead handles autosaves with no special-casing, since an autosave is simply a revision whose content differs.

**It skips protected meta.** Comparing meta wholesale never disables the button at all. Measured on a post whose newest revision matched it exactly:

```
content equal? true    title equal? true    excerpt equal? true

POST meta: {"_crdt_document":"{\"document\":\"AAAV46m+ix0Oqp…\",\"updateId\":151275664}","footnotes":""}
REV  meta: {"_crdt_document":"","footnotes":""}
```

Revisions do not preserve the collaborative editing document, so `_crdt_document` differs on every revision. Underscore-prefixed keys are internal bookkeeping rather than authored content, so they are excluded; public meta such as `footnotes` is still compared.

### Notes for review

- The comparison is byte-exact, so a revision that renders identically but was serialized differently still shows Restore enabled. That is the safe direction — it never wrongly blocks a restore.
- `restoreRevision` itself is unchanged, so a programmatic call can still produce the no-op save. Happy to add a guard there if you would rather the action be authoritative.
- The disabled button carries no explanation of *why*, since that would need a new translatable string. Worth a follow-up if wanted.

## Testing Instructions

Run the unit tests for the changed component:

```
npm run test:unit -- packages/editor/src/components/post-revisions-preview
```

Then, manually:

1. Create a post, then edit and save it two or three times so it has several revisions.
2. Open the Settings sidebar and click **Revisions (N)**. The view opens on the newest revision.
3. **Expected:** "Restore" is disabled. On `trunk` it is enabled, and clicking it shows a "Restored to revision from …" snackbar with nothing having changed.
4. Move the slider to an older revision. **Expected:** "Restore" becomes enabled.
5. Click "Restore" on that older revision. **Expected:** it restores as before — this PR does not change restoring itself.

To check the autosave path is unaffected: with a published post open, let an autosave happen, reload, and use "View the autosave" in the notice. **Expected:** "Restore" is enabled, because the autosave differs from the post.

### Testing Instructions for Keyboard

The button uses `accessibleWhenDisabled`, so it stays reachable when disabled. Tab to the "Restore" button in the revisions header: on the newest revision it should be focusable and announced as disabled, and pressing <kbd>Enter</kbd> or <kbd>Space</kbd> should do nothing. On an older revision it should be focusable and activate normally.

## Screenshots or screencast

| Before | After |
|-|-|
| "Restore" enabled on the current version; clicking it reports a successful restore with no change. | "Restore" disabled on the current version; still enabled on every older revision. |

## Use of AI Tools

The root-cause analysis, the diagnostic instrumentation used to gather the REST and meta measurements above, and this patch were drafted with AI assistance (Claude Code). All reproduction and verification was performed by me on my own machine, and I have reviewed the change and take responsibility for it.
