### PR TITLE
Layout block supports: cast numeric grid attributes before use

### DIFF
--- a/backport-changelog/7.2/12674.md
+++ b/backport-changelog/7.2/12674.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/12674
 
 * https://github.com/WordPress/gutenberg/pull/80501
+* https://github.com/WordPress/gutenberg/pull/81560

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -834,12 +834,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 	} elseif ( 'grid' === $layout_type ) {
 		/*
-		 * Column and row counts are whole numbers. The editor stores them as numbers, but
-		 * content saved by WordPress 6.3 to 6.6 stored columnCount as a numeric string, and
-		 * that migration only runs when a block is parsed in JavaScript, so the front end
-		 * still sees strings. Accept any numeric value and cast it. minimumColumnWidth is a
-		 * CSS length, so only a string is usable. Anything else is treated as absent because
-		 * it can't render as valid CSS.
+		 * Column and row counts are whole numbers, for the same reason as the grid line
+		 * numbers in gutenberg_get_child_layout_style_rules(). minimumColumnWidth is a CSS
+		 * length, so only a string is usable.
 		 */
 		$column_count_attr         = $layout_for_styles['columnCount'] ?? null;
 		$column_count              = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -380,8 +380,17 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 		}
 	}
 
-	$column_start = $child_layout['columnStart'] ?? null;
-	$column_span  = $child_layout['columnSpan'] ?? null;
+	/*
+	 * Grid line numbers and spans are whole numbers. The editor stores them as numbers, but
+	 * content saved by WordPress 6.3 to 6.6 stored them as numeric strings, and that
+	 * migration only runs when a block is parsed in JavaScript, so the front end still sees
+	 * strings. Accept any numeric value and cast it, and treat anything else as absent
+	 * because it can't render as valid CSS.
+	 */
+	$column_start_attr = $child_layout['columnStart'] ?? null;
+	$column_start      = is_numeric( $column_start_attr ) ? (int) $column_start_attr : null;
+	$column_span_attr  = $child_layout['columnSpan'] ?? null;
+	$column_span       = is_numeric( $column_span_attr ) ? (int) $column_span_attr : null;
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'columnStart' ) || $has_viewport_property_override( 'columnSpan' ) ) {
 		if ( $column_start && $column_span ) {
 			$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
@@ -392,8 +401,10 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 		}
 	}
 
-	$row_start = $child_layout['rowStart'] ?? null;
-	$row_span  = $child_layout['rowSpan'] ?? null;
+	$row_start_attr = $child_layout['rowStart'] ?? null;
+	$row_start      = is_numeric( $row_start_attr ) ? (int) $row_start_attr : null;
+	$row_span_attr  = $child_layout['rowSpan'] ?? null;
+	$row_span       = is_numeric( $row_span_attr ) ? (int) $row_span_attr : null;
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'rowStart' ) || $has_viewport_property_override( 'rowSpan' ) ) {
 		if ( $row_start && $row_span ) {
 			$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
@@ -413,7 +424,8 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 
 	$minimum_column_width_attr = $parent_layout['minimumColumnWidth'] ?? null;
 	$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
-	$column_count              = $parent_layout['columnCount'] ?? null;
+	$column_count_attr         = $parent_layout['columnCount'] ?? null;
+	$column_count              = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;
 
 	/*
 	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
@@ -823,6 +835,27 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 	} elseif ( 'grid' === $layout_type ) {
 		/*
+		 * Column and row counts are whole numbers. The editor stores them as numbers, but
+		 * content saved by WordPress 6.3 to 6.6 stored columnCount as a numeric string, and
+		 * that migration only runs when a block is parsed in JavaScript, so the front end
+		 * still sees strings. Accept any numeric value and cast it. minimumColumnWidth is a
+		 * CSS length, so only a string is usable. Anything else is treated as absent because
+		 * it can't render as valid CSS.
+		 */
+		$column_count_attr         = $layout_for_styles['columnCount'] ?? null;
+		$column_count              = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;
+		$row_count_attr            = $layout_for_styles['rowCount'] ?? null;
+		$row_count                 = is_numeric( $row_count_attr ) ? (int) $row_count_attr : null;
+		$minimum_column_width_attr = $layout_for_styles['minimumColumnWidth'] ?? null;
+		$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
+
+		// The same values from the default viewport, used below to decide where to set `container-type`.
+		$base_column_count_attr         = $base_layout['columnCount'] ?? null;
+		$base_column_count              = is_numeric( $base_column_count_attr ) ? (int) $base_column_count_attr : null;
+		$base_minimum_column_width_attr = $base_layout['minimumColumnWidth'] ?? null;
+		$base_minimum_column_width      = is_string( $base_minimum_column_width_attr ) ? $base_minimum_column_width_attr : null;
+
+		/*
 		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
 		 * is the relevant one for computation of responsive grid columns.
 		 */
@@ -867,12 +900,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		 * value for any of the grid properties.
 		 */
 		$should_output_grid_columns = null === $viewport_overrides || $has_viewport_property_override( 'minimumColumnWidth' ) || $has_viewport_property_override( 'columnCount' ) || $has_viewport_property_override( 'autoFit' );
-		$uses_gap_in_grid_columns   = ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] );
+		$uses_gap_in_grid_columns   = ! empty( $column_count ) && ! empty( $minimum_column_width );
 		if ( $has_block_gap_override && $uses_gap_in_grid_columns ) {
 			$should_output_grid_columns = true;
 		}
 
