### PR TITLE
Extensible Site Editor: Add the Identity route

### DIFF
--- a/lib/experimental/pages/site-editor.php
+++ b/lib/experimental/pages/site-editor.php
@@ -25,6 +25,7 @@ add_action( 'admin_menu', 'gutenberg_register_site_editor_admin_page' );
  */
 function gutenberg_site_editor_register_default_menu_items() {
 	gutenberg_register_site_editor_v2_menu_item( 'home', __( 'Home', 'gutenberg' ), '/', '' );
+	gutenberg_register_site_editor_v2_menu_item( 'identity', _x( 'Identity', 'site identity', 'gutenberg' ), '/identity', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'styles', __( 'Styles', 'gutenberg' ), '/styles', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'navigation', __( 'Navigation', 'gutenberg' ), '/navigation', '' );
 	gutenberg_register_site_editor_v2_menu_item( 'pages', __( 'Pages', 'gutenberg' ), '/types/page', '' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17464,6 +17464,10 @@
 			"resolved": "packages/icons",
 			"link": true
 		},
+		"node_modules/@wordpress/identity-route": {
+			"resolved": "routes/identity",
+			"link": true
+		},
 		"node_modules/@wordpress/image-cropper": {
 			"resolved": "packages/image-cropper",
 			"link": true
@@ -54795,6 +54799,19 @@
 			"name": "@wordpress/home-route",
 			"version": "1.0.0",
 			"dependencies": {
+				"@wordpress/i18n": "file:../../packages/i18n"
+			}
+		},
+		"routes/identity": {
+			"name": "@wordpress/identity-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/fields": "file:../../packages/fields",
+				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/i18n": "file:../../packages/i18n"
 			}
 		},

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -1,5 +1,6 @@
 import {
 	home,
+	siteLogo,
 	styles,
 	navigation,
 	page,
@@ -18,6 +19,7 @@ export async function init() {
 	// Define icons for menu items
 	const menuIcons: Record< string, { icon: React.ReactElement } > = {
 		home: { icon: home },
+		identity: { icon: siteLogo },
 		styles: { icon: styles },
 		navigation: { icon: navigation },
 		pages: { icon: page },

--- a/routes/identity/package.json
+++ b/routes/identity/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@wordpress/identity-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/identity",
+		"page": "site-editor-v2"
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/fields": "file:../../packages/fields",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
+		"@wordpress/i18n": "file:../../packages/i18n"
+	}
+}

--- a/routes/identity/route.ts
+++ b/routes/identity/route.ts
@@ -1,0 +1,20 @@
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { _x } from '@wordpress/i18n';
+
+/**
+ * Route configuration for the site identity.
+ */
+export const route = {
+	title: () => _x( 'Identity', 'site identity' ),
+	async canvas() {
+		return {
+			isPreview: true,
+		};
+	},
+	loader: async () => {
+		// The stage renders a form over the site settings, so preload them
+		// before the surface mounts.
+		await resolveSelect( coreStore ).getEntityRecord( 'root', 'site' );
+	},
+};

--- a/routes/identity/stage.tsx
+++ b/routes/identity/stage.tsx
@@ -1,0 +1,104 @@
+import { Page } from '@wordpress/admin-ui';
+import { __, _x } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { DataForm, type Field, type Form } from '@wordpress/dataviews';
+import { MediaEdit } from '@wordpress/fields';
+import { decodeEntities } from '@wordpress/html-entities';
+
+type SiteSettings = {
+	title?: string;
+	description?: string;
+	site_logo?: number;
+	site_icon?: number;
+};
+
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'title',
+		type: 'text',
+		label: __( 'Site Title' ),
+		description: __(
+			"Displays in your site's layout via the Site Title block."
+		),
+		getValue: ( { item } ) => decodeEntities( item.title ?? '' ),
+	},
+	{
+		id: 'description',
+		type: 'text',
+		label: __( 'Site Tagline' ),
+		description: __(
+			"In a few words, explain what this site is about. Displays in your site's layout via the Site Tagline block."
+		),
+		getValue: ( { item } ) => decodeEntities( item.description ?? '' ),
+	},
+	{
+		id: 'site_logo',
+		type: 'media',
+		label: __( 'Site Logo' ),
+		description: __(
+			"Displays in your site's layout via the Site Logo block."
+		),
+		placeholder: __( 'Choose logo' ),
+		Edit: MediaEdit,
+		setValue: ( { value } ) => ( {
+			site_logo: value ?? 0,
+		} ),
+	},
+	{
+		id: 'site_icon',
+		type: 'media',
+		label: __( 'Site Icon' ),
+		description: __(
+			'Shown in browser tabs, bookmarks, and mobile apps. It should be square and at least 512 by 512 pixels.'
+		),
+		placeholder: __( 'Choose icon' ),
+		Edit: MediaEdit,
+		setValue: ( { value } ) => ( {
+			site_icon: value ?? 0,
+		} ),
+	},
+];
+
+const form: Form = {
+	layout: {
+		type: 'regular',
+		labelPosition: 'top',
+	},
+	fields: [ 'title', 'description', 'site_logo', 'site_icon' ],
+};
+
+function Identity() {
+	const data = useSelect(
+		( select ) =>
+			select( coreStore ).getEditedEntityRecord(
+				'root',
+				'site',
+				// The site entity is a singleton and has no record key.
+				undefined as unknown as string
+			) as SiteSettings,
+		[]
+	);
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	const onChange = ( edits: Record< string, any > ) => {
+		editEntityRecord( 'root', 'site', undefined, edits );
+	};
+
+	return (
+		<Page
+			title={ _x( 'Identity', 'site identity' ) }
+			headingLevel={ 2 }
+			hasPadding
+		>
+			<DataForm
+				data={ data }
+				fields={ fields }
+				form={ form }
+				onChange={ onChange }
+			/>
+		</Page>
+	);
+}
+
+export const stage = Identity;


### PR DESCRIPTION
## What?

Adds an `/identity` route to the extensible site editor, porting the Identity screen that already exists in `edit-site`.

## Why?

Identity was the only top-level `edit-site` route with no counterpart in the new site editor, so site title, tagline, logo and icon weren't editable there. (Added to `edit-site` in #76116 and #76264.)

## How?

New `routes/identity` workspace, shaped like `routes/styles`:

- `package.json` declares `{ "path": "/identity", "page": "site-editor-v2" }`, which `@wordpress/build` scans to generate the PHP registration.
- `route.ts` returns the title plus a preview canvas (`{ isPreview: true }`, as the home route does), and preloads the `root`/`site` entity.
- `stage.tsx` ports `edit-site`'s `sidebar-identity` — same four fields, copy and `MediaEdit` controls, editing `root`/`site`.

The menu item is registered after Home, matching `edit-site`'s sidebar order, with the same `siteLogo` icon.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**, then open **Appearance → Design**.
2. Confirm **Identity** appears between Home and Styles.
3. Open it, edit the title and tagline, and pick a logo and icon.
4. Save, reload, and confirm the values persist and match **Settings → General**.

### Testing Instructions for Keyboard

Reach **Identity** from the sidebar with Tab/arrows and Enter, Tab through the two text fields, activate **Choose logo** / **Choose icon** with Enter or Space and confirm the media modal is operable and returns focus on close, then save — all without a mouse.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint and format pass; `npm run build` emits the route into `build/routes/registry.php`; in wp-env, `site-editor-v2_init` registers the menu item and resolves the route's script modules. Not verified: the screen hasn't been exercised in a browser, so the testing steps above still need a manual pass, and `phpcs` couldn't run (no Composer `vendor/` available).
