### PR TITLE
Media editor: keep initial modal focus on the dialog frame

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Keep initial focus on the modal dialog frame instead of moving it to the crop area once the image loads ([#81505](https://github.com/WordPress/gutenberg/issues/81505)).
+-   Keep initial focus on the modal dialog frame instead of moving it to the crop area once the image loads ([#81541](https://github.com/WordPress/gutenberg/pull/81541)).
 
 ## 0.16.0 (2026-08-12)
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Keep initial focus on the modal dialog frame instead of moving it to the crop area once the image loads ([#81505](https://github.com/WordPress/gutenberg/issues/81505)).
+
 ## 0.16.0 (2026-08-12)
 
 

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -8,8 +8,6 @@ import { Cropper } from '../../image-editor';
 import { useMediaEditor, resolveAspectRatio } from '../../state';
 
 export interface MediaEditorCanvasProps {
-	/** Focus the crop area when the canvas mounts. */
-	focusOnMount?: boolean;
 	/** Whether external placement activity should reveal the grid. */
 	isPlacementActive?: boolean;
 	/** Fires when a canvas cropper gesture begins. */
@@ -27,13 +25,11 @@ export interface MediaEditorCanvasProps {
  * guards can render a spinner or fall through to `<MediaPreview>`.
  *
  * @param props
- * @param props.focusOnMount
  * @param props.isPlacementActive
  * @param props.onGestureStart
  * @param props.onGestureEnd
  */
 export default function MediaEditorCanvas( {
-	focusOnMount,
 	isPlacementActive = false,
 	onGestureStart,
 	onGestureEnd,
@@ -143,10 +139,11 @@ export default function MediaEditorCanvas( {
 			 * The cropper stays mounted while loading (hidden behind the
 			 * spinner) so the image decodes off-screen and reveals in one paint
 			 * instead of streaming in top-to-bottom. Until it's revealed it's
-			 * non-interactive (`pointer-events: none` in CSS), and focus is
-			 * withheld by gating `focusOnMount` on the loaded state — the
-			 * cropper's focus effect keys off that prop, so focus lands on the
-			 * crop area only once it's visible.
+			 * non-interactive (`pointer-events: none` in CSS).
+			 *
+			 * The crop area is never focused programmatically: the modal keeps
+			 * initial focus on the dialog frame, and users reach the crop area
+			 * by tabbing to it.
 			 */ }
 			<div
 				className={ clsx( 'media-editor-canvas__cropper', {
@@ -158,7 +155,6 @@ export default function MediaEditorCanvas( {
 					controller={ controller }
 					aspectRatio={ aspectRatio }
 					freeformCrop
-					focusOnMount={ focusOnMount && status === 'loaded' }
 					showGrid="interactive"
 					isPlacementActive={ isPlacementActive }
 					onGestureStart={ handleGestureStart }

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -610,7 +610,6 @@ function MediaEditorContent( {
 									<div className="media-editor__canvas-area">
 										{ isImage ? (
 											<MediaEditorCanvas
-												focusOnMount
 												isPlacementActive={
 													isPlacementActive
 												}


### PR DESCRIPTION
Fixes #81505

## What

Removes `focusOnMount` from `<MediaEditorCanvas>`, so the "Edit media" modal keeps initial focus on its dialog frame.

## Why

The canvas passed `focusOnMount` to the cropper gated on `status === 'loaded'`. The gate flips *after* the image finishes streaming in, so the focus effect ran asynchronously, after `Modal` had already focused the dialog frame. Two consequences:

- Initial focus lands mid-content on the `role="group"` "Crop area", skipping the dialog title and header actions.
- If the image is slow, focus is pulled from whatever control the user tabbed to in the meantime.

`Modal` defaults to `focusOnMount={ true }`, which focuses the frame (`tabIndex={ -1 }`). Other Gutenberg modals either take that default or use `focusOnMount="firstContentElement"`; none focus an interior widget.

The crop area keeps `tabIndex={ 0 }` and is still reachable by Tab. `Cropper`'s own `focusOnMount` prop is unchanged.

## Testing instructions

1. Add an Image block, select it, click Crop in the block toolbar.
2. Confirm focus is on the modal, not the crop area: the crop stencil shows no keyboard outline, and Tab moves to the first header control rather than a resize handle.
3. Tab to the crop area and confirm arrow keys still pan and `+`/`-` still zoom.



https://github.com/user-attachments/assets/015de39e-69c8-49e0-b13f-879e401f31a5


