### PR TITLE
Re-enable editableRoot for multi-selection on mobile web

### DIFF
--- a/packages/block-editor/src/components/block-list/block.jsx
+++ b/packages/block-editor/src/components/block-list/block.jsx
@@ -363,6 +363,18 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 								targetRootClientId,
 								getBlockIndex( _clientId )
 							);
+
+							// Remove the wrapper if it is left empty. The
+							// other branches remove it themselves.
+							if (
+								! getBlockOrder( _clientId ).length &&
+								isUnmodifiedBlock(
+									getBlock( _clientId ),
+									'content'
+								)
+							) {
+								removeBlock( _clientId, false );
+							}
 						} else {
 							const replacement = switchToBlockType(
 								getBlock( firstClientId ),
@@ -389,16 +401,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 							} else {
 								switchToDefaultOrRemove();
 							}
-						}
-
-						if (
-							! getBlockOrder( _clientId ).length &&
-							isUnmodifiedBlock(
-								getBlock( _clientId ),
-								'content'
-							)
-						) {
-							removeBlock( _clientId, false );
 						}
 					} );
 				} else {

--- a/packages/block-editor/src/components/block-list/block.jsx
+++ b/packages/block-editor/src/components/block-list/block.jsx
@@ -363,18 +363,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 								targetRootClientId,
 								getBlockIndex( _clientId )
 							);
