### PR TITLE
Editor: Correctly mark ToolsMoreMenuGroup as a private SlotFill

### DIFF
--- a/packages/editor/src/components/more-menu/tools-more-menu-group.js
+++ b/packages/editor/src/components/more-menu/tools-more-menu-group.js
@@ -1,7 +1,8 @@
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: ToolsMoreMenuGroup, Slot } =
-	createSlotFill( 'ToolsMoreMenuGroup' );
+const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
+	Symbol( 'ToolsMoreMenuGroup' )
+);
 
 ToolsMoreMenuGroup.Slot = ( { fillProps } ) => <Slot fillProps={ fillProps } />;
 


### PR DESCRIPTION
## What?
PR updates `ToolsMoreMenuGroup` slot-fill and correctly mark them as private, preventing them from leaking to consumers using string names. This matches `ViewMoreMenuGroup`.


## Testing Instructions
None. There are no behavioral changes to consumers