### PR TITLE
Add Gutenberg version details for WordPress 7.1

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -8,6 +8,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Version | WordPress Version |
 |  ---------------- | ----------------- |
+| 23.6              | 7.1.X             |
 | 22.6              | 7.0.X             |
 | 21.9              | 6.9.X             |
 | 20.4              | 6.8.X             |


### PR DESCRIPTION
Just a quick update to the [Gutenberg versions in WordPress doc](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/) to cover 7.1. 