### PR TITLE
Theme: Move changelog entry to unreleased

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `ThemeProvider`: Avoid root-level relational selectors when forwarding `cornerRadius` presets to reduce style recalculation work. ([#81457](https://github.com/WordPress/gutenberg/pull/81457))
+
 ## 1.2.0 (2026-08-12)
 
 ### Bug Fixes
 
--   `ThemeProvider`: Avoid root-level relational selectors when forwarding `cornerRadius` presets to reduce style recalculation work. ([#81457](https://github.com/WordPress/gutenberg/pull/81457))
 -   Avoid `ThemeProvider` assigning CSS color properties when a seed value is not provided and there is no ancestor to inherit from. This is consistent with how `cursor` and `cornerRadius` behave, and resolves an issue where `ThemeProvider` may forcibly override colors to the default color scheme in situations where the admin color scheme properties may be provided elsewhere ([#80600](https://github.com/WordPress/gutenberg/pull/80600)).
 
 ### Internal


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/81457.

## What?
Move the `@wordpress/theme` changelog entry from the `1.2.0` release section to `Unreleased`.

## Why?
PR #81457 merged after the `1.2.0` package release, so its changelog entry should not be listed as part of that published release.

## How?
Keep the entry categorized as a bug fix and move the existing line unchanged.

## Testing Instructions
1. Open `packages/theme/CHANGELOG.md`.
2. Confirm #81457 appears once under `Unreleased` > `Bug Fixes`.
3. Confirm #81457 is absent from `1.2.0`.

## Use of AI Tools
This PR was authored with Codex. I reviewed and verified the final change.