### PR TITLE
DataViews: Add an aspect ratio toggle for grid layouts

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   DataViews: Add a `mediaFit` option to the `grid` and `pickerGrid` layouts to fit item previews inside their box (`contain`) instead of cropping them (`cover`), so the media's own aspect ratio stays visible. Consumers can offer this to users as an "Original aspect ratio" toggle in the view options via `config.mediaFitControl` ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
+-   DataViews: Add a `mediaFit` option to the `grid` and `pickerGrid` layouts to fit item previews inside their box (`contain`) instead of cropping them (`cover`), so the media's own aspect ratio stays visible. A fitted preview is letterboxed against a neutral background, so each item still reads as a unit. Consumers can offer this to users as an "Original aspect ratio" toggle in the view options via `config.mediaFitControl` ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
 -   Validated form controls: Align invalid focus styling for `ComboboxControl` and `FormTokenField` with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   DataViews filters: Align filter search input focus styling with `outset-ring__focus` ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   DataViews: Add a `mediaFit` option to the `grid` and `pickerGrid` layouts to fit item previews inside their box (`contain`) instead of cropping them (`cover`), so the media's own aspect ratio stays visible. Consumers can offer this to users as an "Original aspect ratio" toggle in the view options via `config.mediaFitControl` ([#81567](https://github.com/WordPress/gutenberg/issues/81567)).
 -   Validated form controls: Align invalid focus styling for `ComboboxControl` and `FormTokenField` with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   DataViews filters: Align filter search input focus styling with `outset-ring__focus` ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fix
 
