### PR TITLE
Notes: Add the review rail for notes on post previews

### DIFF
--- a/lib/experimental/notes-preview.php
+++ b/lib/experimental/notes-preview.php
@@ -20,3 +20,4 @@ require_once __DIR__ . '/notes-preview/class-gutenberg-rest-comments-controller-
 require_once __DIR__ . '/notes-preview/rest-api.php';
 require_once __DIR__ . '/notes-preview/preview-access.php';
 require_once __DIR__ . '/notes-preview/render.php';
+require_once __DIR__ . '/notes-preview/panel.php';

--- a/lib/experimental/notes-preview/panel.php
+++ b/lib/experimental/notes-preview/panel.php
@@ -1,0 +1,469 @@
+<?php
+/**
+ * The review rail rendered on an active preview.
+ *
+ * Threads are rendered server-side, so the reviewer gets the discussion with
+ * the first paint and the front-end module stays small: it handles selection,
+ * keeps cards aligned with the content, and posts replies.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Avatar colours, in the same order as AVATAR_BORDER_COLORS in
+ * packages/editor/src/components/collab-sidebar/utils.js, so a person is the
+ * same colour in the editor and on the preview.
+ *
+ * @var string[]
+ */
+const GUTENBERG_NOTES_PREVIEW_AUTHOR_COLORS = array(
+	'#6F42C1', // Purple.
+	'#D94145', // Red.
+	'#FBBF24', // Orange.
+	'#FF35EE', // Magenta.
+	'#879F11', // Olive.
+	'#0F766E', // Teal.
+	'#00CFFF', // Cyan.
+);
+
+/**
+ * Returns the colour assigned to a note author.
+ *
+ * @param int $user_id User ID.
+ * @return string A `#RRGGBB` hex colour.
+ */
+function gutenberg_notes_preview_author_color( $user_id ) {
+	$colors = GUTENBERG_NOTES_PREVIEW_AUTHOR_COLORS;
+
+	return $colors[ absint( $user_id ) % count( $colors ) ];
+}
+
+/**
+ * Collects the note threads on a post.
+ *
+ * Mirrors the tree building in useNoteThreads(): top-level notes are threads,
+ * their children are replies, and a child carrying `_wp_note_status` is a
+ * resolution record rather than something somebody said.
+ *
+ * @param int $post_id Post ID.
+ * @return array[] Threads, in the order the conversations started.
+ */
+function gutenberg_notes_preview_get_threads( $post_id ) {
+	$comments = get_comments(
+		array(
+			'post_id'                   => $post_id,
+			'type'                      => 'note',
+			'status'                    => 'all',
+			'orderby'                   => 'comment_date_gmt',
+			'order'                     => 'ASC',
+			'update_comment_meta_cache' => true,
+		)
+	);
+
+	$threads  = array();
+	$children = array();
+
+	foreach ( $comments as $comment ) {
+		$parent_id = (int) $comment->comment_parent;
+
+		if ( 0 === $parent_id ) {
+			$threads[ (int) $comment->comment_ID ] = array(
+				'comment'    => $comment,
+				'replies'    => array(),
+				'resolution' => null,
+				'resolved'   => 1 === (int) $comment->comment_approved,
+			);
+			continue;
+		}
+
+		$children[ $parent_id ][] = $comment;
+	}
+
+	foreach ( $children as $parent_id => $replies ) {
+		if ( ! isset( $threads[ $parent_id ] ) ) {
+			continue;
+		}
+
+		foreach ( $replies as $reply ) {
+			$status = get_comment_meta( $reply->comment_ID, '_wp_note_status', true );
+
+			if ( $status ) {
+				$threads[ $parent_id ]['resolution'] = array(
+					'status'  => $status,
+					'comment' => $reply,
+				);
+				continue;
+			}
+
+			$threads[ $parent_id ]['replies'][] = $reply;
+		}
+	}
+
+	return $threads;
+}
+
+/**
+ * Renders a note's body.
+ *
+ * The content was filtered through the comment allowlist on the way in, but it
+ * is filtered again here: a row written by an `unfiltered_html` user, or
+ * straight into the database, has not been through that allowlist.
+ *
+ * @param WP_Comment $comment Comment object.
+ */
+function gutenberg_notes_preview_render_content( $comment ) {
+	$content = wp_kses(
+		$comment->comment_content,
+		wp_kses_allowed_html( 'pre_comment_content' )
+	);
+
+	echo '<div class="wp-notes-preview__content">' . wpautop( $content ) . '</div>';
+}
+
+/**
+ * Renders the avatar, name and age of a note.
+ *
+ * @param WP_Comment $comment Comment object.
+ */
+function gutenberg_notes_preview_render_byline( $comment ) {
+	$avatar = get_avatar_url( $comment, array( 'size' => 48 ) );
+	$posted = strtotime( $comment->comment_date_gmt . ' GMT' );
+
+	?>
+	<div class="wp-notes-preview__byline">
+		<img
+			class="wp-notes-preview__avatar"
+			src="<?php echo esc_url( $avatar ); ?>"
+			alt=""
+			width="24"
+			height="24"
+			loading="lazy"
+			decoding="async"
+		/>
+		<span class="wp-notes-preview__author"><?php echo esc_html( get_comment_author( $comment ) ); ?></span>
+		<time
+			class="wp-notes-preview__time"
+			datetime="<?php echo esc_attr( gmdate( 'c', $posted ) ); ?>"
+		>
+			<?php
+			printf(
+				/* translators: %s: Human-readable time difference, e.g. "2 hours". */
+				esc_html__( '%s ago', 'gutenberg' ),
+				esc_html( human_time_diff( $posted ) )
+			);
+			?>
+		</time>
+	</div>
+	<?php
+}
+
+/**
+ * Renders one thread card.
+ *
+ * @param int   $note_id  Top-level note ID.
+ * @param array $thread   Thread data from gutenberg_notes_preview_get_threads().
+ * @param bool  $can_repl Whether the viewer may reply.
+ */
+function gutenberg_notes_preview_render_thread( $note_id, $thread, $can_repl ) {
+	$comment = $thread['comment'];
+	$color   = gutenberg_notes_preview_author_color( $comment->user_id );
+	$context = array(
+		'noteId'       => (string) $note_id,
+		'replyText'    => '',
+		'isSubmitting' => false,
+		'replyError'   => '',
+	);
+
+	?>
+	<article
+		class="wp-notes-preview__thread"
+		data-note-id="<?php echo esc_attr( (string) $note_id ); ?>"
+		data-author-color="<?php echo esc_attr( $color ); ?>"
+		data-author-avatar="<?php echo esc_url( get_avatar_url( $comment, array( 'size' => 48 ) ) ); ?>"
+		style="--wp-notes-preview-author-color:<?php echo esc_attr( $color ); ?>"
+		tabindex="0"
+		<?php echo wp_interactivity_data_wp_context( $context ); ?>
+		data-wp-class--is-selected="state.isSelected"
+		data-wp-on--click="actions.selectThread"
+	>
+		<?php
+		gutenberg_notes_preview_render_byline( $comment );
+		gutenberg_notes_preview_render_content( $comment );
+
+		if ( ! empty( $thread['replies'] ) ) {
+			echo '<ol class="wp-notes-preview__replies">';
+			foreach ( $thread['replies'] as $reply ) {
+				echo '<li>';
+				gutenberg_notes_preview_render_byline( $reply );
+				gutenberg_notes_preview_render_content( $reply );
+				echo '</li>';
+			}
+			echo '</ol>';
+		}
+
+		if ( $thread['resolved'] && isset( $thread['resolution']['comment'] ) ) {
+			printf(
+				'<p class="wp-notes-preview__resolution">%s</p>',
+				esc_html(
+					sprintf(
+						/* translators: %s: Name of the person who resolved the note. */
+						__( 'Resolved by %s', 'gutenberg' ),
+						get_comment_author( $thread['resolution']['comment'] )
+					)
+				)
+			);
+		}
+
+		if ( $can_repl && ! $thread['resolved'] ) {
+			?>
+			<form class="wp-notes-preview__reply-form" data-wp-on--submit="actions.submitReply">
+				<label class="screen-reader-text" for="wp-notes-preview-reply-<?php echo esc_attr( (string) $note_id ); ?>">
+					<?php esc_html_e( 'Reply to this note', 'gutenberg' ); ?>
+				</label>
+				<textarea
+					id="wp-notes-preview-reply-<?php echo esc_attr( (string) $note_id ); ?>"
+					class="wp-notes-preview__textarea"
+					rows="3"
+					placeholder="<?php esc_attr_e( 'Reply…', 'gutenberg' ); ?>"
+					data-wp-on--input="actions.updateReply"
+				></textarea>
+				<div class="wp-notes-preview__actions">
+					<button
+						type="submit"
+						class="wp-notes-preview__button"
+						data-wp-bind--disabled="!state.canSubmitReply"
+					>
+						<?php esc_html_e( 'Reply', 'gutenberg' ); ?>
+					</button>
+				</div>
+				<p
+					class="wp-notes-preview__error"
+					role="alert"
+					data-wp-text="context.replyError"
+					data-wp-bind--hidden="!context.replyError"
+				></p>
+			</form>
+			<?php
+		}
+		?>
+	</article>
+	<?php
+}
+
+/**
+ * Prints the review rail.
+ *
+ * Hooked late on `wp_footer` so the rail sits at the end of the document and
+ * the theme's own markup is left exactly as it was.
+ */
+function gutenberg_notes_preview_render_panel() {
+	if ( ! gutenberg_notes_preview_is_active() ) {
+		return;
+	}
+
+	$post_id = get_queried_object_id();
+	$threads = gutenberg_notes_preview_get_threads( $post_id );
+
+	$open     = array();
+	$resolved = array();
+
+	foreach ( $threads as $note_id => $thread ) {
+		if ( $thread['resolved'] ) {
+			$resolved[ $note_id ] = $thread;
+		} else {
+			$open[ $note_id ] = $thread;
+		}
+	}
+
+	$can_reply = current_user_can( 'create_post_notes', $post_id );
+
+	wp_interactivity_state(
+		'gutenberg/notes-preview',
+		array(
+			'postId'       => $post_id,
+			'restUrl'      => rest_url( 'wp/v2/comments' ),
+			'restNonce'    => wp_create_nonce( 'wp_rest' ),
+			'canReply'     => $can_reply,
+			'genericError' => __( 'The reply could not be saved. Please try again.', 'gutenberg' ),
+		)
+	);
+
+	$root_context = array(
+		'selectedId'   => '',
+		'showResolved' => false,
+		'isRailOpen'   => false,
+	);
+
+	?>
+	<div
+		class="wp-notes-preview-root"
+		data-wp-interactive="gutenberg/notes-preview"
+		<?php echo wp_interactivity_data_wp_context( $root_context ); ?>
+		data-wp-init--board="callbacks.initBoard"
+	>
+		<div
+			class="wp-notes-preview__indicators"
+			aria-hidden="true"
+			data-label-single="<?php esc_attr_e( 'Show the note on this block', 'gutenberg' ); ?>"
+			<?php /* translators: %d: Number of notes on the block. */ ?>
+			data-label-plural="<?php esc_attr_e( 'Show the %d notes on this block', 'gutenberg' ); ?>"
+		></div>
+
+		<button
+			type="button"
+			class="wp-notes-preview-toggle"
+			data-wp-on--click="actions.toggleRail"
+		>
+			<?php
+			printf(
+				/* translators: %d: Number of unresolved notes. */
+				esc_html( _n( '%d note', '%d notes', count( $open ), 'gutenberg' ) ),
+				count( $open )
+			);
+			?>
+		</button>
+
+		<aside
+			class="wp-notes-preview"
+			aria-label="<?php esc_attr_e( 'Notes on this post', 'gutenberg' ); ?>"
+			data-wp-class--show-resolved="context.showResolved"
+			data-wp-class--is-open="context.isRailOpen"
+		>
+			<div class="wp-notes-preview__header">
+				<h2 class="wp-notes-preview__title"><?php esc_html_e( 'Notes', 'gutenberg' ); ?></h2>
+				<span class="wp-notes-preview__count">
+					<?php
+					printf(
+						/* translators: %d: Number of unresolved notes. */
+						esc_html( _n( '%d open', '%d open', count( $open ), 'gutenberg' ) ),
+						count( $open )
+					);
+					?>
+				</span>
+				<?php if ( $resolved ) : ?>
+					<button
+						type="button"
+						class="wp-notes-preview__button is-tertiary"
+						style="margin-inline-start:auto"
+						data-wp-on--click="actions.toggleResolved"
+						data-wp-bind--aria-expanded="context.showResolved"
+					>
+						<?php
+						printf(
+							/* translators: %d: Number of resolved notes. */
+							esc_html__( 'Resolved (%d)', 'gutenberg' ),
+							count( $resolved )
+						);
+						?>
+					</button>
+				<?php endif; ?>
+			</div>
+
+			<p class="wp-notes-preview__notice">
+				<?php esc_html_e( 'You are viewing the last saved version of this draft.', 'gutenberg' ); ?>
+			</p>
+
+			<div class="wp-notes-preview__scroller">
+				<div class="wp-notes-preview__board">
+					<?php
+					if ( ! $open ) {
+						printf(
+							'<p class="wp-notes-preview__empty">%s</p>',
+							esc_html__( 'No open notes on this post.', 'gutenberg' )
+						);
+					}
+
+					foreach ( $open as $note_id => $thread ) {
+						gutenberg_notes_preview_render_thread( $note_id, $thread, $can_reply );
+					}
+					?>
+				</div>
+
+				<?php if ( $resolved ) : ?>
+					<div class="wp-notes-preview__resolved">
+						<?php
+						foreach ( $resolved as $note_id => $thread ) {
+							gutenberg_notes_preview_render_thread( $note_id, $thread, false );
+						}
+						?>
+					</div>
+				<?php endif; ?>
+			</div>
+		</aside>
+	</div>
+	<?php
+}
+
+add_action( 'wp_footer', 'gutenberg_notes_preview_render_panel', 100 );
+
+/**
+ * Builds the per-note highlight rules.
+ *
+ * Each inline marker is tinted with its author's colour, matching
+ * buildHighlightCss() in the editor: a soft tint at rest, stronger on hover.
+ *
+ * @param array $threads Threads from gutenberg_notes_preview_get_threads().
+ * @return string CSS.
+ */
+function gutenberg_notes_preview_highlight_css( $threads ) {
+	$rules = array();
+
+	foreach ( $threads as $note_id => $thread ) {
+		if ( $thread['resolved'] ) {
+			continue;
+		}
+
+		$color    = gutenberg_notes_preview_author_color( $thread['comment']->user_id );
+		$selector = sprintf( 'mark.wp-note[data-id="%d"]', (int) $note_id );
+
+		$rules[] = sprintf( '%s{background-color:%s40;}', $selector, $color );
+		$rules[] = sprintf(
+			'%1$s:hover,%1$s:focus-within{background-color:%2$s80;}',
+			$selector,
+			$color
+		);
+	}
+
+	return implode( '', $rules );
+}
+
+/**
+ * Loads the rail's assets on an active preview.
+ */
+function gutenberg_notes_preview_enqueue_assets() {
+	if ( ! gutenberg_notes_preview_is_active() ) {
+		return;
+	}
+
+	wp_enqueue_script_module( '@wordpress/notes-preview' );
+	wp_enqueue_style( 'wp-notes-preview' );
+
+	$css = gutenberg_notes_preview_highlight_css(
+		gutenberg_notes_preview_get_threads( get_queried_object_id() )
+	);
+
+	if ( $css ) {
+		wp_add_inline_style( 'wp-notes-preview', $css );
+	}
+}
+
+add_action( 'wp_enqueue_scripts', 'gutenberg_notes_preview_enqueue_assets' );
+
+/**
+ * Flags the document so the page can make room for the rail.
+ *
+ * Printed in the head rather than set from the module, so the content is laid
+ * out at its final width on the first paint.
+ */
+function gutenberg_notes_preview_print_html_class() {
+	if ( ! gutenberg_notes_preview_is_active() ) {
+		return;
+	}
+
+	wp_print_inline_script_tag(
+		'document.documentElement.classList.add("wp-notes-preview-active");',
+		array( 'id' => 'wp-notes-preview-html-class' )
+	);
+}
+
+add_action( 'wp_head', 'gutenberg_notes_preview_print_html_class', 1 );

