### PR TITLE
Block style variations: reuse instance for consecutive blocks

### DIFF
--- a/backport-changelog/7.2/13049.md
+++ b/backport-changelog/7.2/13049.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13049
+
+* https://github.com/WordPress/gutenberg/pull/81609

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -118,6 +118,34 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 		return $parsed_block;
 	}
 
+	/*
+	 * A block style variation resolves to the same data every time it is
+	 * encountered, so consecutive blocks using the same variation generate
+	 * byte-identical CSS. Reuse the previous instance's class name in that case
+	 * so the stylesheet is only generated and enqueued once.
+	 *
+	 * Reuse is deliberately limited to the immediately preceding instance.
+	 * Variation selectors are wrapped in `:where()`, so every variation rule has
+	 * the same specificity and source order alone decides which one wins. Reusing
+	 * a class emitted before some other variation's styles would move it in the
+	 * cascade, breaking the descendant-wins behaviour this filter relies on for
+	 * nested blocks.
+	 */
+	static $last_variation_key   = null;
+	static $last_variation_class = null;
+
+	$variation_key = $parsed_block['blockName'] . '|' . $variation;
+
+	if ( null !== $last_variation_class && $last_variation_key === $variation_key ) {
+		_wp_array_set(
+			$parsed_block,
+			array( 'attrs', 'className' ),
+			$parsed_block['attrs']['className'] . " $last_variation_class"
+		);
+
+		return $parsed_block;
+	}
+
 	// Recursively resolve any ref values with the appropriate value within the
 	// theme_json data.
 	gutenberg_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
@@ -206,6 +234,11 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 
 	wp_register_style( 'block-style-variation-styles', false, array( 'wp-block-library', 'global-styles' ) );
 	wp_add_inline_style( 'block-style-variation-styles', $variation_styles );
