### PR TITLE
Hide the hover inserter below text blocks

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   The inserter that appears when hovering the gap between blocks now stays out of the way of writing: in vertical lists it is hidden below any block whose type supports splitting, since pressing Enter at the end of such a block already creates a block there. It now also appears before the first block and after the last one, following the same rule.
+-   The inserter that appears when hovering the gap between blocks now stays out of the way of writing: in vertical lists it is hidden below any block whose type supports splitting, since pressing Enter at the end of such a block already creates a block there.
 
 ### Bug Fixes
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The inserter that appears when hovering the gap between blocks now stays out of the way of writing: in vertical lists it is hidden below any block whose type supports splitting, since pressing Enter at the end of such a block already creates a block there. It now also appears before the first block and after the last one, following the same rule.
+
 ### Bug Fixes
 
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -31,7 +31,7 @@ export function useInBetweenInserter() {
 		getBlockAttributes,
 		getParentSectionBlock,
 	} = unlock( useSelect( blockEditorStore ) );
-	const { showInsertionPoint, hideInsertionPoint } =
+	const { showInsertionPoint, hideInsertionPoint, selectBlock } =
 		useDispatch( blockEditorStore );
 
 	return useRefEffect(
@@ -40,13 +40,11 @@ export function useInBetweenInserter() {
 				return;
 			}
 
-			function onMouseMove( event ) {
-				// openRef is the reference to the insertion point between blocks.
-				// If the reference is not set or the insertion point is already open, return.
-				if ( openRef === undefined || openRef.current ) {
-					return;
-				}
-
+			// Resolves the boundary between two blocks under the pointer.
+			// Returns the boundary, `{ hide: true }/`when a shown insertion
+			// point must be hidden, or nothing when the event is not for a
+			// boundary at all.
+			function resolveBoundary( event ) {
 				// Ignore text nodes sometimes detected in FireFox.
 				if ( event.target.nodeType === event.target.TEXT_NODE ) {
 					return;
@@ -61,8 +59,7 @@ export function useInBetweenInserter() {
 						'block-editor-block-list__layout'
 					)
 				) {
-					hideInsertionPoint();
-					return;
+					return { hide: true };
 				}
 
 				let rootClientId;
@@ -112,8 +109,7 @@ export function useInBetweenInserter() {
 				} );
 
 				if ( ! element ) {
-					hideInsertionPoint();
-					return;
+					return { hide: true };
 				}
 
 				// The block may be in an alignment wrapper, so check the first direct
@@ -122,12 +118,11 @@ export function useInBetweenInserter() {
 					element = element.firstElementChild;
 
 					if ( ! element ) {
-						hideInsertionPoint();
-						return;
+						return { hide: true };
 					}
 				}
 
-				// Don't show the insertion point if a parent block has an "overlay"
+				// Don't use the boundary if a parent block has an "overlay"
 				// See https://github.com/WordPress/gutenberg/pull/34012#pullrequestreview-727762337
 				const clientId = element.id.slice( 'block-'.length );
 				if (
@@ -138,8 +133,8 @@ export function useInBetweenInserter() {
 					return;
 				}
 
-				// Don't show the inserter if the following conditions are met,
-				// as it conflicts with the block toolbar:
+				// Don't use the boundary if the following conditions are met,
+				// as the inserter conflicts with the block toolbar:
 				// 1. when hovering above or inside selected block(s)
 				// 2. when the orientation is vertical
 				// 3. when the __experimentalCaptureToolbars is not enabled
@@ -152,6 +147,7 @@ export function useInBetweenInserter() {
 				) {
 					return;
 				}
+
 				const elementRect = element.getBoundingClientRect();
 
 				if (
@@ -162,50 +158,88 @@ export function useInBetweenInserter() {
 						( event.clientX > elementRect.right ||
 							event.clientX < elementRect.left ) )
 				) {
-					hideInsertionPoint();
-					return;
+					return { hide: true };
 				}
 
 				const index = getBlockIndex( clientId );
 
-				// Don't show the in-between inserter before the first block in
-				// the list (preserves the original behaviour).
+				// There is no boundary before the first block in the list
+				// (preserves the original behaviour).
 				if ( index === 0 ) {
-					hideInsertionPoint();
-					return;
+					return { hide: true };
 				}
 
-				// When the block above can split, typing can already create a
-				// block here: pressing Enter at its end starts a new block at
-				// this spot with the caret in it, so the inserter would only
-				// get in the way of writing. Splitting at the start of a
-				// block leaves the caret behind, which is why only the block
-				// above counts. In horizontal rows the inserter doesn't get
-				// in the way of writing, so it stays.
+				return { rootClientId, clientId, index, orientation };
+			}
+
+			// When the block above a boundary can split, typing can already
+			// create a block there: pressing Enter at its end starts a new
+			// block at that spot with the caret in it, so the inserter would
+			// only get in the way of writing. Splitting at the start of a
+			// block leaves the caret behind, which is why only the block
+			// above counts. In horizontal rows the inserter doesn't get in
+			// the way of writing, so it stays.
+			function typingCoversBoundary( boundary ) {
+				const { rootClientId, index, orientation } = boundary;
 				const previousClientId =
 					getBlockOrder( rootClientId )[ index - 1 ];
-				if (
+				return (
 					orientation === 'vertical' &&
-					previousClientId &&
+					!! previousClientId &&
 					hasBlockSupport(
 						getBlockName( previousClientId ),
 						'splitting',
 						false
 					)
-				) {
+				);
+			}
+
+			function onMouseMove( event ) {
+				// openRef is the reference to the insertion point between blocks.
+				// If the reference is not set or the insertion point is already open, return.
+				if ( openRef === undefined || openRef.current ) {
+					return;
+				}
+
+				const boundary = resolveBoundary( event );
+
+				if ( ! boundary ) {
+					return;
+				}
+
+				if ( boundary.hide || typingCoversBoundary( boundary ) ) {
 					hideInsertionPoint();
 					return;
 				}
 
-				showInsertionPoint( rootClientId, index, {
+				showInsertionPoint( boundary.rootClientId, boundary.index, {
 					__unstableWithInserter: true,
 				} );
 			}
 
+			function onClick( event ) {
+				const boundary = resolveBoundary( event );
+
+				// Without an inserter in the boundary, a click between two
+				// blocks would do nothing. Place the caret at the end of the
+				// block below, exactly like a click on the shown insertion
+				// point does.
+				if (
+					boundary &&
+					! boundary.hide &&
+					typingCoversBoundary( boundary ) &&
+					getBlockEditingMode( boundary.clientId ) !== 'disabled'
+				) {
+					selectBlock( boundary.clientId, -1 );
+				}
+			}
+
 			node.addEventListener( 'mousemove', onMouseMove );
+			node.addEventListener( 'click', onClick );
 
 			return () => {
 				node.removeEventListener( 'mousemove', onMouseMove );
+				node.removeEventListener( 'click', onClick );
 			};
 		},
 		[

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -1,3 +1,4 @@
+import { hasBlockSupport } from '@wordpress/blocks';
 import { useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
@@ -19,6 +20,7 @@ export function useInBetweenInserter() {
 	const {
 		getBlockListSettings,
 		getBlockIndex,
+		getBlockOrder,
 		isMultiSelecting,
 		getSelectedBlockClientIds,
 		getSettings,
@@ -109,29 +111,54 @@ export function useInBetweenInserter() {
 					);
 				} );
 
-				if ( ! element ) {
-					hideInsertionPoint();
-					return;
-				}
+				const order = getBlockOrder( rootClientId );
+				let clientId;
+				let index;
 
-				// The block may be in an alignment wrapper, so check the first direct
-				// child if the element has no ID.
-				if ( ! element.id ) {
-					element = element.firstElementChild;
+				const isPastLastBlock =
+					! element ||
+					element.classList.contains( 'block-list-appender' );
 
+				if ( isPastLastBlock ) {
+					// No block follows the pointer, so the boundary is at the
+					// end of the list.
+					if ( ! order.length ) {
+						hideInsertionPoint();
+						return;
+					}
+					index = order.length;
+					element = event.target.ownerDocument.getElementById(
+						'block-' + order[ index - 1 ]
+					);
 					if ( ! element ) {
 						hideInsertionPoint();
 						return;
 					}
+				} else {
+					// The block may be in an alignment wrapper, so check the
+					// first direct child if the element has no ID.
+					if ( ! element.id ) {
+						element = element.firstElementChild;
+
+						if ( ! element ) {
+							hideInsertionPoint();
+							return;
+						}
+					}
+
+					clientId = element.id.slice( 'block-'.length );
+					if ( ! clientId ) {
+						return;
+					}
+					index = getBlockIndex( clientId );
 				}
 
 				// Don't show the insertion point if a parent block has an "overlay"
 				// See https://github.com/WordPress/gutenberg/pull/34012#pullrequestreview-727762337
-				const clientId = element.id.slice( 'block-'.length );
+				const boundaryClientId = clientId ?? order[ order.length - 1 ];
 				if (
-					! clientId ||
-					__unstableIsWithinBlockOverlay( clientId ) ||
-					!! getParentSectionBlock( clientId )
+					__unstableIsWithinBlockOverlay( boundaryClientId ) ||
+					!! getParentSectionBlock( boundaryClientId )
 				) {
 					return;
 				}
@@ -143,6 +170,7 @@ export function useInBetweenInserter() {
 				// 3. when the __experimentalCaptureToolbars is not enabled
 				// 4. when the Top Toolbar is not disabled
 				if (
+					clientId &&
 					getSelectedBlockClientIds().includes( clientId ) &&
 					orientation === 'vertical' &&
 					! captureToolbars &&
@@ -164,11 +192,23 @@ export function useInBetweenInserter() {
 					return;
 				}
 
-				const index = getBlockIndex( clientId );
-
-				// Don't show the in-between inserter before the first block in
-				// the list (preserves the original behaviour).
-				if ( index === 0 ) {
+				// When the block above can split, typing can already create a
+				// block here: pressing Enter at its end starts a new block at
+				// this spot with the caret in it, so the inserter would only
+				// get in the way of writing. Splitting at the start of a
+				// block leaves the caret behind, which is why only the block
+				// above counts. In horizontal rows the inserter doesn't get
+				// in the way of writing, so it stays.
+				const previousClientId = order[ index - 1 ];
+				if (
+					orientation === 'vertical' &&
+					previousClientId &&
+					hasBlockSupport(
+						getBlockName( previousClientId ),
+						'splitting',
+						false
+					)
+				) {
 					hideInsertionPoint();
 					return;
 				}

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -111,54 +111,29 @@ export function useInBetweenInserter() {
 					);
 				} );
 
-				const order = getBlockOrder( rootClientId );
-				let clientId;
-				let index;
+				if ( ! element ) {
+					hideInsertionPoint();
+					return;
+				}
 
-				const isPastLastBlock =
-					! element ||
-					element.classList.contains( 'block-list-appender' );
+				// The block may be in an alignment wrapper, so check the first direct
+				// child if the element has no ID.
+				if ( ! element.id ) {
+					element = element.firstElementChild;
 
-				if ( isPastLastBlock ) {
-					// No block follows the pointer, so the boundary is at the
-					// end of the list.
-					if ( ! order.length ) {
-						hideInsertionPoint();
-						return;
-					}
-					index = order.length;
-					element = event.target.ownerDocument.getElementById(
-						'block-' + order[ index - 1 ]
-					);
 					if ( ! element ) {
 						hideInsertionPoint();
 						return;
 					}
-				} else {
-					// The block may be in an alignment wrapper, so check the
-					// first direct child if the element has no ID.
-					if ( ! element.id ) {
-						element = element.firstElementChild;
-
-						if ( ! element ) {
-							hideInsertionPoint();
-							return;
-						}
-					}
-
-					clientId = element.id.slice( 'block-'.length );
-					if ( ! clientId ) {
-						return;
-					}
-					index = getBlockIndex( clientId );
 				}
 
 				// Don't show the insertion point if a parent block has an "overlay"
 				// See https://github.com/WordPress/gutenberg/pull/34012#pullrequestreview-727762337
-				const boundaryClientId = clientId ?? order[ order.length - 1 ];
+				const clientId = element.id.slice( 'block-'.length );
 				if (
-					__unstableIsWithinBlockOverlay( boundaryClientId ) ||
-					!! getParentSectionBlock( boundaryClientId )
+					! clientId ||
+					__unstableIsWithinBlockOverlay( clientId ) ||
+					!! getParentSectionBlock( clientId )
 				) {
 					return;
 				}
@@ -170,7 +145,6 @@ export function useInBetweenInserter() {
 				// 3. when the __experimentalCaptureToolbars is not enabled
 				// 4. when the Top Toolbar is not disabled
 				if (
-					clientId &&
 					getSelectedBlockClientIds().includes( clientId ) &&
 					orientation === 'vertical' &&
 					! captureToolbars &&
@@ -192,6 +166,15 @@ export function useInBetweenInserter() {
 					return;
 				}
 
+				const index = getBlockIndex( clientId );
+
+				// Don't show the in-between inserter before the first block in
+				// the list (preserves the original behaviour).
+				if ( index === 0 ) {
+					hideInsertionPoint();
+					return;
+				}
+
 				// When the block above can split, typing can already create a
 				// block here: pressing Enter at its end starts a new block at
 				// this spot with the caret in it, so the inserter would only
@@ -199,7 +182,8 @@ export function useInBetweenInserter() {
 				// block leaves the caret behind, which is why only the block
 				// above counts. In horizontal rows the inserter doesn't get
 				// in the way of writing, so it stays.
-				const previousClientId = order[ index - 1 ];
+				const previousClientId =
+					getBlockOrder( rootClientId )[ index - 1 ];
 				if (
 					orientation === 'vertical' &&
 					previousClientId &&

--- a/test/e2e/specs/editor/various/in-between-inserter.spec.js
+++ b/test/e2e/specs/editor/various/in-between-inserter.spec.js
@@ -1,0 +1,230 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+// A 1x1 transparent GIF so the image blocks render without any media
+// library setup.
+const IMAGE_DATA_URI =
+	'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+const IMAGE_BLOCK = `<!-- wp:image --><figure class="wp-block-image"><img src="${ IMAGE_DATA_URI }" alt=""/></figure><!-- /wp:image -->`;
+
+const paragraphBlock = ( content ) =>
+	`<!-- wp:paragraph --><p>${ content }</p><!-- /wp:paragraph -->`;
+
+test.describe( 'In-between block inserter', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	// Moves the mouse away from the canvas, then to the given point. The
+	// extra steps imitate real cursor movement, which the in-between
+	// inserter needs to activate.
+	async function hoverBoundary( page, x, y ) {
+		await page.mouse.move( 0, 0 );
+		await page.mouse.move( x, y, { steps: 10 } );
+	}
+
+	// The vertical midpoint of the gap between two stacked blocks.
+	function gapBetween( box1, box2 ) {
+		return {
+			x: box1.x + box1.width / 2,
+			y: ( box1.y + box1.height + box2.y ) / 2,
+		};
+	}
+
+	test( 'appears between two images', async ( { editor, page } ) => {
+		await editor.setContent( IMAGE_BLOCK + IMAGE_BLOCK );
+		const images = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		const box1 = await images.nth( 0 ).boundingBox();
+		const box2 = await images.nth( 1 ).boundingBox();
+
+		const { x, y } = gapBetween( box1, box2 );
+		await hoverBoundary( page, x, y );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Add block' } )
+		).toBeVisible();
+	} );
+
+	test( 'appears after the last of two images', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent( IMAGE_BLOCK + IMAGE_BLOCK );
+		const images = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		const box = await images.nth( 1 ).boundingBox();
+
+		await hoverBoundary(
+			page,
+			box.x + box.width / 2,
+			box.y + box.height + 10
+		);
+
+		await expect(
+			page.getByRole( 'button', { name: 'Add block' } )
+		).toBeVisible();
+	} );
+
+	test( 'appears before the first block, even a heading', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			'<!-- wp:heading --><h2 class="wp-block-heading">Heading</h2><!-- /wp:heading -->' +
+				paragraphBlock( 'A paragraph' )
+		);
+		const heading = editor.canvas.getByRole( 'document', {
+			name: 'Block: Heading',
+		} );
+		const box = await heading.boundingBox();
+
+		await hoverBoundary( page, box.x + box.width / 2, box.y - 10 );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Add block' } )
+		).toBeVisible();
+	} );
+
+	test( 'appears between an image and a paragraph', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			IMAGE_BLOCK + paragraphBlock( 'A paragraph' )
+		);
+		const image = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const box1 = await image.boundingBox();
+		const box2 = await paragraph.boundingBox();
+
+		const { x, y } = gapBetween( box1, box2 );
+		await hoverBoundary( page, x, y );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Add block' } )
+		).toBeVisible();
+	} );
+
+	test( 'appears between two buttons in a row', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			'<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">One</a></div><!-- /wp:button --><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Two</a></div><!-- /wp:button --></div><!-- /wp:buttons -->'
+		);
+		const buttons = editor.canvas.getByRole( 'document', {
+			name: 'Block: Button',
+			exact: true,
+		} );
+		const box1 = await buttons.nth( 0 ).boundingBox();
+		const box2 = await buttons.nth( 1 ).boundingBox();
+
+		await hoverBoundary(
+			page,
+			( box1.x + box1.width + box2.x ) / 2,
+			box1.y + box1.height / 2
+		);
+
+		// Inside a buttons row the inserter is labelled after the only
+		// allowed block.
+		await expect(
+			page.getByRole( 'button', { name: 'Add button' } )
+		).toBeVisible();
+	} );
+
+	test( 'is hidden between two paragraphs', async ( { editor, page } ) => {
+		await editor.setContent(
+			paragraphBlock( 'First' ) + paragraphBlock( 'Second' )
+		);
+		const paragraphs = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const box1 = await paragraphs.nth( 0 ).boundingBox();
+		const box2 = await paragraphs.nth( 1 ).boundingBox();
+
+		// First show the inserter before the first block, so that the later
+		// hidden state can't be mistaken for the inserter not activating at
+		// all.
+		await hoverBoundary( page, box1.x + box1.width / 2, box1.y - 10 );
+		const inserterButton = page.getByRole( 'button', {
+			name: 'Add block',
+		} );
+		await expect( inserterButton ).toBeVisible();
+
+		const { x, y } = gapBetween( box1, box2 );
+		await hoverBoundary( page, x, y );
+
+		await expect( inserterButton ).toBeHidden();
+	} );
+
+	test( 'is hidden between a paragraph and an image', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			paragraphBlock( 'A paragraph' ) + IMAGE_BLOCK
+		);
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const image = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		const box1 = await paragraph.boundingBox();
+		const box2 = await image.boundingBox();
+
+		// Positive control: the boundary before the first block shows the
+		// inserter.
+		await hoverBoundary( page, box1.x + box1.width / 2, box1.y - 10 );
+		const inserterButton = page.getByRole( 'button', {
+			name: 'Add block',
+		} );
+		await expect( inserterButton ).toBeVisible();
+
+		const { x, y } = gapBetween( box1, box2 );
+		await hoverBoundary( page, x, y );
+
+		await expect( inserterButton ).toBeHidden();
+	} );
+
+	test( 'is hidden after a paragraph that is the last block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.setContent(
+			IMAGE_BLOCK + paragraphBlock( 'A paragraph' )
+		);
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const box = await paragraph.boundingBox();
+
+		// Positive control: the boundary above the paragraph shows the
+		// inserter because an image is above it.
+		const image = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+		const imageBox = await image.boundingBox();
+		const { x, y } = gapBetween( imageBox, box );
+		await hoverBoundary( page, x, y );
+		const inserterButton = page.getByRole( 'button', {
+			name: 'Add block',
+		} );
+		await expect( inserterButton ).toBeVisible();
+
+		await hoverBoundary(
+			page,
+			box.x + box.width / 2,
+			box.y + box.height + 10
+		);
+
+		await expect( inserterButton ).toBeHidden();
+	} );
+} );

