### PR TITLE
Release: Improve changelog categorization

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,14 +4,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/a11y/**'
 
-'[Package] Abilities':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/abilities/**'
-
-'[Package] Admin UI':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/admin-ui/**'
-
 '[Package] API fetch':
     - changed-files:
           - any-glob-to-any-file: 'packages/api-fetch/**'
@@ -27,10 +19,6 @@
 '[Package] Blob':
     - changed-files:
           - any-glob-to-any-file: 'packages/blob/**'
-
-'[Package] Boot':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/boot/**'
 
 '[Package] Block editor':
     - changed-files:
@@ -84,10 +72,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/deprecated/**'
 
-'[Package] Design System MCP':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/design-system-mcp/**'
-
 '[Package] DOM ready':
     - changed-files:
           - any-glob-to-any-file: 'packages/dom-ready/**'
@@ -132,10 +116,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/format-library/**'
 
-'[Package] Grid':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/grid/**'
-
 '[Package] Hooks':
     - changed-files:
           - any-glob-to-any-file: 'packages/hooks/**'
@@ -151,10 +131,6 @@
 '[Package] Icons':
     - changed-files:
           - any-glob-to-any-file: 'packages/icons/**'
-
-'[Package] Image Cropper':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/image-cropper/**'
 
 '[Package] Interactivity':
     - changed-files:
@@ -236,6 +212,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/router/**'
 
+'[Package] Sanitize':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/sanitize/**'
+
 '[Package] Server Side Render':
     - changed-files:
           - any-glob-to-any-file: 'packages/server-side-render/**'
@@ -268,26 +248,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/viewport/**'
 
-'[Package] Views':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/views/**'
-
 '[Package] Warning':
     - changed-files:
           - any-glob-to-any-file: 'packages/warning/**'
 
-'[Package] Widget Dashboard':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/widget-dashboard/**'
-
-'[Package] Widget primitives':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/widget-primitives/**'
-
 '[Package] Word count':
     - changed-files:
           - any-glob-to-any-file: 'packages/wordcount/**'
-
-'[Package] wp-build':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/wp-build/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,14 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/a11y/**'
 
+'[Package] Abilities':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/abilities/**'
+
+'[Package] Admin UI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/admin-ui/**'
+
 '[Package] API fetch':
     - changed-files:
           - any-glob-to-any-file: 'packages/api-fetch/**'
@@ -19,6 +27,10 @@
 '[Package] Blob':
     - changed-files:
           - any-glob-to-any-file: 'packages/blob/**'
+
+'[Package] Boot':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/boot/**'
 
 '[Package] Block editor':
     - changed-files:
@@ -72,6 +84,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/deprecated/**'
 
+'[Package] Design System MCP':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/design-system-mcp/**'
+
 '[Package] DOM ready':
     - changed-files:
           - any-glob-to-any-file: 'packages/dom-ready/**'
@@ -116,6 +132,10 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/format-library/**'
 
+'[Package] Grid':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/grid/**'
+
 '[Package] Hooks':
     - changed-files:
           - any-glob-to-any-file: 'packages/hooks/**'
@@ -131,6 +151,10 @@
 '[Package] Icons':
     - changed-files:
           - any-glob-to-any-file: 'packages/icons/**'
+
+'[Package] Image Cropper':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/image-cropper/**'
 
 '[Package] Interactivity':
     - changed-files:
@@ -212,10 +236,6 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/router/**'
 
-'[Package] Sanitize':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/sanitize/**'
-
 '[Package] Server Side Render':
     - changed-files:
           - any-glob-to-any-file: 'packages/server-side-render/**'
@@ -248,10 +268,26 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/viewport/**'
 
+'[Package] Views':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/views/**'
+
 '[Package] Warning':
     - changed-files:
           - any-glob-to-any-file: 'packages/warning/**'
 
+'[Package] Widget Dashboard':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/widget-dashboard/**'
+
+'[Package] Widget primitives':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/widget-primitives/**'
+
 '[Package] Word count':
     - changed-files:
           - any-glob-to-any-file: 'packages/wordcount/**'
+
+'[Package] wp-build':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/wp-build/**'

--- a/tools/release/commands/changelog.js
+++ b/tools/release/commands/changelog.js
@@ -130,6 +130,7 @@ const LABEL_FEATURE_MAPPING = {
 	'[Package] E2E Tests': 'Testing',
 	'[Package] E2E Test Utils': 'Testing',
 	'[Type] Automated Testing': 'Testing',
+	'[Type] Flaky Test': 'Testing',
 	'Connectors screen': 'Connectors',
 	'[Package] UI': 'Components',
 	'[Package] Compose': 'Components',
@@ -295,6 +296,20 @@ function getFeatureSpecificLabels( labels ) {
 }
 
 /**
+ * Returns the first package or tool-specific label from the given labels.
+ *
+ * @param {string[]} labels Label names.
+ *
+ * @return {string|undefined} the package or tool-specific label.
+ */
+function getPackageOrToolSpecificLabel( labels ) {
+	return labels.find(
+		( label ) =>
+			label.startsWith( '[Package] ' ) || label.startsWith( '[Tool] ' )
+	);
+}
+
+/**
  * Returns type candidates based on given issue title.
  *
  * @param {string} title Issue title.
@@ -380,6 +395,16 @@ function getIssueFeature( issue ) {
 
 	if ( blockSpecificLabels ) {
 		return 'Block Library';
+	}
+
+	// 4. Package and tool-specific labels that do not have an explicit mapping.
+	const packageOrToolSpecificLabel = getPackageOrToolSpecificLabel( labels );
+
+	if ( packageOrToolSpecificLabel ) {
+		return packageOrToolSpecificLabel.replace(
+			/^\[(?:Package|Tool)\] /,
+			''
+		);
 	}
 
 	// Fallback - if we couldn't find a good match.

--- a/tools/release/commands/test/__snapshots__/changelog.js.snap
+++ b/tools/release/commands/test/__snapshots__/changelog.js.snap
@@ -223,7 +223,6 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 ### Tools
 
 - Label enforcer workflow: Make accessibility a focus instead of a type. ([54941](https://github.com/WordPress/gutenberg/pull/54941))
-- Scripts: Update webpack and related dependencies to the latest version. ([54657](https://github.com/WordPress/gutenberg/pull/54657))
 - Update changelog automation and test fixtures to match the last a11y label renaming. ([54974](https://github.com/WordPress/gutenberg/pull/54974))
 
 #### Testing
@@ -251,6 +250,9 @@ exports[`getChangelog verify that the changelog is properly formatted 1`] = `
 - Update the default JSX pragma to React instead of @wordpress/element. ([54494](https://github.com/WordPress/gutenberg/pull/54494))
 - Upgrade wp-prettier to v3.0.3 (final). ([54775](https://github.com/WordPress/gutenberg/pull/54775))
 - [RNMobile] Upgrade \`compileSdkVersion\` to 34 (Android). ([54437](https://github.com/WordPress/gutenberg/pull/54437))
+
+#### Scripts
+- Update webpack and related dependencies to the latest version. ([54657](https://github.com/WordPress/gutenberg/pull/54657))
 
 
 ### Security

--- a/tools/release/commands/test/changelog.js
+++ b/tools/release/commands/test/changelog.js
@@ -352,23 +352,22 @@ describe( 'getIssueFeature', () => {
 		expect( result ).toBe( 'Uncategorized' );
 	} );
 
-	it( 'falls by to "Unknown" as the feature if unable to classify by other means', () => {
-		const result = getIssueFeature( {
-			labels: [
-				{
-					name: 'Some Label',
-				},
-				{
-					name: '[Package] Example Package', // 1. has explicit mapping.
-				},
-				{
-					name: '[Package] Another One',
-				},
-			],
-		} );
+	it.each( [
+		[ '[Package] Element', 'Element' ],
+		[ '[Package] Widget Dashboard', 'Widget Dashboard' ],
+		[ '[Package] Boot', 'Boot' ],
+		[ '[Tool] WP Scripts', 'WP Scripts' ],
+		[ '[Package] Interface', 'Interface' ],
+	] )(
+		'uses an otherwise-unmapped %s label as a fallback category',
+		( label, expected ) => {
+			const result = getIssueFeature( {
+				labels: [ { name: 'Some Label' }, { name: label } ],
+			} );
 
-		expect( result ).toEqual( 'Uncategorized' );
-	} );
+			expect( result ).toEqual( expected );
+		}
+	);
 
 	it( 'gives precedence to manual feature mapping', () => {
 		const result = getIssueFeature( {
@@ -469,18 +468,20 @@ describe( 'getTypesByLabels', () => {
 } );
 
 describe( 'mapLabelsToFeatures', () => {
-	it( 'returns all normalized feature candidates by feature prefix. it is case insensitive', () => {
+	it( 'returns all normalized feature candidates case-insensitively', () => {
 		const result = mapLabelsToFeatures( [
 			'[Package] Commands',
 			'[Package] Block Library',
 			'[Feature] Link Editing',
 			'[Feature] block Multi Selection',
+			'[Type] Flaky Test',
 		] );
 
 		expect( result ).toEqual( [
 			'Commands',
 			'Block Library',
 			'Block Editor',
+			'Testing',
 		] );
 	} );
 } );

--- a/tools/release/commands/test/changelog.js
+++ b/tools/release/commands/test/changelog.js
@@ -346,8 +346,16 @@ describe( 'getIssueType', () => {
 } );
 
 describe( 'getIssueFeature', () => {
-	it( 'returns "Unknown" as feature if there are no labels', () => {
+	it( 'returns "Uncategorized" as feature if there are no labels', () => {
 		const result = getIssueFeature( { labels: [] } );
+
+		expect( result ).toBe( 'Uncategorized' );
+	} );
+
+	it( 'falls back to "Uncategorized" when no label can classify the issue', () => {
+		const result = getIssueFeature( {
+			labels: [ { name: 'Some Label' } ],
+		} );
 
 		expect( result ).toBe( 'Uncategorized' );
 	} );


### PR DESCRIPTION
## What?

Improves release changelog categorization for pull requests with package, tool, and flaky-test labels.

This PR:

- Uses otherwise-unmapped `[Package]` and `[Tool]` labels as fallback changelog subcategories.
- Categorizes `[Type] Flaky Test` pull requests under `Testing`.
- Preserves `Uncategorized` for pull requests with no recognized label.

Related: #76263 handles automatic package/tool labeling and validation of `.github/labeler.yml`.

## Why?

The Gutenberg 23.8 changelog contains several enhancements and bug fixes without subcategories even though the pull requests already have specific package or tool labels. For example, changes labeled `[Package] Element`, `[Package] Interface`, `[Package] Boot`, `[Package] Widget Dashboard`, and `[Tool] WP Scripts` currently render at the top level because every recognized subcategory must be maintained manually in `LABEL_FEATURE_MAPPING`.

Falling back to scoped package and tool labels reduces that maintenance burden while retaining the existing explicit mappings and their grouping behavior.

## How?

After checking the existing explicit label mapping, `[Feature]` labels, and `[Block]` labels, `getIssueFeature` now falls back to the first scoped `[Package]` or `[Tool]` label and removes its prefix for display. Unscoped or arbitrary labels remain uncategorized.

The existing precedence is preserved:

1. Explicit label-to-feature mappings.
2. `[Feature]` labels.
3. `[Block]` labels, grouped under `Block Library`.
4. Otherwise-unmapped `[Package]` or `[Tool]` labels.
5. `Uncategorized`.

This means a pull request such as #81362 remains under its explicit `List View` feature instead of moving to `Interface`, while pull requests that only have `[Package] Interface` now receive an `Interface` subcategory.

## Testing Instructions

1. Run the focused unit tests:

   ```sh
   npm run test:unit tools/release/commands/test/changelog.js -- --runInBand
   ```

2. Generate the Gutenberg 23.8 changelog:

   ```sh
   npm run other:changelog -- --milestone="Gutenberg 23.8"
   ```

3. Confirm the generated changelog includes the following subcategories:
   - `Element`, `Widget Dashboard`, and `Interface` under Enhancements.
   - `Boot`, `WP Scripts`, `Interface`, and `Testing` under Bug Fixes.
4. Confirm PR #81362 remains under `List View`.
5. Run JavaScript linting for the changed release files:

   ```sh
   npm run lint:js -- tools/release/commands/changelog.js tools/release/commands/test/changelog.js
   ```

### Testing Instructions for Keyboard

Not applicable; this PR does not change a user interface.

## Screenshots or screencast

Not applicable; this PR changes release tooling only.

## Use of AI Tools

OpenAI Codex was used to audit the changelog workflow and repository labels, implement the changes, draft tests and this PR description, run verification commands, and separate overlapping labeler work into #76263. The resulting changes and output were reviewed by the contributor.