--- a/lib/experimental/notes-preview/panel.php
+++ b/lib/experimental/notes-preview/panel.php
@@ -49,6 +49,16 @@ function gutenberg_notes_preview_author_color( $user_id ) {
  * @return array[] Threads, in the order the conversations started.
  */
 function gutenberg_notes_preview_get_threads( $post_id ) {
+	static $cache = array();
+
+	$post_id = (int) $post_id;
+
+	// Both the enqueue pass and the render pass want the threads; one query is
+	// enough for either.
+	if ( isset( $cache[ $post_id ] ) ) {
+		return $cache[ $post_id ];
+	}
+
 	$comments = get_comments(
 		array(
 			'post_id'                   => $post_id,
@@ -98,6 +108,8 @@ function gutenberg_notes_preview_get_threads( $post_id ) {
 			$threads[ $parent_id ]['replies'][] = $reply;
 		}
 	}
+
+	$cache[ $post_id ] = $threads;
 
 	return $threads;
 }
@@ -162,9 +174,9 @@ function gutenberg_notes_preview_render_byline( $comment ) {
  *
  * @param int   $note_id  Top-level note ID.
  * @param array $thread   Thread data from gutenberg_notes_preview_get_threads().
- * @param bool  $can_repl Whether the viewer may reply.
+ * @param bool  $can_reply Whether the viewer may reply.
  */
-function gutenberg_notes_preview_render_thread( $note_id, $thread, $can_repl ) {
+function gutenberg_notes_preview_render_thread( $note_id, $thread, $can_reply ) {
 	$comment = $thread['comment'];
 	$color   = gutenberg_notes_preview_author_color( $comment->user_id );
 	$context = array(
@@ -214,7 +226,7 @@ function gutenberg_notes_preview_render_thread( $note_id, $thread, $can_repl ) {
 			);
 		}
 
-		if ( $can_repl && ! $thread['resolved'] ) {
+		if ( $can_reply && ! $thread['resolved'] ) {
 			?>
 			<form class="wp-notes-preview__reply-form" data-wp-on--submit="actions.submitReply">
 				<label class="screen-reader-text" for="wp-notes-preview-reply-<?php echo esc_attr( (string) $note_id ); ?>">
@@ -276,17 +288,6 @@ function gutenberg_notes_preview_render_panel() {
 	}
 
 	$can_reply = current_user_can( 'create_post_notes', $post_id );
-
-	wp_interactivity_state(
-		'gutenberg/notes-preview',
-		array(
-			'postId'       => $post_id,
-			'restUrl'      => rest_url( 'wp/v2/comments' ),
-			'restNonce'    => wp_create_nonce( 'wp_rest' ),
-			'canReply'     => $can_reply,
-			'genericError' => __( 'The reply could not be saved. Please try again.', 'gutenberg' ),
-		)
-	);
 
 	$root_context = array(
 		'selectedId'   => '',
@@ -435,11 +436,30 @@ function gutenberg_notes_preview_enqueue_assets() {
 		return;
 	}
 
+	$post_id = get_queried_object_id();
+
 	wp_enqueue_script_module( '@wordpress/notes-preview' );
 	wp_enqueue_style( 'wp-notes-preview' );
 
+	/*
+	 * Set here rather than alongside the markup: WP_Script_Modules serialises
+	 * the interactivity state on `wp_footer` at priority 10, and the rail
+	 * renders at 100. State added after that point never reaches the page, and
+	 * the reply form would post to nowhere.
+	 */
+	wp_interactivity_state(
+		'gutenberg/notes-preview',
+		array(
+			'postId'       => $post_id,
+			'restUrl'      => rest_url( 'wp/v2/comments' ),
+			'restNonce'    => wp_create_nonce( 'wp_rest' ),
+			'canReply'     => current_user_can( 'create_post_notes', $post_id ),
+			'genericError' => __( 'The reply could not be saved. Please try again.', 'gutenberg' ),
+		)
+	);
+
 	$css = gutenberg_notes_preview_highlight_css(
-		gutenberg_notes_preview_get_threads( get_queried_object_id() )
+		gutenberg_notes_preview_get_threads( $post_id )
 	);
 
 	if ( $css ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17794,6 +17794,10 @@
 			"resolved": "widgets/news",
 			"link": true
 		},
+		"node_modules/@wordpress/notes-preview": {
+			"resolved": "packages/notes-preview",
+			"link": true
+		},
 		"node_modules/@wordpress/notices": {
 			"resolved": "packages/notices",
 			"link": true
@@ -53693,6 +53697,19 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"packages/notes-preview": {
+			"name": "@wordpress/notes-preview",
+			"version": "0.1.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/base-styles": "file:../base-styles",
+				"@wordpress/interactivity": "file:../interactivity"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"packages/notices": {

--- a/packages/notes-preview/CHANGELOG.md
+++ b/packages/notes-preview/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+Initial release.

--- a/packages/notes-preview/README.md
+++ b/packages/notes-preview/README.md
@@ -1,0 +1,49 @@
+# `@wordpress/notes-preview`
+
+The front-end review surface for notes on a post preview. It renders nothing on
+its own: the rail's markup is produced by PHP, and this module makes it work.
+
+Part of the reviewer workflow in
+[#73418](https://github.com/WordPress/gutenberg/issues/73418), behind the
+`gutenberg-notes-on-previews` experiment.
+
+## What it does
+
+- Lines each thread card up with the block or the inline marker it is about, the
+  way a margin comment does in a document editor. The selected card is pinned
+  exactly to its anchor and the rest give way to it.
+- Draws an indicator over each noted block, in its own layer, so no theme markup
+  is touched.
+- Marks the anchored block and its inline highlight when a thread is selected.
+- Posts replies to `/wp/v2/comments` with the REST nonce the page carries.
+
+## What it does not do
+
+- Start a new thread. That writes `metadata.noteId` into `post_content`, which is
+  a change to the post, and a reviewer is precisely somebody who may not make
+  one.
+- Resolve or reopen. Those stay with people who can edit the post.
+- Update live. The rail is a snapshot of the last save; a reload brings it
+  current.
+
+## Layout
+
+Cards are positioned in document space and the board is translated as the page
+scrolls, so a card tracks its anchor without repositioning every card on every
+frame. Below 1100px there is no room to align anything, so the rail becomes a
+drawer and the cards an ordinary list.
+
+`calculateThreadTops()` is exported and pure, so the placement rules can be
+tested without a DOM.
+
+## Installation
+
+Install the module:
+
+```bash
+npm install @wordpress/notes-preview --save
+```
+
+_This package assumes that your code will run in an **ES2015+** environment._
+
+<br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/notes-preview/package.json
+++ b/packages/notes-preview/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@wordpress/notes-preview",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Front-end review surface for reading and replying to notes on a post preview.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"notes",
+		"comments",
+		"preview"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/notes-preview/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/notes-preview"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": ">=18.12.0",
+		"npm": ">=8.19.2"
+	},
+	"files": [
+		"src",
+		"build",
+		"build-module",
+		"build-types",
+		"*.md"
+	],
+	"main": "build/index.cjs",
+	"module": "build-module/index.mjs",
+	"exports": {
+		".": {
+			"import": "./build-module/index.mjs",
+			"require": "./build/index.cjs"
+		},
+		"./package.json": "./package.json",
+		"./build-style/*": "./build-style/*"
+	},
+	"wpScript": true,
+	"wpScriptModuleExports": {
+		".": "./build-module/index.mjs"
+	},
+	"dependencies": {
+		"@wordpress/base-styles": "file:../base-styles",
+		"@wordpress/interactivity": "file:../interactivity"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/notes-preview/src/board.ts
+++ b/packages/notes-preview/src/board.ts
@@ -1,0 +1,365 @@
+/**
+ * Keeps the review rail lined up with the post.
+ *
+ * Cards are placed in document space rather than viewport space, so they scroll
+ * with the content they annotate and no scroll listener is needed. Only a
+ * change in layout - a resize, a font loading, an image settling - can move an
+ * anchor, and a ResizeObserver covers those.
+ */
+
+import { calculateThreadTops, parseNoteIds, type ThreadAnchor } from './layout';
+
+const NOTE_BLOCK_SELECTOR = '[data-wp-note-id]';
+
+/** Below this width the rail becomes a drawer and cards stop being aligned. */
+export const FLOAT_BREAKPOINT = 1100;
+
+export interface BoardHandle {
+	measure: () => void;
+	setSelected: ( id: string | null ) => void;
+	scrollToAnchor: ( id: string ) => void;
+	destroy: () => void;
+}
+
+/**
+ * Finds the element a note points at.
+ *
+ * An inline note anchors to its own marker so the card lines up with the noted
+ * words rather than the whole paragraph. A marker split across several runs
+ * resolves to its first run. A block note has no marker and anchors to the
+ * block itself.
+ *
+ * @param block  Block element carrying the note.
+ * @param noteId Note ID.
+ * @return The element to align against.
+ */
+function resolveAnchor( block: HTMLElement, noteId: string ): HTMLElement {
+	const marker = block.querySelector< HTMLElement >(
+		`mark.wp-note[data-id="${ noteId }"]`
+	);
+
+	return marker ?? block;
+}
+
+/**
+ * Wires up the rail for a preview page.
+ *
+ * @param root     The `.wp-notes-preview` root element.
+ * @param onSelect Called with a note ID when an indicator is activated.
+ * @return Handle for driving and tearing down the board.
+ */
+export function createBoard(
+	root: HTMLElement,
+	onSelect: ( id: string ) => void
+): BoardHandle {
+	const boardEl = root.querySelector< HTMLElement >(
+		'.wp-notes-preview__board'
+	);
+	const indicatorLayer = root.querySelector< HTMLElement >(
+		'.wp-notes-preview__indicators'
+	);
+
+	let selectedId: string | null = null;
+	let frame = 0;
+
+	/** Anchor element for every note that has one, keyed by note ID. */
+	const anchors = new Map< string, HTMLElement >();
+
+	// Only threads on the aligned board take part in layout. Resolved threads
+	// live in their own list and would otherwise push open threads off their
+	// anchors.
+	const cards = new Map< string, HTMLElement >();
+	for ( const card of root.querySelectorAll< HTMLElement >(
+		'.wp-notes-preview__board .wp-notes-preview__thread[data-note-id]'
+	) ) {
+		cards.set( card.dataset.noteId as string, card );
+	}
+
+	/**
+	 * Builds one indicator per noted block, showing the avatars of the notes on
+	 * it. The indicator lives in its own layer rather than inside the block, so
+	 * no theme markup is touched.
+	 */
+	function buildIndicators(): void {
+		if ( ! indicatorLayer ) {
+			return;
+		}
+
+		indicatorLayer.replaceChildren();
+
+		for ( const block of document.querySelectorAll< HTMLElement >(
+			NOTE_BLOCK_SELECTOR
+		) ) {
+			const ids = parseNoteIds( block.dataset.wpNoteId ?? null );
+			const known = ids.filter( ( id ) => cards.has( id ) );
+
+			if ( ! known.length ) {
+				continue;
+			}
+
+			const button = document.createElement( 'button' );
+			button.type = 'button';
+			button.className = 'wp-notes-preview__indicator';
+			button.dataset.noteId = known[ 0 ];
+			// Labels are rendered by PHP so they arrive translated; this module
+			// carries no strings of its own.
+			const template =
+				known.length === 1
+					? indicatorLayer.dataset.labelSingle ?? ''
+					: indicatorLayer.dataset.labelPlural ?? '';
+
+			button.setAttribute(
+				'aria-label',
+				template.replace( '%d', String( known.length ) )
+			);
+
+			for ( const id of known.slice( 0, 3 ) ) {
+				const card = cards.get( id ) as HTMLElement;
+				const avatar = document.createElement( 'span' );
+				avatar.className = 'wp-notes-preview__indicator-avatar';
+				avatar.style.backgroundImage = `url(${ card.dataset.authorAvatar })`;
+				avatar.style.borderColor = card.dataset.authorColor as string;
+				button.append( avatar );
+			}
+
+			if ( known.length > 3 ) {
+				const overflow = document.createElement( 'span' );
+				overflow.className = 'wp-notes-preview__indicator-overflow';
+				overflow.textContent = `+${ known.length - 3 }`;
+				button.append( overflow );
+			}
+
+			button.addEventListener( 'click', () =>
+				onSelect( button.dataset.noteId as string )
+			);
+
+			indicatorLayer.append( button );
+		}
+	}
+
+	/** Finds the anchor element for every note that has one. */
+	function readAnchors(): void {
+		anchors.clear();
+
+		const remember = ( id: string, element: HTMLElement ): void => {
+			if ( cards.has( id ) && ! anchors.has( id ) ) {
+				anchors.set( id, element );
+			}
+		};
+
+		for ( const block of document.querySelectorAll< HTMLElement >(
+			NOTE_BLOCK_SELECTOR
+		) ) {
+			for ( const id of parseNoteIds( block.dataset.wpNoteId ?? null ) ) {
+				remember( id, resolveAnchor( block, id ) );
+			}
+		}
+
+		// An inline note whose block lost its `metadata.noteId` still has its
+		// marker in the content, and the marker is the better anchor anyway.
+		for ( const marker of document.querySelectorAll< HTMLElement >(
+			'mark.wp-note[data-id]'
+		) ) {
+			remember( marker.dataset.id as string, marker );
+		}
+	}
+
+	/** Measures where the anchors sit, in document space. */
+	function anchorTops(): ThreadAnchor[] {
+		const scrollY = window.scrollY;
+
+		return Array.from( anchors, ( [ id, element ] ) => ( {
+			id,
+			top: element.getBoundingClientRect().top + scrollY,
+		} ) );
+	}
+
+	/**
+	 * Positions the indicators against their blocks.
+	 *
+	 * Both coordinates are set from the anchor's own box rather than from a
+	 * CSS edge: an absolutely positioned element resolves against the viewport,
+	 * which is the far side of the rail, and the right edge of the content
+	 * column is where the indicator belongs.
+	 */
+	function placeIndicators(): void {
+		if ( ! indicatorLayer ) {
+			return;
+		}
+
+		const scrollX = window.scrollX;
+		const scrollY = window.scrollY;
+
+		for ( const button of indicatorLayer.querySelectorAll< HTMLElement >(
+			'.wp-notes-preview__indicator'
+		) ) {
+			const anchor = anchors.get( button.dataset.noteId as string );
+
+			if ( ! anchor ) {
+				button.hidden = true;
+				continue;
+			}
+
+			const block =
+				anchor.closest< HTMLElement >( NOTE_BLOCK_SELECTOR ) ?? anchor;
+			const rect = block.getBoundingClientRect();
+
+			button.hidden = false;
+			button.style.top = `${ rect.top + scrollY }px`;
+			button.style.left = `${ rect.right + scrollX + 8 }px`;
+		}
+	}
+
+	/** Re-reads the page and repositions everything. */
+	function measure(): void {
+		if ( ! boardEl ) {
+			return;
+		}
+
+		// The admin bar is fixed to the top of the viewport and would otherwise
+		// sit over the rail's header. Measured rather than assumed: its height
+		// changes with the viewport and a theme may not show it at all.
+		const adminBar = document.getElementById( 'wpadminbar' );
+		root.style.setProperty(
+			'--wp-notes-preview-admin-bar',
+			`${ adminBar?.offsetHeight ?? 0 }px`
+		);
+
+		const floating = window.innerWidth >= FLOAT_BREAKPOINT;
+		root.classList.toggle( 'is-floating', floating );
+
+		readAnchors();
+
+		// Threads whose block was deleted have nothing to line up with. They
+		// stay in the rail, listed under their own heading, rather than
+		// vanishing.
+		for ( const [ id, card ] of cards ) {
+			card.classList.toggle( 'is-unanchored', ! anchors.has( id ) );
+		}
+
+		placeIndicators();
+
+		if ( ! floating ) {
+			for ( const card of cards.values() ) {
+				card.style.top = '';
+			}
+			boardEl.style.height = '';
+			return;
+		}
+
+		const heights: Record< string, number > = {};
+		for ( const [ id, card ] of cards ) {
+			heights[ id ] = card.offsetHeight;
+		}
+
+		const tops = calculateThreadTops( {
+			anchors: anchorTops(),
+			heights,
+			selectedId,
+		} );
+
+		/*
+		 * Card tops are document-space, but the board sits below the rail's
+		 * header inside a fixed panel. Subtracting the scroller's viewport top
+		 * - a constant, since the rail is fixed - converts one to the other.
+		 * The board's own scroll translation supplies the rest.
+		 */
+		const origin = boardEl.parentElement?.getBoundingClientRect().top ?? 0;
+
+		for ( const [ id, top ] of Object.entries( tops ) ) {
+			cards.get( id )?.style.setProperty( 'top', `${ top - origin }px` );
+		}
+
+		boardEl.style.height = '';
+	}
+
+	/**
+	 * Tracks the page scroll.
+	 *
+	 * Card tops are document-space but the rail is fixed, so the board is
+	 * translated to bring the two back into agreement. One property write per
+	 * frame, rather than repositioning every card.
+	 */
+	function applyScroll(): void {
+		root.style.setProperty(
+			'--wp-notes-preview-scroll',
+			`${ -window.scrollY }px`
+		);
+	}
+
+	/** Coalesces bursts of layout changes into one paint. */
+	function schedule(): void {
+		window.cancelAnimationFrame( frame );
+		frame = window.requestAnimationFrame( () => {
+			measure();
+			applyScroll();
+		} );
+	}
+
+	/**
+	 * Marks the block a note belongs to, so the connection between a card and
+	 * the content it is about survives the eye travelling between them.
+	 *
+	 * @param id Selected note ID, or null to clear.
+	 */
+	function markSelectedBlock( id: string | null ): void {
+		for ( const block of document.querySelectorAll< HTMLElement >(
+			NOTE_BLOCK_SELECTOR
+		) ) {
+			block.classList.remove( 'is-note-selected' );
+			block.style.removeProperty( '--wp-notes-preview-author-color' );
+		}
+
+		if ( ! id ) {
+			return;
+		}
+
+		const block = anchors
+			.get( id )
+			?.closest< HTMLElement >( NOTE_BLOCK_SELECTOR );
+
+		if ( ! block ) {
+			return;
+		}
+
+		block.classList.add( 'is-note-selected' );
+		block.style.setProperty(
+			'--wp-notes-preview-author-color',
+			cards.get( id )?.dataset.authorColor ?? ''
+		);
+	}
+
+	function setSelected( id: string | null ): void {
+		selectedId = id;
+		markSelectedBlock( id );
+		schedule();
+	}
+
+	function scrollToAnchor( id: string ): void {
+		anchors
+			.get( id )
+			?.scrollIntoView( { block: 'center', behavior: 'smooth' } );
+	}
+
+	const observer = new window.ResizeObserver( schedule );
+	observer.observe( document.body );
+
+	const passive = { passive: true } as const;
+	window.addEventListener( 'resize', schedule, passive );
+	window.addEventListener( 'scroll', applyScroll, passive );
+
+	buildIndicators();
+	schedule();
+
+	return {
+		measure: schedule,
+		setSelected,
+		scrollToAnchor,
+		destroy() {
+			window.cancelAnimationFrame( frame );
+			observer.disconnect();
+			window.removeEventListener( 'resize', schedule );
+			window.removeEventListener( 'scroll', applyScroll );
+		},
+	};
+}

--- a/packages/notes-preview/src/index.ts
+++ b/packages/notes-preview/src/index.ts
@@ -1,0 +1,196 @@
+/**
+ * Review rail for notes on a post preview.
+ *
+ * The markup is rendered by PHP; this module handles selection, keeps the
+ * cards lined up with the content, and posts replies. It depends on the
+ * Interactivity API and nothing else, so a preview page stays light.
+ */
+
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import { createBoard, type BoardHandle } from './board';
+
+export type { ThreadAnchor, LayoutOptions } from './layout';
+export { calculateThreadTops, parseNoteIds } from './layout';
+
+const NAMESPACE = 'gutenberg/notes-preview';
+
+interface NotesPreviewState {
+	postId: number;
+	restUrl: string;
+	restNonce: string;
+	canReply: boolean;
+	genericError: string;
+}
+
+interface RootContext {
+	selectedId: string;
+	showResolved: boolean;
+	isRailOpen: boolean;
+}
+
+interface ThreadContext extends RootContext {
+	noteId: string;
+	replyText: string;
+	isSubmitting: boolean;
+	replyError: string;
+}
+
+let board: BoardHandle | null = null;
+
+/**
+ * Turns a rejected REST response into something worth showing a person.
+ *
+ * A REST error arrives as a plain object rather than an Error, and a network
+ * failure arrives as neither, so neither `instanceof Error` nor string
+ * interpolation can be trusted here.
+ *
+ * @param error    Whatever the request rejected with.
+ * @param fallback Copy to use when the error carries no message.
+ * @return A message to display.
+ */
+function toMessage( error: unknown, fallback: string ): string {
+	if ( typeof error === 'string' && error ) {
+		return error;
+	}
+
+	if (
+		error &&
+		typeof error === 'object' &&
+		typeof ( error as { message?: unknown } ).message === 'string'
+	) {
+		return ( error as { message: string } ).message;
+	}
+
+	return fallback;
+}
+
+const { state } = store( NAMESPACE, {
+	state: {
+		get isSelected(): boolean {
+			const context = getContext< ThreadContext >();
+			return !! context.noteId && context.selectedId === context.noteId;
+		},
+
+		get hasSelection(): boolean {
+			return !! getContext< RootContext >().selectedId;
+		},
+
+		get canSubmitReply(): boolean {
+			const context = getContext< ThreadContext >();
+			return ! context.isSubmitting && context.replyText.trim() !== '';
+		},
+	},
+
+	actions: {
+		selectThread(): void {
+			const context = getContext< ThreadContext >();
+			const { ref } = getElement();
+			const noteId =
+				context.noteId ?? ( ref as HTMLElement )?.dataset?.noteId ?? '';
+
+			if ( ! noteId ) {
+				return;
+			}
+
+			context.selectedId = noteId;
+			board?.setSelected( noteId );
+			board?.scrollToAnchor( noteId );
+		},
+
+		clearSelection(): void {
+			getContext< RootContext >().selectedId = '';
+			board?.setSelected( null );
+		},
+
+		toggleResolved(): void {
+			const context = getContext< RootContext >();
+			context.showResolved = ! context.showResolved;
+			board?.measure();
+		},
+
+		toggleRail(): void {
+			const context = getContext< RootContext >();
+			context.isRailOpen = ! context.isRailOpen;
+		},
+
+		updateReply( event: InputEvent ): void {
+			const context = getContext< ThreadContext >();
+			context.replyText = ( event.target as HTMLTextAreaElement ).value;
+		},
+
+		*submitReply(
+			event: SubmitEvent
+		): Generator< unknown, void, unknown > {
+			event.preventDefault();
+
+			const context = getContext< ThreadContext >();
+			const content = context.replyText.trim();
+
+			if ( ! content || context.isSubmitting ) {
+				return;
+			}
+
+			context.isSubmitting = true;
+			context.replyError = '';
+
+			try {
+				const response = ( yield fetch( state.restUrl, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': state.restNonce,
+					},
+					body: JSON.stringify( {
+						post: state.postId,
+						parent: Number( context.noteId ),
+						type: 'note',
+						status: 'hold',
+						content,
+					} ),
+				} ) ) as Response;
+
+				const body = ( yield response.json() ) as Record<
+					string,
+					unknown
+				>;
+
+				if ( ! response.ok ) {
+					throw body;
+				}
+
+				// The rail is server-rendered, so the simplest way to show the
+				// reply in place - with its avatar, byline and formatting - is
+				// to ask the server for the page again.
+				window.location.reload();
+			} catch ( error ) {
+				context.replyError = toMessage( error, state.genericError );
+				context.isSubmitting = false;
+			}
+		},
+	},
+
+	callbacks: {
+		initBoard(): () => void {
+			const { ref } = getElement();
+			const context = getContext< RootContext >();
+
+			board = createBoard( ref as HTMLElement, ( noteId ) => {
+				context.selectedId = noteId;
+				board?.setSelected( noteId );
+			} );
+
+			return () => {
+				board?.destroy();
+				board = null;
+			};
+		},
+	},
+} ) as unknown as {
+	/*
+	 * The derived getters above are only half of the state; the rest is printed
+	 * by wp_interactivity_state() on the server and merged in at runtime, so
+	 * the inferred type is narrower than what actually exists.
+	 */
+	state: NotesPreviewState;
+};

--- a/packages/notes-preview/src/layout.ts
+++ b/packages/notes-preview/src/layout.ts
@@ -1,0 +1,124 @@
+/**
+ * Vertical placement for the thread cards in the review rail.
+ *
+ * Cards want to sit level with the thing they are about, the way a margin
+ * comment does in Google Docs, but two notes on adjacent paragraphs would
+ * overlap. The selected card is pinned exactly to its anchor and the rest are
+ * pushed away from it, so the card you are reading is always the one that is
+ * correctly aligned.
+ *
+ * Pure and document-space, so it can be unit tested without a DOM and so the
+ * caller can translate the whole board on scroll rather than recomputing.
+ */
+
+export interface ThreadAnchor {
+	/** Note ID, as a string, matching the card's `data-note-id`. */
+	id: string;
+	/** Document-space top of the anchor element. */
+	top: number;
+}
+
+export interface LayoutOptions {
+	/** Anchors in any order; sorted by `top` internally. */
+	anchors: ThreadAnchor[];
+	/** Measured card heights, keyed by note ID. */
+	heights: Record< string, number >;
+	/** Note ID of the selected thread, if any. */
+	selectedId?: string | null;
+	/** Minimum vertical space between two cards. */
+	gap?: number;
+	/** Nudge applied so a card's first line sits level with its anchor. */
+	alignOffset?: number;
+}
+
+export const DEFAULT_GAP = 12;
+export const DEFAULT_ALIGN_OFFSET = -4;
+
+/**
+ * Places each thread card in document space.
+ *
+ * @param options             Layout options.
+ * @param options.anchors
+ * @param options.heights
+ * @param options.selectedId
+ * @param options.gap
+ * @param options.alignOffset
+ * @return Document-space top for each note ID.
+ */
+export function calculateThreadTops( {
+	anchors,
+	heights,
+	selectedId = null,
+	gap = DEFAULT_GAP,
+	alignOffset = DEFAULT_ALIGN_OFFSET,
+}: LayoutOptions ): Record< string, number > {
+	const tops: Record< string, number > = {};
+
+	if ( ! anchors.length ) {
+		return tops;
+	}
+
+	const ordered = [ ...anchors ].sort( ( a, b ) => a.top - b.top );
+
+	// The selected card is the one that gets to be exactly right; everything
+	// else gives way to it. With nothing selected the topmost card holds that
+	// position, so the page reads top-down.
+	const anchorIndex = Math.max(
+		0,
+		ordered.findIndex( ( anchor ) => anchor.id === selectedId )
+	);
+
+	const pinned = ordered[ anchorIndex ];
+	tops[ pinned.id ] = pinned.top + alignOffset;
+
+	// Downward: a card may sit at its anchor unless that would collide with
+	// the card above it, in which case it follows on directly.
+	let previousTop = tops[ pinned.id ];
+	let previousHeight = heights[ pinned.id ] ?? 0;
+
+	for ( let i = anchorIndex + 1; i < ordered.length; i++ ) {
+		const { id, top } = ordered[ i ];
+		const placed = Math.max(
+			top + alignOffset,
+			previousTop + previousHeight + gap
+		);
+
+		tops[ id ] = placed;
+		previousTop = placed;
+		previousHeight = heights[ id ] ?? 0;
+	}
+
+	// Upward: the mirror image, walking back towards the top of the page.
+	let nextTop = tops[ pinned.id ];
+
+	for ( let i = anchorIndex - 1; i >= 0; i-- ) {
+		const { id, top } = ordered[ i ];
+		const height = heights[ id ] ?? 0;
+		const placed = Math.min( top + alignOffset, nextTop - gap - height );
+
+		tops[ id ] = placed;
+		nextTop = placed;
+	}
+
+	return tops;
+}
+
+/**
+ * Splits a `data-wp-note-id` attribute into note IDs.
+ *
+ * A block can carry several notes, in which case the attribute is a comma
+ * separated list.
+ *
+ * @param value Raw attribute value.
+ * @return Note IDs, as strings, with blanks dropped.
+ */
+export function parseNoteIds( value: string | null ): string[] {
+	if ( ! value ) {
+		return [];
+	}
+
+	return value
+		.split( ',' )
+		.map( ( id ) => id.trim() )
+		.filter( ( id ) => /^\d+$/.test( id ) );
+}

--- a/packages/notes-preview/src/style.scss
+++ b/packages/notes-preview/src/style.scss
@@ -1,0 +1,480 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+/**
+ * Review rail for notes on a post preview.
+ *
+ * The rail is a review tool sitting beside somebody else's design, so it takes
+ * nothing from the theme and gives nothing back: every property the cards rely
+ * on is stated here, and the page keeps its own styling untouched. Layout
+ * follows the editor's notes sidebar - grey cards, white when selected, author
+ * colour on the avatar - so a note looks the same wherever it is read.
+ */
+
+$notes-rail-width: 336px;
+$notes-rail-breakpoint: 1100px;
+
+// Reserve the rail's width so the theme reflows rather than sliding underneath.
+html.wp-notes-preview-active {
+	@media (min-width: $notes-rail-breakpoint) {
+		margin-inline-end: $notes-rail-width;
+	}
+}
+
+// Defined on the wrapper so the rail, the indicators over the page and the
+// mobile toggle all share one accent.
+.wp-notes-preview-root {
+	--wp-notes-preview-accent: #3858e9;
+}
+
+.wp-notes-preview {
+	position: fixed;
+	// The admin bar is fixed over the viewport; the board measures it.
+	inset-block-start: var(--wp-notes-preview-admin-bar, 0);
+	inset-block-end: 0;
+	inset-inline-end: 0;
+	z-index: 99998;
+	display: flex;
+	flex-direction: column;
+	width: $notes-rail-width;
+	background: $white;
+	border-inline-start: $border-width solid $gray-300;
+	box-sizing: border-box;
+
+	// Stated rather than inherited: a theme's body font, size or line height
+	// would otherwise reflow the cards.
+	font-family: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans, ubuntu, cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	line-height: 1.5;
+	color: $gray-900;
+	text-align: start;
+
+	*,
+	*::before,
+	*::after {
+		box-sizing: border-box;
+	}
+
+	p {
+		margin: 0 0 0.6em;
+		font-size: inherit;
+		line-height: inherit;
+		color: inherit;
+
+		&:last-child {
+			margin-block-end: 0;
+		}
+	}
+
+	@media (max-width: #{$notes-rail-breakpoint - 1px}) {
+		transform: translateX(100%);
+		transition: transform 0.2s ease-in-out;
+
+		&.is-open {
+			transform: none;
+			box-shadow: $elevation-medium;
+		}
+	}
+}
+
+/**
+ * Header. Pinned, so the count and the resolved toggle stay reachable however
+ * far down the post the reader has scrolled.
+ */
+.wp-notes-preview__header {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	gap: $grid-unit-10;
+	padding: $grid-unit-15 $grid-unit-20;
+	border-block-end: $border-width solid $gray-300;
+}
+
+.wp-notes-preview__title {
+	margin: 0;
+	padding: 0;
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.5;
+	color: inherit;
+}
+
+.wp-notes-preview__count {
+	color: $gray-700;
+}
+
+.wp-notes-preview__notice {
+	flex: 0 0 auto;
+	padding: $grid-unit-10 $grid-unit-20;
+	border-block-end: $border-width solid $gray-300;
+	background: $gray-100;
+	color: $gray-700;
+	font-size: 12px;
+}
+
+/**
+ * The board. Cards are placed in document space by the layout module and the
+ * whole board is translated as the page scrolls, so each card tracks the words
+ * it is about.
+ */
+.wp-notes-preview__scroller {
+	position: relative;
+	flex: 1 1 auto;
+	overflow: hidden;
+}
+
+.wp-notes-preview__board {
+	position: relative;
+	padding-block: $grid-unit-15;
+}
+
+.wp-notes-preview-root.is-floating .wp-notes-preview__board {
+	padding-block: 0;
+	transform: translateY(var(--wp-notes-preview-scroll, 0));
+	will-change: transform;
+}
+
+// Without alignment - narrow viewports - the rail is an ordinary scrolling list.
+.wp-notes-preview-root:not(.is-floating) .wp-notes-preview__scroller {
+	overflow-y: auto;
+}
+
+.wp-notes-preview__thread {
+	position: relative;
+	margin: 0 $grid-unit-20 $grid-unit-15;
+	padding: $grid-unit-20;
+	border: $border-width solid $gray-300;
+	border-radius: $radius-large;
+	background: $gray-100;
+	// stylelint-disable-next-line declaration-property-value-disallowed-list -- var( --wpds-cursor-control ) is defined by the admin styles, which a front-end preview does not load.
+	cursor: pointer;
+	transition: background-color 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+
+	&:hover {
+		background: $white;
+	}
+
+	// A thread whose block was deleted has nothing to line up with; it keeps
+	// its place in the list rather than disappearing.
+	&.is-unanchored {
+		cursor: default;
+		opacity: 0.7;
+	}
+
+	&.is-selected {
+		z-index: 1;
+		background: $white;
+		box-shadow: $elevation-medium;
+
+		// Ties the card to its highlight and its author's avatar.
+		&::before {
+			content: "";
+			position: absolute;
+			inset-block: -$border-width;
+			inset-inline-start: -$border-width;
+			width: 3px;
+			border-start-start-radius: $radius-large;
+			border-end-start-radius: $radius-large;
+			background: var(--wp-notes-preview-author-color, var(--wp-notes-preview-accent));
+		}
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-notes-preview-accent);
+		outline-offset: 1px;
+	}
+}
+
+.wp-notes-preview-root.is-floating .wp-notes-preview__thread {
+	position: absolute;
+	inset-inline: $grid-unit-20;
+	margin: 0;
+	// Long threads on short posts still need their reply box reachable.
+	max-height: 90vh;
+	overflow-y: auto;
+}
+
+/**
+ * Byline, content and replies.
+ */
+.wp-notes-preview__byline {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	margin-block-end: $grid-unit-10;
+}
+
+.wp-notes-preview__avatar {
+	flex-shrink: 0;
+	width: 24px;
+	height: 24px;
+	padding: 1px;
+	border: 2px solid var(--wp-notes-preview-author-color, $gray-300);
+	border-radius: $radius-round;
+	background: $white;
+}
+
+.wp-notes-preview__author {
+	font-weight: 600;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wp-notes-preview__time {
+	margin-inline-start: auto;
+	flex-shrink: 0;
+	color: $gray-700;
+	font-size: 12px;
+}
+
+.wp-notes-preview__content {
+	overflow-wrap: break-word;
+
+	a {
+		color: var(--wp-notes-preview-accent);
+	}
+
+	code {
+		padding: 0 2px;
+		border-radius: 2px;
+		background: $gray-200;
+		font-family: menlo, consolas, monaco, monospace;
+		font-size: 0.9em;
+	}
+}
+
+.wp-notes-preview__replies {
+	margin: $grid-unit-15 0 0;
+	padding: $grid-unit-15 0 0;
+	border-block-start: $border-width solid $gray-300;
+	list-style: none;
+
+	> li + li {
+		margin-block-start: $grid-unit-15;
+	}
+}
+
+.wp-notes-preview__mention,
+.wp-note-mention {
+	display: inline;
+	padding: 0 3px;
+	border-radius: 2px;
+	background: rgba(56, 88, 233, 0.1);
+	color: var(--wp-notes-preview-accent);
+	font-weight: 600;
+}
+
+/**
+ * Reply form. Only the selected thread offers one, which keeps the rail quiet
+ * and makes the selection meaningful.
+ */
+.wp-notes-preview__reply-form {
+	display: none;
+	margin-block-start: $grid-unit-15;
+}
+
+.wp-notes-preview__thread.is-selected .wp-notes-preview__reply-form {
+	display: block;
+}
+
+.wp-notes-preview__textarea {
+	display: block;
+	width: 100%;
+	min-height: 60px;
+	margin: 0 0 $grid-unit-10;
+	padding: $grid-unit-10;
+	border: $border-width solid $gray-400;
+	border-radius: $radius-small;
+	background: $white;
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	resize: vertical;
+
+	&:focus {
+		border-color: var(--wp-notes-preview-accent);
+		outline: 1px solid var(--wp-notes-preview-accent);
+	}
+}
+
+.wp-notes-preview__actions {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+}
+
+.wp-notes-preview__button {
+	padding: 6px 12px;
+	border: $border-width solid transparent;
+	border-radius: $radius-small;
+	background: var(--wp-notes-preview-accent);
+	color: $white;
+	font-family: inherit;
+	font-size: 13px;
+	line-height: 1.5;
+	// stylelint-disable-next-line declaration-property-value-disallowed-list -- var( --wpds-cursor-control ) is defined by the admin styles, which a front-end preview does not load.
+	cursor: pointer;
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	&.is-tertiary {
+		background: transparent;
+		color: var(--wp-notes-preview-accent);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-notes-preview-accent);
+		outline-offset: 1px;
+	}
+}
+
+.wp-notes-preview__error {
+	margin-block-start: $grid-unit-10;
+	color: $alert-red;
+	font-size: 12px;
+}
+
+.wp-notes-preview__empty {
+	padding: $grid-unit-30 $grid-unit-20;
+	color: $gray-700;
+	text-align: center;
+}
+
+/**
+ * Resolved threads, kept out of the aligned board so they never push an open
+ * thread out of position. The header toggle slides them over the board.
+ */
+.wp-notes-preview__resolved {
+	position: absolute;
+	inset: 0;
+	z-index: 4;
+	display: none;
+	overflow-y: auto;
+	padding-block: $grid-unit-15;
+	background: $white;
+}
+
+.wp-notes-preview.show-resolved .wp-notes-preview__resolved {
+	display: block;
+}
+
+.wp-notes-preview__resolution {
+	margin-block-start: $grid-unit-10;
+	color: $gray-700;
+	font-style: italic;
+	font-size: 12px;
+}
+
+/**
+ * Mobile toggle.
+ */
+.wp-notes-preview-toggle {
+	position: fixed;
+	inset-block-end: $grid-unit-20;
+	inset-inline-end: $grid-unit-20;
+	z-index: 99999;
+	display: none;
+	align-items: center;
+	gap: $grid-unit-05;
+	padding: 10px 16px;
+	border: 0;
+	border-radius: $radius-full;
+	background: var(--wp-notes-preview-accent, #3858e9);
+	box-shadow: $elevation-medium;
+	color: $white;
+	font-family: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, sans-serif;
+	font-size: 13px;
+	// stylelint-disable-next-line declaration-property-value-disallowed-list -- var( --wpds-cursor-control ) is defined by the admin styles, which a front-end preview does not load.
+	cursor: pointer;
+
+	@media (max-width: #{$notes-rail-breakpoint - 1px}) {
+		display: flex;
+	}
+}
+
+/**
+ * On the page itself: the indicator layer and the anchors.
+ */
+// A zero-sized layer at the document origin: each indicator is then placed in
+// document coordinates taken from the block it belongs to, which is the only
+// thing that survives arbitrary theme layouts.
+.wp-notes-preview__indicators {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 0;
+	height: 0;
+	z-index: 99997;
+	pointer-events: none;
+}
+
+.wp-notes-preview__indicator {
+	position: absolute;
+	display: flex;
+	align-items: center;
+	padding: 2px;
+	border: 0;
+	border-radius: $radius-full;
+	background: transparent;
+	// stylelint-disable-next-line declaration-property-value-disallowed-list -- var( --wpds-cursor-control ) is defined by the admin styles, which a front-end preview does not load.
+	cursor: pointer;
+	pointer-events: auto;
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-notes-preview-accent, #3858e9);
+		outline-offset: 2px;
+	}
+}
+
+.wp-notes-preview__indicator-avatar {
+	width: 24px;
+	height: 24px;
+	margin-inline-start: -8px;
+	padding: 1px;
+	border: 2px solid $gray-300;
+	border-radius: $radius-round;
+	background-color: $white;
+	background-position: center;
+	background-size: cover;
+	box-sizing: border-box;
+
+	&:first-child {
+		margin-inline-start: 0;
+	}
+}
+
+.wp-notes-preview__indicator-overflow {
+	margin-inline-start: 4px;
+	color: $gray-700;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+// Inline note markers. The per-author tint is printed by PHP; this only undoes
+// the browser's yellow default and carries the shared transition.
+mark.wp-note {
+	background-color: transparent;
+	color: inherit;
+	border-radius: 1px;
+	transition: background-color 0.1s ease-in-out;
+}
+
+// The block a selected note belongs to.
+[data-wp-note-id].is-note-selected {
+	outline: 2px solid var(--wp-notes-preview-author-color, #3858e9);
+	outline-offset: 3px;
+	border-radius: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wp-notes-preview,
+	.wp-notes-preview__thread,
+	mark.wp-note {
+		transition: none;
+	}
+}

--- a/packages/notes-preview/src/test/layout.ts
+++ b/packages/notes-preview/src/test/layout.ts
@@ -1,0 +1,114 @@
+import {
+	calculateThreadTops,
+	parseNoteIds,
+	DEFAULT_GAP,
+	DEFAULT_ALIGN_OFFSET,
+} from '../layout';
+
+describe( 'calculateThreadTops', () => {
+	const heights = { '1': 100, '2': 100, '3': 100 };
+
+	it( 'returns nothing when there is nothing to place', () => {
+		expect( calculateThreadTops( { anchors: [], heights: {} } ) ).toEqual(
+			{}
+		);
+	} );
+
+	it( 'places a lone card at its anchor', () => {
+		const tops = calculateThreadTops( {
+			anchors: [ { id: '1', top: 500 } ],
+			heights,
+		} );
+
+		expect( tops[ '1' ] ).toBe( 500 + DEFAULT_ALIGN_OFFSET );
+	} );
+
+	it( 'leaves cards alone when their anchors are far apart', () => {
+		const tops = calculateThreadTops( {
+			anchors: [
+				{ id: '1', top: 0 },
+				{ id: '2', top: 400 },
+			],
+			heights,
+		} );
+
+		expect( tops[ '1' ] ).toBe( DEFAULT_ALIGN_OFFSET );
+		expect( tops[ '2' ] ).toBe( 400 + DEFAULT_ALIGN_OFFSET );
+	} );
+
+	it( 'pushes a card down rather than letting it overlap the one above', () => {
+		const tops = calculateThreadTops( {
+			anchors: [
+				{ id: '1', top: 0 },
+				{ id: '2', top: 20 },
+			],
+			heights,
+		} );
+
+		expect( tops[ '2' ] ).toBe( tops[ '1' ] + 100 + DEFAULT_GAP );
+	} );
+
+	it( 'pins the selected card to its anchor and moves the others away', () => {
+		const tops = calculateThreadTops( {
+			anchors: [
+				{ id: '1', top: 0 },
+				{ id: '2', top: 20 },
+				{ id: '3', top: 40 },
+			],
+			heights,
+			selectedId: '2',
+		} );
+
+		// The one being read is exactly where it belongs.
+		expect( tops[ '2' ] ).toBe( 20 + DEFAULT_ALIGN_OFFSET );
+
+		// Its neighbours are pushed clear of it, in both directions.
+		expect( tops[ '1' ] ).toBe( tops[ '2' ] - DEFAULT_GAP - 100 );
+		expect( tops[ '3' ] ).toBe( tops[ '2' ] + 100 + DEFAULT_GAP );
+	} );
+
+	it( 'sorts by anchor position rather than trusting the given order', () => {
+		const tops = calculateThreadTops( {
+			anchors: [
+				{ id: '3', top: 800 },
+				{ id: '1', top: 0 },
+				{ id: '2', top: 400 },
+			],
+			heights,
+		} );
+
+		expect( tops[ '1' ] ).toBeLessThan( tops[ '2' ] );
+		expect( tops[ '2' ] ).toBeLessThan( tops[ '3' ] );
+	} );
+
+	it( 'treats an unmeasured card as having no height', () => {
+		const tops = calculateThreadTops( {
+			anchors: [
+				{ id: '1', top: 0 },
+				{ id: '2', top: 5 },
+			],
+			heights: {},
+		} );
+
+		expect( tops[ '2' ] ).toBe( tops[ '1' ] + DEFAULT_GAP );
+	} );
+} );
+
+describe( 'parseNoteIds', () => {
+	it( 'reads a single id', () => {
+		expect( parseNoteIds( '12' ) ).toEqual( [ '12' ] );
+	} );
+
+	it( 'reads a comma separated list', () => {
+		expect( parseNoteIds( '12,15, 18' ) ).toEqual( [ '12', '15', '18' ] );
+	} );
+
+	it( 'ignores anything that is not a note id', () => {
+		expect( parseNoteIds( '12,,abc,-3,0x1' ) ).toEqual( [ '12' ] );
+	} );
+
+	it( 'copes with a missing attribute', () => {
+		expect( parseNoteIds( null ) ).toEqual( [] );
+		expect( parseNoteIds( '' ) ).toEqual( [] );
+	} );
+} );

--- a/packages/notes-preview/tsconfig.json
+++ b/packages/notes-preview/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"references": [
+		{
+			"path": "../interactivity"
+		}
+	],
+	"include": [ "src/**/*" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,6 +58,7 @@
 		{ "path": "packages/media-editor" },
 		{ "path": "packages/media-fields" },
 		{ "path": "packages/media-utils" },
+		{ "path": "packages/notes-preview" },
 		{ "path": "packages/notices" },
 		{ "path": "packages/plugins" },
 		{ "path": "packages/preferences" },


### PR DESCRIPTION
_Claude drafted the design and built it out, here is where it landed:_

Fixes #73418, together with #81545 below it in the stack.

The visual half of that reviewer workflow. Stacked on #81545, which added the capabilities and the preview access; this is the part the `Needs Design` label is actually about, so it is up for a designer pass rather than finished.

**Please review this as a design proposal.** The code works and is tested, but the arrangement below is one answer to open question 1 on the issue, not a decision.

## The design

Thread cards sit in a rail beside the post and line up with the block or the inline words they are about, which is the arrangement margin comments have had in Google Docs, Word and Figma for years. The selected card is pinned exactly to its anchor and the others give way to it, so the one being read is always the one correctly placed.

![Notes rail on a post preview](https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/73418-notes-preview-01-overview.png)

Four things carry the connection between a note and the content:

- **Colour.** The same seven author colours the editor uses, keyed the same way, so a person is one colour in the sidebar, on the indicator and in the highlight.
- **Alignment.** A card is level with its anchor unless a neighbour is in the way.
- **Indicators.** An avatar stack at the right edge of the content column, in its own layer, so theme markup is untouched.
- **Highlight.** Inline notes tint their `mark.wp-note` at 25%, going to 50% on hover or selection, matching the editor exactly.

Selecting a thread lifts the card to white, gives it an accent bar in the author's colour, outlines the anchored block in the same colour, and opens the reply box. Only the selected thread has one, which keeps the rail quiet.

![A selected thread](https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/73418-notes-preview-02-selected.png)

Resolved threads are kept out of the aligned board entirely, behind a count in the header, so they can never push an open thread off its anchor.

![Resolved threads](https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/73418-notes-preview-04-resolved.png)

Below 1100px there is no room to align anything, so the rail becomes a drawer over the content with a count pill, and the cards an ordinary list.

![The rail as a drawer on a narrow viewport](https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/73418-notes-preview-06-mobile-open.png)

## Notes on the approach

**The rail is a review tool sitting beside somebody else's design**, so it takes nothing from the theme and gives nothing back. Font, size, line height, colours and box sizing are all stated rather than inherited, and the page keeps its own styling untouched: the only thing added to the content is a `data-wp-note-id` attribute. The document reserves the rail's width so the theme reflows instead of sliding underneath.

**Cards are positioned in document space** and the board is translated as the page scrolls, so a card tracks its anchor with one property write per frame rather than a reposition of every card. `calculateThreadTops()` is pure and unit tested; the placement rules do not need a browser to check.

**The editor's components are deliberately not reused.** `NotesSidebar` and its children pull in the block-editor store, the private editor store, `interface`, `preferences` and rich-text infrastructure, none of which exist on the front end, and loading the editor bundle would defeat the point of looking at the post as it really renders. What is shared instead is the data model, the author colours and the layout language.

## How has this been tested

[![Test in WordPress Playground](https://img.shields.io/badge/Test_in-WP_Playground-blue?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=81551)

11 unit tests over the placement rules:

```
npx jest --config test/unit/jest.config.js packages/notes-preview
```

By hand, as an editor (who already holds the capabilities, since they map to `edit_post`):

1. Enable **Notes on post previews** under Gutenberg > Experiments.
2. On a draft, add a block note and select some text and add an inline note.
3. Open the preview. Cards line up with their blocks, indicators sit at the right edge of the content, the inline note is tinted in its author's colour.
4. Click a card, or an indicator, or the highlighted text. The card lifts, the block outlines, the reply box opens.
5. Reply. The rail reloads with the reply in place.
6. Narrow the window past 1100px. The rail becomes a drawer.

To see it as an actual reviewer rather than an editor, grant the capabilities from #81545 to a subscriber and open the same URL as them.

## Types of changes

- Add `packages/notes-preview`, an Interactivity API module: selection, card alignment, indicators, replies.
- Render the rail server-side on an active preview, with the resolved list and per-note highlight rules.

## Open questions for the design team

- **Is a rail the right container**, or should cards float over the theme's own margin with no panel behind them, as Google Docs does? A rail is far more robust across arbitrary themes, but it does announce itself more.
- **Indicators and highlights together, or just one?** Block notes need an indicator since they have no text to tint, but on a paragraph carrying an inline note you currently get both.
- **1100px** is where alignment stops being possible at a 336px rail. Worth checking against the breakpoints the rest of the editor uses.
- **The reply box only on the selected card.** The alternative is one on every card, which is louder but saves a click.
- The rail says **"You are viewing the last saved version of this draft"**, because a reviewer without `edit_post` cannot see the author's newer autosave. Is that the right wording, and the right place for it?

Follow-ups already known: starting a new thread from the preview needs a comment-meta anchor and editor-side reconciliation, and live updates are not in scope.

Part of https://github.com/WordPress/gutenberg/issues/80015

cc: @jasmussen @jeffpaul @fabiankaegy

## AI Use

Claude Code drafted the design and did the typing here, I did the asking. I will review and test.