--- a/test/e2e/specs/editor/various/in-between-inserter.spec.js
+++ b/test/e2e/specs/editor/various/in-between-inserter.spec.js
@@ -153,6 +153,38 @@ test.describe( 'In-between block inserter', () => {
 		await expect( inserterButton ).toBeHidden();
 	} );
 
+	test( 'a click in a hidden gap moves the caret to the block below', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second' },
+		} );
+		await deselect( page );
+		const paragraphs = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		const box1 = await paragraphs.nth( 0 ).boundingBox();
+
+		const x = box1.x + ( 2 * box1.width ) / 3;
+		const y = box1.y + box1.height + 1;
+		await hoverBoundary( page, x, y );
+		await page.mouse.click( x, y );
+		// The caret lands at the end of the block below the gap, the same
+		// place a click on the visible insertion point puts it.
+		await page.keyboard.type( 'X' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'First' } },
+			{ name: 'core/paragraph', attributes: { content: 'SecondX' } },
+		] );
+	} );
+
 	test( 'is hidden between a paragraph and an image', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/in-between-inserter.spec.js
+++ b/test/e2e/specs/editor/various/in-between-inserter.spec.js
@@ -5,15 +5,24 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const IMAGE_DATA_URI =
 	'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-const IMAGE_BLOCK = `<!-- wp:image --><figure class="wp-block-image"><img src="${ IMAGE_DATA_URI }" alt=""/></figure><!-- /wp:image -->`;
-
-const paragraphBlock = ( content ) =>
-	`<!-- wp:paragraph --><p>${ content }</p><!-- /wp:paragraph -->`;
+const IMAGE = {
+	name: 'core/image',
+	attributes: { url: IMAGE_DATA_URI },
+};
 
 test.describe( 'In-between block inserter', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
+
+	// Inserting blocks leaves the last one selected, and its floating
+	// toolbar sits exactly where these tests hover. Clear the selection
+	// so the canvas is in the same resting state a reader starts from.
+	async function deselect( page ) {
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
+	}
 
 	// Moves the mouse away from the canvas, then to the given point. The
 	// extra steps imitate real cursor movement, which the in-between
@@ -32,7 +41,9 @@ test.describe( 'In-between block inserter', () => {
 	}
 
 	test( 'appears between two images', async ( { editor, page } ) => {
-		await editor.setContent( IMAGE_BLOCK + IMAGE_BLOCK );
+		await editor.insertBlock( IMAGE );
+		await editor.insertBlock( IMAGE );
+		await deselect( page );
 		const images = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
 		} );
@@ -51,7 +62,9 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setContent( IMAGE_BLOCK + IMAGE_BLOCK );
+		await editor.insertBlock( IMAGE );
+		await editor.insertBlock( IMAGE );
+		await deselect( page );
 		const images = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
 		} );
@@ -72,10 +85,15 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setContent(
-			'<!-- wp:heading --><h2 class="wp-block-heading">Heading</h2><!-- /wp:heading -->' +
-				paragraphBlock( 'A paragraph' )
-		);
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'Heading' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'A paragraph' },
+		} );
+		await deselect( page );
 		const heading = editor.canvas.getByRole( 'document', {
 			name: 'Block: Heading',
 		} );
