### PR TITLE
Image: Show captions inside the lightbox

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -14,6 +14,10 @@
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 -   Accordion: Resolve the URL fragment with the `:target` pseudo-class instead of decoding `window.location.hash`, so a hash containing malformed percent-encoding no longer throws a `URIError` when a panel is opened ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
 
+### Enhancements
+
+-   Image: Show the image caption inside the lightbox ("Enlarge on click"), for both single images and gallery images.
+
 ## 10.4.0 (2026-08-12)
 
 ### Internal

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -414,11 +414,15 @@ function block_core_image_print_lightbox_overlay() {
 						>
 					</figure>
 				</div>
-				<div
-					class="wp-element-caption wp-lightbox-caption"
-					data-wp-bind--hidden="!state.selectedImage.caption"
-					data-wp-watch="callbacks.setCaption"
-				></div>
+				<div class="wp-lightbox-caption-scroll" data-wp-bind--hidden="!state.selectedImage.caption">
+					<div class="wp-lightbox-caption-spacer" aria-hidden="true"></div>
+					<div class="wp-lightbox-caption-panel" style="background-color: {$background_color}" data-wp-on--click="actions.handleCaptionClick">
+						<div
+							class="wp-element-caption wp-lightbox-caption"
+							data-wp-watch="callbacks.setCaption"
+						></div>
+					</div>
+				</div>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -230,6 +230,25 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 	$figure_class_names = $processor->get_attribute( 'class' );
 	$figure_styles      = $processor->get_attribute( 'style' );
 
+	/*
+	 * Extract the caption so it can be shown inside the lightbox overlay.
+	 *
+	 * The lightbox duplicates the image into a shared overlay but not the
+	 * surrounding markup, so the caption has to be carried over explicitly. The
+	 * rendered content is read here (rather than the block's `caption`
+	 * attribute) so that all sources are covered with one code path: single
+	 * image blocks, static gallery images, and dynamic gallery images whose
+	 * caption comes from the attachment's `post_excerpt`. By this point the
+	 * render filter has already stripped an empty `<figcaption>`, so a match
+	 * here is a real caption. `wp_kses_post()` keeps the stored value safe to
+	 * inject as HTML regardless of what upstream filters produced; the same
+	 * markup is already rendered visibly as the on-page caption.
+	 */
+	$caption = '';
+	if ( preg_match( '/<figcaption[^>]*>(.*)<\/figcaption>/s', $block_content, $caption_match ) ) {
+		$caption = wp_kses_post( $caption_match[1] );
+	}
+
 	// Create unique id and set the image metadata in the state.
 	$unique_image_id = uniqid();
 	wp_interactivity_state(
@@ -247,6 +266,7 @@ function block_core_image_render_lightbox( $block_content, array $block, WP_Bloc
 					'targetHeight'           => $img_height,
 					'scaleAttr'              => $block['attrs']['scale'] ?? false,
 					'alt'                    => $alt,
+					'caption'                => $caption,
 					'galleryId'              => $block_instance->context['galleryId'] ?? null,
 					'customAriaLabel'        => $custom_aria_label ?? null,
 					'navigationButtonType'   => $block_instance->context['navigationButtonType'] ?? 'icon',
@@ -394,6 +414,11 @@ function block_core_image_print_lightbox_overlay() {
 						>
 					</figure>
 				</div>
+				<div
+					class="wp-element-caption wp-lightbox-caption"
+					data-wp-bind--hidden="!state.selectedImage.caption"
+					data-wp-watch="callbacks.setCaption"
+				></div>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$next_button_text}</span>
 					<span class="wp-lightbox-navigation-icon" data-wp-bind--hidden="!state.hasNavigationIcon">{$next_button_icon}</span>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -416,7 +416,7 @@ function block_core_image_print_lightbox_overlay() {
 				</div>
 				<div class="wp-lightbox-caption-scroll" data-wp-bind--hidden="!state.selectedImage.caption">
 					<div class="wp-lightbox-caption-spacer" aria-hidden="true"></div>
-					<div class="wp-lightbox-caption-panel" style="background-color: {$background_color}" data-wp-on--click="actions.handleCaptionClick">
+					<div class="wp-lightbox-caption-panel" style="background-color: color-mix(in srgb, {$background_color} 80%, transparent)" data-wp-on--click="actions.handleCaptionClick">
 						<div
 							class="wp-element-caption wp-lightbox-caption"
 							data-wp-watch="callbacks.setCaption"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -416,7 +416,7 @@ function block_core_image_print_lightbox_overlay() {
 				</div>
 				<div class="wp-lightbox-caption-scroll" data-wp-bind--hidden="!state.selectedImage.caption">
 					<div class="wp-lightbox-caption-spacer" aria-hidden="true"></div>
-					<div class="wp-lightbox-caption-panel" style="background-color: color-mix(in srgb, {$background_color} 80%, transparent)" data-wp-on--click="actions.handleCaptionClick">
+					<div class="wp-lightbox-caption-panel" style="background-color: {$background_color}" data-wp-on--click="actions.handleCaptionClick">
 						<div
 							class="wp-element-caption wp-lightbox-caption"
 							data-wp-watch="callbacks.setCaption"

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -363,20 +363,20 @@
 		}
 	}
 
-	// Transparent spacer that pushes the caption panel down to just above the
-	// image's bottom edge. The image is centered, so its bottom is
-	// `50vh + height/2`; subtracting 32px starts the caption over the image's
-	// bottom 32px, so a short caption is visible without scrolling.
-	// `--wp--lightbox-container-height` is published by `setOverlayStyles()` and
-	// recomputed on resize, so the caption stays anchored responsively.
+	// Transparent spacer that pushes the caption panel down to the image's
+	// bottom edge. The image is centered, so its bottom is `50vh + height/2`;
+	// the enlarged image now reserves extra safe area on every side (see
+	// `setOverlayStyles()`), so a short caption sits in the space below the
+	// image without covering it. `--wp--lightbox-container-height` is published
+	// by `setOverlayStyles()` and recomputed on resize, so the caption stays
+	// anchored responsively.
 	.wp-lightbox-caption-spacer {
-		height: calc(50vh + var(--wp--lightbox-container-height, 0px) / 2 - 32px);
+		height: calc(50vh + var(--wp--lightbox-container-height, 0px) / 2);
 		cursor: zoom-out;
 	}
 
-	// Panel painted with the overlay background (semi-transparent, see the
-	// inline style) so the caption reads clearly while still letting the part
-	// of the image it overlaps show through.
+	// Opaque panel painted with the overlay background, so a caption long enough
+	// to scroll fully covers the image as it moves up over it.
 	.wp-lightbox-caption-panel {
 		padding-block: 24px;
 		cursor: default;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -344,6 +344,31 @@
 		opacity: 0.9;
 	}
 
+	// POC placeholder styling for the lightbox caption. This only makes the
+	// carried-over caption visible so the concept can be verified; the final
+	// appearance is a separate design pass. The caption lives at the overlay
+	// level (not inside `.lightbox-image-container`, which clips and transforms
+	// its contents during the zoom animation).
+	.wp-lightbox-caption {
+		position: absolute;
+		z-index: 2000002;
+		left: 50%;
+		bottom: calc(env(safe-area-inset-bottom) + 16px);
+		transform: translateX(-50%);
+		width: min(90vw, 640px);
+		margin: 0;
+		padding: 8px 12px;
+
+		// Do not set `text-align` here. The element carries the
+		// `wp-element-caption` class, so caption alignment defined in
+		// `theme.json` (`styles.elements.caption`) — which targets
+		// `.wp-element-caption` — is inherited automatically.
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
 	// When fading, make the image come in slightly slower
 	// or faster than the scrim to give a sense of depth.
 	&.active {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -379,6 +379,15 @@
 	// to scroll fully covers the image as it moves up over it.
 	.wp-lightbox-caption-panel {
 		padding-block: 24px;
+		// Aligns the caption's left and right edges with the enlarged image
+		// above it. The image is centered and its width is published as
+		// `--wp--lightbox-container-width`, so its inset from each edge is half
+		// of the leftover space. Because that width is recomputed on resize,
+		// the caption follows the image at every breakpoint — the two are
+		// separate elements, so a fixed padding could only match at one size.
+		// The `max()` floor keeps a sane gutter in the brief moment before
+		// `setOverlayStyles()` publishes the variable.
+		padding-inline: max(16px, calc((100% - var(--wp--lightbox-container-width, 100%)) / 2));
 		cursor: default;
 	}
 
@@ -391,7 +400,6 @@
 		// classic themes and block themes that set no content size, where the
 		// variable is not emitted) keeps the measure readable.
 		max-width: min(90vw, var(--wp--style--global--content-size, 480px));
-		padding-inline: 16px;
 
 		// Do not set `text-align` here. The element carries the
 		// `wp-element-caption` class, so caption alignment defined in

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -363,21 +363,22 @@
 		}
 	}
 
-	// Transparent spacer that pushes the caption panel down to the image's
-	// bottom edge. The image is centered, so its bottom is `50vh + height/2`;
+	// Transparent spacer that pushes the caption panel down to just above the
+	// image's bottom edge. The image is centered, so its bottom is
+	// `50vh + height/2`; subtracting 32px starts the caption over the image's
+	// bottom 32px, so a short caption is visible without scrolling.
 	// `--wp--lightbox-container-height` is published by `setOverlayStyles()` and
 	// recomputed on resize, so the caption stays anchored responsively.
 	.wp-lightbox-caption-spacer {
-		height: calc(50vh + var(--wp--lightbox-container-height, 0px) / 2);
+		height: calc(50vh + var(--wp--lightbox-container-height, 0px) / 2 - 32px);
 		cursor: zoom-out;
 	}
 
-	// Opaque panel (painted with the overlay background) so the caption fully
-	// covers the image as it scrolls up over it. Minimal top padding keeps a
-	// single-line caption within the safe area below the image, so it does not
-	// force a scroll.
+	// Panel painted with the overlay background (semi-transparent, see the
+	// inline style) so the caption reads clearly while still letting the part
+	// of the image it overlaps show through.
 	.wp-lightbox-caption-panel {
-		padding-block: 8px env(safe-area-inset-bottom);
+		padding-block: 24px;
 		cursor: default;
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -344,29 +344,58 @@
 		opacity: 0.9;
 	}
 
-	// POC placeholder styling for the lightbox caption. This only makes the
-	// carried-over caption visible so the concept can be verified; the final
-	// appearance is a separate design pass. The caption lives at the overlay
-	// level (not inside `.lightbox-image-container`, which clips and transforms
-	// its contents during the zoom animation).
-	.wp-lightbox-caption {
+	// The caption lives in a scroll layer laid over the (fixed) enlarged image,
+	// rather than inside `.lightbox-image-container`, which clips and transforms
+	// its contents during the zoom animation. The image never moves: a short
+	// caption sits in the empty space below it, and a long caption scrolls up
+	// and covers the image (scroll back up to reveal it again).
+	.wp-lightbox-caption-scroll {
 		position: absolute;
-		z-index: 2000002;
-		left: 50%;
-		bottom: calc(env(safe-area-inset-bottom) + 16px);
-		transform: translateX(-50%);
-		width: min(90vw, 640px);
-		margin: 0;
-		padding: 8px 12px;
+		inset: 0;
+		// Above the image (2000001), below the navigation/close chrome (>=2000002).
+		z-index: 2000001;
+		overflow-y: auto;
+		// Keeps the scroll from chaining to the page once the caption ends.
+		overscroll-behavior: contain;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	// Transparent spacer that pushes the caption panel down to the image's
+	// bottom edge. The image is centered, so its bottom is `50vh + height/2`;
+	// `--wp--lightbox-container-height` is published by `setOverlayStyles()` and
+	// recomputed on resize, so the caption stays anchored responsively.
+	.wp-lightbox-caption-spacer {
+		height: calc(50vh + var(--wp--lightbox-container-height, 0px) / 2);
+		cursor: zoom-out;
+	}
+
+	// Opaque panel (painted with the overlay background) so the caption fully
+	// covers the image as it scrolls up over it. Minimal top padding keeps a
+	// single-line caption within the safe area below the image, so it does not
+	// force a scroll.
+	.wp-lightbox-caption-panel {
+		padding-block: 8px env(safe-area-inset-bottom);
+		cursor: default;
+	}
+
+	.wp-lightbox-caption {
+		margin: 0 auto;
+		// Inherit the theme's content width (theme.json
+		// `settings.layout.contentSize`), so theme developers control the
+		// caption measure with the same knob as post content. Capped at 90vw
+		// so it never overflows a narrow viewport. The fallback (used by
+		// classic themes and block themes that set no content size, where the
+		// variable is not emitted) keeps the measure readable.
+		max-width: min(90vw, var(--wp--style--global--content-size, 480px));
+		padding-inline: 16px;
 
 		// Do not set `text-align` here. The element carries the
 		// `wp-element-caption` class, so caption alignment defined in
 		// `theme.json` (`styles.elements.caption`) — which targets
 		// `.wp-element-caption` — is inherited automatically.
-
-		&[hidden] {
-			display: none;
-		}
 	}
 
 	// When fading, make the image come in slightly slower

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -411,6 +411,13 @@ const { state, actions, callbacks } = store(
 					state.preloadTimers.delete( imageId );
 				}
 			},
+			handleCaptionClick: withSyncEvent( ( event ) => {
+				// Keeps clicks inside the caption (selecting text, following a
+				// link) from bubbling to the overlay, which would otherwise
+				// close the lightbox. Clicks on the image or surrounding area
+				// still close it.
+				event.stopPropagation();
+			} ),
 		},
 		callbacks: {
 			setOverlayStyles() {

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -550,6 +550,15 @@ const { state, actions, callbacks } = store(
 					verticalPadding = 80;
 				}
 
+				// Adds extra breathing room on every side of the enlarged image
+				// so a caption has room to sit below it without covering it.
+				// Applied to every image (not only captioned ones) so navigating
+				// a gallery never resizes the image. `padding` here is the total
+				// removed from each axis, so the per-side inset is half of it.
+				const imageSafeArea = 24;
+				horizontalPadding += imageSafeArea * 2;
+				verticalPadding += imageSafeArea * 2;
+
 				const targetMaxWidth = Math.min(
 					window.innerWidth - horizontalPadding,
 					containerWidth

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -706,6 +706,25 @@ const { state, actions, callbacks } = store(
 				const { ref } = getElement();
 				state.metadata[ imageId ].buttonRef = ref;
 			},
+			setCaption() {
+				// The caption is injected imperatively rather than through a
+				// `data-wp-bind--innerHTML` binding: Preact reconciles the
+				// element's children and won't apply a plain `innerHTML` prop,
+				// so a binding leaves the node empty. This runs in a
+				// `data-wp-watch`, so it re-applies whenever the selected image
+				// (and therefore its caption) changes while navigating a
+				// gallery. The value was sanitized with `wp_kses_post()` on the
+				// server and is the same markup already shown as the on-page
+				// caption.
+				const { ref } = getElement();
+				if ( ! ref ) {
+					return;
+				}
+				const caption = state.selectedImage?.caption || '';
+				if ( ref.innerHTML !== caption ) {
+					ref.innerHTML = caption;
+				}
+			},
 		},
 	},
 	{ lock: true }


### PR DESCRIPTION
## What?

Closes #56587. Related to, and **blocked on** #79114 (animated mobile swiping) landing first. Opening now for design feedback. 

The lightbox ("Enlarge on click") duplicates the image into a shared overlay but has always dropped the caption. This PR carries the caption into the lightbox for single images and gallery images, with identical handling for both.

<img width="1040" height="653" alt="state" src="https://github.com/user-attachments/assets/ae133dcb-92b2-4a76-bf80-376109b70d57" />

The image is not moved. A short caption sits just below/over the image; a long caption scrolls up and covers the (fixed) image, and you scroll back up to reveal it again.

Alignment inherits from theme.json global styles.elements.caption (via the wp-element-caption class) — no alignment is hardcoded. Width inherits the theme content width (--wp--style--global--content-size, i.e. theme.json settings.layout.contentSize), capped at 90vw, falling back to 480px when a theme sets none.
The panel is painted with the overlay background at 80% (color-mix) so it stays legible while the covered slice of image shows through.

**Note:** I had two ways of solving captions so long they scroll:

1. Present behavior in this branch: allow the caption at the bottom to cover 24px of the image, and as you scroll it covers the whole image but with 80% opacity.
2. Increase the overall safe area around the whole image, so that the caption doesn't need to cover part of it to be visible. If we do this, we can keep the opacity of the caption 100%. That will visually look much closer to the "external caption" design proposed in #56587.

We should pick one of those paths. Which one resonates?

## Why?

Captions in galleries are especially useful on mobile where you might open and swipe, and if they simply disappear as they do now, we're missing an opportunity.

## Testing Instructions
Add an Image block, add a caption, and enable Enlarge on click (link toolbar). Confirm the caption appears in the lightbox.
Repeat inside a Gallery; page through images and confirm each caption follows.
Give one image a very long caption and confirm it scrolls up over the fixed image; a short one should need no scroll.
Try an image with no caption — behavior should be unchanged from today.


## Use of AI Tools
Claude Opus 4.8