-
-							// Remove the wrapper if it is left empty. The
-							// other branches remove it themselves.
-							if (
-								! getBlockOrder( _clientId ).length &&
-								isUnmodifiedBlock(
-									getBlock( _clientId ),
-									'content'
-								)
-							) {
-								removeBlock( _clientId, false );
-							}
 						} else {
 							const replacement = switchToBlockType(
 								getBlock( firstClientId ),
@@ -401,6 +389,18 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 							} else {
 								switchToDefaultOrRemove();
 							}
+						}
+
+						// The store might have already removed the wrapper if
+						// it was unmodified. However, we still want to remove
+						// the wrapper unless there is content like a cite.
+						const wrapper = getBlock( _clientId );
+						if (
+							wrapper &&
+							! getBlockOrder( _clientId ).length &&
+							isUnmodifiedBlock( wrapper, 'content' )
+						) {
+							removeBlock( _clientId, false );
 						}
 					} );
 				} else {

--- a/packages/block-editor/src/components/rich-text/index.jsx
+++ b/packages/block-editor/src/components/rich-text/index.jsx
@@ -363,7 +363,10 @@ function RichTextWrapper(
 	useLayoutEffect( () => {
 		const element = anchorRef.current;
 
-		if ( ! isSelected || ! element ) {
+		// A pointer press outside the field makes it non editable until the
+		// release (see rich text's preventFocusCapture). Focusing it then
+		// makes the block focus handler drop the text selection.
+		if ( ! isSelected || element?.contentEditable !== 'true' ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -206,12 +206,21 @@ export default function useSelectionObserver() {
 						! isMultiSelecting()
 					) {
 						setContentEditableWrapper( node, false );
-						let element =
-							startNode.nodeType === startNode.ELEMENT_NODE
-								? startNode
-								: startNode.parentElement;
-						element = element?.closest( '[contenteditable]' );
-						element?.focus();
+						// Only return focus to the field if the wrapper had
+						// it. If Escape moved focus to the canvas stop in the
+						// parent document, the wrapper is only the stale
+						// active element and focus must not come back.
+						if (
+							ownerDocument.activeElement === node &&
+							ownerDocument.hasFocus()
+						) {
+							let element =
+								startNode.nodeType === startNode.ELEMENT_NODE
+									? startNode
+									: startNode.parentElement;
+							element = element?.closest( '[contenteditable]' );
+							element?.focus();
+						}
 					}
 					return;
 				}

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -1,11 +1,15 @@
 import { __ } from '@wordpress/i18n';
 import { paragraph as icon } from '@wordpress/icons';
+import { privateApis as blocksPrivateApis } from '@wordpress/blocks';
 import initBlock from '../utils/init-block';
 import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import { unlock } from '../lock-unlock';
+
+const { editableRootKey } = unlock( blocksPrivateApis );
 
 const { name } = metadata;
 
@@ -13,6 +17,9 @@ export { metadata, name };
 
 export const settings = {
 	icon,
+	// Opt into the editing host behaviour privately. It's a Symbol setting
+	// rather than a public `supports` key so it stays an internal detail.
+	[ editableRootKey ]: true,
 	example: {
 		attributes: {
 			content: __(

--- a/packages/rich-text/src/hook/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/hook/event-listeners/input-and-selection.js
@@ -268,9 +268,6 @@ export default ( props ) => ( element ) => {
 					selection.collapse( element, 0 );
 				}
 			}
-			// The caret placed after this focus must still be synchronized
-			// in this task (see below).
-			window.queueMicrotask( handleSelectionChange );
 			return;
 		}
 

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -768,7 +768,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		// The editing host, which `RichText` mirrors these attributes onto by
 		// hand, only takes over once the block has a sibling.
 		await editor.canvas
-			.getByRole( 'button', { name: 'Add default block' } )
+			.getByRole( 'document', { name: 'Add default block' } )
 			.click();
 		await page.keyboard.type( 'A first paragraph.' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -761,6 +761,69 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		await expect( page.getByRole( 'listbox' ) ).toBeHidden();
 	} );
 
+	test( 'should mirror the suggestions list reference onto the editing host', async ( {
+		editor,
+		page,
+	} ) => {
+		// The editing host, which `RichText` mirrors these attributes onto by
+		// hand, only takes over once the block has a sibling.
+		await editor.canvas
+			.getByRole( 'button', { name: 'Add default block' } )
+			.click();
+		await page.keyboard.type( 'A first paragraph.' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'hello @fr' );
+
+		await expect(
+			page.getByRole( 'option', {
+				name: 'Frodo Baggins',
+				selected: true,
+			} )
+		).toBeVisible();
+
+		const editingHost = editor.canvas.getByRole( 'textbox', {
+			name: 'Editor canvas',
+		} );
+
+		// The popover renders outside the canvas, so the list is mirrored back
+		// into it — these IDs have to resolve in the host's own document.
+		const listBoxId = await editor.canvas
+			.getByRole( 'listbox' )
+			.getAttribute( 'id' );
+		const optionId = await editor.canvas
+			.getByRole( 'option', { name: 'Frodo Baggins' } )
+			.getAttribute( 'id' );
+
+		await expect( editingHost ).toHaveAttribute(
+			'aria-autocomplete',
+			'list'
+		);
+		await expect( editingHost ).toHaveAttribute(
+			'aria-haspopup',
+			'listbox'
+		);
+		await expect( editingHost ).toHaveAttribute(
+			'aria-controls',
+			listBoxId
+		);
+		await expect( editingHost ).toHaveAttribute( 'aria-owns', listBoxId );
+		await expect( editingHost ).toHaveAttribute(
+			'aria-activedescendant',
+			optionId
+		);
+
+		await page.keyboard.press( 'Escape' );
+		await expect( page.getByRole( 'listbox' ) ).toBeHidden();
+
+		// Only an omitted value clears an attribute here: a `null` would land
+		// on the host as the string "null".
+		await expect( editingHost ).not.toHaveAttribute( 'aria-controls' );
+		await expect( editingHost ).not.toHaveAttribute( 'aria-owns' );
+		await expect( editingHost ).not.toHaveAttribute(
+			'aria-activedescendant'
+		);
+	} );
+
 	test( 'should re-trigger autocomplete when backspacing into a completed mention', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/editable-root-compat.spec.js
+++ b/test/e2e/specs/editor/various/editable-root-compat.spec.js
@@ -1,0 +1,293 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Editable root block event handler compatibility', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'delivers keyboard events to a block wrapperProps handler', async ( {
+		editor,
+		page,
+	} ) => {
+		// A third party adds an event handler to every block through
+		// wrapperProps, the surface host mode would otherwise bypass.
+		await page.evaluate( () => {
+			window.__extKeys = [];
+			const { createElement } = window.wp.element;
+			window.wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'test/compat-events',
+				( BlockListBlock ) => ( props ) =>
+					createElement( BlockListBlock, {
+						...props,
+						wrapperProps: {
+							...props.wrapperProps,
+							onKeyDown: ( event ) =>
+								window.__extKeys.push( event.key ),
+						},
+					} )
+			);
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'b' },
+		} );
+
+		// Move to the first paragraph so the wrapper becomes the editing host.
+		await page.keyboard.press( 'ArrowUp' );
+
+		await page.evaluate( () => ( window.__extKeys = [] ) );
+		await page.keyboard.type( 'x' );
+
+		await expect
+			.poll( () => page.evaluate( () => window.__extKeys ) )
+			.toContain( 'x' );
+	} );
+
+	test( 'lets a block wrapperProps handler cancel the default action', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.evaluate( () => {
+			const { createElement } = window.wp.element;
+			window.wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'test/compat-events-prevent',
+				( BlockListBlock ) => ( props ) =>
+					createElement( BlockListBlock, {
+						...props,
+						wrapperProps: {
+							...props.wrapperProps,
+							onKeyDown: ( event ) => {
+								if ( event.key === 'b' ) {
+									event.preventDefault();
+								}
+							},
+						},
+					} )
+			);
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'End' );
+
+		// 'a' types; 'b' is canceled by the handler.
+		await page.keyboard.type( 'ab' );
+
+		const [ firstParagraph ] = await editor.getBlocks();
+		expect( firstParagraph.attributes.content ).toBe( 'aa' );
+	} );
+
+	test( 'passes a synthetic-like event with a working nativeEvent', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.evaluate( () => {
+			window.__extInput = [];
+			const { createElement } = window.wp.element;
+			window.wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'test/compat-events-synthetic',
+				( BlockListBlock ) => ( props ) =>
+					createElement( BlockListBlock, {
+						...props,
+						wrapperProps: {
+							...props.wrapperProps,
+							onBeforeInput: ( event ) => {
+								window.__extInput.push( {
+									data: event.data,
+									isSynthetic:
+										typeof event.persist === 'function',
+									nativeEventType:
+										event.nativeEvent?.constructor?.name,
+									isDefaultPrevented:
+										event.isDefaultPrevented(),
+									// The real event is wrapped, so these
+									// are faithful, not a scripted copy's.
+									isTrusted: event.isTrusted,
+									// Not on React's synthetic event, so
+									// reached through the native event.
+									hasTargetRanges:
+										event.nativeEvent.getTargetRanges()
+											.length > 0,
+								} );
+							},
+						},
+					} )
+			);
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'b' },
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.evaluate( () => ( window.__extInput = [] ) );
+		await page.keyboard.type( 'x' );
+
+		const record = await page
+			.evaluate( () => window.__extInput )
+			.then( ( entries ) => entries.at( -1 ) );
+		expect( record ).toMatchObject( {
+			data: 'x',
+			isSynthetic: true,
+			nativeEventType: 'InputEvent',
+			isDefaultPrevented: false,
+			isTrusted: true,
+			hasTargetRanges: true,
+		} );
+	} );
+
+	test( 'stops propagation between nested block handlers', async ( {
+		editor,
+		page,
+	} ) => {
+		// The inner (list item) handler stops propagation; the outer (list)
+		// handler must not see the event, like React bubbling.
+		await page.evaluate( () => {
+			window.__extPath = [];
+			const { createElement } = window.wp.element;
+			window.wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'test/compat-events-nested',
+				( BlockListBlock ) => ( props ) =>
+					createElement( BlockListBlock, {
+						...props,
+						wrapperProps: {
+							...props.wrapperProps,
+							onKeyDown: ( event ) => {
+								window.__extPath.push( props.block.name );
+								if ( props.block.name === 'core/list-item' ) {
+									event.stopPropagation();
+								}
+							},
+						},
+					} )
+			);
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{
+					name: 'core/list-item',
+					attributes: { content: 'item' },
+				},
+				{
+					name: 'core/list-item',
+					attributes: { content: 'item two' },
+				},
+			],
+		} );
+
+		// Select the first list item so the wrapper hosts.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'List text' } )
+			.first()
+			.click();
+		await page.evaluate( () => ( window.__extPath = [] ) );
+		await page.keyboard.type( 'x' );
+
+		await expect
+			.poll( () => page.evaluate( () => window.__extPath ) )
+			.toEqual( [ 'core/list-item' ] );
+	} );
+
+	test( 'delivers input events to a block wrapperProps handler', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.evaluate( () => {
+			window.__extInputData = [];
+			const { createElement } = window.wp.element;
+			window.wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'test/compat-events-input',
+				( BlockListBlock ) => ( props ) =>
+					createElement( BlockListBlock, {
+						...props,
+						wrapperProps: {
+							...props.wrapperProps,
+							onInput: ( event ) =>
+								window.__extInputData.push( event.data ),
+						},
+					} )
+			);
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'b' },
+		} );
+
+		await page.keyboard.press( 'ArrowUp' );
+		await page.evaluate( () => ( window.__extInputData = [] ) );
+		await page.keyboard.type( 'x' );
+
+		await expect
+			.poll( () => page.evaluate( () => window.__extInputData ) )
+			.toContain( 'x' );
+	} );
+
+	test( 'does not double up an event React already delivers', async ( {
+		editor,
+		page,
+	} ) => {
+		// The code block is plain text, not part of the rich-text writing flow,
+		// so it will never be an editableRoot host: React delivers the event to
+		// the block as usual. The host bridge must recognise the event isn't on
+		// the host and stay out of the way, so the handler runs once, not twice.
+		await page.evaluate( () => {
+			window.__extCount = 0;
+			const { createElement } = window.wp.element;
+			window.wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'test/compat-events-count',
+				( BlockListBlock ) => ( props ) =>
+					createElement( BlockListBlock, {
+						...props,
+						wrapperProps: {
+							...props.wrapperProps,
+							onKeyDown: () => ( window.__extCount += 1 ),
+						},
+					} )
+			);
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/code',
+			attributes: { content: 'a' },
+		} );
+
+		await page.evaluate( () => ( window.__extCount = 0 ) );
+		await page.keyboard.press( 'x' );
+
+		// One keydown, one call. A second would mean the bridge fired on top of
+		// React's delivery.
+		await expect
+			.poll( () => page.evaluate( () => window.__extCount ) )
+			.toBe( 1 );
+	} );
+} );

