### PR TITLE
Post title: pressing Delete at the end deletes or merges the first block

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -5,7 +5,12 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { ENTER, DELETE } from '@wordpress/keycodes';
-import { pasteHandler, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import {
+	pasteHandler,
+	isUnmodifiedDefaultBlock,
+	getDefaultBlockName,
+	switchToBlockType,
+} from '@wordpress/blocks';
 import {
 	privateApis as richTextPrivateApis,
 	create,
@@ -55,6 +60,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		insertBlocks,
 		insertDefaultBlock,
 		removeBlock,
+		replaceBlocks,
 	} = useDispatch( blockEditorStore );
 
 	const decodedPlaceholder =
@@ -121,38 +127,64 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		}
 
 		const block = getBlock( clientId );
-		const isMergeable =
-			block.name === 'core/paragraph' || block.name === 'core/heading';
 
-		if ( ! isMergeable && ! isUnmodifiedDefaultBlock( block ) ) {
+		if ( isUnmodifiedDefaultBlock( block ) ) {
+			event.preventDefault();
+			// Batch so that when removing the last block reinserts a
+			// selected default block (see ensureDefaultBlock), the
+			// selection never reaches subscribers and focus stays in the
+			// title.
+			registry.batch( () => {
+				removeBlock( clientId, false );
+				clearSelectedBlock();
+			} );
+			return;
+		}
+
+		// Blocks with inner blocks are left alone for now. Between blocks,
+		// forward delete moves the first inner block out of the container
+		// rather than merging text (see onMerge in block.js).
+		if ( getBlockOrder( clientId ).length ) {
+			return;
+		}
+
+		// As between blocks, transform the block to the default type
+		// before merging, so any block with such a transform can merge
+		// into the title. Without a transform, do nothing.
+		const [ blockOfDefaultType, ...remainingBlocks ] =
+			( block.name === getDefaultBlockName()
+				? [ block ]
+				: switchToBlockType( block, getDefaultBlockName() ) ) ?? [];
+
+		if ( ! blockOfDefaultType ) {
 			return;
 		}
 
 		event.preventDefault();
-		// Batch so that when removing the last block reinserts a selected
-		// default block (see ensureDefaultBlock), the selection never
-		// reaches subscribers and focus stays in the title.
 		registry.batch( () => {
-			if ( isMergeable && ! isUnmodifiedDefaultBlock( block ) ) {
-				// Strip HTML as when pasting: it is assumed that HTML in
-				// the title is undesirable.
-				const contentNoHTML = stripHTML(
-					block.attributes.content.toString()
-				);
-				const newValue = insert(
-					getValue(),
-					create( { html: contentNoHTML } ),
-					text.length,
-					text.length
-				);
-				// As with merging blocks, keep the caret at the merge point.
-				onChange( {
-					...newValue,
-					start: text.length,
-					end: text.length,
-				} );
+			// Strip HTML as when pasting: it is assumed that HTML in the
+			// title is undesirable.
+			const contentNoHTML = stripHTML(
+				blockOfDefaultType.attributes.content?.toString() ?? ''
+			);
+			const newValue = insert(
+				getValue(),
+				create( { html: contentNoHTML } ),
+				text.length,
+				text.length
+			);
+			// As with merging blocks, keep the caret at the merge point.
+			onChange( {
+				...newValue,
+				start: text.length,
+				end: text.length,
+			} );
+
+			if ( remainingBlocks.length ) {
+				replaceBlocks( clientId, remainingBlocks );
+			} else {
+				removeBlock( clientId, false );
 			}
-			removeBlock( clientId, false );
 			clearSelectedBlock();
 		} );
 	}

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -2,10 +2,10 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { forwardRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { ENTER } from '@wordpress/keycodes';
-import { pasteHandler } from '@wordpress/blocks';
+import { ENTER, DELETE } from '@wordpress/keycodes';
+import { pasteHandler, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import {
 	privateApis as richTextPrivateApis,
 	create,
@@ -38,6 +38,10 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		[]
 	);
 
+	const registry = useRegistry();
+	const { getBlockOrder, getBlock, canRemoveBlock } =
+		useSelect( blockEditorStore );
+
 	const [ isSelected, setIsSelected ] = useState( false );
 
 	const { ref: focusRef } = usePostTitleFocus( forwardedRef );
@@ -46,14 +50,19 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 
 	const [ selection, setSelection ] = useState( {} );
 
-	const { clearSelectedBlock, insertBlocks, insertDefaultBlock } =
-		useDispatch( blockEditorStore );
+	const {
+		clearSelectedBlock,
+		insertBlocks,
+		insertDefaultBlock,
+		removeBlock,
+	} = useDispatch( blockEditorStore );
 
 	const decodedPlaceholder =
 		decodeEntities( placeholder ) || __( 'Add title' );
 
 	const {
 		value,
+		getValue,
 		onChange,
 		ref: richTextRef,
 	} = useRichText( {
@@ -97,10 +106,63 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		insertDefaultBlock( undefined, undefined, 0 );
 	}
 
+	function onForwardDeletePress( event ) {
+		const { start, end, text } = getValue();
+
+		// The browser handles deletion within the title itself.
+		if ( start !== text.length || end !== text.length ) {
+			return;
+		}
+
+		const clientId = getBlockOrder()[ 0 ];
+
+		if ( ! clientId || ! canRemoveBlock( clientId ) ) {
+			return;
+		}
+
+		const block = getBlock( clientId );
+		const isMergeable =
+			block.name === 'core/paragraph' || block.name === 'core/heading';
+
+		if ( ! isMergeable && ! isUnmodifiedDefaultBlock( block ) ) {
+			return;
+		}
+
+		event.preventDefault();
+		// Batch so that when removing the last block reinserts a selected
+		// default block (see ensureDefaultBlock), the selection never
+		// reaches subscribers and focus stays in the title.
+		registry.batch( () => {
+			if ( isMergeable && ! isUnmodifiedDefaultBlock( block ) ) {
+				// Strip HTML as when pasting: it is assumed that HTML in
+				// the title is undesirable.
+				const contentNoHTML = stripHTML(
+					block.attributes.content.toString()
+				);
+				const newValue = insert(
+					getValue(),
+					create( { html: contentNoHTML } ),
+					text.length,
+					text.length
+				);
+				// As with merging blocks, keep the caret at the merge point.
+				onChange( {
+					...newValue,
+					start: text.length,
+					end: text.length,
+				} );
+			}
+			removeBlock( clientId, false );
+			clearSelectedBlock();
+		} );
+	}
+
 	function onKeyDown( event ) {
 		if ( event.keyCode === ENTER ) {
 			event.preventDefault();
 			onEnterPress();
+		} else if ( event.keyCode === DELETE ) {
+			onForwardDeletePress( event );
 		}
 	}
 

--- a/test/e2e/specs/editor/various/post-title.spec.js
+++ b/test/e2e/specs/editor/various/post-title.spec.js
@@ -108,6 +108,39 @@ test.describe( 'Post title', () => {
 			await page.keyboard.type( ', ' );
 			await expect( titleField ).toHaveText( 'Hello, world' );
 		} );
+
+		test( 'should merge blocks that transform to the default block', async ( {
+			editor,
+			page,
+			admin,
+		} ) => {
+			await admin.createNewPost();
+
+			const titleField = editor.canvas.getByRole( 'textbox', {
+				name: 'Add title',
+			} );
+
+			await expect( titleField ).toBeFocused();
+			await page.keyboard.type( 'Hello' );
+
+			await page.evaluate( () => {
+				const { createBlock } = window.wp.blocks;
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.insertBlocks(
+						[ createBlock( 'core/heading', { content: 'World' } ) ],
+						0,
+						undefined,
+						false
+					);
+			} );
+
+			// The heading transforms to a paragraph and merges, the same
+			// as forward delete between a paragraph and a heading.
+			await page.keyboard.press( 'Delete' );
+			await expect.poll( editor.getBlocks ).toEqual( [] );
+			await expect( titleField ).toHaveText( 'HelloWorld' );
+		} );
 	} );
 
 	test.describe( 'HTML handling', () => {

--- a/test/e2e/specs/editor/various/post-title.spec.js
+++ b/test/e2e/specs/editor/various/post-title.spec.js
@@ -58,6 +58,58 @@ test.describe( 'Post title', () => {
 		} );
 	} );
 
+	test.describe( 'Forward delete', () => {
+		test( 'should delete the first block from the end of the title', async ( {
+			editor,
+			page,
+			admin,
+		} ) => {
+			await admin.createNewPost();
+
+			const titleField = editor.canvas.getByRole( 'textbox', {
+				name: 'Add title',
+			} );
+
+			await expect( titleField ).toBeFocused();
+			await page.keyboard.type( 'Hello' );
+
+			// Insert without updating the selection so that the caret stays
+			// at the end of the title.
+			await page.evaluate( () => {
+				const { createBlock } = window.wp.blocks;
+				window.wp.data.dispatch( 'core/block-editor' ).insertBlocks(
+					[
+						createBlock( 'core/paragraph' ),
+						createBlock( 'core/paragraph', {
+							content: 'world',
+						} ),
+					],
+					0,
+					undefined,
+					false
+				);
+			} );
+
+			// The first press removes the empty paragraph.
+			await page.keyboard.press( 'Delete' );
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'world' },
+				},
+			] );
+			await expect( titleField ).toHaveText( 'Hello' );
+
+			// The second press merges the paragraph into the title.
+			await page.keyboard.press( 'Delete' );
+			await expect.poll( editor.getBlocks ).toEqual( [] );
+
+			// Typing proves the caret stayed at the merge point.
+			await page.keyboard.type( ', ' );
+			await expect( titleField ).toHaveText( 'Hello, world' );
+		} );
+	} );
+
 	test.describe( 'HTML handling', () => {
 		test( `should (visually) render any HTML in Post Editor's post title field when in Visual editing mode`, async ( {
 			editor,


### PR DESCRIPTION
## What?

Pressing <kbd>Delete</kbd> with the caret at the end of the post title now affects the first block, the same way forward delete behaves between blocks.

Fixes #73315.

## Why?

Pressing <kbd>Enter</kbd> from the title creates a block after it, but <kbd>Delete</kbd> from the end of the title did nothing, even when the first block was an empty paragraph.

## How?

A <kbd>Delete</kbd> handler in `PostTitle` that only acts when the caret is collapsed at the end of the title:

1. **An unmodified default block is removed.**
2. **A block that transforms to the default block is merged into the title.** Mirroring `mergeBlocks`, the block is first transformed to the default block type (a heading or verse becomes a paragraph), then its content is appended, stripped of HTML following the same policy as pasting into the title, with the caret kept at the merge point. Blocks without such a transform, an image for example, are left alone, matching the no-op between blocks.
3. **Focus stays in the title.** Removing the last block reinserts a selected default block (`ensureDefaultBlock`), which would pull focus into the canvas. The removal is batched with `clearSelectedBlock` so that selection never reaches subscribers, and the deselected empty paragraph is cleaned up, leaving the post empty.

Everything else stays native: deleting within the title, blocks the template lock prevents from being removed, and blocks with inner blocks. For the latter, forward delete between blocks moves the first inner block out of the container instead of merging text; replicating that for the title would mean reusing the `moveFirstItemUp` logic that currently lives in `block.js`, which is left for a follow-up.

## Testing Instructions

1. Create a new post and type a title.
2. Press <kbd>Enter</kbd> twice and type some text, so the post has an empty paragraph followed by a paragraph with text.
3. Put the caret at the end of the title and press <kbd>Delete</kbd>: the empty paragraph is removed.
4. Press <kbd>Delete</kbd> again: the paragraph text is appended to the title and the caret stays where the title ended.

Covered by a new e2e test.

Written with Claude Code.
