### PR TITLE
Release: recompute the npm changelog backport instead of replaying it

### DIFF
--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -1264,7 +1264,9 @@ async function applyReleaseChangelogCommit(
  * Verifies that the backport did not move any changelog entry into or out of
  * a published version section: for every package changelog in the release,
  * the released portion at the branch tip must be byte-identical to the
- * released content.
+ * released content. Changelogs with nothing published to protect are skipped:
+ * those without a single version heading in the release, and those that no
+ * longer exist on the target branch.
  *
  * @param {Object} options                         Options.
  * @param {string} options.branchName              Target branch name.
@@ -1317,9 +1319,12 @@ async function verifyBackportedChangelogs(
 			await git.raw( 'show', `${ releaseCommit }:${ changelogPath }` )
 		);
 		if ( releasedSection === '' ) {
-			throw new Error(
-				`${ changelogPath } in ${ releaseCommit } has no version heading; refusing to push the backport to "${ branchName }".`
+			// Without a version heading the package has never published a
+			// release, so there is no published section to protect.
+			log(
+				`>> Skipping released changelog verification for ${ changelogPath }: it has no released versions.`
 			);
+			continue;
 		}
 		if ( ! branchChangelogPaths.has( changelogPath ) ) {
 			// A package removed on the target branch has no changelog to
@@ -1388,16 +1393,19 @@ async function backportCommitsToBranch(
 	log( `>> Backporting commits to "${ branchName }".` );
 
 	/*
-	 * Reset any local changes and replace them with the origin branch's copy.
+	 * Force the local branch to exactly the remote tip instead of pulling, so
+	 * that a diverged local branch or debris left by an interrupted earlier
+	 * run can never be merged into the backport that gets pushed.
 	 *
-	 * Perform an additional fetch to ensure that when we push our changes that
-	 * it's very unlikely that new commits could have appeared at the origin
-	 * HEAD between when we started running this script and now when we're
-	 * pushing our changes back upstream.
+	 * Fetching immediately before the work also makes it very unlikely that
+	 * new commits appear at the origin HEAD between when this script started
+	 * and when the backport is pushed back upstream.
 	 */
-	await git.fetch().checkout( branchName ).pull( 'origin', branchName );
+	await git.fetch( 'origin', branchName );
 
 	try {
+		await git.raw( 'checkout', '-B', branchName, `origin/${ branchName }` );
+		await git.raw( 'reset', '--hard', `origin/${ branchName }` );
 		if ( changelogCommit ) {
 			await applyReleaseChangelogCommitFn(
 				{ changelogCommit, gitWorkingDirectoryPath },
@@ -1425,10 +1433,15 @@ async function backportCommitsToBranch(
 		// the next backport target.
 		await git.raw( 'cherry-pick', '--abort' ).catch( () => {} );
 		try {
-			await git.raw( 'reset', '--hard', `origin/${ branchName }` );
+			/*
+			 * Reset in place: the failure may predate `checkout -B`, leaving
+			 * HEAD on another branch that a targeted reset would move. The
+			 * next run's `checkout -B` re-syncs this branch ref anyway.
+			 */
+			await git.raw( 'reset', '--hard' );
 		} catch ( cleanupError ) {
 			throw new Error(
-				`Backporting to "${ branchName }" failed, and restoring the working copy to origin/${ branchName } also failed: ${ getErrorMessage(
+				`Backporting to "${ branchName }" failed, and cleaning the working copy also failed: ${ getErrorMessage(
 					cleanupError
 				) }. Original failure: ${ getErrorMessage( error ) }`
 			);

--- a/tools/release/commands/packages.js
+++ b/tools/release/commands/packages.js
@@ -18,11 +18,37 @@ const {
 	calculateVersionBumpFromChangelog,
 	findPluginReleaseBranchName,
 } = require( './common' );
+const {
+	getReleasedChangelogSection,
+	isPackageChangelogPath,
+	recomputeBackportedChangelog,
+} = require( '../lib/released-changelog' );
 const pluginConfig = require( '../config' );
 
 const NPM_RELEASE_PHASE_ATTEMPTS = 3;
 // Keep tag pushes small enough that GitHub ruleset validation handles each phase predictably.
 const NPM_RELEASE_TAG_PUSH_BATCH_SIZE = 25;
+
+/**
+ * Returns an actionable message for an unknown thrown value.
+ *
+ * @param {*} error Thrown value.
+ *
+ * @return {string} Error message, including an error code when available.
+ */
+function getErrorMessage( error ) {
+	if ( typeof error === 'string' && error ) {
+		return error;
+	}
+	if ( error && typeof error === 'object' ) {
+		const message =
+			typeof error.message === 'string' && error.message
+				? error.message
+				: 'Unknown error';
+		return error.code ? `${ message } (${ error.code })` : message;
+	}
+	return 'Unknown error';
+}
 
 /**
  * Release type names.
@@ -1084,26 +1110,270 @@ async function finalizePreparedNpmRelease(
 		return;
 	}
 
-	const commits = [ changelogCommit, publishCommit ].filter( Boolean );
-	await backportCommitsToBranchFn( 'trunk', commits, config );
+	const branchNames = [ 'trunk' ];
 	if ( config.releaseType === 'latest' && pluginReleaseBranch ) {
-		await backportCommitsToBranchFn( pluginReleaseBranch, commits, config );
+		branchNames.push( pluginReleaseBranch );
+	}
+
+	// The backports are independent: a failure on one branch must not cancel
+	// the other branch's backport.
+	const failures = [];
+	for ( const branchName of branchNames ) {
+		try {
+			await backportCommitsToBranchFn(
+				branchName,
+				{ changelogCommit, publishCommit },
+				config
+			);
+		} catch ( error ) {
+			log(
+				`>> Backporting to "${ branchName }" failed: ${ getErrorMessage(
+					error
+				) }`
+			);
+			failures.push( { branchName, error } );
+		}
+	}
+
+	if ( failures.length ) {
+		throw new Error(
+			'Backporting failed for ' +
+				failures
+					.map(
+						( { branchName, error } ) =>
+							`"${ branchName }": ${ getErrorMessage( error ) }`
+					)
+					.join( '; ' )
+		);
 	}
 }
 
 /**
- * Backports commits from the release branch to the selected branch.
+ * Applies the release's changelog rewrite to the currently checked out
+ * branch.
  *
- * @param {string}           branchName Selected branch name.
- * @param {string[]}         commits    The list of commits to backport.
- * @param {WPPackagesConfig} config     Command config.
+ * The changelog commit is replayed with `git cherry-pick --no-commit` for its
+ * `package.json` changes, but the package changelogs it touched are not
+ * trusted to git's textual merge: when the target branch gained changelog
+ * entries during publication, that merge silently files them under the
+ * just-published version heading (and only conflicts for packages whose
+ * `## Unreleased` section was empty). Every touched changelog is instead
+ * recomputed structurally from the release base, the released content, and
+ * the target branch tip.
+ *
+ * @param {Object}   options                         Options.
+ * @param {string}   options.changelogCommit         Changelog commit hash.
+ * @param {string}   options.gitWorkingDirectoryPath Git working directory path.
+ * @param {Object}   deps                            Dependencies.
+ * @param {Object}   deps.git                        Git client.
+ * @param {Function} deps.writeFileFn                File writer.
+ */
+async function applyReleaseChangelogCommit(
+	{ changelogCommit, gitWorkingDirectoryPath },
+	deps = {}
+) {
+	const {
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		writeFileFn = fs.promises.writeFile,
+	} = deps;
+
+	const changelogPaths = (
+		await git.raw(
+			'diff',
+			'--name-only',
+			`${ changelogCommit }^`,
+			changelogCommit
+		)
+	)
+		.split( '\n' )
+		.filter( isPackageChangelogPath );
+
+	if ( changelogPaths.length === 0 ) {
+		throw new Error(
+			`Found no package changelogs modified by ${ changelogCommit }; refusing to backport it as a changelog commit.`
+		);
+	}
+
+	let cherryPickError = null;
+	try {
+		// Disable `rerere` so a resolution recorded on this machine cannot be
+		// replayed silently into a release backport.
+		await git.raw(
+			'-c',
+			'rerere.enabled=false',
+			'cherry-pick',
+			'--no-commit',
+			changelogCommit
+		);
+	} catch ( error ) {
+		cherryPickError = error;
+	}
+
+	if ( cherryPickError ) {
+		const unmergedPaths = (
+			await git.raw( 'diff', '--name-only', '--diff-filter=U' )
+		)
+			.split( '\n' )
+			.filter( Boolean );
+		if ( unmergedPaths.length === 0 ) {
+			throw cherryPickError;
+		}
+		const unexpectedPaths = unmergedPaths.filter(
+			( filePath ) => ! isPackageChangelogPath( filePath )
+		);
+		if ( unexpectedPaths.length ) {
+			throw new Error(
+				`Cherry-picking ${ changelogCommit } conflicted outside package changelogs (${ unexpectedPaths.join(
+					', '
+				) }); resolve the backport manually.`
+			);
+		}
+		// Conflicted package changelogs are recomputed below, together with
+		// the ones git merged without complaint.
+	}
+
+	for ( const changelogPath of changelogPaths ) {
+		const showFile = ( treeish ) =>
+			git.raw( 'show', `${ treeish }:${ changelogPath }` );
+		let branchContent;
+		try {
+			branchContent = await showFile( 'HEAD' );
+		} catch {
+			throw new Error(
+				`${ changelogPath } was rewritten by the release but does not exist on the target branch; resolve the backport manually.`
+			);
+		}
+		const recomputedContent = recomputeBackportedChangelog( {
+			base: await showFile( `${ changelogCommit }^` ),
+			branch: branchContent,
+			filePath: changelogPath,
+			published: await showFile( changelogCommit ),
+		} );
+		await writeFileFn(
+			path.join( gitWorkingDirectoryPath, changelogPath ),
+			recomputedContent
+		);
+	}
+
+	await git.raw( 'add', '--', ...changelogPaths );
+	// Reuse the changelog commit's message and authorship.
+	await git.raw( 'commit', '-C', changelogCommit );
+}
+
+/**
+ * Verifies that the backport did not move any changelog entry into or out of
+ * a published version section: for every package changelog in the release,
+ * the released portion at the branch tip must be byte-identical to the
+ * released content.
+ *
+ * @param {Object} options                         Options.
+ * @param {string} options.branchName              Target branch name.
+ * @param {string} options.gitWorkingDirectoryPath Git working directory path.
+ * @param {string} options.releaseCommit           Release commit hash to
+ *                                                 verify against.
+ * @param {Object} deps                            Dependencies.
+ * @param {Object} deps.git                        Git client.
+ */
+async function verifyBackportedChangelogs(
+	{ branchName, gitWorkingDirectoryPath, releaseCommit },
+	deps = {}
+) {
+	const { git = SimpleGit( gitWorkingDirectoryPath ) } = deps;
+	const changelogPaths = (
+		await git.raw(
+			'ls-tree',
+			'-r',
+			'--name-only',
+			releaseCommit,
+			'--',
+			'packages'
+		)
+	)
+		.split( '\n' )
+		.filter( isPackageChangelogPath );
+	if ( changelogPaths.length === 0 ) {
+		throw new Error(
+			`Found no package changelogs in ${ releaseCommit } to verify; refusing to push the backport to "${ branchName }".`
+		);
+	}
+	const branchChangelogPaths = new Set(
+		(
+			await git.raw(
+				'ls-tree',
+				'-r',
+				'--name-only',
+				'HEAD',
+				'--',
+				'packages'
+			)
+		)
+			.split( '\n' )
+			.filter( isPackageChangelogPath )
+	);
+
+	const mismatchedPaths = [];
+	for ( const changelogPath of changelogPaths ) {
+		const releasedSection = getReleasedChangelogSection(
+			await git.raw( 'show', `${ releaseCommit }:${ changelogPath }` )
+		);
+		if ( releasedSection === '' ) {
+			throw new Error(
+				`${ changelogPath } in ${ releaseCommit } has no version heading; refusing to push the backport to "${ branchName }".`
+			);
+		}
+		if ( ! branchChangelogPaths.has( changelogPath ) ) {
+			// A package removed on the target branch has no changelog to
+			// corrupt.
+			log(
+				`>> Skipping released changelog verification for ${ changelogPath }: the file does not exist on "${ branchName }".`
+			);
+			continue;
+		}
+		const branchContent = await git.raw(
+			'show',
+			`HEAD:${ changelogPath }`
+		);
+		if (
+			getReleasedChangelogSection( branchContent ) !== releasedSection
+		) {
+			mismatchedPaths.push( changelogPath );
+		}
+	}
+
+	if ( mismatchedPaths.length ) {
+		throw new Error(
+			`Released changelog sections on "${ branchName }" do not match the published release for:\n` +
+				mismatchedPaths
+					.map( ( changelogPath ) => `  - ${ changelogPath }` )
+					.join( '\n' ) +
+				'\nAn entry moved into or out of a published version section. The backport was not pushed.'
+		);
+	}
+}
+
+/**
+ * Backports the release commits from the release branch to the selected
+ * branch, then verifies the released changelog sections before pushing.
+ *
+ * @param {string}           branchName              Selected branch name.
+ * @param {Object}           commits                 Commits to backport.
+ * @param {?string}          commits.changelogCommit Changelog commit hash.
+ * @param {?string}          commits.publishCommit   Version commit hash.
+ * @param {WPPackagesConfig} config                  Command config.
+ * @param {Object}           deps                    Dependencies.
  */
 async function backportCommitsToBranch(
 	branchName,
-	commits,
-	{ abortMessage, gitWorkingDirectoryPath, interactive }
+	{ changelogCommit, publishCommit },
+	{ abortMessage, gitWorkingDirectoryPath, interactive },
+	deps = {}
 ) {
-	if ( commits.length === 0 ) {
+	const {
+		applyReleaseChangelogCommitFn = applyReleaseChangelogCommit,
+		git = SimpleGit( gitWorkingDirectoryPath ),
+		verifyBackportedChangelogsFn = verifyBackportedChangelogs,
+	} = deps;
+	if ( ! changelogCommit && ! publishCommit ) {
 		return;
 	}
 
@@ -1117,8 +1387,6 @@ async function backportCommitsToBranch(
 
 	log( `>> Backporting commits to "${ branchName }".` );
 
-	const repo = SimpleGit( gitWorkingDirectoryPath );
-
 	/*
 	 * Reset any local changes and replace them with the origin branch's copy.
 	 *
@@ -1127,13 +1395,48 @@ async function backportCommitsToBranch(
 	 * HEAD between when we started running this script and now when we're
 	 * pushing our changes back upstream.
 	 */
-	await repo.fetch().checkout( branchName ).pull( 'origin', branchName );
+	await git.fetch().checkout( branchName ).pull( 'origin', branchName );
 
-	for ( const commitHash of commits ) {
-		await repo.raw( 'cherry-pick', commitHash );
+	try {
+		if ( changelogCommit ) {
+			await applyReleaseChangelogCommitFn(
+				{ changelogCommit, gitWorkingDirectoryPath },
+				{ git }
+			);
+		}
+		if ( publishCommit ) {
+			await git.raw(
+				'-c',
+				'rerere.enabled=false',
+				'cherry-pick',
+				publishCommit
+			);
+		}
+		await verifyBackportedChangelogsFn(
+			{
+				branchName,
+				gitWorkingDirectoryPath,
+				releaseCommit: publishCommit || changelogCommit,
+			},
+			{ git }
+		);
+	} catch ( error ) {
+		// Leave the working copy clean so this branch's failure cannot poison
+		// the next backport target.
+		await git.raw( 'cherry-pick', '--abort' ).catch( () => {} );
+		try {
+			await git.raw( 'reset', '--hard', `origin/${ branchName }` );
+		} catch ( cleanupError ) {
+			throw new Error(
+				`Backporting to "${ branchName }" failed, and restoring the working copy to origin/${ branchName } also failed: ${ getErrorMessage(
+					cleanupError
+				) }. Original failure: ${ getErrorMessage( error ) }`
+			);
+		}
+		throw error;
 	}
 
-	await repo.push( 'origin', branchName );
+	await git.push( 'origin', branchName );
 
 	log( `>> Backporting successfully finished.` );
 }
@@ -1289,6 +1592,8 @@ async function publishNpmNext( options ) {
 }
 
 module.exports = {
+	applyReleaseChangelogCommit,
+	backportCommitsToBranch,
 	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
@@ -1308,5 +1613,6 @@ module.exports = {
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
 	runPackagesRelease,
+	verifyBackportedChangelogs,
 	verifyRemotePackageTags,
 };

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -1,4 +1,6 @@
 import {
+	applyReleaseChangelogCommit,
+	backportCommitsToBranch,
 	finalizePreparedNpmRelease,
 	getNpmReleasePackages,
 	getNpmReleaseGitRecoveryCommands,
@@ -13,6 +15,7 @@ import {
 	runNpmPublishPreflight,
 	runNpmReleasePhase,
 	runPackagesRelease,
+	verifyBackportedChangelogs,
 	verifyRemotePackageTags,
 } from '../packages';
 
@@ -77,14 +80,13 @@ describe( 'finalizePreparedNpmRelease', () => {
 		async ( releaseType, pluginReleaseBranch, expectedBranches ) => {
 			const config = { releaseType };
 			const backportCommitsToBranchFn = jest.fn();
-			const commits = [ 'changelog-sha', 'publish-sha' ];
 
 			await finalizePreparedNpmRelease(
 				config,
 				{
-					changelogCommit: commits[ 0 ],
+					changelogCommit: 'changelog-sha',
 					pluginReleaseBranch,
-					publishCommit: commits[ 1 ],
+					publishCommit: 'publish-sha',
 				},
 				{ backportCommitsToBranchFn }
 			);
@@ -92,12 +94,569 @@ describe( 'finalizePreparedNpmRelease', () => {
 			expect( backportCommitsToBranchFn.mock.calls ).toEqual(
 				expectedBranches.map( ( branch ) => [
 					branch,
-					commits,
+					{
+						changelogCommit: 'changelog-sha',
+						publishCommit: 'publish-sha',
+					},
 					config,
 				] )
 			);
 		}
 	);
+
+	it( 'still backports to the remaining branches when one branch fails', async () => {
+		const config = { releaseType: 'latest' };
+		const backportCommitsToBranchFn = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'trunk cherry-pick conflict' ) )
+			.mockResolvedValueOnce();
+
+		await expect(
+			finalizePreparedNpmRelease(
+				config,
+				{
+					changelogCommit: 'changelog-sha',
+					pluginReleaseBranch: 'release/23.5',
+					publishCommit: 'publish-sha',
+				},
+				{ backportCommitsToBranchFn }
+			)
+		).rejects.toThrow(
+			'Backporting failed for "trunk": trunk cherry-pick conflict'
+		);
+
+		expect( backportCommitsToBranchFn ).toHaveBeenCalledTimes( 2 );
+		expect( backportCommitsToBranchFn.mock.calls[ 1 ][ 0 ] ).toBe(
+			'release/23.5'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'reports structured failure details while continuing with the remaining branches', async () => {
+		const backportCommitsToBranchFn = jest
+			.fn()
+			.mockRejectedValueOnce( {
+				code: 'GIT_CONFLICT',
+				message: 'could not apply changelog commit',
+			} )
+			.mockResolvedValueOnce();
+
+		await expect(
+			finalizePreparedNpmRelease(
+				{ releaseType: 'latest' },
+				{
+					changelogCommit: 'changelog-sha',
+					pluginReleaseBranch: 'release/23.5',
+					publishCommit: 'publish-sha',
+				},
+				{ backportCommitsToBranchFn }
+			)
+		).rejects.toThrow(
+			'Backporting failed for "trunk": could not apply changelog commit (GIT_CONFLICT)'
+		);
+
+		expect( backportCommitsToBranchFn ).toHaveBeenCalledTimes( 2 );
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'backportCommitsToBranch', () => {
+	const createGit = () => {
+		const git = {
+			fetch: jest.fn( () => git ),
+			checkout: jest.fn( () => git ),
+			pull: jest.fn().mockResolvedValue(),
+			push: jest.fn().mockResolvedValue(),
+			raw: jest.fn().mockResolvedValue( '' ),
+		};
+		return git;
+	};
+
+	it( 'applies the changelog commit, cherry-picks the publish commit, and verifies before pushing', async () => {
+		const git = createGit();
+		const applyReleaseChangelogCommitFn = jest.fn();
+		const verifyBackportedChangelogsFn = jest.fn();
+
+		await backportCommitsToBranch(
+			'trunk',
+			{ changelogCommit: 'changelog-sha', publishCommit: 'publish-sha' },
+			{ gitWorkingDirectoryPath: '/repo', interactive: false },
+			{ applyReleaseChangelogCommitFn, git, verifyBackportedChangelogsFn }
+		);
+
+		expect( git.checkout ).toHaveBeenCalledWith( 'trunk' );
+		expect( git.pull ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect( applyReleaseChangelogCommitFn ).toHaveBeenCalledWith(
+			{
+				changelogCommit: 'changelog-sha',
+				gitWorkingDirectoryPath: '/repo',
+			},
+			{ git }
+		);
+		expect( git.raw ).toHaveBeenCalledWith(
+			'-c',
+			'rerere.enabled=false',
+			'cherry-pick',
+			'publish-sha'
+		);
+		expect( verifyBackportedChangelogsFn ).toHaveBeenCalledWith(
+			{
+				branchName: 'trunk',
+				gitWorkingDirectoryPath: '/repo',
+				releaseCommit: 'publish-sha',
+			},
+			{ git }
+		);
+		expect( git.push ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect(
+			applyReleaseChangelogCommitFn.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan( git.raw.mock.invocationCallOrder[ 0 ] );
+		expect(
+			verifyBackportedChangelogsFn.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan( git.push.mock.invocationCallOrder[ 0 ] );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'verifies against the changelog commit when there is no publish commit', async () => {
+		const git = createGit();
+		const applyReleaseChangelogCommitFn = jest.fn();
+		const verifyBackportedChangelogsFn = jest.fn();
+
+		await backportCommitsToBranch(
+			'trunk',
+			{ changelogCommit: 'changelog-sha', publishCommit: undefined },
+			{ gitWorkingDirectoryPath: '/repo', interactive: false },
+			{ applyReleaseChangelogCommitFn, git, verifyBackportedChangelogsFn }
+		);
+
+		expect( git.raw ).not.toHaveBeenCalled();
+		expect( verifyBackportedChangelogsFn ).toHaveBeenCalledWith(
+			expect.objectContaining( { releaseCommit: 'changelog-sha' } ),
+			{ git }
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'does nothing when there are no commits to backport', async () => {
+		const git = createGit();
+
+		await backportCommitsToBranch(
+			'trunk',
+			{ changelogCommit: undefined, publishCommit: undefined },
+			{ gitWorkingDirectoryPath: '/repo', interactive: false },
+			{ git }
+		);
+
+		expect( git.fetch ).not.toHaveBeenCalled();
+		expect( git.push ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not push and restores the working copy when verification fails', async () => {
+		const git = createGit();
+		const applyReleaseChangelogCommitFn = jest.fn();
+		const verifyBackportedChangelogsFn = jest
+			.fn()
+			.mockRejectedValue(
+				new Error( 'Released changelog sections on "trunk" differ' )
+			);
+
+		await expect(
+			backportCommitsToBranch(
+				'trunk',
+				{
+					changelogCommit: 'changelog-sha',
+					publishCommit: 'publish-sha',
+				},
+				{ gitWorkingDirectoryPath: '/repo', interactive: false },
+				{
+					applyReleaseChangelogCommitFn,
+					git,
+					verifyBackportedChangelogsFn,
+				}
+			)
+		).rejects.toThrow( 'Released changelog sections on "trunk" differ' );
+
+		expect( git.push ).not.toHaveBeenCalled();
+		expect( git.raw ).toHaveBeenCalledWith( 'cherry-pick', '--abort' );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'reset',
+			'--hard',
+			'origin/trunk'
+		);
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'reports both the backport and cleanup failures when reset fails', async () => {
+		const git = createGit();
+		git.raw.mockImplementation( async ( ...args ) => {
+			if ( args[ 0 ] === 'reset' ) {
+				throw { code: 'LOCKED', message: 'cannot lock index' };
+			}
+			return '';
+		} );
+
+		await expect(
+			backportCommitsToBranch(
+				'trunk',
+				{
+					changelogCommit: 'changelog-sha',
+					publishCommit: 'publish-sha',
+				},
+				{ gitWorkingDirectoryPath: '/repo', interactive: false },
+				{
+					applyReleaseChangelogCommitFn: jest.fn(),
+					git,
+					verifyBackportedChangelogsFn: jest
+						.fn()
+						.mockRejectedValue(
+							new Error( 'verification failed' )
+						),
+				}
+			)
+		).rejects.toThrow(
+			'Backporting to "trunk" failed, and restoring the working copy to origin/trunk also failed: cannot lock index (LOCKED). Original failure: verification failed'
+		);
+
+		expect( git.push ).not.toHaveBeenCalled();
+		expect( console ).toHaveLogged();
+	} );
+} );
+
+describe( 'applyReleaseChangelogCommit', () => {
+	const RELEASE_BASE = `# Changelog
+
+## Unreleased
+
+### Bug Fixes
+
+-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+## 17.9.0 (2026-07-29)
+`;
+	const PUBLISHED = RELEASE_BASE.replace(
+		'## Unreleased',
+		'## Unreleased\n\n## 18.0.0 (2026-08-12)'
+	);
+	const BRANCH = RELEASE_BASE.replace(
+		'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))',
+		'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))\n' +
+			'-   Landed during publish. ([#9](https://github.com/WordPress/gutenberg/pull/9))'
+	);
+
+	const createGit = ( { cherryPickError, unmergedPaths = [] } = {} ) => ( {
+		raw: jest.fn( async ( ...args ) => {
+			const command = args.join( ' ' );
+			if ( command === 'diff --name-only changelog-sha^ changelog-sha' ) {
+				return 'packages/data/CHANGELOG.md\npackages/data/package.json\n';
+			}
+			if (
+				command ===
+				'-c rerere.enabled=false cherry-pick --no-commit changelog-sha'
+			) {
+				if ( cherryPickError ) {
+					throw cherryPickError;
+				}
+				return '';
+			}
+			if ( command === 'diff --name-only --diff-filter=U' ) {
+				return unmergedPaths.join( '\n' ) + '\n';
+			}
+			if (
+				command === 'show changelog-sha^:packages/data/CHANGELOG.md'
+			) {
+				return RELEASE_BASE;
+			}
+			if ( command === 'show changelog-sha:packages/data/CHANGELOG.md' ) {
+				return PUBLISHED;
+			}
+			if ( command === 'show HEAD:packages/data/CHANGELOG.md' ) {
+				return BRANCH;
+			}
+			return '';
+		} ),
+	} );
+
+	it( 'recomputes the released changelogs and commits with the original metadata', async () => {
+		const git = createGit();
+		const writeFileFn = jest.fn();
+
+		await applyReleaseChangelogCommit(
+			{
+				changelogCommit: 'changelog-sha',
+				gitWorkingDirectoryPath: '/repo',
+			},
+			{ git, writeFileFn }
+		);
+
+		expect( writeFileFn ).toHaveBeenCalledTimes( 1 );
+		const [ writtenPath, writtenContent ] = writeFileFn.mock.calls[ 0 ];
+		expect( writtenPath ).toBe( '/repo/packages/data/CHANGELOG.md' );
+		// The entry that landed on the target branch during publication stays
+		// under `## Unreleased` instead of the published version section.
+		expect( writtenContent ).toContain( `## Unreleased
+
+### Bug Fixes
+
+-   Landed during publish. ([#9](https://github.com/WordPress/gutenberg/pull/9))
+
+## 18.0.0 (2026-08-12)
+` );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'add',
+			'--',
+			'packages/data/CHANGELOG.md'
+		);
+		expect( git.raw ).toHaveBeenCalledWith(
+			'commit',
+			'-C',
+			'changelog-sha'
+		);
+	} );
+
+	it( 'continues past cherry-pick conflicts limited to package changelogs', async () => {
+		const git = createGit( {
+			cherryPickError: new Error( 'could not apply changelog-sha' ),
+			unmergedPaths: [ 'packages/data/CHANGELOG.md' ],
+		} );
+		const writeFileFn = jest.fn();
+
+		await applyReleaseChangelogCommit(
+			{
+				changelogCommit: 'changelog-sha',
+				gitWorkingDirectoryPath: '/repo',
+			},
+			{ git, writeFileFn }
+		);
+
+		expect( writeFileFn ).toHaveBeenCalledTimes( 1 );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'commit',
+			'-C',
+			'changelog-sha'
+		);
+	} );
+
+	it( 'fails when the cherry-pick conflicts outside package changelogs', async () => {
+		const git = createGit( {
+			cherryPickError: new Error( 'could not apply changelog-sha' ),
+			unmergedPaths: [ 'packages/data/package.json' ],
+		} );
+		const writeFileFn = jest.fn();
+
+		await expect(
+			applyReleaseChangelogCommit(
+				{
+					changelogCommit: 'changelog-sha',
+					gitWorkingDirectoryPath: '/repo',
+				},
+				{ git, writeFileFn }
+			)
+		).rejects.toThrow(
+			'Cherry-picking changelog-sha conflicted outside package changelogs (packages/data/package.json); resolve the backport manually.'
+		);
+
+		expect( writeFileFn ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rethrows cherry-pick failures that are not content conflicts', async () => {
+		const git = createGit( {
+			cherryPickError: new Error( 'bad object changelog-sha' ),
+		} );
+
+		await expect(
+			applyReleaseChangelogCommit(
+				{
+					changelogCommit: 'changelog-sha',
+					gitWorkingDirectoryPath: '/repo',
+				},
+				{ git, writeFileFn: jest.fn() }
+			)
+		).rejects.toThrow( 'bad object changelog-sha' );
+	} );
+
+	it( 'refuses to backport a commit that modifies no package changelogs', async () => {
+		const git = {
+			raw: jest.fn().mockResolvedValue( 'packages/data/package.json\n' ),
+		};
+
+		await expect(
+			applyReleaseChangelogCommit(
+				{
+					changelogCommit: 'changelog-sha',
+					gitWorkingDirectoryPath: '/repo',
+				},
+				{ git, writeFileFn: jest.fn() }
+			)
+		).rejects.toThrow(
+			'Found no package changelogs modified by changelog-sha; refusing to backport it as a changelog commit.'
+		);
+	} );
+} );
+
+describe( 'verifyBackportedChangelogs', () => {
+	const RELEASED = '## 18.0.0 (2026-08-12)\n\n-   Shipped. ([#1](x))\n';
+
+	it( 'passes when the released sections match the release byte for byte', async () => {
+		const git = {
+			raw: jest.fn( async ( ...args ) => {
+				if ( args[ 0 ] === 'ls-tree' ) {
+					return 'packages/data/CHANGELOG.md\npackages/data/package.json\n';
+				}
+				if ( args[ 0 ] === 'show' ) {
+					const prefix =
+						args[ 1 ] === 'HEAD:packages/data/CHANGELOG.md'
+							? '# Changelog\n\n## Unreleased\n\n-   New. ([#9](x))\n\n'
+							: '# Changelog\n\n## Unreleased\n\n';
+					return prefix + RELEASED;
+				}
+				return '';
+			} ),
+		};
+
+		await expect(
+			verifyBackportedChangelogs(
+				{
+					branchName: 'trunk',
+					gitWorkingDirectoryPath: '/repo',
+					releaseCommit: 'publish-sha',
+				},
+				{ git }
+			)
+		).resolves.toBeUndefined();
+
+		expect( git.raw ).toHaveBeenCalledWith(
+			'ls-tree',
+			'-r',
+			'--name-only',
+			'publish-sha',
+			'--',
+			'packages'
+		);
+	} );
+
+	it( 'fails when an entry moved into a published version section', async () => {
+		const git = {
+			raw: jest.fn( async ( ...args ) => {
+				if ( args[ 0 ] === 'ls-tree' ) {
+					return 'packages/data/CHANGELOG.md\n';
+				}
+				if ( args[ 1 ] === 'HEAD:packages/data/CHANGELOG.md' ) {
+					return (
+						'# Changelog\n\n## Unreleased\n\n' +
+						'## 18.0.0 (2026-08-12)\n\n-   Landed during publish. ([#9](x))\n-   Shipped. ([#1](x))\n'
+					);
+				}
+				return '# Changelog\n\n## Unreleased\n\n' + RELEASED;
+			} ),
+		};
+
+		await expect(
+			verifyBackportedChangelogs(
+				{
+					branchName: 'trunk',
+					gitWorkingDirectoryPath: '/repo',
+					releaseCommit: 'publish-sha',
+				},
+				{ git }
+			)
+		).rejects.toThrow(
+			'Released changelog sections on "trunk" do not match the published release for:\n' +
+				'  - packages/data/CHANGELOG.md\n' +
+				'An entry moved into or out of a published version section. The backport was not pushed.'
+		);
+	} );
+
+	it( 'fails loudly when it finds no changelogs to verify', async () => {
+		const git = { raw: jest.fn().mockResolvedValue( '\n' ) };
+
+		await expect(
+			verifyBackportedChangelogs(
+				{
+					branchName: 'trunk',
+					gitWorkingDirectoryPath: '/repo',
+					releaseCommit: 'publish-sha',
+				},
+				{ git }
+			)
+		).rejects.toThrow(
+			'Found no package changelogs in publish-sha to verify; refusing to push the backport to "trunk".'
+		);
+	} );
+
+	it( 'fails when a published changelog contains no version heading', async () => {
+		const git = {
+			raw: jest.fn( async ( ...args ) => {
+				if ( args[ 0 ] === 'ls-tree' ) {
+					return 'packages/data/CHANGELOG.md\n';
+				}
+				return '# Changelog\n\n## Unreleased\n';
+			} ),
+		};
+
+		await expect(
+			verifyBackportedChangelogs(
+				{
+					branchName: 'trunk',
+					gitWorkingDirectoryPath: '/repo',
+					releaseCommit: 'publish-sha',
+				},
+				{ git }
+			)
+		).rejects.toThrow(
+			'packages/data/CHANGELOG.md in publish-sha has no version heading; refusing to push the backport to "trunk".'
+		);
+	} );
+
+	it( 'propagates failures reading a changelog that exists on the target branch', async () => {
+		const git = {
+			raw: jest.fn( async ( ...args ) => {
+				if ( args[ 0 ] === 'ls-tree' ) {
+					return 'packages/data/CHANGELOG.md\n';
+				}
+				if ( args[ 1 ] === 'HEAD:packages/data/CHANGELOG.md' ) {
+					throw new Error( 'unable to read object' );
+				}
+				return '# Changelog\n\n## Unreleased\n\n' + RELEASED;
+			} ),
+		};
+
+		await expect(
+			verifyBackportedChangelogs(
+				{
+					branchName: 'trunk',
+					gitWorkingDirectoryPath: '/repo',
+					releaseCommit: 'publish-sha',
+				},
+				{ git }
+			)
+		).rejects.toThrow( 'unable to read object' );
+	} );
+
+	it( 'skips changelogs that do not exist on the target branch', async () => {
+		const git = {
+			raw: jest.fn( async ( ...args ) => {
+				if ( args[ 0 ] === 'ls-tree' ) {
+					return args[ 3 ] === 'HEAD'
+						? ''
+						: 'packages/removed/CHANGELOG.md\n';
+				}
+				return '# Changelog\n\n## Unreleased\n\n' + RELEASED;
+			} ),
+		};
+
+		await expect(
+			verifyBackportedChangelogs(
+				{
+					branchName: 'trunk',
+					gitWorkingDirectoryPath: '/repo',
+					releaseCommit: 'publish-sha',
+				},
+				{ git }
+			)
+		).resolves.toBeUndefined();
+
+		expect( console ).toHaveLogged();
+	} );
 } );
 
 describe( 'runPackagesRelease', () => {

--- a/tools/release/commands/test/packages.js
+++ b/tools/release/commands/test/packages.js
@@ -161,15 +161,16 @@ describe( 'finalizePreparedNpmRelease', () => {
 } );
 
 describe( 'backportCommitsToBranch', () => {
-	const createGit = () => {
-		const git = {
-			fetch: jest.fn( () => git ),
-			checkout: jest.fn( () => git ),
-			pull: jest.fn().mockResolvedValue(),
-			push: jest.fn().mockResolvedValue(),
-			raw: jest.fn().mockResolvedValue( '' ),
-		};
-		return git;
+	const createGit = () => ( {
+		fetch: jest.fn().mockResolvedValue(),
+		push: jest.fn().mockResolvedValue(),
+		raw: jest.fn().mockResolvedValue( '' ),
+	} );
+
+	const getRawCallOrder = ( git, matcher ) => {
+		const callIndex = git.raw.mock.calls.findIndex( matcher );
+		expect( callIndex ).toBeGreaterThan( -1 );
+		return git.raw.mock.invocationCallOrder[ callIndex ];
 	};
 
 	it( 'applies the changelog commit, cherry-picks the publish commit, and verifies before pushing', async () => {
@@ -184,8 +185,18 @@ describe( 'backportCommitsToBranch', () => {
 			{ applyReleaseChangelogCommitFn, git, verifyBackportedChangelogsFn }
 		);
 
-		expect( git.checkout ).toHaveBeenCalledWith( 'trunk' );
-		expect( git.pull ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect( git.fetch ).toHaveBeenCalledWith( 'origin', 'trunk' );
+		expect( git.raw ).toHaveBeenCalledWith(
+			'checkout',
+			'-B',
+			'trunk',
+			'origin/trunk'
+		);
+		expect( git.raw ).toHaveBeenCalledWith(
+			'reset',
+			'--hard',
+			'origin/trunk'
+		);
 		expect( applyReleaseChangelogCommitFn ).toHaveBeenCalledWith(
 			{
 				changelogCommit: 'changelog-sha',
@@ -209,8 +220,15 @@ describe( 'backportCommitsToBranch', () => {
 		);
 		expect( git.push ).toHaveBeenCalledWith( 'origin', 'trunk' );
 		expect(
+			getRawCallOrder( git, ( args ) => args.includes( 'checkout' ) )
+		).toBeLessThan(
 			applyReleaseChangelogCommitFn.mock.invocationCallOrder[ 0 ]
-		).toBeLessThan( git.raw.mock.invocationCallOrder[ 0 ] );
+		);
+		expect(
+			applyReleaseChangelogCommitFn.mock.invocationCallOrder[ 0 ]
+		).toBeLessThan(
+			getRawCallOrder( git, ( args ) => args.includes( 'cherry-pick' ) )
+		);
 		expect(
 			verifyBackportedChangelogsFn.mock.invocationCallOrder[ 0 ]
 		).toBeLessThan( git.push.mock.invocationCallOrder[ 0 ] );
@@ -229,7 +247,11 @@ describe( 'backportCommitsToBranch', () => {
 			{ applyReleaseChangelogCommitFn, git, verifyBackportedChangelogsFn }
 		);
 
-		expect( git.raw ).not.toHaveBeenCalled();
+		expect(
+			git.raw.mock.calls.some( ( args ) =>
+				args.includes( 'cherry-pick' )
+			)
+		).toBe( false );
 		expect( verifyBackportedChangelogsFn ).toHaveBeenCalledWith(
 			expect.objectContaining( { releaseCommit: 'changelog-sha' } ),
 			{ git }
@@ -278,18 +300,50 @@ describe( 'backportCommitsToBranch', () => {
 
 		expect( git.push ).not.toHaveBeenCalled();
 		expect( git.raw ).toHaveBeenCalledWith( 'cherry-pick', '--abort' );
-		expect( git.raw ).toHaveBeenCalledWith(
-			'reset',
-			'--hard',
-			'origin/trunk'
-		);
+		// The cleanup reset is in place, unlike the targeted reset that syncs
+		// the branch to the remote tip during setup.
+		expect( git.raw ).toHaveBeenCalledWith( 'reset', '--hard' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'does not push and cleans the working copy when the branch setup fails', async () => {
+		const git = createGit();
+		git.raw.mockImplementation( async ( ...args ) => {
+			if ( args[ 0 ] === 'checkout' && args[ 1 ] === '-B' ) {
+				throw new Error( 'cannot update the branch ref' );
+			}
+			return '';
+		} );
+		const verifyBackportedChangelogsFn = jest.fn();
+
+		await expect(
+			backportCommitsToBranch(
+				'trunk',
+				{
+					changelogCommit: 'changelog-sha',
+					publishCommit: 'publish-sha',
+				},
+				{ gitWorkingDirectoryPath: '/repo', interactive: false },
+				{
+					applyReleaseChangelogCommitFn: jest.fn(),
+					git,
+					verifyBackportedChangelogsFn,
+				}
+			)
+		).rejects.toThrow( 'cannot update the branch ref' );
+
+		expect( git.push ).not.toHaveBeenCalled();
+		expect( verifyBackportedChangelogsFn ).not.toHaveBeenCalled();
+		expect( git.raw ).toHaveBeenCalledWith( 'reset', '--hard' );
 		expect( console ).toHaveLogged();
 	} );
 
 	it( 'reports both the backport and cleanup failures when reset fails', async () => {
 		const git = createGit();
 		git.raw.mockImplementation( async ( ...args ) => {
-			if ( args[ 0 ] === 'reset' ) {
+			// Only the in-place cleanup reset fails; the setup reset targeting
+			// the remote tip succeeds.
+			if ( args[ 0 ] === 'reset' && args.length === 2 ) {
 				throw { code: 'LOCKED', message: 'cannot lock index' };
 			}
 			return '';
@@ -314,7 +368,7 @@ describe( 'backportCommitsToBranch', () => {
 				}
 			)
 		).rejects.toThrow(
-			'Backporting to "trunk" failed, and restoring the working copy to origin/trunk also failed: cannot lock index (LOCKED). Original failure: verification failed'
+			'Backporting to "trunk" failed, and cleaning the working copy also failed: cannot lock index (LOCKED). Original failure: verification failed'
 		);
 
 		expect( git.push ).not.toHaveBeenCalled();
@@ -583,13 +637,18 @@ describe( 'verifyBackportedChangelogs', () => {
 		);
 	} );
 
-	it( 'fails when a published changelog contains no version heading', async () => {
+	it( 'skips changelogs that have never published a release', async () => {
 		const git = {
 			raw: jest.fn( async ( ...args ) => {
 				if ( args[ 0 ] === 'ls-tree' ) {
-					return 'packages/data/CHANGELOG.md\n';
+					return 'packages/connectors/CHANGELOG.md\npackages/data/CHANGELOG.md\n';
 				}
-				return '# Changelog\n\n## Unreleased\n';
+				if (
+					args[ 1 ].endsWith( 'packages/connectors/CHANGELOG.md' )
+				) {
+					return '# Changelog\n\n## Unreleased\n';
+				}
+				return '# Changelog\n\n## Unreleased\n\n' + RELEASED;
 			} ),
 		};
 
@@ -602,9 +661,9 @@ describe( 'verifyBackportedChangelogs', () => {
 				},
 				{ git }
 			)
-		).rejects.toThrow(
-			'packages/data/CHANGELOG.md in publish-sha has no version heading; refusing to push the backport to "trunk".'
-		);
+		).resolves.toBeUndefined();
+
+		expect( console ).toHaveLogged();
 	} );
 
 	it( 'propagates failures reading a changelog that exists on the target branch', async () => {

--- a/tools/release/lib/released-changelog.js
+++ b/tools/release/lib/released-changelog.js
@@ -1,0 +1,290 @@
+/**
+ * Text-level helpers for backporting a release's changelog rewrite to another
+ * branch without trusting git's three-way merge.
+ *
+ * The release commit inserts a `## X.Y.Z (date)` heading directly below
+ * `## Unreleased`, freezing the unreleased entries into the published version.
+ * Replaying that commit textually onto a branch that gained changelog entries
+ * in the meantime silently files those unshipped entries under the published
+ * version heading. These helpers instead recompute the transform: entries the
+ * target branch added since the release base stay under `## Unreleased`, and
+ * everything from the new version heading down is taken verbatim from the
+ * release commit. See https://github.com/WordPress/gutenberg/issues/81506.
+ */
+
+const UNRELEASED_HEADING = '## Unreleased';
+const VERSION_HEADING_PATTERN = /^## \d/m;
+
+/**
+ * Checks whether a repository path is a package changelog.
+ *
+ * @param {string} filePath Repository-relative file path.
+ *
+ * @return {boolean} Whether the path is a package changelog.
+ */
+function isPackageChangelogPath( filePath ) {
+	return /^packages\/[^/]+\/CHANGELOG\.md$/.test( filePath );
+}
+
+/**
+ * Returns the released portion of a changelog: everything from the first
+ * version heading (`## X.Y.Z ...`) to the end of the file.
+ *
+ * @param {string} content Changelog content.
+ *
+ * @return {string} The released portion, or an empty string when the
+ *                  changelog has no version heading.
+ */
+function getReleasedChangelogSection( content ) {
+	const match = VERSION_HEADING_PATTERN.exec( content );
+	return match ? content.slice( match.index ) : '';
+}
+
+/**
+ * Finds the `## Unreleased` section within changelog lines.
+ *
+ * @param {string[]} lines    Changelog lines.
+ * @param {string}   filePath File path for error messages.
+ * @param {string}   label    Which changelog version is being inspected.
+ *
+ * @return {{ headingIndex: number, endIndex: number }} Indexes of the
+ *         `## Unreleased` heading line and of the next `## ` heading (or the
+ *         end of the file).
+ */
+function findUnreleasedSection( lines, filePath, label ) {
+	const headingIndex = lines.findIndex(
+		( line ) => line.replace( /\s+$/, '' ) === UNRELEASED_HEADING
+	);
+	if ( headingIndex === -1 ) {
+		throw new Error(
+			`${ filePath }: the ${ label } changelog has no "${ UNRELEASED_HEADING }" heading.`
+		);
+	}
+	let endIndex = headingIndex + 1;
+	while ( endIndex < lines.length && ! /^## /.test( lines[ endIndex ] ) ) {
+		endIndex++;
+	}
+	return { headingIndex, endIndex };
+}
+
+/**
+ * Parses the lines of an `## Unreleased` section into entry blocks, each
+ * annotated with the `###`+ heading path it sits under. An entry block is a
+ * top-level list item together with its continuation lines and nested list
+ * items.
+ *
+ * @param {string[]} lines Section lines (excluding the `## Unreleased` line).
+ *
+ * @return {Array<{ headingPath: string[], lines: string[] }>} Entry blocks.
+ */
+function parseUnreleasedEntries( lines ) {
+	const blocks = [];
+	const headingPath = [];
+	let currentBlock = null;
+	for ( let index = 0; index < lines.length; index++ ) {
+		const line = lines[ index ];
+		const trimmedLine = line.replace( /\s+$/, '' );
+		const headingMatch = /^(#{3,6}) /.exec( trimmedLine );
+		if ( headingMatch ) {
+			currentBlock = null;
+			const depth = headingMatch[ 1 ].length - 3;
+			headingPath.length = depth;
+			headingPath[ depth ] = trimmedLine;
+			continue;
+		}
+		if ( trimmedLine === '' ) {
+			// A blank line continues an entry only when the entry resumes
+			// with an indented line, e.g. a nested list after a paragraph.
+			let next = index + 1;
+			while ( next < lines.length && lines[ next ].trim() === '' ) {
+				next++;
+			}
+			if (
+				currentBlock &&
+				next < lines.length &&
+				/^\s/.test( lines[ next ] )
+			) {
+				currentBlock.lines.push( line );
+			} else {
+				currentBlock = null;
+			}
+			continue;
+		}
+		if ( /^\s/.test( line ) && currentBlock ) {
+			currentBlock.lines.push( line );
+			continue;
+		}
+		if ( /^[-*+] /.test( trimmedLine ) || ! currentBlock ) {
+			currentBlock = { headingPath: [ ...headingPath ], lines: [ line ] };
+			blocks.push( currentBlock );
+		} else {
+			// Lazy continuation of the previous entry.
+			currentBlock.lines.push( line );
+		}
+	}
+	return blocks;
+}
+
+/**
+ * Returns a comparison key for an entry block.
+ *
+ * @param {{ headingPath: string[], lines: string[] }} block Entry block.
+ *
+ * @return {string} Comparison key.
+ */
+function getBlockKey( block ) {
+	return [
+		...block.headingPath,
+		'',
+		...block.lines.map( ( line ) => line.replace( /\s+$/, '' ) ),
+	].join( '\n' );
+}
+
+/**
+ * Removes from `blocks` one occurrence of every block present in
+ * `blocksToRemove`, comparing by heading path and entry text.
+ *
+ * @param {Array<{ headingPath: string[], lines: string[] }>} blocks         Entry blocks.
+ * @param {Array<{ headingPath: string[], lines: string[] }>} blocksToRemove Blocks to remove.
+ *
+ * @return {Array<{ headingPath: string[], lines: string[] }>} Remaining blocks.
+ */
+function subtractEntries( blocks, blocksToRemove ) {
+	const removalCounts = new Map();
+	for ( const block of blocksToRemove ) {
+		const key = getBlockKey( block );
+		removalCounts.set( key, ( removalCounts.get( key ) ?? 0 ) + 1 );
+	}
+	return blocks.filter( ( block ) => {
+		const key = getBlockKey( block );
+		const count = removalCounts.get( key ) ?? 0;
+		if ( count === 0 ) {
+			return true;
+		}
+		removalCounts.set( key, count - 1 );
+		return false;
+	} );
+}
+
+/**
+ * Serializes entry blocks back into section lines, re-emitting each block's
+ * heading path and separating structural elements with single blank lines.
+ *
+ * @param {Array<{ headingPath: string[], lines: string[] }>} blocks Entry blocks.
+ *
+ * @return {string[]} Section lines without surrounding blank lines.
+ */
+function buildUnreleasedSection( blocks ) {
+	const lines = [];
+	let currentPath = [];
+	for ( const block of blocks ) {
+		const blockPath = block.headingPath.filter(
+			( heading ) => heading !== undefined
+		);
+		let commonDepth = 0;
+		while (
+			commonDepth < blockPath.length &&
+			commonDepth < currentPath.length &&
+			currentPath[ commonDepth ] === blockPath[ commonDepth ]
+		) {
+			commonDepth++;
+		}
+		if ( commonDepth < blockPath.length ) {
+			for ( const heading of blockPath.slice( commonDepth ) ) {
+				if ( lines.length ) {
+					lines.push( '' );
+				}
+				lines.push( heading );
+			}
+			lines.push( '' );
+		} else if ( blockPath.length < currentPath.length ) {
+			lines.push( '' );
+		}
+		lines.push( ...block.lines );
+		currentPath = blockPath;
+	}
+	return lines;
+}
+
+/**
+ * Recomputes a package changelog for a backport of a release's changelog
+ * rewrite.
+ *
+ * The result keeps the target branch's content above `## Unreleased`, keeps
+ * under `## Unreleased` exactly the entries the target branch has that the
+ * release base did not (the entries that did not ship), and takes everything
+ * from the new version heading down verbatim from the released changelog.
+ *
+ * @param {Object} input           Input changelog versions.
+ * @param {string} input.base      Changelog at the release base (the parent
+ *                                 of the changelog commit).
+ * @param {string} input.branch    Changelog at the target branch tip.
+ * @param {string} input.filePath  File path for error messages.
+ * @param {string} input.published Changelog as released (at the changelog
+ *                                 commit).
+ *
+ * @return {string} The recomputed changelog content.
+ */
+function recomputeBackportedChangelog( { base, branch, filePath, published } ) {
+	const baseLines = base.split( '\n' );
+	const branchLines = branch.split( '\n' );
+
+	const baseSection = findUnreleasedSection( baseLines, filePath, 'base' );
+	const branchSection = findUnreleasedSection(
+		branchLines,
+		filePath,
+		'target branch'
+	);
+
+	const normalizeReleased = ( lines ) =>
+		lines
+			.map( ( line ) => line.replace( /\s+$/, '' ) )
+			.join( '\n' )
+			.replace( /\s+$/, '' );
+	if (
+		normalizeReleased( branchLines.slice( branchSection.endIndex ) ) !==
+		normalizeReleased( baseLines.slice( baseSection.endIndex ) )
+	) {
+		throw new Error(
+			`${ filePath }: the released changelog sections on the target branch do not match the release base. ` +
+				'An entry may have moved into or out of a released section, or an intermediate release was never backported. Resolve the backport manually.'
+		);
+	}
+
+	const versionHeadingMatch = VERSION_HEADING_PATTERN.exec( published );
+	if ( ! versionHeadingMatch ) {
+		throw new Error(
+			`${ filePath }: the released changelog contains no version heading.`
+		);
+	}
+	const publishedTail = published.slice( versionHeadingMatch.index );
+
+	const unshippedEntries = subtractEntries(
+		parseUnreleasedEntries(
+			branchLines.slice(
+				branchSection.headingIndex + 1,
+				branchSection.endIndex
+			)
+		),
+		parseUnreleasedEntries(
+			baseLines.slice(
+				baseSection.headingIndex + 1,
+				baseSection.endIndex
+			)
+		)
+	);
+	const unreleasedLines = buildUnreleasedSection( unshippedEntries );
+
+	return [
+		...branchLines.slice( 0, branchSection.headingIndex + 1 ),
+		'',
+		...( unreleasedLines.length ? [ ...unreleasedLines, '' ] : [] ),
+		publishedTail,
+	].join( '\n' );
+}
+
+module.exports = {
+	getReleasedChangelogSection,
+	isPackageChangelogPath,
+	recomputeBackportedChangelog,
+};

--- a/tools/release/lib/test/released-changelog.js
+++ b/tools/release/lib/test/released-changelog.js
@@ -1,0 +1,371 @@
+import {
+	getReleasedChangelogSection,
+	isPackageChangelogPath,
+	recomputeBackportedChangelog,
+} from '../released-changelog';
+
+const RELEASE_BASE = `# Changelog
+
+## Unreleased
+
+### Bug Fixes
+
+-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+### Internal
+
+-   Shipped internal one. ([#2](https://github.com/WordPress/gutenberg/pull/2))
+-   Shipped internal two. ([#3](https://github.com/WordPress/gutenberg/pull/3))
+
+## 17.9.0 (2026-07-29)
+
+### Enhancements
+
+-   Older entry. ([#0](https://github.com/WordPress/gutenberg/pull/0))
+`;
+
+// The release rewrite performed by `updatePackages`: a version heading is
+// inserted directly below `## Unreleased`.
+const PUBLISHED = RELEASE_BASE.replace(
+	'## Unreleased',
+	'## Unreleased\n\n## 18.0.0 (2026-08-12)'
+);
+
+describe( 'recomputeBackportedChangelog', () => {
+	it( 'keeps an entry added on the target branch out of the published version section', () => {
+		// This is the shape git merges cleanly and wrongly: the new entry
+		// sits in the middle of a subsection, far from the heading insertion.
+		const branch = RELEASE_BASE.replace(
+			'-   Shipped internal one. ([#2](https://github.com/WordPress/gutenberg/pull/2))',
+			'-   Shipped internal one. ([#2](https://github.com/WordPress/gutenberg/pull/2))\n' +
+				'-   Landed during publish. ([#9](https://github.com/WordPress/gutenberg/pull/9))'
+		);
+
+		expect(
+			recomputeBackportedChangelog( {
+				base: RELEASE_BASE,
+				branch,
+				filePath: 'packages/data/CHANGELOG.md',
+				published: PUBLISHED,
+			} )
+		).toBe( `# Changelog
+
+## Unreleased
+
+### Internal
+
+-   Landed during publish. ([#9](https://github.com/WordPress/gutenberg/pull/9))
+
+## 18.0.0 (2026-08-12)
+
+### Bug Fixes
+
+-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+### Internal
+
+-   Shipped internal one. ([#2](https://github.com/WordPress/gutenberg/pull/2))
+-   Shipped internal two. ([#3](https://github.com/WordPress/gutenberg/pull/3))
+
+## 17.9.0 (2026-07-29)
+
+### Enhancements
+
+-   Older entry. ([#0](https://github.com/WordPress/gutenberg/pull/0))
+` );
+	} );
+
+	it( 'keeps a new subsection added to an empty unreleased section above the version heading', () => {
+		// This is the shape that conflicts in git: the base unreleased
+		// section is empty, so the branch entry and the version heading are
+		// inserted at the same line.
+		const base = `# Changelog
+
+## Unreleased
+
+## 11.12.0 (2026-07-29)
+
+-   Old. ([#0](https://github.com/WordPress/gutenberg/pull/0))
+`;
+		const published = base.replace(
+			'## Unreleased',
+			'## Unreleased\n\n## 11.13.0 (2026-08-12)'
+		);
+		const branch = base.replace(
+			'## Unreleased',
+			'## Unreleased\n\n### Bug Fixes\n\n-   Update git sources when `--update` is passed.'
+		);
+
+		expect(
+			recomputeBackportedChangelog( {
+				base,
+				branch,
+				filePath: 'packages/env/CHANGELOG.md',
+				published,
+			} )
+		).toBe( `# Changelog
+
+## Unreleased
+
+### Bug Fixes
+
+-   Update git sources when \`--update\` is passed.
+
+## 11.13.0 (2026-08-12)
+
+## 11.12.0 (2026-07-29)
+
+-   Old. ([#0](https://github.com/WordPress/gutenberg/pull/0))
+` );
+	} );
+
+	it( 'returns the released changelog when the target branch has not moved', () => {
+		expect(
+			recomputeBackportedChangelog( {
+				base: RELEASE_BASE,
+				branch: RELEASE_BASE,
+				filePath: 'packages/data/CHANGELOG.md',
+				published: PUBLISHED,
+			} )
+		).toBe( PUBLISHED );
+	} );
+
+	it( 'preserves new entries across existing and new subsections in branch order', () => {
+		const branch = RELEASE_BASE.replace(
+			'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))',
+			'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))\n' +
+				'-   New fix. ([#8](https://github.com/WordPress/gutenberg/pull/8))'
+		).replace(
+			'-   Shipped internal two. ([#3](https://github.com/WordPress/gutenberg/pull/3))',
+			'-   Shipped internal two. ([#3](https://github.com/WordPress/gutenberg/pull/3))\n\n' +
+				'### New Features\n\n' +
+				'-   New feature. ([#7](https://github.com/WordPress/gutenberg/pull/7))'
+		);
+
+		const result = recomputeBackportedChangelog( {
+			base: RELEASE_BASE,
+			branch,
+			filePath: 'packages/data/CHANGELOG.md',
+			published: PUBLISHED,
+		} );
+
+		expect( result ).toContain( `## Unreleased
+
+### Bug Fixes
+
+-   New fix. ([#8](https://github.com/WordPress/gutenberg/pull/8))
+
+### New Features
+
+-   New feature. ([#7](https://github.com/WordPress/gutenberg/pull/7))
+
+## 18.0.0 (2026-08-12)
+` );
+		expect( result ).toContain(
+			'## 18.0.0 (2026-08-12)\n\n### Bug Fixes\n\n-   Shipped fix.'
+		);
+	} );
+
+	it( 'treats a top-level list item with nested lines as one entry', () => {
+		const base = `# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+-   Removed the following components:
+    -   \`ItemGroup\` ([#1](https://github.com/WordPress/gutenberg/pull/1))
+    -   \`Flex\` ([#2](https://github.com/WordPress/gutenberg/pull/2))
+
+## 39.0.0 (2026-07-29)
+`;
+		const published = base.replace(
+			'## Unreleased',
+			'## Unreleased\n\n## 40.0.0 (2026-08-12)'
+		);
+		const branch = base.replace(
+			'    -   `Flex` ([#2](https://github.com/WordPress/gutenberg/pull/2))',
+			'    -   `Flex` ([#2](https://github.com/WordPress/gutenberg/pull/2))\n' +
+				'-   Deprecated the following components:\n' +
+				'    -   `NewThing` ([#9](https://github.com/WordPress/gutenberg/pull/9))'
+		);
+
+		expect(
+			recomputeBackportedChangelog( {
+				base,
+				branch,
+				filePath: 'packages/components/CHANGELOG.md',
+				published,
+			} )
+		).toBe( `# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+-   Deprecated the following components:
+    -   \`NewThing\` ([#9](https://github.com/WordPress/gutenberg/pull/9))
+
+## 40.0.0 (2026-08-12)
+
+### Breaking Changes
+
+-   Removed the following components:
+    -   \`ItemGroup\` ([#1](https://github.com/WordPress/gutenberg/pull/1))
+    -   \`Flex\` ([#2](https://github.com/WordPress/gutenberg/pull/2))
+
+## 39.0.0 (2026-07-29)
+` );
+	} );
+
+	it( 'keeps entries added directly under the unreleased heading', () => {
+		const base = `# Changelog
+
+## Unreleased
+
+-   Shipped loose entry. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+## 1.0.0 (2026-07-29)
+`;
+		const published = base.replace(
+			'## Unreleased',
+			'## Unreleased\n\n## 1.1.0 (2026-08-12)'
+		);
+		const branch = base.replace(
+			'-   Shipped loose entry. ([#1](https://github.com/WordPress/gutenberg/pull/1))',
+			'-   Shipped loose entry. ([#1](https://github.com/WordPress/gutenberg/pull/1))\n' +
+				'-   New loose entry. ([#9](https://github.com/WordPress/gutenberg/pull/9))'
+		);
+
+		expect(
+			recomputeBackportedChangelog( {
+				base,
+				branch,
+				filePath: 'packages/a11y/CHANGELOG.md',
+				published,
+			} )
+		).toBe( `# Changelog
+
+## Unreleased
+
+-   New loose entry. ([#9](https://github.com/WordPress/gutenberg/pull/9))
+
+## 1.1.0 (2026-08-12)
+
+-   Shipped loose entry. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+## 1.0.0 (2026-07-29)
+` );
+	} );
+
+	it( 'removes only one occurrence of a duplicated entry', () => {
+		const branch = RELEASE_BASE.replace(
+			'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))',
+			'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))\n' +
+				'-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))'
+		);
+
+		expect(
+			recomputeBackportedChangelog( {
+				base: RELEASE_BASE,
+				branch,
+				filePath: 'packages/data/CHANGELOG.md',
+				published: PUBLISHED,
+			} )
+		).toContain( `## Unreleased
+
+### Bug Fixes
+
+-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+## 18.0.0 (2026-08-12)
+` );
+	} );
+
+	it( 'throws when the released sections on the target branch diverge from the release base', () => {
+		const branch = RELEASE_BASE.replace(
+			'-   Older entry. ([#0](https://github.com/WordPress/gutenberg/pull/0))',
+			'-   Older entry, reworded. ([#0](https://github.com/WordPress/gutenberg/pull/0))'
+		);
+
+		expect( () =>
+			recomputeBackportedChangelog( {
+				base: RELEASE_BASE,
+				branch,
+				filePath: 'packages/data/CHANGELOG.md',
+				published: PUBLISHED,
+			} )
+		).toThrow(
+			'packages/data/CHANGELOG.md: the released changelog sections on the target branch do not match the release base.'
+		);
+	} );
+
+	it( 'throws when the target branch changelog has no unreleased heading', () => {
+		expect( () =>
+			recomputeBackportedChangelog( {
+				base: RELEASE_BASE,
+				branch: '# Changelog\n\n## 17.9.0 (2026-07-29)\n',
+				filePath: 'packages/data/CHANGELOG.md',
+				published: PUBLISHED,
+			} )
+		).toThrow(
+			'packages/data/CHANGELOG.md: the target branch changelog has no "## Unreleased" heading.'
+		);
+	} );
+
+	it( 'throws when the released changelog contains no version heading', () => {
+		const content = '# Changelog\n\n## Unreleased\n\n-   Entry.\n';
+
+		expect( () =>
+			recomputeBackportedChangelog( {
+				base: content,
+				branch: content,
+				filePath: 'packages/new-package/CHANGELOG.md',
+				published: content,
+			} )
+		).toThrow(
+			'packages/new-package/CHANGELOG.md: the released changelog contains no version heading.'
+		);
+	} );
+} );
+
+describe( 'getReleasedChangelogSection', () => {
+	it( 'returns everything from the first version heading to the end', () => {
+		expect( getReleasedChangelogSection( PUBLISHED ) )
+			.toBe( `## 18.0.0 (2026-08-12)
+
+### Bug Fixes
+
+-   Shipped fix. ([#1](https://github.com/WordPress/gutenberg/pull/1))
+
+### Internal
+
+-   Shipped internal one. ([#2](https://github.com/WordPress/gutenberg/pull/2))
+-   Shipped internal two. ([#3](https://github.com/WordPress/gutenberg/pull/3))
+
+## 17.9.0 (2026-07-29)
+
+### Enhancements
+
+-   Older entry. ([#0](https://github.com/WordPress/gutenberg/pull/0))
+` );
+	} );
+
+	it( 'returns an empty string when the changelog has no version heading', () => {
+		expect(
+			getReleasedChangelogSection( '# Changelog\n\n## Unreleased\n' )
+		).toBe( '' );
+	} );
+} );
+
+describe( 'isPackageChangelogPath', () => {
+	it.each( [
+		[ 'packages/env/CHANGELOG.md', true ],
+		[ 'packages/block-editor/CHANGELOG.md', true ],
+		[ 'packages/env/src/CHANGELOG.md', false ],
+		[ 'packages/env/package.json', false ],
+		[ 'CHANGELOG.md', false ],
+	] )( 'classifies %s as %s', ( filePath, expected ) => {
+		expect( isPackageChangelogPath( filePath ) ).toBe( expected );
+	} );
+} );


### PR DESCRIPTION
## What?

Closes #81506

Makes the npm release's changelog backport deterministic. The release tooling no longer replays the "Update changelog files" commit onto `trunk` with a bare `git cherry-pick` and pushes whatever comes out; it recomputes each changelog from what actually shipped, and it verifies the result before pushing anything.

## Why?

A three-way merge of a markdown list knows line positions, not semantics. When `trunk` gains a changelog entry during the ~10-minute npm publication window, the cherry-pick files that entry under the version heading that was published minutes earlier — an entry attributed to a release that does not contain it. Worse, the merge only conflicts when the package's `## Unreleased` section was empty at release time, which is precisely the case where the package shipped nothing. So the alarm fires only for packages that were fine, and packages that shipped changes are corrupted silently, every time. That is not bad luck; it is the design, and I would gently suggest it is the wrong design.

Both release cycles since July needed hand repair (#81303, #81304, #81480, #81485, #81502), and the August 12 manual recovery reproduced the same corruption it was fixing. Careful people cannot catch this, because nothing checks for it. This PR makes the tooling produce the right result, and refuse loudly when it cannot.

## How?

Three changes, matching the issue's suggested fixes 1–3:

1. **Recompute instead of replay.** The changelog commit is still applied with `git cherry-pick --no-commit` for the `package.json` changes the publish commit depends on, but every package changelog it touched is then rewritten by `recomputeBackportedChangelog` (new `tools/release/lib/released-changelog.js`): entries the target branch added since the release base stay under `## Unreleased` with their subsection structure preserved, and everything from the new version heading down is taken verbatim from the released changelog. Conflicted files and cleanly-merged files go through the identical path, so the empty-`## Unreleased` conflict resolves itself. If the branch's released history does not match the release base (for example, an intermediate release that was never backported), the backport refuses with an explicit error rather than guessing. `rerere` is disabled for the picks so a resolution recorded on someone's machine cannot leak into a release.

2. **Verify before pushing.** `verifyBackportedChangelogs` asserts that the released portion of every package changelog in the release tree is byte-identical on the branch tip. Anything else means an entry moved into or out of a published version section, and the push does not happen. Per the issue's warning about checks that quietly inspect nothing, finding zero changelogs to verify is itself a hard failure. The check runs inside the tool, so it covers the direct push that never becomes a PR.

3. **Independent branch backports.** `finalizePreparedNpmRelease` now attempts `trunk` and the plugin release branch independently and reports every failure, instead of letting the first branch's conflict cancel the second branch's perfectly applicable backport. A failed backport restores the clone to `origin/<branch>` so its debris cannot poison the next target.

The issue's fix 4 (a `finalize` recovery subcommand) is deliberately not included; it is a feature rather than a defect fix, and the recompute/verify functions are exported so it can be built on top of this.

#81561 corrects the historical misattributions in the changelog data and is stacked on this branch.

## Testing Instructions

1. `npm run test:unit -- tools/release` — covers the recompute, the verification, and the backport orchestration, including the two shapes from the August 12 incident: the entry git merges cleanly into the wrong section, and the empty-`## Unreleased` conflict.
2. For an end-to-end check against real git, the scenario from the issue reproduces in a scratch repository:

<details>
<summary>End-to-end reproduction</summary>

```sh
mkdir -p /tmp/backport-e2e && cd /tmp/backport-e2e
git init -q --bare origin.git && git clone -q origin.git work && cd work
git switch -qc main && mkdir -p packages/data
printf '# Changelog\n\n## Unreleased\n\n### Bug Fixes\n\n-   Shipped fix. ([#1](x))\n\n## 1.0.0 (2026-01-01)\n' > packages/data/CHANGELOG.md
printf '{\n\t"version": "1.0.0"\n}\n' > packages/data/package.json
git add -A && git commit -qm base && git push -q origin main

# The release: version heading + prerelease bump, then the publish commit.
git switch -qc wp-latest
perl -0pi -e 's/## Unreleased/## Unreleased\n\n## 1.1.0 (2026-08-12)/' packages/data/CHANGELOG.md
perl -0pi -e 's/1\.0\.0/1.1.0-prerelease/' packages/data/package.json
git commit -qam 'Update changelog files'
perl -0pi -e 's/-prerelease//' packages/data/package.json
git commit -qam 'Publish'

# Trunk moves during publication: this is the entry git silently misfiles.
git switch -q main
perl -0pi -e 's/-   Shipped fix\. \(\[#1\]\(x\)\)/-   Shipped fix. ([#1](x))\n-   Landed during publish. ([#9](x))/' packages/data/CHANGELOG.md
git commit -qam 'trunk moved' && git push -q origin main
```

Then, from a Gutenberg checkout on this branch, drive the backport with the two commit hashes from `git log wp-latest` in the scratch repo:

```js
// node e2e.js <changelog-sha> <publish-sha>
const { backportCommitsToBranch } = require( './tools/release/commands/packages.js' );
backportCommitsToBranch(
	'main',
	{ changelogCommit: process.argv[ 2 ], publishCommit: process.argv[ 3 ] },
	{ gitWorkingDirectoryPath: '/tmp/backport-e2e/work', interactive: false }
);
```

`git show origin/main:packages/data/CHANGELOG.md` in the scratch repo should show "Landed during publish" under `## Unreleased` and only "Shipped fix" under `## 1.1.0 (2026-08-12)` — with the old code, both end up under `1.1.0`. Rewording an entry in a released section of `main` before rerunning makes the backport refuse and push nothing.

</details>

## Use of AI Tools

Implemented with Claude Code (Fable 5), directed and reviewed by @sirreal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
