### PR TITLE
ComboboxControl: narrow `onChange` callback type to `string` | `null`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### TypeScript
 
+-   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
 -   Further improved `WordPressComponent` typecheck performance: intrinsic `as` values use a shared attribute bag instead of remapping props per HTML tag ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `ConfirmDialog`: Type the `size` prop forwarded to `Modal` ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `ToggleGroupControl`: Type the `disabled` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).
 -   `ControlWithError`: Re-read the target's validation message when an `invalid` event is received, so a message that changed without a re-render in between (e.g. a programmatic value change followed by a synthetic `invalid` event) is not revealed stale or empty. While a `validating` custom validity is pending, the message is left untouched so the pending indicator keeps showing ([#81440](https://github.com/WordPress/gutenberg/pull/81440)).
 
+### TypeScript
+
+-   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#81568](https://github.com/WordPress/gutenberg/pull/81568)).
+
 ### Internal
 
 -   Remove `ValidatedComboboxControl` from the private APIs; it now lives internally in `@wordpress/dataviews`, its only consumer ([#81449](https://github.com/WordPress/gutenberg/pull/81449)).
@@ -47,7 +51,6 @@
 
 ### TypeScript
 
--   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#81568](https://github.com/WordPress/gutenberg/pull/81568)).
 -   Further improved `WordPressComponent` typecheck performance: intrinsic `as` values use a shared attribute bag instead of remapping props per HTML tag ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `ConfirmDialog`: Type the `size` prop forwarded to `Modal` ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `ToggleGroupControl`: Type the `disabled` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 ### TypeScript
 
--   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+-   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#81568](https://github.com/WordPress/gutenberg/pull/81568)).
 -   Further improved `WordPressComponent` typecheck performance: intrinsic `as` values use a shared attribute bag instead of remapping props per HTML tag ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `ConfirmDialog`: Type the `size` prop forwarded to `Modal` ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).
 -   `ToggleGroupControl`: Type the `disabled` prop ([#80705](https://github.com/WordPress/gutenberg/pull/80705)).

--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -92,7 +92,7 @@ Function called when the control's search input value changes. The argument cont
 
 Function called when the selected value changes.
 
--   Type: `( value: string | null | undefined ) => void`
+-   Type: `( value: string | null ) => void`
 -   Required: No
 
 #### value

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -7,6 +7,8 @@ export type ComboboxControlOption = {
 	[ key: string ]: any;
 };
 
+type ComboboxControlValue = string | null;
+
 export type ComboboxControlProps = Pick<
 	BaseControlProps,
 	| '__nextHasNoMarginBottom'
@@ -65,7 +67,7 @@ export type ComboboxControlProps = Pick<
 	/**
 	 * Function called with the selected value changes.
 	 */
-	onChange?: ( value: ComboboxControlProps[ 'value' ] ) => void;
+	onChange?: ( value: ComboboxControlValue ) => void;
 	/**
 	 * Function called when the control's search input value changes. The argument contains the next input value.
 	 *
@@ -79,7 +81,7 @@ export type ComboboxControlProps = Pick<
 	/**
 	 * The current value of the control.
 	 */
-	value?: string | null;
+	value?: ComboboxControlValue;
 	/**
 	 * If passed, the combobox input will show a placeholder string if no values are present.
 	 */

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Internal
 
--   DataForm: Narrow the combobox control's `onChange` handler parameter back to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. [#TBD](https://github.com/WordPress/gutenberg/pull/TBD)
+-   DataForm: Narrow the combobox control's `onChange` handler parameter back to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. [#81568](https://github.com/WordPress/gutenberg/pull/81568)
 -   DataViews: Replace the inlined `kebabCase` utility with the new `@wordpress/kebab-case` package. [#81294](https://github.com/WordPress/gutenberg/pull/81294)
 -   DataForm: Internalize `ValidatedSelectControl` and its `ControlWithError` foundation instead of unlocking them from the `@wordpress/components` private APIs. The foundation is a temporary copy slated to be replaced by the upcoming `@wordpress/ui` implementation. [#81391](https://github.com/WordPress/gutenberg/pull/81391)
 -   DataForm: Internalize `ValidatedCheckboxControl` instead of unlocking it from the `@wordpress/components` private APIs. [#81435](https://github.com/WordPress/gutenberg/pull/81435)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Internal
 
+-   DataForm: Narrow the combobox control's `onChange` handler parameter back to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. [#TBD](https://github.com/WordPress/gutenberg/pull/TBD)
 -   DataViews: Replace the inlined `kebabCase` utility with the new `@wordpress/kebab-case` package. [#81294](https://github.com/WordPress/gutenberg/pull/81294)
 -   DataForm: Internalize `ValidatedSelectControl` and its `ControlWithError` foundation instead of unlocking them from the `@wordpress/components` private APIs. The foundation is a temporary copy slated to be replaced by the upcoming `@wordpress/ui` implementation. [#81391](https://github.com/WordPress/gutenberg/pull/81391)
 -   DataForm: Internalize `ValidatedCheckboxControl` instead of unlocking it from the `@wordpress/components` private APIs. [#81435](https://github.com/WordPress/gutenberg/pull/81435)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Internal
 
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))
+-   DataForm: Narrow the combobox control's `onChange` handler parameter back to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. [#81568](https://github.com/WordPress/gutenberg/pull/81568)
 -   DataForm: Internalize `ValidatedComboboxControl` instead of unlocking it from the `@wordpress/components` private APIs. [#81449](https://github.com/WordPress/gutenberg/pull/81449)
 -   DataForm: Internalize `ValidatedFormTokenField` instead of unlocking it from the `@wordpress/components` private APIs. [#81451](https://github.com/WordPress/gutenberg/pull/81451)
 -   DataForm: Internalize `ValidatedToggleControl` instead of unlocking it from the `@wordpress/components` private APIs. [#81492](https://github.com/WordPress/gutenberg/pull/81492)
@@ -30,7 +31,6 @@
 
 ### Internal
 
--   DataForm: Narrow the combobox control's `onChange` handler parameter back to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. [#81568](https://github.com/WordPress/gutenberg/pull/81568)
 -   DataViews: Replace the inlined `kebabCase` utility with the new `@wordpress/kebab-case` package. [#81294](https://github.com/WordPress/gutenberg/pull/81294)
 -   DataForm: Internalize `ValidatedSelectControl` and its `ControlWithError` foundation instead of unlocking them from the `@wordpress/components` private APIs. The foundation is a temporary copy slated to be replaced by the upcoming `@wordpress/ui` implementation. [#81391](https://github.com/WordPress/gutenberg/pull/81391)
 -   DataForm: Internalize `ValidatedCheckboxControl` instead of unlocking it from the `@wordpress/components` private APIs. [#81435](https://github.com/WordPress/gutenberg/pull/81435)

--- a/packages/dataviews/src/components/dataform-controls/combobox.tsx
+++ b/packages/dataviews/src/components/dataform-controls/combobox.tsx
@@ -17,7 +17,7 @@ export default function Combobox< Item >( {
 	const value = getValue( { item: data } ) ?? '';
 
 	const onChangeControl = useCallback(
-		( newValue: string | null | undefined ) =>
+		( newValue: string | null ) =>
 			onChange( setValue( { item: data, value: newValue ?? '' } ) ),
 		[ data, onChange, setValue ]
 	);

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))
+-   `parent`: Narrow the combobox `onChange` handler parameter to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. ([#81568](https://github.com/WordPress/gutenberg/pull/81568))
 
 ## 0.45.0 (2026-08-12)
 

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -239,7 +239,7 @@ export function PageAttributesParent( {
 	 *
 	 * @param {Object} selectedPostId The selected Author.
 	 */
-	const handleChange = ( selectedPostId: string | null | undefined ) => {
+	const handleChange = ( selectedPostId: string | null ) => {
 		if ( selectedPostId ) {
 			return onChangeControl( parseInt( selectedPostId, 10 ) ?? 0 );
 		}

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `attached_to`: Narrow the combobox `onChange` handler parameter to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. ([#81568](https://github.com/WordPress/gutenberg/pull/81568))
+
 ## 0.18.0 (2026-08-12)
 
 ### Bug Fixes

--- a/packages/media-fields/src/attached_to/edit.tsx
+++ b/packages/media-fields/src/attached_to/edit.tsx
@@ -107,9 +107,7 @@ export default function MediaAttachedToEdit( {
 	 *
 	 * @param {Object} selectedPostId The selected post id.
 	 */
-	const handleSelectOption = (
-		selectedPostId: string | null | undefined
-	) => {
+	const handleSelectOption = ( selectedPostId: string | null ) => {
 		if ( ! selectedPostId ) {
 			handleDetach();
 			return;


### PR DESCRIPTION
Follow up to [this comment](https://github.com/WordPress/gutenberg/pull/81449/changes#r3765677427).

# What?

Narrows the ComboboxControl onChange callback parameter type from `string | null | undefined` to `string | null` by hoisting the value type into a named alias, and reverts the undefined widening that #81449 added to the DataForm combobox handler.

## Why?

The `onChange` parameter was typed via an indexed access on the optional value prop:

```ts
type ComboboxControlProps = {
	value?: string | null;
	onChange?: ( value: CaseOne[ 'value' ] ) => void;
};
```

And so `ComboboxControlProps[ 'value' ]` (due to the `?` modifier on `value`) leaks `undefined` into the onChange callback parameter type. The component never actually calls `onChange` with `undefined` — only with a suggestion `string` or `null` on reset — so consumers were forced to widen their handlers for a value that never arrives (as happened in #81449).

## How?

By hoisting and sharing the type:

```ts
type ComboboxControlValue = string | null;
type ComboboxControlProps = {
	value?: ComboboxControlValue;
	onChange?: ( value: ComboboxControlValue ) => void;
};
```

Checked the impact on major consumers and there were no handler breaks.

## Testing Instructions

1. Run `npm run build` (or a TypeScript check) and confirm it passes.
2. In `packages/dataviews/src/components/dataform-controls/combobox.tsx`, confirm the `onChange` handler typed ( `newValue: string | null` ) compiles without the previous `| undefined` widening.

## Use of AI Tools

Authored with the assistance of Claude Code (implementation, consumer-impact analysis, and this description); reviewed and verified by me.
