### PR TITLE
Media Editor Route: Try adding undo/redo and save/cancel actions to the header

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility ([#81559](https://github.com/WordPress/gutenberg/pull/81559)).
--   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, so a frame without a footer can place them itself ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
+-   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, replacing the pre-composed `footerActions`, so each frame arranges them to suit its own chrome ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
 -   Add a `saveActionsSize` prop to `MediaEditor` so frames hosting the cancel/save actions in a page header can render them at the compact size ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
 
 ### Bug Fixes

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Enhancements
 
 -   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility ([#81559](https://github.com/WordPress/gutenberg/pull/81559)).
--   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, so a frame without a footer can place them itself.
--   Add an `actionsSize` prop to `MediaEditor` so frames hosting the cancel/save actions in a page header can render them at the compact size.
+-   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, so a frame without a footer can place them itself ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
+-   Add a `saveActionsSize` prop to `MediaEditor` so frames hosting the cancel/save actions in a page header can render them at the compact size ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
 
 ### Bug Fixes
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Enhancements
 
 -   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility ([#81559](https://github.com/WordPress/gutenberg/pull/81559)).
+-   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, so a frame without a footer can place them itself.
+-   Add an `actionsSize` prop to `MediaEditor` so frames hosting the cancel/save actions in a page header can render them at the compact size.
 
 ### Bug Fixes
 

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility ([#81559](https://github.com/WordPress/gutenberg/pull/81559)).
--   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, replacing the pre-composed `footerActions`, so each frame arranges them to suit its own chrome ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
+-   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, replacing the pre-composed `footerActions`, so each frame arranges them to suit its own chrome. `footerLayout` is now `layout` ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
 -   Add a `saveActionsSize` prop to `MediaEditor` so frames hosting the cancel/save actions in a page header can render them at the compact size ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
 
 ### Bug Fixes

--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### Enhancements
 
 -   Add a `scope` prop to `MediaEditor` so each frame can keep its own persisted details-sidebar visibility ([#81559](https://github.com/WordPress/gutenberg/pull/81559)).
--   Pass the history (reset/undo/redo), save (cancel/save) and image control clusters to `renderFrame` individually, replacing the pre-composed `footerActions`, so each frame arranges them to suit its own chrome. `footerLayout` is now `layout` ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
--   Add a `saveActionsSize` prop to `MediaEditor` so frames hosting the cancel/save actions in a page header can render them at the compact size ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
+-   Expose the header, history (reset/undo/redo), save (cancel/save) and image control clusters as `MediaEditor` sub-components, so each frame imports and arranges them to suit its own chrome. `renderFrame` now passes data only: `footerActions` is gone, `footerLayout` is now `layout`, and `isImage` is new. `showCloseButton` moves from `MediaEditor` to `MediaEditor.HeaderActions` ([#81563](https://github.com/WordPress/gutenberg/pull/81563)).
 
 ### Bug Fixes
 

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { store as noticesStore } from '@wordpress/notices';
 import type { Field } from '@wordpress/dataviews';
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
 import MediaEditor from '../media-editor';
 import type { Media } from '../media-editor-provider';
 import { store as mediaEditorStore } from '../../store';
@@ -24,6 +24,52 @@ interface MediaEditorModalProps {
 	 * always provided by the media editor.
 	 */
 	aspectRatioPresets?: AspectRatioPreset[];
+}
+
+interface ModalFooterProps {
+	layout: 'wide' | 'narrow';
+	historyActions: ReactNode;
+	saveActions: ReactNode;
+	imageControls: ReactNode;
+}
+
+/**
+ * The modal's footer chrome. The fine-rotation ruler always lives under the
+ * canvas (in `media-editor__content`), never here, so it stays constrained to
+ * the canvas column at every viewport. One JSX tree per layout; DOM order
+ * matches visual order.
+ */
+function ModalFooter( {
+	layout,
+	historyActions,
+	saveActions,
+	imageControls,
+}: ModalFooterProps ) {
+	return (
+		<div
+			className={ `media-editor-modal__footer is-${ layout }` }
+			role="region"
+			aria-label={ __( 'Editor actions' ) }
+		>
+			{ layout === 'wide' ? (
+				// Sidebar is a column: the image controls live in the Crop
+				// panel, so the footer is just History + Cancel/Save.
+				<>
+					{ historyActions }
+					{ saveActions }
+				</>
+			) : (
+				// Sidebar collapsed: the image controls drop into the footer.
+				<>
+					{ imageControls }
+					<div className="media-editor-modal__footer-row">
+						{ historyActions }
+						{ saveActions }
+					</div>
+				</>
+			) }
+		</div>
+	);
 }
 
 export function MediaEditorModal( {
@@ -108,7 +154,9 @@ export function MediaEditorModal( {
 			renderFrame={ ( {
 				children,
 				headerActions,
-				footerActions,
+				historyActions,
+				saveActions,
+				imageControls,
 				footerLayout,
 				onRequestClose,
 				onKeyDown,
@@ -129,13 +177,12 @@ export function MediaEditorModal( {
 						headerActions={ headerActions }
 					>
 						{ children }
-						<div
-							className={ `media-editor-modal__footer is-${ footerLayout }` }
-							role="region"
-							aria-label={ __( 'Editor actions' ) }
-						>
-							{ footerActions }
-						</div>
+						<ModalFooter
+							layout={ footerLayout }
+							historyActions={ historyActions }
+							saveActions={ saveActions }
+							imageControls={ imageControls }
+						/>
 					</Modal>
 				</ShortcutProvider>
 			) }

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { store as noticesStore } from '@wordpress/notices';
 import type { Field } from '@wordpress/dataviews';
-import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import MediaEditor from '../media-editor';
 import type { Media } from '../media-editor-provider';
 import { store as mediaEditorStore } from '../../store';
@@ -28,9 +28,6 @@ interface MediaEditorModalProps {
 
 interface ModalFooterProps {
 	layout: 'wide' | 'narrow';
-	historyActions: ReactNode;
-	saveActions: ReactNode;
-	imageControls: ReactNode;
 }
 
 /**
@@ -39,12 +36,7 @@ interface ModalFooterProps {
  * the canvas column at every viewport. One JSX tree per layout; DOM order
  * matches visual order.
  */
-function ModalFooter( {
-	layout,
-	historyActions,
-	saveActions,
-	imageControls,
-}: ModalFooterProps ) {
+function ModalFooter( { layout }: ModalFooterProps ) {
 	return (
 		<div
 			className={ `media-editor-modal__footer is-${ layout }` }
@@ -55,16 +47,16 @@ function ModalFooter( {
 				// Sidebar is a column: the image controls live in the Crop
 				// panel, so the footer is just History + Cancel/Save.
 				<>
-					{ historyActions }
-					{ saveActions }
+					<MediaEditor.HistoryActions />
+					<MediaEditor.SaveActions />
 				</>
 			) : (
 				// Sidebar collapsed: the image controls drop into the footer.
 				<>
-					{ imageControls }
+					<MediaEditor.ImageControls />
 					<div className="media-editor-modal__footer-row">
-						{ historyActions }
-						{ saveActions }
+						<MediaEditor.HistoryActions />
+						<MediaEditor.SaveActions />
 					</div>
 				</>
 			) }
@@ -117,7 +109,6 @@ export function MediaEditorModal( {
 			id={ id }
 			fields={ fields }
 			aspectRatioPresets={ aspectRatioPresets }
-			showCloseButton
 			shouldCloseOnEsc
 			noticesClassName="media-editor-modal__snackbar"
 			noticesPortalElement={ portalElement }
@@ -153,10 +144,6 @@ export function MediaEditorModal( {
 			} }
 			renderFrame={ ( {
 				children,
-				headerActions,
-				historyActions,
-				saveActions,
-				imageControls,
 				layout,
 				onRequestClose,
 				onKeyDown,
@@ -174,15 +161,12 @@ export function MediaEditorModal( {
 						shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
 						onKeyDown={ onKeyDown }
 						onRequestClose={ onRequestClose }
-						headerActions={ headerActions }
+						headerActions={
+							<MediaEditor.HeaderActions showCloseButton />
+						}
 					>
 						{ children }
-						<ModalFooter
-							layout={ layout }
-							historyActions={ historyActions }
-							saveActions={ saveActions }
-							imageControls={ imageControls }
-						/>
+						<ModalFooter layout={ layout } />
 					</Modal>
 				</ShortcutProvider>
 			) }

--- a/packages/media-editor/src/components/media-editor-modal/index.tsx
+++ b/packages/media-editor/src/components/media-editor-modal/index.tsx
@@ -157,7 +157,7 @@ export function MediaEditorModal( {
 				historyActions,
 				saveActions,
 				imageControls,
-				footerLayout,
+				layout,
 				onRequestClose,
 				onKeyDown,
 				shouldCloseOnClickOutside,
@@ -178,7 +178,7 @@ export function MediaEditorModal( {
 					>
 						{ children }
 						<ModalFooter
-							layout={ footerLayout }
+							layout={ layout }
 							historyActions={ historyActions }
 							saveActions={ saveActions }
 							imageControls={ imageControls }

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -46,8 +46,8 @@
 		// Panel mode: the footer holds only History (left) and
 		// Cancel/Save (right). `margin-left: auto` pins the actions to the
 		// right edge whether or not History renders (e.g. non-image
-		// attachments show only `FooterActions`).
-		.media-editor__footer-actions {
+		// attachments show only `SaveActions`).
+		.media-editor__save-actions {
 			margin-left: auto;
 		}
 	}
@@ -76,19 +76,9 @@
 	gap: $grid-unit-20;
 
 	.media-editor-image-controls,
-	.media-editor__footer-actions {
+	.media-editor__save-actions {
 		margin-left: auto;
 	}
-}
-
-// Active (enabled) undo/redo icon buttons take the admin accent colour so
-// they read as live alongside the Reset/Cancel/Save actions. Disabled
-// buttons (rendered with `aria-disabled` via `accessibleWhenDisabled`)
-// keep the default muted icon colour.
-// NOTE: overrides @wordpress/components Button internals (`.components-button`,
-// `.has-icon`), scoped to our history-actions wrapper. Update if renamed.
-.media-editor__history-actions .components-button.has-icon:not([aria-disabled="true"]) {
-	color: var(--wp-admin-theme-color);
 }
 
 .media-editor-modal {

--- a/packages/media-editor/src/components/media-editor-modal/style.scss
+++ b/packages/media-editor/src/components/media-editor-modal/style.scss
@@ -81,6 +81,20 @@
 	}
 }
 
+// Active (enabled) undo/redo icon buttons take the admin accent colour so
+// they read as live alongside the Reset/Cancel/Save actions. Disabled
+// buttons (rendered with `aria-disabled` via `accessibleWhenDisabled`)
+// keep the default muted icon colour.
+// Scoped to the modal: the package ships one stylesheet, so an unscoped
+// selector would also colour the history cluster in frames that place it in
+// their own chrome (the wp-admin route puts it in the page header, where the
+// neutral icon colour matches the header's other buttons).
+// NOTE: overrides @wordpress/components Button internals (`.components-button`,
+// `.has-icon`), scoped to our history-actions wrapper. Update if renamed.
+.media-editor-modal .media-editor__history-actions .components-button.has-icon:not([aria-disabled="true"]) {
+	color: var(--wp-admin-theme-color);
+}
+
 .media-editor-modal {
 	display: flex;
 	flex-direction: column;

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -79,23 +79,22 @@ export interface MediaEditorFrameProps {
 	 */
 	saveActions: ReactNode;
 	/**
-	 * Rotate / flip / zoom and the aspect-ratio control, as a flat toolbar.
-	 * `null` for non-image media.
+	 * Rotate / flip / zoom and the aspect-ratio control, as a flat toolbar —
+	 * but only when placing them is the frame's job. `null` for non-image
+	 * media, and `null` in the `wide` layout, where the Crop panel renders
+	 * them itself.
 	 *
-	 * Render this only when `footerLayout` is `narrow`: above that breakpoint
-	 * the Crop panel renders these itself. Below it the panel is gone, so a
-	 * frame that never places this leaves the transform controls unreachable.
+	 * Frames render this wherever it suits them without checking the layout;
+	 * a frame that never places it leaves the transform controls unreachable
+	 * once the Crop panel is gone.
 	 */
 	imageControls: ReactNode;
 	/**
-	 * Layout selector, tracking the sidebar-collapse breakpoint (`small`).
-	 * Frames arrange the action clusters to suit:
-	 *
-	 * - `wide`   — sidebar is a column, so the transform controls live in the
-	 *              Crop panel and `imageControls` should not be rendered.
-	 * - `narrow` — sidebar is collapsed, so `imageControls` needs a home.
+	 * Which layout the editor is in, tracking the sidebar-collapse breakpoint
+	 * (`small`). `wide` is a side-by-side canvas and sidebar; `narrow` stacks,
+	 * leaving the frame to house the clusters the Crop panel no longer holds.
 	 */
-	footerLayout: 'wide' | 'narrow';
+	layout: 'wide' | 'narrow';
 	onRequestClose: () => void;
 	onKeyDown: ( event: ReactKeyboardEvent< HTMLElement > ) => void;
 	shouldCloseOnClickOutside: boolean;
@@ -390,11 +389,11 @@ function MediaEditorContent( {
 	// to an overlay below it — mirroring InterfaceSkeleton's behaviour, shifted
 	// from `medium` to `small` (see the matching CSS overrides in style.scss).
 	// Track that single breakpoint: in "panel mode" (≥ small) the
-	// rotate/flip/zoom controls live in the Crop panel and the footer is just
-	// History + Cancel/Save; below it the controls drop into the footer. (The
-	// fine-rotation ruler always sits under the canvas.)
+	// rotate/flip/zoom controls live in the Crop panel; below it they have no
+	// panel to live in and the frame places them instead. (The fine-rotation
+	// ruler always sits under the canvas.)
 	const isPanelLayout = useViewportMatch( 'small' );
-	const footerLayout: 'wide' | 'narrow' = isPanelLayout ? 'wide' : 'narrow';
+	const layout: 'wide' | 'narrow' = isPanelLayout ? 'wide' : 'narrow';
 
 	const { media, hasEdits } = useSelect(
 		( select ) => {
@@ -741,8 +740,10 @@ function MediaEditorContent( {
 		),
 		historyActions: history,
 		saveActions: actions,
-		imageControls,
-		footerLayout,
+		// Withheld in the `wide` layout: the Crop panel already renders these,
+		// so the frame has nothing to place.
+		imageControls: layout === 'narrow' ? imageControls : null,
+		layout,
 		onRequestClose: handleRequestClose,
 		onKeyDown: handleKeyDown,
 		shouldCloseOnClickOutside: ! hasChanges && ! isSaving,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -72,11 +72,6 @@ export interface MediaEditorFrameProps {
 	/**
 	 * Reset / Undo / Redo. `null` for non-image media, which has no edit
 	 * history.
-	 *
-	 * A frame with no footer — the wp-admin route, where a footer would be out
-	 * of place — places this itself, alongside `saveActions` and
-	 * `imageControls`. A frame with a footer renders the pre-composed
-	 * `footerActions` instead. Render one or the other, never both.
 	 */
 	historyActions: ReactNode;
 	/**
@@ -93,19 +88,12 @@ export interface MediaEditorFrameProps {
 	 */
 	imageControls: ReactNode;
 	/**
-	 * `historyActions`, `saveActions` and `imageControls` pre-composed into the
-	 * layout selected by `footerLayout`. A convenience for frames with a
-	 * footer; frames that place the clusters themselves should ignore it.
-	 */
-	footerActions: ReactNode;
-	/**
-	 * Footer layout selector. Frames apply this to the footer container
-	 * as a modifier class. Tracks the sidebar-collapse breakpoint (`small`).
+	 * Layout selector, tracking the sidebar-collapse breakpoint (`small`).
+	 * Frames arrange the action clusters to suit:
 	 *
-	 * - `wide`   — sidebar is a column; footer is a single row of History |
-	 *              Cancel/Save (transform controls live in the Crop panel).
-	 * - `narrow` — sidebar collapsed; transform controls sit above a
-	 *              History | Cancel/Save row.
+	 * - `wide`   — sidebar is a column, so the transform controls live in the
+	 *              Crop panel and `imageControls` should not be rendered.
+	 * - `narrow` — sidebar is collapsed, so `imageControls` needs a home.
 	 */
 	footerLayout: 'wide' | 'narrow';
 	onRequestClose: () => void;
@@ -740,33 +728,6 @@ function MediaEditorContent( {
 		/>
 	);
 
-	// The fine-rotation ruler always lives under the canvas (in
-	// `media-editor__content`), never the footer, so it stays constrained to
-	// the canvas column at every viewport. One JSX tree per layout; DOM order
-	// matches visual order.
-	let footerActions: ReactNode;
-	if ( footerLayout === 'wide' ) {
-		// Sidebar is a column: image controls live in the Crop panel, so
-		// the footer is just History + Cancel/Save.
-		footerActions = (
-			<>
-				{ history }
-				{ actions }
-			</>
-		);
-	} else {
-		// Sidebar collapsed: the image controls drop into the footer.
-		footerActions = (
-			<>
-				{ imageControls }
-				<div className="media-editor-modal__footer-row">
-					{ history }
-					{ actions }
-				</div>
-			</>
-		);
-	}
-
 	return renderFrame( {
 		children,
 		headerActions: (
@@ -781,7 +742,6 @@ function MediaEditorContent( {
 		historyActions: history,
 		saveActions: actions,
 		imageControls,
-		footerActions,
 		footerLayout,
 		onRequestClose: handleRequestClose,
 		onKeyDown: handleKeyDown,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -69,6 +69,35 @@ interface EditorTab {
 export interface MediaEditorFrameProps {
 	children: ReactNode;
 	headerActions: ReactNode;
+	/**
+	 * Reset / Undo / Redo. `null` for non-image media, which has no edit
+	 * history.
+	 *
+	 * A frame with no footer — the wp-admin route, where a footer would be out
+	 * of place — places this itself, alongside `saveActions` and
+	 * `imageControls`. A frame with a footer renders the pre-composed
+	 * `footerActions` instead. Render one or the other, never both.
+	 */
+	historyActions: ReactNode;
+	/**
+	 * Cancel / Save.
+	 */
+	saveActions: ReactNode;
+	/**
+	 * Rotate / flip / zoom and the aspect-ratio control, as a flat toolbar.
+	 *
+	 * Non-null only when `footerLayout` is `narrow`: above that breakpoint the
+	 * Crop panel renders these itself, so a frame that rendered this
+	 * unconditionally would show them twice. A frame that composes the
+	 * clusters by hand must give this a home, or the transform controls become
+	 * unreachable once the sidebar collapses.
+	 */
+	imageControls: ReactNode;
+	/**
+	 * `historyActions`, `saveActions` and `imageControls` pre-composed into the
+	 * layout selected by `footerLayout`. A convenience for frames with a
+	 * footer; frames that place the clusters themselves should ignore it.
+	 */
 	footerActions: ReactNode;
 	/**
 	 * Footer layout selector. Frames apply this to the footer container
@@ -111,6 +140,14 @@ export interface MediaEditorProps {
 	 * @default 'media-editor'
 	 */
 	scope?: string;
+	/**
+	 * Size applied to the Cancel/Save buttons. Footers use the 40px default;
+	 * frames that host these actions in a page header should pass `compact` so
+	 * they match the header's other controls.
+	 *
+	 * @default 'default'
+	 */
+	actionsSize?: 'default' | 'compact';
 }
 
 interface MediaEditorSidebarProps {
@@ -297,31 +334,38 @@ function HistoryActions( {
 	);
 }
 
-interface FooterActionsProps {
+interface SaveActionsProps {
 	isSaving: boolean;
 	hasMedia: boolean;
 	hasChanges: boolean;
+	size: 'default' | 'compact';
 	onCancel: () => void;
 	onSave: () => void;
 }
 
-function FooterActions( {
+function SaveActions( {
 	isSaving,
 	hasMedia,
 	hasChanges,
+	size,
 	onCancel,
 	onSave,
-}: FooterActionsProps ) {
+}: SaveActionsProps ) {
 	const saveDisabled = isSaving || ! hasMedia || ! hasChanges;
+	// `size="compact"` fully specifies the height on its own, and the 40px
+	// opt-in applies only to the default size, so the two are mutually
+	// exclusive rather than combined.
+	const isCompact = size === 'compact';
 	return (
 		<Stack
-			className="media-editor__footer-actions"
+			className="media-editor__save-actions"
 			justify="flex-end"
 			align="center"
 			gap="sm"
 		>
 			<Button
-				__next40pxDefaultSize
+				__next40pxDefaultSize={ ! isCompact }
+				size={ isCompact ? 'compact' : undefined }
 				variant="tertiary"
 				onClick={ onCancel }
 				disabled={ isSaving }
@@ -330,7 +374,8 @@ function FooterActions( {
 				{ __( 'Cancel' ) }
 			</Button>
 			<Button
-				__next40pxDefaultSize
+				__next40pxDefaultSize={ ! isCompact }
+				size={ isCompact ? 'compact' : undefined }
 				variant="primary"
 				onClick={ onSave }
 				isBusy={ isSaving }
@@ -355,6 +400,7 @@ function MediaEditorContent( {
 	showCloseButton = false,
 	shouldCloseOnEsc = false,
 	scope = 'media-editor',
+	actionsSize = 'default',
 }: MediaEditorProps ) {
 	const cropper = useMediaEditor();
 	// The sidebar is a side column from the `small` breakpoint up and collapses
@@ -689,10 +735,11 @@ function MediaEditorContent( {
 		/>
 	) : null;
 	const actions = (
-		<FooterActions
+		<SaveActions
 			isSaving={ isSaving }
 			hasMedia={ !! media }
 			hasChanges={ hasChanges }
+			size={ actionsSize }
 			onCancel={ handleRequestClose }
 			onSave={ saveMediaEditor }
 		/>
@@ -736,6 +783,12 @@ function MediaEditorContent( {
 				scope={ scope }
 			/>
 		),
+		historyActions: history,
+		saveActions: actions,
+		// Gated here rather than in the frame: above the breakpoint these
+		// controls already render inside the Crop panel, so handing them to a
+		// frame that placed them unconditionally would show them twice.
+		imageControls: footerLayout === 'narrow' ? imageControls : null,
 		footerActions,
 		footerLayout,
 		onRequestClose: handleRequestClose,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -175,7 +175,6 @@ interface MediaEditorFrameContextValue {
 	hasMedia: boolean;
 	hasChanges: boolean;
 	isUndoRedoDisabled: boolean;
-	layout: 'wide' | 'narrow';
 	scope: string;
 	aspectRatioPresets?: AspectRatioPreset[];
 	onCancel: () => void;
@@ -377,12 +376,11 @@ function SaveActions( { size = 'default' }: SaveActionsProps ) {
 }
 
 function ImageControls() {
-	const { isImage, layout, aspectRatioPresets } =
-		useMediaEditorFrameContext();
-	// Renders only where the frame is responsible for these: in the `wide`
-	// layout the Crop panel holds them, so a frame that places this
-	// unconditionally still won't show them twice.
-	if ( ! isImage || layout !== 'narrow' ) {
+	const { isImage, aspectRatioPresets } = useMediaEditorFrameContext();
+	// Non-image media has nothing to transform. Placement is the frame's call:
+	// render this only in the `narrow` layout, since above that breakpoint the
+	// Crop panel holds these controls already.
+	if ( ! isImage ) {
 		return null;
 	}
 	return (
@@ -733,7 +731,6 @@ function MediaEditorContent( {
 		hasMedia: !! media,
 		hasChanges,
 		isUndoRedoDisabled: isCropInteractionActive,
-		layout,
 		scope,
 		aspectRatioPresets,
 		onCancel: handleRequestClose,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -85,12 +85,11 @@ export interface MediaEditorFrameProps {
 	saveActions: ReactNode;
 	/**
 	 * Rotate / flip / zoom and the aspect-ratio control, as a flat toolbar.
+	 * `null` for non-image media.
 	 *
-	 * Non-null only when `footerLayout` is `narrow`: above that breakpoint the
-	 * Crop panel renders these itself, so a frame that rendered this
-	 * unconditionally would show them twice. A frame that composes the
-	 * clusters by hand must give this a home, or the transform controls become
-	 * unreachable once the sidebar collapses.
+	 * Render this only when `footerLayout` is `narrow`: above that breakpoint
+	 * the Crop panel renders these itself. Below it the panel is gone, so a
+	 * frame that never places this leaves the transform controls unreachable.
 	 */
 	imageControls: ReactNode;
 	/**
@@ -101,7 +100,7 @@ export interface MediaEditorFrameProps {
 	footerActions: ReactNode;
 	/**
 	 * Footer layout selector. Frames apply this to the footer container
-	 * as a modifier class. Tracks the sidebar-collapse breakpoint (`medium`).
+	 * as a modifier class. Tracks the sidebar-collapse breakpoint (`small`).
 	 *
 	 * - `wide`   — sidebar is a column; footer is a single row of History |
 	 *              Cancel/Save (transform controls live in the Crop panel).
@@ -147,7 +146,7 @@ export interface MediaEditorProps {
 	 *
 	 * @default 'default'
 	 */
-	actionsSize?: 'default' | 'compact';
+	saveActionsSize?: 'default' | 'compact';
 }
 
 interface MediaEditorSidebarProps {
@@ -352,10 +351,6 @@ function SaveActions( {
 	onSave,
 }: SaveActionsProps ) {
 	const saveDisabled = isSaving || ! hasMedia || ! hasChanges;
-	// `size="compact"` fully specifies the height on its own, and the 40px
-	// opt-in applies only to the default size, so the two are mutually
-	// exclusive rather than combined.
-	const isCompact = size === 'compact';
 	return (
 		<Stack
 			className="media-editor__save-actions"
@@ -364,8 +359,8 @@ function SaveActions( {
 			gap="sm"
 		>
 			<Button
-				__next40pxDefaultSize={ ! isCompact }
-				size={ isCompact ? 'compact' : undefined }
+				__next40pxDefaultSize
+				size={ size }
 				variant="tertiary"
 				onClick={ onCancel }
 				disabled={ isSaving }
@@ -374,8 +369,8 @@ function SaveActions( {
 				{ __( 'Cancel' ) }
 			</Button>
 			<Button
-				__next40pxDefaultSize={ ! isCompact }
-				size={ isCompact ? 'compact' : undefined }
+				__next40pxDefaultSize
+				size={ size }
 				variant="primary"
 				onClick={ onSave }
 				isBusy={ isSaving }
@@ -400,7 +395,7 @@ function MediaEditorContent( {
 	showCloseButton = false,
 	shouldCloseOnEsc = false,
 	scope = 'media-editor',
-	actionsSize = 'default',
+	saveActionsSize = 'default',
 }: MediaEditorProps ) {
 	const cropper = useMediaEditor();
 	// The sidebar is a side column from the `small` breakpoint up and collapses
@@ -739,7 +734,7 @@ function MediaEditorContent( {
 			isSaving={ isSaving }
 			hasMedia={ !! media }
 			hasChanges={ hasChanges }
-			size={ actionsSize }
+			size={ saveActionsSize }
 			onCancel={ handleRequestClose }
 			onSave={ saveMediaEditor }
 		/>
@@ -785,10 +780,7 @@ function MediaEditorContent( {
 		),
 		historyActions: history,
 		saveActions: actions,
-		// Gated here rather than in the frame: above the breakpoint these
-		// controls already render inside the Crop panel, so handing them to a
-		// frame that placed them unconditionally would show them twice.
-		imageControls: footerLayout === 'narrow' ? imageControls : null,
+		imageControls,
 		footerActions,
 		footerLayout,
 		onRequestClose: handleRequestClose,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -8,8 +8,10 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
+	createContext,
 	createPortal,
 	useCallback,
+	useContext,
 	useEffect,
 	useMemo,
 	useRef,
@@ -68,32 +70,13 @@ interface EditorTab {
 
 export interface MediaEditorFrameProps {
 	children: ReactNode;
-	headerActions: ReactNode;
 	/**
-	 * Reset / Undo / Redo. `null` for non-image media, which has no edit
-	 * history.
+	 * Whether the media being edited is an image. The history and transform
+	 * clusters render nothing for other media types, so a frame uses this to
+	 * decide whether the container it would put them in is worth rendering at
+	 * all.
 	 */
-	historyActions: ReactNode;
-	/**
-	 * Cancel / Save.
-	 */
-	saveActions: ReactNode;
-	/**
-	 * Rotate / flip / zoom and the aspect-ratio control, as a flat toolbar —
-	 * but only when placing them is the frame's job. `null` for non-image
-	 * media, and `null` in the `wide` layout, where the Crop panel renders
-	 * them itself.
-	 *
-	 * Frames render this wherever it suits them without checking the layout;
-	 * a frame that never places it leaves the transform controls unreachable
-	 * once the Crop panel is gone.
-	 */
-	imageControls: ReactNode;
-	/**
-	 * Which layout the editor is in, tracking the sidebar-collapse breakpoint
-	 * (`small`). `wide` is a side-by-side canvas and sidebar; `narrow` stacks,
-	 * leaving the frame to house the clusters the Crop panel no longer holds.
-	 */
+	isImage: boolean;
 	layout: 'wide' | 'narrow';
 	onRequestClose: () => void;
 	onKeyDown: ( event: ReactKeyboardEvent< HTMLElement > ) => void;
@@ -112,7 +95,6 @@ export interface MediaEditorProps {
 	renderFrame: ( props: MediaEditorFrameProps ) => JSX.Element;
 	noticesClassName?: string;
 	noticesPortalElement?: Element | null;
-	showCloseButton?: boolean;
 	shouldCloseOnEsc?: boolean;
 	/**
 	 * The `@wordpress/interface` scope for the details sidebar and its pinned
@@ -126,14 +108,6 @@ export interface MediaEditorProps {
 	 * @default 'media-editor'
 	 */
 	scope?: string;
-	/**
-	 * Size applied to the Cancel/Save buttons. Footers use the 40px default;
-	 * frames that host these actions in a page header should pass `compact` so
-	 * they match the header's other controls.
-	 *
-	 * @default 'default'
-	 */
-	saveActionsSize?: 'default' | 'compact';
 }
 
 interface MediaEditorSidebarProps {
@@ -189,21 +163,58 @@ function MediaEditorSidebar( {
 	);
 }
 
-interface HeaderActionsProps {
-	isSaving: boolean;
+/**
+ * Everything the frame's action clusters need from the editor. Supplied by
+ * context rather than by props so the clusters can be module-level components:
+ * a component created during a render has a new identity on every pass, which
+ * remounts its subtree and drops focus mid-interaction.
+ */
+interface MediaEditorFrameContextValue {
 	isImage: boolean;
-	showCloseButton?: boolean;
-	onCancel: () => void;
+	isSaving: boolean;
+	hasMedia: boolean;
+	hasChanges: boolean;
+	isUndoRedoDisabled: boolean;
+	layout: 'wide' | 'narrow';
 	scope: string;
+	aspectRatioPresets?: AspectRatioPreset[];
+	onCancel: () => void;
+	onSave: () => void;
+	onReset: () => void;
 }
 
-function HeaderActions( {
-	isSaving,
-	isImage,
-	showCloseButton = false,
-	onCancel,
-	scope,
-}: HeaderActionsProps ) {
+const MediaEditorFrameContext =
+	createContext< MediaEditorFrameContextValue | null >( null );
+
+/**
+ * Hook to access the media editor's frame context.
+ *
+ * Must be used within a MediaEditor component.
+ *
+ * @return MediaEditorFrameContextValue the action clusters render from.
+ */
+function useMediaEditorFrameContext(): MediaEditorFrameContextValue {
+	const context = useContext( MediaEditorFrameContext );
+	if ( ! context ) {
+		throw new Error(
+			'useMediaEditorFrameContext must be used within MediaEditor'
+		);
+	}
+	return context;
+}
+
+export interface HeaderActionsProps {
+	/**
+	 * Whether to include a Close button. Frames with a dismissal affordance of
+	 * their own — a route's breadcrumbs, say — leave it out.
+	 *
+	 * @default false
+	 */
+	showCloseButton?: boolean;
+}
+
+function HeaderActions( { showCloseButton = false }: HeaderActionsProps ) {
+	const { isImage, isSaving, onCancel, scope } = useMediaEditorFrameContext();
 	const [ isShortcutsModalOpen, setIsShortcutsModalOpen ] = useState( false );
 	return (
 		<Stack
@@ -240,15 +251,9 @@ function HeaderActions( {
 	);
 }
 
-interface HistoryActionsProps {
-	isUndoRedoDisabled?: boolean;
-	onReset: () => void;
-}
-
-function HistoryActions( {
-	isUndoRedoDisabled = false,
-	onReset,
-}: HistoryActionsProps ) {
+function HistoryActions() {
+	const { isImage, isUndoRedoDisabled, onReset } =
+		useMediaEditorFrameContext();
 	const {
 		reset,
 		isDirty,
@@ -259,6 +264,11 @@ function HistoryActions( {
 		beginGesture,
 		endGesture,
 	} = useMediaEditor();
+	// Non-image media has no edit history. Checked after the hooks above so
+	// the hook order stays stable across renders.
+	if ( ! isImage ) {
+		return null;
+	}
 	const handleUndo = () => {
 		if ( isUndoRedoDisabled ) {
 			return;
@@ -320,23 +330,19 @@ function HistoryActions( {
 	);
 }
 
-interface SaveActionsProps {
-	isSaving: boolean;
-	hasMedia: boolean;
-	hasChanges: boolean;
-	size: 'default' | 'compact';
-	onCancel: () => void;
-	onSave: () => void;
+export interface SaveActionsProps {
+	/**
+	 * Button height. Footers take the 40px default; frames placing these in a
+	 * page header pass `compact` to match the header's other controls.
+	 *
+	 * @default 'default'
+	 */
+	size?: 'default' | 'compact';
 }
 
-function SaveActions( {
-	isSaving,
-	hasMedia,
-	hasChanges,
-	size,
-	onCancel,
-	onSave,
-}: SaveActionsProps ) {
+function SaveActions( { size = 'default' }: SaveActionsProps ) {
+	const { isSaving, hasMedia, hasChanges, onCancel, onSave } =
+		useMediaEditorFrameContext();
 	const saveDisabled = isSaving || ! hasMedia || ! hasChanges;
 	return (
 		<Stack
@@ -370,6 +376,23 @@ function SaveActions( {
 	);
 }
 
+function ImageControls() {
+	const { isImage, layout, aspectRatioPresets } =
+		useMediaEditorFrameContext();
+	// Renders only where the frame is responsible for these: in the `wide`
+	// layout the Crop panel holds them, so a frame that places this
+	// unconditionally still won't show them twice.
+	if ( ! isImage || layout !== 'narrow' ) {
+		return null;
+	}
+	return (
+		<MediaEditorImageControls
+			showAspectRatioControl
+			aspectRatioPresets={ aspectRatioPresets }
+		/>
+	);
+}
+
 function MediaEditorContent( {
 	fields = [],
 	id,
@@ -379,10 +402,8 @@ function MediaEditorContent( {
 	renderFrame,
 	noticesClassName = 'media-editor__snackbar',
 	noticesPortalElement,
-	showCloseButton = false,
 	shouldCloseOnEsc = false,
 	scope = 'media-editor',
-	saveActionsSize = 'default',
 }: MediaEditorProps ) {
 	const cropper = useMediaEditor();
 	// The sidebar is a side column from the `small` breakpoint up and collapses
@@ -704,53 +725,37 @@ function MediaEditorContent( {
 		</MediaEditorProvider>
 	);
 
-	const history = isImage ? (
-		<HistoryActions
-			isUndoRedoDisabled={ isCropInteractionActive }
-			onReset={ resetCropOptions }
-		/>
-	) : null;
-	const imageControls = isImage ? (
-		<MediaEditorImageControls
-			showAspectRatioControl
-			aspectRatioPresets={ aspectRatioPresets }
-		/>
-	) : null;
-	const actions = (
-		<SaveActions
-			isSaving={ isSaving }
-			hasMedia={ !! media }
-			hasChanges={ hasChanges }
-			size={ saveActionsSize }
-			onCancel={ handleRequestClose }
-			onSave={ saveMediaEditor }
-		/>
-	);
-
-	return renderFrame( {
-		children,
-		headerActions: (
-			<HeaderActions
-				isSaving={ isSaving }
-				isImage={ isImage }
-				showCloseButton={ showCloseButton }
-				onCancel={ handleRequestClose }
-				scope={ scope }
-			/>
-		),
-		historyActions: history,
-		saveActions: actions,
-		// Withheld in the `wide` layout: the Crop panel already renders these,
-		// so the frame has nothing to place.
-		imageControls: layout === 'narrow' ? imageControls : null,
-		layout,
-		onRequestClose: handleRequestClose,
-		onKeyDown: handleKeyDown,
-		shouldCloseOnClickOutside: ! hasChanges && ! isSaving,
+	// Rebuilt each render, like the elements it replaces: consumers re-render
+	// as they always did, but the cluster component types stay stable.
+	const contextValue: MediaEditorFrameContextValue = {
+		isImage,
 		isSaving,
-		hasChanges,
 		hasMedia: !! media,
-	} );
+		hasChanges,
+		isUndoRedoDisabled: isCropInteractionActive,
+		layout,
+		scope,
+		aspectRatioPresets,
+		onCancel: handleRequestClose,
+		onSave: saveMediaEditor,
+		onReset: resetCropOptions,
+	};
+
+	return (
+		<MediaEditorFrameContext.Provider value={ contextValue }>
+			{ renderFrame( {
+				children,
+				isImage,
+				layout,
+				onRequestClose: handleRequestClose,
+				onKeyDown: handleKeyDown,
+				shouldCloseOnClickOutside: ! hasChanges && ! isSaving,
+				isSaving,
+				hasChanges,
+				hasMedia: !! media,
+			} ) }
+		</MediaEditorFrameContext.Provider>
+	);
 }
 
 export function MediaEditor( props: MediaEditorProps ) {
@@ -760,5 +765,13 @@ export function MediaEditor( props: MediaEditorProps ) {
 		</MediaEditorStateProvider>
 	);
 }
+
+// Attached to `MediaEditor` so frames import and arrange them, the way
+// `DataViewsPicker` exposes its own sub-components. They read what they need
+// from context, so a frame only chooses where they go and how they look.
+MediaEditor.HeaderActions = HeaderActions;
+MediaEditor.HistoryActions = HistoryActions;
+MediaEditor.SaveActions = SaveActions;
+MediaEditor.ImageControls = ImageControls;
 
 export default MediaEditor;

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -209,16 +209,3 @@
 .media-editor__snackbar {
 	@include snackbar-container();
 }
-
-// Active (enabled) undo/redo icon buttons take the admin accent colour so
-// they read as live alongside the Reset/Cancel/Save actions. Disabled
-// buttons (rendered with `aria-disabled` via `accessibleWhenDisabled`)
-// keep the default muted icon colour.
-// Deliberately outside `.media-editor`: each frame places this cluster in its
-// own chrome — the modal's footer, the route's page header — so neither is a
-// descendant of the editor itself.
-// NOTE: overrides @wordpress/components Button internals (`.components-button`,
-// `.has-icon`), scoped to our history-actions wrapper. Update if renamed.
-.media-editor__history-actions .components-button.has-icon:not([aria-disabled="true"]) {
-	color: var(--wp-admin-theme-color);
-}

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -209,3 +209,16 @@
 .media-editor__snackbar {
 	@include snackbar-container();
 }
+
+// Active (enabled) undo/redo icon buttons take the admin accent colour so
+// they read as live alongside the Reset/Cancel/Save actions. Disabled
+// buttons (rendered with `aria-disabled` via `accessibleWhenDisabled`)
+// keep the default muted icon colour.
+// Deliberately outside `.media-editor`: each frame places this cluster in its
+// own chrome — the modal's footer, the route's page header — so neither is a
+// descendant of the editor itself.
+// NOTE: overrides @wordpress/components Button internals (`.components-button`,
+// `.has-icon`), scoped to our history-actions wrapper. Update if renamed.
+.media-editor__history-actions .components-button.has-icon:not([aria-disabled="true"]) {
+	color: var(--wp-admin-theme-color);
+}

--- a/routes/media-editor/stage.tsx
+++ b/routes/media-editor/stage.tsx
@@ -89,7 +89,7 @@ function MediaEditorRoute() {
 				historyActions,
 				saveActions,
 				imageControls,
-				footerLayout,
+				layout,
 				onKeyDown,
 			} ) => {
 				// Below the sidebar-collapse breakpoint the header has no room
@@ -98,7 +98,7 @@ function MediaEditorRoute() {
 				// toggle, in a single row that does not wrap. History joins the
 				// transform controls in a bar under the canvas instead, which
 				// is what the modal's narrow footer does.
-				const isNarrow = footerLayout === 'narrow';
+				const isNarrow = layout === 'narrow';
 				return (
 					// The keydown handler covers the whole frame, not just the
 					// canvas: undo/redo live in the header, so after clicking

--- a/routes/media-editor/stage.tsx
+++ b/routes/media-editor/stage.tsx
@@ -76,7 +76,7 @@ function MediaEditorRoute() {
 			scope={ MEDIA_EDITOR_SCOPE }
 			// The actions sit in the page header rather than a footer, so they
 			// match the height of the header's other controls.
-			actionsSize="compact"
+			saveActionsSize="compact"
 			onClose={ navigateBack }
 			onSaved={ ( { id: savedId } ) => {
 				if ( savedId !== attachmentId ) {
@@ -131,29 +131,9 @@ function MediaEditorRoute() {
 							}
 							actions={
 								<>
-									{ ! isNarrow && historyActions && (
-										<>
-											{ historyActions }
-											<div
-												className="media-editor-route__actions-divider"
-												aria-hidden="true"
-											/>
-										</>
-									) }
+									{ ! isNarrow && historyActions }
 									{ headerActions }
-									<div
-										className="media-editor-route__actions-divider"
-										aria-hidden="true"
-									/>
-									{ /* A group rather than a region: the page
-									     is already a landmark, and two buttons
-									     do not warrant a second one. */ }
-									<div
-										role="group"
-										aria-label={ __( 'Save actions' ) }
-									>
-										{ saveActions }
-									</div>
+									{ saveActions }
 								</>
 							}
 						>
@@ -162,11 +142,7 @@ function MediaEditorRoute() {
 							</div>
 							{ isNarrow &&
 								( imageControls || historyActions ) && (
-									<div
-										className="media-editor-route__toolbar"
-										role="region"
-										aria-label={ __( 'Editor actions' ) }
-									>
+									<div className="media-editor-route__toolbar">
 										{ imageControls }
 										{ historyActions }
 									</div>

--- a/routes/media-editor/stage.tsx
+++ b/routes/media-editor/stage.tsx
@@ -74,42 +74,107 @@ function MediaEditorRoute() {
 			// A scope of its own, so that the details sidebar opens by default
 			// here regardless of whether it was last collapsed in the modal.
 			scope={ MEDIA_EDITOR_SCOPE }
+			// The actions sit in the page header rather than a footer, so they
+			// match the height of the header's other controls.
+			actionsSize="compact"
 			onClose={ navigateBack }
 			onSaved={ ( { id: savedId } ) => {
 				if ( savedId !== attachmentId ) {
 					navigate( { to: `/media-editor/${ savedId }` } );
 				}
 			} }
-			renderFrame={ ( { children, headerActions, onKeyDown } ) => (
-				<Page
-					className="media-editor-route"
-					ariaLabel={ title }
-					breadcrumbs={
-						<Breadcrumbs
-							items={
-								isStandaloneAdminPage
-									? [ { label: title } ]
-									: [
-											{
-												label: __( 'Media' ),
-												to: MEDIA_LIST_PATH,
-											},
-											{ label: title },
-									  ]
-							}
-						/>
-					}
-					actions={ headerActions }
-				>
-					{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+			renderFrame={ ( {
+				children,
+				headerActions,
+				historyActions,
+				saveActions,
+				imageControls,
+				footerLayout,
+				onKeyDown,
+			} ) => {
+				// Below the sidebar-collapse breakpoint the header has no room
+				// for the history cluster: it already carries the breadcrumbs,
+				// Cancel/Save, and (under `medium`) the framework's navigation
+				// toggle, in a single row that does not wrap. History joins the
+				// transform controls in a bar under the canvas instead, which
+				// is what the modal's narrow footer does.
+				const isNarrow = footerLayout === 'narrow';
+				return (
+					// The keydown handler covers the whole frame, not just the
+					// canvas: undo/redo live in the header, so after clicking
+					// one, focus sits outside the content region and the
+					// keyboard shortcuts would no longer reach the handler.
+					// `Page` takes no `onKeyDown`, hence the wrapper; it is
+					// `display: contents`, so it adds no box to the layout.
+					// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 					<div
-						className="media-editor-route__content"
+						className="media-editor-route__shortcut-scope"
 						onKeyDown={ onKeyDown }
 					>
-						{ children }
+						<Page
+							className="media-editor-route"
+							ariaLabel={ title }
+							breadcrumbs={
+								<Breadcrumbs
+									items={
+										isStandaloneAdminPage
+											? [ { label: title } ]
+											: [
+													{
+														label: __( 'Media' ),
+														to: MEDIA_LIST_PATH,
+													},
+													{ label: title },
+											  ]
+									}
+								/>
+							}
+							actions={
+								<>
+									{ ! isNarrow && historyActions && (
+										<>
+											{ historyActions }
+											<div
+												className="media-editor-route__actions-divider"
+												aria-hidden="true"
+											/>
+										</>
+									) }
+									{ headerActions }
+									<div
+										className="media-editor-route__actions-divider"
+										aria-hidden="true"
+									/>
+									{ /* A group rather than a region: the page
+									     is already a landmark, and two buttons
+									     do not warrant a second one. */ }
+									<div
+										role="group"
+										aria-label={ __( 'Save actions' ) }
+									>
+										{ saveActions }
+									</div>
+								</>
+							}
+						>
+							<div className="media-editor-route__content">
+								{ children }
+							</div>
+							{ isNarrow &&
+								( imageControls || historyActions ) && (
+									<div
+										className="media-editor-route__toolbar"
+										role="region"
+										aria-label={ __( 'Editor actions' ) }
+									>
+										{ imageControls }
+										{ historyActions }
+									</div>
+								) }
+						</Page>
 					</div>
-				</Page>
-			) }
+				);
+			} }
 		/>
 	);
 }

--- a/routes/media-editor/stage.tsx
+++ b/routes/media-editor/stage.tsx
@@ -74,24 +74,13 @@ function MediaEditorRoute() {
 			// A scope of its own, so that the details sidebar opens by default
 			// here regardless of whether it was last collapsed in the modal.
 			scope={ MEDIA_EDITOR_SCOPE }
-			// The actions sit in the page header rather than a footer, so they
-			// match the height of the header's other controls.
-			saveActionsSize="compact"
 			onClose={ navigateBack }
 			onSaved={ ( { id: savedId } ) => {
 				if ( savedId !== attachmentId ) {
 					navigate( { to: `/media-editor/${ savedId }` } );
 				}
 			} }
-			renderFrame={ ( {
-				children,
-				headerActions,
-				historyActions,
-				saveActions,
-				imageControls,
-				layout,
-				onKeyDown,
-			} ) => {
+			renderFrame={ ( { children, isImage, layout, onKeyDown } ) => {
 				// Below the sidebar-collapse breakpoint the header has no room
 				// for the history cluster: it already carries the breadcrumbs,
 				// Cancel/Save, and (under `medium`) the framework's navigation
@@ -131,22 +120,25 @@ function MediaEditorRoute() {
 							}
 							actions={
 								<>
-									{ ! isNarrow && historyActions }
-									{ headerActions }
-									{ saveActions }
+									{ ! isNarrow && (
+										<MediaEditor.HistoryActions />
+									) }
+									<MediaEditor.HeaderActions />
+									{ /* Compact to match the header's other
+									     controls, as elsewhere in wp-admin. */ }
+									<MediaEditor.SaveActions size="compact" />
 								</>
 							}
 						>
 							<div className="media-editor-route__content">
 								{ children }
 							</div>
-							{ isNarrow &&
-								( imageControls || historyActions ) && (
-									<div className="media-editor-route__toolbar">
-										{ imageControls }
-										{ historyActions }
-									</div>
-								) }
+							{ isNarrow && isImage && (
+								<div className="media-editor-route__toolbar">
+									<MediaEditor.ImageControls />
+									<MediaEditor.HistoryActions />
+								</div>
+							) }
 						</Page>
 					</div>
 				);

--- a/routes/media-editor/style.scss
+++ b/routes/media-editor/style.scss
@@ -1,8 +1,43 @@
+@use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/media-editor/build-style/style.css" as media-editor;
+
+// Carries the editor's keydown handler around the whole page, including the
+// header. `display: contents` keeps it out of the flex layout entirely.
+.media-editor-route__shortcut-scope {
+	display: contents;
+}
 
 .media-editor-route__content {
 	display: flex;
 	flex: 1;
 	min-height: 0;
 	overflow: hidden;
+}
+
+// Separates the History, sidebar/shortcut and Save clusters, which share the
+// page header's single actions slot. Mirrors the divider in
+// @wordpress/widget-dashboard's actions.
+.media-editor-route__actions-divider {
+	flex-shrink: 0;
+	align-self: center;
+	width: 1px;
+	height: var(--wpds-dimension-size-2xs);
+	background-color: var(--wpds-color-stroke-surface-neutral);
+}
+
+// Below the sidebar-collapse breakpoint the transform controls have no Crop
+// panel to live in, and History has no room in the header, so both get a bar
+// under the canvas. Centered rather than pushed to the edges: unlike the
+// modal's narrow footer, this bar has no Cancel/Save cluster to anchor its
+// inline end — those stay in the page header — so the controls sit under the
+// middle of the canvas they act on. Centering also keeps each row centered
+// once the clusters wrap.
+.media-editor-route__toolbar {
+	flex-shrink: 0;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: $grid-unit-20;
+	padding: $grid-unit-20 $grid-unit-40 $grid-unit-30;
 }

--- a/routes/media-editor/style.scss
+++ b/routes/media-editor/style.scss
@@ -14,24 +14,10 @@
 	overflow: hidden;
 }
 
-// Separates the History, sidebar/shortcut and Save clusters, which share the
-// page header's single actions slot. Mirrors the divider in
-// @wordpress/widget-dashboard's actions.
-.media-editor-route__actions-divider {
-	flex-shrink: 0;
-	align-self: center;
-	width: 1px;
-	height: var(--wpds-dimension-size-2xs);
-	background-color: var(--wpds-color-stroke-surface-neutral);
-}
-
 // Below the sidebar-collapse breakpoint the transform controls have no Crop
 // panel to live in, and History has no room in the header, so both get a bar
-// under the canvas. Centered rather than pushed to the edges: unlike the
-// modal's narrow footer, this bar has no Cancel/Save cluster to anchor its
-// inline end — those stay in the page header — so the controls sit under the
-// middle of the canvas they act on. Centering also keeps each row centered
-// once the clusters wrap.
+// under the canvas. Centered rather than pushed to the edges: with Cancel/Save
+// staying in the page header, there is no cluster to anchor the inline end.
 .media-editor-route__toolbar {
 	flex-shrink: 0;
 	display: flex;


### PR DESCRIPTION
Part of:

* #72734

## What?

In the Media Editor (Route) experiment, add undo/redo/save/cancel actions to the header, and ensure cropping controls are available on mobile.

Note: this isn't the final place for these things! The goal right now is to get them in there so that we can save and update media items in the experiment. We can explore further polishing in follow-ups.

## Why?

The Media Editor (Route) has been a fairly minimal scaffold but now that 7.1 is nearly out, I'm doing a few of these PRs to build out parity with the media editor modal and so that we can start to test out this interface as a potential replacement (one day) for the core editor screen. Or at the very least, to verify how this interface is going to feel.

As part of that, I'm also exploring how we can make the media editor a bit more composable for different kinds of layouts/usages. I'm a bit tentative about these changes, so happy to rollback / go in a different direction if this feels off.

## How?

This might be too much! But it's a proposal:

* In the route-based version of the editor, flesh out the rest of the UI so that we have undo/redo/reset in the header, alongside save and cancel buttons. And in mobile layout we have image controls in a footer toolbar.
* Split the footerActions out into a dedicated `ModalFooter` component
* Reduce the reliance on `renderFrame` props for rendering components in the frame, and instead use sub-components off `MediaEditor` (following a similar pattern used by DataViews). In this way, the route-based version can compose via `MediaEditor.HistoryActions`, `MediaEditor.HeaderActions`, `MediaEditor.SaveActions`, and `MediaEditor.ImageControls`.

## Testing Instructions

Enable the Media Editor (Route) experiment:

<img width="1214" height="170" alt="image" src="https://github.com/user-attachments/assets/34eec782-3634-467a-afcb-b28c9864cf73" />

Go to the Media library screen in wp-admin and click on an image or its "Edit" link.

Test out undo/redo/reset and saving / cancelling edits.

❗ Then, smoke test the existing media editor modal in the post editor and make sure I haven't accidentally introduced any regressions!

## Screenshots or screencast <!-- if applicable -->

| Desktop | Mobile |
| --- | --- |
| <img width="1369" height="774" alt="image" src="https://github.com/user-attachments/assets/091a958c-ace0-4042-9b29-613677f16afd" /> | <img width="350" height="750" alt="image" src="https://github.com/user-attachments/assets/3b3f60c4-ae55-4461-882d-7ec354a56551" /> |

## Use of AI Tools

Claude Code (Opus 5), reviewed, guided and nudged by me.