### PR TITLE
rich-text: strip every object replacement character in getTextContent

### DIFF
--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `getTextContent`: Remove every object replacement character from the returned text, not just the first one ([#81526](https://github.com/WordPress/gutenberg/pull/81526)).
+
 ## 7.53.0 (2026-08-12)
 
 

--- a/packages/rich-text/src/get-text-content.js
+++ b/packages/rich-text/src/get-text-content.js
@@ -1,5 +1,10 @@
 import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
 
+const OBJECT_REPLACEMENT_CHARACTERS = new RegExp(
+	OBJECT_REPLACEMENT_CHARACTER,
+	'g'
+);
+
 /** @typedef {import('./types').RichTextValue} RichTextValue */
 
 /**
@@ -11,5 +16,5 @@ import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
  * @return {string} The text content.
  */
 export function getTextContent( { text } ) {
-	return text.replace( OBJECT_REPLACEMENT_CHARACTER, '' );
+	return text.replace( OBJECT_REPLACEMENT_CHARACTERS, '' );
 }

--- a/packages/rich-text/src/test/get-text-content.js
+++ b/packages/rich-text/src/test/get-text-content.js
@@ -1,0 +1,22 @@
+import { getTextContent } from '../get-text-content';
+import { OBJECT_REPLACEMENT_CHARACTER } from '../special-characters';
+
+describe( 'getTextContent', () => {
+	it( 'should return the text as is when it holds no objects', () => {
+		expect( getTextContent( { text: 'one two' } ) ).toBe( 'one two' );
+	} );
+
+	it( 'should remove a single object replacement character', () => {
+		expect(
+			getTextContent( { text: `a${ OBJECT_REPLACEMENT_CHARACTER }b` } )
+		).toBe( 'ab' );
+	} );
+
+	it( 'should remove every object replacement character', () => {
+		expect(
+			getTextContent( {
+				text: `a${ OBJECT_REPLACEMENT_CHARACTER }b${ OBJECT_REPLACEMENT_CHARACTER }c`,
+			} )
+		).toBe( 'abc' );
+	} );
+} );


### PR DESCRIPTION
## What?

`getTextContent()` now strips every object replacement character from a rich text value's text, instead of only the first one.

## Why?

The replacement is called with a plain string pattern:

```js
return text.replace( OBJECT_REPLACEMENT_CHARACTER, '' );
```

`String.prototype.replace` with a string pattern replaces the **first** match only, so any value holding two or more replacement objects — two inline images, an image plus a footnote — leaks a literal `U+FFFC` into the returned text.

This looks like an unintended regression: before #54310 the implementation used a pre-built `RegExp` with the `g` flag, and collapsing it to a string pattern dropped the flag.

Callers treat the result as plain user-facing text, so the stray character surfaces in:

- **Copy / cut** - `packages/rich-text/src/hook/event-listeners/copy-handler.js` sets the `text/plain` clipboard flavour from `getTextContent( selectedRecord )`.
- **List View, block breadcrumbs and the a11y label** - `getBlockLabel()` in `packages/blocks/src/api/utils.ts` goes through `RichTextData#toPlainText()`.
- **Document outline** - `packages/editor/src/components/document-outline/index.js`.
- **Revisions diff** - `packages/editor/src/components/post-revisions-preview/block-diff.js` diffs `toPlainText()` on both sides.
- The Link format's text and the Autocomplete trigger/query text.

## How?

Restores a module-scope `RegExp` with the `g` flag and uses it in `replace()`.

```js
const OBJECT_REPLACEMENT_CHARACTERS = new RegExp( OBJECT_REPLACEMENT_CHARACTER, 'g' );
```

Adds `packages/rich-text/src/test/get-text-content.js` with three cases: no objects, one object, and two objects. The two-object case fails on trunk, returning `"ab￼c"` for `"a￼b￼c"`.

## Testing Instructions

```
npm run test:unit -- packages/rich-text/src/test/get-text-content
```

By hand:

1. Add a Paragraph with some text, then insert two inline images into it (or an inline image and a footnote).
2. Select the whole paragraph, copy it, and paste into any plain-text target. Before this change the pasted text keeps a stray `￼` between the two images; after it, the text is clean.
3. Open List View with that paragraph in the post. Before this change the block label shows the stray placeholder character (the same string is used for the screen reader announcement).
4. Add a Heading with the same content and open the Document Outline (the "Details" panel in the editor header). Before this change the outline label shows an extra object placeholder character; after it, the label is the plain text.

### Testing Instructions for Keyboard

n/a — no interaction changes.

## Use of AI Tools

AI tooling (Claude Code) was used to help find this defect and draft the fix and tests. I confirmed the wrong output on trunk myself, verified the test fails before the change and passes after, and take responsibility for the code in this PR.

