### PR TITLE
InputControl: ignore the drag gesture on touch devices

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `InputControl`, `NumberControl`, `UnitControl`: Ignore the drag gesture on touch devices, where it has no cursor affordance and is easy to trigger by accident ([#38865](https://github.com/WordPress/gutenberg/issues/38865)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 -   `ControlWithError`: Re-read the target's validation message when an `invalid` event is received, so a message that changed without a re-render in between (e.g. a programmatic value change followed by a synthetic `invalid` event) is not revealed stale or empty. While a `validating` custom validity is pending, the message is left untouched so the pending indicator keeps showing ([#81440](https://github.com/WordPress/gutenberg/pull/81440)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `InputControl`, `NumberControl`, `UnitControl`: Ignore the drag gesture on touch devices, where it has no cursor affordance and is easy to trigger by accident ([#38865](https://github.com/WordPress/gutenberg/issues/38865)).
+-   `InputControl`, `NumberControl`, `UnitControl`: Ignore the drag gesture on touch devices, where it has no cursor affordance and is easy to trigger by accident ([#38865](https://github.com/WordPress/gutenberg/issues/38865), [#81519](https://github.com/WordPress/gutenberg/pull/81519)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 -   `ControlWithError`: Re-read the target's validation message when an `invalid` event is received, so a message that changed without a re-render in between (e.g. a programmatic value change followed by a synthetic `invalid` event) is not revealed stale or empty. While a `validating` custom validity is pending, the message is left untouched so the pending indicator keeps showing ([#81440](https://github.com/WordPress/gutenberg/pull/81440)).
 

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -133,6 +133,16 @@ function InputField(
 		( dragProps ) => {
 			const { distance, dragging, event, target } = dragProps;
 
+			// The drag gesture is not offered on touch devices, where there is
+			// no cursor affordance for it, and where it's easy to accidentally
+			// change the value when only meaning to tap or move the caret.
+			if (
+				event.pointerType === 'touch' ||
+				event.type.startsWith( 'touch' )
+			) {
+				return;
+			}
+
 			// The `target` prop always references the `input` element while, by
 			// default, the `dragProps.event.target` property would reference the real
 			// event target (i.e. any DOM element that the pointer is hovering while

--- a/packages/components/src/number-control/test/index.tsx
+++ b/packages/components/src/number-control/test/index.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from '@wordpress/element';
 import _NumberControl from '..';
@@ -551,6 +551,44 @@ describe( 'NumberControl', () => {
 			await user.keyboard( '{Shift>}[ArrowDown]{/Shift}' );
 
 			expect( input ).toHaveValue( 4 );
+		} );
+	} );
+
+	describe( 'drag to change value', () => {
+		// jsdom implements neither `PointerEvent` nor `Touch`, so the drag
+		// gesture falls back to touch events that have to be built by hand.
+		const fireTouchEvent = (
+			type: string,
+			input: HTMLElement,
+			clientY: number
+		) => {
+			const event = new Event( type, {
+				bubbles: true,
+				cancelable: true,
+			} );
+			const touches = [
+				{ identifier: 1, target: input, clientX: 0, clientY },
+			];
+			Object.assign( event, {
+				touches,
+				targetTouches: touches,
+				changedTouches: touches,
+			} );
+			fireEvent( type === 'touchstart' ? input : window, event );
+		};
+
+		it( 'should not change the value when dragging on a touch device', () => {
+			const onChange = jest.fn();
+			render( <NumberControl value="5" onChange={ onChange } /> );
+
+			const input = screen.getByRole( 'spinbutton' );
+			fireTouchEvent( 'touchstart', input, 0 );
+			fireTouchEvent( 'touchmove', input, -20 );
+			fireTouchEvent( 'touchmove', input, -60 );
+			fireTouchEvent( 'touchend', input, -60 );
+
+			expect( onChange ).not.toHaveBeenCalled();
+			expect( input ).toHaveValue( 5 );
 		} );
 	} );
 


### PR DESCRIPTION
## What?

Closes #38865

Ignores the drag-to-change-value gesture on touch devices in `InputControl`, and therefore in `NumberControl` and `UnitControl` too.

## Why?

The gesture has no `cursor` affordance on touch, so nothing tells you it exists, and it is easy to trigger by accident: a flick while trying to tap into the field or move the caret changes the value instead. #38865 also notes the gesture doesn't behave well on touch to begin with, since browser scrolling isn't suppressed for it.

## How?

`InputField`'s `useDrag` handler now returns early when the gesture comes from a touch pointer — `event.pointerType === 'touch'`, or a `touch*` event where `PointerEvent` isn't used. Mouse and pen dragging are untouched, and no other behaviour of the control changes.

Added a unit test that drives the gesture with touch events and asserts `onChange` is never called and the value is unchanged. Without the fix the test fails with two `onChange` calls.

## Testing Instructions

1. Open a post and add a Group block, then open Styles → Dimensions so a `UnitControl`/`NumberControl` is visible (padding, for example).
2. On a touch device — or in DevTools with device emulation and touch input — press on the number field and drag up or down.
3. The value should stay unchanged, and you should be able to tap into the field normally.
4. On a desktop browser with a mouse, drag up/down over the same field: the value should still change as before.

Unit tests:

```
npm run test:unit -- packages/components/src/number-control
```

### Testing Instructions for Keyboard

Focus the number field and use ArrowUp/ArrowDown, and Shift+ArrowUp/ArrowDown — stepping is unaffected by this change.

## Use of AI Tools

AI tooling (Claude Code) was used while investigating the issue, drafting the change and writing the unit test. I reviewed the result, confirmed the test fails without the fix and passes with it, and take responsibility for the code in this PR.
