### PR TITLE
BoxControl: update the opposite side when ALT is held on the left or right input

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 -   `ControlWithError`: Re-read the target's validation message when an `invalid` event is received, so a message that changed without a re-render in between (e.g. a programmatic value change followed by a synthetic `invalid` event) is not revealed stale or empty. While a `validating` custom validity is pending, the message is left untouched so the pending indicator keeps showing ([#81440](https://github.com/WordPress/gutenberg/pull/81440)).
 

--- a/packages/components/src/box-control/box-input-control.tsx
+++ b/packages/components/src/box-control/box-input-control.tsx
@@ -57,10 +57,10 @@ function getSidesToModify(
 				modifiedSides.push( 'top' );
 				break;
 			case 'left':
-				modifiedSides.push( 'left' );
+				modifiedSides.push( 'right' );
 				break;
 			case 'right':
-				modifiedSides.push( 'right' );
+				modifiedSides.push( 'left' );
 				break;
 		}
 	}

--- a/packages/components/src/box-control/test/index.tsx
+++ b/packages/components/src/box-control/test/index.tsx
@@ -225,6 +225,33 @@ describe( 'BoxControl', () => {
 			).not.toHaveValue();
 		} );
 
+		it.each( [
+			[ 'Top side', 'Bottom side' ],
+			[ 'Bottom side', 'Top side' ],
+			[ 'Left side', 'Right side' ],
+			[ 'Right side', 'Left side' ],
+		] )(
+			'should update %s together with %s when ALT is held',
+			async ( side, pairedSide ) => {
+				const user = userEvent.setup();
+
+				render( <ControlledBoxControl /> );
+
+				await user.click(
+					screen.getByRole( 'button', { name: 'Unlink sides' } )
+				);
+
+				const input = screen.getByRole( 'textbox', { name: side } );
+				await user.type( input, '10' );
+				await user.keyboard( '{Alt>}{ArrowUp}{/Alt}' );
+
+				expect( input ).toHaveValue( '11' );
+				expect(
+					screen.getByRole( 'textbox', { name: pairedSide } )
+				).toHaveValue( '11' );
+			}
+		);
+
 		it( 'should update a single side value when using slider unlinked', async () => {
 			const user = userEvent.setup();
 


### PR DESCRIPTION
## What?

Holding ALT while changing the **Left** or **Right** input of an unlinked `BoxControl` now also updates the opposite side, as it already does for Top and Bottom.

## Why?

`getSidesToModify()` implements the documented behaviour — *"holding the ALT key when changing the TOP will also update BOTTOM"* — but the two horizontal cases push their own side back onto the list:

```js
case 'left':
	modifiedSides.push( 'left' );
	break;
case 'right':
	modifiedSides.push( 'right' );
	break;
```

`modifiedSides` ends up as `[ 'left', 'left' ]`, so the loop writes the same key twice and never touches the opposite side. The vertical half of the feature works; the horizontal half has been silently dead.

## How?

`left` pairs with `right` and `right` pairs with `left`, matching the `top`/`bottom` cases directly above them. The `allowedSides` filter still applies, so a control configured with only some sides is unaffected.

Added a parameterised test over all four pairs. Top/Bottom pass on trunk; Left/Right fail there and pass with this change — which is exactly the asymmetry being fixed.

## Testing Instructions

1. Select a block with a Dimensions panel (e.g. Group) and open Padding.
2. Click **Unlink sides**.
3. Focus the **Left** input, type a value, then hold ALT and press ArrowUp.
4. Left and Right should both change. Repeat from the Right input — Left should follow.
5. Check Top/Bottom still behave the same way as before.

```
npm run test:unit -- packages/components/src/box-control
```

### Testing Instructions for Keyboard

The whole feature is keyboard-driven: Tab to a side input and press ALT+ArrowUp / ALT+ArrowDown. Without ALT, only the focused side changes.

## Use of AI Tools

AI tooling (Claude Code) was used to help find this defect and draft the fix and tests. I read the surrounding code myself, verified the two horizontal cases fail before the change and pass after while the vertical ones are unaffected, and take responsibility for the code in this PR.
