### PR TITLE
Do not merge: run e2e tests for 7.1 without Gutenberg active

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
 	"$schema": "./schemas/json/wp-env.json",
 	"testsEnvironment": false,
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"phpmyadminPort": 9000
 }

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -3,14 +3,13 @@
 	"testsEnvironment": false,
 	"port": 8889,
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"config": {
 		"WP_DEBUG": false,
 		"SCRIPT_DEBUG": false
 	},
 	"mappings": {
-		"wp-content/plugins/gutenberg": ".",
 		"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 		"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 		"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -135,6 +135,7 @@ const test = base.extend<
 	{
 		requestUtils: RequestUtils;
 		lighthousePort: number;
+		isGutenbergPluginActive: boolean;
 	}
 >( {
 	admin: async ( { page, pageUtils, editor }, use ) => {
@@ -218,6 +219,19 @@ const test = base.extend<
 	metrics: async ( { page }, use ) => {
 		await use( new Metrics( { page } ) );
 	},
+	isGutenbergPluginActive: [
+		async ( { requestUtils }, use ) => {
+			const plugins = await requestUtils.rest( {
+				path: '/wp/v2/plugins',
+			} );
+			const gutenberg = plugins.find(
+				( p: { plugin: string; status: string } ) =>
+					p.plugin === 'gutenberg/gutenberg'
+			);
+			await use( gutenberg?.status === 'active' );
+		},
+		{ scope: 'worker' },
+	],
 } );
 
 export { test, expect };

--- a/packages/e2e-tests/plugins/connectors-empty-state.php
+++ b/packages/e2e-tests/plugins/connectors-empty-state.php
@@ -9,11 +9,12 @@
  * @package gutenberg-test-connectors-empty-state
  */
 
-// Remove the Gutenberg filter that provides default connector data.
+// Remove the filter that provides default connector data.
 add_action(
 	'init',
 	static function () {
 		remove_filter( 'script_module_data_options-connectors-wp-admin', '_gutenberg_get_connector_script_module_data' );
+		remove_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
 	},
 	PHP_INT_MAX
 );

--- a/packages/e2e-tests/plugins/connectors-js-extensibility.php
+++ b/packages/e2e-tests/plugins/connectors-js-extensibility.php
@@ -64,8 +64,12 @@ add_action(
 // Enqueue the script module on the connectors page.
 add_action(
 	'admin_enqueue_scripts',
-	static function () {
-		if ( ! isset( $_GET['page'] ) || 'options-connectors-wp-admin' !== $_GET['page'] ) {
+	static function ( $hook_suffix ) {
+		$connectors_pages = array(
+			'settings_page_options-connectors-wp-admin', // Gutenberg.
+			'options-connectors.php',                    // Core.
+		);
+		if ( ! in_array( $hook_suffix, $connectors_pages, true ) ) {
 			return;
 		}
 

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -56,7 +56,7 @@ function gutenberg_delete_installed_fonts() {
 	}
 
 	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -55,8 +55,13 @@ function gutenberg_delete_installed_fonts() {
 		rmdir( $font_path );
 	}
 
-	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	// Delete any installed fonts from global styles. Gutenberg overrides the
+	// resolver with its own subclass, so prefer it when the plugin is active.
+	$resolver_class = class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' )
+		? 'WP_Theme_JSON_Resolver_Gutenberg'
+		: 'WP_Theme_JSON_Resolver';
+
+	$global_styles_post_id = $resolver_class::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 

--- a/test/e2e/specs/admin/connectors.spec.js
+++ b/test/e2e/specs/admin/connectors.spec.js
@@ -3,8 +3,8 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const SETTINGS_PAGE_PATH = 'options-general.php';
-const CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
+let SETTINGS_PAGE_PATH;
+let CONNECTORS_PAGE_QUERY;
 
 const CONNECTORS = [
 	{
@@ -36,6 +36,16 @@ const getConnectorCardByName = ( page, name ) =>
 		.first();
 
 test.describe( 'Connectors', () => {
+	test.beforeAll( async ( { isGutenbergPluginActive } ) => {
+		if ( isGutenbergPluginActive ) {
+			SETTINGS_PAGE_PATH = 'options-general.php';
+			CONNECTORS_PAGE_QUERY = 'page=options-connectors-wp-admin';
+		} else {
+			SETTINGS_PAGE_PATH = 'options-connectors.php';
+			CONNECTORS_PAGE_QUERY = '';
+		}
+	} );
+
 	test( 'should show a Connectors link in the Settings menu', async ( {
 		page,
 		admin,
@@ -49,7 +59,9 @@ test.describe( 'Connectors', () => {
 		await expect( connectorsLink ).toBeVisible();
 		await expect( connectorsLink ).toHaveAttribute(
 			'href',
-			`${ SETTINGS_PAGE_PATH }?${ CONNECTORS_PAGE_QUERY }`
+			CONNECTORS_PAGE_QUERY
+				? `${ SETTINGS_PAGE_PATH }?${ CONNECTORS_PAGE_QUERY }`
+				: SETTINGS_PAGE_PATH
 		);
 	} );
 

--- a/test/e2e/specs/admin/font-library.spec.js
+++ b/test/e2e/specs/admin/font-library.spec.js
@@ -3,9 +3,20 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+let FONT_LIBRARY_PAGE_PATH;
+let FONT_LIBRARY_PAGE_QUERY;
+
 test.describe( 'Font Library', () => {
 	test.describe( 'When a user manages custom fonts via the UI', () => {
-		test.beforeAll( async ( { requestUtils } ) => {
+		test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+			if ( isGutenbergPluginActive ) {
+				FONT_LIBRARY_PAGE_PATH = 'admin.php';
+				FONT_LIBRARY_PAGE_QUERY = 'page=font-library-wp-admin';
+			} else {
+				FONT_LIBRARY_PAGE_PATH = 'font-library.php';
+				FONT_LIBRARY_PAGE_QUERY = '';
+			}
+
 			await requestUtils.activateTheme( 'twentytwentyone' );
 			/*
 			 * Delete all installed fonts, font files, the fonts directory, and user font settings
@@ -18,8 +29,8 @@ test.describe( 'Font Library', () => {
 
 		test.beforeEach( async ( { admin } ) => {
 			await admin.visitAdminPage(
-				'admin.php',
-				'page=font-library-wp-admin'
+				FONT_LIBRARY_PAGE_PATH,
+				FONT_LIBRARY_PAGE_QUERY
 			);
 		} );
 
@@ -101,8 +112,8 @@ test.describe( 'Font Library', () => {
 
 			// Check fonts can be uninstalled.
 			await admin.visitAdminPage(
-				'admin.php',
-				'page=font-library-wp-admin'
+				FONT_LIBRARY_PAGE_PATH,
+				FONT_LIBRARY_PAGE_QUERY
 			);
 
 			await page.getByRole( 'button', { name: 'Exo 2' } ).click();

--- a/test/e2e/specs/admin/guidelines.spec.js
+++ b/test/e2e/specs/admin/guidelines.spec.js
@@ -92,7 +92,12 @@ async function saveSectionGuidelines( page, title, text ) {
 }
 
 test.describe( 'Guidelines', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-guidelines experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-guidelines',
 		] );

--- a/test/e2e/specs/admin/user-post-types.spec.js
+++ b/test/e2e/specs/admin/user-post-types.spec.js
@@ -20,7 +20,12 @@ async function createUserPostType( requestUtils ) {
 }
 
 test.describe( 'User post types', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-content-types experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-content-types',
 		] );

--- a/test/e2e/specs/admin/user-taxonomies.spec.js
+++ b/test/e2e/specs/admin/user-taxonomies.spec.js
@@ -34,7 +34,12 @@ async function createUserTaxonomy( requestUtils ) {
 }
 
 test.describe( 'User taxonomies', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-content-types experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-content-types',
 		] );

--- a/test/e2e/specs/admin/workflow-palette.spec.js
+++ b/test/e2e/specs/admin/workflow-palette.spec.js
@@ -4,7 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Workflow palette', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-workflow-palette experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-workflow-palette',
 		] );

--- a/test/e2e/specs/editor/collaboration/collaboration-code-editor-performance.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-code-editor-performance.spec.ts
@@ -36,7 +36,13 @@ type Fixtures = {
 // This test only needs collaboration enabled, not a second user.
 const test = base.extend< Fixtures >( {
 	collaborationEnabled: [
-		async ( { requestUtils }, use ) => {
+		async ( { requestUtils, isGutenbergPluginActive }, use ) => {
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! isGutenbergPluginActive,
+				'Collaboration tests require Gutenberg plugin to be active'
+			);
+
 			await setCollaboration( requestUtils, true );
 			try {
 				await use( true );

--- a/test/e2e/specs/editor/collaboration/collaboration-title-reload.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-title-reload.spec.ts
@@ -19,9 +19,15 @@ type Fixtures = {
 
 const test = base.extend< Fixtures >( {
 	collaborationUtils: async (
-		{ admin, editor, requestUtils, page },
+		{ admin, editor, requestUtils, page, isGutenbergPluginActive },
 		use
 	) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Collaboration tests require Gutenberg plugin to be active'
+		);
+
 		const utils = new CollaborationUtilsClass( {
 			admin,
 			cleanupUsersMode: 'tracked',

--- a/test/e2e/specs/editor/collaboration/fixtures/index.ts
+++ b/test/e2e/specs/editor/collaboration/fixtures/index.ts
@@ -18,9 +18,15 @@ type Fixtures = {
 
 export const test = base.extend< Fixtures >( {
 	collaborationUtils: async (
-		{ admin, editor, requestUtils, page },
+		{ admin, editor, requestUtils, page, isGutenbergPluginActive },
 		use
 	) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Collaboration tests require Gutenberg plugin to be active'
+		);
+
 		const utils = new CollaborationUtils( {
 			admin,
 			editor,

--- a/test/e2e/specs/editor/plugins/react-18-compat-block.spec.js
+++ b/test/e2e/specs/editor/plugins/react-18-compat-block.spec.js
@@ -13,7 +13,12 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 // support for function components. The assertions below describe the desired
 // end state and act as a checklist for that work.
 test.describe( 'React 18 compatibility block (React 19 runtime)', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-react-19 experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [ 'gutenberg-react-19' ] );
 		await requestUtils.activatePlugin(
 			'gutenberg-test-react-18-compat-block'

--- a/test/e2e/specs/editor/various/block-bindings/block-fields-pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/block-fields-pattern-overrides.spec.js
@@ -9,7 +9,12 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 // fixtures failing any test that logs a console error.
 // See https://github.com/WordPress/gutenberg/issues/79090.
 test.describe( 'Block Fields with pattern overrides bindings', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Block Fields experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-content-only-inspector-fields',
 		] );

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -376,7 +376,12 @@ test.describe( 'Post Meta source', () => {
 	} );
 
 	test.describe( 'Movie CPT post', () => {
-		test.beforeAll( async ( { requestUtils } ) => {
+		test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				! isGutenbergPluginActive,
+				'Block Fields experiment requires Gutenberg plugin'
+			);
 			await requestUtils.setGutenbergExperiments( [
 				'gutenberg-content-only-inspector-fields',
 			] );

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -40,7 +40,12 @@ test.use( {
 } );
 
 test.describe( 'Document-Isolation-Policy', () => {
-	test.beforeEach( async ( { admin, page } ) => {
+	test.beforeEach( async ( { admin, page, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Document-Isolation-Policy header requires Gutenberg plugin'
+		);
 		// These tests only apply to Chromium 137+.
 		test.skip(
 			( await getChromiumMajorVersion( page ) ) < 137,

--- a/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
+++ b/test/e2e/specs/editor/various/cross-origin-isolation.spec.js
@@ -40,12 +40,7 @@ test.use( {
 } );
 
 test.describe( 'Document-Isolation-Policy', () => {
-	test.beforeEach( async ( { admin, page, isGutenbergPluginActive } ) => {
-		// eslint-disable-next-line playwright/no-skipped-test
-		test.skip(
-			! isGutenbergPluginActive,
-			'Document-Isolation-Policy header requires Gutenberg plugin'
-		);
+	test.beforeEach( async ( { admin, page } ) => {
 		// These tests only apply to Chromium 137+.
 		test.skip(
 			( await getChromiumMajorVersion( page ) ) < 137,

--- a/test/e2e/specs/editor/various/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary.spec.js
@@ -4,7 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Post Summary', () => {
-	test.beforeEach( async ( { requestUtils } ) => {
+	test.beforeEach( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-dataform-inspector experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-dataform-inspector',
 		] );

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -11,6 +11,7 @@ test.describe( 'Should iframe', () => {
 	test( 'should remain iframed when a v1 block is added', async ( {
 		page,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
 		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
 
@@ -33,7 +34,12 @@ test.describe( 'Should iframe', () => {
 		// Insert the v1 block.
 		await editor.insertBlock( { name: 'test/v1' } );
 
-		// The editor should remain iframed because Gutenberg is active.
-		await expect( iframe ).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			// Gutenberg keeps the editor iframed even with v1 blocks.
+			await expect( iframe ).toBeVisible();
+		} else {
+			// Core exits iframe mode when a v1 block is added.
+			await expect( iframe ).toBeHidden();
+		}
 	} );
 } );

--- a/test/e2e/specs/editor/various/should-iframe.spec.js
+++ b/test/e2e/specs/editor/various/should-iframe.spec.js
@@ -11,7 +11,6 @@ test.describe( 'Should iframe', () => {
 	test( 'should remain iframed when a v1 block is added', async ( {
 		page,
 		editor,
-		isGutenbergPluginActive,
 	} ) => {
 		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
 
@@ -34,12 +33,7 @@ test.describe( 'Should iframe', () => {
 		// Insert the v1 block.
 		await editor.insertBlock( { name: 'test/v1' } );
 
-		if ( isGutenbergPluginActive ) {
-			// Gutenberg keeps the editor iframed even with v1 blocks.
-			await expect( iframe ).toBeVisible();
-		} else {
-			// Core exits iframe mode when a v1 block is added.
-			await expect( iframe ).toBeHidden();
-		}
+		// The editor should remain iframed because Gutenberg is active.
+		await expect( iframe ).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -68,9 +68,8 @@ test.describe( 'Preload', () => {
 
 		// Only collab side effects (CRDT persist + first wp-sync poll)
 		// should escape before mount — they're detached promise chains
-		// off `receiveEntityRecords`. The `wp-sync` routes and the notes
-		// comments query below only exist with the Gutenberg plugin, so
-		// core sees neither.
+		// off `receiveEntityRecords`. The `wp-sync` routes only exist with
+		// the Gutenberg plugin, so core sees nothing here.
 		expect( Array.from( new Set( requestsUntilMount ) ).sort() ).toEqual(
 			isGutenbergPluginActive
 				? [ 'POST /wp-sync/v1/save', 'POST /wp-sync/v1/updates' ].sort()
@@ -85,14 +84,13 @@ test.describe( 'Preload', () => {
 		// isn't stable across runs, so this assertion deduplicates.
 		// To do: these should all be removed or preloaded.
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
-			isGutenbergPluginActive
-				? [
-						`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
-						'POST /wp-sync/v1/save',
-						'POST /wp-sync/v1/updates',
-						'POST /wp/v2/users/me',
-				  ].sort()
-				: [ 'POST /wp/v2/users/me' ]
+			[
+				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
+				'POST /wp/v2/users/me',
+				...( isGutenbergPluginActive
+					? [ 'POST /wp-sync/v1/save', 'POST /wp-sync/v1/updates' ]
+					: [] ),
+			].sort()
 		);
 	} );
 } );

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -31,6 +31,7 @@ test.describe( 'Preload', () => {
 		page,
 		admin,
 		editor,
+		isGutenbergPluginActive,
 	} ) => {
 		const { requests, stop } = recordRequests( page );
 		const { requests: requestsUntilMount, stop: stopOnMount } =
@@ -67,9 +68,13 @@ test.describe( 'Preload', () => {
 
 		// Only collab side effects (CRDT persist + first wp-sync poll)
 		// should escape before mount — they're detached promise chains
-		// off `receiveEntityRecords`.
+		// off `receiveEntityRecords`. The `wp-sync` routes and the notes
+		// comments query below only exist with the Gutenberg plugin, so
+		// core sees neither.
 		expect( Array.from( new Set( requestsUntilMount ) ).sort() ).toEqual(
-			[ 'POST /wp-sync/v1/save', 'POST /wp-sync/v1/updates' ].sort()
+			isGutenbergPluginActive
+				? [ 'POST /wp-sync/v1/save', 'POST /wp-sync/v1/updates' ].sort()
+				: []
 		);
 		// Every preloaded path should be consumed by the kickoff.
 		expect( preloadStatus ).toBe(
@@ -80,12 +85,14 @@ test.describe( 'Preload', () => {
 		// isn't stable across runs, so this assertion deduplicates.
 		// To do: these should all be removed or preloaded.
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
-			[
-				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
-				'POST /wp-sync/v1/save',
-				'POST /wp-sync/v1/updates',
-				'POST /wp/v2/users/me',
-			].sort()
+			isGutenbergPluginActive
+				? [
+						`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
+						'POST /wp-sync/v1/save',
+						'POST /wp-sync/v1/updates',
+						'POST /wp/v2/users/me',
+				  ].sort()
+				: [ 'POST /wp/v2/users/me' ]
 		);
 	} );
 } );

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -91,7 +91,12 @@ test.describe( 'Preload', () => {
 } );
 
 test.describe( 'Preload with the DataForm inspector experiment', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'gutenberg-dataform-inspector experiment requires Gutenberg plugin'
+		);
 		await requestUtils.setGutenbergExperiments( [
 			'gutenberg-dataform-inspector',
 		] );

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -20,7 +20,10 @@ test.describe( 'Global styles sidebar', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'should filter blocks list results', async ( { page } ) => {
+	test( 'should filter blocks list results', async ( {
+		page,
+		isGutenbergPluginActive,
+	} ) => {
 		// Navigate to Styles -> Blocks.
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )
@@ -43,5 +46,12 @@ test.describe( 'Global styles sidebar', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Accordion Item' } )
 		).toBeVisible();
+		if ( isGutenbergPluginActive ) {
+			await expect(
+				page.getByRole( 'button', {
+					name: 'Table of Contents',
+				} )
+			).toBeVisible();
+		}
 	} );
 } );

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -4,7 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'calling saveEntityRecord with a theme template ID', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		// Enable the template activation feature.
 		await requestUtils.setGutenbergExperiments( [ 'active_templates' ] );

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -4,7 +4,12 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Template Activate', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );

--- a/test/e2e/specs/site-editor/template-id-format.spec.js
+++ b/test/e2e/specs/site-editor/template-id-format.spec.js
@@ -63,7 +63,12 @@ async function saveEntities( { page } ) {
 test.describe( 'Template ID Format', () => {
 	let pageId;
 
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'twentytwentyfive' );
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );

--- a/test/e2e/specs/site-editor/template-registration-activation.spec.js
+++ b/test/e2e/specs/site-editor/template-registration-activation.spec.js
@@ -10,7 +10,12 @@ test.use( {
 } );
 
 test.describe( 'Block template registration', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
+	test.beforeAll( async ( { requestUtils, isGutenbergPluginActive } ) => {
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip(
+			! isGutenbergPluginActive,
+			'Template activation experiment requires Gutenberg plugin'
+		);
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.activatePlugin(
 			'gutenberg-test-block-template-registration'


### PR DESCRIPTION
## What?

Make e2e tests runnable without the Gutenberg plugin active, this time on `wp/7.1`.

Previously: #74536, #77066, #78464

## Why?

It would be nice if all e2e tests can run on core without the plugin active. This requires a few tests to be skipped or adjusted.

## How?

- Remove Gutenberg plugin from `.wp-env.json` and `.wp-env.test.json`
- Add `isGutenbergPluginActive` fixture to e2e test utils
- Guard or adjust tests that depend on Gutenberg-specific behavior
- Make the connectors test plugins work against both core and Gutenberg

Differences from #78464:

- `setGutenbergExperiments` no longer needs a `boolean` return. On `wp/7.1` it writes through the REST settings endpoint instead of the experiments admin page, so every skip is driven by the `isGutenbergPluginActive` fixture instead.
- A few specs that only exist on `wp/7.1` needed the same experiment guard: `post-summary`, `react-18-compat-block`, `block-fields-pattern-overrides`, and `preload/post-editor`.
- `fullscreen-mode.spec.js` needed no guard here — the admin bar in the editor is no longer behind an experiment on this branch.

## Notes

- Will investigate based on the CI check results.

## History

- Port of #78464 to `wp/7.1`.

## Use of AI Tools

Authored with Claude Code, based on the diff of #78464 and its trunk follow-up. Reviewed by me.
