### PR TITLE
date: drop a trailing backslash instead of formatting it as "undefined"

### DIFF
--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `date`: Drop a backslash that ends the format string instead of emitting the literal text `undefined`, matching PHP's `date()` ([#81528](https://github.com/WordPress/gutenberg/pull/81528)).
+
 ## 5.54.0 (2026-08-26)
 
 ## 5.53.0 (2026-08-12)

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -426,9 +426,12 @@ export function format(
 		char = dateFormat[ i ];
 		// Is this an escape?
 		if ( '\\' === char ) {
-			// Add next character, then move on.
+			// Add next character, then move on. A backslash that ends the
+			// format has nothing to escape, so it is dropped, as in PHP.
 			i++;
-			newFormat.push( '[' + dateFormat[ i ] + ']' );
+			if ( i < dateFormat.length ) {
+				newFormat.push( '[' + dateFormat[ i ] + ']' );
+			}
 			continue;
 		}
 		if ( char in formatMap ) {

--- a/packages/date/src/index.ts
+++ b/packages/date/src/index.ts
@@ -426,8 +426,9 @@ export function format(
 		char = dateFormat[ i ];
 		// Is this an escape?
 		if ( '\\' === char ) {
-			// Add next character, then move on. A backslash that ends the
-			// format has nothing to escape, so it is dropped, as in PHP.
+			// Add next character, then move on. A final backslash is
+			// ignored to align with PHP:
+			// `var_dump( date( 'Y\\', 0 ) );` prints `string(5) "1970"`
 			i++;
 			if ( i < dateFormat.length ) {
 				newFormat.push( '[' + dateFormat[ i ] + ']' );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -109,6 +109,19 @@ describe( 'Function date', () => {
 		}
 	);
 
+	test.each( [
+		[ '\\Y Y', 'Y 2019' ],
+		[ 'Y\\', '2019' ],
+		[ 'Y-m-d\\', '2019-06-18' ],
+	] )(
+		'should treat "%s" the way PHP date() treats an escape',
+		( formatString, expected ) => {
+			expect(
+				dateNoI18n( formatString, '2019-06-18T11:00:00.000Z' )
+			).toBe( expected );
+		}
+	);
+
 	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
 		const settings = getSettings();
 

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -72,6 +72,9 @@ describe( 'Function date', () => {
 		[ 'c', '2019-06-18T11:00:00+00:00' ],
 		[ 'r', 'Tue, 18 Jun 2019 11:00:00 +0000' ],
 		[ 'U', '1560855600' ],
+		[ '\\Y Y', 'Y 2019' ],
+		[ String.raw`\\Y`, String.raw`\2019` ],
+		[ 'Y\\', '2019' ],
 	] )(
 		'should format date as "%s", ignoring locale settings',
 		( formatString, expected ) => {
@@ -106,19 +109,6 @@ describe( 'Function date', () => {
 
 			// Restore default settings.
 			setSettings( settings );
-		}
-	);
-
-	test.each( [
-		[ '\\Y Y', 'Y 2019' ],
-		[ 'Y\\', '2019' ],
-		[ 'Y-m-d\\', '2019-06-18' ],
-	] )(
-		'should treat "%s" the way PHP date() treats an escape',
-		( formatString, expected ) => {
-			expect(
-				dateNoI18n( formatString, '2019-06-18T11:00:00.000Z' )
-			).toBe( expected );
 		}
 	);
 


### PR DESCRIPTION
## What?

`format()` no longer emits the literal string `undefined` when the format string ends with a backslash.

## Why?

The escape branch consumes the next character with no bounds check:

```js
if ( '\\' === char ) {
	i++;
	newFormat.push( '[' + dateFormat[ i ] + ']' );
	continue;
}
```

For a trailing backslash there is no next character, so `dateFormat[ i ]` is `undefined`, string concatenation stringifies it, and moment renders it as a literal:

- `date( 'Y\\', … )` → `"2019undefined"` (expected `"2019"`)
- `date( 'Y-m-d\\', … )` → `"2019-06-18undefined"` (expected `"2019-06-18"`)

The JSDoc points at PHP's `date()` as the reference, and PHP emits nothing for a dangling trailing backslash. A user who mistypes a date format in Settings → General, or a plugin that builds a format by concatenation, gets the word "undefined" printed in every date on the site.

## How?

Only push the escaped character when there is one. Two unit tests cover a trailing backslash on its own and after a full date format; both fail on trunk with the output above.

Out of scope: a format string consisting of *only* a backslash. With this change it behaves exactly like an empty format string, which moment renders as an ISO date. That is the pre-existing behaviour of an empty format and is left alone here.

## Testing Instructions

```
npm run test:unit -- packages/date
```

By hand:

1. Go to **Settings → General** and set the custom date format to `Y-m-d\` (with the trailing backslash).
2. View a post on the front end, or the post list in the editor.
3. Before this change the date reads `2026-08-12undefined`; after it, `2026-08-12`.

### Testing Instructions for Keyboard

n/a — no interaction changes.

## Use of AI Tools

AI tooling (Claude Code) was used to help find this defect and draft the fix and tests. I confirmed the wrong output on trunk myself, verified the tests fail before the change and pass after, and take responsibility for the code in this PR.
