### PR TITLE
Notes: Add reviewer capabilities for notes on post previews

### DIFF
--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -111,6 +111,11 @@ function gutenberg_initialize_experiments_settings() {
 					'description' => __( 'Enables the Workflow Palette for running workflows composed of abilities, from a unified interface.', 'gutenberg' ),
 				),
 				array(
+					'id'          => 'gutenberg-notes-on-previews',
+					'label'       => __( 'Notes on post previews', 'gutenberg' ),
+					'description' => __( 'Adds the read_post_notes and create_post_notes capabilities, so a site can let reviewers read and reply to notes on a post preview without giving them the ability to edit the post.', 'gutenberg' ),
+				),
+				array(
 					'id'          => 'gutenberg-extensible-site-editor',
 					'label'       => __( 'Extensible Site Editor', 'gutenberg' ),
 					'description' => __( 'Redirects the default site editor (Appearance > Design) to use the extensible site editor page.', 'gutenberg' ),

--- a/lib/experimental/notes-preview.php
+++ b/lib/experimental/notes-preview.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Notes on post previews.
+ *
+ * Lets a site give someone the ability to read and reply to a post's notes
+ * without giving them the ability to edit the post, and surfaces those notes on
+ * the post's preview so the discussion sits against the real rendered content.
+ *
+ * The whole feature sits behind the `gutenberg-notes-on-previews` experiment
+ * and, until a site grants the new capabilities to somebody, changes nothing:
+ * both capabilities map to `edit_post` by default.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/73418
+ *
+ * @package gutenberg
+ */
+
+require_once __DIR__ . '/notes-preview/capabilities.php';

--- a/lib/experimental/notes-preview.php
+++ b/lib/experimental/notes-preview.php
@@ -18,3 +18,5 @@
 require_once __DIR__ . '/notes-preview/capabilities.php';
 require_once __DIR__ . '/notes-preview/class-gutenberg-rest-comments-controller-notes.php';
 require_once __DIR__ . '/notes-preview/rest-api.php';
+require_once __DIR__ . '/notes-preview/preview-access.php';
+require_once __DIR__ . '/notes-preview/render.php';

--- a/lib/experimental/notes-preview.php
+++ b/lib/experimental/notes-preview.php
@@ -16,3 +16,5 @@
  */
 
 require_once __DIR__ . '/notes-preview/capabilities.php';
+require_once __DIR__ . '/notes-preview/class-gutenberg-rest-comments-controller-notes.php';
+require_once __DIR__ . '/notes-preview/rest-api.php';

--- a/lib/experimental/notes-preview/capabilities.php
+++ b/lib/experimental/notes-preview/capabilities.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Meta capabilities for reading and creating notes on a given post.
+ *
+ * Notes (comments of type `note`) are editorial discussion attached to blocks.
+ * Core gates every note operation on `edit_post` for the post the note belongs
+ * to, which means anyone who may read or write a note must also be able to edit
+ * the post. Sites that want a reviewer role - legal, compliance, an external
+ * stakeholder - therefore have to hand out full editing rights.
+ *
+ * These two meta capabilities separate note access from post editing:
+ *
+ * - `read_post_notes`   - may read the note threads on a post.
+ * - `create_post_notes` - may reply to a note thread on a post.
+ *
+ * Both are checked against a post ID, following the `edit_post_meta` /
+ * `add_post_meta` shape core uses for post sub-resources:
+ *
+ *     current_user_can( 'read_post_notes', $post->ID );
+ *
+ * By default both map straight to `edit_post`, so installing this experiment
+ * changes nothing: exactly the people who can read and write notes today still
+ * can, and nobody else gains anything.
+ *
+ * To grant them independently, filter `map_meta_cap` at a priority later than
+ * 10 and return the primitive capabilities the role should be measured
+ * against. For example, to let every subscriber read (but not write) notes on
+ * posts in a particular category:
+ *
+ *     add_filter(
+ *         'map_meta_cap',
+ *         function ( $caps, $cap, $user_id, $args ) {
+ *             if ( 'read_post_notes' !== $cap || empty( $args[0] ) ) {
+ *                 return $caps;
+ *             }
+ *             if ( ! has_category( 'in-review', $args[0] ) ) {
+ *                 return $caps;
+ *             }
+ *             return array( 'read' );
+ *         },
+ *         20,
+ *         4
+ *     );
+ *
+ * Granting `read_post_notes` implies nothing about `create_post_notes`; a
+ * read-only reviewer tier is just the first filter without the second.
+ *
+ * Resolving and reopening threads is deliberately not covered here. That writes
+ * the `_wp_note_status` comment meta, whose `auth_callback` in core requires
+ * `edit_comment`, and it stays that way.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Maps the note meta capabilities onto primitive capabilities.
+ *
+ * @param string[] $caps    Primitive capabilities required of the user.
+ * @param string   $cap     Capability being checked.
+ * @param int      $user_id The user ID.
+ * @param array    $args    Adds context to the capability check, typically
+ *                          starting with an object ID.
+ * @return string[] Primitive capabilities required of the user.
+ */
+function gutenberg_map_note_meta_caps( $caps, $cap, $user_id, $args ) {
+	if ( 'read_post_notes' !== $cap && 'create_post_notes' !== $cap ) {
+		return $caps;
+	}
+
+	if ( ! isset( $args[0] ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s: Capability name. */
+				esc_html__( 'When checking for the %s capability, you must always check it against a specific post.', 'gutenberg' ),
+				'<code>' . esc_html( $cap ) . '</code>'
+			),
+			'22.4.0'
+		);
+
+		return array( 'do_not_allow' );
+	}
+
+	$post = get_post( $args[0] );
+
+	if ( ! $post ) {
+		return array( 'do_not_allow' );
+	}
+
+	/*
+	 * Default to today's behaviour: note access rides on post editing. A site
+	 * grants a reviewer role by filtering at a later priority, see the file
+	 * docblock.
+	 */
+	return map_meta_cap( 'edit_post', $user_id, $post->ID );
+}
+
+add_filter( 'map_meta_cap', 'gutenberg_map_note_meta_caps', 10, 4 );

