### PR TITLE
Media Editor Route: Make the route look like it's part of the media menu in the sidebar

### DIFF
--- a/lib/experimental/media-editor/load.php
+++ b/lib/experimental/media-editor/load.php
@@ -5,8 +5,6 @@
  * @package gutenberg
  */
 
-add_action( 'admin_menu', 'gutenberg_register_media_editor_admin_page' );
-
 /**
  * Registers a hidden wp-admin page for direct media editor deep links.
  */
@@ -23,22 +21,43 @@ function gutenberg_register_media_editor_admin_page() {
 	);
 
 	if ( $hook_suffix ) {
-		// Hidden pages do not resolve a title from a visible menu item, so set
-		// one before admin-header.php formats the page title.
-		add_action( "load-$hook_suffix", 'gutenberg_media_editor_wp_admin_set_title' );
+		add_action( "load-$hook_suffix", 'gutenberg_media_editor_wp_admin_prepare_screen' );
 	}
 }
 
 /**
- * Sets the admin page title before wp-admin/admin-header.php renders.
+ * Prepares the admin chrome before wp-admin/admin-header.php renders.
  *
- * @global string $title The admin page title.
+ * @global string $title        The admin page title.
+ * @global string $parent_file  The current top-level menu item.
+ * @global string $submenu_file The current submenu item.
  */
-function gutenberg_media_editor_wp_admin_set_title() {
-	global $title;
+function gutenberg_media_editor_wp_admin_prepare_screen() {
+	global $title, $parent_file, $submenu_file;
 
+	// Hidden pages do not resolve a title from a visible menu item, so set one
+	// before admin-header.php formats the page title.
 	$title = __( 'Edit media', 'gutenberg' );
+
+	/*
+	 * Take the page out of the hidden `''` submenu bucket it was registered in.
+	 * Left in place, get_admin_page_parent() matches it there and resets
+	 * $parent_file to '' — and it does so *after* the `parent_file` filter runs,
+	 * so filtering cannot win. With no match it preserves a non-empty
+	 * $parent_file instead.
+	 *
+	 * Safe at this point: `load-` fires after the capability check in admin.php,
+	 * which needs the page registered, and before the menu is rendered.
+	 */
+	remove_submenu_page( '', 'media-editor-wp-admin' );
+
+	// Match the classic Edit Media screen, which the media editor stands in for:
+	// Media expanded and current, Library the current submenu item.
+	$parent_file  = 'upload.php';
+	$submenu_file = 'upload.php';
 }
+
+add_action( 'admin_menu', 'gutenberg_register_media_editor_admin_page' );
 
 /**
  * Builds the media editor URL for an attachment.


### PR DESCRIPTION
Part of:

* #72734

## What?

Make the experimental Media Editor Route look like it's part of the media menu in the left-hand sidebar when it's open.

## Why?

Previously the Media menu item wasn't selected, so this route looked a bit unmoored.

## How?

Pretend that this route's parent file is `upload.php` so that core's logic opens up this menu item.

## Testing Instructions

Enable the Media Editor (Route) experiment:

<img width="1214" height="170" alt="image" src="https://github.com/user-attachments/assets/78eaf16e-533d-4e01-a4ec-adf09d901d30" />

Go to the Media library screen in wp-admin and (at least in the list mode) click on an image or its "Edit" link.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="1272" height="780" alt="image" src="https://github.com/user-attachments/assets/59a38e38-1b18-438d-9768-784e5ce511b3" />

### After

<img width="2554" height="1554" alt="image" src="https://github.com/user-attachments/assets/25812151-d3cb-42d3-8b8f-b36290508382" />

## Use of AI Tools

Claude Code (Opus 5)