--- a/test/e2e/specs/editor/various/editable-root.spec.js
+++ b/test/e2e/specs/editor/various/editable-root.spec.js
@@ -1,0 +1,66 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'editableRoot host mode', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'wrapper becomes the editing host for a paragraph with siblings', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'b' },
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Host mode: the selected block has a contentEditable ancestor above it
+		// (the canvas wrapper), which does not happen when the block is edited
+		// on its own element.
+		await expect
+			.poll( () =>
+				editor.canvas
+					.locator( ':root' )
+					.evaluate(
+						( root ) =>
+							!! root.ownerDocument.querySelector(
+								'[contenteditable="true"] [data-block]'
+							)
+					)
+			)
+			.toBe( true );
+	} );
+
+	test( 'a heading (no support) is not hosted', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'a' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'b' },
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+
+		await expect
+			.poll( () =>
+				editor.canvas
+					.locator( ':root' )
+					.evaluate(
+						( root ) =>
+							!! root.ownerDocument.querySelector(
+								'[contenteditable="true"] [data-block]'
+							)
+					)
+			)
+			.toBe( false );
+	} );
+} );

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -341,11 +341,27 @@ test.describe( 'List View', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Paragraph text' },
 		} );
-		await expect(
-			editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
-			} )
-		).toBeFocused();
+		// The block owns the caret: it is focused itself, or the engaged
+		// editing host holds focus with the selection inside the block.
+		await expect
+			.poll( () =>
+				editor.canvas
+					.getByRole( 'document', {
+						name: 'Block: Paragraph',
+					} )
+					.evaluate( ( el ) => {
+						const { activeElement } = el.ownerDocument;
+						const { anchorNode } =
+							el.ownerDocument.defaultView.getSelection();
+						return (
+							el === activeElement ||
+							( activeElement?.contentEditable === 'true' &&
+								activeElement.contains( el ) &&
+								el.contains( anchorNode ) )
+						);
+					} )
+			)
+			.toBe( true );
 
 		// Open List View.
 		await pageUtils.pressKeys( 'access+o' );

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -341,25 +341,13 @@ test.describe( 'List View', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Paragraph text' },
 		} );
