### PR TITLE
Enable axial gap for Group and restrict to flex and grid layouts.

### DIFF
--- a/backport-changelog/7.2/13011.md
+++ b/backport-changelog/7.2/13011.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/13011
 
 * https://github.com/WordPress/gutenberg/pull/81460
+* https://github.com/WordPress/gutenberg/pull/81476

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -843,7 +843,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$row_count         = is_numeric( $row_count_attr ) ? (int) $row_count_attr : null;
 
 		/*
-		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
+		 * If the gap value is an array, we use the "left" value because it represents the horizontal gap, which
 		 * is the relevant one for computation of responsive grid columns.
 		 */
 		if ( is_array( $fallback_gap_value ) ) {
@@ -872,10 +872,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					$slug            = _wp_to_kebab_case( substr( $process_value, $index_to_splice ) );
 					$process_value   = "var(--wp--preset--spacing--$slug)";
 				}
+				if ( ! is_array( $gap_value ) || 'left' === $gap_side ) {
+					$responsive_gap_value = $process_value;
+				}
 				$combined_gap_value .= "$process_value ";
 			}
-			$gap_value            = trim( $combined_gap_value );
-			$responsive_gap_value = $gap_value;
+			$gap_value = trim( $combined_gap_value );
 		}
 
 		// Ensure 0 values have a unit so they work in calc().

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2237,7 +2237,8 @@ class WP_Theme_JSON_Gutenberg {
 		// Gap styles will only be output if the theme has block gap support, or supports a fallback gap.
 		// Default layout gap styles will be skipped for themes that do not explicitly opt-in to blockGap with a `true` or `false` value.
 		if ( $has_block_gap_support || $has_fallback_gap_support ) {
-			$block_gap_value = null;
+			$block_gap_value     = null;
+			$block_gap_row_value = null;
 			// Use a fallback gap value if block gap support is not available.
 			if ( ! $has_block_gap_support ) {
 				$block_gap_value = static::ROOT_BLOCK_SELECTOR === $selector ? '0.5em' : null;
@@ -2247,16 +2248,20 @@ class WP_Theme_JSON_Gutenberg {
 			} else {
 				$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) );
 			}
+			$block_gap_row_value = $block_gap_value;
 
 			// Support split row / column values and concatenate to a shorthand value.
 			if ( is_array( $block_gap_value ) ) {
 				if ( isset( $block_gap_value['top'] ) && isset( $block_gap_value['left'] ) ) {
-					$gap_row         = static::get_property_value( $node, array( 'spacing', 'blockGap', 'top' ) );
-					$gap_column      = static::get_property_value( $node, array( 'spacing', 'blockGap', 'left' ) );
-					$block_gap_value = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
+					$block_gap_row_value    = static::get_property_value( $node, array( 'spacing', 'blockGap', 'top' ) );
+					$block_gap_column_value = static::get_property_value( $node, array( 'spacing', 'blockGap', 'left' ) );
+					$block_gap_value        = $block_gap_row_value === $block_gap_column_value
+						? $block_gap_row_value
+						: $block_gap_row_value . ' ' . $block_gap_column_value;
 				} else {
 					// Skip outputting gap value if not all sides are provided.
-					$block_gap_value = null;
+					$block_gap_value     = null;
+					$block_gap_row_value = null;
 				}
 			}
 
@@ -2268,8 +2273,11 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$class_name    = $layout_definition['className'] ?? false;
-					$spacing_rules = $layout_definition['spacingStyles'] ?? array();
+					$class_name       = $layout_definition['className'] ?? false;
+					$spacing_rules    = $layout_definition['spacingStyles'] ?? array();
+					$layout_gap_value = in_array( $layout_definition_key, array( 'default', 'constrained' ), true )
+						? $block_gap_row_value
+						: $block_gap_value;
 
 					if (
 						! empty( $class_name ) &&
@@ -2284,7 +2292,7 @@ class WP_Theme_JSON_Gutenberg {
 							) {
 								// Iterate over each of the styling rules and substitute non-string values such as `null` with the real `blockGap` value.
 								foreach ( $spacing_rule['rules'] as $css_property => $css_value ) {
-									$current_css_value = is_string( $css_value ) ? $css_value : $block_gap_value;
+									$current_css_value = is_string( $css_value ) ? $css_value : $layout_gap_value;
 									if ( static::is_safe_css_declaration( $css_property, $current_css_value ) ) {
 										$declarations[] = array(
 											'name'  => $css_property,

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2252,14 +2252,21 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Support split row / column values and concatenate to a shorthand value.
 			if ( is_array( $block_gap_value ) ) {
-				if ( isset( $block_gap_value['top'] ) && isset( $block_gap_value['left'] ) ) {
-					$block_gap_row_value    = static::get_property_value( $node, array( 'spacing', 'blockGap', 'top' ) );
-					$block_gap_column_value = static::get_property_value( $node, array( 'spacing', 'blockGap', 'left' ) );
+				$has_block_gap_row_value    = isset( $block_gap_value['top'] );
+				$has_block_gap_column_value = isset( $block_gap_value['left'] );
+
+				if ( $has_block_gap_row_value || $has_block_gap_column_value ) {
+					$block_gap_row_value = $has_block_gap_row_value
+						? static::get_property_value( $node, array( 'spacing', 'blockGap', 'top' ) )
+						: '0';
+					$block_gap_column_value = $has_block_gap_column_value
+						? static::get_property_value( $node, array( 'spacing', 'blockGap', 'left' ) )
+						: '0';
 					$block_gap_value        = $block_gap_row_value === $block_gap_column_value
 						? $block_gap_row_value
 						: $block_gap_row_value . ' ' . $block_gap_column_value;
 				} else {
-					// Skip outputting gap value if not all sides are provided.
+					// Skip outputting a gap value if neither supported axis is provided.
 					$block_gap_value     = null;
 					$block_gap_row_value = null;
 				}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2256,7 +2256,7 @@ class WP_Theme_JSON_Gutenberg {
 				$has_block_gap_column_value = isset( $block_gap_value['left'] );
 
 				if ( $has_block_gap_row_value || $has_block_gap_column_value ) {
-					$block_gap_row_value = $has_block_gap_row_value
+					$block_gap_row_value    = $has_block_gap_row_value
 						? static::get_property_value( $node, array( 'spacing', 'blockGap', 'top' ) )
 						: '0';
 					$block_gap_column_value = $has_block_gap_column_value

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Register and handle the keyboard shortcuts that blocks declare on their variations and transforms, so that any block can contribute a shortcut without the editor knowing about it. Shortcuts apply to the selected block, and are listed under "Block shortcuts" in the keyboard shortcuts help modal ([#81588](https://github.com/WordPress/gutenberg/pull/81588)).
 
+### Enhancements
+
+-   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value.
+
 ### Bug Fixes
 
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value.
+-   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
 
 ### Bug Fixes
 

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -1014,6 +1014,7 @@ export default function DimensionsPanel( {
 						) ) }
 					{ showSpacingPresetsControl && (
 						<SpacingSizesControl
+							key={ isAxialGap ? 'axial-gap' : 'single-gap' }
 							label={ __( 'Block spacing' ) }
 							min={ 0 }
 							onChange={ setGapValues }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -347,6 +347,7 @@ export default function DimensionsPanel( {
 	// Special case because the layout controls are not part of the dimensions panel
 	// in global styles but not in block inspector.
 	includeLayoutControls = false,
+	allowAxialBlockGap = true,
 	styleState = DEFAULT_BLOCK_STYLE_STATE,
 	showInheritanceLabelIndicators = isGlobalStylesInheritanceEnabled(),
 } ) {
@@ -556,9 +557,19 @@ export default function DimensionsPanel( {
 		? settings?.spacing?.blockGap
 		: settings?.spacing?.blockGap?.sides;
 	const isAxialGap =
-		gapSides && gapSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
+		allowAxialBlockGap &&
+		gapSides &&
+		gapSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
 	const localGapRaw = decodeValue( value?.spacing?.blockGap );
 	const inheritedGapRaw = decodeValue( inheritedValue?.spacing?.blockGap );
+	const localGapForSingleInput =
+		! isAxialGap && typeof localGapRaw === 'object'
+			? localGapRaw?.top
+			: localGapRaw;
+	const inheritedGapForSingleInput =
+		! isAxialGap && typeof inheritedGapRaw === 'object'
+			? inheritedGapRaw?.top
+			: inheritedGapRaw;
 	// Merge local-then-inherited so SpacingSizesControl's chip slider and
 	// the axial-gap BoxControl reflect the local value when set and fall
 	// back to the inherited value at rest.
@@ -572,8 +583,8 @@ export default function DimensionsPanel( {
 	// at-rest cue for those.
 	const isGapPlaceholder =
 		! hasValue( value?.spacing?.blockGap ) &&
-		typeof inheritedGapRaw === 'string' &&
-		inheritedGapRaw !== '';
+		typeof inheritedGapForSingleInput === 'string' &&
+		inheritedGapForSingleInput !== '';
 	const setGapValue = ( newGapValue ) => {
 		onChange(
 			setImmutably( value, [ 'spacing', 'blockGap' ], newGapValue )
@@ -993,10 +1004,10 @@ export default function DimensionsPanel( {
 								min={ 0 }
 								onChange={ setGapValue }
 								units={ units }
-								value={ localGapRaw ?? undefined }
+								value={ localGapForSingleInput ?? undefined }
 								placeholder={
 									isGapPlaceholder
-										? inheritedGapRaw
+										? inheritedGapForSingleInput
 										: undefined
 								}
 							/>

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -357,6 +357,37 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 				screen.queryByRole( 'group', { name: 'Block spacing' } )
 			).not.toBeInTheDocument();
 		} );
+
+		it( 'keeps the block spacing control visible when axial support changes', () => {
+			const settings = {
+				...settingsWithSpacingPresets,
+				spacing: {
+					...settingsWithSpacingPresets.spacing,
+					blockGap: [ 'horizontal', 'vertical' ],
+				},
+			};
+			const props = {
+				value: {},
+				settings,
+				onChange: () => {},
+				panelId: 'test-panel',
+			};
+			const { rerender } = render(
+				<DimensionsPanel { ...props } allowAxialBlockGap />
+			);
+
+			expect(
+				screen.getAllByRole( 'slider', { name: /block spacing/i } )
+			).toHaveLength( 2 );
+
+			rerender(
+				<DimensionsPanel { ...props } allowAxialBlockGap={ false } />
+			);
+
+			expect(
+				screen.getAllByRole( 'slider', { name: /block spacing/i } )
+			).toHaveLength( 1 );
+		} );
 	} );
 
 	describe( 'padding (BoxControl archetype)', () => {

--- a/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/dimensions-panel.js
@@ -90,6 +90,14 @@ const baseSettings = {
 	},
 };
 
+const settingsWithAxialGap = {
+	...baseSettings,
+	spacing: {
+		...baseSettings.spacing,
+		blockGap: [ 'horizontal', 'vertical' ],
+	},
+};
+
 const settingsWithDimensions = {
 	...baseSettings,
 	dimensions: {
@@ -280,12 +288,7 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 			expect( gapInput ).toHaveAttribute( 'placeholder', '1.5rem' );
 		} );
 
-		it( 'renders no placeholder for blockGap when the inherited value is the compound axial shape (single-input path can only display strings)', () => {
-			// When blockGap is an object (axial split), the panel still
-			// renders the single-input UnitControl path because the
-			// settings here do not enable axial gap sides. The placeholder
-			// must NOT surface a non-string value into a control that
-			// cannot display it.
+		it( 'renders the vertical blockGap as a placeholder when the inherited value has an axial shape', () => {
 			renderPanel( {
 				value: {},
 				inheritedValue: {
@@ -295,7 +298,64 @@ describe( 'DimensionsPanel — per-control placeholder pattern', () => {
 			} );
 
 			const gapInput = screen.getByLabelText( /block spacing/i );
-			expect( gapInput ).not.toHaveAttribute( 'placeholder' );
+			expect( gapInput ).toHaveAttribute( 'placeholder', '1rem' );
+		} );
+
+		it( 'renders the vertical blockGap when a local axial value is shown in a single input', () => {
+			renderPanel( {
+				value: {
+					spacing: { blockGap: { top: '1rem', left: '0.5rem' } },
+				},
+				settings: baseSettings,
+			} );
+
+			const gapInput = screen.getByLabelText( /block spacing/i );
+			expect( gapInput ).toHaveValue( 1 );
+		} );
+	} );
+
+	describe( 'block spacing (axial gap path)', () => {
+		it( 'renders separate horizontal and vertical controls when axial block gap is allowed', async () => {
+			const user = userEvent.setup();
+			renderPanel( {
+				value: {},
+				settings: settingsWithAxialGap,
+			} );
+
+			const blockSpacingControl = screen.getByRole( 'group', {
+				name: 'Block spacing',
+			} );
+			await user.click(
+				within( blockSpacingControl ).getByRole( 'button', {
+					name: 'Unlink sides',
+				} )
+			);
+
+			expect(
+				within( blockSpacingControl ).getByRole( 'textbox', {
+					name: 'Top and bottom sides',
+				} )
+			).toBeInTheDocument();
+			expect(
+				within( blockSpacingControl ).getByRole( 'textbox', {
+					name: 'Left and right sides',
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders a single control when axial block gap is not allowed', () => {
+			renderPanel( {
+				value: {},
+				settings: settingsWithAxialGap,
+				allowAxialBlockGap: false,
+			} );
+
+			expect(
+				screen.getByLabelText( /block spacing/i )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'group', { name: 'Block spacing' } )
+			).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -19,6 +19,7 @@ import {
 	setStyleForState,
 	useBlockStyleState,
 } from './block-style-state';
+import { isAxialBlockGapAllowed } from './gap';
 
 export const DIMENSIONS_SUPPORT_KEY = 'dimensions';
 export const SPACING_SUPPORT_KEY = 'spacing';
@@ -68,7 +69,7 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 	const selectedState = useBlockStyleState();
 	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
 	const isEnabled = useHasDimensionsPanel( settings, selectedState );
-	const { style, className } = useSelect(
+	const { style, className, layout } = useSelect(
 		( select ) => {
 			// Early return to avoid subscription when disabled
 			if ( ! isEnabled ) {
@@ -79,6 +80,7 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 			return {
 				style: attributes.style,
 				className: attributes.className,
+				layout: attributes.layout,
 			};
 		},
 		[ clientId, isEnabled ]
@@ -118,6 +120,7 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 		SPACING_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
+	const { default: defaultLayout } = getBlockSupport( name, 'layout' ) || {};
 	const defaultControls = {
 		// In the block inspector, minHeight and minWidth should not
 		// be shown by default unless the block explicitly opts in.
@@ -133,6 +136,10 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 				as={ DimensionsInspectorControl }
 				panelId={ clientId }
 				settings={ settings }
+				allowAxialBlockGap={ isAxialBlockGapAllowed(
+					layout,
+					defaultLayout
+				) }
 				value={ value }
 				onChange={ onChange }
 				defaultControls={ defaultControls }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -1,6 +1,22 @@
 import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 
 /**
+ * Returns whether the current layout can use separate row and column gaps.
+ *
+ * @param {?Object} layout        The block instance's layout attribute.
+ * @param {?Object} defaultLayout The block's default supported layout.
+ * @return {boolean} Whether axial block gap controls should be available.
+ */
+export function isAxialBlockGapAllowed( layout, defaultLayout ) {
+	const usedLayout =
+		layout?.inherit || layout?.contentSize || layout?.wideSize
+			? { ...layout, type: 'constrained' }
+			: layout || defaultLayout || {};
+
+	return [ 'flex', 'grid' ].includes( usedLayout?.type );
+}
+
+/**
  * Returns a BoxControl object value from a given blockGap style value.
  * The string check is for backwards compatibility before Gutenberg supported
  * split gap values (row and column) and the value was a string n + unit.

--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -1,6 +1,36 @@
-import { getGapCSSValue, getGapBoxControlValueFromStyle } from '../gap';
+import {
+	getGapCSSValue,
+	getGapBoxControlValueFromStyle,
+	isAxialBlockGapAllowed,
+} from '../gap';
 
 describe( 'gap', () => {
+	describe( 'isAxialBlockGapAllowed()', () => {
+		it( 'should allow axial block gap for Flex layouts', () => {
+			expect( isAxialBlockGapAllowed( { type: 'flex' } ) ).toBe( true );
+		} );
+
+		it( 'should allow axial block gap for Grid layouts', () => {
+			expect( isAxialBlockGapAllowed( { type: 'grid' } ) ).toBe( true );
+		} );
+
+		it( 'should not allow axial block gap for Flow layouts', () => {
+			expect( isAxialBlockGapAllowed( { type: 'flow' } ) ).toBe( false );
+		} );
+
+		it( 'should not allow axial block gap for Constrained layouts', () => {
+			expect( isAxialBlockGapAllowed( { type: 'constrained' } ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'should use the default layout when the block has no layout attribute', () => {
+			expect(
+				isAxialBlockGapAllowed( undefined, { type: 'flex' } )
+			).toBe( true );
+		} );
+	} );
+
 	describe( 'getGapBoxControlValueFromStyle()', () => {
 		it( 'should return `null` if argument is falsey', () => {
 			expect( getGapBoxControlValueFromStyle( undefined ) ).toBeNull();

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -247,7 +247,7 @@ export default {
 		const hasViewportOverride = ( key ) =>
 			Object.hasOwn( viewportOverrides || {}, key );
 		const { contentSize, wideSize, justifyContent } = effectiveLayout;
-		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
+		const blockGapStyleValue = style?.spacing?.blockGap;
 		const hasBlockGapOverride =
 			! hasViewportOverrides ||
 			Object.hasOwn( style?.spacing || {}, 'blockGap' );

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -20,7 +20,7 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions = LAYOUT_DEFINITIONS,
 	} ) {
-		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
+		const blockGapStyleValue = style?.spacing?.blockGap;
 
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -246,11 +246,14 @@ export default {
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
-		const blockGapValue =
+		const blockGapBoxControlValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
+				? getGapBoxControlValueFromStyle( style.spacing.blockGap )
 				: undefined;
+		const blockGapValue = blockGapBoxControlValue
+			? getGapCSSValue( style.spacing.blockGap, fallbackGapValue )
+			: undefined;
 		const hasBlockGapOverride =
 			! hasViewportOverrides ||
 			Object.hasOwn( style?.spacing || {}, 'blockGap' );
@@ -273,7 +276,9 @@ export default {
 			minimumColumnWidth &&
 			columnCount > 0
 		) {
-			let blockGapToUse = blockGapValue || fallbackGapValue;
+			let blockGapToUse =
+				getSpacingPresetCssVar( blockGapBoxControlValue?.left ) ||
+				fallbackGapValue;
 			// Ensure 0 values have a unit so they work in calc().
 			if ( blockGapToUse === '0' || blockGapToUse === 0 ) {
 				blockGapToUse = '0px';

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -246,14 +246,11 @@ export default {
 
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
-		const blockGapBoxControlValue =
+		const blockGapValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapBoxControlValueFromStyle( style.spacing.blockGap )
+				? getGapCSSValue( style?.spacing?.blockGap, fallbackGapValue )
 				: undefined;
-		const blockGapValue = blockGapBoxControlValue
-			? getGapCSSValue( style.spacing.blockGap, fallbackGapValue )
-			: undefined;
 		const hasBlockGapOverride =
 			! hasViewportOverrides ||
 			Object.hasOwn( style?.spacing || {}, 'blockGap' );
@@ -276,6 +273,9 @@ export default {
 			minimumColumnWidth &&
 			columnCount > 0
 		) {
+			const blockGapBoxControlValue = blockGapValue
+				? getGapBoxControlValueFromStyle( style.spacing.blockGap )
+				: undefined;
 			let blockGapToUse =
 				getSpacingPresetCssVar( blockGapBoxControlValue?.left ) ||
 				fallbackGapValue;

--- a/packages/block-editor/src/layouts/test/constrained.js
+++ b/packages/block-editor/src/layouts/test/constrained.js
@@ -35,6 +35,32 @@ describe( 'getLayoutStyle', () => {
 		expect( result ).toBe( expected );
 	} );
 
+	it( 'uses the vertical block gap when a constrained layout receives an axial gap', () => {
+		const result = constrained.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {},
+			style: {
+				spacing: { blockGap: { top: '2rem', left: '3rem' } },
+			},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			layoutDefinitions: {
+				constrained: {
+					spacingStyles: [
+						{
+							selector: ' > * + *',
+							rules: { 'margin-block-start': null },
+						},
+					],
+				},
+			},
+		} );
+
+		expect( result ).toBe(
+			'.my-container > * + * { margin-block-start: 2rem; }'
+		);
+	} );
+
 	it( 'should reset constrained sizes when content width is unset in a viewport', () => {
 		const result = constrained.getLayoutStyle( {
 			selector: '.my-container',

--- a/packages/block-editor/src/layouts/test/flow.js
+++ b/packages/block-editor/src/layouts/test/flow.js
@@ -15,4 +15,30 @@ describe( 'getLayoutStyle', () => {
 
 		expect( result ).toBe( expected );
 	} );
+
+	it( 'uses the vertical block gap when a flow layout receives an axial gap', () => {
+		const result = flow.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {},
+			style: {
+				spacing: { blockGap: { top: '2rem', left: '3rem' } },
+			},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			layoutDefinitions: {
+				default: {
+					spacingStyles: [
+						{
+							selector: ' > * + *',
+							rules: { 'margin-block-start': null },
+						},
+					],
+				},
+			},
+		} );
+
+		expect( result ).toBe(
+			'.my-container > * + * { margin-block-start: 2rem; }'
+		);
+	} );
 } );

--- a/packages/block-editor/src/layouts/test/grid.js
+++ b/packages/block-editor/src/layouts/test/grid.js
@@ -93,6 +93,52 @@ describe( 'getLayoutStyle', () => {
 
 		expect( result ).toBe( expected );
 	} );
+	it( 'should use the horizontal block gap to calculate responsive Grid column widths', () => {
+		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(max(min( 12rem, 100%), ( 100% - (3rem*2) ) / 3), 1fr)); container-type: inline-size; }.my-container { gap: 2rem 3rem; }`;
+
+		const result = grid.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { minimumColumnWidth: '12rem', columnCount: 3 },
+			style: {
+				spacing: { blockGap: { top: '2rem', left: '3rem' } },
+			},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe( expected );
+	} );
+	it( 'should use the fallback gap when an axial value has no horizontal gap', () => {
+		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(max(min( 12rem, 100%), ( 100% - (1.2rem*2) ) / 3), 1fr)); container-type: inline-size; }.my-container { gap: 2rem 1.2rem; }`;
+
+		const result = grid.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { minimumColumnWidth: '12rem', columnCount: 3 },
+			style: { spacing: { blockGap: { top: '2rem' } } },
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe( expected );
+	} );
+	it( 'should preserve a zero horizontal gap in responsive Grid column widths', () => {
+		const expected = `.my-container { grid-template-columns: repeat(auto-fill, minmax(max(min( 12rem, 100%), ( 100% - (0px*2) ) / 3), 1fr)); container-type: inline-size; }.my-container { gap: 2rem 0; }`;
+
+		const result = grid.getLayoutStyle( {
+			selector: '.my-container',
+			layout: { minimumColumnWidth: '12rem', columnCount: 3 },
+			style: {
+				spacing: { blockGap: { top: '2rem', left: '0' } },
+			},
+			blockName: 'test-block',
+			hasBlockGapSupport: true,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe( expected );
+	} );
 } );
 
 describe( 'GridLayoutInspectorControls', () => {

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Enhancements
 
+-   Group: Support separate horizontal and vertical block spacing values.
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Enhancements
 
--   Group: Support separate horizontal and vertical block spacing values.
+-   Group: Support separate horizontal and vertical block spacing values ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
 -   Playlist Track: Use a dedicated icon for the block toolbar. ([#80959](https://github.com/WordPress/gutenberg/pull/80959))
 -   Playlist: Expose the parent "Add track" toolbar control to selected Playlist Track child blocks via block toolbar sharing ([#80368](https://github.com/WordPress/gutenberg/pull/80368)).
 -   Playlist: Allow selecting audio tracks individually in the Media Library without holding Shift or Command, transform multiple Audio blocks into a Playlist, and transform a one-track Playlist into Audio. ([#80926](https://github.com/WordPress/gutenberg/pull/80926))

--- a/packages/block-library/src/group/README.md
+++ b/packages/block-library/src/group/README.md
@@ -39,7 +39,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`spacing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#spacing):
   - `margin`: `["top","bottom"]`
   - `padding`: `true`
-  - `blockGap`: `true`
+  - `blockGap`: `["horizontal","vertical"]`
 - [`dimensions`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#dimensions):
   - `minHeight`: `true`
   - `minWidth`: `true`

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -47,7 +47,7 @@
 		"spacing": {
 			"margin": [ "top", "bottom" ],
 			"padding": true,
-			"blockGap": true,
+			"blockGap": [ "horizontal", "vertical" ],
 			"__experimentalDefaultControls": {
 				"padding": true,
 				"blockGap": true

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Use the row block spacing value for Flow and Constrained layouts when Global Styles defines separate row and column values.
+-   Use the row block spacing value for Flow and Constrained layouts when Global Styles defines separate row and column values ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
 
 ## 1.20.0 (2026-08-12)
 

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Use the row block spacing value for Flow and Constrained layouts when Global Styles defines separate row and column values.
+
 ## 1.20.0 (2026-08-12)
 
 ### Bug Fixes

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -766,9 +766,8 @@ export function getLayoutStyles( {
 	fallbackGapValue?: string;
 } ): string {
 	let ruleset = '';
-	let gapValue = hasBlockGapSupport
-		? getGapCSSValue( style?.spacing?.blockGap )
-		: '';
+	const blockGapValue = style?.spacing?.blockGap;
+	let gapValue = hasBlockGapSupport ? getGapCSSValue( blockGapValue ) : '';
 
 	// Ensure a fallback gap value for the root layout definitions,
 	// and use a fallback value if one is provided for the current block.
@@ -779,6 +778,10 @@ export function getLayoutStyles( {
 			gapValue = fallbackGapValue;
 		}
 	}
+	const rowGapValue =
+		hasBlockGapSupport && blockGapValue && typeof blockGapValue !== 'string'
+			? getGapCSSValue( blockGapValue.top )
+			: gapValue;
 
 	if ( gapValue && layoutDefinitions ) {
 		Object.values( layoutDefinitions ).forEach(
@@ -791,6 +794,11 @@ export function getLayoutStyles( {
 				) {
 					return;
 				}
+				const layoutGapValue = [ 'default', 'constrained' ].includes(
+					name
+				)
+					? rowGapValue
+					: gapValue;
 
 				if ( spacingStyles?.length ) {
 					spacingStyles.forEach( ( spacingStyle: any ) => {
@@ -801,7 +809,7 @@ export function getLayoutStyles( {
 								( [ cssProperty, cssValue ] ) => {
 									declarations.push(
 										`${ cssProperty }: ${
-											cssValue ? cssValue : gapValue
+											cssValue ? cssValue : layoutGapValue
 										}`
 									);
 								}

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -403,6 +403,49 @@ describe( 'global styles renderer', () => {
 			rootPadding: false,
 		};
 
+		it( 'uses the row value for Flow and Constrained layouts and both values for Flex and Grid layouts when block spacing is axial', () => {
+			const tree: GlobalStylesConfig = {
+				styles: {
+					blocks: {
+						'core/group': {
+							spacing: {
+								blockGap: { top: '1em', left: '2em' },
+							},
+						},
+					},
+				},
+			};
+			const blockSelectors = {
+				'core/group': {
+					selector: '.wp-block-group',
+					hasLayoutSupport: true,
+				},
+			};
+
+			const result = transformToStyles(
+				Object.freeze( tree ),
+				blockSelectors,
+				true,
+				false,
+				false,
+				true,
+				minimalStyleOptions
+			);
+
+			expect( result ).toContain(
+				':root :where(.wp-block-group-is-layout-flow) > * { margin-block-start: 1em; margin-block-end: 0; }'
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-group-is-layout-constrained) > * { margin-block-start: 1em; margin-block-end: 0; }'
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-group-is-layout-flex) { gap: 1em 2em; }'
+			);
+			expect( result ).toContain(
+				':root :where(.wp-block-group-is-layout-grid) { gap: 1em 2em; }'
+			);
+		} );
+
 		it( 'should return a ruleset', () => {
 			const tree = {
 				settings: {

--- a/packages/global-styles-engine/src/types.ts
+++ b/packages/global-styles-engine/src/types.ts
@@ -253,7 +253,7 @@ export interface GlobalStylesStyles {
 	spacing?: {
 		padding?: UnresolvedValue | Record< string, UnresolvedValue >;
 		margin?: UnresolvedValue | Record< string, UnresolvedValue >;
-		blockGap?: string;
+		blockGap?: string | { top: string; left: string };
 	};
 	background?: BackgroundStyle;
 	border?: {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -491,6 +491,52 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
 			),
+			'grid layout uses horizontal gap for responsive columns' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
+						'type'               => 'grid',
+						'columnCount'        => 3,
+						'minimumColumnWidth' => '12rem',
+					),
+					'has_block_gap_support' => true,
+					'gap_value'             => array(
+						'top'  => '2rem',
+						'left' => '3rem',
+					),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(12rem, 100%), (100% - (3rem * (3 - 1))) /3), 1fr));container-type:inline-size;gap:2rem 3rem;}',
+			),
+			'grid layout uses fallback when horizontal gap is missing' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
+						'type'               => 'grid',
+						'columnCount'        => 3,
+						'minimumColumnWidth' => '12rem',
+					),
+					'has_block_gap_support' => true,
+					'gap_value'             => array( 'top' => '2rem' ),
+					'fallback_gap_value'    => '1.2rem',
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(12rem, 100%), (100% - (1.2rem * (3 - 1))) /3), 1fr));container-type:inline-size;gap:2rem 1.2rem;}',
+			),
+			'grid layout preserves zero horizontal gap'    => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
+						'type'               => 'grid',
+						'columnCount'        => 3,
+						'minimumColumnWidth' => '12rem',
+					),
+					'has_block_gap_support' => true,
+					'gap_value'             => array(
+						'top'  => '2rem',
+						'left' => '0',
+					),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(12rem, 100%), (100% - (0px * (3 - 1))) /3), 1fr));container-type:inline-size;gap:2rem 0;}',
+			),
 			'default layout with blockGap to verify converting gap value into valid CSS' => array(
 				'args'            => array(
 					'selector'              => '.wp-block-group.wp-container-6',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2080,6 +2080,61 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider data_get_stylesheet_with_single_axial_block_gap_value
+	 *
+	 * @param array  $block_gap Block gap value.
+	 * @param string $expected  Expected stylesheet.
+	 */
+	public function test_get_stylesheet_uses_zero_for_unset_axis_when_single_axial_block_gap_value_is_set( $block_gap, $expected ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => '3em',
+					),
+					'blocks'  => array(
+						'core/group' => array(
+							'spacing' => array(
+								'blockGap' => $block_gap,
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertSameCSS(
+			$expected,
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_get_stylesheet_uses_zero_for_unset_axis_when_single_axial_block_gap_value_is_set().
+	 *
+	 * @return array[]
+	 */
+	public function data_get_stylesheet_with_single_axial_block_gap_value() {
+		return array(
+			'row gap only'    => array(
+				array( 'top' => '1em' ),
+				':root :where(.wp-block-group-is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.wp-block-group-is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.wp-block-group-is-layout-flow) > *{margin-block-start: 1em;margin-block-end: 0;}:root :where(.wp-block-group-is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.wp-block-group-is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.wp-block-group-is-layout-constrained) > *{margin-block-start: 1em;margin-block-end: 0;}:root :where(.wp-block-group-is-layout-flex){gap: 1em 0;}:root :where(.wp-block-group-is-layout-grid){gap: 1em 0;}',
+			),
+			'column gap only' => array(
+				array( 'left' => '2em' ),
+				':root :where(.wp-block-group-is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.wp-block-group-is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.wp-block-group-is-layout-flow) > *{margin-block-start: 0;margin-block-end: 0;}:root :where(.wp-block-group-is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.wp-block-group-is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.wp-block-group-is-layout-constrained) > *{margin-block-start: 0;margin-block-end: 0;}:root :where(.wp-block-group-is-layout-flex){gap: 0 2em;}:root :where(.wp-block-group-is-layout-grid){gap: 0 2em;}',
+			),
+		);
+	}
+
 	public function test_get_stylesheet_generates_layout_styles_with_spacing_presets() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2049,6 +2049,37 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_stylesheet_generates_layout_styles_with_axial_block_gap() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'blocks' => array(
+						'core/group' => array(
+							'spacing' => array(
+								'blockGap' => array(
+									'top'  => '1em',
+									'left' => '2em',
+								),
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertSameCSS(
+			':root :where(.wp-block-group-is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.wp-block-group-is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.wp-block-group-is-layout-flow) > *{margin-block-start: 1em;margin-block-end: 0;}:root :where(.wp-block-group-is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.wp-block-group-is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.wp-block-group-is-layout-constrained) > *{margin-block-start: 1em;margin-block-end: 0;}:root :where(.wp-block-group-is-layout-flex){gap: 1em 2em;}:root :where(.wp-block-group-is-layout-grid){gap: 1em 2em;}',
+			$theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
 	public function test_get_stylesheet_generates_layout_styles_with_spacing_presets() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #47084.

In Grid and Flex layouts it's useful to be able to specify different values for row and column gap. This PR enables axial gap on Group block, but so that we don't add confusing UI to the flow/constrained layouts (which have no use for two distinct gap values, because they only ever set `margin-top` on their children) we're restricting the axial gap UI to flex and grid layout types. 

This should be backwards compatible, because axial gap has only been used in flex layouts so far.

In global styles, the Group block has axial gap controls because we don't distinguish between different block variations there, but we do want to provide the ability to set these gap values at a global level.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Test adding gap values to different Group variations and also test adding responsive gap values;
2. Check that other blocks supporting axial gap (e.g. Gallery, Buttons) still work as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
