### PR TITLE
Notes: guard against canvas dimming and remove the dead spotlight state

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Internal
 
 -   Use the new `@wordpress/kebab-case` package instead of unlocking the `kebabCase` utility from the `@wordpress/components` private APIs ([#81294](https://github.com/WordPress/gutenberg/pull/81294)).
+-   Remove the private `toggleBlockSpotlight` action, the state it set, and the private `hasBlockSpotlight` selector. Notes were the only thing that dispatched the action and they now mark their block with the block highlight instead. `BlockList` reads `getEditedContentOnlySection` directly for the one case that still dims the canvas ([#81538](https://github.com/WordPress/gutenberg/pull/81538)).
 
 ### Enhancements
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -42,28 +42,28 @@ function Root( { className, ...settings } ) {
 		isPreviewMode,
 		editedContentOnlySection,
 	} = useSelect( ( select ) => {
-		const {
-			getSettings,
-			isTyping,
-			hasBlockSpotlight,
-			getEditedContentOnlySection,
-		} = unlock( select( blockEditorStore ) );
+		const { getSettings, isTyping, getEditedContentOnlySection } = unlock(
+			select( blockEditorStore )
+		);
 		const {
 			outlineMode,
 			focusMode,
 			isPreviewMode: _isPreviewMode,
 		} = getSettings();
+		const _editedContentOnlySection = getEditedContentOnlySection();
 		return {
 			isOutlineMode: outlineMode && ! isTyping(),
 			/*
-			 * Spotlight fades everything but the block being worked on, which
-			 * has nothing to offer a canvas that cannot be edited — a preview
-			 * would just render most of its content faded out.
+			 * A preview cannot be edited, so nothing should fade there.
+			 * Editing a content-only section dims the rest of the canvas the
+			 * same way the user preference does. Nothing else switches the
+			 * fade on: notes mark their block with its outline instead.
 			 */
 			isFocusMode:
-				! _isPreviewMode && ( focusMode || hasBlockSpotlight() ),
+				! _isPreviewMode &&
+				( focusMode || !! _editedContentOnlySection ),
 			isPreviewMode: _isPreviewMode,
-			editedContentOnlySection: getEditedContentOnlySection(),
+			editedContentOnlySection: _editedContentOnlySection,
 		};
 	}, [] );
 	const registry = useRegistry();

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -465,21 +465,6 @@ export function resetZoomLevel() {
 }
 
 /**
- * Action that toggles the spotlighted block state.
- *
- * @param {string}  clientId          The block's clientId.
- * @param {boolean} hasBlockSpotlight The spotlight state.
- * @return {Object} Action object.
- */
-export function toggleBlockSpotlight( clientId, hasBlockSpotlight ) {
-	return {
-		type: 'TOGGLE_BLOCK_SPOTLIGHT',
-		clientId,
-		hasBlockSpotlight,
-	};
-}
-
-/**
  * Opens the list view content panel popover.
  *
  * @return {Object} Action object.

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -1158,20 +1158,6 @@ export const isBlockParentHiddenAtViewport = ( state, clientId, viewport ) => {
 };
 
 /**
- * Returns true if there is a spotlighted block.
- *
- * The spotlight is also active when a contentOnly section is being edited, the selector
- * also returns true if this is the case.
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} Whether the block is currently spotlighted.
- */
-export function hasBlockSpotlight( state ) {
-	return !! state.hasBlockSpotlight || !! state.editedContentOnlySection;
-}
-
-/**
  * Returns whether a block is locked to prevent editing.
  *
  * This selector only reasons about block lock, not associated features

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1935,45 +1935,6 @@ export function highlightedBlock( state, action ) {
 }
 
 /**
- * Reducer returning current spotlighted block.
- *
- * @param {string|null} state  Current clientId or null.
- * @param {Object}      action Dispatched action.
- *
- * @return {string|null} Updated state.
- */
-export function hasBlockSpotlight( state, action ) {
-	switch ( action.type ) {
-		case 'TOGGLE_BLOCK_SPOTLIGHT':
-			const { clientId, hasBlockSpotlight: _hasBlockSpotlight } = action;
-
-			if ( _hasBlockSpotlight ) {
-				return clientId;
-			} else if ( state === clientId ) {
-				return null;
-			}
-			return state;
-		case 'SELECT_BLOCK':
-			if ( action.clientId !== state ) {
-				return null;
-			}
-			return state;
-		case 'SELECTION_CHANGE':
-			if (
-				action.start?.clientId !== state ||
-				action.end?.clientId !== state
-			) {
-				return null;
-			}
-			return state;
-		case 'CLEAR_SELECTED_BLOCK':
-			return null;
-	}
-
-	return state;
-}
-
-/**
  * Reducer returning current expanded block in the list view.
  *
  * @param {string|null} state  Current expanded block.
@@ -2449,7 +2410,6 @@ const combinedReducers = combineReducers( {
 	blockRemovalRules,
 	registeredInserterMediaCategories,
 	zoomLevel,
-	hasBlockSpotlight,
 	openedListViewPanels,
 	listViewExpandRevision,
 	listViewContentPanelOpen,

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -2187,6 +2187,99 @@ test.describe( 'Block Notes', () => {
 		} );
 	} );
 
+	test.describe( 'Canvas dimming', () => {
+		/**
+		 * Reads the two halves of the spotlight treatment at once: the class
+		 * that switches it on, and the opacity it fades unselected blocks to.
+		 * Asserting both means the test still fails if the fade is ever moved
+		 * off `.is-focus-mode` onto some other hook.
+		 *
+		 * @param {import('@wordpress/e2e-test-utils-playwright').Editor} editor    Editor fixture.
+		 * @param {import('@playwright/test').Locator}                    unrelated A block that carries no note.
+		 * @return {Promise<Object>} `focusMode` and the block's computed `opacity`.
+		 */
+		async function readDimming( editor, unrelated ) {
+			const focusMode = await editor.canvas
+				.locator( '.is-root-container' )
+				.evaluate( ( el ) => el.classList.contains( 'is-focus-mode' ) );
+			const opacity = await unrelated.evaluate(
+				( el ) => window.getComputedStyle( el ).opacity
+			);
+			return { focusMode, opacity };
+		}
+
+		async function insertTwoParagraphs( editor ) {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Move this before the previous one.' },
+			} );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'The paragraph the note is about.' },
+			} );
+		}
+
+		test( 'selecting a note leaves every other block at full opacity', async ( {
+			editor,
+			page,
+			blockNoteUtils,
+		} ) => {
+			await insertTwoParagraphs( editor );
+
+			// The note goes on the second paragraph, so the first is the one a
+			// spotlight would fade. It is also the one the note is most likely
+			// to be *about* - "move this before the previous one" is unreadable
+			// if the previous one is dimmed. See #72860.
+			await blockNoteUtils.addNote( 'Needs the paragraph above it' );
+
+			const unrelated = editor.canvas
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.first();
+
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'treeitem', {
+					name: 'Note: Needs the paragraph above it',
+				} )
+				.click();
+
+			// The noted block is marked by its own outline, not by fading
+			// everything else.
+			await expect(
+				editor.canvas
+					.getByRole( 'document', { name: 'Block: Paragraph' } )
+					.nth( 1 )
+			).toHaveClass( /is-highlighted/ );
+			expect( await readDimming( editor, unrelated ) ).toEqual( {
+				focusMode: false,
+				opacity: '1',
+			} );
+		} );
+
+		test( 'opening the add-note form leaves every other block at full opacity', async ( {
+			editor,
+			page,
+		} ) => {
+			await insertTwoParagraphs( editor );
+
+			const unrelated = editor.canvas
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.first();
+
+			// The composer is its own surface: #72870 spotlighted it separately
+			// from note selection, so it needs its own guard.
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+
+			expect( await readDimming( editor, unrelated ) ).toEqual( {
+				focusMode: false,
+				opacity: '1',
+			} );
+		} );
+	} );
+
 	test.describe( 'Rich text formatting in the note form', () => {
 		test( 'Cmd+B toggles bold in the new note textbox', async ( {
 			editor,


### PR DESCRIPTION
## What?

Two follow-ups to #80578, which is what actually removes the spotlight from the notes flows. Stacked on that branch - please merge #80578 first.

Related: #72860

## Why?

#80578 is approved and thorough about the new markings, but two loose ends came out of reviewing it against the original issue:

1. **Nothing asserts the absence of the dimming.** The e2e suite covers the tint, the underline and its thickening in detail, and none of it would fail if the spotlight came back tomorrow. That fade is the whole complaint in #72860, so it deserves its own guard.
2. **The spotlight plumbing is now dead.** Once #80578 lands, `toggleBlockSpotlight` has no dispatchers anywhere, so the reducer it feeds can never leave its null state.

## How?

**The e2e guard.** A new `Canvas dimming` block in `block-notes.spec.js` with two tests: selecting a note from the sidebar, and opening the add-note form. Both read the class that switches the fade on (`is-focus-mode` on the block list root) together with the `opacity` an unrelated block actually computes to, so the test still fails if the fade is ever moved onto a different hook. The add-note case gets its own test because #72870 spotlighted the composer separately from note selection.

The noted paragraph is deliberately the second of two, so the block a spotlight would fade is the one above it - which is the case desrosj and joedolson both raised, a note saying "move this before the previous one" being unreadable when the previous one is dimmed.

**The dead code.** Removes the `toggleBlockSpotlight` action, the `hasBlockSpotlight` reducer, and its registration in the combined reducer. What was left of the `hasBlockSpotlight` selector is then exactly the `editedContentOnlySection` check that `BlockList` already reads on the line below it, so this inlines that instead of keeping a private selector that only restates one field. All private API, no deprecation needed.

`.is-focus-mode` and its CSS stay: the user's Spotlight mode preference and content-only section editing both still use them. The only thing removed is the notes path into it.

## Testing Instructions

[![Test with WordPress Playground](https://img.shields.io/badge/Test%20with-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=81538)

Enable notes, then in the post editor:

1. Add two paragraphs, note the second one. Select the note in the sidebar - the first paragraph stays fully readable, and the noted one is marked by its outline.
2. Turn on Spotlight mode (Options > Spotlight mode) and click around with no notes involved. The dimming still works exactly as before.
3. Edit a content-only section in a template - the rest of the canvas still dims.

### Automated

- `npm run test:e2e -- test/e2e/specs/editor/various/block-notes.spec.js`
- `npm run test:unit packages/block-editor/src/store` - 637 passing, no test referenced the removed state.

## Notes for reviewers

The plan for #72860 also floated an e2e test that flips the real `focusMode` preference on and off to prove notes leave it alone. That one is left out on purpose: the preference persists to the database, and `block-notes.spec.js` leaving persisted preferences behind has already been implicated in unrelated specs failing. Point 2 of the manual steps above covers the same ground without the shared state.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
