### PR TITLE
Extensible Site Editor: Show only the style book on Styles for classic themes

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.
+
 ## 0.20.0 (2026-08-12)
 
 ### Bug Fixes

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -94,10 +94,16 @@ function createRouteFromDefinition( route: Route, parentRoute: AnyRoute ) {
 				inspector = await routeConfig.inspector( context );
 			}
 
+			let stage = true;
+			if ( routeConfig.stage ) {
+				stage = await routeConfig.stage( context );
+			}
+
 			return {
 				...( loaderData as any ),
 				canvas: canvasData,
 				inspector,
+				stage,
 				title: titleData,
 				routeContentModule: route.content_module,
 			};
@@ -116,12 +122,12 @@ function createRouteFromDefinition( route: Route, parentRoute: AnyRoute ) {
 
 		return createLazyRoute( route.path )( {
 			component: function RouteComponent() {
-				const { inspector: showInspector } =
+				const { inspector: showInspector, stage: showStage } =
 					useLoaderData( { from: route.path } ) ?? {};
 
 				return (
 					<>
-						{ Stage && (
+						{ Stage && showStage && (
 							<div className="boot-layout__stage">
 								<Stage />
 							</div>

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -105,6 +105,25 @@ export interface RouteConfig {
 	inspector?: ( context: RouteLoaderContext ) => boolean | Promise< boolean >;
 
 	/**
+	 * Function that determines whether to show the stage.
+	 * When not defined, defaults to true (always show stage if component exists).
+	 * When it returns false, the stage is hidden even if a stage component is
+	 * exported, leaving the canvas to fill the surfaces area.
+	 *
+	 * @example
+	 * ```tsx
+	 * export const route = {
+	 *   stage: async () => {
+	 *     // Only show the stage when there is something to edit
+	 *     const theme = await resolveSelect( coreStore ).getCurrentTheme();
+	 *     return !! theme?.is_block_theme;
+	 *   },
+	 * };
+	 * ```
+	 */
+	stage?: ( context: RouteLoaderContext ) => boolean | Promise< boolean >;
+
+	/**
 	 * Function that returns the document title for the route.
 	 * The returned title will be formatted as: "{title} ‹ {siteTitle} — WordPress"
 	 * and announced to screen readers for accessibility.

--- a/routes/styles/canvas.tsx
+++ b/routes/styles/canvas.tsx
@@ -1,7 +1,9 @@
 import { useNavigate, useSearch } from '@wordpress/route';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import { useEditorAssets } from '@wordpress/lazy-editor';
+import { useEditorAssets, useEditorSettings } from '@wordpress/lazy-editor';
 import { Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { StyleBookPreview } = unlock( editorPrivateApis );
@@ -10,6 +12,20 @@ function Canvas() {
 	const { isReady: assetsReady } = useEditorAssets();
 	const navigate = useNavigate();
 	const search = useSearch( { strict: false } ) as any;
+	const { globalStylesId, isBlockTheme } = useSelect( ( select ) => {
+		const { getCurrentTheme, __experimentalGetCurrentGlobalStylesId } =
+			select( coreStore ) as any;
+		return {
+			globalStylesId: __experimentalGetCurrentGlobalStylesId(),
+			isBlockTheme: !! getCurrentTheme()?.is_block_theme,
+		};
+	}, [] );
+	// The style book reads the theme's colors and typography from the editor
+	// settings. It cannot fall back to the editor store here, because on this
+	// route nothing mounts the editor that would populate it.
+	const { editorSettings } = useEditorSettings( {
+		stylesId: globalStylesId,
+	} );
 
 	// Get section from URL query params
 	const section = ( search.section ?? '/' ) as string;
@@ -38,8 +54,18 @@ function Canvas() {
 		);
 	}
 
+	// On classic themes the style book is the whole route: there is no styles
+	// UI for a selected section to drive, so its sections aren't clickable.
+	if ( ! isBlockTheme ) {
+		return <StyleBookPreview isStatic settings={ editorSettings } />;
+	}
+
 	return (
-		<StyleBookPreview path={ section } onPathChange={ onChangeSection } />
+		<StyleBookPreview
+			path={ section }
+			onPathChange={ onChangeSection }
+			settings={ editorSettings }
+		/>
 	);
 }
 

--- a/routes/styles/canvas.tsx
+++ b/routes/styles/canvas.tsx
@@ -23,7 +23,7 @@ function Canvas() {
 	// The style book reads the theme's colors and typography from the editor
 	// settings. It cannot fall back to the editor store here, because on this
 	// route nothing mounts the editor that would populate it.
-	const { editorSettings } = useEditorSettings( {
+	const { isReady: settingsReady, editorSettings } = useEditorSettings( {
 		stylesId: globalStylesId,
 	} );
 
@@ -39,7 +39,10 @@ function Canvas() {
 		} );
 	};
 
-	if ( ! assetsReady ) {
+	// Settings are awaited as well as assets: an unresolved `editorSettings` is
+	// still an object, so it would suppress the style book's own fallback and
+	// render a first pass with no theme styles.
+	if ( ! assetsReady || ! settingsReady ) {
 		return (
 			<div
 				style={ {

--- a/routes/styles/route.ts
+++ b/routes/styles/route.ts
@@ -1,14 +1,30 @@
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+
+async function isBlockTheme() {
+	const currentTheme = await resolveSelect( coreStore ).getCurrentTheme();
+	return !! currentTheme?.is_block_theme;
+}
 
 /**
  * Route configuration for styles.
  */
 export const route = {
 	title: () => __( 'Styles' ),
+
+	// Classic themes have no global styles to edit, so the style book is all
+	// this route has to show.
+	stage: isBlockTheme,
+
 	async canvas( context: any ) {
-		// If stylebook preview is active, use custom canvas (StyleBookPreview)
-		// Otherwise, use default editor canvas
-		if ( context.search.preview === 'stylebook' ) {
+		// Use the custom canvas (StyleBookPreview) when the style book is the
+		// only thing to render, or when its preview is toggled on. Otherwise,
+		// use the default editor canvas.
+		if (
+			context.search.preview === 'stylebook' ||
+			! ( await isBlockTheme() )
+		) {
 			return null;
 		}
 		return {


### PR DESCRIPTION
## What?

On the extensible site editor's Styles route, renders only the style book for classic themes, matching `edit-site`.

## Why?

Classic themes have no global styles to edit. `edit-site` handles this by pointing Styles at a dedicated `/stylebook` route, which renders a static style book and no content column. The extensible site editor showed the Global Styles UI instead, with the style book as an optional toggle.

## How?

- `routes/styles/route.ts`: on a non-block theme, the route hides its stage and `canvas()` always returns `null`, so the style book is the canvas rather than a toggle.
- `routes/styles/canvas.tsx`: renders the style book `isStatic` for classic themes — with no styles UI, a selected section has nothing to drive, so its sections aren't clickable. Same as `edit-site`'s stylebook route.

**`@wordpress/boot`.** Hiding the stage needed a `stage` visibility function in a route's config. It mirrors the existing `inspector` one exactly — resolved in the loader, defaults to `true`, and when it returns `false` the stage is skipped and the canvas fills the surfaces area.

**One thing beyond the strict scope.** The style book now also receives the route's editor settings, as it does in `edit-site`. It previously passed none and fell back to `editorStore.getEditorSettings()`, which only holds anything once the editor has mounted — and on a classic theme the editor canvas is never rendered on this route, so the style book would have shown default block styles instead of the theme's. The same settings are now passed on block themes too, rather than splitting the two paths; this also removes the dependency on having visited the editor canvas first before toggling the style book.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**.
2. Activate a classic theme (e.g. Twenty Nineteen) and open **Appearance → Design → Styles**.
3. Confirm the Global Styles UI is gone and the style book fills the width, showing the theme's colors and typography.
4. Confirm style book sections are not clickable.
5. Switch to a block theme and confirm Styles is unchanged: Global Styles UI in the stage, editor canvas beside it, and the **Style Book** toggle still swaps the canvas and keeps its sections clickable.

### Testing Instructions for Keyboard

On a classic theme, Tab from the sidebar and confirm focus moves into the style book without passing through a stage, and that no style book section takes focus as a control.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint and format pass; `tsc --build packages/boot` reports no errors in `boot` (the errors it surfaces in `editor`, `lazy-editor`, `global-styles-ui` and `media-editor` are pre-existing on trunk and in packages this PR does not touch); `npm run build` emits the `stage` predicate into both the route module and the boot module, and in wp-env the plugin's own `@wordpress/boot` build is the one registered, so the new field is honored. Not verified: neither the classic nor the block-theme path has been exercised in a browser, so the testing steps still need a manual pass — in particular the claim that the style book now renders the theme's styles.
