### PR TITLE
Fix viewport state values set by grid resizer

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
 
 ## 16.2.0 (2026-08-12)

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -18,6 +18,8 @@ import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/const
 import {
 	DEFAULT_BLOCK_STYLE_STATE,
 	getStyleForState,
+	hasViewportBlockStyleState,
+	setStyleForState,
 } from './block-style-state';
 
 const { getResponsiveMediaQueries } = unlock( globalStylesEnginePrivateApis );
@@ -273,6 +275,40 @@ export function getResponsiveChildLayoutStyles( {
 		.join( '' );
 }
 
+/**
+ * Merges child layout changes into the active layout style state.
+ *
+ * @param {Object|undefined} style         Block style attributes.
+ * @param {Object}           layout        Child layout changes.
+ * @param {Object}           selectedState Selected block style state.
+ * @return {Object|undefined} Updated block style attributes.
+ */
+export function getUpdatedChildLayoutStyle( style, layout, selectedState ) {
+	if ( ! hasViewportBlockStyleState( selectedState ) ) {
+		return {
+			...style,
+			layout: {
+				...style?.layout,
+				...layout,
+			},
+		};
+	}
+
+	const layoutState = {
+		viewport: selectedState.viewport,
+		pseudo: DEFAULT_BLOCK_STYLE_STATE.pseudo,
+	};
+	const stateStyle = getStyleForState( style, layoutState );
+
+	return setStyleForState( style, layoutState, {
+		...stateStyle,
+		layout: {
+			...stateStyle?.layout,
+			...layout,
+		},
+	} );
+}
+
 function useBlockPropsChildLayoutStyles( { style } ) {
 	const { shouldRenderChildLayoutStyles, viewportSettings } = useSelect(
 		( select ) => {
@@ -374,6 +410,7 @@ function GridTools( {
 		deviceType,
 		viewportSettings,
 		isChildBlockAGrid,
+		selectedState,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -382,8 +419,8 @@ function GridTools( {
 				getTemplateLock,
 				getBlockAttributes,
 				getSettings,
-			} = select( blockEditorStore );
-
+				getSelectedBlockStyleState,
+			} = unlock( select( blockEditorStore ) );
 			const _rootClientId = getBlockRootClientId( clientId );
 
 			if (
@@ -414,6 +451,7 @@ function GridTools( {
 				viewportSettings: settings?.__experimentalFeatures?.viewport,
 				// Check if the selected child block is itself a grid.
 				isChildBlockAGrid: blockAttributes?.layout?.type === 'grid',
+				selectedState: getSelectedBlockStyleState( clientId ),
 			};
 		},
 		[ clientId ]
@@ -475,13 +513,7 @@ function GridTools( {
 
 	function updateLayout( layout ) {
 		setAttributes( {
-			style: {
-				...style,
-				layout: {
-					...style?.layout,
-					...layout,
-				},
-			},
+			style: getUpdatedChildLayoutStyle( style, layout, selectedState ),
 		} );
 	}
 

--- a/packages/block-editor/src/hooks/test/layout-child.js
+++ b/packages/block-editor/src/hooks/test/layout-child.js
@@ -1,4 +1,9 @@
-import { getChildLayoutStyleRules } from '../layout-child';
+import {
+	getChildLayoutStyleRules,
+	getChildLayoutStyles,
+	getResponsiveChildLayoutStyles,
+	getUpdatedChildLayoutStyle,
+} from '../layout-child';
 
 describe( 'layout child', () => {
 	describe( 'getChildLayoutStyleRules()', () => {
@@ -157,6 +162,60 @@ describe( 'layout child', () => {
 					},
 				},
 			] );
+		} );
+	} );
+
+	describe( 'getUpdatedChildLayoutStyle()', () => {
+		it( 'stores resizer changes in the selected viewport when no default child layout exists', () => {
+			const style = getUpdatedChildLayoutStyle(
+				undefined,
+				{
+					columnSpan: 2,
+					rowSpan: 1,
+				},
+				{
+					viewport: '@mobile',
+					pseudo: 'default',
+				}
+			);
+
+			expect(
+				getChildLayoutStyles( {
+					selector: '.wp-container-content-test',
+					layout: style?.layout,
+				} )
+			).toBe( '' );
+			expect(
+				getResponsiveChildLayoutStyles( {
+					style,
+					selector: '.wp-container-content-test',
+				} )
+			).toBe(
+				'@media (width <= 480px){.wp-container-content-test {\n\t\tgrid-column: span 2; grid-row: span 1;\n\t}}'
+			);
+		} );
+
+		it( 'stores resizer changes in the selected viewport when a pseudo state is also selected', () => {
+			expect(
+				getUpdatedChildLayoutStyle(
+					undefined,
+					{
+						columnSpan: 2,
+						rowSpan: 1,
+					},
+					{
+						viewport: '@mobile',
+						pseudo: ':hover',
+					}
+				)
+			).toEqual( {
+				'@mobile': {
+					layout: {
+						columnSpan: 2,
+						rowSpan: 1,
+					},
+				},
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes bug noticed when reviewing #81560.

Currently on trunk, using the grid resizer to set a viewport-specific grid or row span on a grid child when there is no default (desktop) value for that property outputs it without a media query (setting the same spans via the inspector controls works as expected).

This PR ensures that any viewport-specific values set via the resizer are correctly output inside their media queries, regardless of whether a default value exists or not.

Note this is technically a 7.1 regression, but because it's a pretty niche scenario and there's an easy workaround (using the inspector controls instead of the resizer) I think it's safe to leave it for 7.1.1 given how close we are to the release date.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a Grid block with some children
2. Enable responsive styles, select a viewport and set a grid span on one of the children **using the grid resizer drag handles**
3. Unselect the viewport and check that the previously set span doesn't apply to desktop
4. Save and check that front end matches editor.


https://github.com/user-attachments/assets/0bb16e16-a4dd-45cf-b2e7-a82392e7cd27


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Used codex gpt 5.6 sol