### PR TITLE
Build Tools: Stop watcher process trees on shutdown

### DIFF
--- a/tools/build-scripts/dev.mjs
+++ b/tools/build-scripts/dev.mjs
@@ -5,6 +5,7 @@ import { parseArgs } from 'util';
 import path from 'path';
 import fs from 'fs';
 import spawn from 'cross-spawn';
+import { spawnWatchProcess, stopWatchProcess } from './process.mjs';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const ROOT_DIR = path.resolve( __dirname, '../..' );
@@ -70,23 +71,6 @@ function exec( command, args = [], options = {} ) {
 		} );
 
 		child.on( 'error', reject );
-	} );
-}
-
-/**
- * Execute a command without waiting for it to complete.
- * Used for starting watch processes.
- *
- * @param {string}   command Command to execute.
- * @param {string[]} args    Command arguments.
- * @param {Object}   options Spawn options.
- * @return {Object} Child process.
- */
-function execAsync( command, args = [], options = {} ) {
-	return spawn( command, args, {
-		cwd: ROOT_DIR,
-		stdio: 'inherit',
-		...options,
 	} );
 }
 
@@ -214,11 +198,11 @@ async function dev() {
 		// Start TypeScript watch (unless types are skipped).
 		const tscWatch = skipTypes
 			? null
-			: execAsync( 'tsc', [
-					'--build',
-					'--watch',
-					'--preserveWatchOutput',
-			  ] );
+			: spawnWatchProcess(
+					'tsc',
+					[ '--build', '--watch', '--preserveWatchOutput' ],
+					{ cwd: ROOT_DIR, stdio: 'inherit' }
+			  );
 
 		// Start package build watch and wait for initial build to complete
 		// before signaling ready. wp-build outputs "Watching for changes..."
@@ -232,7 +216,7 @@ async function dev() {
 		// Handle process termination
 		const cleanup = () => {
 			console.log( '\n\n👋 Stopping watch mode...' );
-			tscWatch?.kill();
+			stopWatchProcess( tscWatch );
 			buildWatch.kill();
 			readyMarkerFile.cleanup();
 			process.exit( 0 );

--- a/tools/build-scripts/process.mjs
+++ b/tools/build-scripts/process.mjs
@@ -30,18 +30,31 @@ export function stopWatchProcess( child ) {
 		return;
 	}
 
-	try {
-		if ( process.platform === 'win32' ) {
+	if ( process.platform === 'win32' ) {
+		try {
 			execFileSync(
 				'taskkill',
 				[ '/pid', String( child.pid ), '/T', '/F' ],
 				{ stdio: 'ignore' }
 			);
-		} else {
-			// A command launcher can leave its native watcher running, so stop
-			// the detached process group instead of only the direct child.
-			process.kill( -child.pid, 'SIGKILL' );
+		} catch ( error ) {
+			// The tree is usually gone already, since Ctrl+C reaches the
+			// whole console: `taskkill` reports that with exit code 128.
+			// Cleanup runs from a signal handler, so never throw.
+			if ( error.status !== 128 ) {
+				console.warn(
+					`Could not stop the watch process tree (pid ${ child.pid }): ${ error.message }`
+				);
+			}
 		}
+
+		return;
+	}
+
+	try {
+		// A command launcher can leave its native watcher running, so stop
+		// the detached process group instead of only the direct child.
+		process.kill( -child.pid, 'SIGKILL' );
 	} catch ( error ) {
 		if ( error.code !== 'ESRCH' ) {
 			throw error;

--- a/tools/build-scripts/process.mjs
+++ b/tools/build-scripts/process.mjs
@@ -1,0 +1,50 @@
+import { execFileSync } from 'node:child_process';
+import spawn from 'cross-spawn';
+
+/**
+ * Start a long-running watch process.
+ *
+ * @param {string}   command Command to execute.
+ * @param {string[]} args    Command arguments.
+ * @param {Object}   options Spawn options.
+ * @return {Object} Child process.
+ */
+export function spawnWatchProcess( command, args = [], options = {} ) {
+	return spawn( command, args, {
+		...options,
+		detached: process.platform !== 'win32',
+	} );
+}
+
+/**
+ * Stop a long-running watch process.
+ *
+ * @param {Object|null} child Child process.
+ */
+export function stopWatchProcess( child ) {
+	if (
+		! child?.pid ||
+		child.exitCode !== null ||
+		child.signalCode !== null
+	) {
+		return;
+	}
+
+	try {
+		if ( process.platform === 'win32' ) {
+			execFileSync(
+				'taskkill',
+				[ '/pid', String( child.pid ), '/T', '/F' ],
+				{ stdio: 'ignore' }
+			);
+		} else {
+			// A command launcher can leave its native watcher running, so stop
+			// the detached process group instead of only the direct child.
+			process.kill( -child.pid, 'SIGKILL' );
+		}
+	} catch ( error ) {
+		if ( error.code !== 'ESRCH' ) {
+			throw error;
+		}
+	}
+}

--- a/tools/build-scripts/test/fixtures/watch-process.mjs
+++ b/tools/build-scripts/test/fixtures/watch-process.mjs
@@ -1,0 +1,10 @@
+import { spawn } from 'node:child_process';
+
+const descendant = spawn(
+	process.execPath,
+	[ '-e', 'setInterval( () => {}, 1000 )' ],
+	{ stdio: 'inherit' }
+);
+
+console.log( descendant.pid );
+setInterval( () => {}, 1000 );

--- a/tools/build-scripts/test/process-windows.test.js
+++ b/tools/build-scripts/test/process-windows.test.js
@@ -14,6 +14,7 @@ const platformDescriptor = Object.getOwnPropertyDescriptor(
 );
 
 beforeEach( () => {
+	jest.clearAllMocks();
 	Object.defineProperty( process, 'platform', { value: 'win32' } );
 } );
 
@@ -42,4 +43,29 @@ test( 'uses taskkill to terminate a watcher tree on Windows', () => {
 		[ '/pid', '123', '/T', '/F' ],
 		{ stdio: 'ignore' }
 	);
+} );
+
+test( 'ignores a watcher tree that already exited on Windows', () => {
+	execFileSync.mockImplementationOnce( () => {
+		const error = new Error( 'Command failed: taskkill /pid 123 /T /F' );
+		error.status = 128;
+		throw error;
+	} );
+
+	expect( () =>
+		stopWatchProcess( { pid: 123, exitCode: null, signalCode: null } )
+	).not.toThrow();
+} );
+
+test( 'warns without throwing when taskkill fails on Windows', () => {
+	execFileSync.mockImplementationOnce( () => {
+		const error = new Error( 'Access is denied' );
+		error.status = 1;
+		throw error;
+	} );
+
+	expect( () =>
+		stopWatchProcess( { pid: 123, exitCode: null, signalCode: null } )
+	).not.toThrow();
+	expect( console ).toHaveWarned();
 } );

--- a/tools/build-scripts/test/process-windows.test.js
+++ b/tools/build-scripts/test/process-windows.test.js
@@ -1,0 +1,45 @@
+import { execFileSync } from 'node:child_process';
+import spawn from 'cross-spawn';
+import { spawnWatchProcess, stopWatchProcess } from '../process.mjs';
+
+jest.mock( 'node:child_process', () => ( {
+	...jest.requireActual( 'node:child_process' ),
+	execFileSync: jest.fn(),
+} ) );
+jest.mock( 'cross-spawn', () => jest.fn() );
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(
+	process,
+	'platform'
+);
+
+beforeEach( () => {
+	Object.defineProperty( process, 'platform', { value: 'win32' } );
+} );
+
+afterEach( () => {
+	Object.defineProperty( process, 'platform', platformDescriptor );
+} );
+
+test( 'does not detach a watcher on Windows', () => {
+	spawnWatchProcess( 'tsc', [ '--watch' ], { stdio: 'inherit' } );
+
+	expect( spawn ).toHaveBeenCalledWith( 'tsc', [ '--watch' ], {
+		stdio: 'inherit',
+		detached: false,
+	} );
+} );
+
+test( 'uses taskkill to terminate a watcher tree on Windows', () => {
+	stopWatchProcess( {
+		pid: 123,
+		exitCode: null,
+		signalCode: null,
+	} );
+
+	expect( execFileSync ).toHaveBeenCalledWith(
+		'taskkill',
+		[ '/pid', '123', '/T', '/F' ],
+		{ stdio: 'ignore' }
+	);
+} );

--- a/tools/build-scripts/test/process.test.js
+++ b/tools/build-scripts/test/process.test.js
@@ -1,0 +1,46 @@
+import { once } from 'node:events';
+import path from 'node:path';
+import { spawnWatchProcess, stopWatchProcess } from '../process.mjs';
+
+let watcher;
+
+afterEach( () => {
+	stopWatchProcess( watcher );
+} );
+
+async function waitForProcessToExit( pid ) {
+	for ( let attempt = 0; attempt < 20; attempt++ ) {
+		try {
+			process.kill( pid, 0 );
+		} catch ( error ) {
+			if ( error.code === 'ESRCH' ) {
+				return;
+			}
+			throw error;
+		}
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+	}
+
+	throw new Error( `Process ${ pid } did not exit.` );
+}
+
+test( 'terminates a watcher and its descendant process', async () => {
+	watcher = spawnWatchProcess(
+		process.execPath,
+		[ path.join( __dirname, 'fixtures/watch-process.mjs' ) ],
+		{ stdio: [ 'ignore', 'pipe', 'inherit' ] }
+	);
+
+	const [ data ] = await once( watcher.stdout, 'data' );
+	const descendantPid = Number( data.toString().trim() );
+
+	stopWatchProcess( watcher );
+
+	await expect(
+		waitForProcessToExit( watcher.pid )
+	).resolves.toBeUndefined();
+	await expect(
+		waitForProcessToExit( descendantPid )
+	).resolves.toBeUndefined();
+} );


### PR DESCRIPTION
## What?

Fixes `npm run storybook:dev` so Ctrl+C stops the complete TypeScript watch process tree and returns control to the terminal.

## Why?

On Node 20, the TypeScript CLI starts a native compiler process. The existing cleanup stopped only the JavaScript launcher, leaving the native `tsc --watch` process alive and keeping Storybook's terminal session open.

## How?

The TypeScript watcher now runs in its own process group on POSIX systems. Cleanup stops that group, or the full process tree through `taskkill` on Windows. A regression test covers both the watcher and its descendant process.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Wait for Storybook to report that it is ready.
3. Press Ctrl+C once.
4. Confirm that the command exits and no `tsc --watch` process from the command remains.

### Testing Instructions for Keyboard

Not applicable. This change does not affect the user interface.

## Use of AI Tools

Codex was used to investigate the process tree, implement the fix, add regression coverage, and draft this pull request description. The change was verified with focused tests, lint, and a full Storybook startup and shutdown.