### PR TITLE
DataViews: Add a lint rule preventing private API imports

### DIFF
--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Remove `@wordpress/dataviews` from the list of core modules using private APIs, since importing private APIs is no longer allowed in the package. [#81478](https://github.com/WordPress/gutenberg/pull/81478)
+
 ## 1.53.0 (2026-08-12)
 
 ### Internal

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -42,7 +42,6 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/storybook',
 	'@wordpress/sync',
 	'@wordpress/theme',
-	'@wordpress/dataviews',
 	'@wordpress/fields',
 	'@wordpress/lazy-editor',
 	'@wordpress/media-editor',

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -844,6 +844,26 @@ export default dedupePlugins( [
 		},
 	},
 
+	// Override: dataviews — restrict private-apis imports.
+	{
+		files: [ 'packages/dataviews/**' ],
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					paths: [
+						...restrictedImports,
+						{
+							name: '@wordpress/private-apis',
+							message:
+								'dataviews is a bundled package that plugins may import via npm, where a second copy of private-apis cannot unlock objects locked by the WordPress copy and throws at runtime.',
+						},
+					],
+				},
+			],
+		},
+	},
+
 	// Override: edit-post, edit-site — restrict interface imports.
 	{
 		files: [ 'packages/edit-post/**', 'packages/edit-site/**' ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/81230

This PR adds a lint rule so that private API usage can't creep back into DataViews once the cleanup is done.

Note that this is a placeholder PR: CI is expected to be red until all the remaining private imports are gone.


## Testing Instructions
1. After the removal of all private API imports in dataviews(and rebasing) the CI should be 🟢 