-		// The block owns the caret: it is focused itself, or the engaged
-		// editing host holds focus with the selection inside the block.
 		await expect
 			.poll( () =>
-				editor.canvas
-					.getByRole( 'document', {
+				editor.ownsSelection(
+					editor.canvas.getByRole( 'document', {
 						name: 'Block: Paragraph',
 					} )
-					.evaluate( ( el ) => {
-						const { activeElement } = el.ownerDocument;
-						const { anchorNode } =
-							el.ownerDocument.defaultView.getSelection();
-						return (
-							el === activeElement ||
-							( activeElement?.contentEditable === 'true' &&
-								activeElement.contains( el ) &&
-								el.contains( anchorNode ) )
-						);
-					} )
+				)
 			)
 			.toBe( true );
 

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -295,7 +295,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			.toEqual( [ 1, 2, 3 ] );
 	} );
 
-	test( 'should present the editing host semantics during a cross-block selection', async ( {
+	test( 'should keep the editing host semantics across a cross-block selection', async ( {
 		page,
 		editor,
 		pageUtils,
@@ -307,13 +307,16 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 
-		// Without a cross-block selection, the block is edited on its own
-		// element and the canvas wrapper is not an editing host.
+		// The wrapper hosts editing for the selected block: it must present
+		// as a named multiline textbox for as long as it is the editing
+		// host, including while a selection crosses blocks.
 		const host = editor.canvas.locator( 'body' );
-		await expect( host ).not.toHaveAttribute( 'contenteditable', 'true' );
+		await expect( host ).toHaveAttribute( 'contenteditable', 'true' );
+		await expect( host ).toHaveAttribute( 'role', 'textbox' );
+		await expect( host ).toHaveAttribute( 'aria-multiline', 'true' );
+		await expect( host ).toHaveAttribute( 'aria-label', 'Editor canvas' );
 
-		// Extend the selection across blocks: the wrapper becomes the
-		// editing host and must present as a named multiline textbox.
+		// Extend the selection across blocks: the host semantics remain.
 		await pageUtils.pressKeys( 'shift+ArrowUp' );
 		await expect
 			.poll( () =>
@@ -332,9 +335,18 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			'Multiple selected blocks'
 		);
 
-		// Collapse into a block: the editability and the textbox semantics
-		// are removed together.
+		// Collapse into a block: the block still hosts, so the semantics
+		// remain and the generic host name returns.
 		await page.keyboard.press( 'ArrowLeft' );
+		await expect( host ).toHaveAttribute( 'contenteditable', 'true' );
+		await expect( host ).toHaveAttribute( 'role', 'textbox' );
+		await expect( host ).toHaveAttribute( 'aria-label', 'Editor canvas' );
+
+		// Move to the post title: the editability and the textbox semantics
+		// are removed together.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.click();
 		await expect( host ).toHaveAttribute( 'contenteditable', 'false' );
 		await expect( host ).not.toHaveAttribute( 'role' );
 		await expect( host ).not.toHaveAttribute( 'aria-multiline' );

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -988,6 +988,53 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should place the caret at the click inside a multi block selection', async ( {
+		page,
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'One two three' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second' },
+		} );
+
+		const box = await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first()
+			.boundingBox();
+		// Click past the text so the caret lands at the end.
+		await page.mouse.click( box.x + box.width - 4, box.y + box.height / 2 );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Shift+ArrowDown' );
+		await expect
+			.poll( () =>
+				page.evaluate( () => {
+					const { getSelectionStart, getSelectionEnd } =
+						window.wp.data.select( 'core/block-editor' );
+					return [ getSelectionStart(), getSelectionEnd() ].map(
+						( { offset } ) => offset
+					);
+				} )
+			)
+			.toEqual( [ 11, 6 ] );
+
+		// Selecting the first block must not keep the start offset without
+		// an end, which would set the caret at the start of the block.
+		await page.mouse.click( box.x + box.width - 4, box.y + box.height / 2 );
+		await page.keyboard.type( 'a' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'One two threea' },
+			},
+			{ name: 'core/paragraph', attributes: { content: 'Second' } },
+		] );
+	} );
+
 	test( 'should select the whole paragraph on triple click from the block edge', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -868,17 +868,15 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 				cancelled: window.__enterCancelled,
 			} ) );
 		// Nothing happens on keydown: the beforeinput fires, is cancelled,
