### PR TITLE
Docs: clarify what an empty parent array means during block registration

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -173,6 +173,8 @@ An implementation should expect and tolerate unknown categories, providing some 
 
 Setting `parent` lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
+When `parent` is omitted, the block has no parent restriction and can be inserted anywhere insertion is otherwise allowed. An empty array is not the same as omitting the property: it matches no parent, including the root, so the block cannot be inserted anywhere and does not appear in the inserter. The only exception is a container that explicitly lists the block in its own [`allowedBlocks`](#allowed-blocks), which takes precedence.
+
 ### Ancestor
 
 -   Type: `string[]`

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -275,7 +275,8 @@ Transforms provide rules for what a block can be transformed from and what it ca
 
 #### parent (optional)
 
--   **Type:** `Array`
+-   **Type:** `string[]`
+-   **Default:** omitted
 
 Blocks are able to be inserted into blocks that use [`InnerBlocks`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
@@ -284,6 +285,15 @@ Setting `parent` lets a block require that it is only available when nested with
 ```js
 // Only allow this block when it is nested in a Columns block
 parent: [ 'core/columns' ],
+```
+
+When `parent` is omitted, the block has no parent restriction and can be inserted anywhere insertion is otherwise allowed.
+
+An empty array is not the same as omitting the property. It matches no parent, including the root, so the block cannot be inserted anywhere and does not appear in the inserter. The only exception is a container that explicitly lists the block in its own [`allowedBlocks`](#allowedblocks-optional), which takes precedence.
+
+```js
+// The block cannot be inserted anywhere.
+parent: [],
 ```
 
 #### ancestor (optional)

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -274,6 +274,10 @@ export interface BlockType<
 	 * Setting `parent` lets a block require that it is only
 	 * available when nested within the specified blocks.
 	 *
+	 * Omit for no parent restriction. An empty array matches no
+	 * parent, including the root, so the block cannot be inserted
+	 * anywhere.
+	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#parent
 	 */
 	parent?: string[];

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -60,7 +60,7 @@
 			]
 		},
 		"parent": {
-			"description": "Setting parent lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an ‘Add to Cart’ block to only be available within a ‘Product’ block.",
+			"description": "Setting parent lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an ‘Add to Cart’ block to only be available within a ‘Product’ block. Omit the property for no parent restriction; an empty array matches no parent, including the root, so the block cannot be inserted anywhere.",
 			"type": "array",
 			"items": {
 				"type": "string"


### PR DESCRIPTION
## What?

Closes #15731

Documents what an empty `parent` array means during block registration, and corrects the property's documented type.

## Why?

The issue asks for the behaviour to be spelled out, and notes that `Type: Array` isn't quite right and that the default is unclear. The assumption in the issue — that an empty array restricts a block to the root — is the opposite of what actually happens, which is a good reason to write it down.

## How?

`canInsertBlockType` passes `blockType.parent` to `checkAllowList`, which for an array returns `list.includes( item )`. For `[]` that is always `false`, including at the root where the item is `null`. Insertion is then only permitted when a container explicitly allows the block through its own `allowedBlocks` (`hasParentAllowedBlock === true`). So:

- omitted → no parent restriction;
- `[]` → matches no parent, including the root, so the block cannot be inserted anywhere and does not show in the inserter, unless a container lists it in `allowedBlocks`.

Documented that in `block-metadata.md` and `block-registration.md`, changed the documented type from `Array` to `string[]`, noted the default, and mirrored the clarification in the `block.json` schema description and the `BlockType` type's doc comment.

Documentation only — no behaviour change.

## Testing Instructions

1. Read the changed sections and check they match the behaviour described above.
2. To confirm the behaviour itself: register a test block with `parent: []`, then search for it in the inserter at the root and inside a Group — it is offered in neither. Add `allowedBlocks: [ 'your/block' ]` to a container and it becomes insertable there.
3. `npm run docs:build` (or `npm run docs:check-api-docs-unstaged`) should report no changes to regenerate.

### Testing Instructions for Keyboard

n/a — documentation only.

## Use of AI Tools

AI tooling (Claude Code) was used while investigating the issue and drafting the wording. I traced the behaviour through `canInsertBlockType`/`checkAllowList` myself before documenting it, and take responsibility for the content of this PR.