+-   Picker grid layout: Clip item previews to the media box's rounded corners, as the grid layout already does, so an image no longer squares off its corners ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
 -   DataForm: Keep the displayed calendar month of the `date` and `datetime` controls in sync when the value changes from outside the control, e.g. after an undo, a reset, or switching the edited item. [#81635](https://github.com/WordPress/gutenberg/pull/81635)
 -   DataForms: Fix the `date` and `datetime` controls selecting and highlighting the day next to the one clicked. A site configured with a UTC offset rather than a named timezone reports no timezone the calendar can work in, so it fell back to the browser's while the values stayed anchored to the site's. The `datetime` calendar is now given the site's UTC offset itself — which also keeps the day it marks as today the site's — and a `date` value is treated as a plain calendar day, parsed in the same browser timezone the calendar reads it in. [#81498](https://github.com/WordPress/gutenberg/pull/81498)
 -   Validated form controls: Align invalid focus styling for InputBase-based controls with the design system ([#80417](https://github.com/WordPress/gutenberg/pull/80417)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   DataViews: Add a `mediaFit` option to the `grid` and `pickerGrid` layouts to fit item previews inside their box (`contain`) instead of cropping them (`cover`), so the media's own aspect ratio stays visible. Consumers can offer this to users as an "Original aspect ratio" toggle in the view options via `config.mediaFitControl` ([#81567](https://github.com/WordPress/gutenberg/issues/81567)).
+-   DataViews: Add a `mediaFit` option to the `grid` and `pickerGrid` layouts to fit item previews inside their box (`contain`) instead of cropping them (`cover`), so the media's own aspect ratio stays visible. Consumers can offer this to users as an "Original aspect ratio" toggle in the view options via `config.mediaFitControl` ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
 -   Validated form controls: Align invalid focus styling for `ComboboxControl` and `FormTokenField` with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   DataViews filters: Align filter search input focus styling with `outset-ring__focus` ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -276,7 +276,7 @@ Right-align (`'end'`) whenever the cell value is fundamentally quantitative—nu
 -   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the gap between items in the grid.
 -   `previewSize`: a `number` representing the size of the preview.
 -   `aspectRatio` (`grid` only): one of the preset ratios `'1/1'`, `'4/3'`, `'3/4'`, `'3/2'`, `'2/3'`, `'16/9'`, or `'9/16'`, applied uniformly to every item preview, keeping rows aligned. Defaults to `'1/1'`.
--   `mediaFit`: how the media field fills the preview box, either `'cover'` (crop it to fill) or `'contain'` (fit the whole media inside, letterboxing it so its own aspect ratio stays visible). The box keeps the shape set by `aspectRatio` either way, so rows stay aligned. Defaults to `'cover'`. To let users switch this themselves, pass `config={ { mediaFitControl: true } }` to `DataViews` or `DataViewsPicker`, which adds an "Original aspect ratio" toggle to the view options.
+-   `mediaFit`: how the media field fills the preview box, either `'cover'` (crop it to fill) or `'contain'` (fit the whole media inside, letterboxing it so its own aspect ratio stays visible). The box keeps the shape set by `aspectRatio` either way, so rows stay aligned, and takes a neutral background under `'contain'` so a letterboxed preview still reads as a single item. Defaults to `'cover'`. To let users switch this themselves, pass `config={ { mediaFitControl: true } }` to `DataViews` or `DataViewsPicker`, which adds an "Original aspect ratio" toggle to the view options.
 
 `list` layout:
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -258,6 +258,7 @@ Properties:
 | `badgeFields`  |         |               | ✓      | ✓            |        |            |
 | `previewSize`  |         |               | ✓      | ✓            |        |            |
 | `aspectRatio`  | ✓       |               | ✓      |              |        |            |
+| `mediaFit`     |         |               | ✓      | ✓            |        |            |
 
 `table` and `pickerTable` layouts:
 
@@ -275,6 +276,7 @@ Right-align (`'end'`) whenever the cell value is fundamentally quantitative—nu
 -   `density`: one of `comfortable`, `balanced`, or `compact`. Configures the gap between items in the grid.
 -   `previewSize`: a `number` representing the size of the preview.
 -   `aspectRatio` (`grid` only): one of the preset ratios `'1/1'`, `'4/3'`, `'3/4'`, `'3/2'`, `'2/3'`, `'16/9'`, or `'9/16'`, applied uniformly to every item preview, keeping rows aligned. Defaults to `'1/1'`.
+-   `mediaFit`: how the media field fills the preview box, either `'cover'` (crop it to fill) or `'contain'` (fit the whole media inside, letterboxing it so its own aspect ratio stays visible). The box keeps the shape set by `aspectRatio` either way, so rows stay aligned. Defaults to `'cover'`. To let users switch this themselves, pass `config={ { mediaFitControl: true } }` to `DataViews` or `DataViewsPicker`, which adds an "Original aspect ratio" toggle to the view options.
 
 `list` layout:
 
@@ -487,9 +489,11 @@ The component receives the following props:
 
 React component to be rendered next to the view config button.
 
-#### `config`: { perPageSizes: number[] }
+#### `config`: { perPageSizes: number[], mediaFitControl?: boolean }
 
 Optional. Pass an object with a list of `perPageSizes` to control the available item counts per page (defaults to `[10, 20, 50, 100]`). `perPageSizes` needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
+
+Set `mediaFitControl` to `true` to add an "Original aspect ratio" toggle to the view options of grid layouts, letting users switch item previews between cropped (`cover`) and fitted (`contain`). See the `mediaFit` layout property. It is off by default, since cropping to a uniform shape suits datasets whose previews are already consistent. The control is also hidden when the view renders no media field.
 
 #### `empty`: React node
 
@@ -759,9 +763,9 @@ Example:
 }
 ```
 
-#### `config`: { perPageSizes: number[] }
+#### `config`: { perPageSizes: number[], mediaFitControl?: boolean }
 
-Same as `DataViews`. Optional. Pass an object with a list of `perPageSizes` to control the available item counts per page.
+Same as `DataViews`. Optional. Pass an object with a list of `perPageSizes` to control the available item counts per page, and `mediaFitControl` to offer the "Original aspect ratio" toggle in the view options of grid layouts.
 
 #### `empty`: React node
 

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -43,7 +43,7 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	config: { perPageSizes: number[] };
+	config: { perPageSizes: number[]; mediaFitControl?: boolean };
 	empty?: ReactNode;
 	hasInitiallyLoaded?: boolean;
 	itemListLabel?: string;

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -15,7 +15,7 @@ import {
 	useRef,
 	forwardRef,
 } from '@wordpress/element';
-import { MEDIA_ASPECT_RATIOS } from '../../../constants';
+import { MEDIA_ASPECT_RATIOS, MEDIA_FITS } from '../../../constants';
 import ItemActions from '../../dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../dataviews-selection-checkbox';
 import DataViewsContext from '../../dataviews-context';
@@ -353,18 +353,22 @@ export default function CompositeGrid< Item >( {
 	const { paginationInfo, resizeObserverRef } =
 		useContext( DataViewsContext );
 	const gridColumns = useGridColumns();
-	// Consumer-configured aspect ratio for item previews, validated against
-	// the presets (like `density`) so arbitrary values are ignored, and
-	// surfaced to CSS as a custom property the media field's stylesheet
-	// reads. Always set (with the square default), so an identically-named
-	// variable set by a consumer on an ancestor can't leak into the previews
-	// when the view doesn't configure a ratio.
+	// Consumer-configured shape and fill for item previews, each validated
+	// against its presets (like `density`) so arbitrary values are ignored,
+	// and surfaced to CSS as custom properties the media field's stylesheet
+	// reads. Both are always set (with their defaults), so identically-named
+	// variables set by a consumer on an ancestor can't leak into the previews
+	// when the view doesn't configure them.
 	const gridStyle = {
 		'--wp-dataviews-media-aspect-ratio':
 			view.layout?.aspectRatio &&
 			MEDIA_ASPECT_RATIOS.includes( view.layout.aspectRatio )
 				? view.layout.aspectRatio
 				: '1/1',
+		'--wp-dataviews-media-fit':
+			view.layout?.mediaFit && MEDIA_FITS.includes( view.layout.mediaFit )
+				? view.layout.mediaFit
+				: 'cover',
 	} as CSSProperties;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const titleField = fields.find(

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -15,7 +15,7 @@ import {
 	useRef,
 	forwardRef,
 } from '@wordpress/element';
-import { MEDIA_ASPECT_RATIOS, MEDIA_FITS } from '../../../constants';
+import { MEDIA_ASPECT_RATIOS } from '../../../constants';
 import ItemActions from '../../dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../dataviews-selection-checkbox';
 import DataViewsContext from '../../dataviews-context';
@@ -353,23 +353,23 @@ export default function CompositeGrid< Item >( {
 	const { paginationInfo, resizeObserverRef } =
 		useContext( DataViewsContext );
 	const gridColumns = useGridColumns();
-	// Consumer-configured shape and fill for item previews, each validated
-	// against its presets (like `density`) so arbitrary values are ignored,
-	// and surfaced to CSS as custom properties the media field's stylesheet
-	// reads. Both are always set (with their defaults), so identically-named
-	// variables set by a consumer on an ancestor can't leak into the previews
-	// when the view doesn't configure them.
+	// Consumer-configured shape for item previews, validated against the
+	// presets (like `density`) so arbitrary values are ignored, and surfaced
+	// to CSS as a custom property the media field's stylesheet reads. Always
+	// set (with the square default), so an identically-named variable set by
+	// a consumer on an ancestor can't leak into the previews when the view
+	// doesn't configure a ratio.
 	const gridStyle = {
 		'--wp-dataviews-media-aspect-ratio':
 			view.layout?.aspectRatio &&
 			MEDIA_ASPECT_RATIOS.includes( view.layout.aspectRatio )
 				? view.layout.aspectRatio
 				: '1/1',
-		'--wp-dataviews-media-fit':
-			view.layout?.mediaFit && MEDIA_FITS.includes( view.layout.mediaFit )
-				? view.layout.mediaFit
-				: 'cover',
 	} as CSSProperties;
+	// `mediaFit` is a class rather than a custom property (unlike the aspect
+	// ratio above) because it switches the preview box's background token as
+	// well as its `object-fit`, which a custom property can't do.
+	const isMediaContain = view.layout?.mediaFit === 'contain';
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField
@@ -435,6 +435,7 @@ export default function CompositeGrid< Item >( {
 												'compact',
 												'comfortable',
 											].includes( view.layout.density ),
+										'has-media-fit-contain': isMediaContain,
 									}
 								) }
 								previewSize={ view.layout?.previewSize }
@@ -537,6 +538,7 @@ export default function CompositeGrid< Item >( {
 								[ 'compact', 'comfortable' ].includes(
 									view.layout.density
 								),
+							'has-media-fit-contain': isMediaContain,
 						} ) }
 						focusWrap
 						aria-busy={ isLoading }

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -108,7 +108,7 @@
 		}
 
 		img {
-			object-fit: var(--wp-dataviews-media-fit, cover);
+			object-fit: cover;
 			width: 100%;
 			height: 100%;
 		}
@@ -132,6 +132,18 @@
 			border-radius: var(--wpds-border-radius-md);
 			box-shadow: none;
 			background: var(--wpds-color-background-surface-neutral);
+		}
+	}
+
+	// Fitting the whole media inside the box letterboxes it, so the box needs
+	// a background of its own for the item to still read as a unit. Only
+	// applied to `contain`: under `cover` the media covers the box, and a grey
+	// would only show through transparent images and while previews load.
+	&.has-media-fit-contain .dataviews-view-grid__media {
+		background-color: var(--wpds-color-background-surface-neutral);
+
+		img {
+			object-fit: contain;
 		}
 	}
 

--- a/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/style.scss
@@ -108,7 +108,7 @@
 		}
 
 		img {
-			object-fit: cover;
+			object-fit: var(--wp-dataviews-media-fit, cover);
 			width: 100%;
 			height: 100%;
 		}

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { Spinner, Flex, FlexItem, Composite } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
@@ -14,6 +14,7 @@ import type {
 	ViewPickerGridProps,
 } from '../../../types';
 import type { SetSelection } from '../../../types/private';
+import { MEDIA_FITS } from '../../../constants';
 import { GridItems } from '../utils/grid-items';
 import getDataByGroup from '../utils/get-data-by-group';
 import useSelectionProps from '../utils/use-selection-props';
@@ -322,6 +323,19 @@ function ViewPickerGrid< Item >( {
 	const perPage = view?.perPage ?? 0;
 	const setSize = isInfiniteScroll ? paginationInfo?.totalItems : undefined;
 
+	// Consumer-configured fill for item previews, validated against the
+	// presets (like `density`) so arbitrary values are ignored, and surfaced
+	// to CSS as a custom property the media field's stylesheet reads. Always
+	// set (with the `cover` default), so an identically-named variable set by
+	// a consumer on an ancestor can't leak into the previews when the view
+	// doesn't configure it.
+	const gridStyle = {
+		'--wp-dataviews-media-fit':
+			view.layout?.mediaFit && MEDIA_FITS.includes( view.layout.mediaFit )
+				? view.layout.mediaFit
+				: 'cover',
+	} as CSSProperties;
+
 	// Calculate placeholders needed for infinite scroll
 	const gridColumns = useGridColumns();
 	const placeholdersNeeded = usePlaceholdersNeeded(
@@ -373,11 +387,7 @@ function ViewPickerGrid< Item >( {
 								>
 									<GridItems
 										previewSize={ usedPreviewSize }
-										style={ {
-											gridTemplateColumns:
-												usedPreviewSize &&
-												`repeat(auto-fill, minmax(${ usedPreviewSize }px, 1fr))`,
-										} }
+										style={ gridStyle }
 										aria-busy={ isLoading }
 										ref={
 											resizeObserverRef as React.RefObject< HTMLDivElement >
@@ -447,6 +457,7 @@ function ViewPickerGrid< Item >( {
 									}
 								) }
 								previewSize={ usedPreviewSize }
+								style={ gridStyle }
 								aria-busy={ isLoading }
 								ref={
 									resizeObserverRef as React.RefObject< HTMLDivElement >

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Spinner, Flex, FlexItem, Composite } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
@@ -14,7 +14,6 @@ import type {
 	ViewPickerGridProps,
 } from '../../../types';
 import type { SetSelection } from '../../../types/private';
-import { MEDIA_FITS } from '../../../constants';
 import { GridItems } from '../utils/grid-items';
 import getDataByGroup from '../utils/get-data-by-group';
 import useSelectionProps from '../utils/use-selection-props';
@@ -323,18 +322,11 @@ function ViewPickerGrid< Item >( {
 	const perPage = view?.perPage ?? 0;
 	const setSize = isInfiniteScroll ? paginationInfo?.totalItems : undefined;
 
-	// Consumer-configured fill for item previews, validated against the
-	// presets (like `density`) so arbitrary values are ignored, and surfaced
-	// to CSS as a custom property the media field's stylesheet reads. Always
-	// set (with the `cover` default), so an identically-named variable set by
-	// a consumer on an ancestor can't leak into the previews when the view
-	// doesn't configure it.
-	const gridStyle = {
-		'--wp-dataviews-media-fit':
-			view.layout?.mediaFit && MEDIA_FITS.includes( view.layout.mediaFit )
-				? view.layout.mediaFit
-				: 'cover',
-	} as CSSProperties;
+	// Consumer-configured fill for item previews, surfaced as a class rather
+	// than a custom property because it switches the preview box's background
+	// token as well as its `object-fit`. Anything other than `contain` (an
+	// unsupported value included) leaves the previews cropped.
+	const isMediaContain = view.layout?.mediaFit === 'contain';
 
 	// Calculate placeholders needed for infinite scroll
 	const gridColumns = useGridColumns();
@@ -363,6 +355,7 @@ function ViewPickerGrid< Item >( {
 									[ 'compact', 'comfortable' ].includes(
 										view.layout.density
 									),
+								'has-media-fit-contain': isMediaContain,
 							}
 						) }
 						aria-label={ itemListLabel }
@@ -387,7 +380,6 @@ function ViewPickerGrid< Item >( {
 								>
 									<GridItems
 										previewSize={ usedPreviewSize }
-										style={ gridStyle }
 										aria-busy={ isLoading }
 										ref={
 											resizeObserverRef as React.RefObject< HTMLDivElement >
@@ -454,10 +446,10 @@ function ViewPickerGrid< Item >( {
 												'compact',
 												'comfortable',
 											].includes( view.layout.density ),
+										'has-media-fit-contain': isMediaContain,
 									}
 								) }
 								previewSize={ usedPreviewSize }
-								style={ gridStyle }
 								aria-busy={ isLoading }
 								ref={
 									resizeObserverRef as React.RefObject< HTMLDivElement >

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
@@ -80,7 +80,7 @@
 		position: relative;
 
 		img {
-			object-fit: cover;
+			object-fit: var(--wp-dataviews-media-fit, cover);
 			width: 100%;
 			height: 100%;
 		}

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
@@ -77,6 +77,9 @@
 		min-height: 0;
 		background-color: var(--wpds-color-background-surface-neutral-strong);
 		border-radius: var(--wpds-border-radius-md);
+		// Clip the preview to the rounded corners, as the grid layout does.
+		// The selection checkbox is a sibling, so it isn't affected.
+		overflow: hidden;
 		position: relative;
 
 		img {

--- a/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-grid/style.scss
@@ -83,7 +83,7 @@
 		position: relative;
 
 		img {
-			object-fit: var(--wp-dataviews-media-fit, cover);
+			object-fit: cover;
 			width: 100%;
 			height: 100%;
 		}
@@ -98,6 +98,16 @@
 			box-shadow: inset 0 0 0 var(--wpds-border-width-xs) rgba(0, 0, 0, 0.1);
 			border-radius: var(--wpds-border-radius-md);
 			pointer-events: none;
+		}
+	}
+
+	// Keep in sync with the grid layout, which letterboxes fitted previews
+	// against the same background so each item still reads as a unit.
+	&.has-media-fit-contain .dataviews-view-picker-grid__media {
+		background-color: var(--wpds-color-background-surface-neutral);
+
+		img {
+			object-fit: contain;
 		}
 	}
 

--- a/packages/dataviews/src/components/dataviews-layouts/utils/grid-config-options.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/grid-config-options.tsx
@@ -1,10 +1,12 @@
 import DensityPicker from './density-picker';
+import MediaFitControl from './media-fit-control';
 import PreviewSizePicker from './preview-size-picker';
 
 export default function GridConfigOptions() {
 	return (
 		<>
 			<DensityPicker />
+			<MediaFitControl />
 			<PreviewSizePicker />
 		</>
 	);

--- a/packages/dataviews/src/components/dataviews-layouts/utils/media-fit-control.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/media-fit-control.tsx
@@ -1,0 +1,42 @@
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
+import DataViewsContext from '../../dataviews-context';
+import type { ViewGrid, ViewPickerGrid } from '../../../types';
+
+export default function MediaFitControl() {
+	const context = useContext( DataViewsContext );
+	const view = context.view as ViewGrid | ViewPickerGrid;
+
+	// Opt-in: only consumers that ask for this control get it. Cropping to a
+	// square suits datasets whose previews are already uniform (templates,
+	// patterns), where ragged previews would just make the grid harder to
+	// scan, so this isn't shown everywhere by default.
+	if ( ! context.config?.mediaFitControl ) {
+		return null;
+	}
+
+	// Nothing to fit if the view doesn't render a media field.
+	const hasMediaField =
+		view.showMedia !== false &&
+		context.fields.some( ( field ) => field.id === view.mediaField );
+	if ( ! hasMediaField ) {
+		return null;
+	}
+
+	return (
+		<ToggleControl
+			label={ __( 'Original aspect ratio' ) }
+			checked={ view.layout?.mediaFit === 'contain' }
+			onChange={ ( isChecked ) => {
+				context.onChangeView( {
+					...view,
+					layout: {
+						...view.layout,
+						mediaFit: isChecked ? 'contain' : 'cover',
+					},
+				} );
+			} }
+		/>
+	);
+}

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -64,10 +64,3 @@ export const MEDIA_ASPECT_RATIOS = [
 	'16/9',
 	'9/16',
 ] as const;
-
-// How the media field fills its preview box: `cover` crops it to fill,
-// `contain` fits the whole media inside, letterboxing it so its own aspect
-// ratio stays visible. Source of truth for the `MediaFit` type (derived from
-// this array), and used by layouts to validate the configured
-// `layout.mediaFit` before applying it.
-export const MEDIA_FITS = [ 'cover', 'contain' ] as const;

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -64,3 +64,10 @@ export const MEDIA_ASPECT_RATIOS = [
 	'16/9',
 	'9/16',
 ] as const;
+
+// How the media field fills its preview box: `cover` crops it to fill,
+// `contain` fits the whole media inside, letterboxing it so its own aspect
+// ratio stays visible. Source of truth for the `MediaFit` type (derived from
+// this array), and used by layouts to validate the configured
+// `layout.mediaFit` before applying it.
+export const MEDIA_FITS = [ 'cover', 'contain' ] as const;

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -60,6 +60,12 @@ type DataViewsPickerProps< Item > = {
 	children?: ReactNode;
 	config?: {
 		perPageSizes: number[];
+		/**
+		 * Whether the view config popover offers the "Original aspect ratio"
+		 * control for grid layouts, letting users switch item previews
+		 * between cropped (`cover`) and fitted (`contain`).
+		 */
+		mediaFitControl?: boolean;
 	};
 	itemListLabel?: string;
 	empty?: ReactNode;

--- a/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews-picker/stories/index.story.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@wordpress/ui';
 import DataViewsPicker from '../index';
 import { LAYOUT_PICKER_GRID } from '../../constants';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
-import type { ActionButton, View } from '../../types';
+import type { ActionButton, MediaFit, View } from '../../types';
 import { data, fields, type SpaceObject } from './fixtures';
 
 const meta = {
@@ -21,6 +21,8 @@ const storyArgs = {
 	isMultiselectable: false,
 	isGrouped: false,
 	infiniteScrollEnabled: false,
+	mediaFit: 'cover',
+	mediaFitControl: true,
 };
 
 const storyArgTypes = {
@@ -41,6 +43,17 @@ const storyArgTypes = {
 		description:
 			'Whether the infinite scroll is enabled. Enabling this disables the "Is grouped" option',
 	},
+	mediaFit: {
+		control: 'select',
+		options: [ 'cover', 'contain' ],
+		description:
+			'How the media field fills the preview box: cropped to fill it ("cover") or fitted inside it ("contain"), letterboxing the media so its own aspect ratio stays visible',
+	},
+	mediaFitControl: {
+		control: 'boolean',
+		description:
+			'Whether the view options offer the "Original aspect ratio" toggle, letting users switch the media fit themselves',
+	},
 };
 
 interface PickerContentProps {
@@ -48,6 +61,8 @@ interface PickerContentProps {
 	isMultiselectable: boolean;
 	isGrouped: boolean;
 	infiniteScrollEnabled: boolean;
+	mediaFit?: MediaFit;
+	mediaFitControl?: boolean;
 	actions?: ActionButton< SpaceObject >[];
 	selection?: string[];
 }
@@ -57,6 +72,8 @@ const DataViewsPickerContent = ( {
 	isMultiselectable,
 	isGrouped,
 	infiniteScrollEnabled,
+	mediaFit = 'cover',
+	mediaFitControl = true,
 	actions: customActions,
 	selection: customSelection,
 }: PickerContentProps ) => {
@@ -72,6 +89,7 @@ const DataViewsPickerContent = ( {
 				? { field: 'type', direction: 'asc' as const }
 				: undefined,
 			infiniteScrollEnabled,
+			layout: { mediaFit },
 		};
 
 		if ( infiniteScrollEnabled ) {
@@ -100,6 +118,9 @@ const DataViewsPickerContent = ( {
 						? { field: 'type', direction: 'asc' as const }
 						: undefined,
 				infiniteScrollEnabled,
+				// Spread the previous layout so a change made through the
+				// view options popover survives an unrelated arg change.
+				layout: { ...prevView.layout, mediaFit },
 			};
 
 			if ( infiniteScrollEnabled ) {
@@ -120,7 +141,7 @@ const DataViewsPickerContent = ( {
 				startPosition: undefined,
 			} as View;
 		} );
-	}, [ isGrouped, infiniteScrollEnabled ] );
+	}, [ isGrouped, infiniteScrollEnabled, mediaFit ] );
 
 	const [ selection, setSelection ] = useState< string[] >(
 		customSelection || []
@@ -175,7 +196,7 @@ const DataViewsPickerContent = ( {
 				view={ view }
 				fields={ fields }
 				onChangeView={ setView }
-				config={ { perPageSizes } }
+				config={ { perPageSizes, mediaFitControl } }
 				defaultLayouts={ {
 					pickerGrid: true,
 					pickerTable: true,
@@ -192,17 +213,23 @@ export const Default = ( {
 	isMultiselectable,
 	isGrouped,
 	infiniteScrollEnabled,
+	mediaFit,
+	mediaFitControl,
 }: {
 	perPageSizes: number[];
 	isMultiselectable: boolean;
 	isGrouped: boolean;
 	infiniteScrollEnabled: boolean;
+	mediaFit?: MediaFit;
+	mediaFitControl?: boolean;
 } ) => (
 	<DataViewsPickerContent
 		perPageSizes={ perPageSizes }
 		isMultiselectable={ isMultiselectable }
 		isGrouped={ isGrouped }
 		infiniteScrollEnabled={ infiniteScrollEnabled }
+		mediaFit={ mediaFit }
+		mediaFitControl={ mediaFitControl }
 	/>
 );
 
@@ -219,11 +246,15 @@ export const WithModal = ( {
 	isMultiselectable,
 	isGrouped,
 	infiniteScrollEnabled,
+	mediaFit,
+	mediaFitControl,
 }: {
 	perPageSizes: number[];
 	isMultiselectable: boolean;
 	isGrouped: boolean;
 	infiniteScrollEnabled: boolean;
+	mediaFit?: MediaFit;
+	mediaFitControl?: boolean;
 } ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ selectedItems, setSelectedItems ] = useState< SpaceObject[] >( [] );
@@ -297,6 +328,8 @@ export const WithModal = ( {
 							isMultiselectable={ isMultiselectable }
 							isGrouped={ isGrouped }
 							infiniteScrollEnabled={ infiniteScrollEnabled }
+							mediaFit={ mediaFit }
+							mediaFitControl={ mediaFitControl }
 							actions={ modalActions }
 							selection={ selectedItems.map( ( item ) =>
 								String( item.id )

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -496,6 +496,77 @@ describe( 'DataViews Picker', () => {
 				);
 			} );
 		} );
+
+		describe( 'media fit', () => {
+			// The flat branch renders `GridItems` as the listbox itself, so
+			// the element carrying the custom property is the listbox.
+			it( 'crops previews by default', () => {
+				render( <Picker /> );
+				expect( screen.getByRole( 'listbox' ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'cover',
+				} );
+			} );
+
+			it( 'fits previews when configured to contain', () => {
+				render(
+					<Picker
+						view={
+							{
+								layout: { mediaFit: 'contain' },
+							} as Partial< ViewPickerGrid >
+						}
+					/>
+				);
+				expect( screen.getByRole( 'listbox' ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'contain',
+				} );
+			} );
+
+			it( 'ignores an unsupported value and falls back to cropping', () => {
+				render(
+					<Picker
+						view={
+							{
+								// Deliberately outside the `MediaFit` union.
+								layout: { mediaFit: 'fill' },
+							} as unknown as Partial< ViewPickerGrid >
+						}
+					/>
+				);
+				expect( screen.getByRole( 'listbox' ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'cover',
+				} );
+			} );
+
+			// Grouping renders one `GridItems` per group, nested inside the
+			// listbox rather than being it, so each has to carry the property.
+			it( 'applies the fit to every group when the data is grouped', () => {
+				const { container } = render(
+					<Picker
+						fields={ groupingFields }
+						view={
+							{
+								groupBy: { field: 'parity', direction: 'asc' },
+								layout: { mediaFit: 'contain' },
+							} as Partial< ViewPickerGrid >
+						}
+					/>
+				);
+
+				// No role distinguishes the per-group grids from each other,
+				// so reach for them by class, as the DataViews tests do.
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				const groups = container.querySelectorAll(
+					'.dataviews-view-grid-items'
+				);
+				expect( groups ).toHaveLength( 2 );
+				groups.forEach( ( group ) => {
+					expect( group ).toHaveStyle( {
+						'--wp-dataviews-media-fit': 'contain',
+					} );
+				} );
+			} );
+		} );
 	} );
 
 	describe.each( [

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -498,13 +498,14 @@ describe( 'DataViews Picker', () => {
 		} );
 
 		describe( 'media fit', () => {
-			// The flat branch renders `GridItems` as the listbox itself, so
-			// the element carrying the custom property is the listbox.
+			// Both the flat and grouped branches put the class on the listbox:
+			// the flat branch renders `GridItems` as the listbox itself, and
+			// the grouped one nests its per-group grids inside it.
 			it( 'crops previews by default', () => {
 				render( <Picker /> );
-				expect( screen.getByRole( 'listbox' ) ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'cover',
-				} );
+				expect( screen.getByRole( 'listbox' ) ).not.toHaveClass(
+					'has-media-fit-contain'
+				);
 			} );
 
 			it( 'fits previews when configured to contain', () => {
@@ -517,9 +518,9 @@ describe( 'DataViews Picker', () => {
 						}
 					/>
 				);
-				expect( screen.getByRole( 'listbox' ) ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'contain',
-				} );
+				expect( screen.getByRole( 'listbox' ) ).toHaveClass(
+					'has-media-fit-contain'
+				);
 			} );
 
 			it( 'ignores an unsupported value and falls back to cropping', () => {
@@ -533,15 +534,13 @@ describe( 'DataViews Picker', () => {
 						}
 					/>
 				);
-				expect( screen.getByRole( 'listbox' ) ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'cover',
-				} );
+				expect( screen.getByRole( 'listbox' ) ).not.toHaveClass(
+					'has-media-fit-contain'
+				);
 			} );
 
-			// Grouping renders one `GridItems` per group, nested inside the
-			// listbox rather than being it, so each has to carry the property.
-			it( 'applies the fit to every group when the data is grouped', () => {
-				const { container } = render(
+			it( 'applies the fit when the data is grouped', () => {
+				render(
 					<Picker
 						fields={ groupingFields }
 						view={
@@ -553,18 +552,9 @@ describe( 'DataViews Picker', () => {
 					/>
 				);
 
-				// No role distinguishes the per-group grids from each other,
-				// so reach for them by class, as the DataViews tests do.
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-				const groups = container.querySelectorAll(
-					'.dataviews-view-grid-items'
+				expect( screen.getByRole( 'listbox' ) ).toHaveClass(
+					'has-media-fit-contain'
 				);
-				expect( groups ).toHaveLength( 2 );
-				groups.forEach( ( group ) => {
-					expect( group ).toHaveStyle( {
-						'--wp-dataviews-media-fit': 'contain',
-					} );
-				} );
 			} );
 		} );
 	} );

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -61,6 +61,12 @@ type DataViewsProps< Item > = {
 	children?: ReactNode;
 	config?: {
 		perPageSizes: number[];
+		/**
+		 * Whether the view config popover offers the "Original aspect ratio"
+		 * control for grid layouts, letting users switch item previews
+		 * between cropped (`cover`) and fitted (`contain`).
+		 */
+		mediaFitControl?: boolean;
 	};
 	empty?: ReactNode;
 	onReset?: ( () => void ) | false;

--- a/packages/dataviews/src/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/dataviews/stories/index.story.tsx
@@ -101,6 +101,8 @@ export const LayoutGrid = {
 		groupBy: false,
 		groupByLabel: true,
 		hasClickableItems: true,
+		mediaFit: 'cover',
+		mediaFitControl: true,
 		perPageSizes: [ 10, 25, 50, 100 ],
 		showMedia: true,
 	},
@@ -121,6 +123,17 @@ export const LayoutGrid = {
 		hasClickableItems: {
 			control: 'boolean',
 			description: 'Are the items clickable',
+		},
+		mediaFit: {
+			control: 'select',
+			options: [ 'cover', 'contain' ],
+			description:
+				'How the media field fills the preview box: cropped to fill it ("cover") or fitted inside it ("contain"), letterboxing the media so its own aspect ratio stays visible',
+		},
+		mediaFitControl: {
+			control: 'boolean',
+			description:
+				'Whether the view options offer the "Original aspect ratio" toggle, letting users switch the media fit themselves',
 		},
 		perPageSizes: {
 			control: 'object',

--- a/packages/dataviews/src/dataviews/stories/layout-grid.tsx
+++ b/packages/dataviews/src/dataviews/stories/layout-grid.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useEffect } from '@wordpress/element';
 import DataViews from '../index';
 import { LAYOUT_GRID } from '../../constants';
 import filterSortAndPaginate from '../../utils/filter-sort-and-paginate';
-import type { View } from '../../types';
+import type { MediaFit, View } from '../../types';
 import { actions, data, fields, type SpaceObject } from './fixtures';
 
 export const LayoutTableComponent = ( {
@@ -10,6 +10,8 @@ export const LayoutTableComponent = ( {
 	hasClickableItems = true,
 	groupBy = false,
 	groupByLabel = true,
+	mediaFit = 'cover',
+	mediaFitControl = true,
 	perPageSizes = [ 10, 25, 50, 100 ],
 	showMedia = true,
 }: {
@@ -17,6 +19,8 @@ export const LayoutTableComponent = ( {
 	hasClickableItems?: boolean;
 	groupBy?: boolean;
 	groupByLabel?: boolean;
+	mediaFit?: MediaFit;
+	mediaFitControl?: boolean;
 	perPageSizes?: number[];
 	showMedia?: boolean;
 } ) => {
@@ -31,6 +35,7 @@ export const LayoutTableComponent = ( {
 		descriptionField: 'description',
 		mediaField: 'image',
 		showMedia,
+		layout: { mediaFit },
 	} );
 
 	useEffect( () => {
@@ -45,9 +50,12 @@ export const LayoutTableComponent = ( {
 					  }
 					: undefined,
 				showMedia,
-			};
+				// Spread the previous layout so a change made through the
+				// view options popover survives an unrelated arg change.
+				layout: { ...prevView.layout, mediaFit },
+			} as View;
 		} );
-	}, [ groupBy, groupByLabel, showMedia ] );
+	}, [ groupBy, groupByLabel, mediaFit, showMedia ] );
 
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
@@ -90,7 +98,7 @@ export const LayoutTableComponent = ( {
 				defaultLayouts={ {
 					[ LAYOUT_GRID ]: true,
 				} }
-				config={ { perPageSizes } }
+				config={ { perPageSizes, mediaFitControl } }
 			/>
 		</div>
 	);

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -997,28 +997,22 @@ describe( 'DataViews component', () => {
 			};
 
 			// The standard (non-infinite-scroll) grid root, which carries the
-			// custom properties the previews read.
+			// class the previews are styled from.
 			const getGrid = () => screen.getByRole( 'grid' );
 
 			it( 'crops previews by default', () => {
 				renderGrid();
-				expect( getGrid() ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'cover',
-				} );
+				expect( getGrid() ).not.toHaveClass( 'has-media-fit-contain' );
 			} );
 
 			it( 'fits previews when configured to contain', () => {
 				renderGrid( { mediaFit: 'contain' } );
-				expect( getGrid() ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'contain',
-				} );
+				expect( getGrid() ).toHaveClass( 'has-media-fit-contain' );
 			} );
 
 			it( 'ignores an unsupported value and falls back to cropping', () => {
 				renderGrid( { mediaFit: 'fill' } );
-				expect( getGrid() ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'cover',
-				} );
+				expect( getGrid() ).not.toHaveClass( 'has-media-fit-contain' );
 			} );
 
 			it( 'hides the control unless the consumer opts in', async () => {
@@ -1041,9 +1035,7 @@ describe( 'DataViews component', () => {
 				const control = await queryControl();
 				const user = userEvent.setup();
 				await user.click( control as HTMLElement );
-				expect( getGrid() ).toHaveStyle( {
-					'--wp-dataviews-media-fit': 'contain',
-				} );
+				expect( getGrid() ).toHaveClass( 'has-media-fit-contain' );
 			} );
 		} );
 	} );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -956,6 +956,89 @@ describe( 'DataViews component', () => {
 			expect( previewSizeSlider ).toBeInTheDocument();
 			expect( previewSizeSlider ).toHaveValue( '0' ); // Falls back to the smallest size, which is the first one.
 		} );
+
+		describe( 'media fit', () => {
+			// `layout` is loosely typed so the invalid-value case below can
+			// pass something the `mediaFit` union rejects.
+			const renderGrid = (
+				layout: Record< string, unknown > = {},
+				props = {}
+			) =>
+				render(
+					<DataViewWrapper
+						view={
+							{
+								type: 'grid',
+								mediaField: 'image',
+								layout,
+							} as unknown as View
+						}
+						{ ...props }
+					/>
+				);
+
+			const getGrid = ( container: HTMLElement ) =>
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				container.querySelector( '.dataviews-view-grid-items' );
+
+			it( 'crops previews by default', () => {
+				const { container } = renderGrid();
+				expect( getGrid( container ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'cover',
+				} );
+			} );
+
+			it( 'fits previews when configured to contain', () => {
+				const { container } = renderGrid( { mediaFit: 'contain' } );
+				expect( getGrid( container ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'contain',
+				} );
+			} );
+
+			it( 'ignores an unsupported value and falls back to cropping', () => {
+				const { container } = renderGrid( { mediaFit: 'fill' } );
+				expect( getGrid( container ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'cover',
+				} );
+			} );
+
+			it( 'hides the control unless the consumer opts in', async () => {
+				renderGrid();
+				const user = userEvent.setup();
+				await user.click(
+					screen.getByRole( 'button', { name: 'View options' } )
+				);
+				expect(
+					screen.queryByRole( 'checkbox', {
+						name: 'Original aspect ratio',
+					} )
+				).not.toBeInTheDocument();
+			} );
+
+			it( 'toggles the fit from the view options when opted in', async () => {
+				const { container } = renderGrid(
+					{},
+					{
+						config: {
+							perPageSizes: [ 10, 20 ],
+							mediaFitControl: true,
+						},
+					}
+				);
+				const user = userEvent.setup();
+				await user.click(
+					screen.getByRole( 'button', { name: 'View options' } )
+				);
+				await user.click(
+					screen.getByRole( 'checkbox', {
+						name: 'Original aspect ratio',
+					} )
+				);
+				expect( getGrid( container ) ).toHaveStyle( {
+					'--wp-dataviews-media-fit': 'contain',
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'in list view', () => {

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -962,7 +962,8 @@ describe( 'DataViews component', () => {
 			// pass something the `mediaFit` union rejects.
 			const renderGrid = (
 				layout: Record< string, unknown > = {},
-				props = {}
+				props = {},
+				view: Record< string, unknown > = {}
 			) =>
 				render(
 					<DataViewWrapper
@@ -971,11 +972,29 @@ describe( 'DataViews component', () => {
 								type: 'grid',
 								mediaField: 'image',
 								layout,
+								...view,
 							} as unknown as View
 						}
 						{ ...props }
 					/>
 				);
+
+			const optedIn = {
+				config: {
+					perPageSizes: [ 10, 20 ],
+					mediaFitControl: true,
+				},
+			};
+
+			const queryControl = async () => {
+				const user = userEvent.setup();
+				await user.click(
+					screen.getByRole( 'button', { name: 'View options' } )
+				);
+				return screen.queryByRole( 'checkbox', {
+					name: 'Original aspect ratio',
+				} );
+			};
 
 			// The standard (non-infinite-scroll) grid root, which carries the
 			// custom properties the previews read.
@@ -1004,36 +1023,24 @@ describe( 'DataViews component', () => {
 
 			it( 'hides the control unless the consumer opts in', async () => {
 				renderGrid();
-				const user = userEvent.setup();
-				await user.click(
-					screen.getByRole( 'button', { name: 'View options' } )
-				);
-				expect(
-					screen.queryByRole( 'checkbox', {
-						name: 'Original aspect ratio',
-					} )
-				).not.toBeInTheDocument();
+				expect( await queryControl() ).not.toBeInTheDocument();
+			} );
+
+			it( 'hides the control when the view is not showing media', async () => {
+				renderGrid( {}, optedIn, { showMedia: false } );
+				expect( await queryControl() ).not.toBeInTheDocument();
+			} );
+
+			it( 'hides the control when the media field is not one of the fields', async () => {
+				renderGrid( {}, optedIn, { mediaField: 'not-a-field' } );
+				expect( await queryControl() ).not.toBeInTheDocument();
 			} );
 
 			it( 'toggles the fit from the view options when opted in', async () => {
-				renderGrid(
-					{},
-					{
-						config: {
-							perPageSizes: [ 10, 20 ],
-							mediaFitControl: true,
-						},
-					}
-				);
+				renderGrid( {}, optedIn );
+				const control = await queryControl();
 				const user = userEvent.setup();
-				await user.click(
-					screen.getByRole( 'button', { name: 'View options' } )
-				);
-				await user.click(
-					screen.getByRole( 'checkbox', {
-						name: 'Original aspect ratio',
-					} )
-				);
+				await user.click( control as HTMLElement );
 				expect( getGrid() ).toHaveStyle( {
 					'--wp-dataviews-media-fit': 'contain',
 				} );

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -977,27 +977,27 @@ describe( 'DataViews component', () => {
 					/>
 				);
 
-			const getGrid = ( container: HTMLElement ) =>
-				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-				container.querySelector( '.dataviews-view-grid-items' );
+			// The standard (non-infinite-scroll) grid root, which carries the
+			// custom properties the previews read.
+			const getGrid = () => screen.getByRole( 'grid' );
 
 			it( 'crops previews by default', () => {
-				const { container } = renderGrid();
-				expect( getGrid( container ) ).toHaveStyle( {
+				renderGrid();
+				expect( getGrid() ).toHaveStyle( {
 					'--wp-dataviews-media-fit': 'cover',
 				} );
 			} );
 
 			it( 'fits previews when configured to contain', () => {
-				const { container } = renderGrid( { mediaFit: 'contain' } );
-				expect( getGrid( container ) ).toHaveStyle( {
+				renderGrid( { mediaFit: 'contain' } );
+				expect( getGrid() ).toHaveStyle( {
 					'--wp-dataviews-media-fit': 'contain',
 				} );
 			} );
 
 			it( 'ignores an unsupported value and falls back to cropping', () => {
-				const { container } = renderGrid( { mediaFit: 'fill' } );
-				expect( getGrid( container ) ).toHaveStyle( {
+				renderGrid( { mediaFit: 'fill' } );
+				expect( getGrid() ).toHaveStyle( {
 					'--wp-dataviews-media-fit': 'cover',
 				} );
 			} );
@@ -1016,7 +1016,7 @@ describe( 'DataViews component', () => {
 			} );
 
 			it( 'toggles the fit from the view options when opted in', async () => {
-				const { container } = renderGrid(
+				renderGrid(
 					{},
 					{
 						config: {
@@ -1034,7 +1034,7 @@ describe( 'DataViews component', () => {
 						name: 'Original aspect ratio',
 					} )
 				);
-				expect( getGrid( container ) ).toHaveStyle( {
+				expect( getGrid() ).toHaveStyle( {
 					'--wp-dataviews-media-fit': 'contain',
 				} );
 			} );

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -7,7 +7,7 @@ import type {
 	SortDirection,
 } from './field-api';
 import type { SetSelection } from './private';
-import type { MEDIA_ASPECT_RATIOS, MEDIA_FITS } from '../constants';
+import type { MEDIA_ASPECT_RATIOS } from '../constants';
 
 /**
  * The filters applied to the dataset.
@@ -235,11 +235,13 @@ export type Density = 'compact' | 'balanced' | 'comfortable';
 export type MediaAspectRatio = ( typeof MEDIA_ASPECT_RATIOS )[ number ];
 
 /**
- * How the media field fills its preview box. Derived from the `MEDIA_FITS`
- * constant, which layouts also use to validate the configured value at
- * runtime, so the two can't drift apart.
+ * How the media field fills its preview box. `cover` crops it to fill,
+ * `contain` fits the whole media inside, letterboxing it so its own aspect
+ * ratio stays visible. Unlike `MediaAspectRatio` there is no matching runtime
+ * constant: layouts style the fit from a class they add for `contain` alone,
+ * so any other value simply leaves previews cropped.
  */
-export type MediaFit = ( typeof MEDIA_FITS )[ number ];
+export type MediaFit = 'cover' | 'contain';
 
 export interface ViewTable extends ViewBase {
 	type: 'table';

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -7,7 +7,7 @@ import type {
 	SortDirection,
 } from './field-api';
 import type { SetSelection } from './private';
-import type { MEDIA_ASPECT_RATIOS } from '../constants';
+import type { MEDIA_ASPECT_RATIOS, MEDIA_FITS } from '../constants';
 
 /**
  * The filters applied to the dataset.
@@ -234,6 +234,13 @@ export type Density = 'compact' | 'balanced' | 'comfortable';
  */
 export type MediaAspectRatio = ( typeof MEDIA_ASPECT_RATIOS )[ number ];
 
+/**
+ * How the media field fills its preview box. Derived from the `MEDIA_FITS`
+ * constant, which layouts also use to validate the configured value at
+ * runtime, so the two can't drift apart.
+ */
+export type MediaFit = ( typeof MEDIA_FITS )[ number ];
+
 export interface ViewTable extends ViewBase {
 	type: 'table';
 
@@ -309,6 +316,14 @@ export interface ViewGrid extends ViewBase {
 		 * stay aligned. Defaults to `'1/1'`.
 		 */
 		aspectRatio?: MediaAspectRatio;
+
+		/**
+		 * How the media field fills the preview box. `'cover'` crops it to
+		 * fill, `'contain'` fits the whole media inside so its own aspect
+		 * ratio stays visible. The box keeps the shape set by `aspectRatio`
+		 * either way, so rows stay aligned. Defaults to `'cover'`.
+		 */
+		mediaFit?: MediaFit;
 	};
 }
 
@@ -330,6 +345,14 @@ export interface ViewPickerGrid extends ViewBase {
 		 * The density of the grid layout.
 		 */
 		density?: Density;
+
+		/**
+		 * How the media field fills the preview box. `'cover'` crops it to
+		 * fill, `'contain'` fits the whole media inside so its own aspect
+		 * ratio stays visible. The box stays square either way, so rows stay
+		 * aligned. Defaults to `'cover'`.
+		 */
+		mediaFit?: MediaFit;
 	};
 }
 

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Media upload modal: Show thumbnails at their original aspect ratio inside the grid cell rather than cropping them to a square, so a media item's orientation is visible before it is inserted. Adds an "Original aspect ratio" toggle to the view options for switching back to cropped previews ([#81567](https://github.com/WordPress/gutenberg/issues/81567)).
+
 ### Bug Fixes
 
 -   Prevent editor block removal by stopping undo/redo event propagation when the Media Library modal is open ([#79898](https://github.com/WordPress/gutenberg/pull/79898)).

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Media upload modal: Show thumbnails at their original aspect ratio inside the grid cell rather than cropping them to a square, so a media item's orientation is visible before it is inserted. Adds an "Original aspect ratio" toggle to the view options for switching back to cropped previews ([#81567](https://github.com/WordPress/gutenberg/issues/81567)).
+-   Media upload modal: Show thumbnails at their original aspect ratio inside the grid cell rather than cropping them to a square, so a media item's orientation is visible before it is inserted. Adds an "Original aspect ratio" toggle to the view options for switching back to cropped previews ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
 
 ### Bug Fixes
 

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -92,6 +92,10 @@ const defaultView: View = {
 	layout: {
 		previewSize: 170,
 		density: 'compact',
+		// Fit each thumbnail inside its square cell rather than cropping it,
+		// so the media's own orientation is visible before it's inserted.
+		// Users can switch back to cropped in the view options.
+		mediaFit: 'contain',
 	},
 };
 
@@ -102,6 +106,7 @@ const defaultLayouts: SupportedLayouts = {
 		layout: {
 			previewSize: 170,
 			density: 'compact',
+			mediaFit: 'contain',
 		},
 	},
 	[ LAYOUT_PICKER_TABLE ]: {
@@ -114,6 +119,15 @@ const defaultLayouts: SupportedLayouts = {
 		],
 		showTitle: true,
 	},
+};
+
+const dataViewsConfig = {
+	// Repeats `DataViewsPicker`'s own default, which passing `config` at all
+	// would otherwise replace.
+	perPageSizes: [ 10, 20, 50, 100 ],
+	// Seeing whether a media item is portrait or landscape before inserting
+	// it matters here, so offer the crop/fit switch in the view options.
+	mediaFitControl: true,
 };
 
 interface MediaUploadModalProps {
@@ -631,6 +645,7 @@ export function MediaUploadModal( {
 				isLoading={ isLoading }
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
+				config={ dataViewsConfig }
 				getItemId={ ( item: RestAttachment ) => String( item.id ) }
 				itemListLabel={ __( 'Media items' ) }
 				onReset={ isModified ? resetToDefault : false }


### PR DESCRIPTION
## What?

Fixes: #81567 

Add an aspect ratio toggle to DataViews grid layouts to allow the media preview to be displayed via `contain` (so it preserves its aspect ratio) or via `cover` (default as on trunk) where it fills the container.

## Why?

As described in #81567, and flagged in #79729, for many kinds of grid items (but especially user uploads of photos) it's essential to be able to see the full aspect ratio before you can reliably choose an item. This is especially true of media that someone has cropped or uploaded different images in portrait or vertical orientations.

Without some way of previewing the image in its full aspect ratio, you can only know what you're getting after selection. So, the idea here is that DataViews should _support_ showing the media in its aspect ratio, but not require it.

## How?

* Add a `mediaFit` layout property to the grid-based DataViews layouts
* Add an optional `mediaFitControl` prop and toggle button in the settings dropdown in DataViews (optional so that consumers can decide whether or not they want to allow the toggle)
* Try this out in the experimental Media Upload Modal (the one that uses DataViews)

## Testing Instructions

Enable the Media Upload Modal experiment:

<img width="589" height="88" alt="image" src="https://github.com/user-attachments/assets/179f9493-3967-45c1-b5ff-dfe7b04fd4ec" />

Go to add an image to an Image or Gallery block and see how it looks and feels. What do you reckon? What needs changing to make this feel better?

## Questions

* How does this look?
* Do the grid items need a background color now to make it feel more pleasing when an image is displayed in its aspect ratio?

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9b8cb326-4300-4c2a-bada-f6c43e33f296

## Use of AI Tools

Claude Code (Opus 5)