--- a/lib/experimental/notes-preview/class-gutenberg-rest-comments-controller-notes.php
+++ b/lib/experimental/notes-preview/class-gutenberg-rest-comments-controller-notes.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Notes-aware REST comments controller.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Extends the core comments controller so that the `read_post_notes` and
+ * `create_post_notes` meta capabilities can stand in for `edit_post` when a
+ * request is about notes.
+ *
+ * Core gates every note operation on `edit_post` for the parent post. This
+ * subclass leaves those checks in place and adds a second, narrower path
+ * alongside them: a request that core rejects is re-examined, and allowed only
+ * when it is a well-formed note request from someone holding the matching note
+ * capability on every post involved.
+ *
+ * Three rules keep the extra path tight:
+ *
+ * - It never grants anything in `edit` context. Edit context exposes raw
+ *   content and moderation fields, and stays on `edit_post`.
+ * - It never applies to logged-out visitors. Notes are private editorial
+ *   discussion and every branch below requires a user.
+ * - It never covers editing, deleting, resolving or reopening. Those keep
+ *   core's `edit_comment` rules untouched.
+ *
+ * @see WP_REST_Comments_Controller
+ */
+class Gutenberg_REST_Comments_Controller_Notes extends WP_REST_Comments_Controller {
+
+	/**
+	 * Whether a post can carry reviewer-visible notes at all.
+	 *
+	 * This is everything except the capability itself, so that the read and the
+	 * create paths share one definition of "eligible post".
+	 *
+	 * @param WP_Post|null $post Post object.
+	 * @return bool True when the post is eligible, false otherwise.
+	 */
+	protected function post_accepts_reviewer_notes( $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
+
+		// Notes are never exposed to anonymous visitors.
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		if ( ! $this->post_type_supports_notes( $post->post_type ) ) {
+			return false;
+		}
+
+		if ( 'trash' === $post->post_status ) {
+			return false;
+		}
+
+		// Do not hand out a way around the post password.
+		if ( post_password_required( $post ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether the current user may read the notes on a post as a reviewer.
+	 *
+	 * @param WP_Post|null $post Post object.
+	 * @return bool True when the current user may read notes, false otherwise.
+	 */
+	protected function reviewer_can_read_notes( $post ) {
+		return $this->post_accepts_reviewer_notes( $post )
+			&& current_user_can( 'read_post_notes', $post->ID );
+	}
+
+	/**
+	 * Whether the current user may add notes to a post as a reviewer.
+	 *
+	 * @param WP_Post|null $post Post object.
+	 * @return bool True when the current user may create notes, false otherwise.
+	 */
+	protected function reviewer_can_create_notes( $post ) {
+		return $this->post_accepts_reviewer_notes( $post )
+			&& current_user_can( 'create_post_notes', $post->ID );
+	}
+
+	/**
+	 * Whether a request is about notes rather than ordinary comments.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool True when the request targets notes, false otherwise.
+	 */
+	protected function request_targets_notes( $request ) {
+		if ( 'note' === $request['type'] ) {
+			return true;
+		}
+
+		if ( ! empty( $request['id'] ) ) {
+			$comment = get_comment( (int) $request['id'] );
+
+			return $comment && 'note' === $comment->comment_type;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether a post type opts in to notes.
+	 *
+	 * Mirrors WP_REST_Comments_Controller::check_post_type_supports_notes(),
+	 * which is private and so cannot be reached from a subclass.
+	 *
+	 * @param string $post_type Post type name.
+	 * @return bool True if the post type supports notes, false otherwise.
+	 */
+	protected function post_type_supports_notes( $post_type ) {
+		$supports = get_all_post_type_supports( $post_type );
+
+		if ( ! isset( $supports['editor'] ) || ! is_array( $supports['editor'] ) ) {
+			return false;
+		}
+
+		foreach ( $supports['editor'] as $item ) {
+			if ( ! empty( $item['notes'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if the post can be read.
+	 *
+	 * Adds the reviewer path: a note reader may reach the parent post of the
+	 * notes they are entitled to read, which is how a draft under review
+	 * becomes readable to someone without `edit_post`.
+	 *
+	 * @param WP_Post         $post    Post object.
+	 * @param WP_REST_Request $request Request data to check.
+	 * @return bool Whether post can be read.
+	 */
+	protected function check_read_post_permission( $post, $request ) {
+		if ( parent::check_read_post_permission( $post, $request ) ) {
+			return true;
+		}
+
+		if ( ! $this->request_targets_notes( $request ) ) {
+			return false;
+		}
+
+		return $this->reviewer_can_read_notes( $post );
+	}
+
+	/**
+	 * Checks if the comment can be read.
+	 *
+	 * This is the gate that matters most for listing: WP_REST_Comments_Controller::get_items()
+	 * runs every matched comment through it, so a note the reviewer is not
+	 * entitled to is dropped from the collection here.
+	 *
+	 * @param WP_Comment      $comment Comment object.
+	 * @param WP_REST_Request $request Request data to check.
+	 * @return bool Whether the comment can be read.
+	 */
+	protected function check_read_permission( $comment, $request ) {
+		if ( parent::check_read_permission( $comment, $request ) ) {
+			return true;
+		}
+
+		if ( 'note' !== $comment->comment_type || empty( $comment->comment_post_ID ) ) {
+			return false;
+		}
+
+		return $this->reviewer_can_read_notes( get_post( (int) $comment->comment_post_ID ) );
+	}
+
+	/**
+	 * Checks if a given request has access to read notes.
+	 *
+	 * Core requires the site-wide `edit_posts` capability before the `type` and
+	 * `status` query parameters may be used at all, which stops a reviewer from
+	 * asking for `type=note&status=all` however the per-post capabilities are
+	 * granted. Requests that core turns down are allowed through when they are
+	 * a plain per-post note read and the reviewer holds `read_post_notes` on
+	 * every post named.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$result = parent::get_items_permissions_check( $request );
+
+		if ( ! is_wp_error( $result ) || ! $this->is_reviewer_notes_read_request( $request ) ) {
+			return $result;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a collection request is a note read this controller may permit.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool True when the request may be permitted, false otherwise.
+	 */
+	protected function is_reviewer_notes_read_request( $request ) {
+		if ( 'note' !== $request['type'] || 'edit' === $request['context'] ) {
+			return false;
+		}
+
+		/*
+		 * Reviewers get `type` and `status`, nothing else from core's protected
+		 * parameter list. The author filters would let them probe who wrote
+		 * what across the site.
+		 */
+		foreach ( array( 'author', 'author_exclude', 'author_email' ) as $param ) {
+			if ( ! empty( $request[ $param ] ) ) {
+				return false;
+			}
+		}
+
+		// The per-post capability is the whole grant, so a post is required.
+		if ( empty( $request['post'] ) ) {
+			return false;
+		}
+
+		foreach ( (array) $request['post'] as $post_id ) {
+			if ( ! $this->reviewer_can_read_notes( get_post( (int) $post_id ) ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if a given request has access to create a note.
+	 *
+	 * Requests core turns down are retried once with `edit_post` granted for
+	 * the single post being replied to, so that every other rule core applies
+	 * to note creation - author and author_ip limits, post type support, trash
+	 * and password handling, content filtering - still runs verbatim rather
+	 * than being restated here and drifting out of step.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access to create items, error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		$result = parent::create_item_permissions_check( $request );
+
+		if ( ! is_wp_error( $result ) || ! $this->is_reviewer_reply_request( $request ) ) {
+			return $result;
+		}
+
+		$post_id        = (int) $request['post'];
+		$current_user   = get_current_user_id();
+		$grant_for_post = static function ( $caps, $cap, $user_id, $args ) use ( $post_id, $current_user ) {
+			if ( 'edit_post' === $cap
+				&& (int) $user_id === $current_user
+				&& isset( $args[0] )
+				&& (int) $args[0] === $post_id
+			) {
+				// 'exist' is granted to every real user by WP_User::has_cap().
+				return array( 'exist' );
+			}
+
+			return $caps;
+		};
+
+		add_filter( 'map_meta_cap', $grant_for_post, 20, 4 );
+
+		try {
+			return parent::create_item_permissions_check( $request );
+		} finally {
+			remove_filter( 'map_meta_cap', $grant_for_post, 20 );
+		}
+	}
+
+	/**
+	 * Whether a create request is a reviewer reply this controller may permit.
+	 *
+	 * Replies only. Starting a new thread writes `metadata.noteId` into the
+	 * block delimiter in `post_content`, which is exactly the write a reviewer
+	 * must not be able to make.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool True when the request may be permitted, false otherwise.
+	 */
+	protected function is_reviewer_reply_request( $request ) {
+		if ( 'note' !== $request['type'] ) {
+			return false;
+		}
+
+		$parent_id = (int) $request['parent'];
+
+		if ( $parent_id <= 0 ) {
+			return false;
+		}
+
+		// Notes are created unresolved; any other status is a moderation action.
+		if ( ! empty( $request['status'] ) && 'hold' !== $request['status'] ) {
+			return false;
+		}
+
+		// Resolving and reopening stay on edit_comment.
+		if ( ! empty( $request['meta']['_wp_note_status'] ) ) {
+			return false;
+		}
+
+		if ( empty( $request['post'] ) ) {
+			return false;
+		}
+
+		$post = get_post( (int) $request['post'] );
+
+		if ( ! $post || ! $this->reviewer_can_create_notes( $post ) ) {
+			return false;
+		}
+
+		// The parent must be a note already on this post.
+		$parent = get_comment( $parent_id );
+
+		return $parent
+			&& 'note' === $parent->comment_type
+			&& (int) $parent->comment_post_ID === $post->ID;
+	}
+}

--- a/lib/experimental/notes-preview/preview-access.php
+++ b/lib/experimental/notes-preview/preview-access.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Preview access for reviewers.
+ *
+ * Viewing a draft, pending or scheduled post on the front end normally
+ * requires `edit_post`: WP_Query::get_posts() empties the result set for
+ * anyone who fails that check, which is why a preview link only works for
+ * people who could edit the post anyway.
+ *
+ * A reviewer holding `read_post_notes` on the post is let through that gate.
+ * The capability is the whole grant - there is no token or nonce involved.
+ * The `preview_id` / `preview_nonce` parameters on a preview URL only select
+ * autosave content and are bound to the session that generated them, so a
+ * reviewer sees the last saved revision of the draft, which is the artifact
+ * they are being asked to review.
+ *
+ * Logged-out visitors are turned away by core before this file gets a say
+ * (WP_Query::get_posts() empties the results for them first) and nothing here
+ * reinstates them.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Post statuses a reviewer may preview.
+ *
+ * Deliberately excludes `private`, which follows core's `read_post` rules, and
+ * `trash`.
+ *
+ * @var string[]
+ */
+const GUTENBERG_NOTES_PREVIEW_STATUSES = array( 'draft', 'pending', 'future' );
+
+/**
+ * Whether the current user may review the given post without being able to edit it.
+ *
+ * @param WP_Post|null $post Post object.
+ * @return bool True when the current user may preview the post as a reviewer.
+ */
+function gutenberg_notes_preview_user_can_review( $post ) {
+	if ( ! $post instanceof WP_Post || ! is_user_logged_in() ) {
+		return false;
+	}
+
+	if ( ! in_array( $post->post_status, GUTENBERG_NOTES_PREVIEW_STATUSES, true ) ) {
+		return false;
+	}
+
+	if ( ! gutenberg_notes_preview_post_type_supports_notes( $post->post_type ) ) {
+		return false;
+	}
+
+	// Never a way around the post password.
+	if ( post_password_required( $post ) ) {
+		return false;
+	}
+
+	return current_user_can( 'read_post_notes', $post->ID );
+}
+
+/**
+ * Whether a post type opts in to notes.
+ *
+ * @param string $post_type Post type name.
+ * @return bool True if the post type supports notes, false otherwise.
+ */
+function gutenberg_notes_preview_post_type_supports_notes( $post_type ) {
+	$supports = get_all_post_type_supports( $post_type );
+
+	if ( ! isset( $supports['editor'] ) || ! is_array( $supports['editor'] ) ) {
+		return false;
+	}
+
+	foreach ( $supports['editor'] as $item ) {
+		if ( ! empty( $item['notes'] ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Remembers the real status of a post whose status is temporarily swapped.
+ *
+ * @param int         $post_id Post ID.
+ * @param string|null $status  Status to store, or null to read the stored one.
+ * @return string|null The stored status, or null when none is stored.
+ */
+function gutenberg_notes_preview_original_status( $post_id, $status = null ) {
+	static $statuses = array();
+
+	$post_id = (int) $post_id;
+
+	if ( null !== $status ) {
+		$statuses[ $post_id ] = $status;
+	}
+
+	return isset( $statuses[ $post_id ] ) ? $statuses[ $post_id ] : null;
+}
+
+/**
+ * Lets a reviewer's preview request past the protected-status gate.
+ *
+ * `posts_results` runs before the status check in WP_Query::get_posts(), so
+ * presenting the post as published for the length of that check is enough. The
+ * real status is put back on `the_posts`, before the results reach the post
+ * cache, so nothing downstream sees a draft claiming to be published.
+ *
+ * @param WP_Post[] $posts Array of post objects.
+ * @param WP_Query  $query The query instance.
+ * @return WP_Post[] Array of post objects.
+ */
+function gutenberg_notes_preview_posts_results( $posts, $query ) {
+	if ( ! $query instanceof WP_Query || ! $query->is_main_query() || ! $query->is_preview() ) {
+		return $posts;
+	}
+
+	if ( ! is_array( $posts ) || 1 !== count( $posts ) ) {
+		return $posts;
+	}
+
+	$post = reset( $posts );
+
+	if ( ! $post instanceof WP_Post ) {
+		return $posts;
+	}
+
+	// Core already admits anyone who can edit the post.
+	if ( current_user_can( 'edit_post', $post->ID ) ) {
+		return $posts;
+	}
+
+	if ( ! gutenberg_notes_preview_user_can_review( $post ) ) {
+		return $posts;
+	}
+
+	gutenberg_notes_preview_original_status( $post->ID, $post->post_status );
+	$post->post_status = 'publish';
+
+	// A review URL is not something to cache or index.
+	nocache_headers();
+	add_filter( 'wp_robots', 'wp_robots_no_robots' );
+
+	return $posts;
+}
+
+add_filter( 'posts_results', 'gutenberg_notes_preview_posts_results', 10, 2 );
+
+/**
+ * Restores the real status of any post swapped by the filter above.
+ *
+ * @param WP_Post[] $posts Array of post objects.
+ * @return WP_Post[] Array of post objects.
+ */
+function gutenberg_notes_preview_restore_status( $posts ) {
+	if ( ! is_array( $posts ) ) {
+		return $posts;
+	}
+
+	foreach ( $posts as $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			continue;
+		}
+
+		$status = gutenberg_notes_preview_original_status( $post->ID );
+
+		if ( null !== $status ) {
+			$post->post_status = $status;
+		}
+	}
+
+	return $posts;
+}
+
+add_filter( 'the_posts', 'gutenberg_notes_preview_restore_status', 10 );

--- a/lib/experimental/notes-preview/render.php
+++ b/lib/experimental/notes-preview/render.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Note anchors in rendered preview markup.
+ *
+ * On a preview request from someone entitled to read the post's notes, each
+ * block carrying `metadata.noteId` gets a `data-wp-note-id` attribute, and the
+ * inline `<mark class="wp-note">` markers that core unwraps on the front end
+ * are left in place. Together these give a front-end script the same anchors
+ * the editor has, without the editor bundle.
+ *
+ * Nothing here runs on a published view, for a logged-out visitor, or for
+ * anyone without `read_post_notes` on the post being previewed.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Whether the current request is a preview a note reader is entitled to see.
+ *
+ * @return bool True when note anchors should be rendered.
+ */
+function gutenberg_notes_preview_is_active() {
+	if ( ! is_singular() || ! is_preview() || ! is_user_logged_in() ) {
+		return false;
+	}
+
+	$post = get_post( get_queried_object_id() );
+
+	if ( ! $post instanceof WP_Post ) {
+		return false;
+	}
+
+	if ( ! gutenberg_notes_preview_post_type_supports_notes( $post->post_type ) ) {
+		return false;
+	}
+
+	if ( post_password_required( $post ) ) {
+		return false;
+	}
+
+	return current_user_can( 'read_post_notes', $post->ID );
+}
+
+/**
+ * Arms the note anchor filters for this request.
+ *
+ * Hooking the decision once on `template_redirect` keeps the capability check
+ * off the per-block path: when the viewer is not entitled to notes the render
+ * filters are simply never added. `template_redirect` also does not fire for
+ * admin, REST, cron or CLI requests, so block rendering in those contexts is
+ * untouched.
+ */
+function gutenberg_notes_preview_maybe_enable_anchors() {
+	if ( ! gutenberg_notes_preview_is_active() ) {
+		return;
+	}
+
+	/*
+	 * Inline note markers carry the same information the reviewer is entitled
+	 * to read in the panel, so keep them rather than unwrapping them. Both the
+	 * core filter and the plugin's copy are removed.
+	 */
+	remove_filter( 'render_block', 'wp_strip_inline_note_markers' );
+	remove_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
+
+	// Priority 20, after any stripping that other code may still do.
+	add_filter( 'render_block', 'gutenberg_notes_preview_add_block_anchor', 20, 2 );
+}
+
+add_action( 'template_redirect', 'gutenberg_notes_preview_maybe_enable_anchors' );
+
+/**
+ * Normalises a block's `metadata.noteId` into a list of note IDs.
+ *
+ * Mirrors getNoteIdsFromMetadata() in
+ * packages/editor/src/components/collab-sidebar/utils.js: the attribute holds
+ * either a single ID or an array of them, and only positive integers count.
+ *
+ * @param mixed $note_id Raw `metadata.noteId` attribute value.
+ * @return int[] Unique note IDs, in the order they appear.
+ */
+function gutenberg_notes_preview_note_ids( $note_id ) {
+	$raw = is_array( $note_id ) ? $note_id : array( $note_id );
+	$ids = array();
+
+	foreach ( $raw as $value ) {
+		if ( ! is_scalar( $value ) || ! is_numeric( $value ) ) {
+			continue;
+		}
+
+		$id = (int) $value;
+
+		if ( $id > 0 && ! in_array( $id, $ids, true ) ) {
+			$ids[] = $id;
+		}
+	}
+
+	return $ids;
+}
+
+/**
+ * Adds the note anchor attribute to a rendered block.
+ *
+ * @param string $block_content Rendered block HTML.
+ * @param array  $block         Parsed block, including its attributes.
+ * @return string Block HTML, with `data-wp-note-id` on the outermost tag.
+ */
+function gutenberg_notes_preview_add_block_anchor( $block_content, $block ) {
+	if ( ! isset( $block['attrs']['metadata']['noteId'] ) || '' === $block_content ) {
+		return $block_content;
+	}
+
+	$note_ids = gutenberg_notes_preview_note_ids( $block['attrs']['metadata']['noteId'] );
+
+	if ( empty( $note_ids ) ) {
+		return $block_content;
+	}
+
+	$processor = new WP_HTML_Tag_Processor( $block_content );
+
+	// Blocks whose output has no tag at all cannot carry an anchor; the thread
+	// still reaches the reviewer through the panel.
+	if ( ! $processor->next_tag() ) {
+		return $block_content;
+	}
+
+	$processor->set_attribute( 'data-wp-note-id', implode( ',', $note_ids ) );
+
+	return $processor->get_updated_html();
+}

--- a/lib/experimental/notes-preview/rest-api.php
+++ b/lib/experimental/notes-preview/rest-api.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Registers the notes-aware REST comments controller.
+ *
+ * Core builds the comments routes from a hardcoded
+ * `new WP_REST_Comments_Controller()` in create_initial_rest_routes(), with no
+ * filter for the controller class the way post types have
+ * `rest_controller_class`. Re-registering the routes would append a second set
+ * of handlers rather than replace the first, so instead the already-registered
+ * handlers are rebound to an instance of the subclass. Route definitions,
+ * schema and arguments all stay exactly as core registered them.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Points the comments routes at the notes-aware controller.
+ *
+ * @param array $endpoints The registered REST API endpoints, keyed by route.
+ * @return array The registered REST API endpoints, keyed by route.
+ */
+function gutenberg_notes_preview_swap_comments_controller( $endpoints ) {
+	$routes     = array( '/wp/v2/comments', '/wp/v2/comments/(?P<id>[\d]+)' );
+	$controller = null;
+
+	foreach ( $routes as $route ) {
+		if ( empty( $endpoints[ $route ] ) || ! is_array( $endpoints[ $route ] ) ) {
+			continue;
+		}
+
+		foreach ( $endpoints[ $route ] as $index => $handler ) {
+			// Non-numeric keys are route options such as `namespace` or `schema`.
+			if ( ! is_numeric( $index ) || ! is_array( $handler ) ) {
+				continue;
+			}
+
+			foreach ( array( 'callback', 'permission_callback' ) as $key ) {
+				if ( ! isset( $handler[ $key ] ) || ! is_array( $handler[ $key ] ) || ! isset( $handler[ $key ][0] ) ) {
+					continue;
+				}
+
+				$object = $handler[ $key ][0];
+
+				if ( ! $object instanceof WP_REST_Comments_Controller
+					|| $object instanceof Gutenberg_REST_Comments_Controller_Notes
+				) {
+					continue;
+				}
+
+				if ( null === $controller ) {
+					$controller = new Gutenberg_REST_Comments_Controller_Notes();
+				}
+
+				$endpoints[ $route ][ $index ][ $key ][0] = $controller;
+			}
+		}
+	}
+
+	return $endpoints;
+}
+
+add_filter( 'rest_endpoints', 'gutenberg_notes_preview_swap_comments_controller' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -151,6 +151,10 @@ if ( gutenberg_is_experiment_enabled( 'gutenberg-workflow-palette' ) ) {
 	require __DIR__ . '/experimental/workflow-palette.php';
 }
 
+if ( gutenberg_is_experiment_enabled( 'gutenberg-notes-on-previews' ) ) {
+	require __DIR__ . '/experimental/notes-preview.php';
+}
+
 // Load the BC Layer to avoid fatal errors of extenders using the Fonts API.
 // @core-merge: do not merge the BC layer files into WordPress Core.
 require __DIR__ . '/experimental/font-face/bc-layer/class-wp-fonts-provider.php';

--- a/phpunit/experimental/notes-preview-test.php
+++ b/phpunit/experimental/notes-preview-test.php
@@ -1,0 +1,594 @@
+<?php
+/**
+ * Tests for the notes-on-previews experiment.
+ *
+ * @package gutenberg
+ */
+
+require_once __DIR__ . '/../../lib/experimental/notes-preview.php';
+
+/**
+ * @group notes
+ * @group notes-preview
+ */
+class Gutenberg_Notes_Preview_Test extends WP_Test_REST_TestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Subscriber user ID, used as the reviewer throughout.
+	 *
+	 * @var int
+	 */
+	protected static $reviewer_id;
+
+	/**
+	 * A second subscriber, never granted anything.
+	 *
+	 * @var int
+	 */
+	protected static $outsider_id;
+
+	/**
+	 * Draft post under review.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * A second draft the reviewer is never granted access to.
+	 *
+	 * @var int
+	 */
+	protected static $other_post_id;
+
+	/**
+	 * Top-level note on the post under review.
+	 *
+	 * @var int
+	 */
+	protected static $note_id;
+
+	/**
+	 * Top-level note on the other post.
+	 *
+	 * @var int
+	 */
+	protected static $other_note_id;
+
+	/**
+	 * Capability filters added by a test, removed on tear down.
+	 *
+	 * @var callable[]
+	 */
+	protected $granted = array();
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id    = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$reviewer_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$outsider_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$post_id = $factory->post->create(
+			array(
+				'post_title'   => 'Draft under review',
+				'post_content' => '<!-- wp:paragraph {"metadata":{"noteId":[1]}} --><p>Reviewed paragraph.</p><!-- /wp:paragraph -->',
+				'post_status'  => 'draft',
+				'post_author'  => self::$admin_id,
+			)
+		);
+
+		self::$other_post_id = $factory->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		self::$note_id = $factory->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_type'     => 'note',
+				'comment_approved' => 0,
+			)
+		);
+
+		self::$other_note_id = $factory->comment->create(
+			array(
+				'comment_post_ID'  => self::$other_post_id,
+				'comment_type'     => 'note',
+				'comment_approved' => 0,
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$reviewer_id );
+		self::delete_user( self::$outsider_id );
+
+		wp_delete_post( self::$post_id, true );
+		wp_delete_post( self::$other_post_id, true );
+	}
+
+	public function tear_down() {
+		foreach ( $this->granted as $filter ) {
+			remove_filter( 'map_meta_cap', $filter, 20 );
+		}
+		$this->granted = array();
+
+		// Put the render filters back the way the rest of the suite expects.
+		remove_filter( 'render_block', 'gutenberg_notes_preview_add_block_anchor', 20 );
+
+		if ( ! has_filter( 'render_block', 'wp_strip_inline_note_markers' ) ) {
+			add_filter( 'render_block', 'wp_strip_inline_note_markers' );
+		}
+
+		if ( ! has_filter( 'render_block', 'gutenberg_strip_inline_note_markers' ) ) {
+			add_filter( 'render_block', 'gutenberg_strip_inline_note_markers' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Grants note capabilities on a post, the way a site plugin would.
+	 *
+	 * @param int      $post_id Post to grant on.
+	 * @param string[] $caps    Capabilities to grant.
+	 */
+	protected function grant( $post_id, $caps ) {
+		$post_id = (int) $post_id;
+		$filter  = static function ( $required, $cap, $user_id, $args ) use ( $post_id, $caps ) {
+			if ( in_array( $cap, $caps, true ) && isset( $args[0] ) && (int) $args[0] === $post_id ) {
+				return array( 'read' );
+			}
+
+			return $required;
+		};
+
+		add_filter( 'map_meta_cap', $filter, 20, 4 );
+		$this->granted[] = $filter;
+	}
+
+	/**
+	 * Builds the preview URL for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Preview URL.
+	 */
+	protected function preview_url( $post_id ) {
+		return add_query_arg(
+			array(
+				'p'       => $post_id,
+				'preview' => 'true',
+			),
+			home_url( '/' )
+		);
+	}
+
+	/*
+	 * Capability mapping.
+	 */
+
+	public function test_note_caps_map_to_edit_post_by_default() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( current_user_can( 'read_post_notes', self::$post_id ) );
+		$this->assertTrue( current_user_can( 'create_post_notes', self::$post_id ) );
+
+		wp_set_current_user( self::$reviewer_id );
+		$this->assertFalse( current_user_can( 'read_post_notes', self::$post_id ) );
+		$this->assertFalse( current_user_can( 'create_post_notes', self::$post_id ) );
+	}
+
+	public function test_note_caps_are_granted_independently() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->assertTrue( current_user_can( 'read_post_notes', self::$post_id ) );
+		$this->assertFalse( current_user_can( 'create_post_notes', self::$post_id ) );
+
+		// The grant is per post, and never leaks into post editing.
+		$this->assertFalse( current_user_can( 'read_post_notes', self::$other_post_id ) );
+		$this->assertFalse( current_user_can( 'edit_post', self::$post_id ) );
+	}
+
+	public function test_note_caps_denied_for_missing_post() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertFalse( current_user_can( 'read_post_notes', 999999 ) );
+		$this->assertFalse( current_user_can( 'create_post_notes', 999999 ) );
+	}
+
+	/*
+	 * Reading notes over REST.
+	 */
+
+	public function test_reviewer_can_list_notes() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertContains( self::$note_id, $ids );
+	}
+
+	public function test_reviewer_without_grant_cannot_list_notes() {
+		wp_set_current_user( self::$outsider_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_cannot_list_notes_for_ungranted_post() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$other_post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_cannot_list_notes_in_edit_context() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+		$request->set_param( 'context', 'edit' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
+	}
+
+	public function test_reviewer_cannot_list_notes_without_a_post() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden_param', $response, 403 );
+	}
+
+	public function test_reviewer_cannot_filter_notes_by_author() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+		$request->set_param( 'author', array( self::$admin_id ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden_param', $response, 403 );
+	}
+
+	public function test_logged_out_cannot_list_notes() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'all' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_can_read_single_note() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/comments/' . self::$note_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( self::$note_id, $response->get_data()['id'] );
+	}
+
+	/*
+	 * Writing notes over REST.
+	 */
+
+	public function test_reviewer_can_reply_to_a_note() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'parent', self::$note_id );
+		$request->set_param( 'status', 'hold' );
+		$request->set_param( 'content', 'Looks good to legal.' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( self::$note_id, $response->get_data()['parent'] );
+	}
+
+	public function test_reviewer_cannot_start_a_new_thread() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'status', 'hold' );
+		$request->set_param( 'content', 'A brand new thread.' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_create_note', $response, 403 );
+	}
+
+	public function test_read_only_reviewer_cannot_reply() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'parent', self::$note_id );
+		$request->set_param( 'status', 'hold' );
+		$request->set_param( 'content', 'Should not be allowed.' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_create_note', $response, 403 );
+	}
+
+	public function test_reviewer_cannot_reply_with_a_moderation_status() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'parent', self::$note_id );
+		$request->set_param( 'status', 'approved' );
+		$request->set_param( 'content', 'Resolving on the sly.' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_cannot_resolve_a_thread() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'parent', self::$note_id );
+		$request->set_param( 'status', 'hold' );
+		$request->set_param( 'content', '' );
+		$request->set_param( 'meta', array( '_wp_note_status' => 'resolved' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_cannot_reply_to_a_note_on_another_post() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'parent', self::$other_note_id );
+		$request->set_param( 'status', 'hold' );
+		$request->set_param( 'content', 'Wrong post.' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_cannot_delete_a_note() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/comments/' . self::$note_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	public function test_reviewer_cannot_edit_a_note() {
+		$this->grant( self::$post_id, array( 'read_post_notes', 'create_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/comments/' . self::$note_id );
+		$request->set_param( 'content', 'Rewritten by a reviewer.' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+	}
+
+	/*
+	 * Preview access.
+	 */
+
+	public function test_reviewer_can_load_the_preview() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->go_to( $this->preview_url( self::$post_id ) );
+
+		$this->assertTrue( is_preview() );
+		$this->assertCount( 1, $GLOBALS['wp_query']->posts );
+		$this->assertSame( self::$post_id, $GLOBALS['wp_query']->posts[0]->ID );
+	}
+
+	public function test_preview_restores_the_real_post_status() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->go_to( $this->preview_url( self::$post_id ) );
+
+		$this->assertSame( 'draft', $GLOBALS['wp_query']->posts[0]->post_status );
+		$this->assertSame( 'draft', get_post_status( self::$post_id ) );
+	}
+
+	public function test_user_without_grant_cannot_load_the_preview() {
+		wp_set_current_user( self::$outsider_id );
+
+		$this->go_to( $this->preview_url( self::$post_id ) );
+
+		$this->assertEmpty( $GLOBALS['wp_query']->posts );
+	}
+
+	public function test_logged_out_visitor_cannot_load_the_preview() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( 0 );
+
+		$this->go_to( $this->preview_url( self::$post_id ) );
+
+		$this->assertEmpty( $GLOBALS['wp_query']->posts );
+	}
+
+	public function test_password_protected_post_is_not_previewable() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'draft',
+				'post_author'   => self::$admin_id,
+				'post_password' => 'hunter2',
+			)
+		);
+
+		$this->grant( $post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->go_to( $this->preview_url( $post_id ) );
+
+		$this->assertEmpty( $GLOBALS['wp_query']->posts );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	public function test_non_preview_request_is_untouched() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->go_to( add_query_arg( 'p', self::$post_id, home_url( '/' ) ) );
+
+		$this->assertEmpty( $GLOBALS['wp_query']->posts );
+	}
+
+	/*
+	 * Rendering note anchors.
+	 */
+
+	public function test_note_ids_are_normalised() {
+		$this->assertSame( array( 3 ), gutenberg_notes_preview_note_ids( 3 ) );
+		$this->assertSame( array( 3 ), gutenberg_notes_preview_note_ids( '3' ) );
+		$this->assertSame( array( 3, 5 ), gutenberg_notes_preview_note_ids( array( 3, 5, 3 ) ) );
+		$this->assertSame( array(), gutenberg_notes_preview_note_ids( array( 0, -1, 'abc', null ) ) );
+	}
+
+	public function test_anchor_is_added_to_the_outermost_tag() {
+		$rendered = gutenberg_notes_preview_add_block_anchor(
+			'<p>Reviewed <em>paragraph</em>.</p>',
+			array( 'attrs' => array( 'metadata' => array( 'noteId' => array( 7, 9 ) ) ) )
+		);
+
+		$this->assertStringContainsString( 'data-wp-note-id="7,9"', $rendered );
+		$this->assertStringContainsString( '<p data-wp-note-id="7,9">', $rendered );
+	}
+
+	public function test_anchor_is_skipped_for_blocks_without_notes_or_tags() {
+		$this->assertSame(
+			'<p>No note here.</p>',
+			gutenberg_notes_preview_add_block_anchor( '<p>No note here.</p>', array( 'attrs' => array() ) )
+		);
+
+		$this->assertSame(
+			'Just text.',
+			gutenberg_notes_preview_add_block_anchor(
+				'Just text.',
+				array( 'attrs' => array( 'metadata' => array( 'noteId' => 7 ) ) )
+			)
+		);
+	}
+
+	public function test_anchor_filters_are_armed_on_an_active_preview() {
+		$this->grant( self::$post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->go_to( $this->preview_url( self::$post_id ) );
+		gutenberg_notes_preview_maybe_enable_anchors();
+
+		$this->assertNotFalse( has_filter( 'render_block', 'gutenberg_notes_preview_add_block_anchor' ) );
+
+		// Inline markers carry information the reviewer is entitled to read.
+		$this->assertFalse( has_filter( 'render_block', 'wp_strip_inline_note_markers' ) );
+		$this->assertFalse( has_filter( 'render_block', 'gutenberg_strip_inline_note_markers' ) );
+	}
+
+	public function test_anchor_filters_are_not_armed_without_the_capability() {
+		wp_set_current_user( self::$outsider_id );
+
+		$this->go_to( $this->preview_url( self::$post_id ) );
+		gutenberg_notes_preview_maybe_enable_anchors();
+
+		$this->assertFalse( has_filter( 'render_block', 'gutenberg_notes_preview_add_block_anchor' ) );
+		$this->assertNotFalse( has_filter( 'render_block', 'wp_strip_inline_note_markers' ) );
+	}
+
+	public function test_anchor_filters_are_not_armed_on_a_published_view() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		$this->grant( $post_id, array( 'read_post_notes' ) );
+		wp_set_current_user( self::$reviewer_id );
+
+		$this->go_to( get_permalink( $post_id ) );
+		gutenberg_notes_preview_maybe_enable_anchors();
+
+		$this->assertFalse( has_filter( 'render_block', 'gutenberg_notes_preview_add_block_anchor' ) );
+		$this->assertNotFalse( has_filter( 'render_block', 'wp_strip_inline_note_markers' ) );
+
+		wp_delete_post( $post_id, true );
+	}
+}


### PR DESCRIPTION
_I pointed Claude at the implementation plan for this one and it came back with:_

Part of #73418. The UI half is #81551, stacked on this branch; that PR carries the `Fixes` keyword, so the issue stays open until both have landed.

Notes are only visible inside the block editor today, so reading or answering one requires `edit_post`. That forces sites to hand full editing rights to people whose only job is to review: legal, compliance, outside stakeholders. This is the server-side half of the reviewer workflow described in that issue.

Two new meta capabilities, `read_post_notes` and `create_post_notes`, both checked against a post ID. Both map to `edit_post` by default, so installing this changes nothing until a site decides otherwise. Naming follows core's `edit_post_meta` / `add_post_meta` shape, since core's own notes code already treats a note as a post sub-resource and remaps every comment capability to a post one.

**Everything here is behind the `gutenberg-notes-on-previews` experiment, off by default.**

Sites grant the capabilities with a later-priority `map_meta_cap` filter, per the direction on the issue that this should come through extensibility rather than a role in core:

```php
add_filter(
	'map_meta_cap',
	function ( $caps, $cap, $user_id, $args ) {
		if ( 'read_post_notes' !== $cap || empty( $args[0] ) ) {
			return $caps;
		}
		return has_category( 'in-review', $args[0] ) ? array( 'read' ) : $caps;
	},
	20,
	4
);
```

Granting read implies nothing about create, which is what makes a view-only reviewer tier possible.

## What is in here

Three layers, each in `lib/experimental/notes-preview/`:

- **Capabilities.** The two meta caps and their default mapping.
- **REST.** A `WP_REST_Comments_Controller` subclass. A request core turns down gets re-examined and allowed when it is a well-formed note request from someone holding the matching capability on every post involved.
- **Preview surface.** `posts_results` lets a note reader past the protected-status gate, and blocks carrying `metadata.noteId` get a `data-wp-note-id` anchor on an active preview.

A few things worth calling out for review:

Reading needed two overrides rather than one. `check_read_post_permission` otherwise blocks the draft itself before any note logic runs, and `get_items()` re-filters every matched comment through `check_read_permission`, so without both the list comes back empty even with the capability granted.

Creation is limited to replies. Starting a new thread writes `metadata.noteId` into `post_content`, which is exactly the write a reviewer must not make. A confirmed reply is retried with `edit_post` granted for that one post, for that one user, inside a `finally`, so core's remaining rules still run verbatim instead of being restated here and drifting. New threads from the preview need a comment-meta anchor and editor-side reconciliation, and are left for a follow up.

Core builds the comments routes from a hardcoded `new WP_REST_Comments_Controller()` with no `rest_controller_class` filter, and re-registering the route appends handlers rather than replacing them, so core's would still win. The existing handlers get rebound through `rest_endpoints` instead, which leaves core's route definitions, args and schema alone.

The preview status swap is reverted before the post cache sees it. `posts_results` runs at class-wp-query.php:3484, the status gate at :3535, `the_posts` at :3641 and `update_post_caches` at :3656, so restoring on `the_posts` keeps a draft from entering the cache claiming to be published.

## What is not in here

The front-end overlay: the panel, the indicators, the reply form, the styles, and the Playwright coverage that goes with them. That is the half the `Needs Design` label is really about, and it is up in #81551, stacked on this branch.

One consequence of that split: with the experiment on, an editor previewing their own draft will see inline note markers rendered as browser-default yellow highlights, because the CSS lands in the follow up. Capability behavior is unchanged for everyone.

## How has this been tested

[![Test in WordPress Playground](https://img.shields.io/badge/Test_in-WP_Playground-blue?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=81545)

31 unit tests in `phpunit/experimental/notes-preview-test.php`, covering the refusals as closely as the grants:

```
npm run wp-env-test start
npx wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/gutenberg' \
  wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter Gutenberg_Notes_Preview_Test
```

To check the tests are not passing vacuously, comment out the `add_filter` calls at the end of `rest-api.php` and `preview-access.php`. That produces 7 failures and 1 error across REST reads, single-note reads, replies, preview access and anchor arming.

By hand:

1. Enable Notes on post previews under Gutenberg > Experiments.
2. Drop the snippet above into a plugin, swapping the category check for whatever suits your test site.
3. As an editor, add a note to a block on a draft and copy the preview URL.
4. Open that URL as a subscriber who matches the filter. The draft renders, and the noted block carries `data-wp-note-id` in the markup.
5. `GET /wp/v2/comments?post=N&type=note&status=all` returns the threads for that user; the same request with `context=edit`, or for a post the filter does not match, is refused.
6. Log out and reload the preview URL. Nothing.

## Types of changes

- Add `read_post_notes` and `create_post_notes` meta capabilities, mapped to `edit_post` by default.
- Add a notes-aware `WP_REST_Comments_Controller` subclass and bind the comments routes to it.
- Let a note reader past the protected-status gate on a preview request.
- Add `data-wp-note-id` anchors and keep inline note markers on an active preview.
- Register the `gutenberg-notes-on-previews` experiment.

## Open questions

- `read_post_notes` / `create_post_notes` follow core's meta-cap shape, but the issue floated `review_notes` and `view_notes`. Worth settling before these names end up in other people's filters. Core's closest precedent is `add_post_meta`, so `add_post_notes` is also defensible over `create_post_notes`.
- Should a reviewer be able to edit or delete their own notes? Core's own-comment path still wants `edit_comment`, so today they cannot.
- Should inline `mark.wp-note` markers stay in the preview output, or should stripping continue and notes anchor at block level only? Keeping them is the current behavior, on the grounds that they carry information the reviewer is already entitled to read, but it is more exposed to adversarial theme CSS.
- This starts in `lib/experimental/`. If design signoff is expected soon, the REST subclass could go straight into a new `lib/compat/wordpress-7.2/` so it is on the core backport track from the start.

Part of https://github.com/WordPress/gutenberg/issues/80015

cc: @jeffpaul @fabiankaegy

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.

