### PR TITLE
rich-text: move the selection in replace() when it starts at index 0

### DIFF
--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `replace`: Move the selection past the replacement when it starts at the beginning of the value, instead of treating index `0` as no selection ([#81527](https://github.com/WordPress/gutenberg/pull/81527)).
+
 ## 7.53.0 (2026-08-12)
 
 

--- a/packages/rich-text/src/replace.js
+++ b/packages/rich-text/src/replace.js
@@ -56,7 +56,7 @@ export function replace(
 				replacements.slice( offset + match.length )
 			);
 
-		if ( start ) {
+		if ( start !== undefined ) {
 			start = end = offset + newText.length;
 		}
 

--- a/packages/rich-text/src/test/replace.js
+++ b/packages/rich-text/src/test/replace.js
@@ -27,6 +27,39 @@ describe( 'replace', () => {
 		expect( getSparseArrayLength( result.formats ) ).toBe( 1 );
 	} );
 
+	it( 'should move a selection at the start of the value', () => {
+		const record = {
+			formats: [ , , , ],
+			replacements: [ , , , ],
+			text: 'abc',
+			start: 0,
+			end: 0,
+		};
+		const expected = {
+			formats: [ , , , , ],
+			replacements: [ , , , , ],
+			text: 'XYbc',
+			start: 2,
+			end: 2,
+		};
+
+		expect( replace( deepFreeze( record ), 'a', 'XY' ) ).toEqual(
+			expected
+		);
+	} );
+
+	it( 'should leave a value without a selection alone', () => {
+		const record = {
+			formats: [ , , , ],
+			replacements: [ , , , ],
+			text: 'abc',
+		};
+		const result = replace( deepFreeze( record ), 'a', 'XY' );
+
+		expect( result.start ).toBeUndefined();
+		expect( result.end ).toBeUndefined();
+	} );
+
 	it( 'should replace string to record', () => {
 		const record = {
 			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],


### PR DESCRIPTION
## What?

`replace()` now moves the selection past the replacement when the selection sits at index `0`, instead of leaving it behind.

## Why?

The guard is a truthiness check:

```js
if ( start ) {
	start = end = offset + newText.length;
}
```

It is meant to separate "this value has a selection" from "this value has none" (`start === undefined`), but `0` is a perfectly valid caret position and fails the test. So for a caret at the very start of the value, `replace()` returns a selection that has not been moved, while every other index is handled.

`slice()` gets this right for the same distinction — it checks `startIndex === undefined` — so this is an inconsistency inside the package rather than a deliberate rule.

## How?

Compares against `undefined` explicitly. Values with no selection still come back with `start`/`end` untouched.

Two unit tests: a caret at index `0` (fails on trunk — `start` stays `0` where `2` is expected), and a value with no selection at all, which pins down the case the original guard was protecting.

## Testing Instructions

```
npm run test:unit -- packages/rich-text/src/test/replace
```

There is no direct UI for `replace()` in trunk today — it is a public API of `@wordpress/rich-text` — so the unit tests are the check. Consumers calling it with a caret at the start of a field get the caret placed correctly after this change.

### Testing Instructions for Keyboard

n/a — no interaction changes.

## Use of AI Tools

AI tooling (Claude Code) was used to help find this defect and draft the fix and tests. I confirmed the wrong output on trunk myself, verified the test fails before the change and passes after, and take responsibility for the code in this PR.
