### PR TITLE
Components: Improve text detection for button icon-with-text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 -   `ControlWithError`: Re-read the target's validation message when an `invalid` event is received, so a message that changed without a re-render in between (e.g. a programmatic value change followed by a synthetic `invalid` event) is not revealed stale or empty. While a `validating` custom validity is pending, the message is left untouched so the pending indicator keeps showing ([#81440](https://github.com/WordPress/gutenberg/pull/81440)).
--   `Button`: Apply the `has-text` class when the children that render the label are conditional, wrapped in an element, or preceded by other children, so that such buttons are no longer styled as icon-only buttons.
+-   `Button`: Apply the `has-text` class when the children that render the label are conditional, wrapped in an element, or preceded by other children, so that such buttons are no longer styled as icon-only buttons ([#81521](https://github.com/WordPress/gutenberg/pull/81521)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 -   `ControlWithError`: Re-read the target's validation message when an `invalid` event is received, so a message that changed without a re-render in between (e.g. a programmatic value change followed by a synthetic `invalid` event) is not revealed stale or empty. While a `validating` custom validity is pending, the message is left untouched so the pending indicator keeps showing ([#81440](https://github.com/WordPress/gutenberg/pull/81440)).
+-   `Button`: Apply the `has-text` class when the children that render the label are conditional, wrapped in an element, or preceded by other children, so that such buttons are no longer styled as icon-only buttons.
 
 ### Internal
 

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -5,9 +5,15 @@ import type {
 	HTMLAttributes,
 	MouseEvent,
 	ReactElement,
+	ReactNode,
 } from 'react';
 import deprecated from '@wordpress/deprecated';
-import { forwardRef } from '@wordpress/element';
+import {
+	Children,
+	Fragment,
+	forwardRef,
+	isValidElement,
+} from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import Tooltip from '../tooltip';
 import Icon from '../icon';
@@ -16,6 +22,30 @@ import type { ButtonProps, DeprecatedButtonProps } from './types';
 import { positionToPlacement } from '../popover/utils';
 
 const disabledEventsOnDisabledButton = [ 'onMouseDown', 'onClick' ] as const;
+
+/**
+ * Whether `children` will render any content, to differentiate an icon-only
+ * button or an icon-with-text button.
+ *
+ * `Children.toArray` discards the children that render nothing (`null`,
+ * `undefined`, and booleans), which is what conditionally rendered content
+ * evaluates to when its condition is unmet.
+ *
+ * @param children The children passed to the button.
+ */
+const hasRenderableChildren = ( children: ReactNode ): boolean =>
+	Children.toArray( children ).some( ( child ) => {
+		if ( ! isValidElement( child ) ) {
+			return child !== '';
+		}
+
+		if ( child.type === Fragment ) {
+			return hasRenderableChildren( child.props.children );
+		}
+
+		// A tooltip should not be considered as a child.
+		return child.props.className !== 'components-tooltip';
+	} );
 
 function useDeprecatedProps( {
 	__experimentalIsFocusable,
@@ -135,14 +165,6 @@ export const Button = forwardRef( function UnforwardedButton(
 		'components-button__description'
 	);
 
-	const hasChildren =
-		( 'string' === typeof children && !! children ) ||
-		( Array.isArray( children ) &&
-			children?.[ 0 ] &&
-			children[ 0 ] !== null &&
-			// Tooltip should not considered as a child
-			children?.[ 0 ]?.props?.className !== 'components-tooltip' );
-
 	const truthyAriaPressedValues: ( typeof ariaPressed )[] = [
 		true,
 		'true',
@@ -163,7 +185,7 @@ export const Button = forwardRef( function UnforwardedButton(
 		'is-busy': isBusy,
 		'is-link': variant === 'link',
 		'is-destructive': isDestructive,
-		'has-text': !! icon && ( hasChildren || text ),
+		'has-text': !! icon && ( text || hasRenderableChildren( children ) ),
 		'has-icon': !! icon,
 		'has-icon-right': iconPosition === 'right',
 	} );

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -95,6 +95,57 @@ describe( 'Button', () => {
 			);
 		} );
 
+		it( 'should render a button element with has-text when the text is not the first child', () => {
+			const isBusy = false;
+
+			render(
+				<Button icon={ plusCircle } isBusy={ isBusy }>
+					{ isBusy && 'Saving…' }
+					{ ! isBusy && 'Save' }
+				</Button>
+			);
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'has-text' );
+		} );
+
+		it( 'should render a button element with has-text when children are wrapped in an element', () => {
+			render(
+				<Button icon={ plusCircle }>
+					<span>Children</span>
+				</Button>
+			);
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'has-text' );
+		} );
+
+		it( 'should render a button element with has-text when children are wrapped in a fragment', () => {
+			render(
+				<Button icon={ plusCircle }>
+					<>Children</>
+				</Button>
+			);
+
+			expect( screen.getByRole( 'button' ) ).toHaveClass( 'has-text' );
+		} );
+
+		it( 'should render a button element without has-text when every child is falsy', () => {
+			const isBusy: boolean = false;
+
+			render(
+				<Button icon={ plusCircle }>
+					{ isBusy && 'Generating…' }
+					{ null }
+					{ /* See: https://github.com/jsx-eslint/eslint-plugin-react/issues/3995 */ }
+					{ /* eslint-disable-next-line react/jsx-curly-brace-presence */ }
+					{ '' }
+				</Button>
+			);
+
+			expect( screen.getByRole( 'button' ) ).not.toHaveClass(
+				'has-text'
+			);
+		} );
+
 		it( 'should render a button element without has-text when a button wrapped in Tooltip', () => {
 			render(
 				<Tooltip text="Help text">

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -133,7 +133,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
             class="post-publish-panel__postpublish-buttons"
           >
             <a
-              class="components-button is-next-40px-default-size is-primary has-icon has-icon-right"
+              class="components-button is-next-40px-default-size is-primary has-text has-icon has-icon-right"
               href="https://wordpress.local/sample-page/"
               target="_blank"
             >


### PR DESCRIPTION
## What?

Updates `@wordpress/component`'s `Button`'s `hasChildren` check to more accurately discern the content of the button, replacing a naive check of the first child with a more complete check on all of its children, including recursing into fragments.

## Why?

As seen in the test cases that are added, there are a number of valid scenarios where Button would previously not assign the `has-text` class, causing the styling to appear broken. 

## How?

Inspects all children, rather than just the first. And recurses into Fragments. Relies on `Children.toArray` to eliminate falsey values. 

The updated approach also includes some performance micro-optimization to defer the evaluation of children until it's known that the result of `has-text` can't be determined by `icon` or `text` alone, leveraging [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation). This is in-part to offset the potential cost of checking more than just the first child of the element.

## Testing Instructions

Careful scrutiny should be paid to places where we may have inadvertently been relying on the broken behavior. The updated snapshot is one example of this. It's not a problem in the actual post-publish panel because the snapshot lacks the actual text that would be shown in the real editor. The real editor _does_ have `has-text` here. 

Another side-effect that can be seen in this same snapshot is that we can't always know about "truly visible" text. The Button already had some built-in logic around ignoring tooltips. Now this surfaces additional cases like `VisuallyHidden`. Previously this wasn't considered text because it was wrapped by a `<span>` element, but now that we respect element-wrapped children as rendered content, it's treated as text. I'm hesitant about building-in a bunch of awareness about other components, and in this specific scenario I think it would be better to treat VisuallyHidden-only Button content (which would probably be inadvisable to begin with) as having text.

Verify tests pass:

```
npm run test:unit packages/components/src/button/test/index.tsx
```

I could not find an instance in the editor where the bug is actually present, and this would likely come up in third-party extension (which, in fact, is the source of the bug fix).

You can simulate the issue with a small patch to the Button story example to include a false-y first child, followed by actual text:

```diff
diff --git a/packages/components/src/button/stories/index.story.tsx b/packages/components/src/button/stories/index.story.tsx
index d2012ff4969..c1f0ba610ac 100644
--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -70,2 +70,4 @@ Primary.args = {
 	variant: 'primary',
+	children: [ false, 'Code is poetry' ],
+	icon: 'wordpress',
 };
```

1. Run `npm run storybook:dev`
2. Go to http://localhost:50240/?path=/story/components-button--primary
3. Observe expected spacing with text and icon
4. Compare with `trunk`

## Screenshots or screencast <!-- if applicable -->

The screenshots below demonstrate the test patch described above in "Testing Instructions":

|Before|After|
|-|-|
<img width="1284" height="820" alt="Screenshot 2026-08-12 at 1 01 17 PM" src="https://github.com/user-attachments/assets/0e4821c5-a306-4474-b259-90499850e52b" />|<img width="1284" height="820" alt="Screenshot 2026-08-12 at 1 01 04 PM" src="https://github.com/user-attachments/assets/0c2145bf-e657-40ed-a379-87133eab5f46" />

## Use of AI Tools

Used Cursor IDE + Claude Opus 5 to research and implement the fix, with manual review and prompted iterations.
