### PR TITLE
Drag a multi-selection by pressing anywhere inside it

### DIFF
--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -2,7 +2,9 @@
 
 // This creates a "slot" where the block you're dragging appeared.
 // We use !important as one of the rules are meant to be overridden.
-.block-editor-block-list__layout .is-dragging {
+// Blocks riding the drag pile are the drag visual itself, not a slot
+// left behind, so they keep their looks.
+.block-editor-block-list__layout .is-dragging:not([data-drag-pile]) {
 	opacity: 0.1;
 
 	iframe {

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -44,6 +44,9 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 
 	// Block multi selection
 	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {
+		// The whole selection can be dragged from any of its blocks.
+		cursor: grab;
+
 		// Hide the native selection indicator, for the selection, and children.
 		&::selection,
 		& ::selection {
@@ -435,4 +438,31 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 			pointer-events: none;
 		}
 	}
+}
+
+// While dragging a multi selection, every block in it shows the
+// grabbing cursor.
+.is-dragging .block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {
+	cursor: grabbing;
+}
+
+// The number of dragged blocks, next to the pointer while dragging a
+// multi selection.
+.block-editor-block-list__drag-count {
+	position: fixed;
+	z-index: 1001;
+	pointer-events: none;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: $grid-unit-30;
+	height: $grid-unit-30;
+	padding: 0 $grid-unit-05;
+	border-radius: $grid-unit-30 * 0.5;
+	background: var(--wp-admin-theme-color);
+	color: $white;
+	font-family: $default-font;
+	font-size: 12px;
+	font-weight: 500;
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -170,7 +170,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		useFocusFirstElement( { clientId, initialPosition } ),
 		useBlockRefProvider( clientId ),
 		useFocusHandler( clientId ),
-		useEventHandlers( { clientId, isSelected } ),
+		useEventHandlers( { clientId, isSelected, isMultiSelected } ),
 		useIsHovered( { isEnabled: isHoverEnabled } ),
 		useIntersectionObserver(),
 		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -1,6 +1,6 @@
 import { isReusableBlock, isTemplatePart } from '@wordpress/blocks';
 import { isTextField } from '@wordpress/dom';
-import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
+import { ENTER, BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../../store';
@@ -16,11 +16,15 @@ function isColorTransparent( color ) {
  *   - Inserts a default block on ENTER.
  *   - Disables dragging of block contents.
  *
+ * For a block that is part of a multi selection, only the drag handling is
+ * added, so that dragging any of the selected blocks moves them all.
+ *
  * @param {string} clientId Block client ID.
  */
-export function useEventHandlers( { clientId, isSelected } ) {
+export function useEventHandlers( { clientId, isSelected, isMultiSelected } ) {
 	const {
 		getBlockRootClientId,
+		getSelectedBlockClientIds,
 		isZoomOut,
 		hasMultiSelection,
 		isSectionBlock,
@@ -28,6 +32,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 		getBlock,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
+		multiSelect,
 		removeBlock,
 		resetZoomLevel,
 		startDraggingBlocks,
@@ -37,7 +42,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 	return useRefEffect(
 		( node ) => {
-			if ( ! isSelected ) {
+			if ( ! isSelected && ! isMultiSelected ) {
 				return;
 			}
 
@@ -77,25 +82,622 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			}
 
 			/**
-			 * Prevents default dragging behavior within a block. To do: we must
-			 * handle this in the future and clean up the drag target.
+			 * Starts a multi-selection drag from plain mouse events. The
+			 * browser only starts a native drag by itself when the press
+			 * lands exactly on selected text, which makes dragging a multi
+			 * selection unreliable. From the movement threshold on, this
+			 * drives the exact same machinery as a native drag: a synthetic
+			 * dragstart runs the handler below, and synthetic dragover and
+			 * drop events feed the drop zones and the insertion indicator.
+			 *
+			 * @param {MouseEvent} event Mouse down event.
+			 */
+			function onMouseDown( event ) {
+				if ( event.button !== 0 || ! hasMultiSelection() ) {
+					return;
+				}
+
+				// Shift and other modifiers adjust the selection; those
+				// presses keep their native behavior.
+				if (
+					event.shiftKey ||
+					event.metaKey ||
+					event.ctrlKey ||
+					event.altKey
+				) {
+					return;
+				}
+
+				// Without a constructable DataTransfer (older Safari) the
+				// synthetic flow cannot carry the block payload; the native
+				// press-on-text drag remains the only path there.
+				if ( typeof window.DataTransfer !== 'function' ) {
+					return;
+				}
+
+				// The press either drags the selection or collapses it on
+				// click; it never starts a text selection or moves the
+				// caret. Preventing the default also stops the browser
+				// from starting its own selection gesture, which Safari
+				// otherwise keeps extending during the drag.
+				event.preventDefault();
+
+				const { ownerDocument } = node;
+				const startX = event.clientX;
+				const startY = event.clientY;
+				const selectedClientIds = getSelectedBlockClientIds();
+				let dragging = false;
+				let dataTransfer = null;
+
+				function dispatchDragEvent( type, e, target ) {
+					const dragEvent = new window.DragEvent( type, {
+						bubbles: true,
+						cancelable: true,
+						clientX: e.clientX,
+						clientY: e.clientY,
+						dataTransfer,
+					} );
+					( target ?? node ).dispatchEvent( dragEvent );
+				}
+
+				// Pressing on selected text also makes the browser start
+				// its own drag of the selection, but only when the press
+				// lands exactly on the glyphs, and the two drags would
+				// fight over the same gesture. Cancel the native drag for
+				// the length of the press; the synthetic one below handles
+				// every press the same way.
+				function suppressNativeDragStart( e ) {
+					if ( e.isTrusted ) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+					}
+				}
+
+				function onMouseMove( e ) {
+					if ( ! dragging ) {
+						if (
+							Math.abs( e.clientX - startX ) < 5 &&
+							Math.abs( e.clientY - startY ) < 5
+						) {
+							return;
+						}
+						dragging = true;
+						dataTransfer = new window.DataTransfer();
+						// The press placed the caret where it landed, which
+						// collapses the multi selection to that block. Now
+						// that the press is a drag, not a click, restore the
+						// selection from before the press so the whole
+						// selection is dragged and stays selected after the
+						// drop.
+						multiSelect(
+							selectedClientIds[ 0 ],
+							selectedClientIds[ selectedClientIds.length - 1 ]
+						);
+						// The handler is called directly instead of through
+						// a dispatched dragstart event: automation tools
+						// watch dragstart events to decide whether a native
+						// drag session follows, and would wait forever on
+						// one that is dispatched from a script.
+						onDragStart( {
+							target: node,
+							clientX: startX,
+							clientY: startY,
+							dataTransfer,
+							preventDefault() {},
+						} );
+					}
+					// Stop the press from growing a text selection while
+					// the blocks are being dragged.
+					e.preventDefault();
+					const under = ownerDocument.elementFromPoint(
+						e.clientX,
+						e.clientY
+					);
+					dispatchDragEvent( 'dragover', e, under ?? node );
+				}
+
+				function suppressNextClick( e ) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
+
+				function onMouseUp( e ) {
+					if ( ! dragging ) {
+						// The prevented press also prevented the browser
+						// from placing the caret for the coming click;
+						// place it where the press landed, so collapsing
+						// the selection by clicking keeps putting the
+						// caret at the click position.
+						const selection =
+							ownerDocument.defaultView.getSelection();
+						const position = ownerDocument.caretPositionFromPoint?.(
+							e.clientX,
+							e.clientY
+						);
+
+						if ( position ) {
+							selection.setPosition(
+								position.offsetNode,
+								position.offset
+							);
+						} else {
+							const range = ownerDocument.caretRangeFromPoint?.(
+								e.clientX,
+								e.clientY
+							);
+
+							if ( range ) {
+								selection.removeAllRanges();
+								selection.addRange( range );
+							}
+						}
+					}
+					if ( dragging ) {
+						const under = ownerDocument.elementFromPoint(
+							e.clientX,
+							e.clientY
+						);
+						dispatchDragEvent(
+							'drop',
+							e,
+							under ?? ownerDocument.body
+						);
+						// The press placed a caret where it landed. Remove
+						// it and select the dropped blocks, so the caret
+						// does not pull the selection to its block once the
+						// drag is over.
+						ownerDocument.defaultView
+							.getSelection()
+							.removeAllRanges();
+						multiSelect(
+							selectedClientIds[ 0 ],
+							selectedClientIds[ selectedClientIds.length - 1 ]
+						);
+						// The click after the drop would collapse the multi
+						// selection to the pressed block.
+						ownerDocument.addEventListener(
+							'click',
+							suppressNextClick,
+							{ capture: true, once: true }
+						);
+					}
+					cleanup();
+				}
+
+				function onDragKeyDown( e ) {
+					if ( e.keyCode !== ESCAPE ) {
+						return;
+					}
+					if ( dragging ) {
+						// Ends the visuals and lets the drop zones clear
+						// the insertion indicator.
+						dispatchDragEvent( 'dragend', e );
+					}
+					cleanup();
+				}
+
+				function cleanup() {
+					ownerDocument.removeEventListener(
+						'dragstart',
+						suppressNativeDragStart,
+						{ capture: true }
+					);
+					ownerDocument.removeEventListener(
+						'mousemove',
+						onMouseMove
+					);
+					ownerDocument.removeEventListener( 'mouseup', onMouseUp );
+					ownerDocument.removeEventListener(
+						'keydown',
+						onDragKeyDown
+					);
+				}
+
+				ownerDocument.addEventListener(
+					'dragstart',
+					suppressNativeDragStart,
+					{ capture: true }
+				);
+				ownerDocument.addEventListener( 'mousemove', onMouseMove );
+				ownerDocument.addEventListener( 'mouseup', onMouseUp );
+				ownerDocument.addEventListener( 'keydown', onDragKeyDown );
+			}
+
+			/**
+			 * Starts the visuals of a multi-selection drag: the grabbed
+			 * block hangs below and right of the pointer, one block of
+			 * the selection peeks out over its top edge and one under
+			 * its bottom edge, slightly turned, and a count of all
+			 * dragged blocks sits on its top right corner. The rest of
+			 * the selection hides in place.
+			 *
+			 * @param {DragEvent}   event       Drag event.
+			 * @param {string[]}    clientIds   The dragged block client IDs.
+			 * @param {HTMLElement} dragElement The fake drag image element.
+			 */
+			function startPileDrag( event, clientIds, dragElement ) {
+				const { ownerDocument } = node;
+				const { defaultView } = ownerDocument;
+				const blockNodes = clientIds
+					.map( ( selectedClientId ) =>
+						ownerDocument.querySelector(
+							`[data-block="${ selectedClientId }"]`
+						)
+					)
+					.filter( Boolean );
+
+				// Every block of the selection visible on screen joins
+				// the stack; the rest hides in place. When fewer than
+				// five are visible, the nearest out of view blocks fill
+				// the stack up to five, so it still reads as a stack.
+				const pileNodes = blockNodes.filter( ( blockNode ) => {
+					if ( blockNode === node ) {
+						return true;
+					}
+					const rect = blockNode.getBoundingClientRect();
+					return (
+						rect.bottom > 0 && rect.top < defaultView.innerHeight
+					);
+				} );
+				const minCount = Math.min( 5, blockNodes.length );
+
+				if ( pileNodes.length < minCount ) {
+					const anchorPlace = blockNodes.indexOf( node );
+					const fillers = blockNodes
+						.filter(
+							( blockNode ) => ! pileNodes.includes( blockNode )
+						)
+						.sort(
+							( a, b ) =>
+								Math.abs(
+									blockNodes.indexOf( a ) - anchorPlace
+								) -
+								Math.abs(
+									blockNodes.indexOf( b ) - anchorPlace
+								)
+						);
+
+					while ( pileNodes.length < minCount && fillers.length ) {
+						pileNodes.push( fillers.shift() );
+					}
+
+					pileNodes.sort(
+						( a, b ) =>
+							blockNodes.indexOf( a ) - blockNodes.indexOf( b )
+					);
+				}
+
+				const anchorIndex = pileNodes.indexOf( node );
+				const restNodes = blockNodes.filter(
+					( blockNode ) => ! pileNodes.includes( blockNode )
+				);
+
+				let _scale = 1;
+
+				{
+					let parentElement = node;
+					while ( ( parentElement = parentElement.parentElement ) ) {
+						const { scale } =
+							defaultView.getComputedStyle( parentElement );
+						if ( scale && scale !== 'none' ) {
+							_scale = parseFloat( scale );
+							break;
+						}
+					}
+				}
+
+				const inverted = 1 / _scale;
+				const rects = pileNodes.map( ( blockNode ) =>
+					blockNode.getBoundingClientRect()
+				);
+				const anchorRect = rects[ anchorIndex ];
+				// One rule: every block scales towards the same diagonal,
+				// and only ever down. Wide blocks come out long and thin,
+				// tall ones narrow.
+				const cardScale = ( rect ) =>
+					Math.min( 1, 420 / Math.hypot( rect.width, rect.height ) );
+				const dragScale = cardScale( anchorRect );
+				const scales = rects.map( cardScale );
+				const grabX = event.clientX;
+				const grabY = event.clientY;
+				// The whole stack hangs just below and right of the
+				// pointer, wherever the press landed in the block.
+				const anchorVisual = {
+					left: grabX + 8,
+					top: grabY + 10,
+					width: anchorRect.width * dragScale,
+					height: anchorRect.height * dragScale,
+				};
+				const tileVisuals = pileNodes.map( ( blockNode, index ) => {
+					const width = rects[ index ].width * scales[ index ];
+					const height = rects[ index ].height * scales[ index ];
+
+					if ( index === anchorIndex ) {
+						return anchorVisual;
+					}
+
+					// Centered on the grabbed block, peeking out over its
+					// top or under its bottom edge; a taller block tucks
+					// the rest of itself behind the stack.
+					const left =
+						anchorVisual.left + ( anchorVisual.width - width ) / 2;
+
+					const depth = Math.abs( index - anchorIndex );
+
+					if ( index < anchorIndex ) {
+						return {
+							left,
+							top: anchorVisual.top - 12 * depth,
+							width,
+							height,
+						};
+					}
+
+					return {
+						left,
+						top:
+							anchorVisual.top +
+							anchorVisual.height +
+							16 * depth -
+							height,
+						width,
+						height,
+					};
+				} );
+				const turns = pileNodes.map( ( blockNode, index ) => {
+					if ( index === anchorIndex ) {
+						return 0;
+					}
+					const depth = Math.abs( index - anchorIndex );
+					return index < anchorIndex
+						? -2 - ( depth - 1 ) * 1.2
+						: 1.6 + ( depth - 1 ) * 1.2;
+				} );
+				const translations = pileNodes.map( ( blockNode, index ) => {
+					const tile = tileVisuals[ index ];
+					const rect = rects[ index ];
+					const scale = scales[ index ];
+					// Scaling happens around the center; compensate the
+					// shift so the box still lands on its slot.
+					return {
+						x:
+							tile.left -
+							rect.left -
+							( rect.width * ( 1 - scale ) ) / 2,
+						y:
+							tile.top -
+							rect.top -
+							( rect.height * ( 1 - scale ) ) / 2,
+					};
+				} );
+				const restoreCallbacks = [];
+
+				pileNodes.forEach( ( blockNode, index ) => {
+					const savedProperties = {};
+
+					for ( const property of [
+						'transform',
+						'transformOrigin',
+						'transition',
+						'zIndex',
+						'position',
+						'top',
+						'left',
+						'pointerEvents',
+						'backgroundColor',
+						'boxShadow',
+					] ) {
+						savedProperties[ property ] =
+							blockNode.style[ property ];
+					}
+
+					// Remove the id and leave it on a hidden shallow clone
+					// so that drop target calculations are correct.
+					const blockId = blockNode.id;
+					const placeholder = blockNode.cloneNode();
+					placeholder.style.display = 'none';
+					blockNode.id = null;
+					blockNode.after( placeholder );
+					// The attribute keeps the slot styling for dragged
+					// blocks from hiding the selection overlay on the
+					// stack.
+					blockNode.dataset.dragPile = 'true';
+
+					restoreCallbacks.push( () => {
+						for ( const [ property, value ] of Object.entries(
+							savedProperties
+						) ) {
+							blockNode.style[ property ] = value;
+						}
+						delete blockNode.dataset.dragPile;
+						blockNode.id = blockId;
+						placeholder.remove();
+					} );
+
+					const { style } = blockNode;
+					style.position = 'relative';
+					style.zIndex = `${
+						1000 - Math.abs( index - anchorIndex )
+					}`;
+					style.transformOrigin = '50% 50%';
+					style.pointerEvents = 'none';
+					style.transition = 'transform 0.2s ease-out';
+					style.boxShadow = '4px 4px 8px rgba(0, 0, 0, 0.15)';
+
+					// If the block has no background color, use the
+					// nearest ancestor's, so it does not show the content
+					// it moves over through the gaps between lines.
+					if (
+						isColorTransparent(
+							defaultView.getComputedStyle( blockNode )
+								.backgroundColor
+						)
+					) {
+						let bgColor = 'transparent';
+						let parentElement = blockNode;
+
+						while (
+							( parentElement = parentElement.parentElement )
+						) {
+							const { backgroundColor } =
+								defaultView.getComputedStyle( parentElement );
+							if ( ! isColorTransparent( backgroundColor ) ) {
+								bgColor = backgroundColor;
+								break;
+							}
+						}
+
+						style.backgroundColor = bgColor;
+					}
+				} );
+
+				// Flush the starting styles, then set the targets, so the
+				// blocks animate from their places into the stack. The
+				// blocks are opaque, so the stacking order alone keeps
+				// the layers from showing through each other.
+				void pileNodes[ 0 ].offsetHeight;
+				pileNodes.forEach( ( blockNode, index ) => {
+					const translateX = translations[ index ].x * inverted;
+					const translateY = translations[ index ].y * inverted;
+					blockNode.style.transform = `translate(${ translateX }px, ${ translateY }px) scale(${ scales[ index ] }) rotate(${ turns[ index ] }deg)`;
+				} );
+
+				// The other selected blocks hide in place; their spots
+				// keep their size until the drag ends.
+				for ( const blockNode of restNodes ) {
+					const savedVisibility = blockNode.style.visibility;
+					blockNode.style.visibility = 'hidden';
+					restoreCallbacks.push( () => {
+						blockNode.style.visibility = savedVisibility;
+					} );
+				}
+
+				const originScrollTop = defaultView.scrollY;
+				const originScrollLeft = defaultView.scrollX;
+				const originClientX = grabX;
+				const originClientY = grabY;
+				let lastClientX = originClientX;
+				let lastClientY = originClientY;
+
+				// A count near the pointer: most of the selection may be
+				// hidden, so the stack alone does not tell how many
+				// blocks are dragged.
+				const countBadge = ownerDocument.createElement( 'div' );
+				countBadge.className = 'block-editor-block-list__drag-count';
+				countBadge.textContent = String( clientIds.length );
+				ownerDocument.body.appendChild( countBadge );
+
+				function positionCountBadge() {
+					// On the stack's top right corner, clear of the
+					// pointer at its top left.
+					countBadge.style.left = `${
+						( lastClientX + 8 + anchorVisual.width ) * inverted - 12
+					}px`;
+					countBadge.style.top = `${
+						( lastClientY + 10 ) * inverted - 12
+					}px`;
+				}
+				positionCountBadge();
+
+				function over() {
+					const topDelta =
+						( lastClientY -
+							originClientY +
+							defaultView.scrollY -
+							originScrollTop ) *
+						inverted;
+					const leftDelta =
+						( lastClientX -
+							originClientX +
+							defaultView.scrollX -
+							originScrollLeft ) *
+						inverted;
+
+					for ( const blockNode of pileNodes ) {
+						blockNode.style.top = `${ topDelta }px`;
+						blockNode.style.left = `${ leftDelta }px`;
+					}
+
+					positionCountBadge();
+				}
+				over();
+
+				function dragOver( e ) {
+					// Only move if the pointer has moved.
+					if (
+						e.clientX === lastClientX &&
+						e.clientY === lastClientY
+					) {
+						return;
+					}
+					lastClientX = e.clientX;
+					lastClientY = e.clientY;
+					over();
+				}
+
+				function end() {
+					ownerDocument.removeEventListener( 'dragover', dragOver );
+					ownerDocument.removeEventListener( 'dragend', end );
+					ownerDocument.removeEventListener( 'drop', end );
+					ownerDocument.removeEventListener( 'scroll', over );
+					restoreCallbacks.forEach( ( restore ) => restore() );
+					countBadge.remove();
+					dragElement.remove();
+					stopDraggingBlocks();
+					document.body.classList.remove(
+						'is-dragging-components-draggable'
+					);
+					ownerDocument.documentElement.classList.remove(
+						'is-dragging'
+					);
+				}
+
+				ownerDocument.addEventListener( 'dragover', dragOver );
+				ownerDocument.addEventListener( 'dragend', end );
+				ownerDocument.addEventListener( 'drop', end );
+				ownerDocument.addEventListener( 'scroll', over );
+
+				startDraggingBlocks( clientIds );
+				// Important because it hides the block toolbar.
+				document.body.classList.add(
+					'is-dragging-components-draggable'
+				);
+				ownerDocument.documentElement.classList.add( 'is-dragging' );
+			}
+
+			/**
+			 * Prevents default dragging behavior within a block, except when
+			 * the block is part of a multi selection (then the drag moves
+			 * all selected blocks).
+			 * To do: we must handle partial selections in the future and
+			 * clean up the drag target.
 			 *
 			 * @param {DragEvent} event Drag event.
 			 */
 			function onDragStart( event ) {
-				if (
-					node !== event.target ||
-					node.isContentEditable ||
-					node.ownerDocument.activeElement !== node ||
-					hasMultiSelection()
-				) {
+				const { activeElement } = node.ownerDocument;
+				const isDirectBlockDrag =
+					node === event.target &&
+					! node.isContentEditable &&
+					activeElement === node &&
+					! hasMultiSelection();
+				// When multiple blocks are selected, dragging any of them
+				// moves the whole selection, the same way dragging the drag
+				// handle in the block toolbar does.
+				const isMultiSelectionDrag =
+					isMultiSelected && hasMultiSelection();
+
+				if ( ! isDirectBlockDrag && ! isMultiSelectionDrag ) {
 					event.preventDefault();
 					return;
 				}
+				const clientIds = isMultiSelectionDrag
+					? getSelectedBlockClientIds()
+					: [ clientId ];
 				const data = JSON.stringify( {
 					type: 'block',
-					srcClientIds: [ clientId ],
-					srcRootClientId: getBlockRootClientId( clientId ),
+					srcClientIds: clientIds,
+					srcRootClientId: getBlockRootClientId( clientIds[ 0 ] ),
 				} );
 				event.dataTransfer.effectAllowed = 'move'; // remove "+" cursor
 				event.dataTransfer.clearData();
@@ -119,6 +721,11 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				dragElement.style.visibility = 'hidden';
 				ownerDocument.body.appendChild( dragElement );
 				event.dataTransfer.setDragImage( dragElement, 0, 0 );
+
+				if ( isMultiSelectionDrag ) {
+					startPileDrag( event, clientIds, dragElement );
+					return;
+				}
 
 				const rect = node.getBoundingClientRect();
 
@@ -275,7 +882,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.addEventListener( 'drop', end );
 				ownerDocument.addEventListener( 'scroll', over );
 
-				startDraggingBlocks( [ clientId ] );
+				startDraggingBlocks( clientIds );
 				// Important because it hides the block toolbar.
 				document.body.classList.add(
 					'is-dragging-components-draggable'
@@ -283,8 +890,19 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.documentElement.classList.add( 'is-dragging' );
 			}
 
-			node.addEventListener( 'keydown', onKeyDown );
 			node.addEventListener( 'dragstart', onDragStart );
+			node.addEventListener( 'mousedown', onMouseDown );
+
+			// Blocks in a multi selection only get the drag handling; the
+			// key and double click handling is for the selected block.
+			if ( ! isSelected ) {
+				return () => {
+					node.removeEventListener( 'dragstart', onDragStart );
+					node.removeEventListener( 'mousedown', onMouseDown );
+				};
+			}
+
+			node.addEventListener( 'keydown', onKeyDown );
 
 			/**
 			 * Handles double-click events on section blocks to edit content only section.
@@ -316,13 +934,16 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			return () => {
 				node.removeEventListener( 'keydown', onKeyDown );
 				node.removeEventListener( 'dragstart', onDragStart );
+				node.removeEventListener( 'mousedown', onMouseDown );
 				node.removeEventListener( 'dblclick', onDoubleClick );
 			};
 		},
 		[
 			clientId,
 			isSelected,
+			isMultiSelected,
 			getBlockRootClientId,
+			getSelectedBlockClientIds,
 			getBlock,
 			isReusableBlock,
 			isTemplatePart,
@@ -330,6 +951,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			isZoomOut,
 			resetZoomLevel,
 			hasMultiSelection,
+			multiSelect,
 			startDraggingBlocks,
 			stopDraggingBlocks,
 			isSectionBlock,

--- a/packages/block-editor/src/components/writing-flow/use-click-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-click-selection.js
@@ -11,10 +11,18 @@ export default function useClickSelection() {
 		getBlockSelectionStart,
 		getSelectionStart,
 		hasMultiSelection,
+		isBlockMultiSelected,
+		isAncestorMultiSelected,
 	} = useSelect( blockEditorStore );
 	return useRefEffect(
 		( node ) => {
+			// The block to collapse a multi-selection to on click, recorded
+			// on mousedown. See the comment in `onMouseDown`.
+			let clickCollapseClientId;
+
 			function onMouseDown( event ) {
+				clickCollapseClientId = undefined;
+
 				// The main button.
 				// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
 				if ( ! isSelectionEnabled() || event.button !== 0 ) {
@@ -83,14 +91,37 @@ export default function useClickSelection() {
 					// multiselection, as focus can be incurred by starting a
 					// multiselection (focus moved to first block's multi-
 					// controls).
-					selectBlock( clickedClientId );
+					if (
+						clickedClientId &&
+						( isBlockMultiSelected( clickedClientId ) ||
+							isAncestorMultiSelected( clickedClientId ) )
+					) {
+						// Pressing on one of the selected blocks may start a
+						// drag of the whole selection, so wait for the click
+						// event to collapse the selection: no click fires
+						// when a drag takes place.
+						clickCollapseClientId = clickedClientId;
+					} else {
+						selectBlock( clickedClientId );
+					}
+				}
+			}
+
+			function onClick() {
+				const clientId = clickCollapseClientId;
+				clickCollapseClientId = undefined;
+
+				if ( clientId && hasMultiSelection() ) {
+					selectBlock( clientId );
 				}
 			}
 
 			node.addEventListener( 'mousedown', onMouseDown );
+			node.addEventListener( 'click', onClick );
 
 			return () => {
 				node.removeEventListener( 'mousedown', onMouseDown );
+				node.removeEventListener( 'click', onClick );
 			};
 		},
 		[
@@ -99,6 +130,8 @@ export default function useClickSelection() {
 			getBlockSelectionStart,
 			getSelectionStart,
 			hasMultiSelection,
+			isBlockMultiSelected,
+			isAncestorMultiSelected,
 		]
 	);
 }

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -104,6 +104,7 @@ export default function useSelectionObserver() {
 	const {
 		getBlockParents,
 		getBlockSelectionStart,
+		isDraggingBlocks,
 		isMultiSelecting,
 		getSelectionStart,
 		getSelectionEnd,
@@ -134,6 +135,13 @@ export default function useSelectionObserver() {
 			}
 
 			function onSelectionChange( event ) {
+				// While blocks are being dragged, the selection is driven
+				// by the drag, not by the caret the press may have left
+				// behind.
+				if ( isDraggingBlocks() ) {
+					return;
+				}
+
 				const selection = defaultView.getSelection();
 
 				if ( ! selection.rangeCount ) {

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -538,4 +538,341 @@ test.describe( 'Draggable block', () => {
 			},
 		] );
 	} );
+
+	test( 'can drag a multi-selection by dragging inside a selected block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/spacer' } );
+		await editor.insertBlock( { name: 'core/separator' } );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'end' },
+		} );
+
+		// Confirm correct setup.
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [
+				{ name: 'core/spacer' },
+				{ name: 'core/separator' },
+				{ name: 'core/paragraph', attributes: { content: 'end' } },
+			] );
+
+		// Select the spacer and the separator.
+		const spacerBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Spacer',
+		} );
+		const separatorBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Separator',
+		} );
+		await spacerBlock.click();
+		await separatorBlock.click( { modifiers: [ 'Shift' ] } );
+
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.getSelectedBlockClientIds()
+				)
+			)
+			.toHaveLength( 2 );
+
+		// Start dragging on one of the selected blocks, not on a drag handle.
+		await spacerBlock.hover();
+		await page.mouse.down();
+
+		// Move to and hover on the bottom half of the paragraph block to
+		// trigger the indicator.
+		const paragraph = editor.canvas.locator(
+			'role=document[name="Block: Paragraph"i] >> text=end'
+		);
+		const paragraphBound = await paragraph.boundingBox();
+		await dragTo(
+			page,
+			paragraphBound.x + 32,
+			paragraphBound.y + paragraphBound.height * 0.75
+		);
+
+		// Both selected blocks follow the pointer as a pile, with the
+		// count next to the pointer.
+		await expect
+			.poll( () => spacerBlock.evaluate( ( n ) => n.style.position ) )
+			.toBe( 'relative' );
+		await expect
+			.poll( () => separatorBlock.evaluate( ( n ) => n.style.position ) )
+			.toBe( 'relative' );
+		await expect(
+			editor.canvas.locator( '.block-editor-block-list__drag-count' )
+		).toHaveText( '2' );
+
+		const indicator = page.locator(
+			'data-testid=block-list-insertion-point-indicator'
+		);
+		await expect( indicator ).toBeVisible();
+		// Expect the indicator to be below the paragraph.
+		await expect
+			.poll( () =>
+				indicator.boundingBox().then( ( { y, height } ) => y + height )
+			)
+			.toBeGreaterThan( paragraphBound.y + paragraphBound.height );
+
+		// Drop both blocks after the paragraph.
+		await page.mouse.up();
+
+		// The blocks return to the flow when the drag ends.
+		await expect
+			.poll( () => spacerBlock.evaluate( ( n ) => n.style.position ) )
+			.toBe( '' );
+		await expect
+			.poll( () => separatorBlock.evaluate( ( n ) => n.style.position ) )
+			.toBe( '' );
+		await expect(
+			editor.canvas.locator( '.block-editor-block-list__drag-count' )
+		).toHaveCount( 0 );
+
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [
+				{ name: 'core/paragraph', attributes: { content: 'end' } },
+				{ name: 'core/spacer' },
+				{ name: 'core/separator' },
+			] );
+	} );
+
+	test( 'starts a multi-selection drag only from the selected blocks', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+
+		// Confirm correct setup.
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: '1' } },
+			{ name: 'core/paragraph', attributes: { content: '2' } },
+			{ name: 'core/paragraph', attributes: { content: '3' } },
+		] );
+
+		// Select the first two paragraphs.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Paragraph"i] >> text=1' )
+			.click();
+		await page.keyboard.press( 'Escape' );
+		await page.keyboard.press( 'Shift+ArrowDown' );
+
+		const selectedClientIds = await page.evaluate( () =>
+			window.wp.data
+				.select( 'core/block-editor' )
+				.getSelectedBlockClientIds()
+		);
+		expect( selectedClientIds ).toHaveLength( 2 );
+		const [ , , thirdClientId ] = await page.evaluate( () =>
+			window.wp.data.select( 'core/block-editor' ).getBlockOrder()
+		);
+
+		// A drag that starts inside one of the selected blocks carries all
+		// selected blocks.
+		const selectedResult = await editor.canvas
+			.locator( `[data-block="${ selectedClientIds[ 1 ] }"]` )
+			.evaluate( ( node ) => {
+				const dataTransfer = new DataTransfer();
+				const event = new DragEvent( 'dragstart', {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer,
+				} );
+				const notPrevented = node.dispatchEvent( event );
+				return {
+					notPrevented,
+					data: dataTransfer.getData( 'wp-blocks' ),
+				};
+			} );
+		expect( selectedResult.notPrevented ).toBe( true );
+		expect( JSON.parse( selectedResult.data ) ).toMatchObject( {
+			type: 'block',
+			srcClientIds: selectedClientIds,
+			srcRootClientId: '',
+		} );
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.getDraggedBlockClientIds()
+				)
+			)
+			.toEqual( selectedClientIds );
+
+		// End the drag before testing the next case. The event is dispatched
+		// on the body because the dragged block is cloned while dragging, so
+		// its block selector would match two elements.
+		await editor.canvas.locator( 'body' ).evaluate( ( body ) => {
+			body.dispatchEvent( new DragEvent( 'dragend', { bubbles: true } ) );
+		} );
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.isDraggingBlocks()
+				)
+			)
+			.toBe( false );
+
+		// A drag that starts inside an unselected block does not carry the
+		// multi-selection.
+		const unselectedResult = await editor.canvas
+			.locator( `[data-block="${ thirdClientId }"]` )
+			.evaluate( ( node ) => {
+				const dataTransfer = new DataTransfer();
+				const event = new DragEvent( 'dragstart', {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer,
+				} );
+				node.dispatchEvent( event );
+				return { data: dataTransfer.getData( 'wp-blocks' ) };
+			} );
+		expect( unselectedResult.data ).toBe( '' );
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.isDraggingBlocks()
+				)
+			)
+			.toBe( false );
+	} );
+
+	async function multiSelectTwoParagraphs( { editor, page } ) {
+		for ( const content of [ 'First', 'Second', 'Landing' ] ) {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content },
+			} );
+		}
+		const paragraphs = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		await paragraphs.nth( 0 ).click();
+		await paragraphs.nth( 1 ).click( { modifiers: [ 'Shift' ] } );
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.getSelectedBlockClientIds()
+				)
+			)
+			.toHaveLength( 2 );
+		return paragraphs;
+	}
+
+	// Presses to the right of the text of the first selected paragraph,
+	// where there are no glyphs, and drags below the last paragraph. The
+	// browser only starts a drag by itself when the press lands exactly on
+	// selected text; this exercises the mouse event driven drag.
+	async function dragSelectionBelowLanding( { page }, paragraphs ) {
+		const box = await paragraphs.nth( 0 ).boundingBox();
+		await page.mouse.move( box.x + box.width - 20, box.y + box.height / 2 );
+		await page.mouse.down();
+		const landingBox = await paragraphs.nth( 2 ).boundingBox();
+		await page.mouse.move(
+			landingBox.x + 40,
+			landingBox.y + landingBox.height - 2,
+			{ steps: 10 }
+		);
+		// The drop target computation is throttled; wait until the
+		// insertion indicator reaches the drop position before releasing.
+		const indicator = page.locator(
+			'data-testid=block-list-insertion-point-indicator'
+		);
+		await expect( indicator ).toBeVisible();
+		await expect
+			.poll( async () => ( await indicator.boundingBox() ).y )
+			.toBeGreaterThan( landingBox.y );
+	}
+
+	function isDraggingBlocks( page ) {
+		return page.evaluate( () =>
+			window.wp.data.select( 'core/block-editor' ).isDraggingBlocks()
+		);
+	}
+
+	test( 'drags a multi-selection from anywhere inside it', async ( {
+		editor,
+		page,
+	} ) => {
+		const paragraphs = await multiSelectTwoParagraphs( { editor, page } );
+		await dragSelectionBelowLanding( { page }, paragraphs );
+		await expect.poll( () => isDraggingBlocks( page ) ).toBe( true );
+		// The first selected block follows the pointer.
+		await expect
+			.poll( () =>
+				paragraphs.nth( 0 ).evaluate( ( n ) => n.style.position )
+			)
+			.toBe( 'relative' );
+		await page.mouse.up();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'Landing' } },
+			{ name: 'core/paragraph', attributes: { content: 'First' } },
+			{ name: 'core/paragraph', attributes: { content: 'Second' } },
+		] );
+	} );
+
+	test( 'pressing Escape cancels a multi-selection drag', async ( {
+		editor,
+		page,
+	} ) => {
+		const paragraphs = await multiSelectTwoParagraphs( { editor, page } );
+		await dragSelectionBelowLanding( { page }, paragraphs );
+		await expect.poll( () => isDraggingBlocks( page ) ).toBe( true );
+		await page.keyboard.press( 'Escape' );
+		await expect.poll( () => isDraggingBlocks( page ) ).toBe( false );
+		// The blocks return to the flow when the drag is canceled.
+		await expect
+			.poll( () =>
+				paragraphs.nth( 0 ).evaluate( ( n ) => n.style.position )
+			)
+			.toBe( '' );
+		await page.mouse.up();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'First' } },
+			{ name: 'core/paragraph', attributes: { content: 'Second' } },
+			{ name: 'core/paragraph', attributes: { content: 'Landing' } },
+		] );
+	} );
+
+	test( 'keeps the blocks selected after dropping a multi-selection', async ( {
+		editor,
+		page,
+	} ) => {
+		const paragraphs = await multiSelectTwoParagraphs( { editor, page } );
+		await dragSelectionBelowLanding( { page }, paragraphs );
+		await page.mouse.up();
+
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data
+						.select( 'core/block-editor' )
+						.getSelectedBlockClientIds()
+				)
+			)
+			.toHaveLength( 2 );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{ name: 'core/paragraph', attributes: { content: 'Landing' } },
+			{ name: 'core/paragraph', attributes: { content: 'First' } },
+			{ name: 'core/paragraph', attributes: { content: 'Second' } },
+		] );
+	} );
 } );


### PR DESCRIPTION
WIP do not code review!

<img width="444" height="253" alt="image" src="https://github.com/user-attachments/assets/70f413dc-4e5f-44fa-83aa-5dca19213ffe" />


## What?

Dragging a multi-selection by pressing anywhere inside it. Part of #67305.

## Why?

Dragging several selected blocks only worked from the drag handle in the toolbar. Pressing on the blocks themselves only sometimes started a drag, because the browser only starts one by itself when the press lands exactly on selected text, and Safari would grow a text selection alongside it.

## How?

1. **The gesture is driven by mouse events.** A press inside a multi-selection is prevented from the start, so no text selection ever begins. From a 5px movement threshold on, the drag start handler runs directly and synthetic `dragover` and `drop` events feed the existing drop zones. A plain click still collapses the selection, with the caret placed from the click position, and Escape cancels the drag.
2. **The dragged blocks show as a stack.** The grabbed block hangs below and right of the pointer, scaled towards a shared diagonal (only ever down). The nearest blocks before and after it peek out over its top and bottom edges, slightly turned, and a count of all dragged blocks sits on the stack's top right corner. At least five blocks join the stack, with out of view blocks filling in; the rest hides in place until the drag ends.
3. **The selection survives the drag.** The selection observer ignores selection changes while blocks are being dragged, and the blocks are re-selected on drop, so the caret the press leaves behind cannot pull the selection away.

## Testing Instructions

1. Select several blocks (shift+click or shift+arrows).
2. Press anywhere inside the selection, also next to the text, and drag: the stack follows the pointer with the count on its corner, and the insertion indicator shows the drop position.
3. Drop: the blocks move and stay selected. Press Escape during a drag: everything returns to place.
4. Click inside a multi-selection without moving: the selection collapses with the caret at the click position.

## Screenshots or screencast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