@@ -92,9 +110,12 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setContent(
-			IMAGE_BLOCK + paragraphBlock( 'A paragraph' )
-		);
+		await editor.insertBlock( IMAGE );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'A paragraph' },
+		} );
+		await deselect( page );
 		const image = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
 		} );
@@ -116,9 +137,14 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setContent(
-			'<!-- wp:buttons --><div class="wp-block-buttons"><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">One</a></div><!-- /wp:button --><!-- wp:button --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Two</a></div><!-- /wp:button --></div><!-- /wp:buttons -->'
-		);
+		await editor.insertBlock( {
+			name: 'core/buttons',
+			innerBlocks: [
+				{ name: 'core/button', attributes: { text: 'One' } },
+				{ name: 'core/button', attributes: { text: 'Two' } },
+			],
+		} );
+		await deselect( page );
 		const buttons = editor.canvas.getByRole( 'document', {
 			name: 'Block: Button',
 			exact: true,
@@ -140,9 +166,15 @@ test.describe( 'In-between block inserter', () => {
 	} );
 
 	test( 'is hidden between two paragraphs', async ( { editor, page } ) => {
-		await editor.setContent(
-			paragraphBlock( 'First' ) + paragraphBlock( 'Second' )
-		);
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second' },
+		} );
+		await deselect( page );
 		const paragraphs = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );
@@ -168,9 +200,12 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setContent(
-			paragraphBlock( 'A paragraph' ) + IMAGE_BLOCK
-		);
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'A paragraph' },
+		} );
+		await editor.insertBlock( IMAGE );
+		await deselect( page );
 		const paragraph = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );
