### PR TITLE
Notes: Explore a dedicated wp/v2/notes REST endpoint

### DIFF
--- a/backport-changelog/7.2/13043.md
+++ b/backport-changelog/7.2/13043.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13043
+
+* https://github.com/WordPress/gutenberg/pull/81599

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-notes-controller.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-notes-controller.php
@@ -1,0 +1,442 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Notes_Controller class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Serves editorial notes from a dedicated `wp/v2/notes` collection.
+ *
+ * Notes are stored as `note` comments, so this controller extends the comments
+ * controller and keeps the same underlying object type: the same comment meta,
+ * the same `rest_prepare_comment` filter, and the same registered REST fields
+ * all continue to apply. What changes is the shape of the collection, which is
+ * modelled on how notes are actually used rather than on how comments are:
+ *
+ * - Notes are always scoped to a post. `post` is required, and access is a
+ *   single question - can the current user edit that post?
+ * - The collection returns *threads*. Replies are nested under their parent in
+ *   a `replies` array instead of being interleaved as sibling rows, so
+ *   pagination cuts between threads and never orphans a reply from its parent.
+ * - Replies are prepared in the same context as their parent, so a thread
+ *   fetched with `context=edit` carries `content.raw` all the way down. The
+ *   `_embed` route on `wp/v2/comments` can only return them in `view` context.
+ * - `type` is fixed to `note` and `status` defaults to `all`, because a note is
+ *   equally interesting whether it is open (`hold`) or resolved (`approved`).
+ *
+ * Threads are one level deep, matching the editor UI. A reply to a reply would
+ * be stored fine but is not nested any further than its top-level ancestor.
+ *
+ * @since 7.2.0
+ *
+ * @see WP_REST_Comments_Controller
+ */
+class Gutenberg_REST_Notes_Controller extends WP_REST_Comments_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->rest_base = 'notes';
+	}
+
+	/**
+	 * Checks whether the request may list notes.
+	 *
+	 * Notes live alongside a post and are visible to everyone who can edit that
+	 * post, so the check collapses to `edit_post` for every requested post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_notes_not_logged_in',
+				__( 'Sorry, you are not allowed to read notes.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		$post_ids = array_filter( array_map( 'absint', (array) $request['post'] ) );
+
+		if ( empty( $post_ids ) ) {
+			return new WP_Error(
+				'rest_notes_missing_post',
+				__( 'Notes must be requested for at least one post.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		foreach ( $post_ids as $post_id ) {
+			$check = $this->check_note_post_permission( $post_id );
+
+			if ( is_wp_error( $check ) ) {
+				return $check;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves a collection of note threads.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error otherwise.
+	 */
+	public function get_items( $request ) {
+		/*
+		 * `type` and `parent` are not exposed as collection params, so the
+		 * comments controller never maps them onto the comment query. They are
+		 * pinned here instead: without an explicit `type`, WP_Comment_Query
+		 * excludes notes outright.
+		 */
+		$scope_to_threads = static function ( $prepared_args ) {
+			$prepared_args['type']   = 'note';
+			$prepared_args['parent'] = 0;
+
+			return $prepared_args;
+		};
+
+		add_filter( 'rest_comment_query', $scope_to_threads, PHP_INT_MAX );
+
+		try {
+			$response = parent::get_items( $request );
+		} finally {
+			remove_filter( 'rest_comment_query', $scope_to_threads, PHP_INT_MAX );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return $this->attach_replies( $response, $request );
+	}
+
+	/**
+	 * Retrieves a single note thread.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error otherwise.
+	 */
+	public function get_item( $request ) {
+		$response = parent::get_item( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return $this->attach_replies( $response, $request );
+	}
+
+	/**
+	 * Creates a note.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error otherwise.
+	 */
+	public function create_item( $request ) {
+		$request['type'] = 'note';
+
+		return parent::create_item( $request );
+	}
+
+	/**
+	 * Checks whether the request may create a note.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		$request['type'] = 'note';
+
+		return parent::create_item_permissions_check( $request );
+	}
+
+	/**
+	 * Gets the note for a given ID, rejecting comments of any other type.
+	 *
+	 * Guards the single-note routes so `wp/v2/notes/<id>` cannot be used to read
+	 * or edit an ordinary comment that happens to share the ID space.
+	 *
+	 * @param int $id Supplied ID.
+	 * @return WP_Comment|WP_Error Comment object if the ID is a note, WP_Error otherwise.
+	 */
+	protected function get_comment( $id ) {
+		$comment = parent::get_comment( $id );
+
+		if ( is_wp_error( $comment ) ) {
+			return $comment;
+		}
+
+		if ( 'note' !== $comment->comment_type ) {
+			return new WP_Error(
+				'rest_note_invalid_id',
+				__( 'Invalid note ID.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $comment;
+	}
+
+	/**
+	 * Prepares links for a note.
+	 *
+	 * Drops the `children` link the comments controller builds. Replies already
+	 * travel inside the response, and assembling that link costs a `COUNT` query
+	 * per note - the single most expensive part of rendering a large thread list.
+	 *
+	 * @param WP_Comment $comment Comment object.
+	 * @return array Links for the given note.
+	 */
+	protected function prepare_links( $comment ) {
+		$links = parent::prepare_links( $comment );
+
+		unset( $links['children'] );
+
+		return $links;
+	}
+
+	/**
+	 * Retrieves the note schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		/*
+		 * The schema title stays `comment`: a note is a comment record, so
+		 * comment meta and anything registered through
+		 * `register_rest_field( 'comment', ... )` must keep applying here.
+		 */
+		$schema = parent::get_item_schema();
+
+		// Notes are authored by logged-in users, so the anonymous-commenter
+		// identity fields never carry a value, and a note has no permalink.
+		unset(
+			$schema['properties']['author_email'],
+			$schema['properties']['author_ip'],
+			$schema['properties']['author_url'],
+			$schema['properties']['author_user_agent'],
+			$schema['properties']['link']
+		);
+
+		$schema['properties']['reply_count'] = array(
+			'description' => __( 'The number of replies in the thread.', 'gutenberg' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['replies'] = array(
+			'description' => __( 'The replies in the thread, oldest first.', 'gutenberg' ),
+			'type'        => 'array',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+			'items'       => array(
+				'type' => 'object',
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Retrieves the query params for the notes collection.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		// A note is always read by someone editing the post it belongs to.
+		$query_params['context']['default'] = 'edit';
+
+		// The collection is threads-only and always `note` typed, so the params
+		// that would let a client ask for anything else are not exposed.
+		unset(
+			$query_params['type'],
+			$query_params['parent'],
+			$query_params['parent_exclude'],
+			$query_params['author_email'],
+			$query_params['password']
+		);
+
+		// Dropping the default is what makes `required` bite: an empty array
+		// would otherwise satisfy the presence check.
+		unset( $query_params['post']['default'] );
+		$query_params['post']['required'] = true;
+
+		// Open and resolved notes are both interesting; `approve` is not a
+		// useful default for a collection that models a review workflow.
+		$query_params['status']['default'] = 'all';
+
+		return $query_params;
+	}
+
+	/**
+	 * Confirms a post exists, supports notes, and is editable by the current user.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return true|WP_Error True when notes on the post are readable, WP_Error otherwise.
+	 */
+	protected function check_note_post_permission( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! $this->post_type_supports_notes( $post->post_type ) ) {
+			return new WP_Error(
+				'rest_note_not_supported_post_type',
+				__( 'Sorry, this post type does not support notes.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+			return new WP_Error(
+				'rest_cannot_read_notes',
+				__( 'Sorry, you are not allowed to read notes for this post.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determines whether a post type opts into notes.
+	 *
+	 * Mirrors the private check in the comments controller, which cannot be
+	 * reused from a subclass.
+	 *
+	 * @param string $post_type Post type name.
+	 * @return bool True when the post type's editor support declares notes.
+	 */
+	protected function post_type_supports_notes( $post_type ) {
+		$supports = get_all_post_type_supports( $post_type );
+
+		if ( empty( $supports['editor'] ) || ! is_array( $supports['editor'] ) ) {
+			return false;
+		}
+
+		foreach ( $supports['editor'] as $editor_support ) {
+			if ( ! empty( $editor_support['notes'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Nests each thread's replies into the prepared response.
+	 *
+	 * Replies for the whole page are fetched in one query, so the cost does not
+	 * grow with the number of threads on the page.
+	 *
+	 * @param WP_REST_Response $response Prepared response holding one thread or a page of them.
+	 * @param WP_REST_Request  $request  Full details about the request.
+	 * @return WP_REST_Response Response with `replies` and `reply_count` filled in.
+	 */
+	protected function attach_replies( $response, $request ) {
+		if ( $request->is_method( 'HEAD' ) ) {
+			return $response;
+		}
+
+		$fields       = $this->get_fields_for_response( $request );
+		$want_replies = rest_is_field_included( 'replies', $fields );
+		$want_count   = rest_is_field_included( 'reply_count', $fields );
+
+		if ( ! $want_replies && ! $want_count ) {
+			return $response;
+		}
+
+		$data      = $response->get_data();
+		$is_single = ! wp_is_numeric_array( $data );
+		$threads   = $is_single ? array( $data ) : $data;
+
+		$thread_ids = array();
+		foreach ( $threads as $thread ) {
+			// `_fields` can omit the ID, and without it there is nothing to
+			// hang replies off of.
+			if ( isset( $thread['id'] ) ) {
+				$thread_ids[] = (int) $thread['id'];
+			}
+		}
+
+		if ( empty( $thread_ids ) ) {
+			return $response;
+		}
+
+		$replies_by_parent = $this->get_replies( $thread_ids, $request );
+
+		foreach ( $threads as $index => $thread ) {
+			if ( ! isset( $thread['id'] ) ) {
+				continue;
+			}
+
+			$replies = isset( $replies_by_parent[ $thread['id'] ] ) ? $replies_by_parent[ $thread['id'] ] : array();
+
+			if ( $want_replies ) {
+				$threads[ $index ]['replies'] = $replies;
+			}
+
+			if ( $want_count ) {
+				$threads[ $index ]['reply_count'] = count( $replies );
+			}
+		}
+
+		$response->set_data( $is_single ? $threads[0] : $threads );
+
+		return $response;
+	}
+
+	/**
+	 * Fetches and prepares the replies belonging to a set of threads.
+	 *
+	 * @param int[]           $thread_ids Top-level note IDs.
+	 * @param WP_REST_Request $request    Full details about the request.
+	 * @return array Prepared reply arrays keyed by parent note ID, oldest first.
+	 */
+	protected function get_replies( $thread_ids, $request ) {
+		$query = new WP_Comment_Query();
+
+		$replies = $query->query(
+			array(
+				'parent__in'                => $thread_ids,
+				'type'                      => 'note',
+				'status'                    => 'all',
+				'orderby'                   => 'comment_date_gmt',
+				'order'                     => 'ASC',
+				'number'                    => 0,
+				'no_found_rows'             => true,
+				'update_comment_post_cache' => true,
+			)
+		);
+
+		$replies_by_parent = array();
+
+		foreach ( $replies as $reply ) {
+			if ( ! $this->check_read_permission( $reply, $request ) ) {
+				continue;
+			}
+
+			$prepared = $this->prepare_item_for_response( $reply, $request );
+
+			$replies_by_parent[ (int) $reply->comment_parent ][] = $this->prepare_response_for_collection( $prepared );
+		}
+
+		return $replies_by_parent;
+	}
+}

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-notes-controller.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-notes-controller.php
@@ -226,7 +226,7 @@ class Gutenberg_REST_Notes_Controller extends WP_REST_Comments_Controller {
 		);
 
 		$schema['properties']['reply_count'] = array(
-			'description' => __( 'The number of replies in the thread.', 'gutenberg' ),
+			'description' => __( 'The number of replies written in the thread, not counting the entries that record a resolution.', 'gutenberg' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
@@ -379,21 +379,19 @@ class Gutenberg_REST_Notes_Controller extends WP_REST_Comments_Controller {
 			return $response;
 		}
 
-		$replies_by_parent = $this->get_replies( $thread_ids, $request );
+		list( $replies_by_parent, $counts_by_parent ) = $this->get_replies( $thread_ids, $request );
 
 		foreach ( $threads as $index => $thread ) {
 			if ( ! isset( $thread['id'] ) ) {
 				continue;
 			}
 
-			$replies = isset( $replies_by_parent[ $thread['id'] ] ) ? $replies_by_parent[ $thread['id'] ] : array();
-
 			if ( $want_replies ) {
-				$threads[ $index ]['replies'] = $replies;
+				$threads[ $index ]['replies'] = isset( $replies_by_parent[ $thread['id'] ] ) ? $replies_by_parent[ $thread['id'] ] : array();
 			}
 
 			if ( $want_count ) {
-				$threads[ $index ]['reply_count'] = count( $replies );
+				$threads[ $index ]['reply_count'] = isset( $counts_by_parent[ $thread['id'] ] ) ? $counts_by_parent[ $thread['id'] ] : 0;
 			}
 		}
 
@@ -407,7 +405,12 @@ class Gutenberg_REST_Notes_Controller extends WP_REST_Comments_Controller {
 	 *
 	 * @param int[]           $thread_ids Top-level note IDs.
 	 * @param WP_REST_Request $request    Full details about the request.
-	 * @return array Prepared reply arrays keyed by parent note ID, oldest first.
+	 * @return array {
+	 *     Two maps, both keyed by parent note ID.
+	 *
+	 *     @type array $0 Prepared reply arrays, oldest first.
+	 *     @type array $1 Written reply counts.
+	 * }
 	 */
 	protected function get_replies( $thread_ids, $request ) {
 		$query = new WP_Comment_Query();
@@ -426,17 +429,31 @@ class Gutenberg_REST_Notes_Controller extends WP_REST_Comments_Controller {
 		);
 
 		$replies_by_parent = array();
+		$counts_by_parent  = array();
 
 		foreach ( $replies as $reply ) {
 			if ( ! $this->check_read_permission( $reply, $request ) ) {
 				continue;
 			}
 
+			$parent_id = (int) $reply->comment_parent;
+
 			$prepared = $this->prepare_item_for_response( $reply, $request );
 
-			$replies_by_parent[ (int) $reply->comment_parent ][] = $this->prepare_response_for_collection( $prepared );
+			$replies_by_parent[ $parent_id ][] = $this->prepare_response_for_collection( $prepared );
+
+			/*
+			 * Resolving or reopening a thread records a reply of its own, marked
+			 * with `_wp_note_status`. The thread needs those to render its
+			 * history, but they are not something anyone wrote, so they stay out
+			 * of the count a caller shows as "N replies". The meta cache is
+			 * primed by the query above, so this costs no extra round trip.
+			 */
+			if ( '' === (string) get_comment_meta( $reply->comment_ID, '_wp_note_status', true ) ) {
+				$counts_by_parent[ $parent_id ] = isset( $counts_by_parent[ $parent_id ] ) ? $counts_by_parent[ $parent_id ] + 1 : 1;
+			}
 		}
 
-		return $replies_by_parent;
+		return array( $replies_by_parent, $counts_by_parent );
 	}
 }

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * WordPress 7.2 compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the notes REST API route.
+ */
+function gutenberg_register_notes_controller_endpoints() {
+	$notes_controller = new Gutenberg_REST_Notes_Controller();
+	$notes_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_notes_controller_endpoints' );

--- a/lib/experimental/collaboration/class-wp-sync-config.php
+++ b/lib/experimental/collaboration/class-wp-sync-config.php
@@ -108,6 +108,11 @@ if ( ! class_exists( 'WP_Sync_Config' ) ) {
 				if ( 'root' === $entity_kind && 'comment' === $entity_name ) {
 					return current_user_can( 'edit_comment', $object_id );
 				}
+
+				// A comment type entity, notes included, is a comment row.
+				if ( 'commentType' === $entity_kind ) {
+					return current_user_can( 'edit_comment', $object_id );
+				}
 			}
 
 			if ( null !== $object_id ) {
@@ -124,6 +129,7 @@ if ( ! class_exists( 'WP_Sync_Config' ) ) {
 			}
 
 			$allowed_collection_entity_kinds = array(
+				'commentType',
 				'postType',
 				'root',
 				'taxonomy',

--- a/lib/load.php
+++ b/lib/load.php
@@ -79,6 +79,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.1/query-block.php';
 	require __DIR__ . '/compat/wordpress-7.1/block-comments.php';
 
+	// WordPress 7.2 compat.
+	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-notes-controller.php';
+	require __DIR__ . '/compat/wordpress-7.2/rest-api.php';
+
 	// Real-time collaboration.
 	require __DIR__ . '/experimental/collaboration/class-gutenberg-rest-autosaves-controller.php';
 	require __DIR__ . '/experimental/collaboration/rest-api.php';

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a `note` entity backed by the `wp/v2/notes` endpoint. Records are whole threads: each carries its replies in a `replies` array plus a `reply_count` ([#81599](https://github.com/WordPress/gutenberg/pull/81599)).
+
 ## 7.53.0 (2026-08-12)
 
 ### Enhancements

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Add a `note` entity backed by the `wp/v2/notes` endpoint. Records are whole threads: each carries its replies in a `replies` array plus a `reply_count` ([#81599](https://github.com/WordPress/gutenberg/pull/81599)).
+-   Add a `commentType`, `note` entity backed by the `wp/v2/notes` endpoint. Records are whole threads: each carries its replies in a `replies` array plus a `reply_count` ([#81599](https://github.com/WordPress/gutenberg/pull/81599)).
 
 ## 7.53.0 (2026-08-12)
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -138,6 +138,26 @@ export const rootEntitiesConfig = [
 		syncConfig: defaultCollectionSyncConfig,
 	},
 	{
+		/*
+		 * Editorial notes. Backed by `note` comments, but served from a
+		 * dedicated collection that returns whole threads - each record carries
+		 * its replies in a `replies` array - so a page break never separates a
+		 * reply from its parent and replies arrive in the same context as the
+		 * thread.
+		 */
+		name: 'note',
+		kind: 'root',
+		baseURL: '/wp/v2/notes',
+		baseURLParams: { context: 'edit' },
+		plural: 'notes',
+		label: __( 'Note' ),
+		supportsPagination: true,
+		// Notes are broadcast as a collection: a peer's change invalidates the
+		// whole list rather than one record, since a reply lands inside its
+		// thread rather than alongside it.
+		syncConfig: defaultCollectionSyncConfig,
+	},
+	{
 		name: 'menu',
 		kind: 'root',
 		baseURL: '/wp/v2/menus',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -144,9 +144,16 @@ export const rootEntitiesConfig = [
 		 * its replies in a `replies` array - so a page break never separates a
 		 * reply from its parent and replies arrive in the same context as the
 		 * thread.
+		 *
+		 * Keyed under a `commentType` kind, mirroring `postType`. Comment types
+		 * have no registry to discover them from yet, so the kind carries no
+		 * loader in `additionalEntityConfigLoaders` and its entities are
+		 * declared here instead; `getEntitiesConfig` no-ops for a kind without
+		 * one. The existing `root`, `comment` entity moves under the same kind
+		 * separately, since that rename reaches consumers beyond notes.
 		 */
 		name: 'note',
-		kind: 'root',
+		kind: 'commentType',
 		baseURL: '/wp/v2/notes',
 		baseURLParams: { context: 'edit' },
 		plural: 'notes',

--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -13,6 +13,7 @@ import type { Icon } from './icon';
 import type { MenuLocation } from './menu-location';
 import type { NavMenu } from './nav-menu';
 import type { NavMenuItem } from './nav-menu-item';
+import type { Note } from './note';
 import type { Page } from './page';
 import type { Plugin } from './plugin';
 import type { Post } from './post';
@@ -47,6 +48,7 @@ export type {
 	MenuLocation,
 	NavMenu,
 	NavMenuItem,
+	Note,
 	Page,
 	Plugin,
 	Post,
@@ -112,6 +114,7 @@ export interface PerPackageEntityRecords< C extends Context > {
 		| MenuLocation< C >
 		| NavMenu< C >
 		| NavMenuItem< C >
+		| Note< C >
 		| Page< C >
 		| Plugin< C >
 		| Post< C >

--- a/packages/core-data/src/entity-types/note.ts
+++ b/packages/core-data/src/entity-types/note.ts
@@ -61,7 +61,8 @@ declare module './base-entity-records' {
 			 */
 			replies: Note< C >[];
 			/**
-			 * The number of replies in the thread.
+			 * The number of replies written in the thread. The entries that
+			 * record a resolution are in `replies` but not in this count.
 			 */
 			reply_count: number;
 			/**

--- a/packages/core-data/src/entity-types/note.ts
+++ b/packages/core-data/src/entity-types/note.ts
@@ -1,0 +1,81 @@
+import type {
+	AvatarUrls,
+	Context,
+	ContextualField,
+	OmitNevers,
+	RenderedText,
+} from './helpers';
+import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+
+export type NoteStatus = 'hold' | 'approved';
+
+declare module './base-entity-records' {
+	export namespace BaseEntityRecords {
+		export interface Note< C extends Context > {
+			/**
+			 * Unique identifier for the note.
+			 */
+			id: number;
+			/**
+			 * The ID of the user object, if author was a user.
+			 */
+			author: number;
+			/**
+			 * Display name for the note author.
+			 */
+			author_name: string;
+			/**
+			 * Avatar URLs for the note author.
+			 */
+			author_avatar_urls: AvatarUrls;
+			/**
+			 * The content for the note.
+			 */
+			content: RenderedText< C >;
+			/**
+			 * The date the note was published, in the site's timezone.
+			 */
+			date: string;
+			/**
+			 * The date the note was published, as GMT.
+			 */
+			date_gmt: ContextualField< string, 'view' | 'edit', C >;
+			/**
+			 * The ID of the note this one replies to, or 0 for a thread.
+			 */
+			parent: number;
+			/**
+			 * The ID of the associated post object.
+			 */
+			post: ContextualField< number, 'view' | 'edit', C >;
+			/**
+			 * Whether the note is open (`hold`) or resolved (`approved`).
+			 */
+			status: ContextualField< NoteStatus, 'view' | 'edit', C >;
+			/**
+			 * Type of the note. Always `note`.
+			 */
+			type: string;
+			/**
+			 * The replies in the thread, oldest first. Only threads carry them.
+			 */
+			replies: Note< C >[];
+			/**
+			 * The number of replies in the thread.
+			 */
+			reply_count: number;
+			/**
+			 * Meta fields.
+			 */
+			meta: ContextualField<
+				Record< string, unknown >,
+				'view' | 'edit',
+				C
+			>;
+		}
+	}
+}
+
+export type Note< C extends Context = 'edit' > = OmitNevers<
+	_BaseEntityRecords.Note< C >
+>;

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Tally the post list's notes count from the notes endpoint, fetching only `id`, `post` and `reply_count` instead of a row per note ([#81599](https://github.com/WordPress/gutenberg/pull/81599)).
+
 ### Internal
 
 -   Stop rendering `EditorKeyboardShortcutsRegister`, which the editor provider now renders itself ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).

--- a/packages/edit-site/src/components/post-list/use-notes-count.js
+++ b/packages/edit-site/src/components/post-list/use-notes-count.js
@@ -13,7 +13,7 @@ import { useEntityRecords } from '@wordpress/core-data';
  */
 export default function useNotesCount( postIds ) {
 	const { records: notes, isResolving } = useEntityRecords(
-		'root',
+		'commentType',
 		'note',
 		{
 			post: postIds,

--- a/packages/edit-site/src/components/post-list/use-notes-count.js
+++ b/packages/edit-site/src/components/post-list/use-notes-count.js
@@ -4,9 +4,9 @@ import { useEntityRecords } from '@wordpress/core-data';
 /**
  * Hook to fetch notes counts for a list of post IDs.
  *
- * Notes are stored as comments with type 'note'.
- * This hook fetches all notes for the given posts and returns
- * a map of post ID to notes count.
+ * The notes endpoint returns one record per thread, so the per-post total is
+ * the number of threads plus the replies they report. `_fields` keeps the
+ * response to the three values the tally needs rather than whole threads.
  *
  * @param {number[]} postIds - Array of post IDs to fetch notes for.
  * @return {{ notesCount: Object, isResolving: boolean }} Object with notesCount map and loading state.
@@ -14,13 +14,11 @@ import { useEntityRecords } from '@wordpress/core-data';
 export default function useNotesCount( postIds ) {
 	const { records: notes, isResolving } = useEntityRecords(
 		'root',
-		'comment',
+		'note',
 		{
 			post: postIds,
-			type: 'note',
-			status: 'all',
 			per_page: -1,
-			_fields: 'id,post',
+			_fields: 'id,post,reply_count',
 		},
 		{
 			enabled: postIds?.length > 0,
@@ -35,7 +33,8 @@ export default function useNotesCount( postIds ) {
 		const counts = {};
 		notes.forEach( ( note ) => {
 			const postId = note.post;
-			counts[ postId ] = ( counts[ postId ] || 0 ) + 1;
+			counts[ postId ] =
+				( counts[ postId ] || 0 ) + 1 + ( note.reply_count ?? 0 );
 		} );
 
 		return counts;

--- a/packages/edit-site/src/components/post-list/use-notes-count.js
+++ b/packages/edit-site/src/components/post-list/use-notes-count.js
@@ -8,6 +8,10 @@ import { useEntityRecords } from '@wordpress/core-data';
  * the number of threads plus the replies they report. `_fields` keeps the
  * response to the three values the tally needs rather than whole threads.
  *
+ * `reply_count` covers replies someone wrote; resolving or reopening a thread
+ * records a reply of its own that the endpoint leaves out, so a thread nobody
+ * answered counts as one however many times it changed hands.
+ *
  * @param {number[]} postIds - Array of post IDs to fetch notes for.
  * @return {{ notesCount: Object, isResolving: boolean }} Object with notesCount map and loading state.
  */

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Read and write notes through the `note` entity rather than the comments endpoint, so threads arrive pre-assembled and replies come back in edit context ([#81599](https://github.com/WordPress/gutenberg/pull/81599)).
+
 ### Bug Fixes
 
 -   Register the editor and block editor keyboard shortcuts from the editor provider, so shortcuts work for consumers that mount the editor without rendering `EditorKeyboardShortcutsRegister` themselves ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -38,17 +38,12 @@ const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
 export function useNoteThreads( postId ) {
 	const queryArgs = {
 		post: postId,
-		type: 'note',
-		status: 'all',
 		per_page: -1,
 	};
 
-	const { records: threads } = useEntityRecords(
-		'root',
-		'comment',
-		queryArgs,
-		{ enabled: !! postId && typeof postId === 'number' }
-	);
+	const { records: threads } = useEntityRecords( 'root', 'note', queryArgs, {
+		enabled: !! postId && typeof postId === 'number',
+	} );
 
 	const { getBlockAttributes } = useSelect( blockEditorStore );
 	const { clientIds } = useSelect( ( select ) => {
@@ -67,7 +62,7 @@ export function useNoteThreads( postId ) {
 		/*
 		 * Single pass over clientIds builds the forward map and reverse lookup
 		 * together. getNoteIdsFromMetadata returns numeric ids, matching the
-		 * types returned by the comments REST endpoint.
+		 * types returned by the notes REST endpoint.
 		 */
 		const blocksWithNotes = {};
 		const clientIdByNoteId = new Map();
@@ -82,31 +77,21 @@ export function useNoteThreads( postId ) {
 			}
 		}
 
-		// Materialize threads; collect roots; replies linked in a second pass
-		// via unshift to invert order (matches prior reverse semantics).
+		/*
+		 * The notes endpoint returns whole threads: every record is top level
+		 * and already carries its replies, oldest first. Only the block link
+		 * has to be resolved here.
+		 */
 		const threadsById = new Map();
-		const rootThreads = [];
-		for ( const item of threads ) {
+		const rootThreads = threads.map( ( item ) => {
 			const thread = {
 				...item,
-				reply: [],
-				blockClientId:
-					item.parent === 0
-						? clientIdByNoteId.get( item.id ) ?? null
-						: null,
+				replies: item.replies ?? [],
+				blockClientId: clientIdByNoteId.get( item.id ) ?? null,
 			};
 			threadsById.set( item.id, thread );
-			if ( item.parent === 0 ) {
-				rootThreads.push( thread );
-			}
-		}
-		for ( const item of threads ) {
-			if ( item.parent !== 0 ) {
-				threadsById
-					.get( item.parent )
-					?.reply.unshift( threadsById.get( item.id ) );
-			}
-		}
+			return thread;
+		} );
 
 		if ( rootThreads.length === 0 ) {
 			return { notes: [], unresolvedNotes: [] };
@@ -305,12 +290,11 @@ export function useNoteActions() {
 
 			const savedRecord = await saveEntityRecord(
 				'root',
-				'comment',
+				'note',
 				{
 					post: getCurrentPostId(),
 					content,
 					status: 'hold',
-					type: 'note',
 					parent: parent || 0,
 				},
 				{ throwOnError: true }
@@ -373,7 +357,7 @@ export function useNoteActions() {
 				// First, update the thread status.
 				await saveEntityRecord(
 					'root',
-					'comment',
+					'note',
 					{
 						id,
 						status,
@@ -387,7 +371,6 @@ export function useNoteActions() {
 				const newNoteData = {
 					post: getCurrentPostId(),
 					content: content || '', // Empty content for resolve, content for reopen.
-					type: 'note',
 					status,
 					parent: id,
 					meta: {
@@ -398,7 +381,7 @@ export function useNoteActions() {
 
 				const savedRecord = await saveEntityRecord(
 					'root',
-					'comment',
+					'note',
 					newNoteData,
 					{
 						throwOnError: true,
@@ -435,7 +418,7 @@ export function useNoteActions() {
 
 			const savedRecord = await saveEntityRecord(
 				'root',
-				'comment',
+				'note',
 				updateData,
 				{
 					throwOnError: true,
@@ -462,7 +445,7 @@ export function useNoteActions() {
 				? note.blockClientId || getSelectedBlockClientId()
 				: null;
 
-			await deleteEntityRecord( 'root', 'comment', note.id, undefined, {
+			await deleteEntityRecord( 'root', 'note', note.id, undefined, {
 				throwOnError: true,
 			} );
 

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -41,9 +41,14 @@ export function useNoteThreads( postId ) {
 		per_page: -1,
 	};
 
-	const { records: threads } = useEntityRecords( 'root', 'note', queryArgs, {
-		enabled: !! postId && typeof postId === 'number',
-	} );
+	const { records: threads } = useEntityRecords(
+		'commentType',
+		'note',
+		queryArgs,
+		{
+			enabled: !! postId && typeof postId === 'number',
+		}
+	);
 
 	const { getBlockAttributes } = useSelect( blockEditorStore );
 	const { clientIds } = useSelect( ( select ) => {
@@ -289,7 +294,7 @@ export function useNoteActions() {
 				: null;
 
 			const savedRecord = await saveEntityRecord(
-				'root',
+				'commentType',
 				'note',
 				{
 					post: getCurrentPostId(),
@@ -356,7 +361,7 @@ export function useNoteActions() {
 			if ( status === 'approved' || status === 'hold' ) {
 				// First, update the thread status.
 				await saveEntityRecord(
-					'root',
+					'commentType',
 					'note',
 					{
 						id,
@@ -380,7 +385,7 @@ export function useNoteActions() {
 				};
 
 				const savedRecord = await saveEntityRecord(
-					'root',
+					'commentType',
 					'note',
 					newNoteData,
 					{
@@ -417,7 +422,7 @@ export function useNoteActions() {
 			};
 
 			const savedRecord = await saveEntityRecord(
-				'root',
+				'commentType',
 				'note',
 				updateData,
 				{
@@ -445,9 +450,15 @@ export function useNoteActions() {
 				? note.blockClientId || getSelectedBlockClientId()
 				: null;
 
-			await deleteEntityRecord( 'root', 'note', note.id, undefined, {
-				throwOnError: true,
-			} );
+			await deleteEntityRecord(
+				'commentType',
+				'note',
+				note.id,
+				undefined,
+				{
+					throwOnError: true,
+				}
+			);
 
 			if ( clientId ) {
 				const attributes = getBlockAttributes( clientId );

--- a/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.js
@@ -72,7 +72,7 @@ export function NoteAvatarIndicator( { onClick, note } ) {
 		// Track thread participants (original author + repliers), sorted by
 		// date so they appear in chronological order.
 		const participantsMap = new Map();
-		const allNotes = [ note, ...note.reply ].sort(
+		const allNotes = [ note, ...note.replies ].sort(
 			( a, b ) => new Date( a.date ) - new Date( b.date )
 		);
 

--- a/packages/editor/src/components/collab-sidebar/note-thread.js
+++ b/packages/editor/src/components/collab-sidebar/note-thread.js
@@ -151,7 +151,7 @@ export function NoteThread( {
 		}
 	}
 
-	const allReplies = note?.reply || [];
+	const allReplies = note?.replies || [];
 	const lastReply =
 		allReplies.length > 0 ? allReplies[ allReplies.length - 1 ] : undefined;
 	const restReplies = allReplies.length > 0 ? allReplies.slice( 0, -1 ) : [];

--- a/phpunit/class-gutenberg-rest-notes-controller-test.php
+++ b/phpunit/class-gutenberg-rest-notes-controller-test.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * Unit tests covering Gutenberg_REST_Notes_Controller functionality.
+ *
+ * @package gutenberg
+ *
+ * @coversDefaultClass Gutenberg_REST_Notes_Controller
+ */
+class Tests_REST_Notes_Controller extends WP_Test_REST_TestCase {
+
+	/**
+	 * The REST route the controller registers.
+	 */
+	const ROUTE = '/wp/v2/notes';
+
+	/**
+	 * Editor user id. Can edit the test post, so can read its notes.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * A second editor, used to prove notes are shared across everyone who can
+	 * edit the post rather than scoped to their author.
+	 *
+	 * @var int
+	 */
+	protected static $other_editor_id;
+
+	/**
+	 * Subscriber user id. Cannot edit the test post.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Post the notes hang off.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Creates shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id       = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$other_editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_id   = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$post_id = $factory->post->create(
+			array(
+				'post_author' => self::$editor_id,
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	/**
+	 * Deletes shared fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$editor_id );
+		self::delete_user( self::$other_editor_id );
+		self::delete_user( self::$subscriber_id );
+
+		wp_delete_post( self::$post_id, true );
+	}
+
+	/**
+	 * Creates a note.
+	 *
+	 * @param array $args Optional. Overrides for the comment fields.
+	 * @return int Comment ID.
+	 */
+	protected function create_note( $args = array() ) {
+		return self::factory()->comment->create(
+			array_merge(
+				array(
+					'comment_post_ID'  => self::$post_id,
+					'comment_type'     => 'note',
+					'comment_approved' => '0',
+					'user_id'          => self::$editor_id,
+					'comment_content'  => 'A note.',
+				),
+				$args
+			)
+		);
+	}
+
+	/**
+	 * Dispatches a GET request to the notes collection.
+	 *
+	 * @param array $params Optional. Query parameters.
+	 * @return WP_REST_Response Response object.
+	 */
+	protected function get_notes( $params = array() ) {
+		$request = new WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_query_params( array_merge( array( 'post' => self::$post_id ), $params ) );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * The routes are registered.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+		$this->assertArrayHasKey( self::ROUTE . '/(?P<id>[\d]+)', $routes );
+	}
+
+	/**
+	 * The collection returns top-level notes only, with replies nested.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_returns_threads_with_nested_replies() {
+		$thread    = $this->create_note();
+		$reply_one = $this->create_note(
+			array(
+				'comment_parent'   => $thread,
+				'comment_content'  => 'First reply.',
+				'comment_date_gmt' => '2026-01-01 00:00:00',
+				'comment_date'     => '2026-01-01 00:00:00',
+			)
+		);
+		$reply_two = $this->create_note(
+			array(
+				'comment_parent'   => $thread,
+				'comment_content'  => 'Second reply.',
+				'comment_date_gmt' => '2026-01-02 00:00:00',
+				'comment_date'     => '2026-01-02 00:00:00',
+			)
+		);
+
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->get_notes();
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $data, 'Replies should not appear as their own records.' );
+		$this->assertSame( $thread, $data[0]['id'] );
+
+		$reply_ids = wp_list_pluck( $data[0]['replies'], 'id' );
+		$this->assertSame(
+			array( $reply_one, $reply_two ),
+			$reply_ids,
+			'Replies should be nested under the thread, oldest first.'
+		);
+		$this->assertSame( 2, $data[0]['reply_count'] );
+	}
+
+	/**
+	 * Replies are prepared in the same context as their thread.
+	 *
+	 * This is the behaviour `_embed` on the comments collection cannot provide:
+	 * embedded children are always prepared in `view` context, so `content.raw`
+	 * - the value the editor writes back - never reaches the client.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_replies_are_prepared_in_edit_context() {
+		$thread = $this->create_note();
+		$this->create_note(
+			array(
+				'comment_parent'  => $thread,
+				'comment_content' => 'Raw reply body.',
+			)
+		);
+
+		wp_set_current_user( self::$editor_id );
+
+		$data = $this->get_notes( array( 'context' => 'edit' ) )->get_data();
+
+		$this->assertArrayHasKey( 'raw', $data[0]['content'] );
+		$this->assertArrayHasKey( 'raw', $data[0]['replies'][0]['content'] );
+		$this->assertSame( 'Raw reply body.', $data[0]['replies'][0]['content']['raw'] );
+	}
+
+	/**
+	 * Both open and resolved notes come back without asking for a status.
+	 *
+	 * @covers ::get_collection_params
+	 */
+	public function test_get_items_defaults_to_all_statuses() {
+		$open     = $this->create_note( array( 'comment_approved' => '0' ) );
+		$resolved = $this->create_note( array( 'comment_approved' => '1' ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$data     = $this->get_notes()->get_data();
+		$statuses = array();
+
+		foreach ( $data as $note ) {
+			$statuses[ $note['id'] ] = $note['status'];
+		}
+
+		$this->assertSame( 'hold', $statuses[ $open ] );
+		$this->assertSame( 'approved', $statuses[ $resolved ] );
+	}
+
+	/**
+	 * Pagination counts and cuts between threads, never inside one.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_pagination_counts_threads_not_replies() {
+		$first  = $this->create_note( array( 'comment_date_gmt' => '2026-01-01 00:00:00' ) );
+		$second = $this->create_note( array( 'comment_date_gmt' => '2026-01-02 00:00:00' ) );
+
+		$this->create_note( array( 'comment_parent' => $first ) );
+		$this->create_note( array( 'comment_parent' => $second ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->get_notes( array( 'per_page' => 1 ) );
+		$data     = $response->get_data();
+		$headers  = $response->get_headers();
+
+		$this->assertSame( '2', (string) $headers['X-WP-Total'], 'Only threads should be counted.' );
+		$this->assertSame( '2', (string) $headers['X-WP-TotalPages'] );
+		$this->assertCount( 1, $data );
+		$this->assertCount( 1, $data[0]['replies'], 'A page break must not strip a thread of its replies.' );
+	}
+
+	/**
+	 * `_fields` can trim the response down to a per-post tally.
+	 *
+	 * @covers ::attach_replies
+	 */
+	public function test_reply_count_is_available_without_the_replies() {
+		$thread = $this->create_note();
+		$this->create_note( array( 'comment_parent' => $thread ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$data = $this->get_notes( array( '_fields' => 'id,post,reply_count' ) )->get_data();
+
+		$this->assertSame(
+			array( 'id', 'post', 'reply_count' ),
+			array_keys( $data[0] )
+		);
+		$this->assertSame( 1, $data[0]['reply_count'] );
+	}
+
+	/**
+	 * The collection is scoped to a post.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_requires_a_post() {
+		wp_set_current_user( self::$editor_id );
+
+		$request  = new WP_REST_Request( 'GET', self::ROUTE );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Anyone who can edit the post can read its notes, not just their author.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_notes_are_readable_by_every_editor_of_the_post() {
+		$this->create_note( array( 'user_id' => self::$editor_id ) );
+
+		wp_set_current_user( self::$other_editor_id );
+
+		$response = $this->get_notes();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+	}
+
+	/**
+	 * Users who cannot edit the post cannot read its notes.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_denied_without_edit_post() {
+		$this->create_note();
+
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertErrorResponse( 'rest_cannot_read_notes', $this->get_notes(), 403 );
+	}
+
+	/**
+	 * Logged-out requests are rejected outright.
+	 *
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_denied_when_logged_out() {
+		$this->create_note();
+
+		wp_set_current_user( 0 );
+
+		$this->assertErrorResponse( 'rest_notes_not_logged_in', $this->get_notes(), 401 );
+	}
+
+	/**
+	 * The single-note routes do not expose ordinary comments.
+	 *
+	 * @covers ::get_comment
+	 */
+	public function test_single_route_rejects_a_regular_comment() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		wp_set_current_user( self::$editor_id );
+
+		$request  = new WP_REST_Request( 'GET', self::ROUTE . '/' . $comment_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_note_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * A single note is returned with its replies.
+	 *
+	 * @covers ::get_item
+	 */
+	public function test_get_item_returns_the_thread_replies() {
+		$thread = $this->create_note();
+		$reply  = $this->create_note( array( 'comment_parent' => $thread ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'GET', self::ROUTE . '/' . $thread );
+		$request->set_param( 'context', 'edit' );
+
+		$data = rest_get_server()->dispatch( $request )->get_data();
+
+		$this->assertSame( $thread, $data['id'] );
+		$this->assertSame( array( $reply ), wp_list_pluck( $data['replies'], 'id' ) );
+	}
+
+	/**
+	 * Creating a note does not require the client to name the comment type.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_create_item_forces_the_note_type() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_body_params(
+			array(
+				'post'    => self::$post_id,
+				'content' => 'Created through the notes route.',
+				'status'  => 'hold',
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'note', $data['type'] );
+		$this->assertSame( 'hold', $data['status'] );
+		$this->assertSame( 'note', get_comment( $data['id'] )->comment_type );
+	}
+
+	/**
+	 * A reply created through the route shows up nested in the thread.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_created_reply_is_nested_in_its_thread() {
+		$thread = $this->create_note();
+
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_body_params(
+			array(
+				'post'    => self::$post_id,
+				'parent'  => $thread,
+				'content' => 'A reply.',
+				'status'  => 'hold',
+			)
+		);
+
+		$created = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $created->get_status() );
+
+		$data = $this->get_notes()->get_data();
+
+		$this->assertCount( 1, $data, 'The reply should not surface as its own thread.' );
+		$this->assertSame(
+			array( $created->get_data()['id'] ),
+			wp_list_pluck( $data[0]['replies'], 'id' )
+		);
+	}
+
+	/**
+	 * Fields that only make sense for anonymous commenters are not exposed.
+	 *
+	 * @covers ::get_item_schema
+	 */
+	public function test_schema_drops_the_anonymous_commenter_fields() {
+		$controller = new Gutenberg_REST_Notes_Controller();
+		$props      = $controller->get_item_schema()['properties'];
+
+		foreach ( array( 'author_email', 'author_ip', 'author_url', 'author_user_agent', 'link' ) as $removed ) {
+			$this->assertArrayNotHasKey( $removed, $props );
+		}
+
+		$this->assertArrayHasKey( 'replies', $props );
+		$this->assertArrayHasKey( 'reply_count', $props );
+	}
+}

--- a/phpunit/class-gutenberg-rest-notes-controller-test.php
+++ b/phpunit/class-gutenberg-rest-notes-controller-test.php
@@ -253,6 +253,39 @@ class Tests_REST_Notes_Controller extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Resolving and reopening a thread each record a reply of their own, and
+	 * neither counts as a reply someone wrote.
+	 *
+	 * @covers ::attach_replies
+	 */
+	public function test_reply_count_ignores_resolution_entries() {
+		$thread = $this->create_note();
+		$this->create_note(
+			array(
+				'comment_parent'  => $thread,
+				'comment_content' => 'A written reply.',
+			)
+		);
+
+		$resolved = $this->create_note( array( 'comment_parent' => $thread ) );
+		update_comment_meta( $resolved, '_wp_note_status', 'resolved' );
+
+		$reopened = $this->create_note( array( 'comment_parent' => $thread ) );
+		update_comment_meta( $reopened, '_wp_note_status', 'reopen' );
+
+		wp_set_current_user( self::$editor_id );
+
+		$data = $this->get_notes()->get_data();
+
+		$this->assertSame( 1, $data[0]['reply_count'], 'Only the written reply should be counted.' );
+		$this->assertCount(
+			3,
+			$data[0]['replies'],
+			'The thread still needs the resolution entries to render its history.'
+		);
+	}
+
+	/**
 	 * The collection is scoped to a post.
 	 *
 	 * @covers ::get_items_permissions_check

--- a/phpunit/tests/collaboration/wpSyncConfig.php
+++ b/phpunit/tests/collaboration/wpSyncConfig.php
@@ -205,6 +205,18 @@ class Tests_Collaboration_WpSyncConfig extends WP_UnitTestCase {
 		$this->assertTrue( WP_Sync_Config::can_user_sync_entity_type( 'root', 'comment', (string) self::$comment_id ) );
 	}
 
+	public function test_can_user_sync_single_note_entity() {
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertTrue( WP_Sync_Config::can_user_sync_entity_type( 'commentType', 'note', (string) self::$comment_id ) );
+	}
+
+	public function test_can_user_sync_single_note_entity_requires_edit_permission() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertFalse( WP_Sync_Config::can_user_sync_entity_type( 'commentType', 'note', (string) self::$comment_id ) );
+	}
+
 	/**
 	 * @dataProvider data_collection_entity_types
 	 *
@@ -224,9 +236,10 @@ class Tests_Collaboration_WpSyncConfig extends WP_UnitTestCase {
 	 */
 	public function data_collection_entity_types(): array {
 		return array(
-			'post type collection' => array( 'postType', 'post' ),
-			'taxonomy collection'  => array( 'taxonomy', 'category' ),
-			'root collection'      => array( 'root', 'site' ),
+			'post type collection'    => array( 'postType', 'post' ),
+			'taxonomy collection'     => array( 'taxonomy', 'category' ),
+			'root collection'         => array( 'root', 'site' ),
+			'comment type collection' => array( 'commentType', 'note' ),
 		);
 	}
 

--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -82,7 +82,7 @@ test.describe( 'Preload', () => {
 		// To do: these should all be removed or preloaded.
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
-				`GET /wp/v2/comments?context=edit&post=${ postId }&type=note&status=all&per_page=100`,
+				`GET /wp/v2/notes?context=edit&post=${ postId }&per_page=100`,
 				'POST /wp-sync/v1/save',
 				'POST /wp-sync/v1/updates',
 				'POST /wp/v2/users/me',

--- a/test/e2e/specs/preload/site-editor.spec.js
+++ b/test/e2e/specs/preload/site-editor.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Preload', () => {
 		// To do: these should all be removed or preloaded.
 		expect( Array.from( new Set( requests ) ).sort() ).toEqual(
 			[
-				`GET /wp/v2/comments?context=edit&post=${ pageId }&type=note&status=all&per_page=100`,
+				`GET /wp/v2/notes?context=edit&post=${ pageId }&per_page=100`,
 				`GET /wp/v2/pages/${ pageId }/autosaves?context=edit`,
 				'GET /wp/v2/taxonomies?context=edit',
 				'GET /wp/v2/templates/lookup?slug=front-page',


### PR DESCRIPTION
An exploration of @Mamaduka's suggestion in https://github.com/WordPress/gutenberg/pull/80018#issuecomment-5197051794:

> I have this nagging idea that we should introduce a custom REST API endpoint for notes. The domain requirements differ from the general comments; we always want threaded (one-level) results. The replies can't be simply embedded because they need to be fetched with `context=edit`. This would also make it easier to assemble the notes tree on the client.

This adds `wp/v2/notes` and moves the editor off `wp/v2/comments` to see what it buys.

## What the comments endpoint costs us

Notes are comments in storage, but not in use. Reading them through the general comments collection means:

- Every client repeats `type=note&status=all` and hopes no caller forgets, because `WP_Comment_Query` excludes notes by default.
- Replies arrive as sibling rows interleaved with their parents, so the client rebuilds the thread tree in two passes over a flat list.
- `_embed` cannot supply the replies: embedded children are always prepared in `view` context, so `content.raw` never arrives, which is the value the editor writes back.
- Pagination counts individual comments, so a page boundary can fall inside a thread. That is the concrete problem behind the `RECEIVE_INTERMEDIATE_RESULTS` caveat in the comment above: replies can land before their parents and the sidebar renders misaligned notes until loading finishes.

## What this does

`Gutenberg_REST_Notes_Controller` extends `WP_REST_Comments_Controller`, so comment meta, capability mapping, the `rest_prepare_comment` filter and anything registered through `register_rest_field( 'comment', ... )` all keep working. What changes is the collection:

- **Threads, not rows.** `GET wp/v2/notes` returns top-level notes only. Each carries its replies in a `replies` array, oldest first, plus a `reply_count`. Pagination counts threads, so a page break can never separate a reply from the note it answers.
- **Replies in the parent's context.** They are prepared with the same request, so a thread fetched with `context=edit` carries `content.raw` all the way down.
- **`post` is required**, and access is one question: can the current user edit that post? That replaces the branching in `get_items_permissions_check` that has to reconcile note rules with public comment rules.
- **`type` is fixed and `status` defaults to `all`**, since a note matters whether it is open or resolved.
- **The schema drops what does not apply**: `author_email`, `author_ip`, `author_url`, `author_user_agent`, `link`. Notes are written by logged-in users and have no permalink.
- **One query for the replies** on a whole page, via `parent__in`, and the per-note `children` link is dropped - that link costs a `COUNT` query per note and is redundant once replies travel inside the response.

On the client, a `commentType/note` entity replaces `root/comment` in the collab sidebar and the post-list count. The kind mirrors `postType`, per @Mamaduka's review: comment types have no registry to discover them from yet, so the entity is declared statically rather than loaded. Moving `root/comment` to `commentType/comment` and deprecating it is left for a separate PR, since that rename reaches consumers well beyond notes. The tree assembly in `useNoteThreads` collapses from two passes over a flat list to one map, and `useNotesCount` fetches `_fields=id,post,reply_count` instead of every note row.

## Testing

An editor with a few notes and replies should behave exactly as before. `wp/v2/notes?post=<id>&context=edit` shows the shape.

- PHPUnit: 16/16 new tests in `Tests_REST_Notes_Controller`, 44/44 in `Tests_Collaboration_WpSyncConfig`
- E2E `block-notes.spec.js`: 48/48
- E2E `collaboration-notes.spec.ts`: 3/3
- E2E `preload/*`: 4/4
- JS unit (core-data + collab-sidebar): 369/369

Two things worth flagging, both of which break real-time collaboration on notes silently and only the collaboration spec catches:

- The notes entity needs `syncConfig: defaultCollectionSyncConfig` the same way the comment entity does, or a peer's notes stop propagating.
- The entity kind names the sync room, so `WP_Sync_Config` has to allow `commentType` rooms. Without that the server rejects the notes collection room and nothing surfaces client side.

## Open questions

- Does this belong in Core rather than the plugin? Very likely yes - see the companion PR below, which suggests the plugin may need no code at all here.
- Should `useNotesCount` count threads instead of threads-plus-replies? The current behavior is preserved via `reply_count`, but a badge reading "3 notes" may be more useful than "3 notes and 7 replies". Resolution entries no longer inflate it either way: resolving or reopening a thread writes a reply of its own carrying `_wp_note_status`, and a thread nobody answered was reading as 3 notes once it had been resolved and reopened.
- The count still costs a second request per page of posts. `X-WP-Total` cannot replace it, since that is one total per request and the list needs one per post. A `notes_count` REST field on post types that support notes would remove the request and make the column sortable server side, but that is its own PR.
- Nothing preloads notes today. With a stable route there is now something worth adding to `block_editor_rest_api_preload_paths`.
## Core companion

[WordPress/wordpress-develop#13043](https://github.com/WordPress/wordpress-develop/pull/13043) ports the controller to Core and then does the half this PR cannot: it takes note handling back out of `WP_REST_Comments_Controller`, which comes to **+54 / -129** in the controller and **-440** in its tests. Nine note branches go; one stays, because `check_read_permission()` has to keep notes out of the approved-comment shortcut or `wp/v2/comments/<id>` hands them to anonymous readers.

Read that PR to see what the change actually costs Core and what it buys back. If it lands, the plugin drops its copy of the controller entirely and consumes the Core route, leaving only the client changes here.
- Progressive loading (#80018) becomes safe on this endpoint, since each page is a set of whole threads. Left out of this PR to keep the two changes separable.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.


