### PR TITLE
Extensible Site Editor: Preview the site on Home for classic themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55559,7 +55559,11 @@
 			"name": "@wordpress/home-route",
 			"version": "1.0.0",
 			"dependencies": {
-				"@wordpress/i18n": "file:../../packages/i18n"
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/dom": "file:../../packages/dom",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/url": "file:../../packages/url"
 			}
 		},
 		"routes/lock-unlock": {

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Register the content module for routes that only export a `canvas`, so a route without a stage or inspector can render a custom canvas.
+
 ## 0.21.0 (2026-08-12)
 
 ### Enhancements

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Register the content module for routes that only export a `canvas`, so a route without a stage or inspector can render a custom canvas.
+-   Register the content module for routes that only export a `canvas`, so a route without a stage or inspector can render a custom canvas ([#81578](https://github.com/WordPress/gutenberg/pull/81578)).
 
 ## 0.21.0 (2026-08-12)
 

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -2401,7 +2401,12 @@ async function buildAll( baseUrlExpression ) {
 				path: metadata.path,
 				page,
 				hasRoute: routeFiles.hasRoute,
-				hasContent: routeFiles.hasStage || routeFiles.hasInspector,
+				// Must match the condition that builds `content.js`, which
+				// bundles the canvas alongside the stage and inspector.
+				hasContent:
+					routeFiles.hasStage ||
+					routeFiles.hasInspector ||
+					routeFiles.hasCanvas,
 			};
 		} );
 	} );

--- a/routes/home/canvas.tsx
+++ b/routes/home/canvas.tsx
@@ -1,0 +1,64 @@
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { focus } from '@wordpress/dom';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Renders the site's front end in an iframe.
+ *
+ * Used for themes that have no block templates for the canvas to edit, so that
+ * the home route still shows what the site looks like.
+ */
+function SitePreview() {
+	const siteUrl = useSelect( ( select ) => {
+		const siteData = select( coreStore ).getEntityRecord(
+			'root',
+			'__unstableBase'
+		) as { home?: unknown } | undefined;
+		return siteData?.home;
+	}, [] );
+
+	// `home` comes from the REST index. Without a usable URL the iframe would
+	// resolve its `src` against the current admin page and embed that instead,
+	// so render nothing until there is one.
+	if ( typeof siteUrl !== 'string' || ! siteUrl ) {
+		return null;
+	}
+
+	return (
+		<iframe
+			src={ addQueryArgs( siteUrl, {
+				// Parameter for hiding the admin bar.
+				wp_site_preview: 1,
+			} ) }
+			title={ __( 'Site Preview' ) }
+			style={ {
+				display: 'block',
+				width: '100%',
+				height: '100%',
+				backgroundColor: '#fff',
+			} }
+			onLoad={ ( event ) => {
+				const iframeDocument = ( event.target as HTMLIFrameElement )
+					.contentDocument;
+
+				// Not readable when the site is served from another origin.
+				if ( ! iframeDocument ) {
+					return;
+				}
+
+				// Make interactive elements unclickable.
+				focus.focusable
+					.find( iframeDocument.documentElement )
+					.forEach( ( element ) => {
+						element.style.pointerEvents = 'none';
+						element.tabIndex = -1;
+						element.setAttribute( 'aria-hidden', 'true' );
+					} );
+			} }
+		/>
+	);
+}
+
+export const canvas = SitePreview;

--- a/routes/home/package.json
+++ b/routes/home/package.json
@@ -7,6 +7,10 @@
 		"page": "site-editor-v2"
 	},
 	"dependencies": {
-		"@wordpress/i18n": "file:../../packages/i18n"
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/dom": "file:../../packages/dom",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/url": "file:../../packages/url"
 	}
 }

--- a/routes/home/route.ts
+++ b/routes/home/route.ts
@@ -1,8 +1,19 @@
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 export const route = {
 	title: () => __( 'Home' ),
 	async canvas() {
+		const currentTheme = await resolveSelect( coreStore ).getCurrentTheme();
+
+		// Classic themes have no block templates for the editor canvas to
+		// resolve, so fall back to the custom canvas, which previews the site's
+		// front end in an iframe.
+		if ( ! currentTheme?.is_block_theme ) {
+			return null;
+		}
+
 		return {
 			isPreview: true,
 		};


### PR DESCRIPTION
## What?

On the extensible site editor's home route, renders the site's front end in an iframe for classic themes, matching what `edit-site` does.

## Why?

The home canvas asks the editor to resolve the homepage. Classic themes have no block templates, so unless a static front page is set, `getHomePage()` resolves to nothing and the canvas renders the "You attempted to edit an item that doesn't exist" notice. `edit-site` handles this by rendering `SitePreview` — an iframe of the front end — for the home route on non-block themes.

## How?

- `routes/home/route.ts`: `canvas()` returns `null` for non-block themes, which tells the router to use the route's own canvas module rather than the editor.
- `routes/home/canvas.tsx`: new, ported from `edit-site`'s `editor/site-preview.js`. Iframes `home` from the REST index with `wp_site_preview=1` (Core defines `IFRAME_REQUEST` for that param, hiding the admin bar) and makes focusable elements inert on load.

Two small hardening changes over the `edit-site` original: it bails when `home` isn't a usable string, since an empty `src` would otherwise resolve against the current admin page and embed that; and it bails when `contentDocument` is unreadable, which happens when the site is served from another origin.

**`@wordpress/build` fix.** `content.js` is built when a route has a stage, an inspector *or* a canvas, but the generated PHP marked a route as having content only for a stage or inspector. A canvas-only route — which `routes/home` now is — built its content module and then never registered it, so the custom canvas could never load. The two conditions now match.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**.
2. Activate a classic theme (e.g. Twenty Nineteen) with **Settings → Reading** set to show latest posts.
3. Open **Appearance → Design**. On `trunk` the canvas shows an "item that doesn't exist" notice; with this change it shows the site's front page.
4. Confirm the preview is inert — links and buttons inside it aren't clickable or tabbable.
5. Confirm the admin bar is not visible inside the preview.
6. Switch to a block theme and confirm Home still opens the editor canvas as before.

### Testing Instructions for Keyboard

Tab through the Home screen and confirm focus never enters the preview iframe's contents — it should skip from the sidebar past the preview.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint and format pass; `npm run build` marks the home route `has_content => true` and emits both modules; in wp-env on Twenty Nineteen the route resolves to its content module, `is_block_theme` is `false`, and `/?wp_site_preview=1` returns 200. Not verified: the preview hasn't been seen rendered in a browser, so the testing steps still need a manual pass, and `phpcs` wasn't run (no Composer `vendor/` available) — though no PHP source changed here.