@@ -198,9 +233,12 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
-		await editor.setContent(
-			IMAGE_BLOCK + paragraphBlock( 'A paragraph' )
-		);
+		await editor.insertBlock( IMAGE );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'A paragraph' },
+		} );
+		await deselect( page );
 		const paragraph = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );

--- a/test/e2e/specs/editor/various/in-between-inserter.spec.js
+++ b/test/e2e/specs/editor/various/in-between-inserter.spec.js
@@ -58,54 +58,6 @@ test.describe( 'In-between block inserter', () => {
 		).toBeVisible();
 	} );
 
-	test( 'appears after the last of two images', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( IMAGE );
-		await editor.insertBlock( IMAGE );
-		await deselect( page );
-		const images = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		const box = await images.nth( 1 ).boundingBox();
-
-		await hoverBoundary(
-			page,
-			box.x + box.width / 2,
-			box.y + box.height + 10
-		);
-
-		await expect(
-			page.getByRole( 'button', { name: 'Add block' } )
-		).toBeVisible();
-	} );
-
-	test( 'appears before the first block, even a heading', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( {
-			name: 'core/heading',
-			attributes: { content: 'Heading' },
-		} );
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'A paragraph' },
-		} );
-		await deselect( page );
-		const heading = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
-		} );
-		const box = await heading.boundingBox();
-
-		await hoverBoundary( page, box.x + box.width / 2, box.y - 10 );
-
-		await expect(
-			page.getByRole( 'button', { name: 'Add block' } )
-		).toBeVisible();
-	} );
-
 	test( 'appears between an image and a paragraph', async ( {
 		editor,
 		page,
@@ -166,6 +118,7 @@ test.describe( 'In-between block inserter', () => {
 	} );
 
 	test( 'is hidden between two paragraphs', async ( { editor, page } ) => {
+		await editor.insertBlock( IMAGE );
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'First' },
@@ -175,16 +128,20 @@ test.describe( 'In-between block inserter', () => {
 			attributes: { content: 'Second' },
 		} );
 		await deselect( page );
+		const image = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
 		const paragraphs = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );
+		const imageBox = await image.boundingBox();
 		const box1 = await paragraphs.nth( 0 ).boundingBox();
 		const box2 = await paragraphs.nth( 1 ).boundingBox();
 
-		// First show the inserter before the first block, so that the later
-		// hidden state can't be mistaken for the inserter not activating at
-		// all.
-		await hoverBoundary( page, box1.x + box1.width / 2, box1.y - 10 );
+		// First show the inserter below the image, so that the later hidden
+		// state can't be mistaken for the inserter not activating at all.
+		const control = gapBetween( imageBox, box1 );
+		await hoverBoundary( page, control.x, control.y );
 		const inserterButton = page.getByRole( 'button', {
 			name: 'Add block',
 		} );
@@ -200,24 +157,27 @@ test.describe( 'In-between block inserter', () => {
 		editor,
 		page,
 	} ) => {
+		await editor.insertBlock( IMAGE );
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'A paragraph' },
 		} );
 		await editor.insertBlock( IMAGE );
 		await deselect( page );
+		const images = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
 		const paragraph = editor.canvas.getByRole( 'document', {
 			name: 'Block: Paragraph',
 		} );
-		const image = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
+		const imageBox = await images.nth( 0 ).boundingBox();
 		const box1 = await paragraph.boundingBox();
-		const box2 = await image.boundingBox();
+		const box2 = await images.nth( 1 ).boundingBox();
 
-		// Positive control: the boundary before the first block shows the
-		// inserter.
-		await hoverBoundary( page, box1.x + box1.width / 2, box1.y - 10 );
+		// Positive control: the boundary between the image and the
+		// paragraph shows the inserter.
+		const control = gapBetween( imageBox, box1 );
+		await hoverBoundary( page, control.x, control.y );
 		const inserterButton = page.getByRole( 'button', {
 			name: 'Add block',
 		} );
@@ -225,43 +185,6 @@ test.describe( 'In-between block inserter', () => {
 
 		const { x, y } = gapBetween( box1, box2 );
 		await hoverBoundary( page, x, y );
-
-		await expect( inserterButton ).toBeHidden();
-	} );
-
-	test( 'is hidden after a paragraph that is the last block', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( IMAGE );
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'A paragraph' },
-		} );
-		await deselect( page );
-		const paragraph = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		const box = await paragraph.boundingBox();
-
-		// Positive control: the boundary above the paragraph shows the
-		// inserter because an image is above it.
-		const image = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		const imageBox = await image.boundingBox();
-		const { x, y } = gapBetween( imageBox, box );
-		await hoverBoundary( page, x, y );
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Add block',
-		} );
-		await expect( inserterButton ).toBeVisible();
-
-		await hoverBoundary(
-			page,
-			box.x + box.width / 2,
-			box.y + box.height + 10
-		);
 
 		await expect( inserterButton ).toBeHidden();
 	} );

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -516,17 +516,15 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		// The block before the hovered boundary must be one where typing
 		// can't create a block after it, so that the in-between inserter
 		// shows in the gap.
