### PR TITLE
Post Featured Image: show the Scale control when only a height is set

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Bug Fixes
 
+-   `DimensionsTool`: Add a `hasImplicitWidth` prop for elements that fill their container's width, so the scale control is offered once a height is set instead of waiting for an explicit width ([#80167](https://github.com/WordPress/gutenberg/issues/80167)).
 -   `ListView`: Drop the block icon's variation colors while the row is selected, so the icon keeps contrast against the selection background ([#82498](https://github.com/WordPress/gutenberg/pull/82498)).
 -   Flex layout: Output `flex-direction: row` when a viewport override switches a vertical layout to horizontal, so the base `flex-direction: column` no longer keeps applying on that viewport ([#82364](https://github.com/WordPress/gutenberg/pull/82364)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))

--- a/packages/block-editor/src/components/dimensions-tool/index.jsx
+++ b/packages/block-editor/src/components/dimensions-tool/index.jsx
@@ -33,6 +33,7 @@ import WidthHeightTool from './width-height-tool';
  * @property {SelectControlProps[]}       [aspectRatioOptions] Aspect ratio options.
  * @property {SelectControlProps[]}       [scaleOptions]       Scale options.
  * @property {WPUnitControlUnit[]}        [unitsOptions]       Units options.
+ * @property {boolean}                    [hasImplicitWidth]   Whether the element is sized to its container when no width is set.
  */
 
 /**
@@ -52,6 +53,7 @@ function DimensionsTool( {
 	defaultScale = 'cover',
 	unitsOptions, // Default options handled by UnitControl.
 	tools = [ 'aspectRatio', 'widthHeight', 'scale' ],
+	hasImplicitWidth = false,
 } ) {
 	// Coerce undefined and CSS default values to be null.
 	const width =
@@ -100,7 +102,11 @@ function DimensionsTool( {
 	// as a custom aspect ratio.
 	const aspectRatioValue = hasCustomAspectRatio ? 'custom' : aspectRatio;
 
-	const showScaleControl = aspectRatio || ( width && height );
+	// Scale only does something once the box can differ from the image's own
+	// ratio, which needs a width as well as a height unless the element already
+	// fills its container.
+	const showScaleControl =
+		aspectRatio || ( height && ( width || hasImplicitWidth ) );
 
 	return (
 		<>
@@ -181,6 +187,7 @@ function DimensionsTool( {
 						// Auto-update scale.
 						if (
 							! lastAspectRatioRef.current &&
+							! ( hasImplicitWidth && nextHeight ) &&
 							!! nextWidth !== !! nextHeight
 						) {
 							delete nextValue.scale;

--- a/packages/block-library/src/post-featured-image/dimension-controls.jsx
+++ b/packages/block-library/src/post-featured-image/dimension-controls.jsx
@@ -81,20 +81,12 @@ const DimensionControls = ( {
 	} );
 
 	const setDimensionAttributes = ( nextDimensions ) => {
-		const nextImageDimensions = {
-			...nextDimensions,
-			width:
-				! nextDimensions.width && nextDimensions.height
-					? 'auto'
-					: nextDimensions.width,
-		};
-
 		setAttributes(
 			getDimensionUpdateAttributes( {
 				style,
 				selectedState: selectedStyleState,
 				hasSelectedStyleState,
-				nextDimensions: nextImageDimensions,
+				nextDimensions,
 				dimensionKeyMap: { scale: 'objectFit' },
 				dimensionKeys: DIMENSION_KEYS,
 			} )
@@ -116,6 +108,8 @@ const DimensionControls = ( {
 			defaultAspectRatio="auto"
 			scaleOptions={ scaleOptions }
 			unitsOptions={ units }
+			// The block's stylesheet stretches the image to the container width.
+			hasImplicitWidth
 		/>
 	);
 };

--- a/packages/block-library/src/post-featured-image/test/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/test/dimension-controls.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import DimensionControls from '../dimension-controls';
+
+function Example( { attributes = {}, setAttributes = () => {} } ) {
+	return (
+		<ToolsPanel label="Dimensions" panelId="panel-id" resetAll={ () => {} }>
+			<DimensionControls
+				clientId="panel-id"
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+		</ToolsPanel>
+	);
+}
+
+describe( 'PostFeaturedImage dimension controls', () => {
+	it( 'offers scale when only a height is set', () => {
+		render( <Example attributes={ { height: '200px' } } /> );
+
+		expect(
+			screen.getByRole( 'radiogroup', { name: 'Scale' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'setting a height on its own keeps the width unset and picks up the default scale', async () => {
+		const user = userEvent.setup();
+		const setAttributes = jest.fn();
+
+		render( <Example setAttributes={ setAttributes } /> );
+
+		await user.type(
+			screen.getByRole( 'spinbutton', { name: 'Height' } ),
+			'200'
+		);
+
+		expect( setAttributes ).toHaveBeenLastCalledWith( {
+			aspectRatio: undefined,
+			width: undefined,
+			height: '200px',
+			scale: 'cover',
+		} );
+	} );
+} );

--- a/packages/block-library/src/post-featured-image/test/dimension-controls.jsdom.test.tsx
+++ b/packages/block-library/src/post-featured-image/test/dimension-controls.jsdom.test.tsx
@@ -1,18 +1,11 @@
-/**
- * External dependencies
- */
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-/**
- * WordPress dependencies
- */
 import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import DimensionControls from '../dimension-controls';
+
+globalThis.wpVitest.mockMatchMedia();
+globalThis.wpVitest.mockResizeObserver();
 
 function Example( { attributes = {}, setAttributes = () => {} } ) {
 	return (
@@ -21,6 +14,7 @@ function Example( { attributes = {}, setAttributes = () => {} } ) {
 				clientId="panel-id"
 				attributes={ attributes }
 				setAttributes={ setAttributes }
+				selectedStyleState={ undefined }
 			/>
 		</ToolsPanel>
 	);
@@ -37,7 +31,7 @@ describe( 'PostFeaturedImage dimension controls', () => {
 
 	it( 'setting a height on its own keeps the width unset and picks up the default scale', async () => {
 		const user = userEvent.setup();
-		const setAttributes = jest.fn();
+		const setAttributes = vi.fn();
 
 		render( <Example setAttributes={ setAttributes } /> );
 

--- a/packages/block-library/tsconfig.test.json
+++ b/packages/block-library/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"emitDeclarationOnly": false,
+		"noEmit": true,
+		"checkJs": false,
+		"rootDir": ".",
+		"types": [ "gutenberg-env", "gutenberg-vitest-test-env" ]
+	},
+	"files": [],
+	"include": [ "src/**/test/**/*.ts", "src/**/test/**/*.tsx" ],
+	"exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		{ "path": "packages/autop" },
 		{ "path": "packages/blob" },
 		{ "path": "packages/block-editor" },
+		{ "path": "packages/block-library/tsconfig.test.json" },
 		{ "path": "packages/components" },
 		{ "path": "packages/components/tsconfig.stories.json" },
 		{ "path": "packages/compose" },


### PR DESCRIPTION
## What?

See #80167

The Post Featured Image block now offers the **Scale** control as soon as a height is set, and no longer writes `width: auto` behind your back when you set only a height.

This addresses the first two inconsistencies listed in the issue.

## Why?

The featured image stretches to its container's width by default, so a height on its own is already enough to make the box differ from the image's own aspect ratio — which is exactly when scale matters. Requiring both width *and* height meant the control stayed hidden in the one case where you most need it, and (per #48892) it used to appear when either was set.

The block also patched an unset width to `auto` before saving. That looks harmless but it makes the "width is unset" state unrepresentable, which is what made a height-only `%` value apply to the placeholder but not to the image.

## How?

- `DimensionsTool` takes a new optional `hasImplicitWidth` prop. When set, the scale control is shown for a height-only value, and the "auto-update scale" branch — which clears scale when exactly one of width/height is set — no longer fires for that case, so the default scale is applied instead of removed.
- The Post Featured Image block passes `hasImplicitWidth` (its stylesheet stretches the image to the container width) and stops rewriting an unset width to `auto`.

Behaviour for every other consumer of `DimensionsTool` is unchanged, since the prop defaults to `false`.

Added unit tests for the block's dimension controls covering both paths; both fail on trunk.

## Testing Instructions

1. Edit a template that contains a Post Featured Image block (e.g. Single).
2. Select the block and open the Dimensions panel.
3. Set only a **Height** (say `300px`), leaving Width empty.
4. The **Scale** control should now appear, defaulting to Cover, and the image should be cropped to that height rather than squashed.
5. Set a Width as well — Scale keeps working as before. Clear both — Scale disappears as before.
6. Check another block that uses the same control (Image, Site Logo): nothing about their Dimensions panel should change.

```
npm run test:unit -- packages/block-library/src/post-featured-image packages/block-editor/src/components/dimensions-tool
```

### Testing Instructions for Keyboard

In the Dimensions panel, Tab to the Height field, type a value, then continue tabbing — focus should reach the Scale control that has appeared, which is operable with the arrow keys.

## Use of AI Tools

AI tooling (Claude Code) was used while investigating the issue, drafting the change and writing the unit tests. I reviewed the result, confirmed the tests fail without the fix and pass with it, and take responsibility for the code in this PR.
