### PR TITLE
Vitest: Resolve @flakiness/vitest reporter to an absolute path

### DIFF
--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { playwright } from '@vitest/browser-playwright';
@@ -76,7 +77,13 @@ export default defineConfig( {
 						'default',
 						'github-actions',
 						[
-							'@flakiness/vitest',
+							/*
+							 * Resolve to an absolute path so Vitest can load
+							 * the reporter regardless of hoisting layout.
+							 */
+							createRequire( import.meta.url ).resolve(
+								'@flakiness/vitest'
+							),
 							{
 								duplicates: 'rename',
 								flakinessProject: 'WordPress/gutenberg',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/81037#discussion_r3765131563

Resolves the `@flakiness/vitest` reporter to an absolute path in [test/unit/vitest.config.mjs](https://github.com/WordPress/gutenberg/blob/c099637b7b6b2b2b7be0ea9d26de17bc3d11a777/test/unit/vitest.config.mjs) using `createRequire( import.meta.url ).resolve()`.

## Why?
With the bare specifier, Vitest fails to load the reporter under the isolated node_modules install strategy, since the package isn't hoisted where Vitest looks for it. See [this failing run](https://github.com/WordPress/gutenberg/actions/runs/31574330557/job/94042942237?pr=75814).

## How?
`createRequire( import.meta.url )` resolves the package relative to the config file, so the reporter loads regardless of the hoisting layout.

## Testing Instructions
1. Run `npm run test:unit:vitest`.
2. Confirm the tests run and the reporter loads without a module resolution error.

## Use of AI Tools
Authored with the assistance of Claude Code, reviewed and taken responsibility for by the author.
