### PR TITLE
Editor: Guard taxonomy selectors with REST assign actions

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -74,8 +74,16 @@ export function FlatTermSelector( { slug } ) {
 				select( coreStore );
 			const post = getCurrentPost();
 			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
-			const _termIds = _taxonomy
-				? getEditedPostAttribute( _taxonomy.rest_base )
+			const _hasAssignAction = _taxonomy
+				? post._links?.[ 'wp:action-assign-' + _taxonomy.rest_base ] ??
+				  false
+				: false;
+			const editedTermIds =
+				_taxonomy && _hasAssignAction
+					? getEditedPostAttribute( _taxonomy.rest_base )
+					: EMPTY_ARRAY;
+			const _termIds = Array.isArray( editedTermIds )
+				? editedTermIds
 				: EMPTY_ARRAY;
 
 			const query = {
@@ -93,11 +101,7 @@ export function FlatTermSelector( { slug } ) {
 							'wp:action-create-' + _taxonomy.rest_base
 					  ] ?? false
 					: false,
-				hasAssignAction: _taxonomy
-					? post._links?.[
-							'wp:action-assign-' + _taxonomy.rest_base
-					  ] ?? false
-					: false,
+				hasAssignAction: _hasAssignAction,
 				taxonomy: _taxonomy,
 				termIds: _termIds,
 				terms: _termIds?.length

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -229,6 +229,16 @@ export function HierarchicalTermSelector( { slug } ) {
 				select( coreStore );
 			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
 			const post = getCurrentPost();
+			const _hasAssignAction = _taxonomy
+				? !! post._links?.[ 'wp:action-assign-' + _taxonomy.rest_base ]
+				: false;
+			const editedTerms =
+				_taxonomy && _hasAssignAction
+					? getEditedPostAttribute( _taxonomy.rest_base )
+					: EMPTY_ARRAY;
+			const _terms = Array.isArray( editedTerms )
+				? editedTerms
+				: EMPTY_ARRAY;
 
 			return {
 				hasCreateAction: _taxonomy
@@ -236,14 +246,8 @@ export function HierarchicalTermSelector( { slug } ) {
 							'wp:action-create-' + _taxonomy.rest_base
 					  ]
 					: false,
-				hasAssignAction: _taxonomy
-					? !! post._links?.[
-							'wp:action-assign-' + _taxonomy.rest_base
-					  ]
-					: false,
-				terms: _taxonomy
-					? getEditedPostAttribute( _taxonomy.rest_base )
-					: EMPTY_ARRAY,
+				hasAssignAction: _hasAssignAction,
+				terms: _terms,
 				loading: isResolving( 'getEntityRecords', [
 					'taxonomy',
 					slug,

--- a/packages/editor/src/components/post-taxonomies/panel.js
+++ b/packages/editor/src/components/post-taxonomies/panel.js
@@ -16,20 +16,28 @@ import PostTaxonomiesCheck from './check';
 function TaxonomyPanel( { taxonomy, children } ) {
 	const slug = taxonomy?.slug;
 	const panelName = slug ? `taxonomy-panel-${ slug }` : '';
-	const { isEnabled, isOpened } = useSelect(
+	const { isEnabled, isOpened, hasAssignAction } = useSelect(
 		( select ) => {
-			const { isEditorPanelEnabled, isEditorPanelOpened } =
-				select( editorStore );
+			const {
+				getCurrentPost,
+				isEditorPanelEnabled,
+				isEditorPanelOpened,
+			} = select( editorStore );
+			const post = getCurrentPost();
+			const restBase = taxonomy?.rest_base;
 			return {
 				isEnabled: slug ? isEditorPanelEnabled( panelName ) : false,
 				isOpened: slug ? isEditorPanelOpened( panelName ) : false,
+				hasAssignAction: restBase
+					? post?._links?.[ 'wp:action-assign-' + restBase ] ?? false
+					: false,
 			};
 		},
-		[ panelName, slug ]
+		[ panelName, slug, taxonomy?.rest_base ]
 	);
 	const { toggleEditorPanelOpened } = useDispatch( editorStore );
 
-	if ( ! isEnabled ) {
+	if ( ! isEnabled || ! hasAssignAction ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-taxonomies/test/flat-term-selector.tsx
+++ b/packages/editor/src/components/post-taxonomies/test/flat-term-selector.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react';
+import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { FlatTermSelector } from '../flat-term-selector';
+
+describe( 'FlatTermSelector', () => {
+	const taxonomy = {
+		name: 'Types',
+		slug: 'type',
+		rest_base: 'type',
+		hierarchical: false,
+	};
+
+	beforeEach( () => {
+		jest.spyOn( select( coreStore ), 'getEntityRecord' ).mockReturnValue(
+			taxonomy
+		);
+		jest.spyOn( select( coreStore ), 'getEntityRecords' ).mockReturnValue(
+			[]
+		);
+		jest.spyOn(
+			select( coreStore ),
+			'hasFinishedResolution'
+		).mockReturnValue( true );
+	} );
+
+	it( 'should not read the taxonomy post attribute without an assign action', () => {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {},
+		} );
+		const getEditedPostAttribute = jest
+			.spyOn( select( editorStore ), 'getEditedPostAttribute' )
+			.mockReturnValue( 'post' );
+
+		render( <FlatTermSelector slug="type" /> );
+
+		expect( getEditedPostAttribute ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should read the taxonomy post attribute when an assign action exists', () => {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {
+				'wp:action-assign-type_terms': [
+					{
+						href: 'http://localhost:8889/index.php?rest_route=/wp/v2/posts/1/assign-type_terms',
+					},
+				],
+			},
+		} );
+		jest.spyOn( select( coreStore ), 'getEntityRecord' ).mockReturnValue( {
+			...taxonomy,
+			rest_base: 'type_terms',
+		} );
+		const getEditedPostAttribute = jest
+			.spyOn( select( editorStore ), 'getEditedPostAttribute' )
+			.mockReturnValue( [] );
+
+		render( <FlatTermSelector slug="type" /> );
+
+		expect( getEditedPostAttribute ).toHaveBeenCalledWith( 'type_terms' );
+	} );
+} );

--- a/packages/editor/src/components/post-taxonomies/test/hierarchical-term-selector.tsx
+++ b/packages/editor/src/components/post-taxonomies/test/hierarchical-term-selector.tsx
@@ -1,4 +1,9 @@
+import { render } from '@testing-library/react';
+import { select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 import {
+	HierarchicalTermSelector,
 	sortBySelected,
 	getFilterMatcher,
 	findTerm,
@@ -158,5 +163,33 @@ describe( 'getFilterMatcher', () => {
 		};
 		const matcher = getFilterMatcher( 'parent' );
 		expect( matcher( input ) ).toEqual( output );
+	} );
+} );
+
+describe( 'HierarchicalTermSelector', () => {
+	it( 'should not read the taxonomy post attribute without an assign action', () => {
+		jest.spyOn( select( coreStore ), 'getEntityRecord' ).mockReturnValue( {
+			name: 'Types',
+			slug: 'type',
+			rest_base: 'type',
+			hierarchical: true,
+		} );
+		jest.spyOn( select( coreStore ), 'getEntityRecords' ).mockReturnValue(
+			[]
+		);
+		jest.spyOn( select( coreStore ), 'isResolving' ).mockReturnValue(
+			false
+		);
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {},
+		} );
+
+		const getEditedPostAttribute = jest
+			.spyOn( select( editorStore ), 'getEditedPostAttribute' )
+			.mockReturnValue( 'post' );
+
+		render( <HierarchicalTermSelector slug="type" /> );
+
+		expect( getEditedPostAttribute ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/editor/src/components/post-taxonomies/test/panel.tsx
+++ b/packages/editor/src/components/post-taxonomies/test/panel.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import PostTaxonomies from '../panel';
+
+jest.mock(
+	'../check',
+	() =>
+		( { children } ) =>
+			children
+);
+
+jest.mock(
+	'../index',
+	() =>
+		( { taxonomyWrapper } ) =>
+			taxonomyWrapper( 'Taxonomy content', {
+				slug: 'type',
+				rest_base: 'type',
+				labels: {
+					menu_name: 'Types',
+				},
+			} )
+);
+
+describe( 'PostTaxonomies panel', () => {
+	beforeEach( () => {
+		jest.spyOn(
+			select( editorStore ),
+			'isEditorPanelEnabled'
+		).mockReturnValue( true );
+		jest.spyOn(
+			select( editorStore ),
+			'isEditorPanelOpened'
+		).mockReturnValue( true );
+	} );
+
+	it( 'should not render a taxonomy panel without an assign action', () => {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {},
+		} );
+
+		render( <PostTaxonomies /> );
+
+		expect(
+			screen.queryByText( 'Taxonomy content' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render a taxonomy panel when an assign action exists', () => {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {
+				'wp:action-assign-type': [
+					{
+						href: 'http://localhost:8889/index.php?rest_route=/wp/v2/posts/1/assign-type',
+					},
+				],
+			},
+		} );
+
+		render( <PostTaxonomies /> );
+
+		expect( screen.getByText( 'Taxonomy content' ) ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/81482

Related WordPress Core issue and fix:

* Core Trac: https://core.trac.wordpress.org/ticket/65855
* Core PR: https://github.com/WordPress/wordpress-develop/pull/13013

## What?

Prevents post taxonomy selectors from reading a post REST property as taxonomy term IDs unless the current post response exposes the corresponding `wp:action-assign-<rest_base>` action.

The change:

* gates `FlatTermSelector` attribute reads behind the assign action;
* applies the same defensive behavior to `HierarchicalTermSelector`;
* normalizes edited taxonomy values to arrays;
* prevents the default taxonomy panel from rendering when the taxonomy cannot be assigned;
* leaves `PostTaxonomies` filtering unchanged so custom taxonomy wrappers and selector integrations are not globally removed.

## Why?

A taxonomy can have a REST base that conflicts with an existing post REST property.

For example, a taxonomy named `type` defaults to:

`rest_base = type`

while posts already expose:

`type: "post"`

When the taxonomy is not safely exposed as an assignable REST item field, the REST response does not provide:

`wp:action-assign-type`

The editor already uses this action as the authority for whether taxonomy assignment is available, but the selectors could read the edited post property before applying that gate.

This can cause a non-taxonomy value to be treated as term IDs. In affected WordPress builds, this can result in a runtime error. On current Gutenberg code, it can still result in invalid or unnecessary taxonomy processing before the component returns `null`.

The corresponding Core fix prevents conflicting taxonomy REST bases from replacing existing post item properties. This PR provides a client-side guard as well, which remains useful for older Core versions and custom REST responses.

## How?

`FlatTermSelector` now determines whether the matching assign action exists before reading the edited taxonomy attribute.

`HierarchicalTermSelector` follows the same invariant.

Edited taxonomy values are normalized with `Array.isArray()` before being treated as term IDs.

The default taxonomy panel also checks the corresponding assign action and returns `null` when assignment is unavailable.

Filtering in `PostTaxonomies` itself is deliberately unchanged.

## Testing Instructions

Run:

`npm run test:unit -- --runInBand packages/editor/src/components/post-taxonomies/test`

Expected:

* Test Suites: 4 passed, 4 total
* Tests: 16 passed, 16 total
* Snapshots: 0 total

Also run:

`git diff --check`

Expected: no output.
