### PR TITLE
url: clamp the truncated file name slice in filterURLForDisplay

### DIFF
--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `filterURLForDisplay`: Clamp the truncated file name's head slice at zero, so a small `maxLength` no longer returns a string longer than the untruncated one ([#81529](https://github.com/WordPress/gutenberg/pull/81529)).
 -   `getQueryArgs`: Split each query argument on its first `=` only, so values containing `=` — base64 padding, JWTs, nested URLs — are no longer truncated, and ignore malformed pairs with no key instead of promoting the value to one ([#81066](https://github.com/WordPress/gutenberg/pull/81066)).
 
 ## 4.53.0 (2026-08-12)

--- a/packages/url/src/filter-url-for-display.ts
+++ b/packages/url/src/filter-url-for-display.ts
@@ -57,7 +57,9 @@ export function filterURLForDisplay(
 	];
 	const truncatedFile = fileName.slice( -3 ) + '.' + extension;
 	return (
-		file.slice( 0, maxLength - truncatedFile.length - 1 ) +
+		// A negative end would be read as an offset from the end of the string,
+		// keeping most of the file name and returning more than `maxLength`.
+		file.slice( 0, Math.max( 0, maxLength - truncatedFile.length - 1 ) ) +
 		'…' +
 		truncatedFile
 	);

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1190,6 +1190,13 @@ describe( 'filterURLForDisplay', () => {
 		);
 		expect( url ).toBe( 'superlongti…ion.jpeg' );
 	} );
+	it( 'should not return more than the shortest truncation when maxLength is tiny', () => {
+		const url = filterURLForDisplay(
+			'https://example.com/averylongfilename.png',
+			5
+		);
+		expect( url ).toBe( '…ame.png' );
+	} );
 	it( 'should remove query arguments', () => {
 		const url = filterURLForDisplay(
 			'http://www.wordpress.org/wp-content/uploads/myimage.jpeg?query_args=a',


### PR DESCRIPTION
## What?

`filterURLForDisplay()` no longer returns a string far *longer* than the `maxLength` it was given.

## Why?

In the branch that truncates a long file name, the head slice is:

```js
file.slice( 0, maxLength - truncatedFile.length - 1 )
```

`truncatedFile` is always `fileName.slice( -3 ) + '.' + extension` — seven characters for a three-character extension. As soon as `maxLength` is at or below that, the second argument goes negative, and `String.slice` reads a negative end as an offset from the end of the string. Instead of clipping the head to nothing, it keeps nearly the whole file name:

```js
filterURLForDisplay( 'https://example.com/averylongfilename.png', 5 );
// actual:   'averylongfilename.…ame.png'   (26 characters, for maxLength 5)
// expected: '…ame.png'
```

So the smaller the `maxLength`, the longer the output — the opposite of the function's contract. `maxLength: 8` already returns `'…ame.png'`, so that is the shortest form this branch can produce.

Callers pass `maxLength` to fit a URL into a fixed-width UI (LinkControl's preview, for example), so an over-long return overflows the very layout the argument exists to protect.

## How?

Clamps the head slice at zero with `Math.max( 0, … )`. Anything that was already producing a non-negative end is unaffected — the existing `maxLength: 20` test still passes unchanged.

Adds a unit test for the tiny-`maxLength` case, which fails on trunk with the 26-character output above.

## Testing Instructions

```
npm run test:unit -- packages/url
```

### Testing Instructions for Keyboard

n/a — no interaction changes.

## Use of AI Tools

AI tooling (Claude Code) was used to help find this defect and draft the fix and test. I confirmed the wrong output on trunk myself, verified the test fails before the change and passes after, and take responsibility for the code in this PR.
