### PR TITLE
ActionItem: Move the more menu deduplication out of the Slot

### DIFF
--- a/packages/e2e-tests/plugins/plugins-api/sidebar.js
+++ b/packages/e2e-tests/plugins/plugins-api/sidebar.js
@@ -88,4 +88,22 @@
 		icon: 'text',
 		render: MySidebarPlugin,
 	} );
+
+	// A pinnable sidebar without a PluginSidebarMoreMenuItem of its own, so the
+	// only More Menu item for it is the one PluginSidebar injects.
+	function MyInjectedItemSidebarPlugin() {
+		return el(
+			PluginSidebar,
+			{
+				name: 'injected-item-sidebar',
+				title: __( 'Injected menu item' ),
+			},
+			el( PanelBody, {}, __( 'Injected menu item content' ) )
+		);
+	}
+
+	registerPlugin( 'my-injected-item-sidebar-plugin', {
+		icon: 'text',
+		render: MyInjectedItemSidebarPlugin,
+	} );
 } )();

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -709,7 +709,7 @@ _Parameters_
 -   _props.href_ `[string]`: When `href` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
 -   _props.onClick_ `[Function]`: The callback function to be executed when the user clicks the menu item.
--   _props.other_ `[...*]`: Any additional props are passed through to the underlying [Button](/packages/components/src/button/README.md) component.
+-   _props.other_ `[...*]`: Any additional props are passed through to the underlying menu item component.
 
 _Returns_
 

--- a/packages/editor/src/components/plugin-more-menu-item/index.js
+++ b/packages/editor/src/components/plugin-more-menu-item/index.js
@@ -1,4 +1,3 @@
-import { MenuItem } from '@wordpress/components';
 import { usePluginContext } from '@wordpress/plugins';
 import { ActionItem } from '@wordpress/interface';
 
@@ -11,7 +10,7 @@ import { ActionItem } from '@wordpress/interface';
  * @param {string}                [props.href]                          When `href` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
  * @param {Function}              [props.onClick=noop]                  The callback function to be executed when the user clicks the menu item.
- * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying [Button](/packages/components/src/button/README.md) component.
+ * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying menu item component.
  *
  * @example
  * ```js
@@ -64,7 +63,6 @@ export default function PluginMoreMenuItem( props ) {
 	return (
 		<ActionItem
 			name="core/plugin-more-menu"
-			as={ props.as ?? MenuItem }
 			icon={ props.icon || context.icon }
 			{ ...props }
 		/>

--- a/packages/editor/src/components/plugin-preview-menu-item/index.js
+++ b/packages/editor/src/components/plugin-preview-menu-item/index.js
@@ -1,4 +1,3 @@
-import { MenuItem } from '@wordpress/components';
 import { usePluginContext } from '@wordpress/plugins';
 import { ActionItem } from '@wordpress/interface';
 
@@ -43,7 +42,6 @@ export default function PluginPreviewMenuItem( props ) {
 	return (
 		<ActionItem
 			name="core/plugin-preview-menu"
-			as={ props.as ?? MenuItem }
 			icon={ props.icon || context.icon }
 			{ ...props }
 		/>

--- a/packages/editor/src/components/plugin-sidebar-more-menu-item/index.js
+++ b/packages/editor/src/components/plugin-sidebar-more-menu-item/index.js
@@ -49,13 +49,5 @@ import { ComplementaryAreaMoreMenuItem } from '@wordpress/interface';
  * @return {React.ReactNode} The rendered component.
  */
 export default function PluginSidebarMoreMenuItem( props ) {
-	return (
-		<ComplementaryAreaMoreMenuItem
-			// Menu item is marked with unstable prop for backward compatibility.
-			// @see https://github.com/WordPress/gutenberg/issues/14457
-			__unstableExplicitMenuItem
-			scope="core"
-			{ ...props }
-		/>
-	);
+	return <ComplementaryAreaMoreMenuItem scope="core" { ...props } />;
 }

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
--   `ActionItem`: `as` now defaults to `MenuItem` instead of `Button`, to nest in the `MenuGroup` that `ActionItem.Slot` renders by default ([#81507](https://github.com/WordPress/gutenberg/pull/81507)).
+-   `ActionItem`: `as` now defaults to `MenuItem` instead of `Button` ([#81507](https://github.com/WordPress/gutenberg/pull/81507)).
+-   `ActionItem.Slot`: Remove the `bubblesVirtually` prop ([#81507](https://github.com/WordPress/gutenberg/pull/81507)).
 
 ## 9.38.0 (2026-08-12)
 

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `ActionItem`: `as` now defaults to `MenuItem` instead of `Button`, to nest in the `MenuGroup` that `ActionItem.Slot` renders by default ([#81507](https://github.com/WordPress/gutenberg/pull/81507)).
+
 ## 9.38.0 (2026-08-12)
 
 ### Enhancements

--- a/packages/interface/src/components/action-item/README.md
+++ b/packages/interface/src/components/action-item/README.md
@@ -15,13 +15,6 @@ The name of the slot and fill pair passed to the `Slot` component.
 -   Type: `String`
 -   Required: Yes
 
-### bubblesVirtually
-
-Property used to change the event bubbling behavior, passed to the `Slot` component.
-
--   Type: `boolean`
--   Required: no
-
 ### as
 
 The component used as the container of the fills. Defaults to the `MenuGroup` component.

--- a/packages/interface/src/components/action-item/README.md
+++ b/packages/interface/src/components/action-item/README.md
@@ -4,7 +4,7 @@
 
 ## ActionItem.Slot
 
-The props not referred below are passed to the container component.
+Renders nothing when no fill is present. The props not referred below are passed to the container component.
 
 ## Props
 
@@ -30,6 +30,20 @@ The component used as the container of the fills. Defaults to the `MenuGroup` co
 -   Required: no
 -   Default: `MenuGroup`
 
+### fillProps
+
+Props passed to every fill. An `as` among them provides the component the items render as, unless the item asks for one of its own.
+
+-   Type: `Object`
+-   Required: no
+
+### children
+
+A function receiving the rendered fills as a flat array. Use it when the container has to wrap each fill rather than just group them. Takes precedence over `as`.
+
+-   Type: `Function`
+-   Required: no
+
 ## ActionItem
 
 The props not referred below are passed to the item component.
@@ -50,8 +64,8 @@ Callback function executed when a click on the item happens.
 
 ### as
 
-The component that is going to be used to render an action item. Defaults to the `Button` component.
+The component that is going to be used to render an action item. Defaults to the `as` the slot provides through `fillProps`, or to the `MenuItem` component, so that it nests in the `MenuGroup` the slot renders by default.
 
 -   Type: `Component`
 -   Required: no
--   Default: `Button`
+-   Default: `MenuItem`

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -5,16 +5,11 @@ function ActionItemSlot( {
 	name,
 	as: Component = MenuGroup,
 	fillProps = {},
-	bubblesVirtually,
 	children,
 	...props
 } ) {
 	return (
-		<Slot
-			name={ name }
-			bubblesVirtually={ bubblesVirtually }
-			fillProps={ fillProps }
-		>
+		<Slot name={ name } fillProps={ fillProps }>
 			{ ( fills ) => {
 				// Each fill renders an array of its own, so flatten them into a
 				// single list before handing them over.

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,13 +1,12 @@
-import { MenuGroup, Button, Slot, Fill } from '@wordpress/components';
+import { MenuGroup, MenuItem, Slot, Fill } from '@wordpress/components';
 import { Children } from '@wordpress/element';
-
-const noop = () => {};
 
 function ActionItemSlot( {
 	name,
 	as: Component = MenuGroup,
 	fillProps = {},
 	bubblesVirtually,
+	children,
 	...props
 } ) {
 	return (
@@ -17,56 +16,44 @@ function ActionItemSlot( {
 			fillProps={ fillProps }
 		>
 			{ ( fills ) => {
-				if ( ! Children.toArray( fills ).length ) {
+				// Each fill renders an array of its own, so flatten them into a
+				// single list before handing them over.
+				const items = Children.toArray( fills );
+
+				if ( ! items.length ) {
 					return null;
 				}
 
-				// Special handling exists for backward compatibility.
-				// It ensures that menu items created by plugin authors aren't
-				// duplicated with automatically injected menu items coming
-				// from pinnable plugin sidebars.
-				// @see https://github.com/WordPress/gutenberg/issues/14457
-				const initializedByPlugins = [];
-				Children.forEach(
-					fills,
-					( {
-						props: { __unstableExplicitMenuItem, __unstableTarget },
-					} ) => {
-						if ( __unstableTarget && __unstableExplicitMenuItem ) {
-							initializedByPlugins.push( __unstableTarget );
-						}
-					}
-				);
-				const children = Children.map( fills, ( child ) => {
-					if (
-						! child.props.__unstableExplicitMenuItem &&
-						initializedByPlugins.includes(
-							child.props.__unstableTarget
-						)
-					) {
-						return null;
-					}
-					return child;
-				} );
+				if ( typeof children === 'function' ) {
+					return children( items );
+				}
 
-				return <Component { ...props }>{ children }</Component>;
+				return <Component { ...props }>{ items }</Component>;
 			} }
 		</Slot>
 	);
 }
 
-function ActionItem( { name, as: Component = Button, onClick, ...props } ) {
+function ActionItem( { name, as, onClick, ...props } ) {
 	return (
 		<Fill name={ name }>
-			{ ( { onClick: fpOnClick } ) => {
+			{ ( { as: slotAs = MenuItem, onClick: slotOnClick } ) => {
+				// The slot provides the component to render the item with, so
+				// that it fits the menu it ends up in, and an onClick handler,
+				// for example one that closes that menu. The `as` prop
+				// replaces the component. The `onClick` prop does not replace
+				// the handler: both run.
+				const Component = as ?? slotAs;
+				const handlers = [ onClick, slotOnClick ].filter( Boolean );
+
 				return (
 					<Component
 						onClick={
-							onClick || fpOnClick
-								? ( ...args ) => {
-										( onClick || noop )( ...args );
-										( fpOnClick || noop )( ...args );
-								  }
+							handlers.length
+								? ( ...args ) =>
+										handlers.forEach( ( handler ) =>
+											handler( ...args )
+										)
 								: undefined
 						}
 						{ ...props }

--- a/packages/interface/src/components/complementary-area-more-menu-item/index.js
+++ b/packages/interface/src/components/complementary-area-more-menu-item/index.js
@@ -1,42 +1,69 @@
+import { observableMap, useObservableValue } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 import { check } from '@wordpress/icons';
-import { MenuItem } from '@wordpress/components';
 import ComplementaryAreaToggle from '../complementary-area-toggle';
 import ActionItem from '../action-item';
 
-const PluginsMenuItem = ( {
-	// Menu item is marked with unstable prop for backward compatibility.
-	// They are removed so they don't leak to DOM elements.
-	// @see https://github.com/WordPress/gutenberg/issues/14457
-	__unstableExplicitMenuItem,
-	__unstableTarget,
-	...restProps
-} ) => <MenuItem { ...restProps } />;
+// How many more menu items are rendered for a complementary area, by
+// `scope/target`.
+const menuItems = observableMap();
 
-export default function ComplementaryAreaMoreMenuItem( {
+export function useHasComplementaryAreaMenuItem( scope, target ) {
+	return !! useObservableValue( menuItems, `${ scope }/${ target }` );
+}
+
+// The more menu item `ComplementaryArea` injects for every pinnable area. It is
+// left out while a plugin renders one of its own for the same area.
+// @see https://github.com/WordPress/gutenberg/issues/14457
+export function DefaultComplementaryAreaMoreMenuItem( {
 	scope,
 	target,
-	__unstableExplicitMenuItem,
 	...props
 } ) {
 	return (
 		<ComplementaryAreaToggle
-			as={ ( toggleProps ) => {
-				return (
-					<ActionItem
-						__unstableExplicitMenuItem={
-							__unstableExplicitMenuItem
-						}
-						__unstableTarget={ `${ scope }/${ target }` }
-						as={ PluginsMenuItem }
-						name={ `${ scope }/plugin-more-menu` }
-						{ ...toggleProps }
-					/>
-				);
-			} }
+			as={ ( toggleProps ) => (
+				<ActionItem
+					name={ `${ scope }/plugin-more-menu` }
+					{ ...toggleProps }
+				/>
+			) }
 			role="menuitemcheckbox"
 			selectedIcon={ check }
 			name={ target }
 			scope={ scope }
+			{ ...props }
+		/>
+	);
+}
+
+export default function ComplementaryAreaMoreMenuItem( {
+	scope,
+	target,
+	// Accepted so they don't leak to DOM elements. Registering the menu item is
+	// what keeps `ComplementaryArea` from injecting a second one.
+	__unstableExplicitMenuItem,
+	__unstableTarget,
+	...props
+} ) {
+	useEffect( () => {
+		const key = `${ scope }/${ target }`;
+		menuItems.set( key, ( menuItems.get( key ) ?? 0 ) + 1 );
+
+		return () => {
+			const count = menuItems.get( key ) - 1;
+			if ( count ) {
+				menuItems.set( key, count );
+			} else {
+				menuItems.delete( key );
+			}
+		};
+	}, [ scope, target ] );
+
+	return (
+		<DefaultComplementaryAreaMoreMenuItem
+			scope={ scope }
+			target={ target }
 			{ ...props }
 		/>
 	);

--- a/packages/interface/src/components/complementary-area-more-menu-item/index.js
+++ b/packages/interface/src/components/complementary-area-more-menu-item/index.js
@@ -1,5 +1,5 @@
 import { observableMap, useObservableValue } from '@wordpress/compose';
-import { useEffect } from '@wordpress/element';
+import { useLayoutEffect } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 import ComplementaryAreaToggle from '../complementary-area-toggle';
 import ActionItem from '../action-item';
@@ -46,7 +46,7 @@ export default function ComplementaryAreaMoreMenuItem( {
 	__unstableTarget,
 	...props
 } ) {
-	useEffect( () => {
+	useLayoutEffect( () => {
 		const key = `${ scope }/${ target }`;
 		menuItems.set( key, ( menuItems.get( key ) ?? 0 ) + 1 );
 

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -26,7 +26,10 @@ import {
 } from '@wordpress/compose';
 import { usePluginContext } from '@wordpress/plugins';
 import ComplementaryAreaHeader from '../complementary-area-header';
-import ComplementaryAreaMoreMenuItem from '../complementary-area-more-menu-item';
+import {
+	DefaultComplementaryAreaMoreMenuItem,
+	useHasComplementaryAreaMenuItem,
+} from '../complementary-area-more-menu-item';
 import ComplementaryAreaToggle from '../complementary-area-toggle';
 import PinnedItems from '../pinned-items';
 import { store as interfaceStore } from '../../store';
@@ -232,6 +235,7 @@ function ComplementaryArea( {
 		[ identifier, scope ]
 	);
 
+	const hasMenuItem = useHasComplementaryAreaMenuItem( scope, name );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	useAdjustComplementaryListener(
@@ -294,15 +298,15 @@ function ComplementaryArea( {
 					) }
 				</PinnedItems>
 			) }
-			{ name && isPinnable && (
-				<ComplementaryAreaMoreMenuItem
+			{ name && isPinnable && ! hasMenuItem && (
+				<DefaultComplementaryAreaMoreMenuItem
 					target={ name }
 					scope={ scope }
 					icon={ icon }
 					identifier={ identifier }
 				>
 					{ title }
-				</ComplementaryAreaMoreMenuItem>
+				</DefaultComplementaryAreaMoreMenuItem>
 			) }
 			<ComplementaryAreaFill
 				activeArea={ activeArea }

--- a/test/e2e/specs/editor/plugins/plugins-api.spec.js
+++ b/test/e2e/specs/editor/plugins/plugins-api.spec.js
@@ -101,6 +101,38 @@ test.describe( 'Plugins API', () => {
 			).toBeVisible();
 		} );
 
+		test( 'Should render a single More Menu item for a sidebar that renders one of its own', async ( {
+			page,
+		} ) => {
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Options' } )
+				.click();
+
+			// The menu item PluginSidebar injects is labelled with the sidebar
+			// title, the one the plugin renders with its own children.
+			await expect(
+				page.getByRole( 'menuitemcheckbox', {
+					name: 'Plugin more menu title',
+				} )
+			).toHaveCount( 1 );
+			await expect(
+				page.getByRole( 'menuitemcheckbox', { name: 'Plugin title' } )
+			).toBeHidden();
+
+			// Both are labelled the same here, so a duplicate shows up as a count.
+			await expect(
+				page.getByRole( 'menuitemcheckbox', { name: 'Annotations' } )
+			).toHaveCount( 1 );
+
+			// A sidebar that renders no menu item of its own still gets one.
+			await expect(
+				page.getByRole( 'menuitemcheckbox', {
+					name: 'Injected menu item',
+				} )
+			).toHaveCount( 1 );
+		} );
+
 		test( 'Should be pinned by default and can be opened and closed using pinned items', async ( {
 			page,
 		} ) => {


### PR DESCRIPTION
## What?
Required for #81564, when you can see the cleanup in action.

RP removes backward-compatibility deduplication from `ActionItem.Slot` in `@wordpress/interface`, adds a `children` render prop to the slot, and changes the `as` default for the fill from `Button` to `MenuItem`.

## Why?

`ActionItem` is a generic slot and fill pair, but its slot scans every rendered fill for the `__unstableExplicitMenuItem` and `__unstableTarget` props so that a plugin rendering `PluginSidebarMoreMenuItem` would not get a second menu item next to the one `ComplementaryArea` injects for pinnable sidebars (#14457). That check only concerns `ComplementaryArea`, and it makes the slot hard to build on.

> [!NOTE]
> This was extracted from WIP migration to the new `Menu` component (#79560) from `@wordpress/ui`, where the host supplies the group container and wraps each fill, which the current slot cannot express. 

## How?

`ComplementaryAreaMoreMenuItem` now registers itself in a module-level observable map keyed by `scope/target`, and `ComplementaryArea` leaves out the menu item it injects while one is registered for the same area. The duplicate is never rendered, so the slot no longer needs to filter anything. `ActionItem.Slot` takes an optional `children` function that receives the fills as a flat array and replaces the `as` container, which is the seam the `Menu` migration needs. Both `__unstable*` props are still accepted on `ComplementaryAreaMoreMenuItem`, so they do not reach the DOM, but nothing reads them.

Dropping the `Button` default lets three call sites stop passing `as` explicitly, since `MenuItem` is what they all want.

## Testing Instructions

Automated coverage is in `test/e2e/specs/editor/plugins/plugins-api.spec.js`.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
