### PR TITLE
Global Styles: Allow editing duotone palettes

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.

--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -18,6 +18,7 @@ function DuotoneControl( {
 	disableCustomColors,
 	disableCustomDuotone,
 	value,
+	selectedSlug,
 	onChange,
 } ) {
 	let toolbarIcon;
@@ -75,6 +76,7 @@ function DuotoneControl( {
 						disableCustomColors={ disableCustomColors }
 						disableCustomDuotone={ disableCustomDuotone }
 						value={ value }
+						selectedSlug={ selectedSlug }
 						onChange={ onChange }
 					/>
 				</MenuGroup>

--- a/packages/block-editor/src/components/duotone-control/test/index.js
+++ b/packages/block-editor/src/components/duotone-control/test/index.js
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DuotoneControl from '../';
+
+// Adding two custom duotones in Global Styles seeds both from the palette's
+// darkest and lightest colors, so two presets holding the same pair is the
+// ordinary case. Only the slug tells them apart.
+const DUPLICATE_PALETTE = [
+	{
+		name: 'Duotone 1',
+		slug: 'custom-duotone-1',
+		colors: [ '#000000', '#ffffff' ],
+	},
+	{
+		name: 'Duotone 2',
+		slug: 'custom-duotone-2',
+		colors: [ '#000000', '#ffffff' ],
+	},
+];
+
+const COLOR_PALETTE = [
+	{ color: '#000000', name: 'Black', slug: 'black' },
+	{ color: '#ffffff', name: 'White', slug: 'white' },
+];
+
+async function openControl( user ) {
+	await user.click(
+		screen.getByRole( 'button', { name: 'Apply duotone filter' } )
+	);
+}
+
+describe( 'DuotoneControl', () => {
+	it( 'reports the slug of the duplicate that was picked', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<DuotoneControl
+				duotonePalette={ DUPLICATE_PALETTE }
+				colorPalette={ COLOR_PALETTE }
+				value={ undefined }
+				onChange={ onChange }
+			/>
+		);
+		await openControl( user );
+
+		await user.click(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 2' } )
+		);
+
+		expect( onChange ).toHaveBeenCalledWith(
+			[ '#000000', '#ffffff' ],
+			1,
+			'custom-duotone-2'
+		);
+	} );
+
+	it( 'marks only the stored preset as selected when two share colors', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<DuotoneControl
+				duotonePalette={ DUPLICATE_PALETTE }
+				colorPalette={ COLOR_PALETTE }
+				value={ [ '#000000', '#ffffff' ] }
+				selectedSlug="custom-duotone-2"
+				onChange={ jest.fn() }
+			/>
+		);
+		await openControl( user );
+
+		expect(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 1' } )
+		).toHaveAttribute( 'aria-selected', 'false' );
+		expect(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 2' } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+	} );
+
+	it( 'falls back to color matching when no slug is stored', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<DuotoneControl
+				duotonePalette={ DUPLICATE_PALETTE }
+				colorPalette={ COLOR_PALETTE }
+				value={ [ '#000000', '#ffffff' ] }
+				onChange={ jest.fn() }
+			/>
+		);
+		await openControl( user );
+
+		expect(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 1' } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+		expect(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 2' } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -17,7 +17,10 @@ import { __, _x } from '@wordpress/i18n';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { reset as resetIcon } from '@wordpress/icons';
 import { getValueFromVariable } from '@wordpress/global-styles-engine';
-import { useToolsPanelDropdownMenuProps } from './utils';
+import {
+	useToolsPanelDropdownMenuProps,
+	getDuotoneSlugFromPreset,
+} from './utils';
 import { setImmutably } from '../../utils/object';
 import {
 	getInheritanceProps,
@@ -202,14 +205,24 @@ export default function FiltersPanel( {
 	const localDuotone = decodeValue( value?.filter?.duotone );
 	const inheritedDuotone = decodeValue( inheritedValue?.filter?.duotone );
 	const duotone = localDuotone ?? inheritedDuotone;
+	// Read from the raw value, since decoding resolves a preset reference to
+	// its colors and two presets can hold the same pair.
+	const localDuotoneSlug = getDuotoneSlugFromPreset( value?.filter?.duotone );
+	const inheritedDuotoneSlug = getDuotoneSlugFromPreset(
+		inheritedValue?.filter?.duotone
+	);
+	const duotoneSlug =
+		localDuotone !== undefined ? localDuotoneSlug : inheritedDuotoneSlug;
 	const isDuotonePlaceholder =
 		localDuotone === undefined && inheritedDuotone !== undefined;
-	const setDuotone = ( newValue ) => {
-		const duotonePreset = duotonePalette.find( ( { colors } ) => {
-			return colors === newValue;
-		} );
-		const duotoneValue = duotonePreset
-			? `var:preset|duotone|${ duotonePreset.slug }`
+	const setDuotone = ( newValue, slug ) => {
+		// A slug identifies the picked preset exactly. Falling back to a value
+		// match cannot tell two presets holding the same colors apart.
+		const presetSlug =
+			slug ??
+			duotonePalette.find( ( { colors } ) => colors === newValue )?.slug;
+		const duotoneValue = presetSlug
+			? `var:preset|duotone|${ presetSlug }`
 			: newValue;
 		onChange(
 			setImmutably( value, [ 'filter', 'duotone' ], duotoneValue )
@@ -217,16 +230,16 @@ export default function FiltersPanel( {
 	};
 	// Commit the inherited value when the user clicks the active preset
 	// while the picker is showing inherited duotone at rest.
-	const setDuotoneWithInheritedCommit = ( newValue ) => {
+	const setDuotoneWithInheritedCommit = ( newValue, index, slug ) => {
 		if (
 			newValue === undefined &&
 			isDuotonePlaceholder &&
 			inheritedDuotone !== undefined
 		) {
-			setDuotone( inheritedDuotone );
+			setDuotone( inheritedDuotone, inheritedDuotoneSlug );
 			return;
 		}
-		setDuotone( newValue );
+		setDuotone( newValue, slug );
 	};
 	const hasDuotone = () => !! value?.filter?.duotone;
 	const resetDuotone = () => setDuotone( undefined );
@@ -292,6 +305,7 @@ export default function FiltersPanel( {
 										disableCustomColors
 										disableCustomDuotone
 										value={ duotone }
+										selectedSlug={ duotoneSlug }
 										onChange={
 											setDuotoneWithInheritedCommit
 										}

--- a/packages/block-editor/src/components/global-styles/test/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/test/filters-panel.js
@@ -185,3 +185,87 @@ describe( 'FiltersPanel — visual treatment and display-without-commit', () => 
 		expect( onChange ).not.toHaveBeenCalled();
 	} );
 } );
+
+// Adding two custom duotones in Global Styles seeds both from the palette's
+// darkest and lightest colors, so duplicates are the ordinary case. Only the
+// slug tells them apart.
+const duplicateSettings = {
+	color: {
+		customDuotone: true,
+		defaultDuotone: true,
+		duotone: {
+			custom: [
+				{
+					name: 'Duotone 1',
+					slug: 'custom-duotone-1',
+					colors: [ '#000000', '#ffffff' ],
+				},
+				{
+					name: 'Duotone 2',
+					slug: 'custom-duotone-2',
+					colors: [ '#000000', '#ffffff' ],
+				},
+			],
+		},
+		palette: {
+			default: [
+				{ name: 'Black', slug: 'black', color: '#000000' },
+				{ name: 'White', slug: 'white', color: '#ffffff' },
+			],
+		},
+	},
+};
+
+async function openDuotone( user ) {
+	await user.click( screen.getByRole( 'button', { name: /duotone/i } ) );
+}
+
+describe( 'FiltersPanel — duplicate duotone presets', () => {
+	it( 'marks only the stored preset as selected', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<FiltersPanel
+				value={ {
+					filter: { duotone: 'var:preset|duotone|custom-duotone-2' },
+				} }
+				inheritedValue={ {} }
+				settings={ duplicateSettings }
+				onChange={ () => {} }
+				panelId="test-panel"
+			/>
+		);
+		await openDuotone( user );
+
+		expect(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 1' } )
+		).toHaveAttribute( 'aria-selected', 'false' );
+		expect(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 2' } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+	} );
+
+	it( 'saves the slug of the preset that was picked', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<FiltersPanel
+				value={ {} }
+				inheritedValue={ {} }
+				settings={ duplicateSettings }
+				onChange={ onChange }
+				panelId="test-panel"
+			/>
+		);
+		await openDuotone( user );
+
+		await user.click(
+			screen.getByRole( 'option', { name: 'Duotone: Duotone 2' } )
+		);
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			filter: { duotone: 'var:preset|duotone|custom-duotone-2' },
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/test/utils.js
+++ b/packages/block-editor/src/components/global-styles/test/utils.js
@@ -1,0 +1,30 @@
+import { getDuotoneSlugFromPreset } from '../utils';
+
+describe( 'global styles utils', () => {
+	describe( 'getDuotoneSlugFromPreset', () => {
+		it( 'should return the slug of a preset reference', () => {
+			expect(
+				getDuotoneSlugFromPreset( 'var:preset|duotone|grayscale' )
+			).toBe( 'grayscale' );
+		} );
+
+		it( 'should return the slug of a custom preset', () => {
+			expect(
+				getDuotoneSlugFromPreset(
+					'var:preset|duotone|custom-duotone-2'
+				)
+			).toBe( 'custom-duotone-2' );
+		} );
+
+		it( 'should return undefined for custom colors', () => {
+			expect(
+				getDuotoneSlugFromPreset( [ '#000000', '#ffffff' ] )
+			).toBeUndefined();
+		} );
+
+		it( 'should return undefined for unset and for no value', () => {
+			expect( getDuotoneSlugFromPreset( 'unset' ) ).toBeUndefined();
+			expect( getDuotoneSlugFromPreset( undefined ) ).toBeUndefined();
+		} );
+	} );
+} );

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -47,3 +47,26 @@ export function scopeSelector( scope, selector ) {
 
 	return selectorsScoped.join( ', ' );
 }
+
+/**
+ * Reads the preset slug out of a duotone style value.
+ *
+ * Two presets can hold the same pair of colors, so the slug is the only thing
+ * that identifies which one is applied. The colors alone do not.
+ *
+ * Lives here rather than beside its siblings in `hooks/duotone` because that
+ * module imports the filters panel, so the panel cannot import back from it.
+ *
+ * @param {string|string[]|undefined} duotone A duotone style value.
+ *
+ * @return {string|undefined} The preset slug, if the value references one.
+ */
+export function getDuotoneSlugFromPreset( duotone ) {
+	if ( typeof duotone !== 'string' ) {
+		return undefined;
+	}
+
+	const [ , slug ] = duotone.match( /^var:preset\|duotone\|(.+)$/ ) ?? [];
+
+	return slug;
+}

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -19,7 +19,10 @@ import {
 	__experimentalDuotoneControl as DuotoneControl,
 	useSettings,
 } from '../components';
-import { scopeSelector } from '../components/global-styles/utils';
+import {
+	scopeSelector,
+	getDuotoneSlugFromPreset,
+} from '../components/global-styles/utils';
 import {
 	cleanEmptyObject,
 	useBlockSettings,
@@ -141,8 +144,13 @@ function DuotonePanelPure( { style, setAttributes, name, clientId } ) {
 		<>
 			<InspectorControls group="filter">
 				<StylesFiltersPanel
+					// The raw value, not the resolved colors. The panel
+					// decodes it for display, but needs the preset reference
+					// to know which preset is applied: two presets can hold
+					// the same pair of colors, and resolving first throws the
+					// slug away.
 					value={ {
-						filter: { duotone: duotonePresetOrColors },
+						filter: { duotone: duotoneStyle },
 					} }
 					onChange={ ( newDuotone ) => {
 						const newStyle = {
@@ -166,11 +174,19 @@ function DuotonePanelPure( { style, setAttributes, name, clientId } ) {
 					disableCustomDuotone={ disableCustomDuotone }
 					disableCustomColors={ disableCustomColors }
 					value={ duotonePresetOrColors }
-					onChange={ ( newDuotone ) => {
-						const maybePreset = getDuotonePresetFromColors(
-							newDuotone,
-							duotonePalette
-						);
+					selectedSlug={ getDuotoneSlugFromPreset( duotoneStyle ) }
+					onChange={ ( newDuotone, index, slug ) => {
+						// A slug means a preset was picked out of the palette,
+						// so it identifies the choice exactly. Matching back by
+						// color would resolve to whichever preset holding those
+						// colors comes first, which is the wrong one whenever
+						// two presets share a pair.
+						const maybePreset = slug
+							? `var:preset|duotone|${ slug }`
+							: getDuotonePresetFromColors(
+									newDuotone,
+									duotonePalette
+							  );
 
 						const newStyle = {
 							...style,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Enhancements
 
+-   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER)).
 -   `TextControl`, `TextareaControl`, `FormTokenField`, `ContentEditableControl`, `ComboboxControl`: Align focus and hover styles with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Align focus rings with the design system ([#80417](https://github.com/WordPress/gutenberg/pull/80417)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 
+-   `DuotonePicker`: Do not render the custom controls wrapper when `disableCustomDuotone` is set, so a read-only picker no longer adds trailing padding below its swatches ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
--   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
+-   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered, and the rest are normalized to hex, since the front end's duotone parser does not accept CSS named colors ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `DuotonePicker`: Pass the picked preset's index and slug to `onChange`, alongside its colors. Two presets can hold the same pair of colors, so the value alone does not identify which one was picked ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `TextControl`, `TextareaControl`, `FormTokenField`, `ContentEditableControl`, `ComboboxControl`: Align focus and hover styles with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Align focus rings with the design system ([#80417](https://github.com/WordPress/gutenberg/pull/80417)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Enhancements
 
 -   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered, and the rest are normalized to hex, since the front end's duotone parser does not accept CSS named colors ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
--   `DuotonePicker`: Pass the picked preset's index and slug to `onChange`, alongside its colors. Two presets can hold the same pair of colors, so the value alone does not identify which one was picked ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
+-   `DuotonePicker`: Add `selectedSlug` prop for slug-based selection and pass the picked preset's index and slug to `onChange`, so two presets sharing a pair of colors keep their identity ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
+-   `PaletteEdit`: Name the swatch picker after the palette's heading, so it is announced as Theme, Default or Custom rather than an unlabelled list ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `TextControl`, `TextareaControl`, `FormTokenField`, `ContentEditableControl`, `ComboboxControl`: Align focus and hover styles with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Align focus rings with the design system ([#80417](https://github.com/WordPress/gutenberg/pull/80417)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements
 
 -   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
+-   `DuotonePicker`: Pass the picked preset's index and slug to `onChange`, alongside its colors. Two presets can hold the same pair of colors, so the value alone does not identify which one was picked ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `TextControl`, `TextareaControl`, `FormTokenField`, `ContentEditableControl`, `ComboboxControl`: Align focus and hover styles with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Align focus rings with the design system ([#80417](https://github.com/WordPress/gutenberg/pull/80417)).
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
--   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER)).
+-   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `TextControl`, `TextareaControl`, `FormTokenField`, `ContentEditableControl`, `ComboboxControl`: Align focus and hover styles with the design system ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   `InputControl`, `SelectControl`, `CustomSelectControl`: Align focus rings with the design system ([#80417](https://github.com/WordPress/gutenberg/pull/80417)).
 

--- a/packages/components/src/duotone-picker/README.md
+++ b/packages/components/src/duotone-picker/README.md
@@ -71,7 +71,9 @@ An empty string is treated the same as `undefined`: selection falls back to matc
 -   Type: `(value: string[] | 'unset' | undefined, index?: number | undefined, slug?: string | undefined) => void`
 -   Required: Yes
 
-The function called when the duotone colors change. It is passed the new `value` as an argument. When a preset from `duotonePalette` is picked, the second argument is its index and the third is its slug. Both are omitted for the custom, unset and clear controls, which do not correspond to a preset.
+The function called when the duotone colors change. It is passed the new `value` as an argument. When a preset from `duotonePalette` is picked, the second argument is its index and the third is its slug.
+
+Both are omitted whenever no preset is being picked: the custom, unset and clear controls, and deselecting the currently selected preset, which reports `undefined` alone.
 
 ### `asButtons`: `boolean`
 

--- a/packages/components/src/duotone-picker/README.md
+++ b/packages/components/src/duotone-picker/README.md
@@ -57,12 +57,21 @@ Array of duotone presets of the form `{ colors: [ '#000000', '#ffffff' ], name: 
 
 An array of colors for the duotone effect.
 
+### `selectedSlug`
+
+-   Type: `string`
+-   Required: No
+
+The slug of the selected duotone preset. When a non-empty `selectedSlug` is given, selection is decided strictly by slug, which keeps two presets holding the same pair of colors apart. Presets whose slug does not match will not appear selected in this mode, even if their colors match `value`.
+
+An empty string is treated the same as `undefined`: selection falls back to matching by color value.
+
 ### `onChange`
 
--   Type: `Function`
+-   Type: `(value: string[] | 'unset' | undefined, index?: number | undefined, slug?: string | undefined) => void`
 -   Required: Yes
 
-Callback which is called when the duotone colors change.
+The function called when the duotone colors change. It is passed the new `value` as an argument. When a preset from `duotonePalette` is picked, the second argument is its index and the third is its slug. Both are omitted for the custom, unset and clear controls, which do not correspond to a preset.
 
 ### `asButtons`: `boolean`
 

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -161,15 +161,17 @@ function DuotonePicker( {
 				)
 			}
 		>
-			<Spacer paddingTop={ options.length === 0 ? 0 : 4 }>
-				<VStack spacing={ 3 }>
-					{ ! disableCustomColors && ! disableCustomDuotone && (
-						<CustomDuotoneBar
-							value={ isUnset ? undefined : value }
-							onChange={ onChange }
-						/>
-					) }
-					{ ! disableCustomDuotone && (
+			{ /* Both controls are hidden when custom duotones are disabled,
+			   so the wrapper would contribute only its padding. */ }
+			{ ! disableCustomDuotone && (
+				<Spacer paddingTop={ options.length === 0 ? 0 : 4 }>
+					<VStack spacing={ 3 }>
+						{ ! disableCustomColors && (
+							<CustomDuotoneBar
+								value={ isUnset ? undefined : value }
+								onChange={ onChange }
+							/>
+						) }
 						<ColorListPicker
 							labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
 							colors={ colorPalette }
@@ -193,9 +195,9 @@ function DuotonePicker( {
 								onChange( newValue );
 							} }
 						/>
-					) }
-				</VStack>
-			</Spacer>
+					</VStack>
+				</Spacer>
+			) }
 		</CircularOptionPicker>
 	);
 }

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -54,6 +54,7 @@ function DuotonePicker( {
 	disableCustomColors,
 	disableCustomDuotone,
 	value,
+	selectedSlug,
 	onChange,
 	'aria-label': ariaLabel,
 	'aria-labelledby': ariaLabelledby,
@@ -101,7 +102,13 @@ function DuotonePicker( {
 						name
 				  )
 				: tooltipText;
-			const isSelected = fastDeepEqual( colors, value );
+			// When a non-empty selectedSlug is provided, selection is decided
+			// strictly by slug, which keeps two presets holding the same
+			// colors apart. Otherwise selection falls back to matching the
+			// colors themselves.
+			const isSelected = selectedSlug
+				? slug === selectedSlug
+				: fastDeepEqual( colors, value );
 
 			return (
 				<CircularOptionPicker.Option

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -118,13 +118,15 @@ function DuotonePicker( {
 					aria-label={ label }
 					tooltipText={ tooltipText }
 					style={ style }
-					onClick={ () => {
-						onChange(
-							isSelected ? undefined : colors,
-							index,
-							slug
-						);
-					} }
+					onClick={
+						// Deselecting reports no preset, matching
+						// `ColorPalette` and `GradientPicker`. Passing the slug
+						// back would leave a controlled consumer marking the
+						// swatch as selected after its value had been cleared.
+						isSelected
+							? () => onChange( undefined )
+							: () => onChange( colors, index, slug )
+					}
 				/>
 			);
 		}

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -81,41 +81,47 @@ function DuotonePicker( {
 		/>
 	);
 
-	const duotoneOptions = duotonePalette.map( ( { colors, slug, name } ) => {
-		const style = {
-			background: getGradientFromCSSColors( colors, '135deg' ),
-			color: 'transparent',
-		};
-		const tooltipText =
-			name ??
-			sprintf(
-				// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
-				__( 'Duotone code: %s' ),
-				slug
-			);
-		const label = name
-			? sprintf(
-					// translators: %s: The name of the option e.g: "Dark grayscale".
-					__( 'Duotone: %s' ),
-					name
-			  )
-			: tooltipText;
-		const isSelected = fastDeepEqual( colors, value );
+	const duotoneOptions = duotonePalette.map(
+		( { colors, slug, name }, index ) => {
+			const style = {
+				background: getGradientFromCSSColors( colors, '135deg' ),
+				color: 'transparent',
+			};
+			const tooltipText =
+				name ??
+				sprintf(
+					// translators: %s: duotone code e.g: "dark-grayscale" or "7f7f7f-ffffff".
+					__( 'Duotone code: %s' ),
+					slug
+				);
+			const label = name
+				? sprintf(
+						// translators: %s: The name of the option e.g: "Dark grayscale".
+						__( 'Duotone: %s' ),
+						name
+				  )
+				: tooltipText;
+			const isSelected = fastDeepEqual( colors, value );
 
-		return (
-			<CircularOptionPicker.Option
-				key={ slug }
-				value={ colors }
-				isSelected={ isSelected }
-				aria-label={ label }
-				tooltipText={ tooltipText }
-				style={ style }
-				onClick={ () => {
-					onChange( isSelected ? undefined : colors );
-				} }
-			/>
-		);
-	} );
+			return (
+				<CircularOptionPicker.Option
+					key={ slug }
+					value={ colors }
+					isSelected={ isSelected }
+					aria-label={ label }
+					tooltipText={ tooltipText }
+					style={ style }
+					onClick={ () => {
+						onChange(
+							isSelected ? undefined : colors,
+							index,
+							slug
+						);
+					} }
+				/>
+			);
+		}
+	);
 
 	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
 		asButtons,

--- a/packages/components/src/duotone-picker/stories/duotone-picker.story.tsx
+++ b/packages/components/src/duotone-picker/stories/duotone-picker.story.tsx
@@ -47,9 +47,9 @@ const Template: StoryFn< typeof DuotonePicker > = ( { onChange, ...args } ) => {
 	return (
 		<DuotonePicker
 			{ ...args }
-			onChange={ ( ...changeArgs ) => {
-				setValue( ...changeArgs );
-				onChange( ...changeArgs );
+			onChange={ ( newValue, ...rest ) => {
+				setValue( newValue );
+				onChange( newValue, ...rest );
 			} }
 			value={ value }
 		/>

--- a/packages/components/src/duotone-picker/stories/duotone-picker.story.tsx
+++ b/packages/components/src/duotone-picker/stories/duotone-picker.story.tsx
@@ -1,13 +1,16 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 import { useState } from '@wordpress/element';
 import { DuotonePicker } from '..';
-import type { DuotonePickerProps } from '../types';
 
 const meta: Meta< typeof DuotonePicker > = {
 	title: 'Components/DuotonePicker',
 	component: DuotonePicker,
+	args: {
+		onChange: fn(),
+	},
 	argTypes: {
-		onChange: { action: 'onChange' },
+		selectedSlug: { control: false },
 		value: { control: false },
 	},
 	parameters: {
@@ -20,6 +23,8 @@ const meta: Meta< typeof DuotonePicker > = {
 	},
 };
 export default meta;
+
+type DuotonePickerStory = StoryObj< typeof DuotonePicker >;
 
 const DUOTONE_PALETTE = [
 	{
@@ -34,6 +39,22 @@ const DUOTONE_PALETTE = [
 	},
 ];
 
+// Two presets holding the same colors. Adding duotones with the `+` button in
+// the Global Styles palette editor seeds each one from the palette's darkest
+// and lightest colors, so this is the normal case rather than a contrived one.
+const DUPLICATE_DUOTONE_PALETTE = [
+	{
+		colors: [ '#000000', '#ffffff' ],
+		name: 'Dark background',
+		slug: 'dark-background',
+	},
+	{
+		colors: [ '#000000', '#ffffff' ],
+		name: 'Dark text',
+		slug: 'dark-text',
+	},
+];
+
 const COLOR_PALETTE = [
 	{ color: '#ff4747', name: 'Red', slug: 'red' },
 	{ color: '#fcff41', name: 'Yellow', slug: 'yellow' },
@@ -41,23 +62,50 @@ const COLOR_PALETTE = [
 	{ color: '#8c00b7', name: 'Purple', slug: 'purple' },
 ];
 
-const Template: StoryFn< typeof DuotonePicker > = ( { onChange, ...args } ) => {
-	const [ value, setValue ] = useState< DuotonePickerProps[ 'value' ] >();
-
+const Template = ( {
+	onChange,
+	value,
+	selectedSlug,
+	...props
+}: React.ComponentProps< typeof DuotonePicker > ) => {
+	const [ duotone, setDuotone ] =
+		useState< React.ComponentProps< typeof DuotonePicker >[ 'value' ] >(
+			value
+		);
+	const [ slug, setSlug ] = useState< string | undefined >( selectedSlug );
 	return (
 		<DuotonePicker
-			{ ...args }
-			onChange={ ( newValue, ...rest ) => {
-				setValue( newValue );
-				onChange( newValue, ...rest );
+			{ ...props }
+			value={ duotone }
+			selectedSlug={ slug }
+			onChange={ ( newValue, index, newSlug ) => {
+				setDuotone( newValue );
+				setSlug( newSlug );
+				onChange?.( newValue, index, newSlug );
 			} }
-			value={ value }
 		/>
 	);
 };
 
-export const Default = Template.bind( {} );
-Default.args = {
-	colorPalette: COLOR_PALETTE,
-	duotonePalette: DUOTONE_PALETTE,
+export const Default: DuotonePickerStory = {
+	render: Template,
+	args: {
+		colorPalette: COLOR_PALETTE,
+		duotonePalette: DUOTONE_PALETTE,
+	},
+};
+
+export const DuplicateDuotones: DuotonePickerStory = {
+	render: Template,
+	args: {
+		colorPalette: COLOR_PALETTE,
+		duotonePalette: DUPLICATE_DUOTONE_PALETTE,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Two presets can hold the same pair of colors. Selection is tracked by slug, so picking one marks only that preset rather than both.',
+			},
+		},
+	},
 };

--- a/packages/components/src/duotone-picker/test/index.tsx
+++ b/packages/components/src/duotone-picker/test/index.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from '@wordpress/element';
 import { DuotonePicker } from '..';
+import type { DuotonePickerProps } from '../types';
 
 const COLORS_A = [ '#000000', '#ffffff' ];
 const COLORS_B = [ '#8c00b7', '#fcff41' ];
@@ -152,6 +154,78 @@ describe( 'DuotonePicker', () => {
 				0,
 				'dark-background'
 			);
+		} );
+	} );
+
+	describe( 'controlled usage', () => {
+		// Mirrors how a consumer wires the picker up: value and slug both held
+		// in state and fed back in.
+		function Controlled( {
+			duotonePalette,
+		}: Pick< DuotonePickerProps, 'duotonePalette' > ) {
+			const [ value, setValue ] =
+				useState< DuotonePickerProps[ 'value' ] >();
+			const [ slug, setSlug ] = useState< string | undefined >();
+			return (
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ duotonePalette }
+					colorPalette={ COLOR_PALETTE }
+					value={ value }
+					selectedSlug={ slug }
+					onChange={ ( newValue, index, newSlug ) => {
+						setValue( newValue );
+						setSlug( newSlug );
+					} }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+		}
+
+		it( 'should clear both the value and the selected state when the selected preset is clicked again', async () => {
+			const user = userEvent.setup();
+			render( <Controlled duotonePalette={ DUPLICATE_DUOTONES } /> );
+
+			const option = () =>
+				screen.getByRole( 'option', { name: 'Duotone: Dark Text' } );
+
+			await user.click( option() );
+			expect( option() ).toHaveAttribute( 'aria-selected', 'true' );
+
+			// Clicking it again deselects. If the slug were reported back on
+			// deselection, the swatch would stay selected with no value.
+			await user.click( option() );
+			expect( option() ).toHaveAttribute( 'aria-selected', 'false' );
+			expect(
+				screen.getByRole( 'option', {
+					name: 'Duotone: Dark Background',
+				} )
+			).toHaveAttribute( 'aria-selected', 'false' );
+		} );
+
+		it( 'should move the selection when a different preset is clicked', async () => {
+			const user = userEvent.setup();
+			render( <Controlled duotonePalette={ DUPLICATE_DUOTONES } /> );
+
+			await user.click(
+				screen.getByRole( 'option', { name: 'Duotone: Dark Text' } )
+			);
+			await user.click(
+				screen.getByRole( 'option', {
+					name: 'Duotone: Dark Background',
+				} )
+			);
+
+			expect(
+				screen.getByRole( 'option', {
+					name: 'Duotone: Dark Background',
+				} )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			expect(
+				screen.getByRole( 'option', { name: 'Duotone: Dark Text' } )
+			).toHaveAttribute( 'aria-selected', 'false' );
 		} );
 	} );
 

--- a/packages/components/src/duotone-picker/test/index.tsx
+++ b/packages/components/src/duotone-picker/test/index.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DuotonePicker } from '..';
+
+const COLORS_A = [ '#000000', '#ffffff' ];
+const COLORS_B = [ '#8c00b7', '#fcff41' ];
+
+// Adding two duotones with the `+` button in the Global Styles palette editor
+// seeds both from the palette's darkest and lightest colors, so two presets
+// holding the same pair is the normal case rather than a contrived one.
+const DUPLICATE_DUOTONES = [
+	{ name: 'Dark Background', slug: 'dark-background', colors: COLORS_A },
+	{ name: 'Dark Text', slug: 'dark-text', colors: COLORS_A },
+];
+
+const COLOR_PALETTE = [
+	{ color: '#000000', name: 'Black', slug: 'black' },
+	{ color: '#ffffff', name: 'White', slug: 'white' },
+];
+
+describe( 'DuotonePicker', () => {
+	describe( 'duplicate duotones in palette', () => {
+		it( 'should render all swatches even when two entries share the same colors', () => {
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ DUPLICATE_DUOTONES }
+					colorPalette={ COLOR_PALETTE }
+					value={ undefined }
+					onChange={ jest.fn() }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			expect( screen.getAllByRole( 'option' ) ).toHaveLength( 3 );
+		} );
+
+		it( 'should select by slug when selectedSlug is provided, marking only the matching entry', () => {
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ DUPLICATE_DUOTONES }
+					colorPalette={ COLOR_PALETTE }
+					value={ COLORS_A }
+					selectedSlug="dark-text"
+					onChange={ jest.fn() }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			// "dark-background" is index 0, "dark-text" is index 1.
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		it( 'should fall back to value selection and mark all matching duplicates when no selectedSlug is provided', () => {
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ DUPLICATE_DUOTONES }
+					colorPalette={ COLOR_PALETTE }
+					value={ COLORS_A }
+					onChange={ jest.fn() }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		it( 'should treat an empty-string selectedSlug as no slug and fall back to value selection', () => {
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ DUPLICATE_DUOTONES }
+					colorPalette={ COLOR_PALETTE }
+					value={ COLORS_A }
+					selectedSlug=""
+					onChange={ jest.fn() }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+
+		it( 'should pass index and slug to onChange when a swatch is clicked', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ DUPLICATE_DUOTONES }
+					colorPalette={ COLOR_PALETTE }
+					value={ undefined }
+					onChange={ onChange }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'option', { name: 'Duotone: Dark Text' } )
+			);
+
+			expect( onChange ).toHaveBeenCalledWith( COLORS_A, 1, 'dark-text' );
+		} );
+
+		it( 'should clear only the selected preset, identified by slug', async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
+
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ DUPLICATE_DUOTONES }
+					colorPalette={ COLOR_PALETTE }
+					value={ COLORS_A }
+					selectedSlug="dark-text"
+					onChange={ onChange }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			// The unselected twin must still report its own identity rather
+			// than clearing, which is what happens when selection is decided
+			// by color alone.
+			await user.click(
+				screen.getByRole( 'option', {
+					name: 'Duotone: Dark Background',
+				} )
+			);
+
+			expect( onChange ).toHaveBeenCalledWith(
+				COLORS_A,
+				0,
+				'dark-background'
+			);
+		} );
+	} );
+
+	describe( 'distinct duotones', () => {
+		it( 'should mark the preset matching value as selected', () => {
+			render(
+				<DuotonePicker
+					aria-label="Duotone"
+					duotonePalette={ [
+						{ name: 'A', slug: 'a', colors: COLORS_A },
+						{ name: 'B', slug: 'b', colors: COLORS_B },
+					] }
+					colorPalette={ COLOR_PALETTE }
+					value={ COLORS_B }
+					onChange={ jest.fn() }
+					unsetable={ false }
+					disableCustomDuotone
+					disableCustomColors
+				/>
+			);
+
+			const options = screen.getAllByRole( 'option' );
+			expect( options[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( options[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+	} );
+} );

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -52,8 +52,11 @@ export type DuotonePickerProps = {
 	 * When the change comes from picking a preset out of `duotonePalette`, the
 	 * preset's index and slug are passed too. Two presets can hold the same
 	 * pair of colors, so the value alone does not identify which one was
-	 * picked. Both are omitted for the custom, unset and clear controls, which
-	 * do not correspond to a preset.
+	 * picked.
+	 *
+	 * Both are omitted whenever no preset is being picked: the custom, unset
+	 * and clear controls, and deselecting the currently selected preset, which
+	 * reports `undefined` alone.
 	 */
 	onChange: (
 		value: DuotonePickerProps[ 'value' ] | undefined,

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -36,6 +36,17 @@ export type DuotonePickerProps = {
 	 */
 	value?: string[] | 'unset';
 	/**
+	 * The slug of the selected duotone preset. When a non-empty `selectedSlug`
+	 * is provided, selection is decided strictly by slug, which keeps two
+	 * presets holding the same pair of colors apart. Presets whose slug does
+	 * not match will not appear selected in this mode, even if their colors
+	 * match `value`.
+	 *
+	 * An empty string is treated the same as `undefined`: selection falls back
+	 * to matching by color value.
+	 */
+	selectedSlug?: string;
+	/**
 	 * Callback which is called when the duotone colors change.
 	 *
 	 * When the change comes from picking a preset out of `duotonePalette`, the

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -37,8 +37,18 @@ export type DuotonePickerProps = {
 	value?: string[] | 'unset';
 	/**
 	 * Callback which is called when the duotone colors change.
+	 *
+	 * When the change comes from picking a preset out of `duotonePalette`, the
+	 * preset's index and slug are passed too. Two presets can hold the same
+	 * pair of colors, so the value alone does not identify which one was
+	 * picked. Both are omitted for the custom, unset and clear controls, which
+	 * do not correspond to a preset.
 	 */
-	onChange: ( value: DuotonePickerProps[ 'value' ] | undefined ) => void;
+	onChange: (
+		value: DuotonePickerProps[ 'value' ] | undefined,
+		index?: number,
+		slug?: string
+	) => void;
 	/**
 	 * Whether the control should present as a set of buttons,
 	 * each with its own tab stop.

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -1,4 +1,6 @@
 import clsx from 'clsx';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
 import {
 	useState,
 	useRef,
@@ -18,6 +20,13 @@ import { Item, ItemGroup } from '../item-group';
 import { VStack } from '../v-stack';
 import GradientPicker from '../gradient-picker';
 import ColorPalette from '../color-palette';
+import { DuotonePicker } from '../duotone-picker';
+import ColorListPicker from '../duotone-picker/color-list-picker';
+import CustomDuotoneBar from '../duotone-picker/custom-duotone-bar';
+import {
+	getDefaultColors,
+	getGradientFromCSSColors,
+} from '../duotone-picker/utils';
 import DropdownMenu from '../dropdown-menu';
 import Popover from '../popover';
 import {
@@ -37,14 +46,172 @@ import CustomGradientPicker from '../custom-gradient-picker';
 import type {
 	Color,
 	ColorPickerPopoverProps,
+	Duotone,
 	NameInputProps,
 	OptionProps,
 	PaletteEditListViewProps,
 	PaletteEditProps,
 	PaletteElement,
+	PaletteVariant,
 } from './types';
 
+extend( [ namesPlugin ] );
+
 const DEFAULT_COLOR = '#000';
+
+/**
+ * Filters a color palette down to the colors a duotone can actually be built
+ * from. Duotone values are turned into SVG filter matrices, so each color has
+ * to resolve to a concrete value. A theme palette may legitimately contain CSS
+ * that does not, such as `color-mix()` or `currentColor` — Twenty Twenty-Five
+ * ships one — and picking such a color would produce a duotone that neither the
+ * editor nor the front end can render.
+ *
+ * @param colorPalette The colors to filter.
+ *
+ * @return The colors usable in a duotone.
+ */
+function getUsableDuotoneColors( colorPalette: Color[] = [] ) {
+	return colorPalette.filter(
+		( { color } ) => typeof color === 'string' && colord( color ).isValid()
+	);
+}
+
+/**
+ * Reads the colors off a duotone element. Duotone presets can come from a
+ * theme's `theme.json`, so the value is not guaranteed to be an array.
+ *
+ * @param element The palette element.
+ *
+ * @return The duotone's colors, or an empty array if it has none usable.
+ */
+function getDuotoneColors( element: PaletteElement | undefined ) {
+	const colors = ( element as Duotone | undefined )?.colors;
+	return Array.isArray( colors ) ? colors : [];
+}
+
+/**
+ * Returns the single CSS value that represents a palette element, used both for
+ * its swatch and for the labels that refer to it. Duotones have two colors, so
+ * they are represented by the same gradient the duotone swatches use.
+ *
+ * @param element The palette element.
+ * @param variant The kind of preset being edited.
+ *
+ * @return A CSS color or gradient string.
+ */
+function getElementValue(
+	element: PaletteElement | undefined,
+	variant: PaletteVariant
+) {
+	if ( ! element ) {
+		return undefined;
+	}
+	switch ( variant ) {
+		case 'duotone':
+			return getGradientFromCSSColors(
+				getDuotoneColors( element ),
+				'135deg'
+			);
+		case 'gradient':
+			return element.gradient;
+		default:
+			return element.color;
+	}
+}
+
+/**
+ * Returns the hidden label for the name input of a palette element.
+ *
+ * @param variant The kind of preset being edited.
+ */
+function getNameInputLabel( variant: PaletteVariant ) {
+	switch ( variant ) {
+		case 'duotone':
+			return __( 'Duotone name' );
+		case 'gradient':
+			return __( 'Gradient name' );
+		default:
+			return __( 'Color name' );
+	}
+}
+
+/**
+ * Returns the `sprintf` format string for the remove button label.
+ *
+ * @param variant The kind of preset being edited.
+ */
+function getRemoveLabelFormat( variant: PaletteVariant ) {
+	return variant === 'duotone'
+		? /* translators: %s is a duotone name, e.g. "Purple and yellow". */
+		  __( 'Remove duotone: %s' )
+		: /* translators: %s is a color or gradient name, e.g. "Red". */
+		  __( 'Remove color: %s' );
+}
+
+/**
+ * Returns the label for the button that adds a new palette element.
+ *
+ * @param variant The kind of preset being edited.
+ */
+function getAddLabel( variant: PaletteVariant ) {
+	switch ( variant ) {
+		case 'duotone':
+			return __( 'Add duotone' );
+		case 'gradient':
+			return __( 'Add gradient' );
+		default:
+			return __( 'Add color' );
+	}
+}
+
+/**
+ * Returns the label for the palette's options menu.
+ *
+ * @param variant The kind of preset being edited.
+ */
+function getOptionsLabel( variant: PaletteVariant ) {
+	switch ( variant ) {
+		case 'duotone':
+			return __( 'Duotone options' );
+		case 'gradient':
+			return __( 'Gradient options' );
+		default:
+			return __( 'Color options' );
+	}
+}
+
+/**
+ * Returns the label for the menu item that empties the palette.
+ *
+ * @param variant The kind of preset being edited.
+ */
+function getRemoveAllLabel( variant: PaletteVariant ) {
+	switch ( variant ) {
+		case 'duotone':
+			return __( 'Remove all duotones' );
+		case 'gradient':
+			return __( 'Remove all gradients' );
+		default:
+			return __( 'Remove all colors' );
+	}
+}
+
+/**
+ * Returns the label for the menu item that resets the palette.
+ *
+ * @param variant The kind of preset being edited.
+ */
+function getResetLabel( variant: PaletteVariant ) {
+	switch ( variant ) {
+		case 'duotone':
+			return __( 'Reset duotones' );
+		case 'gradient':
+			return __( 'Reset gradient' );
+		default:
+			return __( 'Reset colors' );
+	}
+}
 
 function NameInput( { value, onChange, label }: NameInputProps ) {
 	return (
@@ -88,14 +255,19 @@ export function deduplicateElementSlugs< T extends PaletteElement >(
  *
  * @param elements   An array of color palette items.
  * @param slugPrefix The slug prefix used to match the element slug.
+ * @param variant    The kind of preset being edited. Duotones are named
+ *                   "Duotone + id" and slugged with a `duotone-` stem;
+ *                   colors and gradients both use `color-`.
  *
  * @return A name and slug for the new palette item.
  */
 export function getNameAndSlugForPosition(
 	elements: PaletteElement[],
-	slugPrefix: string
+	slugPrefix: string,
+	variant: PaletteVariant = 'color'
 ) {
-	const nameRegex = new RegExp( `^${ slugPrefix }color-([\\d]+)$` );
+	const stem = variant === 'duotone' ? 'duotone' : 'color';
+	const nameRegex = new RegExp( `^${ slugPrefix }${ stem }-([\\d]+)$` );
 	const position = elements.reduce( ( previousValue, currentValue ) => {
 		if ( typeof currentValue?.slug === 'string' ) {
 			const matches = currentValue?.slug.match( nameRegex );
@@ -110,17 +282,25 @@ export function getNameAndSlugForPosition(
 	}, 1 );
 
 	return {
-		name: sprintf(
-			/* translators: %d: is an id for a custom color */
-			__( 'Color %d' ),
-			position
-		),
-		slug: `${ slugPrefix }color-${ position }`,
+		name:
+			variant === 'duotone'
+				? sprintf(
+						/* translators: %d: is an id for a custom duotone */
+						__( 'Duotone %d' ),
+						position
+				  )
+				: sprintf(
+						/* translators: %d: is an id for a custom color */
+						__( 'Color %d' ),
+						position
+				  ),
+		slug: `${ slugPrefix }${ stem }-${ position }`,
 	};
 }
 
 function ColorPickerPopover< T extends PaletteElement >( {
-	isGradient,
+	variant,
+	colorPalette,
 	element,
 	onChange,
 	popoverProps: receivedPopoverProps,
@@ -147,7 +327,7 @@ function ColorPickerPopover< T extends PaletteElement >( {
 
 	return (
 		<Popover { ...popoverProps } onClose={ onClose }>
-			{ ! isGradient && (
+			{ variant === 'color' && (
 				<ColorPicker
 					color={ element.color }
 					enableAlpha
@@ -159,7 +339,7 @@ function ColorPickerPopover< T extends PaletteElement >( {
 					} }
 				/>
 			) }
-			{ isGradient && (
+			{ variant === 'gradient' && (
 				<div className="components-palette-edit__popover-gradient-picker">
 					<CustomGradientPicker
 						__experimentalIsRenderedInSidebar
@@ -173,6 +353,41 @@ function ColorPickerPopover< T extends PaletteElement >( {
 					/>
 				</div>
 			) }
+			{ variant === 'duotone' && (
+				<div className="components-palette-edit__popover-duotone-picker">
+					{ /* Mirrors the layout `DuotonePicker` uses for its own
+					     custom duotone controls, so the editor here reads the
+					     same as the one in the block toolbar. */ }
+					<VStack spacing={ 3 }>
+						<CustomDuotoneBar
+							value={ getDuotoneColors( element ) }
+							onChange={ ( newColors ) => {
+								onChange( {
+									...element,
+									colors: newColors ?? [],
+								} );
+							} }
+						/>
+						<ColorListPicker
+							labels={ [ __( 'Shadows' ), __( 'Highlights' ) ] }
+							colors={ colorPalette ?? [] }
+							value={ getDuotoneColors( element ) }
+							enableAlpha
+							onChange={ ( newColors ) => {
+								const [ defaultDark, defaultLight ] =
+									getDefaultColors( colorPalette ?? [] );
+								onChange( {
+									...element,
+									colors: [
+										newColors[ 0 ] ?? defaultDark,
+										newColors[ 1 ] ?? defaultLight,
+									],
+								} );
+							} }
+						/>
+					</VStack>
+				</div>
+			) }
 		</Popover>
 	);
 }
@@ -184,9 +399,10 @@ function Option< T extends PaletteElement >( {
 	onRemove,
 	popoverProps: receivedPopoverProps,
 	slugPrefix,
-	isGradient,
+	variant,
+	colorPalette,
 }: OptionProps< T > ) {
-	const value = isGradient ? element.gradient : element.color;
+	const value = getElementValue( element, variant );
 	const [ isEditingColor, setIsEditingColor ] = useState( false );
 
 	// Use internal state instead of a ref to make sure that the component
@@ -210,7 +426,7 @@ function Option< T extends PaletteElement >( {
 						setIsEditingColor( true );
 					} }
 					aria-label={ sprintf(
-						// translators: %s is a color or gradient name, e.g. "Red".
+						// translators: %s is a color, gradient or duotone name, e.g. "Red".
 						__( 'Edit: %s' ),
 						element.name.trim().length ? element.name : value || ''
 					) }
@@ -221,11 +437,7 @@ function Option< T extends PaletteElement >( {
 				<FlexBlock>
 					{ ! canOnlyChangeValues ? (
 						<NameInput
-							label={
-								isGradient
-									? __( 'Gradient name' )
-									: __( 'Color name' )
-							}
+							label={ getNameInputLabel( variant ) }
 							value={ element.name }
 							onChange={ ( nextName?: string ) =>
 								onChange( {
@@ -252,8 +464,7 @@ function Option< T extends PaletteElement >( {
 							size="small"
 							icon={ lineSolid }
 							label={ sprintf(
-								// translators: %s is a color or gradient name, e.g. "Red".
-								__( 'Remove color: %s' ),
+								getRemoveLabelFormat( variant ),
 								element.name.trim().length
 									? element.name
 									: value || ''
@@ -265,7 +476,8 @@ function Option< T extends PaletteElement >( {
 			</HStack>
 			{ isEditingColor && (
 				<ColorPickerPopover
-					isGradient={ isGradient }
+					variant={ variant }
+					colorPalette={ colorPalette }
 					onChange={ onChange }
 					element={ element }
 					popoverProps={ popoverProps }
@@ -281,7 +493,8 @@ function PaletteEditListView< T extends PaletteElement >( {
 	onChange,
 	canOnlyChangeValues,
 	slugPrefix,
-	isGradient,
+	variant,
+	colorPalette,
 	popoverProps,
 	addColorRef,
 }: PaletteEditListViewProps< T > ) {
@@ -302,7 +515,8 @@ function PaletteEditListView< T extends PaletteElement >( {
 			<ItemGroup isRounded isBordered isSeparated>
 				{ elements.map( ( element, index ) => (
 					<Option
-						isGradient={ isGradient }
+						variant={ variant }
+						colorPalette={ colorPalette }
 						canOnlyChangeValues={ canOnlyChangeValues }
 						key={ index }
 						element={ element }
@@ -344,7 +558,7 @@ function PaletteEditListView< T extends PaletteElement >( {
 const EMPTY_ARRAY: Color[] = [];
 
 /**
- * Allows editing a palette of colors or gradients.
+ * Allows editing a palette of colors, gradients or duotones.
  *
  * ```jsx
  * import { PaletteEdit } from '@wordpress/components';
@@ -365,7 +579,9 @@ const EMPTY_ARRAY: Color[] = [];
  */
 export function PaletteEdit( {
 	gradients,
+	duotones,
 	colors = EMPTY_ARRAY,
+	colorPalette,
 	onChange,
 	paletteLabel,
 	paletteLabelHeadingLevel = 2,
@@ -375,8 +591,20 @@ export function PaletteEdit( {
 	slugPrefix = '',
 	popoverProps,
 }: PaletteEditProps ) {
-	const isGradient = !! gradients;
-	const elements = isGradient ? gradients : colors;
+	let variant: PaletteVariant = 'color';
+	if ( gradients ) {
+		variant = 'gradient';
+	} else if ( duotones ) {
+		variant = 'duotone';
+	}
+	const elements = gradients ?? duotones ?? colors;
+	// Filtered once here so every duotone path — the swatches, the shadows and
+	// highlights pickers, and the value a newly added duotone starts from —
+	// works from colors a duotone can actually be built with.
+	const duotoneColorPalette = useMemo(
+		() => getUsableDuotoneColors( colorPalette ),
+		[ colorPalette ]
+	);
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ editingElement, setEditingElement ] = useState<
 		number | null | undefined
@@ -398,7 +626,7 @@ export function PaletteEdit( {
 				newEditingElementIndex === undefined
 					? undefined
 					: elements[ newEditingElementIndex ];
-			const key = isGradient ? 'gradient' : 'color';
+			const key = variant === 'gradient' ? 'gradient' : 'color';
 			// Ensures that the index returned matches a known element value.
 			if ( !! selectedElement && selectedElement[ key ] === value ) {
 				setEditingElement( newEditingElementIndex );
@@ -406,7 +634,25 @@ export function PaletteEdit( {
 				setIsEditing( true );
 			}
 		},
-		[ isGradient, elements ]
+		[ variant, elements ]
+	);
+
+	// `DuotonePicker` reports the selected colors rather than an index, so the
+	// matching element has to be looked up by value.
+	const onSelectDuotoneItem = useCallback(
+		( value?: string[] | 'unset' ) => {
+			const newEditingElementIndex = ( duotones ?? [] ).findIndex(
+				( element ) =>
+					Array.isArray( value ) &&
+					getDuotoneColors( element ).join() === value.join()
+			);
+			if ( newEditingElementIndex > -1 ) {
+				setEditingElement( newEditingElementIndex );
+			} else {
+				setIsEditing( true );
+			}
+		},
+		[ duotones ]
 	);
 
 	const addColorRef = useRef< HTMLButtonElement >( null );
@@ -435,16 +681,13 @@ export function PaletteEdit( {
 							size="small"
 							isPressed={ isAdding }
 							icon={ plus }
-							label={
-								isGradient
-									? __( 'Add gradient' )
-									: __( 'Add color' )
-							}
+							label={ getAddLabel( variant ) }
 							onClick={ () => {
 								const { name, slug } =
 									getNameAndSlugForPosition(
 										elements,
-										slugPrefix
+										slugPrefix,
+										variant
 									);
 
 								if ( !! gradients ) {
@@ -452,6 +695,17 @@ export function PaletteEdit( {
 										...gradients,
 										{
 											gradient: DEFAULT_GRADIENT,
+											name,
+											slug,
+										},
+									] );
+								} else if ( !! duotones ) {
+									onChange( [
+										...duotones,
+										{
+											colors: getDefaultColors(
+												duotoneColorPalette
+											),
 											name,
 											slug,
 										},
@@ -478,11 +732,7 @@ export function PaletteEdit( {
 							canReset ) && (
 							<DropdownMenu
 								icon={ moreVertical }
-								label={
-									isGradient
-										? __( 'Gradient options' )
-										: __( 'Color options' )
-								}
+								label={ getOptionsLabel( variant ) }
 								toggleProps={ {
 									size: 'small',
 								} }
@@ -517,13 +767,9 @@ export function PaletteEdit( {
 													} }
 													className="components-palette-edit__menu-button"
 												>
-													{ isGradient
-														? __(
-																'Remove all gradients'
-														  )
-														: __(
-																'Remove all colors'
-														  ) }
+													{ getRemoveAllLabel(
+														variant
+													) }
 												</Button>
 											) }
 											{ canReset && (
@@ -539,9 +785,7 @@ export function PaletteEdit( {
 														onClose();
 													} }
 												>
-													{ isGradient
-														? __( 'Reset gradient' )
-														: __( 'Reset colors' ) }
+													{ getResetLabel( variant ) }
 												</Button>
 											) }
 										</NavigableMenu>
@@ -560,14 +804,16 @@ export function PaletteEdit( {
 							// @ts-expect-error TODO: Don't know how to resolve
 							onChange={ onChange }
 							slugPrefix={ slugPrefix }
-							isGradient={ isGradient }
+							variant={ variant }
+							colorPalette={ duotoneColorPalette }
 							popoverProps={ popoverProps }
 							addColorRef={ addColorRef }
 						/>
 					) }
 					{ ! isEditing && editingElement !== null && (
 						<ColorPickerPopover
-							isGradient={ isGradient }
+							variant={ variant }
+							colorPalette={ duotoneColorPalette }
 							onClose={ () => setEditingElement( null ) }
 							onChange={ (
 								newElement: ( typeof elements )[ number ]
@@ -593,22 +839,33 @@ export function PaletteEdit( {
 							popoverProps={ popoverProps }
 						/>
 					) }
-					{ ! isEditing &&
-						( isGradient ? (
-							<GradientPicker
-								gradients={ gradients }
-								onChange={ onSelectPaletteItem }
-								clearable={ false }
-								disableCustomGradients
-							/>
-						) : (
-							<ColorPalette
-								colors={ colors }
-								onChange={ onSelectPaletteItem }
-								clearable={ false }
-								disableCustomColors
-							/>
-						) ) }
+					{ ! isEditing && variant === 'gradient' && (
+						<GradientPicker
+							gradients={ gradients }
+							onChange={ onSelectPaletteItem }
+							clearable={ false }
+							disableCustomGradients
+						/>
+					) }
+					{ ! isEditing && variant === 'duotone' && (
+						<DuotonePicker
+							duotonePalette={ duotones ?? [] }
+							colorPalette={ duotoneColorPalette }
+							onChange={ onSelectDuotoneItem }
+							clearable={ false }
+							unsetable={ false }
+							disableCustomDuotone
+							disableCustomColors
+						/>
+					) }
+					{ ! isEditing && variant === 'color' && (
+						<ColorPalette
+							colors={ colors }
+							onChange={ onSelectPaletteItem }
+							clearable={ false }
+							disableCustomColors
+						/>
+					) }
 				</PaletteEditContents>
 			) }
 			{ ! hasElements && emptyMessage && (

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -362,10 +362,13 @@ function ColorPickerPopover< T extends PaletteElement >( {
 						<CustomDuotoneBar
 							value={ getDuotoneColors( element ) }
 							onChange={ ( newColors ) => {
-								onChange( {
-									...element,
-									colors: newColors ?? [],
-								} );
+								// A duotone needs two colors to render, and the
+								// bar refuses to drop below two stops, so an
+								// empty value means there is nothing to save.
+								if ( ! newColors?.length ) {
+									return;
+								}
+								onChange( { ...element, colors: newColors } );
 							} }
 						/>
 						<ColorListPicker
@@ -379,8 +382,11 @@ function ColorPickerPopover< T extends PaletteElement >( {
 								onChange( {
 									...element,
 									colors: [
-										newColors[ 0 ] ?? defaultDark,
-										newColors[ 1 ] ?? defaultLight,
+										// Falsy rather than nullish, to match
+										// how `DuotonePicker` fills a cleared
+										// shadow or highlight.
+										newColors[ 0 ] || defaultDark,
+										newColors[ 1 ] || defaultLight,
 									],
 								} );
 							} }

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { lineSolid, moreVertical, plus } from '@wordpress/icons';
-import { useDebounce } from '@wordpress/compose';
+import { useDebounce, useInstanceId } from '@wordpress/compose';
 import { kebabCase } from '@wordpress/kebab-case';
 import Button from '../button';
 import { ColorPicker } from '../color-picker';
@@ -678,10 +678,20 @@ export function PaletteEdit( {
 
 	const addColorRef = useRef< HTMLButtonElement >( null );
 
+	// Names the swatch picker after this palette's heading, so a screen reader
+	// announces "Theme", "Default" or "Custom" rather than an unlabelled list.
+	const paletteLabelId = useInstanceId(
+		PaletteEdit,
+		'components-palette-edit__heading'
+	);
+
 	return (
 		<PaletteEditStyles>
 			<HStack>
-				<PaletteHeading level={ paletteLabelHeadingLevel }>
+				<PaletteHeading
+					id={ paletteLabelId }
+					level={ paletteLabelHeadingLevel }
+				>
 					{ paletteLabel }
 				</PaletteHeading>
 				<PaletteActionsContainer>
@@ -862,6 +872,7 @@ export function PaletteEdit( {
 					) }
 					{ ! isEditing && variant === 'gradient' && (
 						<GradientPicker
+							aria-labelledby={ paletteLabelId }
 							gradients={ gradients }
 							onChange={ onSelectPaletteItem }
 							clearable={ false }
@@ -870,6 +881,7 @@ export function PaletteEdit( {
 					) }
 					{ ! isEditing && variant === 'duotone' && (
 						<DuotonePicker
+							aria-labelledby={ paletteLabelId }
 							duotonePalette={ duotones ?? [] }
 							colorPalette={ duotoneColorPalette }
 							onChange={ onSelectDuotoneItem }
@@ -881,6 +893,7 @@ export function PaletteEdit( {
 					) }
 					{ ! isEditing && variant === 'color' && (
 						<ColorPalette
+							aria-labelledby={ paletteLabelId }
 							colors={ colors }
 							onChange={ onSelectPaletteItem }
 							clearable={ false }

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -643,16 +643,15 @@ export function PaletteEdit( {
 		[ variant, elements ]
 	);
 
-	// `DuotonePicker` reports the selected colors rather than an index, so the
-	// matching element has to be looked up by value.
+	// Two duotones can hold the same pair of colors, so the picker's reported
+	// index is what identifies the one that was clicked. Matching on the colors
+	// instead would edit whichever duotone happened to come first.
 	const onSelectDuotoneItem = useCallback(
-		( value?: string[] | 'unset' ) => {
-			const newEditingElementIndex = ( duotones ?? [] ).findIndex(
-				( element ) =>
-					Array.isArray( value ) &&
-					getDuotoneColors( element ).join() === value.join()
-			);
-			if ( newEditingElementIndex > -1 ) {
+		( value?: string[] | 'unset', newEditingElementIndex?: number ) => {
+			if (
+				newEditingElementIndex !== undefined &&
+				( duotones ?? [] )[ newEditingElementIndex ]
+			) {
 				setEditingElement( newEditingElementIndex );
 			} else {
 				setIsEditing( true );

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -61,20 +61,36 @@ const DEFAULT_COLOR = '#000';
 
 /**
  * Filters a color palette down to the colors a duotone can actually be built
- * from. Duotone values are turned into SVG filter matrices, so each color has
- * to resolve to a concrete value. A theme palette may legitimately contain CSS
+ * from, and normalizes each one to hex.
+ *
+ * Duotone values are turned into SVG filter matrices, so each color has to
+ * resolve to a concrete value. A theme palette may legitimately contain CSS
  * that does not, such as `color-mix()` or `currentColor` — Twenty Twenty-Five
  * ships one — and picking such a color would produce a duotone that neither the
  * editor nor the front end can render.
  *
+ * Surviving colors are normalized because the two ends disagree on syntax. The
+ * front end parses duotone colors with a PHP port of colord that only accepts
+ * hex, `rgb()` and `hsl()` (`WP_Duotone::colord_parse`), while colord in the
+ * editor also accepts CSS named colors such as `red`, since `namesPlugin` is
+ * registered. Passing a palette value straight through would let a named color
+ * be saved as a duotone that renders in the editor and is dropped, with a
+ * `_doing_it_wrong` notice, on the front end.
+ *
  * @param colorPalette The colors to filter.
  *
- * @return The colors usable in a duotone.
+ * @return The colors usable in a duotone, as hex.
  */
 function getUsableDuotoneColors( colorPalette: Color[] = [] ) {
-	return colorPalette.filter(
-		( { color } ) => typeof color === 'string' && colord( color ).isValid()
-	);
+	return colorPalette.flatMap( ( paletteColor ) => {
+		if ( typeof paletteColor.color !== 'string' ) {
+			return [];
+		}
+		const parsed = colord( paletteColor.color );
+		return parsed.isValid()
+			? [ { ...paletteColor, color: parsed.toHex() } ]
+			: [];
+	} );
 }
 
 /**

--- a/packages/components/src/palette-edit/stories/index.story.tsx
+++ b/packages/components/src/palette-edit/stories/index.story.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import { useState } from '@wordpress/element';
 import PaletteEdit from '..';
-import type { Color, Gradient } from '../types';
+import type { Color, Duotone, Gradient, PaletteElement } from '../types';
 
 const meta: Meta< typeof PaletteEdit > = {
 	title: 'Components/PaletteEdit',
@@ -22,27 +22,44 @@ const meta: Meta< typeof PaletteEdit > = {
 export default meta;
 
 const Template: StoryFn< typeof PaletteEdit > = ( args ) => {
-	const { colors, gradients, onChange, ...props } = args;
-	const [ value, setValue ] = useState( gradients || colors );
+	const { colors, gradients, duotones, colorPalette, onChange, ...props } =
+		args;
+	const [ value, setValue ] = useState< PaletteElement[] | undefined >(
+		gradients ?? duotones ?? colors
+	);
+	// The story's `onChange` is a mock shared by all three variants, so it is
+	// called through a single loosely typed reference.
+	const handleChange = ( newValue?: PaletteElement[] ) => {
+		setValue( newValue );
+		( onChange as ( values?: PaletteElement[] ) => void )( newValue );
+	};
+
+	if ( gradients ) {
+		return (
+			<PaletteEdit
+				{ ...props }
+				gradients={ ( value ?? [] ) as Gradient[] }
+				onChange={ handleChange }
+			/>
+		);
+	}
+
+	if ( duotones ) {
+		return (
+			<PaletteEdit
+				{ ...props }
+				duotones={ ( value ?? [] ) as Duotone[] }
+				colorPalette={ colorPalette }
+				onChange={ handleChange }
+			/>
+		);
+	}
 
 	return (
 		<PaletteEdit
-			{ ...( gradients
-				? {
-						gradients: value as Gradient[],
-						onChange: ( newValue?: Gradient[] ) => {
-							setValue( newValue );
-							onChange( newValue );
-						},
-				  }
-				: {
-						colors: value as Color[],
-						onChange: ( newValue?: Color[] ) => {
-							setValue( newValue );
-							onChange( newValue );
-						},
-				  } ) }
 			{ ...props }
+			colors={ ( value ?? [] ) as Color[] }
+			onChange={ handleChange }
 		/>
 	);
 };
@@ -80,4 +97,28 @@ Gradients.args = {
 	],
 	paletteLabel: 'Gradients',
 	emptyMessage: 'Gradients are empty',
+};
+
+export const Duotones = Template.bind( {} );
+Duotones.args = {
+	duotones: [
+		{
+			colors: [ '#8c00b7', '#fcff41' ],
+			name: 'Purple and yellow',
+			slug: 'purple-yellow',
+		},
+		{
+			colors: [ '#000097', '#ff4747' ],
+			name: 'Blue and red',
+			slug: 'blue-red',
+		},
+	],
+	colorPalette: [
+		{ color: '#ff4747', name: 'Red', slug: 'red' },
+		{ color: '#fcff41', name: 'Yellow', slug: 'yellow' },
+		{ color: '#000097', name: 'Blue', slug: 'blue' },
+		{ color: '#8c00b7', name: 'Purple', slug: 'purple' },
+	],
+	paletteLabel: 'Duotones',
+	emptyMessage: 'Duotones are empty',
 };

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/variables" as *;
 
-.components-palette-edit__popover-gradient-picker {
+.components-palette-edit__popover-gradient-picker,
+.components-palette-edit__popover-duotone-picker {
 	width: 260px;
 	padding: $grid-unit-10;
 }

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -6,16 +6,6 @@
 	padding: $grid-unit-10;
 }
 
-.components-palette-edit__popover-duotone-picker {
-	// A duotone is often white at one end, which against the popover's white
-	// background leaves that half of the bar with no visible edge — you cannot
-	// tell where the draggable area stops. Outline it with the same hairline
-	// the color swatches use.
-	.components-custom-gradient-picker__gradient-bar-background {
-		border-radius: $radius-small;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-	}
-}
 .components-dropdown-menu__menu {
 	.components-palette-edit__menu-button {
 		width: 100%;

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -5,6 +5,17 @@
 	width: 260px;
 	padding: $grid-unit-10;
 }
+
+.components-palette-edit__popover-duotone-picker {
+	// A duotone is often white at one end, which against the popover's white
+	// background leaves that half of the bar with no visible edge — you cannot
+	// tell where the draggable area stops. Outline it with the same hairline
+	// the color swatches use.
+	.components-custom-gradient-picker__gradient-bar-background {
+		border-radius: $radius-small;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	}
+}
 .components-dropdown-menu__menu {
 	.components-palette-edit__menu-button {
 		width: 100%;

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -679,6 +679,53 @@ describe( 'PaletteEdit', () => {
 		} );
 	} );
 
+	// The same filtering and normalization that applies when adding a duotone
+	// has to apply when editing one, or the shadows and highlights picker can
+	// offer a color the saved duotone cannot be built from.
+	it( 'hides unusable colors and saves named ones as hex when editing a duotone', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ duotones }
+				colorPalette={ [
+					{
+						color: 'black',
+						name: 'Named black',
+						slug: 'named-black',
+					},
+					{
+						color: 'color-mix(in srgb, currentColor 20%, transparent)',
+						name: 'Contrast overlay',
+						slug: 'contrast-overlay',
+					},
+				] }
+				onChange={ onChange }
+			/>
+		);
+
+		await click( screen.getByLabelText( 'Duotone: Blue and red' ) );
+		await click( screen.getByRole( 'button', { name: /Shadows/ } ) );
+
+		// The unusable color must not be offered at all.
+		expect(
+			screen.queryByRole( 'option', { name: 'Contrast overlay' } )
+		).not.toBeInTheDocument();
+
+		await click( screen.getByRole( 'option', { name: 'Named black' } ) );
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				duotones[ 0 ],
+				{
+					...duotones[ 1 ],
+					colors: [ '#000000', duotones[ 1 ].colors[ 1 ] ],
+				},
+			] );
+		} );
+	} );
+
 	// Adding two duotones with the `+` button seeds both from the palette's
 	// darkest and lightest colors, so duplicate values are the normal case
 	// rather than an edge one. The duotone that was clicked has to be the one

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -615,4 +615,67 @@ describe( 'PaletteEdit', () => {
 			] );
 		} );
 	} );
+
+	it( 'can update duotone palette value', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ duotones }
+				colorPalette={ colors }
+				onChange={ onChange }
+			/>
+		);
+
+		await click( screen.getByLabelText( 'Duotone: Blue and red' ) );
+		await click( screen.getByRole( 'button', { name: /Shadows/ } ) );
+		await click( screen.getByRole( 'option', { name: 'Primary' } ) );
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				duotones[ 0 ],
+				{
+					...duotones[ 1 ],
+					colors: [ '#1a4548', duotones[ 1 ].colors[ 1 ] ],
+				},
+			] );
+		} );
+	} );
+
+	// Adding two duotones with the `+` button seeds both from the palette's
+	// darkest and lightest colors, so duplicate values are the normal case
+	// rather than an edge one. The duotone that was clicked has to be the one
+	// that gets edited.
+	it( 'updates the clicked duotone when two share the same colors', async () => {
+		const onChange = jest.fn();
+		const twins = [
+			{ colors: [ '#000000', '#ffffff' ], name: 'First', slug: 'first' },
+			{
+				colors: [ '#000000', '#ffffff' ],
+				name: 'Second',
+				slug: 'second',
+			},
+		];
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ twins }
+				colorPalette={ colors }
+				onChange={ onChange }
+			/>
+		);
+
+		await click( screen.getByLabelText( 'Duotone: Second' ) );
+		await click( screen.getByRole( 'button', { name: /Shadows/ } ) );
+		await click( screen.getByRole( 'option', { name: 'Primary' } ) );
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				twins[ 0 ],
+				{ ...twins[ 1 ], colors: [ '#1a4548', '#ffffff' ] },
+			] );
+		} );
+	} );
 } );

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -91,6 +91,47 @@ describe( 'getNameAndSlugForPosition', () => {
 			slug: 'test-color-151',
 		} );
 	} );
+
+	test( 'should return a duotone name and slug for the duotone variant', () => {
+		const slugPrefix = 'custom-';
+		const elements: PaletteElement[] = [];
+
+		expect(
+			getNameAndSlugForPosition( elements, slugPrefix, 'duotone' )
+		).toEqual( {
+			name: 'Duotone 1',
+			slug: 'custom-duotone-1',
+		} );
+	} );
+
+	test( 'should increment the duotone slug id independently of colors', () => {
+		const slugPrefix = 'custom-';
+		const elements = [
+			{
+				slug: 'custom-duotone-1',
+				colors: [ '#000000', '#ffffff' ],
+				name: 'Duotone 1',
+			},
+			{
+				slug: 'custom-duotone-4',
+				colors: [ '#8c00b7', '#fcff41' ],
+				name: 'Duotone 4',
+			},
+			// A color preset sharing the prefix must not affect the count.
+			{
+				slug: 'custom-color-99',
+				color: '#ffffff',
+				name: 'Color 99',
+			},
+		];
+
+		expect(
+			getNameAndSlugForPosition( elements, slugPrefix, 'duotone' )
+		).toEqual( {
+			name: 'Duotone 5',
+			slug: 'custom-duotone-5',
+		} );
+	} );
 } );
 
 describe( 'deduplicateElementSlugs', () => {
@@ -162,6 +203,18 @@ describe( 'PaletteEdit', () => {
 				'linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)',
 			name: 'Midnight',
 			slug: 'midnight',
+		},
+	];
+	const duotones = [
+		{
+			colors: [ '#8c00b7', '#fcff41' ],
+			name: 'Purple and yellow',
+			slug: 'purple-yellow',
+		},
+		{
+			colors: [ '#000097', '#ff4747' ],
+			name: 'Blue and red',
+			slug: 'blue-red',
 		},
 	];
 
@@ -310,6 +363,107 @@ describe( 'PaletteEdit', () => {
 						'linear-gradient(135deg, rgba(6, 147, 227, 1) 0%, rgb(155, 81, 224) 100%)',
 					name: 'Color 1',
 					slug: 'color-1',
+				},
+			] );
+		} );
+	} );
+
+	it( 'calls the `onChange` with the new duotone appended, seeded from the color palette', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ duotones }
+				colorPalette={ colors }
+				onChange={ onChange }
+			/>
+		);
+
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Add duotone',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				...duotones,
+				{
+					// The darkest and lightest colors of `colors`.
+					colors: [ '#0000ff', '#1a4548' ],
+					name: 'Duotone 1',
+					slug: 'duotone-1',
+				},
+			] );
+		} );
+	} );
+
+	it( 'ignores palette colors a duotone cannot be built from when adding one', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ duotones }
+				colorPalette={ [
+					...colors,
+					// Twenty Twenty-Five ships a color like this. `colord`
+					// cannot parse it and treats it as black, which would
+					// otherwise win as the duotone's shadow color and produce a
+					// duotone that cannot be rendered.
+					{
+						color: 'color-mix(in srgb, currentColor 20%, transparent)',
+						name: 'Contrast overlay',
+						slug: 'contrast-overlay',
+					},
+				] }
+				onChange={ onChange }
+			/>
+		);
+
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Add duotone',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				...duotones,
+				{
+					colors: [ '#0000ff', '#1a4548' ],
+					name: 'Duotone 1',
+					slug: 'duotone-1',
+				},
+			] );
+		} );
+	} );
+
+	it( 'falls back to black and white when adding a duotone without a color palette', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ duotones }
+				onChange={ onChange }
+			/>
+		);
+
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Add duotone',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				...duotones,
+				{
+					colors: [ '#000', '#fff' ],
+					name: 'Duotone 1',
+					slug: 'duotone-1',
 				},
 			] );
 		} );

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -440,6 +440,42 @@ describe( 'PaletteEdit', () => {
 		} );
 	} );
 
+	// The front end parses duotone colors with a PHP port of colord that only
+	// accepts hex, `rgb()` and `hsl()`, so a named color saved as-is would
+	// render in the editor and be dropped on the front end.
+	it( 'normalizes palette colors to hex when adding a duotone', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<PaletteEdit
+				{ ...defaultProps }
+				duotones={ duotones }
+				colorPalette={ [
+					{ color: 'black', name: 'Black', slug: 'black' },
+					{ color: 'white', name: 'White', slug: 'white' },
+				] }
+				onChange={ onChange }
+			/>
+		);
+
+		await click(
+			screen.getByRole( 'button', {
+				name: 'Add duotone',
+			} )
+		);
+
+		await waitFor( () => {
+			expect( onChange ).toHaveBeenCalledWith( [
+				...duotones,
+				{
+					colors: [ '#000000', '#ffffff' ],
+					name: 'Duotone 1',
+					slug: 'duotone-1',
+				},
+			] );
+		} );
+	} );
+
 	it( 'falls back to black and white when adding a duotone without a color palette', async () => {
 		const onChange = jest.fn();
 

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -7,6 +7,7 @@ export type Color = {
 	name: string;
 	slug: string;
 	gradient?: never;
+	colors?: never;
 };
 
 export type Gradient = {
@@ -14,9 +15,23 @@ export type Gradient = {
 	name: string;
 	slug: string;
 	color?: never;
+	colors?: never;
 };
 
-export type PaletteElement = Color | Gradient;
+export type Duotone = {
+	colors: string[];
+	name: string;
+	slug: string;
+	color?: never;
+	gradient?: never;
+};
+
+export type PaletteElement = Color | Gradient | Duotone;
+
+/**
+ * The kind of preset a `PaletteEdit` instance is editing.
+ */
+export type PaletteVariant = 'color' | 'gradient' | 'duotone';
 
 export type BasePaletteEdit = {
 	/**
@@ -71,6 +86,8 @@ type PaletteEditColors = {
 	 */
 	onChange: ( values?: Color[] ) => void;
 	gradients?: never;
+	duotones?: never;
+	colorPalette?: never;
 };
 
 type PaletteEditGradients = {
@@ -83,17 +100,40 @@ type PaletteEditGradients = {
 	 */
 	onChange: ( values?: Gradient[] ) => void;
 	colors?: never;
+	duotones?: never;
+	colorPalette?: never;
+};
+
+type PaletteEditDuotones = {
+	/**
+	 * The duotones in the palette.
+	 */
+	duotones: Duotone[];
+	/**
+	 * Runs on changing the value.
+	 */
+	onChange: ( values?: Duotone[] ) => void;
+	/**
+	 * The colors offered when picking the shadows and highlights of a duotone,
+	 * and from which the value of a newly added duotone is derived.
+	 *
+	 * @default []
+	 */
+	colorPalette?: Color[];
+	colors?: never;
+	gradients?: never;
 };
 
 export type PaletteEditProps = BasePaletteEdit &
-	( PaletteEditColors | PaletteEditGradients );
+	( PaletteEditColors | PaletteEditGradients | PaletteEditDuotones );
 
 type EditingElement = number | null;
 
-export type ColorPickerPopoverProps< T extends Color | Gradient > = {
+export type ColorPickerPopoverProps< T extends PaletteElement > = {
 	element: T;
 	onChange: ( newElement: T ) => void;
-	isGradient?: T extends Gradient ? true : false;
+	variant: PaletteVariant;
+	colorPalette?: Color[];
 	onClose?: () => void;
 	popoverProps?: PaletteEditProps[ 'popoverProps' ];
 };
@@ -104,10 +144,11 @@ export type NameInputProps = {
 	value: PaletteElement[ 'name' ];
 };
 
-export type OptionProps< T extends Color | Gradient > = {
+export type OptionProps< T extends PaletteElement > = {
 	element: T;
 	onChange: ( newElement: T ) => void;
-	isGradient: T extends Gradient ? true : false;
+	variant: PaletteVariant;
+	colorPalette?: Color[];
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
 	key: Key;
 	onRemove: MouseEventHandler< HTMLButtonElement >;
@@ -115,10 +156,11 @@ export type OptionProps< T extends Color | Gradient > = {
 	slugPrefix: string;
 };
 
-export type PaletteEditListViewProps< T extends Color | Gradient > = {
+export type PaletteEditListViewProps< T extends PaletteElement > = {
 	elements: T[];
 	onChange: ( newElements?: T[] ) => void;
-	isGradient: T extends Gradient ? true : false;
+	variant: PaletteVariant;
+	colorPalette?: Color[];
 	canOnlyChangeValues: PaletteEditProps[ 'canOnlyChangeValues' ];
 	addColorRef: React.RefObject< HTMLButtonElement | null >;
 	editingElement?: EditingElement;

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Use the row block spacing value for Flow and Constrained layouts when Global Styles defines separate row and column values ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
+-   Generate SVG filters for user-defined duotone presets, not just theme and default ones. A duotone a user had created rendered on the front end but had no filter in the editor, so applying it showed no preview ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 
 ### Internal
 

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -296,7 +296,11 @@ function getPresetsSvgFilters(
 			metadata.path,
 			{}
 		) as PresetsByOrigin;
-		return [ 'default', 'theme' ]
+		// User-defined duotones are included too. The front end renders every
+		// origin (`WP_Duotone::get_all_global_styles_presets`), so leaving
+		// `custom` out here meant a duotone a user had created applied on the
+		// front end but pointed at a filter that did not exist in the editor.
+		return [ 'default', 'theme', 'custom' ]
 			.filter( ( origin ) => presetByOrigin[ origin ] )
 			.flatMap( ( origin ) =>
 				presetByOrigin[ origin ].map( ( preset: any ) =>

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -296,10 +296,7 @@ function getPresetsSvgFilters(
 			metadata.path,
 			{}
 		) as PresetsByOrigin;
-		// User-defined duotones are included too. The front end renders every
-		// origin (`WP_Duotone::get_all_global_styles_presets`), so leaving
-		// `custom` out here meant a duotone a user had created applied on the
-		// front end but pointed at a filter that did not exist in the editor.
+		// Includes `custom`, since the front end renders every origin.
 		return [ 'default', 'theme', 'custom' ]
 			.filter( ( origin ) => presetByOrigin[ origin ] )
 			.flatMap( ( origin ) =>

--- a/packages/global-styles-engine/src/test/render.test.ts
+++ b/packages/global-styles-engine/src/test/render.test.ts
@@ -1787,6 +1787,23 @@ describe( 'global styles renderer', () => {
 									colors: [ '#263135', '#69a8a7' ],
 								},
 							],
+							default: [
+								{
+									slug: 'grayscale',
+									name: 'Grayscale',
+									colors: [ '#000000', '#ffffff' ],
+								},
+							],
+							// User-created duotones need a filter in the
+							// editor too, or they render on the front end but
+							// not on the canvas.
+							custom: [
+								{
+									slug: 'custom-duotone-1',
+									name: 'Duotone 1',
+									colors: [ '#0000ff', '#1a4548' ],
+								},
+							],
 						},
 					},
 				},
@@ -1811,9 +1828,11 @@ describe( 'global styles renderer', () => {
 
 			expect( svgStyle ).toBeDefined();
 			expect( svgStyle.__unstableType ).toBe( 'svgs' );
-			expect( svgStyle.assets.join( '' ) ).toContain(
-				'wp-duotone-midnight'
-			);
+
+			const assets = svgStyle.assets.join( '' );
+			expect( assets ).toContain( 'wp-duotone-midnight' );
+			expect( assets ).toContain( 'wp-duotone-grayscale' );
+			expect( assets ).toContain( 'wp-duotone-custom-duotone-1' );
 		} );
 	} );
 

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Expose typography and color controls for citations, inputs, and selects in Global Styles ([#80852](https://github.com/WordPress/gutenberg/pull/80852)).
 -   Mark blocks that have user styles in the block list, and add a filter to show only those blocks ([#81373](https://github.com/WordPress/gutenberg/pull/81373)).
--   Add a Duotone tab to the Edit palette screen, so theme and default duotones can be edited and custom duotones added, alongside Color and Gradient. Replaces the read-only duotone list previously shown at the bottom of the Gradient tab ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER)).
+-   Add a Duotone tab to the Edit palette screen, so theme and default duotones can be edited and custom duotones added, alongside Color and Gradient. Replaces the read-only duotone list previously shown at the bottom of the Gradient tab ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 
 ### Internal
 

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Expose typography and color controls for citations, inputs, and selects in Global Styles ([#80852](https://github.com/WordPress/gutenberg/pull/80852)).
 -   Mark blocks that have user styles in the block list, and add a filter to show only those blocks ([#81373](https://github.com/WordPress/gutenberg/pull/81373)).
+-   Add a Duotone tab to the Edit palette screen, so theme and default duotones can be edited and custom duotones added, alongside Color and Gradient. Replaces the read-only duotone list previously shown at the bottom of the Gradient tab ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER)).
 
 ### Internal
 

--- a/packages/global-styles-ui/src/duotone-palette-panel.tsx
+++ b/packages/global-styles-ui/src/duotone-palette-panel.tsx
@@ -1,0 +1,119 @@
+import { useViewportMatch } from '@wordpress/compose';
+import { __experimentalPaletteEdit as PaletteEdit } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
+import type { Color, Duotone } from '@wordpress/global-styles-engine';
+import { useSetting } from './hooks';
+
+const mobilePopoverProps = { placement: 'bottom-start' as const, offset: 8 };
+
+// Presets come from `theme.json`, so they are not guaranteed to be arrays.
+const asArray = < T, >( value: T[] | undefined ) =>
+	Array.isArray( value ) ? value : [];
+
+interface DuotonePalettePanelProps {
+	name?: string;
+}
+
+export default function DuotonePalettePanel( {
+	name,
+}: DuotonePalettePanelProps ) {
+	const [ themeDuotone, setThemeDuotone ] = useSetting< Duotone[] >(
+		'color.duotone.theme',
+		name
+	);
+	const [ baseThemeDuotone ] = useSetting< Duotone[] >(
+		'color.duotone.theme',
+		name,
+		'base'
+	);
+	const [ defaultDuotone, setDefaultDuotone ] = useSetting< Duotone[] >(
+		'color.duotone.default',
+		name
+	);
+	const [ baseDefaultDuotone ] = useSetting< Duotone[] >(
+		'color.duotone.default',
+		name,
+		'base'
+	);
+	const [ customDuotone, setCustomDuotone ] = useSetting< Duotone[] >(
+		'color.duotone.custom',
+		name
+	);
+
+	const [ defaultDuotoneEnabled ] = useSetting< boolean >(
+		'color.defaultDuotone',
+		name
+	);
+
+	// The colors offered when picking a duotone's shadows and highlights, and
+	// from which the value of a newly added duotone is derived.
+	const [ themeColors ] = useSetting< Color[] >(
+		'color.palette.theme',
+		name
+	);
+	const [ defaultColors ] = useSetting< Color[] >(
+		'color.palette.default',
+		name
+	);
+	const [ customColors ] = useSetting< Color[] >(
+		'color.palette.custom',
+		name
+	);
+	const [ defaultPaletteEnabled ] = useSetting< boolean >(
+		'color.defaultPalette',
+		name
+	);
+
+	const colorPalette = [
+		...asArray( customColors ),
+		...asArray( themeColors ),
+		...( defaultPaletteEnabled ? asArray( defaultColors ) : [] ),
+	];
+
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
+
+	return (
+		<Stack
+			direction="column"
+			className="global-styles-ui-duotone-palette-panel"
+			gap="2xl"
+		>
+			{ !! asArray( themeDuotone ).length && (
+				<PaletteEdit
+					canReset={ themeDuotone !== baseThemeDuotone }
+					canOnlyChangeValues
+					duotones={ asArray( themeDuotone ) }
+					colorPalette={ colorPalette }
+					onChange={ setThemeDuotone }
+					paletteLabel={ __( 'Theme' ) }
+					paletteLabelHeadingLevel={ 3 }
+					popoverProps={ popoverProps }
+				/>
+			) }
+			{ !! asArray( defaultDuotone ).length &&
+				!! defaultDuotoneEnabled && (
+					<PaletteEdit
+						canReset={ defaultDuotone !== baseDefaultDuotone }
+						canOnlyChangeValues
+						duotones={ asArray( defaultDuotone ) }
+						colorPalette={ colorPalette }
+						onChange={ setDefaultDuotone }
+						paletteLabel={ __( 'Default' ) }
+						paletteLabelHeadingLevel={ 3 }
+						popoverProps={ popoverProps }
+					/>
+				) }
+			<PaletteEdit
+				duotones={ asArray( customDuotone ) }
+				colorPalette={ colorPalette }
+				onChange={ setCustomDuotone }
+				paletteLabel={ __( 'Custom' ) }
+				paletteLabelHeadingLevel={ 3 }
+				slugPrefix="custom-"
+				popoverProps={ popoverProps }
+			/>
+		</Stack>
+	);
+}

--- a/packages/global-styles-ui/src/duotone-palette-panel.tsx
+++ b/packages/global-styles-ui/src/duotone-palette-panel.tsx
@@ -1,4 +1,5 @@
 import { useViewportMatch } from '@wordpress/compose';
+import { useMemo } from '@wordpress/element';
 import { __experimentalPaletteEdit as PaletteEdit } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
@@ -65,11 +66,17 @@ export default function DuotonePalettePanel( {
 		name
 	);
 
-	const colorPalette = [
-		...asArray( customColors ),
-		...asArray( themeColors ),
-		...( defaultPaletteEnabled ? asArray( defaultColors ) : [] ),
-	];
+	// A stable array, so the filtering and darkest/lightest lookups that
+	// `PaletteEdit` and `DuotonePicker` memoize on it are not redone on every
+	// render.
+	const colorPalette = useMemo(
+		() => [
+			...asArray( customColors ),
+			...asArray( themeColors ),
+			...( defaultPaletteEnabled ? asArray( defaultColors ) : [] ),
+		],
+		[ customColors, themeColors, defaultColors, defaultPaletteEnabled ]
+	);
 
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;

--- a/packages/global-styles-ui/src/gradients-palette-panel.tsx
+++ b/packages/global-styles-ui/src/gradients-palette-panel.tsx
@@ -2,17 +2,12 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalVStack as VStack,
 	__experimentalPaletteEdit as PaletteEdit,
-	__experimentalSpacer as Spacer,
-	DuotonePicker,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { Gradient } from '@wordpress/global-styles-engine';
-import { Subtitle } from './subtitle';
 import { useSetting } from './hooks';
 
 const mobilePopoverProps = { placement: 'bottom-start' as const, offset: 8 };
-
-const noop = () => {};
 
 interface GradientPalettePanelProps {
 	name?: string;
@@ -48,17 +43,6 @@ export default function GradientPalettePanel( {
 		'color.defaultGradients',
 		name
 	);
-
-	const [ customDuotone ] = useSetting( 'color.duotone.custom' ) || [];
-	const [ defaultDuotone ] = useSetting( 'color.duotone.default' ) || [];
-	const [ themeDuotone ] = useSetting( 'color.duotone.theme' ) || [];
-	const [ defaultDuotoneEnabled ] = useSetting( 'color.defaultDuotone' );
-
-	const duotonePalette = [
-		...( customDuotone || [] ),
-		...( themeDuotone || [] ),
-		...( defaultDuotone && defaultDuotoneEnabled ? defaultDuotone : [] ),
-	];
 
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
@@ -100,20 +84,6 @@ export default function GradientPalettePanel( {
 				slugPrefix="custom-"
 				popoverProps={ popoverProps }
 			/>
-			{ !! duotonePalette && !! duotonePalette.length && (
-				<div>
-					<Subtitle level={ 3 }>{ __( 'Duotone' ) }</Subtitle>
-					<Spacer margin={ 3 } />
-					<DuotonePicker
-						duotonePalette={ duotonePalette }
-						disableCustomDuotone
-						disableCustomColors
-						clearable={ false }
-						onChange={ noop }
-						colorPalette={ [] }
-					/>
-				</div>
-			) }
 		</VStack>
 	);
 }

--- a/packages/global-styles-ui/src/screen-color-palette.tsx
+++ b/packages/global-styles-ui/src/screen-color-palette.tsx
@@ -3,6 +3,7 @@ import { Tabs } from '@wordpress/ui';
 import { ScreenHeader } from './screen-header';
 import ColorPalettePanel from './color-palette-panel';
 import GradientPalettePanel from './gradients-palette-panel';
+import DuotonePalettePanel from './duotone-palette-panel';
 
 function ScreenColorPalette( { name }: { name?: string } ) {
 	return (
@@ -20,6 +21,7 @@ function ScreenColorPalette( { name }: { name?: string } ) {
 						<Tabs.Tab value="gradient">
 							{ __( 'Gradient' ) }
 						</Tabs.Tab>
+						<Tabs.Tab value="duotone">{ __( 'Duotone' ) }</Tabs.Tab>
 					</Tabs.List>
 				</div>
 				<Tabs.Panel value="color" tabIndex={ -1 }>
@@ -27,6 +29,9 @@ function ScreenColorPalette( { name }: { name?: string } ) {
 				</Tabs.Panel>
 				<Tabs.Panel value="gradient" tabIndex={ -1 }>
 					<GradientPalettePanel name={ name } />
+				</Tabs.Panel>
+				<Tabs.Panel value="duotone" tabIndex={ -1 }>
+					<DuotonePalettePanel name={ name } />
 				</Tabs.Panel>
 			</Tabs.Root>
 		</>

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -292,6 +292,7 @@
 }
 
 .global-styles-ui-color-palette-panel,
-.global-styles-ui-gradient-palette-panel {
+.global-styles-ui-gradient-palette-panel,
+.global-styles-ui-duotone-palette-panel {
 	padding: variables.$grid-unit-20;
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1732,7 +1732,7 @@
 	},
 	"packages/global-styles-ui/src/gradients-palette-panel.tsx": {
 		"@wordpress/use-recommended-components": {
-			"count": 2
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/navigation-button.tsx": {


### PR DESCRIPTION
## What?

This adds a Duotone tab to the Global Styles "Edit palette" screen, alongside Color and Gradient, so duotone palettes can be edited and custom duotones added.

**I welcome someone to take this over, create a new PR inspired by this, etc. This is meant to give us something to play around with and evaluate, especially to analyze if there's enough space with three items there.**

Closes #36541.

## Why?

Colors and gradients have been editable in Global Styles but duotones still cannot be. They appeared as a read-only swatch grid at the bottom of the Gradient tab, so you could see the theme's duotones but not change them or add your own.

This follows the direction @jasmussen [proposed](https://github.com/WordPress/gutenberg/issues/36541#issuecomment-5279688601) with three tabs (Colour, Gradient, Duotone) with the same UI underneath, and the duotone editor when you add a custom duotone.

## How?

`PaletteEdit` gains a third variant. The private `isGradient` boolean becomes a `variant: 'color' | 'gradient' | 'duotone'` discriminator, and a new `duotones` prop (with an optional `colorPalette`) joins the props union. The public surface is additive.

The duotone branches reuse pieces `DuotonePicker` already owns:

| Site | Duotone branch | Reused from |
| --- | --- | --- |
| Edit popover | `CustomDuotoneBar` + `ColorListPicker` (Shadows / Highlights) | `duotone-picker` |
| Collapsed preview | `DuotonePicker` | `duotone-picker` |
| Swatch + labels | `getGradientFromCSSColors( colors, '135deg' )` | `duotone-picker/utils` |
| Value of a newly added duotone | `getDefaultColors( colorPalette )` | `duotone-picker/utils` |

A new `DuotonePalettePanel` mirrors `GradientPalettePanel`: Theme and Default sections with `canOnlyChangeValues`, a Custom section with `slugPrefix="custom-"`, and the Default section gated on `color.defaultDuotone`. The read-only duotone list is removed from the Gradient tab.

Also fixed along the way:

-   **Palette colors are filtered and normalized before they reach the duotone paths.** Duotone values become SVG filter matrices, so each color has to resolve to a concrete value. Twenty Twenty-Five ships a `color-mix()` palette entry that `colord` reads as black, which would seed every new duotone with an unrenderable value. Surviving colors are normalized to hex, because the front end's parser accepts only hex, `rgb()` and `hsl()` while `colord` in the editor also accepts CSS named colors.
-   **`DuotonePicker` gains `selectedSlug` and reports the picked preset's index and slug to `onChange`,** matching `ColorPalette` and `GradientPicker` (#80554). Selection compared colors alone, so two presets holding the same pair both appeared selected, and editing one edited the other. `+` seeds every new duotone from the palette's darkest and lightest colors, so duplicates are the normal case.
-   **The editor now generates SVG filters for user-defined duotones,** not just theme and default ones. A custom duotone rendered on the front end but had no filter on the canvas, so applying it showed no preview.
-   **Each swatch picker is named after its palette heading,** so it announces as Theme, Default or Custom rather than an unlabelled list.

### No PHP changes needed

`settings.color.duotone.custom` is already a valid user-origin path, and `WP_Duotone::get_all_global_styles_presets()` iterates every origin. Confirmed on a test site that a custom-origin duotone produces a valid `feColorMatrix` filter.

### Deferred

Two pre-existing issues in this area, neither caused by this PR:

-   #81799 — the duotone bar announces gradient stop positions it cannot save.
-   #81800 — the palette swatch pickers are exposed as listboxes but act as edit commands. Point 1 of that report, giving each picker a descriptive accessible name, is fixed here.

## Testing Instructions

1. Appearance → Editor → Styles → Colors → Edit palette. There should be three tabs: Color, Gradient, Duotone.
2. On the Duotone tab, press `+` under Custom. A duotone should be added, named "Duotone 1", seeded from your palette's darkest and lightest colors.
3. Click its swatch. The popover should show the duotone bar plus Shadows and Highlights rows.
4. Press `+` again, then edit the second duotone. The one you clicked should change, not the first.
5. Rename it, change both colors, remove it. Check the `⋮` menu: "Remove all duotones" and "Reset duotones".
6. Save and reload, and confirm it persists.
7. Apply the custom duotone to an Image block. It should preview on the canvas and render on the front end.
8. Confirm the Gradient tab no longer shows a read-only duotone list.

To test a Theme section showing up, add some duotones via `theme.json` or a `wp_theme_json_data_theme` filter.

## Screenshots

https://github.com/user-attachments/assets/bfa45e82-e848-44c8-838c-02ce4a6bc819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