-		await editor.setContent( `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">Heading</h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>First paragraph</p>
-<!-- /wp:paragraph -->` );
+		await editor.insertBlock( { name: 'core/image' } );
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'Heading' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First paragraph' },
+		} );
 		// Put the caret in the trailing paragraph so the test can catch an
 		// insertion that wrongly follows the caret instead of the inserter.
 		await editor.canvas.locator( 'p:text("First paragraph")' ).click();

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -525,9 +525,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'First paragraph' },
 		} );
-		// Put the caret in the trailing paragraph so the test can catch an
-		// insertion that wrongly follows the caret instead of the inserter.
-		await editor.canvas.locator( 'p:text("First paragraph")' ).click();
+		// Inserting the paragraph leaves the caret in it, away from the
+		// hovered boundary, so the test can catch an insertion that wrongly
+		// follows the caret instead of the inserter.
 
 		const boundingBox = await editor.canvas
 			.getByRole( 'document', { name: 'Block: Heading' } )

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -513,16 +513,23 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		page,
 	} ) => {
 		await admin.createNewPost();
-		await editor.canvas
-			.getByRole( 'document', { name: 'Add default block' } )
-			.click();
-		await page.keyboard.type( 'First paragraph' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '## Heading' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Second paragraph' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Third paragraph' );
+		// The block before the hovered boundary must be one where typing
+		// can't create a block after it, so that the in-between inserter
+		// shows in the gap.
+		await editor.setContent( `<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->` );
+		// Put the caret in the trailing paragraph so the test can catch an
+		// insertion that wrongly follows the caret instead of the inserter.
+		await editor.canvas.locator( 'p:text("First paragraph")' ).click();
 
 		const boundingBox = await editor.canvas
 			.getByRole( 'document', { name: 'Block: Heading' } )
@@ -551,10 +558,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await expect
 			.poll( editor.getBlocks )
 			.toMatchObject( [
-				{ name: 'core/paragraph' },
+				{ name: 'core/image' },
 				{ name: 'core/image' },
 				{ name: 'core/heading' },
-				{ name: 'core/paragraph' },
 				{ name: 'core/paragraph' },
 			] );
 	} );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -873,13 +873,14 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 	} ) => {
 		// The first block must be one where typing can't create a block
 		// after it, so that the in-between inserter shows in the gap.
-		await editor.setContent( `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph -->` );
+		await editor.insertBlock( { name: 'core/image' } );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '2' },
+		} );
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
 
 		const imageBlock = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'