-		$should_output_grid_rows = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['rowCount'] );
+		$should_output_grid_rows = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $column_count ) && ! empty( $row_count );
 		$grid_declarations       = array();
 
 		/* When enabled, columns stretch to fill the available space using
@@ -880,19 +913,19 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		 */
 		$auto_placement = ! empty( $layout_for_styles['autoFit'] ) ? 'auto-fit' : 'auto-fill';
 
-		if ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
-			$max_value                                  = 'max(min(' . $layout_for_styles['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout_for_styles['columnCount'] . ' - 1))) /' . $layout_for_styles['columnCount'] . ')';
+		if ( $should_output_grid_columns && ! empty( $column_count ) && ! empty( $minimum_column_width ) ) {
+			$max_value                                  = 'max(min(' . $minimum_column_width . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $column_count . ' - 1))) /' . $column_count . ')';
 			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(' . $max_value . ', 1fr))';
-		} elseif ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) ) {
-			$grid_declarations['grid-template-columns'] = 'repeat(' . $layout_for_styles['columnCount'] . ', minmax(0, 1fr))';
+		} elseif ( $should_output_grid_columns && ! empty( $column_count ) ) {
+			$grid_declarations['grid-template-columns'] = 'repeat(' . $column_count . ', minmax(0, 1fr))';
 		} elseif ( $should_output_grid_columns ) {
-			$minimum_column_width                       = ! empty( $layout_for_styles['minimumColumnWidth'] ) ? $layout_for_styles['minimumColumnWidth'] : '12rem';
-			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(min(' . $minimum_column_width . ', 100%), 1fr))';
+			$responsive_column_width                    = ! empty( $minimum_column_width ) ? $minimum_column_width : '12rem';
+			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(min(' . $responsive_column_width . ', 100%), 1fr))';
 		}
 
 		if ( ! empty( $grid_declarations ) ) {
-			$base_has_container_type = empty( $base_layout['columnCount'] ) || ( ! empty( $base_layout['columnCount'] ) && ! empty( $base_layout['minimumColumnWidth'] ) );
-			if ( empty( $layout_for_styles['columnCount'] ) || ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
+			$base_has_container_type = empty( $base_column_count ) || ( ! empty( $base_column_count ) && ! empty( $base_minimum_column_width ) );
+			if ( empty( $column_count ) || ! empty( $minimum_column_width ) ) {
 				if ( null === $viewport_overrides || ! $base_has_container_type ) {
 					$grid_declarations['container-type'] = 'inline-size';
 				}
@@ -906,7 +939,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $should_output_grid_rows ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout_for_styles['rowCount'] . ', minmax(1rem, auto))' ),
+				'declarations' => array( 'grid-template-rows' => 'repeat(' . $row_count . ', minmax(1rem, auto))' ),
 			);
 		}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -424,8 +424,7 @@ function gutenberg_get_child_layout_style_rules( $selector, $child_layout, $pare
 
 	$minimum_column_width_attr = $parent_layout['minimumColumnWidth'] ?? null;
 	$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
-	$column_count_attr         = $parent_layout['columnCount'] ?? null;
-	$column_count              = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;
+	$column_count              = $parent_layout['columnCount'] ?? null;
 
 	/*
 	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
@@ -849,12 +848,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$minimum_column_width_attr = $layout_for_styles['minimumColumnWidth'] ?? null;
 		$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
 
-		// The same values from the default viewport, used below to decide where to set `container-type`.
-		$base_column_count_attr         = $base_layout['columnCount'] ?? null;
-		$base_column_count              = is_numeric( $base_column_count_attr ) ? (int) $base_column_count_attr : null;
-		$base_minimum_column_width_attr = $base_layout['minimumColumnWidth'] ?? null;
-		$base_minimum_column_width      = is_string( $base_minimum_column_width_attr ) ? $base_minimum_column_width_attr : null;
-
 		/*
 		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
 		 * is the relevant one for computation of responsive grid columns.
@@ -924,7 +917,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $grid_declarations ) ) {
-			$base_has_container_type = empty( $base_column_count ) || ( ! empty( $base_column_count ) && ! empty( $base_minimum_column_width ) );
+			$base_has_container_type = empty( $base_layout['columnCount'] ) || ( ! empty( $base_layout['columnCount'] ) && ! empty( $base_layout['minimumColumnWidth'] ) );
 			if ( empty( $column_count ) || ! empty( $minimum_column_width ) ) {
 				if ( null === $viewport_overrides || ! $base_has_container_type ) {
 					$grid_declarations['container-type'] = 'inline-size';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -914,7 +914,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $grid_declarations ) ) {
-			$base_has_container_type = empty( $base_layout['columnCount'] ) || ( ! empty( $base_layout['columnCount'] ) && ! empty( $base_layout['minimumColumnWidth'] ) );
+			/*
+			 * This flag records whether the default viewport already set `container-type`, so
+			 * it has to read the base values through the same guards the default viewport pass
+			 * used. Reading them raw would claim a `container-type` that was never written.
+			 */
+			$base_column_count         = is_numeric( $base_layout['columnCount'] ?? null ) ? (int) $base_layout['columnCount'] : null;
+			$base_minimum_column_width = is_string( $base_layout['minimumColumnWidth'] ?? null ) ? $base_layout['minimumColumnWidth'] : null;
+			$base_has_container_type   = empty( $base_column_count ) || ( ! empty( $base_column_count ) && ! empty( $base_minimum_column_width ) );
 			if ( empty( $column_count ) || ! empty( $minimum_column_width ) ) {
 				if ( null === $viewport_overrides || ! $base_has_container_type ) {
 					$grid_declarations['container-type'] = 'inline-size';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -835,15 +835,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	} elseif ( 'grid' === $layout_type ) {
 		/*
 		 * Column and row counts are whole numbers, for the same reason as the grid line
-		 * numbers in gutenberg_get_child_layout_style_rules(). minimumColumnWidth is a CSS
-		 * length, so only a string is usable.
+		 * numbers in gutenberg_get_child_layout_style_rules().
 		 */
-		$column_count_attr         = $layout_for_styles['columnCount'] ?? null;
-		$column_count              = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;
-		$row_count_attr            = $layout_for_styles['rowCount'] ?? null;
-		$row_count                 = is_numeric( $row_count_attr ) ? (int) $row_count_attr : null;
-		$minimum_column_width_attr = $layout_for_styles['minimumColumnWidth'] ?? null;
-		$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
+		$column_count_attr = $layout_for_styles['columnCount'] ?? null;
+		$column_count      = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;
+		$row_count_attr    = $layout_for_styles['rowCount'] ?? null;
+		$row_count         = is_numeric( $row_count_attr ) ? (int) $row_count_attr : null;
 
 		/*
 		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
@@ -890,7 +887,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		 * value for any of the grid properties.
 		 */
 		$should_output_grid_columns = null === $viewport_overrides || $has_viewport_property_override( 'minimumColumnWidth' ) || $has_viewport_property_override( 'columnCount' ) || $has_viewport_property_override( 'autoFit' );
-		$uses_gap_in_grid_columns   = ! empty( $column_count ) && ! empty( $minimum_column_width );
+		$uses_gap_in_grid_columns   = ! empty( $column_count ) && ! empty( $layout_for_styles['minimumColumnWidth'] );
 		if ( $has_block_gap_override && $uses_gap_in_grid_columns ) {
 			$should_output_grid_columns = true;
 		}
@@ -903,26 +900,19 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		 */
 		$auto_placement = ! empty( $layout_for_styles['autoFit'] ) ? 'auto-fit' : 'auto-fill';
 
-		if ( $should_output_grid_columns && ! empty( $column_count ) && ! empty( $minimum_column_width ) ) {
-			$max_value                                  = 'max(min(' . $minimum_column_width . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $column_count . ' - 1))) /' . $column_count . ')';
+		if ( $should_output_grid_columns && ! empty( $column_count ) && ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
+			$max_value                                  = 'max(min(' . $layout_for_styles['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $column_count . ' - 1))) /' . $column_count . ')';
 			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(' . $max_value . ', 1fr))';
 		} elseif ( $should_output_grid_columns && ! empty( $column_count ) ) {
 			$grid_declarations['grid-template-columns'] = 'repeat(' . $column_count . ', minmax(0, 1fr))';
 		} elseif ( $should_output_grid_columns ) {
-			$responsive_column_width                    = ! empty( $minimum_column_width ) ? $minimum_column_width : '12rem';
-			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(min(' . $responsive_column_width . ', 100%), 1fr))';
+			$minimum_column_width                       = ! empty( $layout_for_styles['minimumColumnWidth'] ) ? $layout_for_styles['minimumColumnWidth'] : '12rem';
+			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(min(' . $minimum_column_width . ', 100%), 1fr))';
 		}
 
 		if ( ! empty( $grid_declarations ) ) {
-			/*
-			 * This flag records whether the default viewport already set `container-type`, so
-			 * it has to read the base values through the same guards the default viewport pass
-			 * used. Reading them raw would claim a `container-type` that was never written.
-			 */
-			$base_column_count         = is_numeric( $base_layout['columnCount'] ?? null ) ? (int) $base_layout['columnCount'] : null;
-			$base_minimum_column_width = is_string( $base_layout['minimumColumnWidth'] ?? null ) ? $base_layout['minimumColumnWidth'] : null;
-			$base_has_container_type   = empty( $base_column_count ) || ( ! empty( $base_column_count ) && ! empty( $base_minimum_column_width ) );
-			if ( empty( $column_count ) || ! empty( $minimum_column_width ) ) {
+			$base_has_container_type = empty( $base_layout['columnCount'] ) || ( ! empty( $base_layout['columnCount'] ) && ! empty( $base_layout['minimumColumnWidth'] ) );
+			if ( empty( $column_count ) || ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
 				if ( null === $viewport_overrides || ! $base_has_container_type ) {
 					$grid_declarations['container-type'] = 'inline-size';
 				}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1414,4 +1414,108 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			'Group inner container restore should not fatal when tagName is not a string.'
 		);
 	}
+
+	/**
+	 * Tests that non-numeric grid placement values are dropped rather than being
+	 * interpolated into the `grid-column` and `grid-row` declarations.
+	 *
+	 * @covers ::gutenberg_get_child_layout_style_rules
+	 */
+	public function test_gutenberg_get_child_layout_style_rules_with_non_numeric_grid_placement() {
+		$actual_output = gutenberg_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array(
+				'columnStart' => array( 2 ),
+				'columnSpan'  => array( 3 ),
+				'rowStart'    => array( 1 ),
+				'rowSpan'     => array( 2 ),
+			),
+			array(),
+			null
+		);
+
+		$this->assertSame(
+			array(),
+			$actual_output,
+			'Non-numeric grid placement values should not produce any child layout rules.'
+		);
+	}
+
+	/**
+	 * Tests that grid placement values saved as numeric strings (WordPress 6.3 to 6.6)
+	 * produce the same declarations as numbers.
+	 *
+	 * @covers ::gutenberg_get_child_layout_style_rules
+	 */
+	public function test_gutenberg_get_child_layout_style_rules_with_numeric_string_grid_placement() {
+		$expected_output = array(
+			array(
+				'selector'     => '.wp-container-content-test',
+				'declarations' => array(
+					'grid-column' => '2 / span 3',
+					'grid-row'    => '1 / span 2',
+				),
+			),
+		);
+
+		$actual_output = gutenberg_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array(
+				'columnStart' => '2',
+				'columnSpan'  => '3',
+				'rowStart'    => '1',
+				'rowSpan'     => '2',
+			),
+			array( 'columnCount' => '3' ),
+			null
+		);
+
+		$this->assertSame( $expected_output, $actual_output );
+	}
+
+	/**
+	 * Tests that non-numeric columnCount and rowCount, and a non-string minimumColumnWidth,
+	 * fall back to the responsive default instead of leaking into the CSS.
+	 *
+	 * @covers ::gutenberg_get_layout_style
+	 */
+	public function test_gutenberg_get_layout_style_with_non_numeric_grid_counts() {
+		$layout_styles = gutenberg_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'               => 'grid',
+				'columnCount'        => array( 3 ),
+				'rowCount'           => array( 2 ),
+				'minimumColumnWidth' => array( '20rem' ),
+			)
+		);
+
+		$this->assertSame(
+			'.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
+			$layout_styles,
+			'Non-numeric grid counts should fall back to the responsive default.'
+		);
+	}
+
+	/**
+	 * Tests that grid counts saved as numeric strings (WordPress 6.3 to 6.6) produce the
+	 * same CSS as numbers.
+	 *
+	 * @covers ::gutenberg_get_layout_style
+	 */
+	public function test_gutenberg_get_layout_style_with_numeric_string_grid_counts() {
+		$layout_styles = gutenberg_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'        => 'grid',
+				'columnCount' => '3',
+				'rowCount'    => '2',
+			)
+		);
+
+		$this->assertSame(
+			'.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-template-rows:repeat(2, minmax(1rem, auto));}',
+			$layout_styles
+		);
+	}
 }

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1525,6 +1525,38 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a viewport still gets `container-type` when the default viewport's
+	 * minimumColumnWidth is unusable. The default viewport skips the declaration in that
+	 * case, so the viewport rule must not assume it was already written.
+	 *
+	 * @covers ::gutenberg_get_layout_style
+	 */
+	public function test_gutenberg_get_layout_style_sets_container_type_when_base_minimum_column_width_is_unusable() {
+		$layout_styles = gutenberg_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'               => 'grid',
+				'columnCount'        => 3,
+				'minimumColumnWidth' => array( '9rem' ),
+			),
+			false,
+			null,
+			false,
+			'0.5em',
+			null,
+			array(
+				'viewport_overrides' => array( 'minimumColumnWidth' => '20rem' ),
+				'rules_group'        => '@media (min-width: 600px)',
+			)
+		);
+
+		$this->assertSame(
+			'@media (min-width: 600px){.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(20rem, 100%), (100% - (0.5em * (3 - 1))) /3), 1fr));container-type:inline-size;}}',
+			$layout_styles
+		);
+	}
+
+	/**
 	 * Tests that grid counts saved as numeric strings (WordPress 6.3 to 6.6) produce the
 	 * same CSS as numbers.
 	 *

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1474,44 +1474,34 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that non-numeric grid counts and a non-string minimumColumnWidth are treated as
-	 * absent instead of leaking into the CSS. Each case leaves the other attributes valid so
-	 * that the branch the guard protects is actually reached.
+	 * Tests that non-numeric grid counts are treated as absent instead of leaking into the
+	 * CSS. The rowCount case keeps columnCount valid, because the row track rule is only
+	 * reached when there is a column count.
 	 *
-	 * @dataProvider data_gutenberg_get_layout_style_with_non_numeric_grid_values
+	 * @dataProvider data_gutenberg_get_layout_style_with_non_numeric_grid_counts
 	 *
 	 * @covers ::gutenberg_get_layout_style
 	 *
 	 * @param array  $layout          Grid layout values.
 	 * @param string $expected_output The expected output.
 	 */