+
+	// Record the instance so an immediately following block using the same
+	// variation can reuse it instead of emitting a duplicate stylesheet.
+	$last_variation_key   = $variation_key;
+	$last_variation_class = $class_name;
 
 	/*
 	 * Add variation instance class name to block's className string so it can

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -348,6 +348,84 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Renders a group block with the given block style variation applied.
+	 *
+	 * @param string $variation Block style variation slug.
+	 *
+	 * @return array The parsed block after the block style variation support has run.
+	 */
+	private function render_group_with_variation( $variation ) {
+		return gutenberg_render_block_style_variation_support_styles(
+			array(
+				'blockName' => 'core/group',
+				'attrs'     => array( 'className' => "is-style-$variation" ),
+			)
+		);
+	}
+
+	/**
+	 * Tests that consecutive blocks using the same block style variation share a
+	 * single instance class, so the identical stylesheet is only emitted once.
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_support_styles
+	 */
+	public function test_block_style_variation_reuses_instance_for_consecutive_blocks() {
+		switch_theme( 'block-theme' );
+
+		/*
+		 * Render a different variation first so the reuse cache is primed with a
+		 * known value regardless of what earlier tests left behind.
+		 */
+		$this->render_group_with_variation( 'block-style-variation-b' );
+
+		// Start counting emitted stylesheets from here.
+		$GLOBALS['wp_styles'] = null;
+
+		$first  = $this->render_group_with_variation( 'block-style-variation-a' );
+		$second = $this->render_group_with_variation( 'block-style-variation-a' );
+
+		$this->assertSame(
+			$first['attrs']['className'],
+			$second['attrs']['className'],
+			'Consecutive blocks using the same variation should share one instance class'
+		);
+
+		$this->assertCount(
+			1,
+			wp_styles()->get_data( 'block-style-variation-styles', 'after' ),
+			'The variation stylesheet should only be emitted once for consecutive identical variations'
+		);
+	}
+
+	/**
+	 * Tests that a variation interrupted by a different one gets a fresh instance
+	 * class. Variation selectors are wrapped in `:where()`, so they all share the
+	 * same specificity and source order alone decides which rule wins. Reusing an
+	 * earlier class here would move it in the cascade.
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_support_styles
+	 */
+	public function test_block_style_variation_does_not_reuse_instance_across_a_different_variation() {
+		switch_theme( 'block-theme' );
+
+		$first  = $this->render_group_with_variation( 'block-style-variation-a' );
+		$second = $this->render_group_with_variation( 'block-style-variation-b' );
+		$third  = $this->render_group_with_variation( 'block-style-variation-a' );
+
+		$this->assertNotSame(
+			$first['attrs']['className'],
+			$third['attrs']['className'],
+			'A variation separated by a different variation should get a fresh instance class'
+		);
+
+		$this->assertNotSame(
+			$first['attrs']['className'],
+			$second['attrs']['className'],
+			'Different variations should never share an instance class'
+		);
+	}
+
+	/**
 	 * Tests that a non-string `className` attribute does not cause a fatal
 	 * error and the block content is returned unmodified.
 	 *


### PR DESCRIPTION
## What?

Closes #81583

Core backport: https://github.com/WordPress/wordpress-develop/pull/13049 (Trac https://core.trac.wordpress.org/ticket/65876)

Block style variations emit a complete copy of the same CSS for every block instance that uses them. This reuses the previous instance when consecutive blocks share a variation, so the identical stylesheet is generated and enqueued once instead of once per block.

## Why?

`gutenberg_render_block_style_variation_support_styles()` mints a fresh instance on `render_block_data` for every block:

```php
$variation_instance = wp_unique_id( $variation . '--' );
$class_name         = "is-style-$variation_instance";
```

The variation data comes from the merged theme.json and its `ref` values resolve against that same tree, so nothing block-specific is involved — for a given block type and variation the generated CSS is identical every time apart from the scope class.

The result is linear, unbounded duplication. With Twenty Twenty-Five and the markup from the issue:

| Outline buttons on page | Inline CSS | Rules emitted | Distinct rules |
| --- | --- | --- | --- |
| 3 | 1,663 bytes | 6 | 2 |
| 20 | 10,782 bytes | 40 | 2 |

There is no rendering difference — computed border colour, width, background and padding are identical regardless of how many copies are emitted. It is purely wasted payload.

## How?

Reuse the previous instance **only when the immediately preceding variation instance is the same one**.

A broader "cache by variation slug" would be incorrect. Every variation rule is wrapped in `:where()`, so all variation rules share the same specificity and source order alone decides which wins. The per-instance class is what places a nested variation's styles after its ancestor's. Caching by slug makes a nested variation reuse a class emitted earlier in the document, which flips the cascade:

| | Emission order | Inner paragraph |
| --- | --- | --- |
| trunk today | `demo-a--2 -> demo-b--3 -> demo-a--4` | red (correct) |
| cache by slug | `demo-a--2 -> demo-b--3` | blue (wrong) |

Limiting reuse to the immediately preceding instance means nothing can have been emitted in between, so re-emitting would be a no-op in cascade terms and sharing the class is safe. Anything interleaved forces a fresh instance, preserving current ordering exactly.

This matters because the per-instance class is itself a deliberate fix: [Core 0a9dcb4](https://github.com/WordPress/wordpress-develop/commit/0a9dcb4bfcdd9d01373e4396c209c1b88d384375) replaced `md5( serialize( $block ) )` with `wp_unique_id()` for [Trac #61877](https://core.trac.wordpress.org/ticket/61877), precisely because sharing a class between copies of a block produced conflicting styles. A nested block always has its ancestor's variation emitted in between, so it never shares with an earlier instance, and #61877 is not reopened. `test_block_style_variation_does_not_reuse_instance_across_a_different_variation` guards this.

This collapses runs of the same variation, which covers the reported case and the common ones (repeated blocks in a Query Loop, sibling buttons). An alternating `A B A B` sequence still emits per instance. Fully deduplicating would require collecting variations during render and emitting them ordered by nesting depth rather than document order — a considerably larger change, discussed in [the issue](https://github.com/WordPress/gutenberg/issues/81583).

## Testing Instructions

Run the unit tests:

```
npm run test:unit:php:base -- --filter WP_Block_Supports_Block_Style_Variations_Test
```

`test_block_style_variation_reuses_instance_for_consecutive_blocks` fails on trunk without this change.

Then, with a block theme active (Twenty Twenty-Five), create a page with this content and view it on the front end:

```html
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">Button 1</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">Button 2</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">Button 3</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

Paste this into the browser console to check the result:

```js
const s = document.getElementById( 'block-style-variation-styles-inline-css' );
const c = [ ...document.querySelectorAll( '[class*="is-style-outline--"]' ) ]
	.map( ( el ) => el.className.match( /is-style-outline--\d+/ )[ 0 ] );
( { bytes: s.textContent.length, rules: s.sheet.cssRules.length,
	buttons: c.length, distinctClasses: new Set( c ).size } );
```

- [x] Before: `bytes 1663, rules 6, buttons 3, distinctClasses 3`
- [x] After: `bytes 593, rules 2, buttons 3, distinctClasses 1`
- [x] The buttons render identically in both cases.

To confirm the cascade is untouched, add two block style variations for `core/group` that style paragraphs differently — `styles/demo-a.json` with `core/paragraph` text `#cc0000`, and `styles/demo-b.json` with `#0000cc` — then create a page with a standalone A, followed by a B containing an A, each holding a paragraph:

- [x] The paragraph inside `B > A` stays red, before and after this change.
- [x] Nesting Twenty Twenty-Five's own `section-1` inside `section-2` produces byte-identical CSS before and after (6,130 bytes, 58 rules, order `section-1--2 -> section-2--3 -> section-1--4`).

Note that Twenty Twenty-Five's section styles set descendant colours with `currentColor`, so nesting those alone will not surface an ordering regression — hence the two purpose-built variations above.

### Testing Instructions for Keyboard

Not applicable — this is a server-side change to generated CSS with no user interface.

## Screenshots or screencast

Not applicable — there is no visual change. Rendering is identical before and after; only the volume of emitted CSS differs.

## Use of AI Tools

AI tooling (Claude) was used to help investigate the cause, implement the change and write the tests. All changes have been reviewed, tested and verified by me.