@@ -918,13 +919,14 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 	} ) => {
 		// The first block must be one where typing can't create a block
 		// after it, so that the in-between inserter shows in the gap.
-		await editor.setContent( `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:image {"align":"wide"} -->
-<figure class="wp-block-image alignwide"><img alt=""/></figure>
-<!-- /wp:image -->` );
+		await editor.insertBlock( { name: 'core/image' } );
+		await editor.insertBlock( {
+			name: 'core/image',
+			attributes: { align: 'wide' },
+		} );
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock()
+		);
 
 		const imageBlocks = editor.canvas.locator(
 			'role=document[name="Block: Image"i]'

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -871,18 +871,22 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		editor,
 		page,
 	} ) => {
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '1' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '2' );
-		await page.keyboard.press( 'ArrowUp' );
+		// The first block must be one where typing can't create a block
+		// after it, so that the in-between inserter shows in the gap.
+		await editor.setContent( `<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
 
-		const paragraphBlock = editor.canvas
-			.locator( 'role=document[name="Block: Paragraph"i]' )
-			.first();
-		const paragraphRect = await paragraphBlock.boundingBox();
-		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
-		const y = paragraphRect.y + paragraphRect.height + 1;
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->` );
+
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		const imageRect = await imageBlock.boundingBox();
+		const x = imageRect.x + ( 2 * imageRect.width ) / 3;
+		const y = imageRect.y + imageRect.height + 1;
 
 		// The typing observer requires two mouse moves to detect an actual
 		// move.