-	public function test_gutenberg_get_layout_style_with_non_numeric_grid_values( $layout, $expected_output ) {
+	public function test_gutenberg_get_layout_style_with_non_numeric_grid_counts( $layout, $expected_output ) {
 		$this->assertSame( $expected_output, gutenberg_get_layout_style( '.wp-layout', $layout ) );
 	}
 
 	/**
-	 * Data provider for test_gutenberg_get_layout_style_with_non_numeric_grid_values().
+	 * Data provider for test_gutenberg_get_layout_style_with_non_numeric_grid_counts().
 	 *
 	 * @return array
 	 */
-	public function data_gutenberg_get_layout_style_with_non_numeric_grid_values() {
+	public function data_gutenberg_get_layout_style_with_non_numeric_grid_counts() {
 		return array(
-			'every value unusable falls back to the responsive default' => array(
+			'non-numeric columnCount falls back to the responsive default' => array(
 				'layout'          => array(
-					'type'               => 'grid',
-					'columnCount'        => array( 3 ),
-					'rowCount'           => array( 2 ),
-					'minimumColumnWidth' => array( '20rem' ),
+					'type'        => 'grid',
+					'columnCount' => array( 3 ),
 				),
 				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
-			),
-			'non-string minimumColumnWidth drops the container query' => array(
-				'layout'          => array(
-					'type'               => 'grid',
-					'columnCount'        => 3,
-					'minimumColumnWidth' => array( '20rem' ),
-				),
-				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
 			),
 			'non-numeric rowCount drops the row track rule' => array(
 				'layout'          => array(
@@ -1521,38 +1511,6 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
 			),
-		);
-	}
-
-	/**
-	 * Tests that a viewport still gets `container-type` when the default viewport's
-	 * minimumColumnWidth is unusable. The default viewport skips the declaration in that
-	 * case, so the viewport rule must not assume it was already written.
-	 *
-	 * @covers ::gutenberg_get_layout_style
-	 */
-	public function test_gutenberg_get_layout_style_sets_container_type_when_base_minimum_column_width_is_unusable() {
-		$layout_styles = gutenberg_get_layout_style(
-			'.wp-layout',
-			array(
-				'type'               => 'grid',
-				'columnCount'        => 3,
-				'minimumColumnWidth' => array( '9rem' ),
-			),
-			false,
-			null,
-			false,
-			'0.5em',
-			null,
-			array(
-				'viewport_overrides' => array( 'minimumColumnWidth' => '20rem' ),
-				'rules_group'        => '@media (min-width: 600px)',
-			)
-		);
-
-		$this->assertSame(
-			'@media (min-width: 600px){.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(20rem, 100%), (100% - (0.5em * (3 - 1))) /3), 1fr));container-type:inline-size;}}',
-			$layout_styles
 		);
 	}
 

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1525,38 +1525,6 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a non-numeric parent columnCount is treated as absent, so a child of a
-	 * responsive grid still gets its container query.
-	 *
-	 * @covers ::gutenberg_get_child_layout_style_rules
-	 */
-	public function test_gutenberg_get_child_layout_style_rules_with_non_numeric_parent_column_count() {
-		$expected_output = array(
-			array(
-				'selector'     => '.wp-container-content-test',
-				'declarations' => array( 'grid-column' => 'span 2' ),
-			),
-			array(
-				'rules_group'  => '@container (max-width: 25.5rem )',
-				'selector'     => '.wp-container-content-test',
-				'declarations' => array(
-					'grid-column' => '1/-1',
-					'grid-row'    => 'auto',
-				),
-			),
-		);
-
-		$actual_output = gutenberg_get_child_layout_style_rules(
-			'.wp-container-content-test',
-			array( 'columnSpan' => 2 ),
-			array( 'columnCount' => array( 3 ) ),
-			null
-		);
-
-		$this->assertSame( $expected_output, $actual_output );
-	}
-
-	/**
 	 * Tests that grid counts saved as numeric strings (WordPress 6.3 to 6.6) produce the
 	 * same CSS as numbers.
 	 *

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1474,27 +1474,86 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that non-numeric columnCount and rowCount, and a non-string minimumColumnWidth,
-	 * fall back to the responsive default instead of leaking into the CSS.
+	 * Tests that non-numeric grid counts and a non-string minimumColumnWidth are treated as
+	 * absent instead of leaking into the CSS. Each case leaves the other attributes valid so
+	 * that the branch the guard protects is actually reached.
+	 *
+	 * @dataProvider data_gutenberg_get_layout_style_with_non_numeric_grid_values
 	 *
 	 * @covers ::gutenberg_get_layout_style
+	 *
+	 * @param array  $layout          Grid layout values.
+	 * @param string $expected_output The expected output.
 	 */
-	public function test_gutenberg_get_layout_style_with_non_numeric_grid_counts() {
-		$layout_styles = gutenberg_get_layout_style(
-			'.wp-layout',
+	public function test_gutenberg_get_layout_style_with_non_numeric_grid_values( $layout, $expected_output ) {
+		$this->assertSame( $expected_output, gutenberg_get_layout_style( '.wp-layout', $layout ) );
+	}
+
+	/**
+	 * Data provider for test_gutenberg_get_layout_style_with_non_numeric_grid_values().
+	 *
+	 * @return array
+	 */
+	public function data_gutenberg_get_layout_style_with_non_numeric_grid_values() {
+		return array(
+			'every value unusable falls back to the responsive default' => array(
+				'layout'          => array(
+					'type'               => 'grid',
+					'columnCount'        => array( 3 ),
+					'rowCount'           => array( 2 ),
+					'minimumColumnWidth' => array( '20rem' ),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
+			),
+			'non-string minimumColumnWidth drops the container query' => array(
+				'layout'          => array(
+					'type'               => 'grid',
+					'columnCount'        => 3,
+					'minimumColumnWidth' => array( '20rem' ),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
+			),
+			'non-numeric rowCount drops the row track rule' => array(
+				'layout'          => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+					'rowCount'    => array( 2 ),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
+			),
+		);
+	}
+
+	/**
+	 * Tests that a non-numeric parent columnCount is treated as absent, so a child of a
+	 * responsive grid still gets its container query.
+	 *
+	 * @covers ::gutenberg_get_child_layout_style_rules
+	 */
+	public function test_gutenberg_get_child_layout_style_rules_with_non_numeric_parent_column_count() {
+		$expected_output = array(
 			array(
-				'type'               => 'grid',
-				'columnCount'        => array( 3 ),
-				'rowCount'           => array( 2 ),
-				'minimumColumnWidth' => array( '20rem' ),
-			)
+				'selector'     => '.wp-container-content-test',
+				'declarations' => array( 'grid-column' => 'span 2' ),
+			),
+			array(
+				'rules_group'  => '@container (max-width: 25.5rem )',
+				'selector'     => '.wp-container-content-test',
+				'declarations' => array(
+					'grid-column' => '1/-1',
+					'grid-row'    => 'auto',
+				),
+			),
 		);
 
-		$this->assertSame(
-			'.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
-			$layout_styles,
-			'Non-numeric grid counts should fall back to the responsive default.'
+		$actual_output = gutenberg_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array( 'columnSpan' => 2 ),
+			array( 'columnCount' => array( 3 ) ),
+			null
 		);
+
+		$this->assertSame( $expected_output, $actual_output );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Follow-up to #80501, addressing [review feedback](https://github.com/WordPress/wordpress-develop/pull/12674#pullrequestreview-4877066420) on its core backport: the numeric grid attributes should be checked with `is_numeric()` and cast to `int` before use.

## Why?

#80501 guarded the string-valued layout attributes and left the numeric ones going straight into string interpolation, so an array attribute emits an `Array to string conversion` warning and writes `grid-column: span Array` into the page. `is_numeric()` rather than `is_int()` because content saved by WordPress 6.3 to 6.6 stored `columnCount`, `columnSpan` and `rowSpan` as numeric strings, and `convert-legacy-block.ts` only migrates those when a block is parsed in JavaScript — front end rendering still receives `'3'`.

## How?

Six attributes go through `is_numeric()` and are cast to `int`; anything else is treated as absent. `columnStart`, `columnSpan`, `rowStart` and `rowSpan` in `gutenberg_get_child_layout_style_rules()`, and `columnCount` and `rowCount` in the grid branch of `gutenberg_get_layout_style()`. Same `$..._attr` pattern as #80501.

Nothing else changes. Only these six values are read differently; every other attribute, including `minimumColumnWidth`, is read exactly as `trunk` reads it.

`minimumColumnWidth` has the same problem in the grid branch — a non-string value lands in the CSS as `min(Array, 100%)`. It is a string rather than a numeric attribute, so it is outside what the review asked for, and guarding it changes which rule carries `container-type`. Worth a separate PR.

## Testing Instructions

There should be no regressions.

<details>

<summary>Example HTML (paste into editor code view and save (don't switch back to visual)</summary>

```html
<!-- wp:heading -->
<h2 class="wp-block-heading">A — well-formed (control: must not change)</h2>
<!-- /wp:heading -->

<!-- wp:group {"layout":{"type":"grid","columnCount":3,"rowCount":2}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"layout":{"columnStart":2,"columnSpan":2,"rowStart":1,"rowSpan":1}}} -->
<p>One</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:heading -->
<h2 class="wp-block-heading">B — legacy numeric strings, as saved by WP 6.3 to 6.6</h2>
<!-- /wp:heading -->

<!-- wp:group {"layout":{"type":"grid","columnCount":"3","rowCount":"2"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"layout":{"columnStart":"2","columnSpan":"2","rowStart":"1","rowSpan":"1"}}} -->
<p>One</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:heading -->
<h2 class="wp-block-heading">C — malformed, e.g. hand-edited or generated content</h2>
<!-- /wp:heading -->

<!-- wp:group {"layout":{"type":"grid","columnCount":[3],"rowCount":[2]}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"layout":{"columnStart":[2],"columnSpan":[2],"rowStart":[1],"rowSpan":[1]}}} -->
<p>One</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

```

</details>


```
npm run test:unit:php -- --filter WP_Block_Supports_Layout_Test
```

Every `non_numeric` case fails on `trunk`, each one reaching a different guard. The two `numeric_string` cases pass on `trunk` and are there to prove the cast leaves 6.3 to 6.6 content rendering identically.




