### PR TITLE
Block Bindings: Don't throw on non-string values bound to a url attribute

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 
+-   Block Bindings: Return `false` from `isURLLike` for non-string values, instead of throwing. A source bound to a `url` attribute passes its value through unchanged, so a post meta field registered as `integer`, `array` or `object` crashed the block it was bound to.
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Bug Fixes
 
--   Block Bindings: Return `false` from `isURLLike` for non-string values, instead of throwing. A source bound to a `url` attribute passes its value through unchanged, so a post meta field registered as `integer`, `array` or `object` crashed the block it was bound to.
+-   Block Bindings: Return `false` from `isURLLike` for non-string values, instead of throwing. A source bound to a `url` attribute passes its value through unchanged, so a post meta field registered as `integer`, `array` or `object` crashed the block it was bound to ([#81533](https://github.com/WordPress/gutenberg/pull/81533)).
 -   `isBlockSelected`: Return `false` when called without a client ID, instead of matching the `undefined` client ID of an empty selection ([#81212](https://github.com/WordPress/gutenberg/pull/81212)).
 -   `URLInput`: Collapse a text selection reaching the start of the field before letting an up arrow press through to the editor, so selecting to the start and pressing up no longer navigates out of the field instead of collapsing the caret ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).
 -   `URLInput`: Leave Shift-modified arrow keys to the browser, so extending a selection with Shift+Up or Shift+Down no longer collapses it to the start or end of the field ([#80780](https://github.com/WordPress/gutenberg/pull/80780)).

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -3,9 +3,12 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 	getBlockTypes,
+	registerBlockBindingsSource,
+	unregisterBlockBindingsSource,
 } from '@wordpress/blocks';
 import Edit from '../edit';
 import { BlockContextProvider } from '../../block-context';
+import { PrivateBlockContext } from '../../block-list/private-block-context';
 
 const noop = () => {};
 
@@ -100,6 +103,105 @@ describe( 'Edit', () => {
 		);
 
 		expect( container ).toHaveTextContent( 'Ok' );
+	} );
+
+	describe( 'bound `url` attributes', () => {
+		const SOURCE_NAME = 'test/url-source';
+		let view;
+
+		function renderBoundBlock( value ) {
+			const edit = ( { attributes } ) => (
+				<div
+					data-testid="foo-bar"
+					data-url={ String( attributes.url ) }
+				/>
+			);
+
+			registerBlockType( 'core/test-block', {
+				apiVersion: 3,
+				category: 'text',
+				title: 'block title',
+				attributes: { url: { type: 'string' } },
+				edit,
+				save: noop,
+			} );
+
+			registerBlockBindingsSource( {
+				name: SOURCE_NAME,
+				label: 'Test source',
+				getValues: () => ( { url: value } ),
+			} );
+
+			view = render(
+				<PrivateBlockContext.Provider
+					value={ { bindableAttributes: [ 'url' ] } }
+				>
+					<Edit
+						name="core/test-block"
+						clientId="test-client-id"
+						attributes={ {
+							url: 'https://wordpress.org',
+							metadata: {
+								bindings: { url: { source: SOURCE_NAME } },
+							},
+						} }
+					/>
+				</PrivateBlockContext.Provider>
+			);
+
+			return view;
+		}
+
+		afterEach( () => {
+			// Unmount before unregistering, so that the store update does not
+			// re-render a still mounted subscriber outside of `act`.
+			view?.unmount();
+			view = undefined;
+			unregisterBlockBindingsSource( SOURCE_NAME );
+		} );
+
+		// Sources return raw values (e.g. post meta registered as `integer` or
+		// `array`), which previously threw inside `isURLLike` and crashed the
+		// block. See https://github.com/WordPress/gutenberg/pull/67523.
+		it.each( [
+			[ 'an integer', 123 ],
+			[ 'a float', 1.5 ],
+			[ 'a boolean', true ],
+			[ 'an array', [ 'https://wordpress.org' ] ],
+			[ 'an object', { url: 'https://wordpress.org' } ],
+		] )( 'nulls the url when the source returns %s', ( _label, value ) => {
+			renderBoundBlock( value );
+
+			expect( screen.getByTestId( 'foo-bar' ) ).toHaveAttribute(
+				'data-url',
+				'null'
+			);
+		} );
+
+		// These already returned `null` via the falsy check preceding
+		// `isURLLike`, which is what masked the crash for non-string values.
+		it.each( [
+			[ 'zero', 0 ],
+			[ 'an empty string', '' ],
+			[ 'null', null ],
+			[ 'false', false ],
+		] )( 'nulls the url when the source returns %s', ( _label, value ) => {
+			renderBoundBlock( value );
+
+			expect( screen.getByTestId( 'foo-bar' ) ).toHaveAttribute(
+				'data-url',
+				'null'
+			);
+		} );
+
+		it( 'keeps the url when the source returns a URL-like string', () => {
+			renderBoundBlock( 'https://example.com/image.png' );
+
+			expect( screen.getByTestId( 'foo-bar' ) ).toHaveAttribute(
+				'data-url',
+				'https://example.com/image.png'
+			);
+		} );
 	} );
 
 	describe( 'light wrapper', () => {

--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -43,6 +43,13 @@ export function isRelativePath( val ) {
  * @return {boolean} whether or not the value is potentially a URL.
  */
 export default function isURLLike( val ) {
+	// Values can arrive from arbitrary sources. Block Bindings, for example,
+	// passes raw post meta values here, which may be numbers, arrays or
+	// objects. Anything that isn't a string cannot be URL-like.
+	if ( typeof val !== 'string' ) {
+		return false;
+	}
+
 	const hasSpaces = val.includes( ' ' );
 
 	if ( hasSpaces ) {

--- a/packages/block-editor/src/components/link-control/test/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/test/is-url-like.js
@@ -23,6 +23,18 @@ describe( 'isURLLike', () => {
 		expect( isURLLike( 'somedirectentryhere' ) ).toBe( false );
 	} );
 
+	it.each( [
+		[ 'an integer', 123 ],
+		[ 'a float', 1.5 ],
+		[ 'a boolean', true ],
+		[ 'an array', [ 'https://wordpress.org' ] ],
+		[ 'an object', { url: 'https://wordpress.org' } ],
+		[ 'null', null ],
+		[ 'undefined', undefined ],
+	] )( 'returns false without throwing for %s', ( _label, value ) => {
+		expect( isURLLike( value ) ).toBe( false );
+	} );
+
 	it( 'returns true for a string beginning with www.', () => {
 		expect( isURLLike( 'www.wordpress.org' ) ).toBe( true );
 	} );


### PR DESCRIPTION
## What
A bindings source value bound to a url attribute is passed to isURLLike, which starts with val.includes( ' ' ). When the value isn't a string that throws a TypeError and the block renders the crash warning instead of its content.

## Why
Sources return raw values. core/post-meta hands back the meta value untouched, so a field registered as integer, array or object and bound to an image or button url breaks the block. The falsy check before isURLLike hid this for 0, '', null and false, so only truthy non-strings hit it.

The bindings UI only offers fields whose type matches the attribute, but bindings set in block markup, in patterns, or by third-party sources aren't filtered. This is reachable when the binding comes from somewhere other than that UI.


## How
Return false from isURLLike for anything that isn't a string. Such values then take the existing "not a valid URL" branch and the attribute is set to null, which is what already happened for the falsy ones.

The guard is in isURLLike rather than at the call site because the rest of that function is already written defensively (val?.startsWith) and the fix covers the other LinkControl callers too. Happy to move it into BlockEdit instead if reviewers would rather the source contract be enforced there.

## Testing Instructions
- register_post_meta( 'post', 'my_number', [ 'show_in_rest' => true, 'type' => 'integer', 'default' => 123 ] );
- Add an Image block and bind its url to my_number in the block markup:
```<!-- wp:image {"metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"my_number"}}}}} -->```
- On trunk the block shows "This block has encountered an error and cannot be previewed". With this change it renders the image placeholder.
- Unit tests cover integer, float, boolean, array and object values, plus the falsy cases.

## Use Of AI

Yes, Verified with claude opus.