### PR TITLE
Inner Blocks: Fix bug that caused alignment controls to show in Image blocks within a Gallery

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit.
+-   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit.
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -94,7 +94,11 @@ function UncontrolledInnerBlocks( props ) {
 		EMPTY_OBJECT;
 
 	const { allowSizingOnChildren = false } = defaultLayoutBlockSupport;
-	const usedLayout = layout || defaultLayoutBlockSupport;
+	// The support is a config object, e.g. `{ allowSwitching: false, default: { type: 'flex' } }`,
+	// so the layout itself lives under `default`. Passing the config through would leave the
+	// context without a `type`, and consumers would resolve it to the flow layout.
+	const usedLayout =
+		layout || defaultLayoutBlockSupport.default || EMPTY_OBJECT;
 
 	const memoedLayout = useMemo(
 		() => ( {

--- a/packages/block-library/src/gallery/test/edit.js
+++ b/packages/block-library/src/gallery/test/edit.js
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react';
+import { createBlock } from '@wordpress/blocks';
+import {
+	initializeEditor,
+	selectBlock,
+} from '@wordpress/integration-tests/helpers/integration-test-editor';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+const IMAGE_ATTRIBUTES = {
+	id: 1,
+	url: 'https://example.com/image.jpg',
+	alt: 'Example image',
+};
+
+/**
+ * Registers the core blocks up front so inner blocks can be created before the
+ * editor is initialized, then renders the given block.
+ *
+ * @param {Object} block Block to render, created with `createBlock`.
+ */
+async function setup( block ) {
+	return initializeEditor( block, false );
+}
+
+describe( 'Gallery block', () => {
+	beforeEach( () => {
+		registerCoreBlocks();
+	} );
+
+	describe( 'Block toolbar', () => {
+		test( 'does not offer alignment for an image inside a gallery', async () => {
+			await setup(
+				createBlock( 'core/gallery', {}, [
+					createBlock( 'core/image', IMAGE_ATTRIBUTES ),
+				] )
+			);
+
+			await selectBlock( 'Block: Image' );
+
+			// The gallery lays its images out with the flex layout, which
+			// permits no alignments, so the child image must not offer them.
+			expect(
+				screen.queryByRole( 'button', { name: 'Align block' } )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'offers alignment for an image outside a gallery', async () => {
+			await setup( createBlock( 'core/image', IMAGE_ATTRIBUTES ) );
+
+			await selectBlock( 'Block: Image' );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Align block' } )
+			).toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
## What?

Fix a bug in Inner Blocks where it was referencing the block support's default layout object via the parent `layout` block support property and not the nested `default` key. The `default` key is where the "default" layout object is meant to live, rather than the values for the block support itself.

## Why?

In the Gallery block, it sets a default flex layout that the user never interacts with so for Inner Blocks to know which layout is in use, it needs to look up the default value from the block support.

I.e. in the Gallery block's `block.json` the real path to the default layout is `supports.layout.default` but the existing code was effectively looking up `support.layout` so wasn't reaching deep enough. That meant that the Image block fell back to looking up the default/flow layout which include left/center/right alignment controls.

With this change, the Image block should show alignment controls when it's anywhere within a normal post or a child of a Group block. But if it's the child of a Gallery block, the alignment controls should not show.

## How?

* Basically a one-line change, look up `defaultLayoutBlockSupport.default` instead of `defaultLayoutBlockSupport`

## Testing Instructions

* Add a Gallery block and give it some images
* The parent Gallery block should have align controls
* The inner Image blocks should not
* Add an Image outside of the Gallery block or as a child of a normal Group block, and it should show its align controls in the toolbar

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="720" height="295" alt="image" src="https://github.com/user-attachments/assets/a8a93931-0868-4c42-92d8-4558bae36f21" />

### After

<img width="545" height="233" alt="image" src="https://github.com/user-attachments/assets/d98066e3-3eed-46eb-ad63-5e54513fdbf5" />

## Use of AI Tools

Claude Code (Opus 5)