### PR TITLE
DataViews: Pass the WordPress locale to the date/datetime calendar controls

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   DataViews: Prevent the filter operator select focus ring from being clipped. [#80417](https://github.com/WordPress/gutenberg/pull/80417)
 -   DataForm: Send a single update per calendar interaction in the `datetime` control instead of two identical ones. Selecting or clearing a date now reveals the validation message by firing a synthetic `invalid` event on the input, rather than briefly moving focus into it and re-sending the value, and announces it to screen readers since focus stays on the calendar. [#81440](https://github.com/WordPress/gutenberg/pull/81440)
 -   DataForms: Fix focus not returning to a `panel` layout field's edit button after its flyout is opened by clicking the field row. Focus landed on the dropdown's container element instead, so the field could not be reopened with <kbd>Enter</kbd>. The edit button is now the actual dropdown toggle, instead of the row delegating clicks to it. [#80689](https://github.com/WordPress/gutenberg/pull/80689)
+-   DataViews: Pass the site's locale and text direction to the `date`/`datetime` controls' `Calendar` and `RangeCalendar`, so month and weekday names follow the site's language, and an RTL admin gets an RTL calendar, instead of always defaulting to English. [#81592](https://github.com/WordPress/gutenberg/pull/81592)
 
 ### Internal
 

--- a/packages/dataviews/src/components/dataform-controls/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/date.tsx
@@ -24,7 +24,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { getDate, getSettings } from '@wordpress/date';
 import {
 	Calendar,
@@ -34,6 +34,7 @@ import {
 } from '@wordpress/ui';
 import RelativeDateControl from './utils/relative-date-control';
 import useDisabledDateMatchers from './utils/use-disabled-date-matchers';
+import getCalendarLocale from './utils/get-calendar-locale';
 import {
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,
@@ -300,6 +301,7 @@ function CalendarDateControl< Item >( {
 	const weekStartsOn =
 		( fieldFormat as FormatDate ).weekStartsOn ??
 		getSettings().l10n.startOfWeek;
+	const locale = getCalendarLocale( getSettings().l10n.locale );
 
 	const fieldValue = getValue( { item: data } );
 	const value = typeof fieldValue === 'string' ? fieldValue : undefined;
@@ -452,6 +454,8 @@ function CalendarDateControl< Item >( {
 						onValueChange={ onSelectDate }
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
+						locale={ locale }
+						dir={ isRTL() ? 'rtl' : 'ltr' }
 						weekStartsOn={ weekStartsOn }
 						disabled={ disabled || disabledMatchers }
 						disableNavigation={ disabled }
@@ -493,6 +497,7 @@ function CalendarDateRangeControl< Item >( {
 	const weekStartsOn =
 		( fieldFormat as FormatDate ).weekStartsOn ??
 		getSettings().l10n.startOfWeek;
+	const locale = getCalendarLocale( getSettings().l10n.locale );
 
 	const { minConstraint, maxConstraint, disabledMatchers } =
 		useDisabledDateMatchers( isValid, parseDate );
@@ -726,6 +731,8 @@ function CalendarDateRangeControl< Item >( {
 						onValueChange={ onSelectCalendarRange }
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
+						locale={ locale }
+						dir={ isRTL() ? 'rtl' : 'ltr' }
 						weekStartsOn={ weekStartsOn }
 						disabled={ disabled || disabledMatchers }
 					/>

--- a/packages/dataviews/src/components/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/components/dataform-controls/datetime.tsx
@@ -4,7 +4,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { Calendar, Stack } from '@wordpress/ui';
@@ -14,6 +14,7 @@ import RelativeDateControl from './utils/relative-date-control';
 import toCalendarDate from './utils/to-calendar-date';
 import useDisabledDateMatchers from './utils/use-disabled-date-matchers';
 import getCustomValidity from './utils/get-custom-validity';
+import getCalendarLocale from './utils/get-calendar-locale';
 import parseDateTime from '../../field-types/utils/parse-date-time';
 import { unlock } from '../../lock-unlock';
 
@@ -152,6 +153,7 @@ function CalendarDateTimeControl< Item >( {
 	const weekStartsOn =
 		( fieldFormat as FormatDatetime ).weekStartsOn ??
 		getSettings().l10n.startOfWeek;
+	const locale = getCalendarLocale( getSettings().l10n.locale );
 
 	let displayLabel = label;
 	if ( isValid?.required && ! markWhenOptional && ! hideLabelFromVision ) {
@@ -203,6 +205,8 @@ function CalendarDateTimeControl< Item >( {
 						month={ calendarMonth }
 						onMonthChange={ setCalendarMonth }
 						timeZone={ timeZone }
+						locale={ locale }
+						dir={ isRTL() ? 'rtl' : 'ltr' }
 						weekStartsOn={ weekStartsOn }
 						disabled={ disabled || disabledMatchers }
 					/>

--- a/packages/dataviews/src/components/dataform-controls/test/date.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/date.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getSettings, setSettings } from '@wordpress/date';
+import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import normalizeFields from '../../../field-types';
 import { OPERATOR_BETWEEN } from '../../../constants';
@@ -394,5 +395,53 @@ describe( 'DateControl', () => {
 		expect(
 			screen.getByLabelText< HTMLInputElement >( 'Date' ).value
 		).toBe( '2026-08-25' );
+	} );
+	describe( 'localization', () => {
+		const setLocale = ( locale: string, isRTL: boolean ) => {
+			const settings = getSettings();
+			setSettings( {
+				...settings,
+				l10n: { ...settings.l10n, locale },
+			} );
+			// Tannin keys a contextual string as `context\u0004singular`.
+			setLocaleData( {
+				'text direction\u0004ltr': [ isRTL ? 'rtl' : 'ltr' ],
+			} );
+		};
+
+		afterEach( () => {
+			resetLocaleData();
+		} );
+
+		it( 'should format the calendar with the site locale', () => {
+			setLocale( 'ur', true );
+			render(
+				<DateControl
+					data={ { published: '2026-01-15' } as TestItem }
+					field={ field }
+					onChange={ noop }
+				/>
+			);
+
+			// January 2026 in Urdu.
+			expect( getMonthGrid( 'جنوری 2026' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should take the text direction from the site, not the locale', () => {
+			// `skr` is RTL, but `Intl` has no data for it, so the calendar
+			// resolves it to the `en-US` fallback.
+			setLocale( 'skr', true );
+			render(
+				<DateControl
+					data={ { published: '2026-01-15' } as TestItem }
+					field={ field }
+					onChange={ noop }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'application', { name: 'Date calendar' } )
+			).toHaveAttribute( 'dir', 'rtl' );
+		} );
 	} );
 } );

--- a/packages/dataviews/src/components/dataform-controls/utils/get-calendar-locale.ts
+++ b/packages/dataviews/src/components/dataform-controls/utils/get-calendar-locale.ts
@@ -1,0 +1,42 @@
+/**
+ * WordPress locale slugs with no `Intl` data, mapped to the closest tag that
+ * has some. `Intl` canonicalizes slugs like `bel` and `oci` on its own.
+ */
+const LANGUAGE_ALIASES: Record< string, string > = {
+	ary: 'ar-MA', // Moroccan Arabic.
+	haz: 'fa', // Hazaragi, a variety of Persian.
+};
+
+/**
+ * Turns a WordPress locale slug into a BCP 47 tag for the `Calendar` and
+ * `RangeCalendar` components' `locale` prop, which fall back to `en-US` for a
+ * tag they cannot resolve.
+ *
+ * Keeps only the language, script and region: WordPress variant suffixes are
+ * not always valid BCP 47 variants, and `pt_PT_ao90` would resolve to nothing.
+ *
+ * @param wpLocale WordPress locale slug, e.g. `getSettings().l10n.locale`.
+ */
+export default function getCalendarLocale(
+	wpLocale: string
+): string | undefined {
+	// The slug comes from the host's date settings, so it may be missing.
+	const subtags = wpLocale?.trim().split( /[_-]/ ) ?? [];
+	const language = subtags.shift()?.toLowerCase();
+	if ( ! language ) {
+		return undefined;
+	}
+
+	const normalized = [ LANGUAGE_ALIASES[ language ] ?? language ];
+	for ( const subtag of subtags ) {
+		// A script is four letters, a region two letters or three digits.
+		if (
+			/^[a-z]{4}$/i.test( subtag ) ||
+			/^([a-z]{2}|\d{3})$/i.test( subtag )
+		) {
+			normalized.push( subtag );
+		}
+	}
+
+	return normalized.join( '-' );
+}

--- a/packages/dataviews/src/components/dataform-controls/utils/test/get-calendar-locale.ts
+++ b/packages/dataviews/src/components/dataform-controls/utils/test/get-calendar-locale.ts
@@ -1,0 +1,25 @@
+import getCalendarLocale from '../get-calendar-locale';
+
+describe( 'getCalendarLocale', () => {
+	it( 'turns a WordPress locale slug into a BCP 47 tag', () => {
+		expect( getCalendarLocale( 'en_US' ) ).toBe( 'en-US' );
+		expect( getCalendarLocale( 'pt_BR' ) ).toBe( 'pt-BR' );
+	} );
+
+	it( 'drops variant suffixes, including invalid BCP 47 ones', () => {
+		expect( getCalendarLocale( 'de_DE_formal' ) ).toBe( 'de-DE' );
+		expect( getCalendarLocale( 'pt_PT_ao90' ) ).toBe( 'pt-PT' );
+	} );
+
+	it( 'aliases a language with no date data', () => {
+		// Moroccan Arabic; `Intl` has no `ary` data.
+		expect( getCalendarLocale( 'ary' ) ).toBe( 'ar-MA' );
+	} );
+
+	it( 'returns undefined when there is no locale to resolve', () => {
+		expect( getCalendarLocale( '' ) ).toBeUndefined();
+		expect(
+			getCalendarLocale( undefined as unknown as string )
+		).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Fixes #81512

## What?

Passes the site's locale and text direction to the `Calendar`/`RangeCalendar` components used by the `date` and `datetime` DataForm controls.

## Why?

These components localize dates from the `locale` prop, but DataViews never passed one, so calendars always rendered in English regardless of the site's language.

## How?

DataViews passes the site's locale to `@wordpress/ui` as a BCP 47 locale code. The new `getCalendarLocale()` utility converts WordPress locale slugs to that format, maps known aliases such as `ary` to `ar-MA`, and removes WordPress variant suffixes that are not valid BCP 47 variants. This avoids importing `date-fns` locale data while DataViews continues to supply the site's `weekStartsOn` setting.

Text direction comes from `isRTL()` rather than the locale, so an RTL admin gets an RTL calendar even when `Intl` cannot format dates for the language and the calendar falls back to `en-US` (for example, `skr`).

## Testing Instructions

1. Switch the site language to one with distinct month/weekday names (e.g. French).
2. Open a `date`/`datetime` field's calendar (e.g. Site Editor → Pages → Add filter → Date).
3. Confirm the month header and weekday abbreviations render in that language.
4. Switch to an RTL locale (e.g. Arabic) and confirm the calendar's layout flips direction.

`npm run test:unit packages/dataviews`

## Screenshots

Arabic -

<img width="1166" height="758" alt="image" src="https://github.com/user-attachments/assets/92eb6abf-54c9-4b34-941e-dd613bc5ed8a" />

French -

<img width="1466" height="768" alt="image" src="https://github.com/user-attachments/assets/e6c8ffda-45a6-4149-9b40-3bd395707b55" />

Hindi - 

<img width="1470" height="787" alt="image" src="https://github.com/user-attachments/assets/2404203e-b4e1-4d11-85f0-57f176471524" />

German -

<img width="1460" height="764" alt="image" src="https://github.com/user-attachments/assets/acfacbce-d518-4125-b5d6-68a3c3bd077c" />


## Use of AI Tools

Model: Claude Sonnet 5
Purpose - drafting implementation plan and tests
