### PR TITLE
Notes: restore the sidebar the add-note flow displaced

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Notes: Restore the sidebar that was open before a note was added when the note form is cancelled, instead of leaving no sidebar open.
+
 ## 14.53.0 (2026-08-12)
 
 ### Internal

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Notes: Restore the sidebar that was open before a note was added when the note form is cancelled, instead of leaving no sidebar open.
+-   Notes: Restore the sidebar that was open before a note was added when the note form is cancelled, instead of leaving no sidebar open ([#81547](https://github.com/WordPress/gutenberg/pull/81547)).
 
 ## 14.53.0 (2026-08-12)
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { comment as commentIcon } from '@wordpress/icons';
@@ -17,18 +17,28 @@ import { NoteAvatarIndicator } from './note-indicator-toolbar';
 import { NoteHighlightStyles } from './note-highlight-styles';
 import { useNoteThreads } from './hooks';
 import { getNoteIdsFromMetadata, pickPrimaryNote } from './utils';
+import { resolveRestoreTarget } from './restore-sidebar';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
 
 function NotesSidebar( { postId } ) {
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
 	const { toggleBlockSpotlight, selectBlock } = unlock(
 		useDispatch( blockEditorStore )
 	);
 	const { selectNote } = unlock( useDispatch( editorStore ) );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const sidebarRef = useRef( null );
+	/*
+	 * The sidebar the add-note flow displaced, so the composer can put it back
+	 * when it is cancelled. Transient memory for a single in-flight composer:
+	 * a ref keeps it out of the render path and out of the preferences that
+	 * persist the active area, where a stale target could misfire in a later
+	 * session. Holds a `SidebarCapture` from `./restore-sidebar`, or nothing.
+	 */
+	const restoreAreaRef = useRef();
 
 	const { clientId, noteId, isClassicBlock } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId, getBlockName } =
@@ -78,6 +88,51 @@ function NotesSidebar( { postId } ) {
 		( unresolvedNotes.length > 0 || selectedNoteId !== undefined ) &&
 		! isAllNotesSidebarOpen;
 
+	/*
+	 * Put the displaced sidebar back once the composer closes without saving.
+	 * Keyed to the note selection rather than to the sidebar's own visibility,
+	 * so it covers every dismissal - Cancel, Escape, clicking away, switching
+	 * blocks - and fires whether or not the post has other notes. Submitting
+	 * leaves the notes sidebar open: it is where the new note now lives, and
+	 * it has a close button.
+	 */
+	const prevSelectedNoteIdRef = useRef( selectedNoteId );
+	useEffect( () => {
+		const prevSelectedNoteId = prevSelectedNoteIdRef.current;
+		if ( prevSelectedNoteId === selectedNoteId ) {
+			return;
+		}
+		prevSelectedNoteIdRef.current = selectedNoteId;
+
+		if ( prevSelectedNoteId !== 'new' ) {
+			return;
+		}
+
+		// The composer is gone either way, so the capture is spent.
+		const capture = restoreAreaRef.current;
+		restoreAreaRef.current = undefined;
+		if ( ! capture || selectedNoteId !== undefined ) {
+			return;
+		}
+
+		const target = resolveRestoreTarget( {
+			capturedArea: capture.capturedArea,
+			activeArea: getActiveComplementaryArea( 'core' ),
+			openedArea: capture.openedArea,
+		} );
+
+		if ( target.type === 'enable' ) {
+			enableComplementaryArea( 'core', target.area );
+		} else if ( target.type === 'disable' ) {
+			disableComplementaryArea( 'core' );
+		}
+	}, [
+		selectedNoteId,
+		getActiveComplementaryArea,
+		enableComplementaryArea,
+		disableComplementaryArea,
+	] );
+
 	async function focusNote( {
 		targetClientId,
 		noteId: targetNoteId,
@@ -92,6 +147,23 @@ function NotesSidebar( { postId } ) {
 		// viewports the floating notes show automatically once a note is
 		// selected, so no sidebar needs to be opened.
 		if ( isApproved || ! showFloatingNotes ) {
+			/*
+			 * Remember what this open is about to displace so cancelling the
+			 * composer can put it back. Only the new-note flow is cancellable,
+			 * and an already open "All notes" sidebar displaced nothing, which
+			 * also stops a second "Add note" during composition from
+			 * overwriting the original capture.
+			 */
+			const capturedArea = getActiveComplementaryArea( 'core' );
+			if (
+				targetNoteId === 'new' &&
+				capturedArea !== ALL_NOTES_SIDEBAR
+			) {
+				restoreAreaRef.current = {
+					capturedArea,
+					openedArea: ALL_NOTES_SIDEBAR,
+				};
+			}
 			enableComplementaryArea( 'core', ALL_NOTES_SIDEBAR );
 		}
 

--- a/packages/editor/src/components/collab-sidebar/restore-sidebar.ts
+++ b/packages/editor/src/components/collab-sidebar/restore-sidebar.ts
@@ -1,0 +1,71 @@
+import { ALL_NOTES_SIDEBAR } from './constants';
+
+/**
+ * A complementary area identifier, or the absence of one. `null` means the
+ * user explicitly closed the area, `undefined` that they never toggled it;
+ * both mean no sidebar was on screen.
+ */
+export type ComplementaryArea = string | null | undefined;
+
+/**
+ * What the add-note flow displaced when it opened a notes sidebar.
+ */
+export type SidebarCapture = {
+	/** The area that was active at the moment of the programmatic switch. */
+	capturedArea: ComplementaryArea;
+	/** The notes sidebar the flow opened in its place. */
+	openedArea: string;
+};
+
+/**
+ * What should happen to the complementary area once the composer is gone.
+ */
+export type RestoreTarget =
+	| { type: 'enable'; area: string }
+	| { type: 'disable' }
+	| { type: 'none' };
+
+/**
+ * Decides how to restore the complementary area after a note composer that
+ * displaced a sidebar is dismissed.
+ *
+ * Only one complementary area can be active at a time, so opening a notes
+ * sidebar to compose a note necessarily closes whatever the user had open.
+ * The composer can be cancelled, unlike an ordinary sidebar switch, so the
+ * displaced area is put back rather than leaving the user without their
+ * place. See https://github.com/WordPress/gutenberg/issues/75450.
+ *
+ * @param options
+ * @param options.capturedArea The area recorded when the notes sidebar opened.
+ * @param options.activeArea   The area active now, as the composer closes.
+ * @param options.openedArea   The notes sidebar the flow opened.
+ *
+ * @return The restore to perform.
+ */
+export function resolveRestoreTarget( {
+	capturedArea,
+	activeArea,
+	openedArea,
+}: {
+	capturedArea: ComplementaryArea;
+	activeArea: ComplementaryArea;
+	openedArea: string;
+} ): RestoreTarget {
+	// The user moved the sidebars themselves while composing; their choice wins.
+	if ( activeArea !== openedArea ) {
+		return { type: 'none' };
+	}
+
+	// A notes sidebar was already open, so nothing was displaced.
+	if ( capturedArea === ALL_NOTES_SIDEBAR ) {
+		return { type: 'none' };
+	}
+
+	// Returning to "no sidebar" is the restore when none was open. Opening the
+	// default document sidebar here is the regression that sank PR #75455.
+	if ( ! capturedArea ) {
+		return { type: 'disable' };
+	}
+
+	return { type: 'enable', area: capturedArea };
+}

--- a/packages/editor/src/components/collab-sidebar/test/restore-sidebar.ts
+++ b/packages/editor/src/components/collab-sidebar/test/restore-sidebar.ts
@@ -1,0 +1,62 @@
+import { resolveRestoreTarget } from '../restore-sidebar';
+import { ALL_NOTES_SIDEBAR } from '../constants';
+
+describe( 'resolveRestoreTarget', () => {
+	// The composer opened the "All notes" sidebar and it is still the active
+	// area, so the flow still owns the slot it took.
+	describe( 'when the notes sidebar the flow opened is still active', () => {
+		it.each( [
+			[ 'the block inspector', 'edit-post/block' ],
+			[ 'the document sidebar', 'edit-post/document' ],
+			[ 'a plugin sidebar', 'my-plugin/my-sidebar' ],
+		] )( 'restores %s', ( _label, capturedArea ) => {
+			expect(
+				resolveRestoreTarget( {
+					capturedArea,
+					activeArea: ALL_NOTES_SIDEBAR,
+					openedArea: ALL_NOTES_SIDEBAR,
+				} )
+			).toEqual( { type: 'enable', area: capturedArea } );
+		} );
+
+		it.each( [
+			[ 'the user had explicitly closed the sidebar', null ],
+			[ 'the user had never toggled the sidebar', undefined ],
+		] )( 'closes the sidebar when %s', ( _label, capturedArea ) => {
+			expect(
+				resolveRestoreTarget( {
+					capturedArea,
+					activeArea: ALL_NOTES_SIDEBAR,
+					openedArea: ALL_NOTES_SIDEBAR,
+				} )
+			).toEqual( { type: 'disable' } );
+		} );
+
+		it( 'does nothing when the notes sidebar was already open', () => {
+			expect(
+				resolveRestoreTarget( {
+					capturedArea: ALL_NOTES_SIDEBAR,
+					activeArea: ALL_NOTES_SIDEBAR,
+					openedArea: ALL_NOTES_SIDEBAR,
+				} )
+			).toEqual( { type: 'none' } );
+		} );
+	} );
+
+	// The user moved the sidebars themselves while composing, so restoring
+	// would undo their explicit choice.
+	describe( 'when the active area changed during composition', () => {
+		it.each( [
+			[ 'switched to another sidebar', 'edit-post/document' ],
+			[ 'closed the notes sidebar', null ],
+		] )( 'does nothing when the user %s', ( _label, activeArea ) => {
+			expect(
+				resolveRestoreTarget( {
+					capturedArea: 'edit-post/block',
+					activeArea,
+					openedArea: ALL_NOTES_SIDEBAR,
+				} )
+			).toEqual( { type: 'none' } );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -2096,6 +2096,272 @@ test.describe( 'Block Notes', () => {
 			await expect( textbox ).toBeFocused();
 		} );
 	} );
+
+	/*
+	 * Composing a note used to leave the user without their place: the notes
+	 * surface took the single complementary-area slot and nothing put the
+	 * displaced sidebar back when the composer was cancelled. See #75450.
+	 *
+	 * Above the `medium` breakpoint the floating notes are part of the canvas
+	 * and displace nothing, so the remaining flow to cover is the small
+	 * viewport, where "All notes" is the only notes surface.
+	 */
+	test.describe( 'Sidebar restoration around the add-note flow', () => {
+		const SMALL_VIEWPORT = { width: 600, height: 800 };
+
+		/*
+		 * Which sidebar is open is a persisted user preference, so these
+		 * tests both need a known starting point and must not leave one open
+		 * for the rest of the suite. Resetting before the post is created is
+		 * what makes it take effect in the editor these tests load.
+		 */
+		test.beforeEach( async ( { requestUtils, admin } ) => {
+			await requestUtils.resetPreferences();
+			await admin.createNewPost();
+		} );
+
+		/*
+		 * Preferences are persisted on a debounce, so a reset can land before
+		 * the previous editor has written its last state. Leaving every test
+		 * with the sidebar closed makes anything that does leak harmless.
+		 */
+		test.afterEach( async ( { page } ) => {
+			const closeButton = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: /^Close / } );
+			if ( await closeButton.isVisible() ) {
+				await closeButton.click();
+				await expect( closeButton ).toBeHidden();
+			}
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.resetPreferences();
+		} );
+
+		/**
+		 * Opens the settings sidebar on the given tab. The viewport is set
+		 * first so the sidebar isn't closed by the editor's own
+		 * large-to-small viewport handling.
+		 *
+		 * @param {Object}                                                utils
+		 * @param {import('@playwright/test').Page}                       utils.page
+		 * @param {import('@wordpress/e2e-test-utils-playwright').Editor} utils.editor
+		 * @param {string}                                                tabName
+		 */
+		async function openSettingsTab( { page, editor }, tabName ) {
+			await editor.openDocumentSettingsSidebar();
+			const settings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			await settings.getByRole( 'tab', { name: tabName } ).click();
+			await expect(
+				settings.getByRole( 'tab', { name: tabName } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			return settings;
+		}
+
+		// The headline repro from #75450, at the default viewport: the floating
+		// notes never take the sidebar slot, so nothing is displaced.
+		test( 'keeps the settings sidebar open through the add-note flow', async ( {
+			page,
+			editor,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note me' },
+			} );
+			const settings = await openSettingsTab( { page, editor }, 'Block' );
+
+			await editor.clickBlockOptionsMenuItem( 'Add note' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+			await expect(
+				settings.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+
+			await page.keyboard.press( 'Escape' );
+
+			await expect(
+				settings.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		test( 'restores the block inspector after cancelling a new note', async ( {
+			page,
+			editor,
+			pageUtils,
+		} ) => {
+			await page.setViewportSize( SMALL_VIEWPORT );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note me' },
+			} );
+			const settings = await openSettingsTab( { page, editor }, 'Block' );
+
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+			await expect(
+				settings.getByRole( 'button', { name: 'Close Notes' } )
+			).toBeVisible();
+
+			await settings.getByRole( 'button', { name: 'Cancel' } ).click();
+
+			await expect(
+				settings.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} )
+			).toBeFocused();
+		} );
+
+		test( 'restores the document tab after dismissing a new note with Escape', async ( {
+			page,
+			editor,
+			pageUtils,
+		} ) => {
+			await page.setViewportSize( SMALL_VIEWPORT );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note me' },
+			} );
+			const settings = await openSettingsTab( { page, editor }, 'Post' );
+
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+
+			await page.keyboard.press( 'Escape' );
+
+			await expect(
+				settings.getByRole( 'tab', { name: 'Post' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		// The previous attempt at this fix (#75455) opened the document
+		// sidebar here, which is worse than leaving the user where they were.
+		test( 'does not open any sidebar after cancelling when none was open', async ( {
+			page,
+			editor,
+			pageUtils,
+		} ) => {
+			await page.setViewportSize( SMALL_VIEWPORT );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note me' },
+			} );
+
+			const settings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			await expect( settings ).toBeHidden();
+
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await expect(
+				settings.getByRole( 'button', { name: 'Close Notes' } )
+			).toBeVisible();
+
+			await settings.getByRole( 'button', { name: 'Cancel' } ).click();
+
+			await expect( settings ).toBeHidden();
+		} );
+
+		test( 'restores the inspector even when the post has other notes', async ( {
+			page,
+			editor,
+			pageUtils,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Already noted' },
+				comment: 'An existing note',
+			} );
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: { content: 'Note me too' },
+			} );
+
+			await page.setViewportSize( SMALL_VIEWPORT );
+			const settings = await openSettingsTab( { page, editor }, 'Block' );
+
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+			await settings.getByRole( 'button', { name: 'Cancel' } ).click();
+
+			await expect(
+				settings.getByRole( 'tab', { name: 'Block' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		test( 'keeps the notes sidebar open after submitting a note', async ( {
+			page,
+			editor,
+			pageUtils,
+		} ) => {
+			await page.setViewportSize( SMALL_VIEWPORT );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note me' },
+			} );
+			const settings = await openSettingsTab( { page, editor }, 'Block' );
+
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await page
+				.getByRole( 'textbox', { name: 'New note', exact: true } )
+				.pressSequentially( 'Submitted note' );
+			await settings
+				.getByRole( 'button', { name: 'Add note', exact: true } )
+				.click();
+
+			// The new note lives in the sidebar the user is looking at, so
+			// yanking it away to re-show the inspector would hide their work.
+			await expect(
+				settings.getByRole( 'treeitem', {
+					name: 'Note: Submitted note',
+				} )
+			).toBeVisible();
+			await expect(
+				settings.getByRole( 'button', { name: 'Close Notes' } )
+			).toBeVisible();
+		} );
+
+		test( 'does not restore when the user switches sidebars while composing', async ( {
+			page,
+			editor,
+			pageUtils,
+		} ) => {
+			await page.setViewportSize( SMALL_VIEWPORT );
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Note me' },
+			} );
+			const settings = await openSettingsTab( { page, editor }, 'Block' );
+
+			await pageUtils.pressKeys( 'primaryAlt+m' );
+			await expect(
+				page.getByRole( 'textbox', { name: 'New note', exact: true } )
+			).toBeFocused();
+
+			// Switching away dismisses the composer through focus-out.
+			await editor.openDocumentSettingsSidebar();
+			await expect(
+				settings.getByRole( 'tab', { name: 'Post' } )
+			).toBeVisible();
+
+			await expect(
+				settings.getByRole( 'button', { name: 'Close Notes' } )
+			).toBeHidden();
+		} );
+	} );
 } );
 
 class BlockNoteUtils {


### PR DESCRIPTION
## What?

Restores the sidebar that was open before a note was composed, when the note form is cancelled.

Stacked on #79864 - please merge that first. This PR only adds the follow-up on top of it.

Fixes #75450
Supersedes #75455 (closed)

## Why?

From @talldan's report: open the block inspector, add a note, cancel the note form, and no sidebar is open at all. The inspector is gone and nothing brings it back, so the user loses their place.

Only one complementary area can be active at a time, so opening a notes surface necessarily closes the inspector, the document sidebar, or whatever plugin sidebar was there. @Mamaduka is right that this is ordinary complementary-area behavior - closing one sidebar has never reopened the previous one. What makes notes different is that the switch was programmatic and the thing it opened can be *cancelled*. An ordinary sidebar switch is something the user asked for; a cancelled note composer is a detour that ended with nothing to show for it.

#79864 already fixes the headline repro at large viewports: floating notes become part of the canvas and stop competing for the sidebar slot, so nothing is displaced and there is nothing to restore. That is what this issue was punted to 7.2 for. What is left after it is the small viewport (below the `medium` breakpoint, 782px), where "All notes" is the only notes surface and still has to take the slot.

## How?

Two small pieces in `packages/editor/src/components/collab-sidebar/`:

**Capture at the moment of the switch.** `focusNote` already read the active area and threw it away. It now records it in a ref, right before `enableComplementaryArea` overwrites the slot, and only for the new-note path - that is the only one that can be cancelled. A capture is skipped when a notes sidebar is already active, which also keeps a second "Add note" during composition from clobbering the original target.

**Restore keyed to the composer, not to the sidebar.** A `useEffect` watches the `'new' -> undefined` note-selection transition, which is what every dismissal produces: the Cancel button, Escape, clicking away, and switching blocks. `resolveRestoreTarget` in the new `restore-sidebar.ts` then decides what to do, and it is a pure function so the rules are readable and unit-testable:

| Situation | Result |
| --- | --- |
| The user switched or closed sidebars mid-composition | do nothing, their choice wins |
| A notes sidebar was already open | do nothing, nothing was displaced |
| Nothing was open before (`null` or `undefined`) | close the sidebar |
| Anything else | re-enable that exact identifier |

Submitting clears the capture without restoring: on a small viewport the new note lives in the sidebar the user is now looking at, and yanking it away to re-show the inspector would hide their own note. That sidebar has a "Close Notes" button, unlike the old floating one the issue was written about.

The three reasons #75455 didn't land are each addressed by construction, and the table above is where each one lives: it restores the real identifier rather than a hardcoded document sidebar, "nothing was open" maps to closing rather than opening, and the restore no longer hangs off `useEnableFloatingSidebar`'s enable flag, so it fires whether or not the post has other unresolved notes.

The state is a component ref rather than store state on purpose. It is transient memory for a single in-flight composer: it must not persist (the active area is backed by `@wordpress/preferences`, and a stale restore target firing in a later session would be a worse bug than the one being fixed), it must not sync to other users, and it is produced and consumed in one component. A store slice would only buy survival across a `NotesSidebar` remount, and every remount that matters also destroys the composer.

## Testing Instructions

[![Test with WordPress Playground](https://img.shields.io/badge/Test%20with-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=81547)

Enable notes, then in the post editor at a narrow window (under 782px wide):

1. Add a paragraph, open the Settings sidebar on the Block tab, then add a note (block options > "Add note", or `ctrl+alt+m`). "All notes" takes over. Cancel the form - the Block tab comes back, and focus is on the paragraph. Escape behaves the same.
2. Same flow starting from the Post tab, and from a plugin sidebar - each one comes back.
3. Close all sidebars, then add a note and cancel. No sidebar opens. This is the case #75455 got wrong.
4. Add a note and submit it this time. "All notes" stays open showing the new note.
5. With the composer open, open the Settings sidebar yourself. The composer dismisses and Settings stays - no restore fights you for it.
6. Add a second note to a post that already has notes, then cancel. The inspector still comes back.

At a normal window width, open the Settings sidebar and add a note: the inspector never moves, because the floating notes don't take the slot.

### Automated

- `npm run test:unit packages/editor/src/components/collab-sidebar/test/restore-sidebar.ts` - 8 passing.
- `npm run test:e2e -- test/e2e/specs/editor/various/block-notes.spec.js -g "Sidebar restoration"` - 7 passing. The four that assert a restore were confirmed to fail against this branch without the source change.

## Notes for reviewers

A few open questions, none of them blocking:

- **Submit on small viewports** keeps "All notes" open rather than restoring. The issue text ("no obvious way to return") was written when the floating sidebar had no close button, which no longer applies. Happy to flip this if reviewers read composition as a strictly modal detour.
- **Mid-composition manual switching** is detected by comparing the active area at dismissal against the one the flow opened. Someone who switches away and back to "All notes" before cancelling still gets a restore. Catching that exactly would need a store subscription open for the life of the composer, which seems like a poor trade.
- **`undefined` becomes an explicit `null`** when cancelling from a never-toggled state, which suppresses the document sidebar's `isActiveByDefault` auto-open later on. `focusNote`'s own `enableComplementaryArea` has already set the visibility preference by that point, so that state is unrecoverable either way.
- The resolved-note path (`isApproved`) also opens "All notes" over the inspector, but restoring on thread *collapse* is a different question from restoring after a cancelled composer, so it is left alone here.
- The new `beforeEach`/`afterEach` in the e2e block reset preferences and close sidebars. The active area persists to user meta on a debounce, and without that cleanup the new tests both inherit and leak sidebar state - `block-notes.spec.js` has already been implicated in unrelated specs failing for this reason.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
