### PR TITLE
Docs: Fix broken links to the Block API reference guides.

### DIFF
--- a/docs/getting-started/fundamentals/file-structure-of-a-block.md
+++ b/docs/getting-started/fundamentals/file-structure-of-a-block.md
@@ -27,9 +27,9 @@ The [build process](/docs/getting-started/fundamentals/javascript-in-the-block-e
 
 ### `block.json`
 
-The `block.json` file contains the [block's metadata](docs/block-editor/reference-guides/block-api/block-metadata/), streamlining its definition and registration across client-side and server-side environments. 
+The `block.json` file contains the [block's metadata](/docs/reference-guides/block-api/block-metadata.md), streamlining its definition and registration across client-side and server-side environments. 
 
-This file includes the block name, description, [attributes](docs/block-editor/reference-guides/block-api/block-attributes/), [supports](docs/block-editor/reference-guides/block-api/block-supports/), and more, as well as the locations of essential files responsible for the block's functionality, appearance, and styling. 
+This file includes the block name, description, [attributes](/docs/reference-guides/block-api/block-attributes.md), [supports](/docs/reference-guides/block-api/block-supports.md), and more, as well as the locations of essential files responsible for the block's functionality, appearance, and styling. 
 
 When a build process is applied, the `block.json` file and the other generated files are moved to a designated folder, often the `build` folder. Consequently, the file paths specified within `block.json` point to these processed, bundled versions of the files. 
 

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -44,7 +44,7 @@ A unique identifier for a block type, consisting of a plugin-specific namespace 
 
 ## Block Templates
 
-A template is a pre-defined arrangement of blocks, possibly with predefined attributes or placeholder content. You can provide a template for a post type, to give users a starting point when creating a new piece of content, or inside a custom block with the <code>InnerBlocks</code> component. At their core, templates are simply HTML files of block markup that map to templates from the standard WordPress template hierarchy, for example index, single or archive. This helps control the front-end defaults of a site that are not edited via the Page Editor or the Post Editor. See the <a href="../../developers/block-api/block-templates/">templates documentation</a> for more information.
+A template is a pre-defined arrangement of blocks, possibly with predefined attributes or placeholder content. You can provide a template for a post type, to give users a starting point when creating a new piece of content, or inside a custom block with the <code>InnerBlocks</code> component. At their core, templates are simply HTML files of block markup that map to templates from the standard WordPress template hierarchy, for example index, single or archive. This helps control the front-end defaults of a site that are not edited via the Page Editor or the Post Editor. See the [templates documentation](/docs/reference-guides/block-api/block-templates.md) for more information.
 
 ## Block Template Parts
 


### PR DESCRIPTION
Four links to the Block API reference guides point to 404 destinations: three on the file structure of a block page use `docs/block-editor/...` paths that don't exist, and the glossary links the templates documentation using the old `../../developers/...` handbook path. This PR updates all four links to the correct destinations.

## Testing Instructions

Verify the four links updated on this PR load the Block API reference pages for metadata, attributes, supports, and templates, while the previous destinations return a 404.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
