### PR TITLE
Cover: serve the empty state with the default block ghost

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -26,6 +26,7 @@ import {
 } from '../block-edit/context';
 import { ZoomOutSeparator } from './zoom-out-separator';
 import { unlock } from '../../lock-unlock';
+import { omitUnsupportedBlockAttributes } from '../../utils/unsupported-block-attributes';
 
 export const IntersectionObserver = createContext();
 IntersectionObserver.displayName = 'IntersectionObserverContext';
@@ -194,6 +195,7 @@ function Items( {
 				isContainerInsertableToInContentOnlyMode,
 				getBlockName,
 				getBlockListSettings,
+				getBlockSettings,
 				isZoomOut: _isZoomOut,
 				canInsertBlockType,
 			} = unlock( select( blockEditorStore ) );
@@ -223,7 +225,10 @@ function Items( {
 					canInsertBlockType( defaultBlock.name, rootClientId )
 				) {
 					_ghostBlockName = defaultBlock.name;
-					_ghostBlockAttributes = defaultBlock.attributes;
+					_ghostBlockAttributes = omitUnsupportedBlockAttributes(
+						defaultBlock.attributes,
+						( path ) => getBlockSettings( rootClientId, path )[ 0 ]
+					);
 				}
 			}
 

--- a/packages/block-editor/src/utils/unsupported-block-attributes.js
+++ b/packages/block-editor/src/utils/unsupported-block-attributes.js
@@ -1,0 +1,80 @@
+/**
+ * Attribute paths whose control is gated by an editor setting, so a newly
+ * created block only carries values its author can also see and change.
+ */
+const SETTING_GATES = [
+	{
+		attribute: 'fontSize',
+		setting: 'typography.fontSizes',
+		isSupported: ( fontSizes ) => !! fontSizes?.length,
+	},
+	{
+		attribute: 'style.typography.textAlign',
+		setting: 'typography.textAlign',
+		isSupported: ( textAlign ) => !! textAlign,
+	},
+];
+
+function getValueAtPath( object, path ) {
+	return path.reduce( ( value, key ) => value?.[ key ], object );
+}
+
+function omitPath( object, [ key, ...rest ] ) {
+	if ( ! object?.hasOwnProperty( key ) ) {
+		return object;
+	}
+	const { [ key ]: value, ...remaining } = object;
+	if ( rest.length ) {
+		const child = omitPath( value, rest );
+		if ( child && Object.keys( child ).length ) {
+			return { ...object, [ key ]: child };
+		}
+	}
+	return remaining;
+}
+
+// Cache per declared attributes object so repeated store reads return the
+// same filtered reference while the resolved settings are unchanged.
+const cache = new WeakMap();
+
+/**
+ * Returns the attributes without the ones whose governing editor setting
+ * resolves to an unsupported value.
+ *
+ * @param {Object}   attributes Declared block attributes.
+ * @param {Function} getSetting Resolves a setting path to its value.
+ *
+ * @return {Object} The filtered attributes.
+ */
+export function omitUnsupportedBlockAttributes( attributes, getSetting ) {
+	if ( ! attributes ) {
+		return attributes;
+	}
+
+	const gates = SETTING_GATES.filter(
+		( { attribute } ) =>
+			getValueAtPath( attributes, attribute.split( '.' ) ) !== undefined
+	);
+	const settingValues = gates.map( ( { setting } ) => getSetting( setting ) );
+
+	const cached = cache.get( attributes );
+	if (
+		cached &&
+		cached.settingValues.length === settingValues.length &&
+		cached.settingValues.every(
+			( value, index ) => value === settingValues[ index ]
+		)
+	) {
+		return cached.result;
+	}
+
+	const result = gates.reduce(
+		( filtered, { attribute, isSupported }, index ) =>
+			isSupported( settingValues[ index ] )
+				? filtered
+				: omitPath( filtered, attribute.split( '.' ) ),
+		attributes
+	);
+	cache.set( attributes, { settingValues, result } );
+	return result;
+}

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -39,7 +39,7 @@ export default function CoverBlockControls( {
 		backgroundType,
 		allowedVideoProviders,
 	} = attributes;
-	const { hasInnerBlocks, url } = currentSettings;
+	const { isPlaceholder, url } = currentSettings;
 
 	const filteredVideoProviders = getAllowedVideoProviders(
 		allowedVideoProviders
@@ -102,12 +102,12 @@ export default function CoverBlockControls( {
 								contentPosition: nextPosition,
 							} )
 						}
-						isDisabled={ ! hasInnerBlocks }
+						isDisabled={ isPlaceholder }
 					/>
 					<FullHeightAlignmentControl
 						isActive={ isMinFullHeight }
 						onToggle={ toggleMinFullHeight }
-						isDisabled={ ! hasInnerBlocks }
+						isDisabled={ isPlaceholder }
 					/>
 					{ showEditMediaButton && (
 						<ToolbarButton

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -22,7 +22,6 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
-import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
 import { isBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
 import {
@@ -62,23 +61,6 @@ const DEFAULT_BLOCK = {
 		placeholder: __( 'Write title…' ),
 	},
 };
-
-function getInnerBlocksTemplate( attributes ) {
-	return [
-		[
-			'core/paragraph',
-			{
-				style: {
-					typography: {
-						textAlign: 'center',
-					},
-				},
-				placeholder: __( 'Write title…' ),
-				...attributes,
-			},
-		],
-	];
-}
 
 /**
  * Is the URL a temporary blob URL? A blob URL is one that is used temporarily while
@@ -136,7 +118,7 @@ function CoverEdit( {
 		[]
 	);
 
-	const { __unstableMarkNextChangeAsNotPersistent, replaceInnerBlocks } =
+	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 	const registry = useRegistry();
 
@@ -228,35 +210,6 @@ function CoverEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { gradientClass, gradientValue } = __experimentalUseGradient();
 
-	// Create the initial inner paragraph when the block gains a background
-	// and has no content yet.
-	const scaffoldInnerBlocks = () => {
-		const {
-			getBlocks,
-			isBlockSelected,
-			getSelectedBlocksInitialCaretPosition,
-		} = registry.select( blockEditorStore );
-		if ( getBlocks( clientId ).length > 0 ) {
-			return;
-		}
-		// Check for fontSize support before we pass a fontSize attribute to
-		// the innerBlocks.
-		const [ fontSizes ] = unlock(
-			registry.select( blockEditorStore )
-		).getBlockSettings( clientId, 'typography.fontSizes' );
-		const hasFontSizes = fontSizes?.length > 0;
-		replaceInnerBlocks(
-			clientId,
-			createBlocksFromInnerBlocksTemplate(
-				getInnerBlocksTemplate( {
-					fontSize: hasFontSizes ? 'large' : undefined,
-				} )
-			),
-			isBlockSelected( clientId ),
-			getSelectedBlocksInitialCaretPosition()
-		);
-	};
-
 	const onSelectMedia = async ( newMedia ) => {
 		const mediaAttributes = attributesFromMedia( newMedia );
 		const isImage = [ newMedia?.type, newMedia?.media_type ].includes(
@@ -330,8 +283,6 @@ function CoverEdit( {
 				isDark: newIsDark,
 				isUserOverlayColor: currentAttrs.isUserOverlayColor || false,
 			} );
-
-			scaffoldInnerBlocks();
 		} );
 	};
 
@@ -386,12 +337,6 @@ function CoverEdit( {
 				isUserOverlayColor: true,
 				isDark: newIsDark,
 			} );
-
-			// Skip when the color is cleared: that returns the block to its
-			// placeholder, which only renders while there is no content.
-			if ( newOverlayColor ) {
-				scaffoldInnerBlocks();
-			}
 		} );
 	};
 
@@ -541,11 +486,13 @@ function CoverEdit( {
 
 	const mediaElement = useRef();
 	const editMediaButtonRef = useRef();
+	const isPlaceholder =
+		! useFeaturedImage && ! hasInnerBlocks && ! hasBackground;
 	const currentSettings = {
 		isVideoBackground,
 		isImageBackground,
 		mediaElement,
-		hasInnerBlocks,
+		isPlaceholder,
 		url,
 		isImgElement,
 		overlayColor,
@@ -681,13 +628,6 @@ function CoverEdit( {
 					: undefined,
 				isDark: newIsDark,
 			} );
-
-			// Skip when the featured image is disabled: that can return the
-			// block to its placeholder, which only renders while there is no
-			// content.
-			if ( newUseFeaturedImage ) {
-				scaffoldInnerBlocks();
-			}
 		} );
 	};
 
@@ -745,7 +685,7 @@ function CoverEdit( {
 		width,
 	};
 
-	if ( ! useFeaturedImage && ! hasInnerBlocks && ! hasBackground ) {
+	if ( isPlaceholder ) {
 		return (
 			<>
 				{ blockControls }

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -53,6 +53,7 @@ const { openMediaEditorModalKey } = unlock( blockEditorPrivateApis );
 const DEFAULT_BLOCK = {
 	name: 'core/paragraph',
 	attributes: {
+		fontSize: 'large',
 		style: {
 			typography: {
 				textAlign: 'center',

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -51,6 +51,18 @@ import { unlock } from '../../lock-unlock';
 
 const { openMediaEditorModalKey } = unlock( blockEditorPrivateApis );
 
+const DEFAULT_BLOCK = {
+	name: 'core/paragraph',
+	attributes: {
+		style: {
+			typography: {
+				textAlign: 'center',
+			},
+		},
+		placeholder: __( 'Write title…' ),
+	},
+};
+
 function getInnerBlocksTemplate( attributes ) {
 	return [
 		[
@@ -521,6 +533,7 @@ function CoverEdit( {
 		},
 		{
 			allowedBlocks,
+			defaultBlock: DEFAULT_BLOCK,
 			templateLock,
 			dropZoneElement: ref.current,
 		}

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -144,9 +144,7 @@ describe( 'Cover block', () => {
 				} )
 			);
 
-			const title = screen.getByLabelText( 'Empty block;', {
-				exact: false,
-			} );
+			const title = screen.getByLabelText( 'Add default block' );
 			await userEvent.click( title );
 			await userEvent.keyboard( 'abc' );
 			expect( title ).toHaveTextContent( 'abc' );
@@ -471,7 +469,11 @@ describe( 'Cover block', () => {
 				name: 'White',
 			} );
 			await userEvent.click( popupColorPicker );
-			expect( coverBlock ).not.toHaveClass( 'is-light' );
+			// Removing the color returns the empty cover to its placeholder,
+			// which remounts the block wrapper, so query it again.
+			expect( screen.getByLabelText( 'Block: Cover' ) ).not.toHaveClass(
+				'is-light'
+			);
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -195,7 +195,7 @@ test.describe( 'Cover', () => {
 		// Activate the paragraph block inside the Cover block.
 		// The name of the block differs depending on whether text has been entered or not.
 		const coverBlockParagraph = coverBlock.getByRole( 'document', {
-			name: /Block: Paragraph|Empty block; start writing or type forward slash to choose a block/,
+			name: /Block: Paragraph|Add default block/,
 		} );
 		await expect( coverBlockParagraph ).toBeEditable();
 
@@ -329,15 +329,15 @@ test.describe( 'Cover', () => {
 			} )
 			.click();
 
-		// Insert a Navigation block inside the Cover block
-		await editor.selectBlocks( coverBlock );
-		await coverBlock.getByRole( 'button', { name: 'Add block' } ).click();
-		await page.keyboard.type( 'Navigation' );
-		const blockResults = page.getByRole( 'listbox', {
-			name: 'Blocks',
-		} );
-		const blockResultOptions = blockResults.getByRole( 'option' );
-		await blockResultOptions.nth( 0 ).click();
+		// Insert a Navigation block inside the Cover block by typing a slash
+		// command into its default block ghost.
+		await coverBlock
+			.getByRole( 'document', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( '/navigation' );
+		await page
+			.getByRole( 'option', { name: 'Navigation', exact: true } )
+			.click();
 
 		// Insert a second Cover block.
 		await editor.insertBlock( { name: 'core/cover' } );

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -155,8 +155,8 @@ test.describe( 'List View', () => {
 		await editor.insertBlock( { name: 'core/cover' } );
 		await editor.insertBlock( { name: 'core/group' } );
 
-		// Click first color option from the block placeholder's color picker to
-		// make the inner blocks appear.
+		// Click first color option from the block placeholder's color picker,
+		// then click the title ghost to materialise the inner paragraph.
 		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Cover' } )
 			.getByRole( 'group', {
@@ -164,6 +164,10 @@ test.describe( 'List View', () => {
 			} )
 			.getByRole( 'button' )
 			.first()
+			.click();
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Cover' } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 
 		// Open List View.
@@ -209,7 +213,7 @@ test.describe( 'List View', () => {
 			} )
 			.click();
 
-		// Click the Cover block title placeholder.
+		// Click the Cover block title paragraph.
 		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Cover' } )
 			.getByRole( 'document', { name: /Empty block/i } )


### PR DESCRIPTION
## What?

Part of #81239. The cover block's empty state becomes the ghost of its declared default block, replacing the imperative paragraph scaffold from #80028.

## Why?

Since #81231 an empty container renders a real instance of its default child that materialises when entered. Cover still scaffolded an actual paragraph the moment it gained a background, leaving an empty paragraph behind when the user typed nothing. Declaring the title paragraph as the default block gives cover the same empty-state behaviour as every other container: the invitation is a ghost, and a block only exists once there is content.

## How?

1. **Declaration**: cover declares its centered "Write title…" paragraph (`fontSize: large`, `align: center`) as the `defaultBlock` of its inner blocks.
2. **Scaffold removal**: picking a background no longer inserts a paragraph. The content position and full height controls previously keyed off "has inner blocks" as a proxy for the placeholder state, so they now key off the placeholder state itself.
3. **Attribute omission**: the ghost drops declared attributes whose controls the editor settings do not expose (for example `fontSize` when the theme defines no font sizes), so materialised blocks never carry styling the user has no UI to remove.

## Testing Instructions

1. Insert a cover block and pick a background color: no paragraph is inserted (the post stays unmodified in code view).
2. The cover shows the centered "Write title…" invitation; typing materialises a large, centered paragraph.
3. Leave the cover without typing: the content stays empty.
4. In a theme without font size presets, the materialised paragraph carries no `fontSize` attribute.

### Testing Instructions for Keyboard

Arrow into the empty cover: the caret enters the ghost paragraph; typing materialises it in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
