### PR TITLE
Editor: Register the editor keyboard shortcuts from the provider

### DIFF
--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Stop rendering `EditorKeyboardShortcutsRegister`, which the editor provider now renders itself ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).
+
 ## 8.53.0 (2026-08-12)
 
 ### Enhancements

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -4,7 +4,6 @@ import {
 	AutosaveMonitor,
 	LocalAutosaveMonitor,
 	UnsavedChangesWarning,
-	EditorKeyboardShortcutsRegister,
 	ErrorBoundary,
 	PostLockedModal,
 	store as editorStore,
@@ -593,7 +592,6 @@ function Layout( {
 								<AutosaveMonitor />
 								<LocalAutosaveMonitor />
 								<EditPostKeyboardShortcuts />
-								<EditorKeyboardShortcutsRegister />
 								<BlockKeyboardShortcuts />
 								{ currentPostType === 'wp_block' && (
 									<InitPatternModal />

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Stop rendering `EditorKeyboardShortcutsRegister`, which the editor provider now renders itself ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).
+
 ## 7.2.0 (2026-08-12)
 
 ### Bug Fixes

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -2,7 +2,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
-	EditorKeyboardShortcutsRegister,
 	privateApis as editorPrivateApis,
 	store as editorStore,
 } from '@wordpress/editor';
@@ -167,7 +166,6 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 		<SitePreview />
 	) : (
 		<>
-			<EditorKeyboardShortcutsRegister />
 			{ isEditMode && <BlockKeyboardShortcuts /> }
 			{ ! isReady ? <CanvasLoader id={ loadingProgressId } /> : null }
 			{ isEditMode && isReady && (

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Register the editor and block editor keyboard shortcuts from the editor provider, so shortcuts work for consumers that mount the editor without rendering `EditorKeyboardShortcutsRegister` themselves ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).
+
 ## 14.53.0 (2026-08-12)
 
 ### Internal

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -35,6 +35,7 @@ import StartPageOptions from '../start-page-options';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 import StartTemplateOptions from '../start-template-options';
 import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
+import EditorKeyboardShortcutsRegister from '../global-keyboard-shortcuts/register-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
@@ -426,6 +427,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 									{ type === 'wp_navigation' && (
 										<NavigationBlockEditingMode />
 									) }
+									<EditorKeyboardShortcutsRegister />
 									<EditorKeyboardShortcuts />
 									<KeyboardShortcutHelpModal />
 									<BlockRemovalWarnings />


### PR DESCRIPTION
## What?

Renders `EditorKeyboardShortcutsRegister` from the editor provider, so the editor's keyboard shortcuts work for anything that mounts the editor without an app shell.

## Why?

`EditorKeyboardShortcuts` binds its handlers from inside the provider, but the component that *registers* the key combinations is a separate public component each shell renders itself — `edit-post` in its layout, `edit-site` alongside its editor. Mount the editor without one of those shells, as `@wordpress/lazy-editor` and therefore the extensible site editor canvas do, and the handlers are bound to nothing.

The reach is wider than the editor's own shortcuts. `EditorKeyboardShortcutsRegister` ends with `return <BlockEditorKeyboardShortcuts.Register />`, and that is the only place in the repo rendering it, so the block shortcuts go unregistered as well. In the extensible site editor canvas today that means undo, redo, duplicate, remove, insert before/after, rename, focus toolbar, toggle list view, toggle sidebar, distraction free, code editor and the shortcut help modal are all inert — and because the block settings menu asks `getShortcutRepresentation()` for its hints, those come back empty too. Save is the one exception: `@wordpress/boot` registers its own `core/boot/save`.

The split is historical rather than deliberate. Register was separated in #14116 (2019) so an app could register once at the shell level; the handler component was later moved into the provider by #61860 (2024), and Register stayed put because both consumers at the time already rendered it.

## How?

Renders it next to the handler component, under the same `! settings.isPreviewMode` guard — preview canvases should neither bind nor register. That position is inside `BlockEditorProviderComponent`, which is where `BlockEditorKeyboardShortcuts.Register`'s `useSettings( 'blockVisibility.allowEditing' )` belongs.

Both shells then stop rendering it themselves, since the provider covers them.

- `edit-post` never sets `isPreviewMode`, so the provider's guard always holds there and the removal changes nothing.
- `edit-site` rendered it *outside* the editor and unconditionally, including at `canvas=view`, where it sets `isPreviewMode: canvas === 'view'` and the provider's guard therefore skips it. Nothing consumes the registrations in that state: its save shortcut registers its own `core/edit-site/save`, `useNavigateRegions` matches hardcoded key combinations via `isKeyboardEvent` rather than the shortcuts store (so the `next-region`/`previous-region` entries are only there for the help modal, which isn't rendered in preview mode either), and the handlers, the `isMatch` call sites in block-tools and list-view, and `getShortcutRepresentation` in the block settings dropdown all live inside the editor at `! isPreviewMode`.

The public `EditorKeyboardShortcutsRegister` export stays — third parties may render it, and `registerShortcut` is keyed by name, so doing so remains harmless.

One thing this does not change: the register effect has no cleanup, so shortcuts stay registered after the editor unmounts. That never mattered while only `edit-post` and `edit-site` mounted the editor, since neither unmounts it, but it is now reachable by navigating away from the editor canvas in the extensible site editor. Nothing fires, because the handlers are gone with it; the only visible effect would be the help modal still listing them. Worth a separate fix.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design**.
2. Open a page or template in the editor canvas and make an edit.
3. Confirm <kbd>Ctrl/Cmd</kbd>+<kbd>Z</kbd> undoes it and <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> redoes it. On `trunk` neither does anything.
4. Select a block and confirm <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> duplicates it.
5. Open the block settings menu (⋮) and confirm the items now show their shortcut hints.
6. Confirm <kbd>Ctrl/Cmd</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> opens the keyboard shortcuts modal and that it lists the shortcuts.
7. Regression check the post editor and the current site editor, which no longer register the shortcuts themselves: shortcuts should behave exactly as before, including the hints in block menus and the contents of the shortcut help modal.

### Testing Instructions for Keyboard

The whole change is keyboard behaviour — the steps above are the keyboard test.

## Screenshots or screencast

<!-- Not applicable. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: the `@wordpress/editor`, `@wordpress/edit-post` and `@wordpress/edit-site` unit suites pass (73 suites, 846 tests); lint is clean on the changed files. Not verified: no browser pass, so the testing steps above still need a manual run. There is no e2e coverage of the extensible site editor canvas to assert the fix; the existing shortcut specs under `test/e2e/specs/editor/various/` cover the post editor and will catch a regression there.
