### PR TITLE
Fix parent inserter toolbar button alignment when text labels is enabled

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -215,8 +215,6 @@
 			// like every other toolbar button, not the black square.
 			.show-icon-labels & {
 				width: auto;
-				height: auto;
-				min-width: 0;
 				padding: 0 $grid-unit-15;
 				color: inherit;
 


### PR DESCRIPTION
## What?

Quick follow-up to:

* https://github.com/WordPress/gutenberg/pull/81532

Fix an issue where the button was displaying too high visually when the text labels mode is switched on in the editor.

## Why?

The `show-icon-labels` rule of `height: auto` seemed to be making the component pop up out of its visual position. That is, it set the vertical height of the button area to the height of the text itself, which we don't want. If we remove the rule, it fills the available height of the toolbar as expected instead.

## How?

Remove the unneeded rules. (I hope they weren't needed, anyhow!)

Hopefully this should fix the bug while _not_ introducing any issues for the button in either the text-labels or non-text labels modes

## Testing Instructions

* Add a Gallery block and some images within it
* Add a Group block with some paragraphs within it
* Select an Image block, make sure the toolbar + button displays correctly and inserts an Image block
* Select one of the paragraphs in the Group block and make sure the toolbar + button displays correctly and opens the block inserter popover
* Switch on the text-labels mode in block editor settings

<img width="450" height="140" alt="image" src="https://github.com/user-attachments/assets/6ec23970-266b-4a35-abb1-f369594494a1" />

* Repeat the above and ensure it all works as expected

## Screenshots or screencast <!-- if applicable -->

### Before

| The UI | What the height rule was doing |
| --- | --- |
| <img width="886" height="332" alt="image" src="https://github.com/user-attachments/assets/7a9c7ccd-2945-4ea1-b070-85e26b55e99b" /> | <img width="934" height="504" alt="image" src="https://github.com/user-attachments/assets/599a5ac2-5cf0-4d4c-93e9-4d0fa6f76765" /> |

### After

<img width="439" height="119" alt="image" src="https://github.com/user-attachments/assets/d6229989-b0bf-4a7c-b4fa-47369f5eec80" />

<img width="383" height="152" alt="image" src="https://github.com/user-attachments/assets/4ead79de-47e2-4da4-a364-50a62fae9fc6" />

<img width="594" height="179" alt="image" src="https://github.com/user-attachments/assets/64272985-a3d3-4b50-b1dc-31843142957b" />

<img width="347" height="172" alt="image" src="https://github.com/user-attachments/assets/3a669f68-5b3d-4ada-bd99-9d0aaecdf659" />

## Use of AI Tools

Claude Code (Opus 5)