### PR TITLE
Add Custom CSS Support for Responsive control

### DIFF
--- a/lib/block-supports/custom-css.php
+++ b/lib/block-supports/custom-css.php
@@ -6,6 +6,101 @@
  */
 
 /**
+ * Returns whether a style object contains custom CSS at any nesting level.
+ *
+ * @param mixed $style Block style attribute value.
+ * @return bool Whether custom CSS is present.
+ */
+function gutenberg_style_has_custom_css( $style ) {
+	if ( ! is_array( $style ) ) {
+		return false;
+	}
+
+	if ( isset( $style['css'] ) && is_string( $style['css'] ) && '' !== trim( $style['css'] ) ) {
+		return true;
+	}
+
+	foreach ( $style as $value ) {
+		if ( gutenberg_style_has_custom_css( $value ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Removes custom CSS keys from a style object at every nesting level.
+ *
+ * @param mixed $style Block style attribute value.
+ * @return mixed Style value with custom CSS removed.
+ */
+function gutenberg_strip_custom_css_from_style( $style ) {
+	if ( ! is_array( $style ) ) {
+		return $style;
+	}
+
+	unset( $style['css'] );
+
+	foreach ( $style as $key => $value ) {
+		if ( is_array( $value ) ) {
+			$style[ $key ] = gutenberg_strip_custom_css_from_style( $value );
+			if ( empty( $style[ $key ] ) ) {
+				unset( $style[ $key ] );
+			}
+		}
+	}
+
+	return $style;
+}
+
+/**
+ * Builds processed custom CSS rules for the default and viewport states.
+ *
+ * @param array  $style    Block style attribute.
+ * @param string $selector CSS selector used to scope nested custom CSS.
+ * @return string[] Processed CSS rule strings.
+ */
+function gutenberg_get_processed_custom_css_rules( $style, $selector ) {
+	$css_rules = array();
+
+	$append_processed_css = static function ( $css, $media_query = null ) use ( &$css_rules, $selector ) {
+		if ( ! is_string( $css ) || '' === trim( $css ) ) {
+			return;
+		}
+
+		// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).
+		if ( preg_match( '#</?\w+#', $css ) ) {
+			return;
+		}
+
+		$processed_css = WP_Theme_JSON_Gutenberg::process_blocks_custom_css( $css, $selector );
+		if ( empty( $processed_css ) ) {
+			return;
+		}
+
+		$css_rules[] = $media_query
+			? $media_query . '{' . $processed_css . '}'
+			: $processed_css;
+	};
+
+	$append_processed_css( $style['css'] ?? null );
+
+	$viewport_settings        = gutenberg_get_global_settings( array( 'viewport' ) );
+	$responsive_media_queries = WP_Theme_JSON_Gutenberg::get_viewport_media_queries( $viewport_settings );
+
+	foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
+		$viewport_css = null;
+		if ( isset( $style[ $breakpoint ] ) && is_array( $style[ $breakpoint ] ) ) {
+			$viewport_css = $style[ $breakpoint ]['css'] ?? null;
+		}
+		$append_processed_css( $viewport_css, $media_query );
+	}
+
+	return $css_rules;
+}
+
+/**
  * Render the custom CSS stylesheet and add class name to block as required.
  *
  * @param array $parsed_block The parsed block.
@@ -25,8 +120,8 @@
  * } $parsed_block
  */
 function gutenberg_render_custom_css_support_styles( $parsed_block ) {
-	$custom_css = $parsed_block['attrs']['style']['css'] ?? null;
-	if ( ! is_string( $custom_css ) || '' === trim( $custom_css ) ) {
+	$style = $parsed_block['attrs']['style'] ?? null;
+	if ( ! gutenberg_style_has_custom_css( $style ) ) {
 		return $parsed_block;
 	}
 
@@ -35,13 +130,15 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 		return $parsed_block;
 	}
 
-	// Validate CSS doesn't contain HTML markup (same validation as global styles REST API).
-	if ( preg_match( '#</?\w+#', $custom_css ) ) {
+	// Generate a unique class name for this block instance.
+	$class_name    = wp_unique_id_from_values( $parsed_block, 'wp-custom-css-' );
+	$selector      = '.' . $class_name;
+	$processed_css = implode( '', gutenberg_get_processed_custom_css_rules( $style, $selector ) );
+
+	if ( empty( $processed_css ) ) {
 		return $parsed_block;
 	}
 
-	// Generate a unique class name for this block instance.
-	$class_name          = wp_unique_id_from_values( $parsed_block, 'wp-custom-css-' );
 	$existing_class_name = $parsed_block['attrs']['className'] ?? null;
 	$updated_class_name  = is_string( $existing_class_name )
 		? "$existing_class_name $class_name"
@@ -49,28 +146,22 @@ function gutenberg_render_custom_css_support_styles( $parsed_block ) {
 
 	$parsed_block['attrs']['className'] = $updated_class_name;
 
-	// Process the custom CSS using the same method as global styles.
-	$selector      = '.' . $class_name;
-	$processed_css = WP_Theme_JSON_Gutenberg::process_blocks_custom_css( $custom_css, $selector );
-
-	if ( ! empty( $processed_css ) ) {
-		/**
-		 * Reuse one handle so identical custom CSS is enqueued only once via
-		 * {@see wp_unique_id_from_values()}. Explicitly declare the `wp-block-library`
-		 * dependency so `global-styles` is guaranteed to print after it, preventing
-		 * block default styles from unintentionally overriding global styles.
-		 */
-		$handle = 'wp-block-custom-css';
-		if ( ! wp_style_is( $handle, 'registered' ) ) {
-			wp_register_style( $handle, false, array( 'wp-block-library', 'global-styles' ) );
-		}
-		$after_styles = wp_styles()->get_data( $handle, 'after' );
-		if ( ! is_array( $after_styles ) ) {
-			$after_styles = array();
-		}
-		if ( ! in_array( $processed_css, $after_styles, true ) ) {
-			wp_add_inline_style( $handle, $processed_css );
-		}
+	/**
+	 * Reuse one handle so identical custom CSS is enqueued only once via
+	 * {@see wp_unique_id_from_values()}. Explicitly declare the `wp-block-library`
+	 * dependency so `global-styles` is guaranteed to print after it, preventing
+	 * block default styles from unintentionally overriding global styles.
+	 */
+	$handle = 'wp-block-custom-css';
+	if ( ! wp_style_is( $handle, 'registered' ) ) {
+		wp_register_style( $handle, false, array( 'wp-block-library', 'global-styles' ) );
+	}
+	$after_styles = wp_styles()->get_data( $handle, 'after' );
+	if ( ! is_array( $after_styles ) ) {
+		$after_styles = array();
+	}
+	if ( ! in_array( $processed_css, $after_styles, true ) ) {
+		wp_add_inline_style( $handle, $processed_css );
 	}
 
 	return $parsed_block;
@@ -210,14 +301,16 @@ function gutenberg_strip_custom_css_from_blocks( $content ) {
 			continue;
 		}
 
-		if ( ! isset( $attrs['style']['css'] ) ) {
+		if ( ! isset( $attrs['style'] ) || ! gutenberg_style_has_custom_css( $attrs['style'] ) ) {
 			continue;
 		}
 
-		// Remove css and clean up empty style.
-		unset( $attrs['style']['css'] );
-		if ( empty( $attrs['style'] ) ) {
+		$stripped_style = gutenberg_strip_custom_css_from_style( $attrs['style'] );
+
+		if ( empty( $stripped_style ) ) {
 			unset( $attrs['style'] );
+		} else {
+			$attrs['style'] = $stripped_style;
 		}
 
 		// Locate the JSON portion within the token.

--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -45,6 +45,8 @@ function gutenberg_normalize_state_preset_vars( $value ) {
 function gutenberg_normalize_state_style_for_css_output( $style ) {
 	// Layout is processed separately by gutenberg_render_layout_support_flag(), so we remove it before declaration generation.
 	unset( $style['layout'] );
+	// Custom CSS is rendered by gutenberg_render_custom_css_support_styles().
+	unset( $style['css'] );
 	$style = gutenberg_normalize_state_preset_vars( $style );
 	return $style;
 }

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Enhancements
 
 -   Creating a new block next to a sibling of the same type now inherits the sibling's attributes consistently, whether it is created by the appender, the inserter, or Enter at the edge of the text. Everything except the sibling's content (attributes with the `content` role) and its `metadata` is copied. The `attributesToCopy` list of a default block is removed: the copied attributes derive from the block's attribute roles.
--   Additional CSS supports responsive style states: the control remains available in Mobile/Tablet viewport mode and stores values under the selected viewport in `style` ([#80333](https://github.com/WordPress/gutenberg/issues/80333)).
+-   Additional CSS supports responsive style states: the control remains available in Mobile/Tablet viewport mode and stores values under the selected viewport in `style` ([#81591](https://github.com/WordPress/gutenberg/pull/81591)).
 
 ### Enhancements
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Enhancements
 
 -   Creating a new block next to a sibling of the same type now inherits the sibling's attributes consistently, whether it is created by the appender, the inserter, or Enter at the edge of the text. Everything except the sibling's content (attributes with the `content` role) and its `metadata` is copied. The `attributesToCopy` list of a default block is removed: the copied attributes derive from the block's attribute roles.
+-   Additional CSS supports responsive style states: the control remains available in Mobile/Tablet viewport mode and stores values under the selected viewport in `style` ([#80333](https://github.com/WordPress/gutenberg/issues/80333)).
 
 ### Enhancements
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -101,6 +101,8 @@ function StyleStateInspectorSlots( {
 	const showLayoutControls =
 		hasViewportBlockStyleState( selectedBlockStyleState ) &&
 		! hasPseudoBlockStyleState( selectedBlockStyleState );
+	// Additional CSS is viewport-scoped; HTML anchor / CSS classes are not.
+	const showAdvancedControls = showLayoutControls;
 	const showSectionStyleControls =
 		isSectionBlock && blockName !== 'core/template-part';
 	return (
@@ -149,6 +151,7 @@ function StyleStateInspectorSlots( {
 						label={ __( 'Elements' ) }
 						className="elements-block-support-panel__inner-wrapper"
 					/>
+					{ showAdvancedControls && <AdvancedControls initialOpen /> }
 				</>
 			) }
 		</>

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -2,8 +2,11 @@ import { addFilter } from '@wordpress/hooks';
 import { TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 import { InspectorControls } from '../components';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
 
 /**
  * Regular expression matching invalid anchor characters for replacement.
@@ -38,10 +41,18 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
+function BlockEditAnchorControlPure( { clientId, anchor, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
+	const hasSelectedStyleState = useSelect(
+		( select ) => {
+			const { hasSelectedStyleState: hasSelectedBlockStyleState } =
+				unlock( select( blockEditorStore ) );
+			return hasSelectedBlockStyleState( clientId );
+		},
+		[ clientId ]
+	);
 
-	if ( blockEditingMode !== 'default' ) {
+	if ( blockEditingMode !== 'default' || hasSelectedStyleState ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -3,8 +3,11 @@ import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 import { InspectorControls } from '../components';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
 
 /**
  * Filters registered block settings, extending attributes to include `className`.
@@ -27,9 +30,18 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
-function CustomClassNameControlsPure( { className, setAttributes } ) {
+function CustomClassNameControlsPure( { clientId, className, setAttributes } ) {
 	const blockEditingMode = useBlockEditingMode();
-	if ( blockEditingMode !== 'default' ) {
+	const hasSelectedStyleState = useSelect(
+		( select ) => {
+			const { hasSelectedStyleState: hasSelectedBlockStyleState } =
+				unlock( select( blockEditorStore ) );
+			return hasSelectedBlockStyleState( clientId );
+		},
+		[ clientId ]
+	);
+
+	if ( blockEditingMode !== 'default' || hasSelectedStyleState ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/custom-css.js
+++ b/packages/block-editor/src/hooks/custom-css.js
@@ -3,15 +3,27 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
-import { processCSSNesting } from '@wordpress/global-styles-engine';
+import {
+	processCSSNesting,
+	privateApis as globalStylesEnginePrivateApis,
+} from '@wordpress/global-styles-engine';
 import { store as noticesStore } from '@wordpress/notices';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import InspectorControls from '../components/inspector-controls';
 import AdvancedPanel, {
 	validateCSS,
 } from '../components/global-styles/advanced-panel';
+import { useSettings } from '../components/use-settings';
 import { cleanEmptyObject, usePrivateStyleOverride } from './utils';
+import {
+	getStyleForState,
+	isDefaultBlockStyleState,
+	setStyleForState,
+} from './block-style-state';
 import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
+
+const { getResponsiveMediaQueries } = unlock( globalStylesEnginePrivateApis );
 
 // Stable reference for useInstanceId.
 const CUSTOM_CSS_INSTANCE_REFERENCE = {};
@@ -20,26 +32,108 @@ const CUSTOM_CSS_INSTANCE_REFERENCE = {};
 const EMPTY_STYLE = {};
 
 /**
+ * Returns whether a style object (including viewport/pseudo nests) has custom CSS.
+ *
+ * @param {Object|undefined} style Block style attribute.
+ * @return {boolean} Whether any custom CSS is present.
+ */
+export function styleHasCustomCSS( style ) {
+	if ( ! style || typeof style !== 'object' ) {
+		return false;
+	}
+
+	if ( typeof style.css === 'string' && style.css.trim() ) {
+		return true;
+	}
+
+	return Object.values( style ).some(
+		( value ) =>
+			value && typeof value === 'object' && styleHasCustomCSS( value )
+	);
+}
+
+/**
+ * Builds scoped custom CSS rules for the default state and each viewport.
+ *
+ * @param {Object}           style             Block style attribute.
+ * @param {string}           customCSSSelector Selector used to scope nested CSS.
+ * @param {Object|undefined} viewportSettings  Viewport settings from theme.json.
+ * @return {string|undefined} Combined CSS, or undefined when empty/invalid.
+ */
+function getCustomCSSRules( style, customCSSSelector, viewportSettings ) {
+	const cssRules = [];
+
+	const appendProcessedCSS = ( css, mediaQuery ) => {
+		if ( typeof css !== 'string' || ! css.trim() || ! validateCSS( css ) ) {
+			return;
+		}
+
+		const processed = processCSSNesting( css, customCSSSelector );
+		if ( ! processed ) {
+			return;
+		}
+
+		cssRules.push(
+			mediaQuery ? `${ mediaQuery }{${ processed }}` : processed
+		);
+	};
+
+	appendProcessedCSS( style?.css );
+
+	Object.entries( getResponsiveMediaQueries( viewportSettings ) ).forEach(
+		( [ viewport, mediaQuery ] ) => {
+			appendProcessedCSS(
+				getStyleForState( style, {
+					viewport,
+					pseudo: 'default',
+				} )?.css,
+				mediaQuery
+			);
+		}
+	);
+
+	return cssRules.length > 0 ? cssRules.join( '' ) : undefined;
+}
+
+/**
  * Inspector control for custom CSS.
  *
  * @param {Object}   props               Component props.
+ * @param {string}   props.clientId      Block client ID.
  * @param {string}   props.blockName     Block name.
  * @param {Function} props.setAttributes Function to set block attributes.
  * @param {Object}   props.style         Block style attribute.
  */
-function CustomCSSControl( { blockName, setAttributes, style } ) {
+function CustomCSSControl( { clientId, blockName, setAttributes, style } ) {
 	const blockEditingMode = useBlockEditingMode();
+	const selectedState = useSelect(
+		( select ) => {
+			const { getSelectedBlockStyleState } = unlock(
+				select( blockEditorStore )
+			);
+			return getSelectedBlockStyleState( clientId );
+		},
+		[ clientId ]
+	);
 
 	if ( blockEditingMode !== 'default' ) {
 		return null;
 	}
 	const blockType = getBlockType( blockName );
+	const isStateSelected = ! isDefaultBlockStyleState( selectedState );
+	const stateStyle = isStateSelected
+		? getStyleForState( style, selectedState ) || EMPTY_STYLE
+		: style;
 
 	function onChange( newStyle ) {
 		// Normalize whitespace-only CSS to undefined so it gets cleaned up.
 		const css = newStyle?.css?.trim() ? newStyle.css : undefined;
+		const nextStateStyle = cleanEmptyObject( { ...newStyle, css } );
+
 		setAttributes( {
-			style: cleanEmptyObject( { ...newStyle, css } ),
+			style: isStateSelected
+				? setStyleForState( style, selectedState, nextStateStyle )
+				: nextStateStyle,
 		} );
 	}
 
@@ -54,9 +148,9 @@ function CustomCSSControl( { blockName, setAttributes, style } ) {
 	return (
 		<InspectorControls group="advanced">
 			<AdvancedPanel
-				value={ style }
+				value={ stateStyle }
 				onChange={ onChange }
-				inheritedValue={ style }
+				inheritedValue={ stateStyle }
 				help={ cssHelpText }
 			/>
 		</InspectorControls>
@@ -85,6 +179,7 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
 
 	return (
 		<CustomCSSControl
+			clientId={ clientId }
 			blockName={ name }
 			setAttributes={ setAttributes }
 			style={ style }
@@ -102,13 +197,7 @@ function CustomCSSEdit( { clientId, name, setAttributes } ) {
  * @return {Object} Block props including className for custom CSS scoping.
  */
 function useBlockProps( { style, clientId } ) {
-	const customCSS = style?.css;
-
-	// Validate CSS is non-empty and passes validation checks.
-	const isValidCSS =
-		typeof customCSS === 'string' &&
-		customCSS.trim().length > 0 &&
-		validateCSS( customCSS );
+	const [ viewportSettings ] = useSettings( 'viewport' );
 
 	const canEditCSS = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().canEditCSS,
@@ -120,7 +209,7 @@ function useBlockProps( { style, clientId } ) {
 	// Show a warning notice when the user lacks edit_css and a block has
 	// custom CSS. The fixed notice ID ensures only one notice is shown
 	// regardless of how many blocks have CSS.
-	const hasCustomCSS = !! customCSS?.trim();
+	const hasCustomCSS = styleHasCustomCSS( style );
 	useEffect( () => {
 		if ( ! canEditCSS && hasCustomCSS ) {
 			createWarningNotice(
@@ -145,11 +234,8 @@ function useBlockProps( { style, clientId } ) {
 	// Transform the custom CSS using the same logic as global styles.
 	// Only process if CSS is valid (doesn't contain HTML markup).
 	const transformedCSS = useMemo( () => {
-		if ( ! isValidCSS ) {
-			return undefined;
-		}
-		return processCSSNesting( customCSS, customCSSSelector );
-	}, [ customCSS, customCSSSelector, isValidCSS ] );
+		return getCustomCSSRules( style, customCSSSelector, viewportSettings );
+	}, [ style, customCSSSelector, viewportSettings ] );
 
 	// Inject the CSS via style override. The type makes EditorStyles print
 	// it after all other overrides (e.g. block style variations), matching
@@ -163,7 +249,7 @@ function useBlockProps( { style, clientId } ) {
 	} );
 
 	// Only add the class if there's valid custom CSS.
-	if ( ! isValidCSS ) {
+	if ( ! transformedCSS ) {
 		return {};
 	}
 
@@ -185,7 +271,7 @@ function addSaveProps( props, blockType, attributes ) {
 		return props;
 	}
 
-	if ( ! attributes?.style?.css?.trim() ) {
+	if ( ! styleHasCustomCSS( attributes?.style ) ) {
 		return props;
 	}
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -445,7 +445,7 @@ export function getResponsiveStateCSSRules(
 ) {
 	const cssRules = [];
 	const validPseudoStates = VALID_BLOCK_PSEUDO_STATES[ name ] ?? [];
-	const nestedStateKeys = [ 'elements', ...validPseudoStates ];
+	const nestedStateKeys = [ 'elements', 'css', ...validPseudoStates ];
 	const responsiveMediaQueries =
 		getResponsiveMediaQueries( viewportSettings );
 

--- a/packages/block-editor/src/hooks/test/custom-css.js
+++ b/packages/block-editor/src/hooks/test/custom-css.js
@@ -1,0 +1,55 @@
+import { getStyleForState, setStyleForState } from '../block-style-state';
+import { styleHasCustomCSS } from '../custom-css';
+
+describe( 'styleHasCustomCSS', () => {
+	it( 'returns false when style is empty', () => {
+		expect( styleHasCustomCSS( undefined ) ).toBe( false );
+		expect( styleHasCustomCSS( {} ) ).toBe( false );
+	} );
+
+	it( 'returns true for root custom CSS', () => {
+		expect( styleHasCustomCSS( { css: 'color: red;' } ) ).toBe( true );
+	} );
+
+	it( 'returns true for viewport custom CSS', () => {
+		expect(
+			styleHasCustomCSS( {
+				'@tablet': { css: 'color: blue;' },
+			} )
+		).toBe( true );
+	} );
+
+	it( 'ignores whitespace-only CSS', () => {
+		expect( styleHasCustomCSS( { css: '   ' } ) ).toBe( false );
+	} );
+} );
+
+describe( 'custom CSS style state helpers', () => {
+	it( 'stores custom CSS under the selected viewport state', () => {
+		const style = { css: 'color: red;' };
+		const selectedState = { viewport: '@mobile', pseudo: 'default' };
+
+		expect(
+			setStyleForState( style, selectedState, {
+				css: 'color: blue;',
+			} )
+		).toEqual( {
+			css: 'color: red;',
+			'@mobile': { css: 'color: blue;' },
+		} );
+	} );
+
+	it( 'reads custom CSS for the selected viewport state', () => {
+		const style = {
+			css: 'color: red;',
+			'@tablet': { css: 'color: green;' },
+		};
+
+		expect(
+			getStyleForState( style, {
+				viewport: '@tablet',
+				pseudo: 'default',
+			} )
+		).toEqual( { css: 'color: green;' } );
+	} );
+} );

--- a/phpunit/block-supports/custom-css-test.php
+++ b/phpunit/block-supports/custom-css-test.php
@@ -478,6 +478,55 @@ class WP_Block_Supports_Custom_CSS_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that custom CSS support adds a class when only viewport CSS is present.
+	 *
+	 * @covers ::gutenberg_render_custom_css_support_styles
+	 */
+	public function test_custom_css_support_adds_class_name_when_viewport_css_present() {
+		$this->register_custom_css_block_with_support(
+			'test/custom-css-viewport',
+			array( 'customCSS' => true )
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-viewport',
+			'attrs'     => array(
+				'style' => array(
+					'@mobile' => array(
+						'css' => 'color: blue;',
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_render_custom_css_support_styles( $parsed_block );
+
+		$this->assertArrayHasKey( 'className', $result['attrs'], 'Block should have className added when viewport CSS is present.' );
+		$this->assertMatchesRegularExpression( '/wp-custom-css-/', $result['attrs']['className'], 'className should contain wp-custom-css- prefix.' );
+
+		$after_styles = wp_styles()->get_data( 'wp-block-custom-css', 'after' );
+		$this->assertIsArray( $after_styles, 'Custom CSS stylesheet should have inline rules.' );
+		$combined_css = implode( '', $after_styles );
+		$this->assertStringContainsString( '@media', $combined_css, 'Viewport custom CSS should be wrapped in a media query.' );
+		$this->assertStringContainsString( 'color: blue', $combined_css, 'Viewport custom CSS declarations should be present.' );
+	}
+
+	/**
+	 * Tests that viewport custom CSS is stripped from block attributes.
+	 *
+	 * @covers ::gutenberg_strip_custom_css_from_blocks
+	 */
+	public function test_strip_custom_css_removes_viewport_css_from_block() {
+		$content = '<!-- wp:paragraph {"style":{"@mobile":{"css":"color: blue;"},"color":{"text":"#ff0000"}}} --><p>Hello</p><!-- /wp:paragraph -->';
+
+		$result = wp_unslash( gutenberg_strip_custom_css_from_blocks( $content ) );
+		$blocks = parse_blocks( $result );
+
+		$this->assertArrayNotHasKey( 'css', $blocks[0]['attrs']['style']['@mobile'] ?? array(), 'Viewport style.css should be stripped.' );
+		$this->assertSame( '#ff0000', $blocks[0]['attrs']['style']['color']['text'], 'Other style properties should be preserved.' );
+	}
+
+	/**
 	 * Tests that style.css is stripped from a single block.
 	 *
 	 * @covers ::gutenberg_strip_custom_css_from_blocks


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/80333
Part of https://github.com/WordPress/gutenberg/issues/80388

Makes block **Additional CSS** available when editing Mobile/Tablet viewport style states, and stores/applies that CSS per viewport.

<!-- In a few words, what is the PR actually doing? -->

## Why?
With Responsive styles enabled, selecting Tablet or Mobile hide the Advanced panel, so Additional CSS could only be set for the default viewport. That blocked per-breakpoint custom CSS even though other style supports already work with style states.

## How?
- Show the Advanced inspector panel in viewport style-state mode (not for pseudo states).
- Wire Additional CSS through `getStyleForState` / `setStyleForState` so values live under keys like `style['@tablet'].css`.
- Apply viewport custom CSS in the editor and on the front end inside the matching media queries.
- Hide HTML anchor and Additional CSS class controls in style-state mode (they are not viewport-scoped).
- Strip nested viewport custom CSS when the user cannot edit CSS.
- Ignore `css` when generating normal state-style declarations so it is only handled by the custom CSS pipeline.

## Testing Instructions

- Insert a Paragraph (or any block), select it, open **Advanced**, and confirm **Additional CSS** is visible in the default viewport.
- Open the View menu → enable **Responsive styles** → choose **Tablet**.
- Confirm the block inspector shows the Tablet badge and **Advanced → Additional CSS** is still available.
- Enter CSS and confirm it applies in the tablet preview.
- Switch to **Mobile**, add different CSS, and confirm tablet vs mobile values stay separate.
- Switch back to Desktop / turn off Responsive styles and confirm default Additional CSS is unchanged.
- Open the Code editor and confirm viewport CSS is stored under `@tablet` / `@mobile` .
- Save and view on the front end; resize the browser (or use device tools) and confirm each viewport’s CSS applies only in its breakpoint.
- Confirm HTML anchor and Additional CSS class fields do **not** appear while a Tablet/Mobile style state is selected.

## Use of AI Tools
- Cursor