-		// and focus only moves while it is being handled. Focus can move
-		// twice: into the new field, then to the editing host that engages
-		// once the block has a sibling.
-		expect( events.slice( 0, 2 ) ).toEqual( [
+		// and focus only moves while it is being handled. Focus moves into
+		// the new field, then to the editing host that engages once the
+		// block has a sibling.
+		expect( events ).toEqual( [
 			'keydown',
 			'beforeinput:insertParagraph',
+			'focusin',
+			'focusin',
 		] );
-		expect( events.length ).toBeGreaterThan( 2 );
-		expect( events.slice( 2 ).every( ( e ) => e === 'focusin' ) ).toBe(
-			true
-		);
 		expect( cancelled ).toBe( true );
 
 		// The caret is at the very start of the new field: not after the

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -868,12 +868,17 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 				cancelled: window.__enterCancelled,
 			} ) );
 		// Nothing happens on keydown: the beforeinput fires, is cancelled,
-		// and focus only moves while it is being handled.
-		expect( events ).toEqual( [
+		// and focus only moves while it is being handled. Focus can move
+		// twice: into the new field, then to the editing host that engages
+		// once the block has a sibling.
+		expect( events.slice( 0, 2 ) ).toEqual( [
 			'keydown',
 			'beforeinput:insertParagraph',
-			'focusin',
 		] );
+		expect( events.length ).toBeGreaterThan( 2 );
+		expect( events.slice( 2 ).every( ( e ) => e === 'focusin' ) ).toBe(
+			true
+		);
 		expect( cancelled ).toBe( true );
 
 		// The caret is at the very start of the new field: not after the


### PR DESCRIPTION
> [!NOTE]
> The typing metrics in the performance job are expected to go up. With the canvas body as the editing host, Chrome rebuilds its text input state after every insertion, counting from the start of the host to the caret. The large post fixture types at the end of 1436 blocks, which adds about 40% per keystroke on CI. 40% sounds like a lot, but it is still performant.

## What?

Restores the `editableRoot` opt-in removed for the WordPress 7.0 RC in #81184.

## Why?

The opt-in was removed because the behavior was not ready for the RC. Double tap was broken on iOS, but has since been fixed with #82581.

## How?

1. **Restore the paragraph opt-in** removed in #81184.
2. **Fix latent trunk bugs surfaced by re-enabling**: an emptied-wrapper cleanup acting on an already removed block, the selection observer pulling focus into the canvas when disengaging, the rich text wrapper focusing a field made non editable during a pointer press, and a selection sync after focus inside an editing host reporting a stale range. Each one has a test that fails without it.
3. **Needs #80605** (merged) for typing performance with a host engaged.

## Testing Instructions

1. Select a paragraph with siblings and verify the canvas wrapper (iframe body) is `contenteditable`.
2. Verify typing, merging, and cross-block selection behave as before.

## Use of AI Tools

Authored by Claude (Fable 5) in collaboration with @ellatrix.







