### PR TITLE
Editor: Stop `:has()` selectors recalculating the whole document on every block selection

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -10,12 +10,16 @@ body.js.block-editor-page {
 
 	&.is-fullscreen-mode {
 		@include break-medium {
+			// Relayed through a custom property to keep `body` the subject of
+			// its own `:has()`. With `body:has(…) #wpadminbar`, every DOM change
+			// in the editor recalculates the whole document.
 			&:has(.editor-editor-interface.is-distraction-free) {
 				--wp-admin--admin-bar--height: 0px;
+				--wp-editor-admin-bar-display: none;
+			}
 
-				#wpadminbar {
-					display: none;
-				}
+			#wpadminbar {
+				display: var(--wp-editor-admin-bar-display, block);
 			}
 		}
 	}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -56,12 +56,16 @@ body.js.site-editor-php {
 	background: var(--wpds-color-background-surface-neutral-weak);
 
 	@include break-medium {
+		// Relayed through a custom property to keep `body` the subject of its
+		// own `:has()`. With `body:has(…) #wpadminbar`, every DOM change in the
+		// editor recalculates the whole document.
 		&:has(.editor-editor-interface.is-distraction-free) {
 			--wp-admin--admin-bar--height: 0px;
+			--wp-editor-admin-bar-display: none;
+		}
 
-			#wpadminbar {
-				display: none;
-			}
+		#wpadminbar {
+			display: var(--wp-editor-admin-bar-display, block);
 		}
 	}
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -4,10 +4,10 @@
 
 .interface-interface-skeleton__sidebar:has(.editor-collab-sidebar) {
 	box-shadow: none;
+}
 
-	.interface-complementary-area-header {
-		display: none;
-	}
+.editor-collab-sidebar__header {
+	display: none;
 }
 
 .editor-collab-sidebar {

--- a/packages/editor/src/components/post-revisions-timeline/style.scss
+++ b/packages/editor/src/components/post-revisions-timeline/style.scss
@@ -3,15 +3,18 @@
 //
 // The timeline only renders in revisions mode, so its ancestors are scoped
 // with `:has()` — keeping this layout out of the generic editor sidebar.
+//
+// Keep each `:has()` the subject of its rule: a subject below it recalculates
+// the anchor's whole subtree on every DOM change in the editor.
 .interface-complementary-area:has(.editor-post-revisions-timeline) {
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+}
 
-	// The tabs header keeps its natural height.
-	.editor-sidebar__panel-tabs {
-		flex-shrink: 0;
-	}
+// The tabs header keeps its natural height. Inert unless the rule above applies.
+.interface-complementary-area > .editor-sidebar__panel-tabs {
+	flex-shrink: 0;
 }
 
 .editor-sidebar__panel:has(.editor-post-revisions-timeline) {
@@ -19,25 +22,25 @@
 	flex-direction: column;
 	flex: 1;
 	min-height: 0;
+}
 
-	// The document tab panel hands its bounded height down to the timeline.
-	[role="tabpanel"]:has(.editor-post-revisions-timeline) {
-		display: flex;
-		flex-direction: column;
-		flex: 1;
-		min-height: 0;
-	}
+// The document tab panel hands its bounded height down to the timeline.
+.editor-sidebar__panel [role="tabpanel"]:has(.editor-post-revisions-timeline) {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+}
 
-	// Cap only the post-meta diff content so a large
-	// diff (e.g. footnotes) can't dominate the column.
-	.editor-revision-meta-diff__content {
-		max-height: 80px;
-		overflow-y: auto;
-	}
+// Cap only the post-meta diff content so a large
+// diff (e.g. footnotes) can't dominate the column.
+.editor-sidebar__panel .editor-revision-meta-diff__content {
+	max-height: 80px;
+	overflow-y: auto;
+}
 
-	// timeline grows to fill the leftover space and scrolls internally.
-	.editor-post-revisions-timeline {
-		flex: 1;
-		min-height: 0;
-	}
+// timeline grows to fill the leftover space and scrolls internally.
+.editor-sidebar__panel .editor-post-revisions-timeline {
+	flex: 1;
+	min-height: 0;
 }


### PR DESCRIPTION
## What?
Related #81457.

Rewrites four `:has()` rules in the editor and interface styles so that each `:has()` compound is the subject of its own rule.

## Why?

Clicking a paragraph in a 1000-paragraph post ran about 8 full document-style recalcs in the `post.php` frame. The cause is `body:has(.editor-editor-interface.is-distraction-free) #wpadminbar { display: none }`. Blink treats a `:has()` whose subject sits below the anchor differently from one where the anchor is the subject: it cannot tell which descendants are affected, so it flags the anchor's entire subtree and recalculates it on every DOM change during the React commit. The same pattern appeared in the revisions timeline and the collab sidebar rules.

Splitting the distraction-free rule in two confirmed where the cost was. The inherited custom property half is free, and the `#wpadminbar` half accounts for all of it.

## How?

The distraction-free state now reaches the admin bar through a second inherited custom property, so `body` stays the subject of its own `:has()`. The revisions timeline rules are unnested, since their subjects exist only in revisions mode and do not require the extra scoping. The collab sidebar header is targeted by its own class instead of a `:has()` on the skeleton sidebar.

## Results

Measured across two real builds with the arms alternating within one session, since sequential A/B blocks are not reliable at this size.

| Metric | Trunk | This PR |
| --- | --- | --- |
| `Selecting blocks` perf metric (median of 40 clicks) | 32.86 ms | 27.32 ms |
| First click after load (median) | 55.5 ms | 43.6 ms |
| Style recalc, first click | 20.3 ms | 6.3 ms |
| Elements recalculated, first click | 6178 | 476 |
| Largest single recalc pass | 850 elements | 142 elements |
| `BODY` subtree invalidations per click | 8 | 0 |

The document has 792 elements, so the whole document recalcs are gone.

The `Selecting blocks` metric discards the first click, so it reports the steady state improvement of about 17 percent rather than the larger first click one. Head won all four rounds with no overlap between the per-round ranges.

## Testing Instructions

Some of these have e2e test coverage, so the smoke test affected features:

* Enabled distraction-free mode. The adminbar should be hidden.
* Open editor revisions. The sidebar should be rendered as before, no double scrollbars.
* The floating notes sidebar shouldn't render a header and shadow.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude