### PR TITLE
PanelColorSettings: keep the panel rendered when it has children but no colors

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `PanelColorSettings`/`PanelColorGradientSettings`: Keep the panel rendered when it has `children` but no colors or gradients to choose from, instead of hiding the children along with the empty color controls ([#12583](https://github.com/WordPress/gutenberg/issues/12583)).
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
 
 ## 16.2.0 (2026-08-12)

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -31,6 +31,7 @@ export const PanelColorGradientSettingsInner = ( {
 	const panelId = useInstanceId( PanelColorGradientSettingsInner );
 	const { batch } = useRegistry();
 	if (
+		! children &&
 		( ! colors || colors.length === 0 ) &&
 		( ! gradients || gradients.length === 0 ) &&
 		disableCustomColors &&

--- a/packages/block-editor/src/components/panel-color-settings/test/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/test/index.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import PanelColorSettings from '../';
 
 const noop = () => {};
@@ -25,6 +25,26 @@ describe( 'PanelColorSettings', () => {
 			/>
 		);
 		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render children even if there are no colors to choose', async () => {
+		render(
+			<PanelColorSettings
+				title="Test Title"
+				colors={ [] }
+				disableCustomColors
+				colorSettings={ [
+					{
+						value: '#000',
+						onChange: noop,
+						label: 'border color',
+					},
+				] }
+			>
+				<p>Child content</p>
+			</PanelColorSettings>
+		);
+		expect( screen.getByText( 'Child content' ) ).toBeVisible();
 	} );
 
 	it( 'should render a color panel if at least one setting supports custom colors', async () => {


### PR DESCRIPTION
## What?

Closes #12583

`PanelColorSettings` (and the underlying `PanelColorGradientSettings`) keep rendering when they have `children` but nothing to choose from, instead of returning `null` and taking the children down with them.

## Why?

The early return only counted colors, gradients and the custom-color flags. So a consumer that renders its own controls as children of the panel loses them entirely whenever the palette happens to be empty — for example a theme that defines no palette and disables custom colors. The children have nothing to do with whether a palette exists, and they disappear with no way to opt out.

## How?

Adds `! children` to the existing early-return condition, so the panel bails out only when there is genuinely nothing to show. When the palette is empty but children are present, the panel renders with just the children; nothing else about the component changes.

Covered by a unit test that renders the panel with an empty palette, `disableCustomColors`, and a child element, and asserts the child is visible. It fails on trunk.

## Testing Instructions

```
npm run test:unit -- packages/block-editor/src/components/panel-color-settings
```

There is no UI in trunk that hits this path today (it affects consumers passing `children`), so the unit test is the primary check. To see it by hand, render a `PanelColorSettings` with `colors={ [] }`, `disableCustomColors` and a child node in a block's inspector: before this change the whole panel is missing, after it the child renders.

### Testing Instructions for Keyboard

n/a — no interaction changes; the panel that now renders is reachable by Tab as any other inspector panel.

## Use of AI Tools

AI tooling (Claude Code) was used while investigating the issue, drafting the change and writing the unit test. I reviewed the result, confirmed the test fails without the fix and passes with it, and take responsibility for the code in this PR.
