### PR TITLE
Media Editor Route Experiment: Override media edit links to point to the new experimental media editor

### DIFF
--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -48,7 +48,7 @@ function gutenberg_initialize_experiments_settings() {
 				array(
 					'id'          => 'gutenberg-media-editor',
 					'label'       => __( 'Media Editor (Route)', 'gutenberg' ),
-					'description' => __( 'Enables a dedicated route-based media editor screen for editing media items (metadata and content).', 'gutenberg' ),
+					'description' => __( 'Replaces the core Edit Media screen with a dedicated route-based media editor for editing media items (metadata and content).', 'gutenberg' ),
 				),
 				array(
 					'id'          => 'gutenberg-dataviews-media-modal',

--- a/lib/experimental/media-editor/load.php
+++ b/lib/experimental/media-editor/load.php
@@ -39,3 +39,99 @@ function gutenberg_media_editor_wp_admin_set_title() {
 
 	$title = __( 'Edit media', 'gutenberg' );
 }
+
+/**
+ * Builds the media editor URL for an attachment.
+ *
+ * The router reads its internal path from the `p` query argument, so the
+ * attachment id travels as `p=/media-editor/<id>` rather than as a query
+ * argument of its own.
+ *
+ * @param int    $post_id   Attachment ID.
+ * @param string $separator Argument separator. `&amp;` when the URL is
+ *                          destined for HTML output, `&` otherwise.
+ * @return string The media editor URL.
+ */
+function gutenberg_media_editor_get_url( $post_id, $separator = '&' ) {
+	return admin_url(
+		'admin.php?page=media-editor-wp-admin' . $separator . 'p=' . rawurlencode( '/media-editor/' . (int) $post_id )
+	);
+}
+
+/**
+ * Points every "edit this attachment" link at the media editor.
+ *
+ * Filtering here rather than redirecting means the Media Library list table,
+ * the media modal's "Edit more details" and "Edit Image" links, and the admin
+ * bar all navigate straight to the media editor with no redirect hop.
+ *
+ * @param string|null $link    The edit link, or null when the user cannot edit the post.
+ * @param int         $post_id Post ID.
+ * @param string      $context The link context. `display` expects an HTML-escaped separator.
+ * @return string|null The filtered edit link.
+ */
+function gutenberg_media_editor_filter_edit_post_link( $link, $post_id, $context ) {
+	// A null link means the user lacks the capability. Leave that alone.
+	if ( ! $link || 'attachment' !== get_post_type( $post_id ) ) {
+		return $link;
+	}
+
+	// `edit_post` is enough for the classic screen, but the media editor page
+	// requires `upload_files`. A contributor can own an attachment and edit it
+	// without being able to upload, so pointing them at the media editor would
+	// send them to a screen they cannot open.
+	if ( ! current_user_can( 'upload_files' ) ) {
+		return $link;
+	}
+
+	return gutenberg_media_editor_get_url( $post_id, 'display' === $context ? '&amp;' : '&' );
+}
+
+add_filter( 'get_edit_post_link', 'gutenberg_media_editor_filter_edit_post_link', 10, 3 );
+
+/**
+ * Redirects the classic Edit Media screen to the media editor.
+ *
+ * The `get_edit_post_link` filter above covers links rendered by WordPress,
+ * but bookmarks, hand-typed URLs, and hard-coded links still reach post.php.
+ * This catches those. It deliberately bails on the failure paths so that
+ * WordPress keeps rendering its own error messages instead of sending people
+ * to a screen that would only fail again.
+ */
+function gutenberg_media_editor_redirect_classic_screen() {
+	// GET renders the form. POST is the editattachment/editpost save handler,
+	// which must run untouched.
+	if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) ) {
+		return;
+	}
+
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Reading the same unauthenticated query args post.php itself reads to decide what to render.
+	if ( ! isset( $_GET['action'] ) || 'edit' !== $_GET['action'] ) {
+		return;
+	}
+
+	// Guard against `?post[]=1`, where an array casts to int 1 without warning.
+	$post_id = isset( $_GET['post'] ) && is_scalar( $_GET['post'] ) ? (int) $_GET['post'] : 0;
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( ! $post_id || 'attachment' !== get_post_type( $post_id ) ) {
+		return;
+	}
+
+	// Let post.php own these: it already renders the appropriate wp_die().
+	if ( ! current_user_can( 'edit_post', $post_id ) || 'trash' === get_post_status( $post_id ) ) {
+		return;
+	}
+
+	// The media editor page requires `upload_files`, which `edit_post` does not
+	// imply. Without this, a contributor who owns an attachment would be
+	// redirected off a screen that works onto one that refuses them.
+	if ( ! current_user_can( 'upload_files' ) ) {
+		return;
+	}
+
+	wp_safe_redirect( gutenberg_media_editor_get_url( $post_id ) );
+	exit;
+}
+
+add_action( 'load-post.php', 'gutenberg_media_editor_redirect_classic_screen' );

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility.
+
 ### Bug Fixes
 
 -   Keep initial focus on the modal dialog frame instead of moving it to the crop area once the image loads ([#81541](https://github.com/WordPress/gutenberg/pull/81541)).

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility.
+-   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility ([#81559](https://github.com/WordPress/gutenberg/pull/81559)).
 
 ### Bug Fixes
 

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -99,22 +99,36 @@ export interface MediaEditorProps {
 	noticesPortalElement?: Element | null;
 	showCloseButton?: boolean;
 	shouldCloseOnEsc?: boolean;
+	/**
+	 * The `@wordpress/interface` scope for the details sidebar and its pinned
+	 * items. Frames should pass a distinct scope so that sidebar visibility —
+	 * which is persisted per scope to user meta — is remembered separately for
+	 * each surface. The modal is a transient surface where a collapsed sidebar
+	 * is a reasonable choice; the full-screen route is one where the sidebar is
+	 * the primary metadata surface and should open by default. Sharing a scope
+	 * would let a choice made in one decide the other's starting state.
+	 *
+	 * @default 'media-editor'
+	 */
+	scope?: string;
 }
 
 interface MediaEditorSidebarProps {
 	tabs: EditorTab[];
 	activeTabId?: string;
 	onTabChange: ( tabId: string ) => void;
+	scope: string;
 }
 
 function MediaEditorSidebar( {
 	tabs,
 	activeTabId,
 	onTabChange,
+	scope,
 }: MediaEditorSidebarProps ) {
 	return (
 		<ComplementaryArea
-			scope="media-editor"
+			scope={ scope }
 			identifier="media-editor/details"
 			title={ __( 'Details' ) }
 			icon={ drawerRight }
@@ -157,6 +171,7 @@ interface HeaderActionsProps {
 	isImage: boolean;
 	showCloseButton?: boolean;
 	onCancel: () => void;
+	scope: string;
 }
 
 function HeaderActions( {
@@ -164,6 +179,7 @@ function HeaderActions( {
 	isImage,
 	showCloseButton = false,
 	onCancel,
+	scope,
 }: HeaderActionsProps ) {
 	const [ isShortcutsModalOpen, setIsShortcutsModalOpen ] = useState( false );
 	return (
@@ -181,7 +197,7 @@ function HeaderActions( {
 					onClick={ () => setIsShortcutsModalOpen( true ) }
 				/>
 			) }
-			<PinnedItems.Slot scope="media-editor" />
+			<PinnedItems.Slot scope={ scope } />
 			{ showCloseButton && (
 				<Button
 					size="compact"
@@ -338,6 +354,7 @@ function MediaEditorContent( {
 	noticesPortalElement,
 	showCloseButton = false,
 	shouldCloseOnEsc = false,
+	scope = 'media-editor',
 }: MediaEditorProps ) {
 	const cropper = useMediaEditor();
 	// The sidebar is a side column from the `small` breakpoint up and collapses
@@ -596,6 +613,7 @@ function MediaEditorContent( {
 							tabs={ tabs }
 							activeTabId={ activeTabId }
 							onTabChange={ setSelectedTabId }
+							scope={ scope }
 						/>
 						<InterfaceSkeleton
 							className="media-editor__skeleton"
@@ -632,7 +650,7 @@ function MediaEditorContent( {
 								</div>
 							}
 							sidebar={
-								<ComplementaryArea.Slot scope="media-editor" />
+								<ComplementaryArea.Slot scope={ scope } />
 							}
 						/>
 					</>
@@ -715,6 +733,7 @@ function MediaEditorContent( {
 				isImage={ isImage }
 				showCloseButton={ showCloseButton }
 				onCancel={ handleRequestClose }
+				scope={ scope }
 			/>
 		),
 		footerActions,

--- a/routes/media-editor/stage.tsx
+++ b/routes/media-editor/stage.tsx
@@ -18,6 +18,7 @@ const { MediaEditor } = unlock( mediaEditorPrivateApis );
 const MEDIA_LIST_PATH = '/types/attachment/list/all';
 const MEDIA_LIBRARY_ADMIN_PATH = 'upload.php';
 const MEDIA_EDITOR_ADMIN_PAGE = 'media-editor-wp-admin';
+const MEDIA_EDITOR_SCOPE = 'media-editor-route';
 
 function isMediaEditorAdminPage() {
 	return (
@@ -70,6 +71,9 @@ function MediaEditorRoute() {
 		<MediaEditor
 			id={ attachmentId }
 			fields={ fields }
+			// A scope of its own, so that the details sidebar opens by default
+			// here regardless of whether it was last collapsed in the modal.
+			scope={ MEDIA_EDITOR_SCOPE }
 			onClose={ navigateBack }
 			onSaved={ ( { id: savedId } ) => {
 				if ( savedId !== attachmentId ) {


### PR DESCRIPTION
Part of:

* #72734

## What?

Override edit post links, i.e. those used in the core media library to point to the experimental media editor, when the "Media Editor (Route)" experiment is active.

## Why?

While the media editor is very far from being feature complete (see the parity gaps in #72734) to help those of us working on this to test out the editor and get a feel for those gaps, this PR proposes wiring up the editor so that it's part of the flow of editing and managing media (when the experiment is on).

⚠️ there are _very_ big gaps in behaviour between the core editor and this one, for example there's currently no way to save changes in this flow 😄. Fixes and filling in gaps will be for follow-ups.

## How?

* Filter on `'get_edit_post_link'` and point to the URL for the experimental new media editor.
* Also add a redirect to the new screen in case folks attempt to access the classic screen via direct url (I can remove this from the PR if it feels like too much for now)
* JS change: in the media editor code add a `scope` prop that allows a consumer to pass in a custom scope for the editor — this could arguably be its own PR but while testing this PR out, I noticed that in the route-based approach if I'd had the sidebar closed in the media editor modal closed, then it'd be closed in the route-based editor. I think these should be separate scopes and we really want this editor to default to the sidebar being open.

## Testing Instructions

Enable the Media Editor (Route) experiment:

<img width="607" height="85" alt="image" src="https://github.com/user-attachments/assets/a90c1b6f-b25d-4336-af56-157553b566ba" />

Go to the Media library screen in wp-admin and click on an image or its "Edit" link:

<img width="529" height="163" alt="image" src="https://github.com/user-attachments/assets/5fa30dd8-49e5-423d-90a7-87d6c234da42" />

This should navigate you to the new media editor screen, instead of the core screen.

Then, disable the experiment and double-check that when you use the above link it takes you back to the old screen.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ce2fde55-9b6c-4d3c-917d-5c465e7ceebc

## Use of AI Tools

Claude Code (Opus 5) to generate the change, reviewed and tested by me.