@@ -899,9 +903,9 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		await page.keyboard.type( '3' );
 
 		await expect.poll( editor.getEditedPostContent )
-			.toBe( `<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->
+			.toBe( `<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
 
 <!-- wp:paragraph -->
 <p>23</p>
@@ -911,65 +915,41 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 	test( 'should not have a dead zone above an aligned block', async ( {
 		editor,
 		page,
-		pageUtils,
 	} ) => {
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '1' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '/image' );
-		await expect(
-			page.getByRole( 'option', { name: 'Image', selected: true } )
-		).toBeVisible();
-		await page.keyboard.press( 'Enter' );
-		await editor.clickBlockToolbarButton( 'Align block' );
-
-		const wideButton = page.locator(
-			'role=menuitemradio[name="Wide width"i]'
-		);
-		await wideButton.click();
-
-		// Focus the block content
-		await pageUtils.pressKeys( 'Tab' );
-
-		// Select the previous block.
-		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
-
-		// Confirm correct setup.
-		await expect.poll( editor.getEditedPostContent )
-			.toBe( `<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->
+		// The first block must be one where typing can't create a block
+		// after it, so that the in-between inserter shows in the gap.
+		await editor.setContent( `<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
 
 <!-- wp:image {"align":"wide"} -->
 <figure class="wp-block-image alignwide"><img alt=""/></figure>
 <!-- /wp:image -->` );
 
-		const paragraphBlock = editor.canvas.locator(
-			'role=document[name="Block: Paragraph"i]'
+		const imageBlocks = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
 		);
 
-		// Find a point outside the paragraph between the blocks where it's
+		// Find a point outside the first image between the blocks where it's
 		// expected that the sibling inserter would be placed.
-		const paragraphRect = await paragraphBlock.boundingBox();
-		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
-		const y = paragraphRect.y + paragraphRect.height + 1;
+		const firstImageRect = await imageBlocks.first().boundingBox();
+		const x = firstImageRect.x + ( 2 * firstImageRect.width ) / 3;
+		const y = firstImageRect.y + firstImageRect.height + 1;
 
 		await page.mouse.move( x, y );
 
 		const inserter = page.locator( 'role=button[name="Add block"i]' );
 		await expect( inserter ).toBeVisible();
 
-		// Find the space between the inserter and the image block.
+		// Find the space between the inserter and the aligned image block.
 		const inserterRect = await inserter.boundingBox();
 		const lowerInserterY = inserterRect.y + ( 2 * inserterRect.height ) / 3;
 
-		// Clicking that in-between space should select the image block.
+		// Clicking that in-between space should select the aligned image
+		// block.
 		await page.mouse.click( x, lowerInserterY );
 
-		await expect(
-			editor.canvas.locator( 'role=document[name="Block: Image"i]' )
-		).toHaveClass( /is-selected/ );
+		await expect( imageBlocks.last() ).toHaveClass( /is-selected/ );
 	} );
 
 	test( 'should focus preceding tabbable using shift+tab from post title and writing flow container', async ( {

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -175,12 +175,12 @@ test.describe( 'Widgets screen', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Second Paragraph' );
 
-		const secondParagraphBlock = firstWidgetArea
+		const firstParagraphBlockLocator = firstWidgetArea
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
-			.filter( { hasText: 'Second Paragraph' } );
+			.filter( { hasText: 'First Paragraph' } );
 
-		const secondParagraphBlockBoundingBox =
-			await secondParagraphBlock.boundingBox();
+		const firstParagraphBlockBoundingBox =
+			await firstParagraphBlockLocator.boundingBox();
 
 		// Click outside the block to move the focus back to the widget area.
 		await firstWidgetArea.click( {
@@ -190,11 +190,13 @@ test.describe( 'Widgets screen', () => {
 			},
 		} );
 
-		// Hover above the last block to trigger the inline inserter between blocks.
+		// Hover above the first block to trigger the inline inserter. The
+		// boundary between the two paragraphs no longer shows it, because
+		// typing can already create a block there.
 		await page.mouse.move(
-			secondParagraphBlockBoundingBox.x +
-				secondParagraphBlockBoundingBox.width / 2,
-			secondParagraphBlockBoundingBox.y - 10
+			firstParagraphBlockBoundingBox.x +
+				firstParagraphBlockBoundingBox.width / 2,
+			firstParagraphBlockBoundingBox.y - 10
 		);
 
 		// There will be 2 matches here.
@@ -230,12 +232,12 @@ test.describe( 'Widgets screen', () => {
 		await expect.poll( widgetsScreen.getWidgetAreaBlocks ).toMatchObject( {
 			'sidebar-1': [
 				{
-					name: 'core/paragraph',
-					attributes: { content: 'First Paragraph' },
-				},
-				{
 					name: 'core/heading',
 					attributes: { content: 'My Heading' },
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'First Paragraph' },
 				},
 				{
 					name: 'core/paragraph',

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -160,27 +160,27 @@ test.describe( 'Widgets screen', () => {
 			name: 'Blocks',
 		} );
 
-		const paragraphBlock = inlineQuickInserter.getByRole( 'option', {
-			name: 'Paragraph',
+		// The first block must be one where typing can't create a block
+		// after it, so that the in-between inserter shows in the gap.
+		await page
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Separator' );
+		const separatorOption = inlineQuickInserter.getByRole( 'option', {
+			name: 'Separator',
 			exact: true,
 		} );
-		await paragraphBlock.click();
+		await separatorOption.click();
 
-		const firstParagraphBlock = firstWidgetArea.getByRole( 'document', {
-			name: /^Empty block/,
-		} );
-		await firstParagraphBlock.focus();
-		await page.keyboard.type( 'First Paragraph' );
-
+		// Enter on the selected separator starts a paragraph after it.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Second Paragraph' );
 
-		const firstParagraphBlockLocator = firstWidgetArea
+		const secondParagraphBlock = firstWidgetArea
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
-			.filter( { hasText: 'First Paragraph' } );
+			.filter( { hasText: 'Second Paragraph' } );
 
-		const firstParagraphBlockBoundingBox =
-			await firstParagraphBlockLocator.boundingBox();
+		const secondParagraphBlockBoundingBox =
+			await secondParagraphBlock.boundingBox();
 
 		// Click outside the block to move the focus back to the widget area.
 		await firstWidgetArea.click( {
@@ -190,13 +190,11 @@ test.describe( 'Widgets screen', () => {
 			},
 		} );
 
-		// Hover above the first block to trigger the inline inserter. The
-		// boundary between the two paragraphs no longer shows it, because
-		// typing can already create a block there.
+		// Hover above the last block to trigger the inline inserter between blocks.
 		await page.mouse.move(
-			firstParagraphBlockBoundingBox.x +
-				firstParagraphBlockBoundingBox.width / 2,
-			firstParagraphBlockBoundingBox.y - 10
+			secondParagraphBlockBoundingBox.x +
+				secondParagraphBlockBoundingBox.width / 2,
+			secondParagraphBlockBoundingBox.y - 10
 		);
 
 		// There will be 2 matches here.
@@ -231,13 +229,10 @@ test.describe( 'Widgets screen', () => {
 
 		await expect.poll( widgetsScreen.getWidgetAreaBlocks ).toMatchObject( {
 			'sidebar-1': [
+				{ name: 'core/separator' },
 				{
 					name: 'core/heading',
 					attributes: { content: 'My Heading' },
-				},
-				{
-					name: 'core/paragraph',
-					attributes: { content: 'First Paragraph' },
 				},
 				{
 					name: 'core/paragraph',


### PR DESCRIPTION
## What?

See #81453. The hover inserter between blocks no longer appears where pressing Enter already creates a block: below paragraphs, headings, list items, and other blocks that split.

## Why?

Hovering across text keeps flashing an inserter between every line, and it gets in the way while writing. Below a text block it adds nothing: Enter at the end of the block creates an empty block in the same spot, which shows you an inserter + allows you to insert blocks with the slash command.

## How?

1. In the hook that shows the hover inserter, the boundary is hidden when the block above it splits on Enter (the `splitting` support: paragraph, heading, list item, button) and the container flows vertically. Horizontal rows keep the inserter everywhere, so the Buttons block is unaffected even though buttons split.
2. Clicking the gap between blocks was handled by the insertion point itself, so where it is now hidden, the click handler takes over: the caret moves to the end of the block below the gap, the same place a click on the visible insertion point puts it.
3. Drag and drop indicators, the other inserters, the document edges, and keyboard insertion are untouched.

## Testing Instructions

1. Write a few paragraphs. Hovering between them shows no inserter; clicking between them still places the caret.
2. Add two images. Hovering between them shows the inserter.
3. Add a Buttons block with two buttons. Hovering between the buttons shows the inserter.
4. Drag a block around: the drop indicators are unchanged.

### Testing Instructions for Keyboard

Unchanged: Enter, the slash inserter, and the toolbar inserters work as before.

## Screenshots or screencast

|Between two images|Between two paragraphs|
|-|-|
|<img src="https://github.com/user-attachments/assets/796b2e36-4016-42f0-852e-30c12a66aa6b" width="400" alt="The inserter appears in the gap between two image blocks" />|<img src="https://github.com/user-attachments/assets/35cf8261-f391-4341-a389-3714669ff629" width="400" alt="No inserter appears in the gap between two paragraphs" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)


