### PR TITLE
Social Links: fix label overlapping itself when it wraps

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
+-   Social Links: Give the visible label its own line height, so a label that wraps in a narrow container no longer draws every line on top of the previous one ([#81611](https://github.com/WordPress/gutenberg/pull/81611)).
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 
 ## 10.4.0 (2026-08-12)

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -33,6 +33,11 @@
 			margin-left: 0.5em;
 			margin-right: 0.5em;
 			font-size: 0.65em;
+			// The anchor sets `line-height: 0` so the icon adds no vertical
+			// space. The label inherits it, which stacks every wrapped line at
+			// the same position and renders them on top of each other once the
+			// container is too narrow for the label to fit on one line.
+			line-height: normal;
 		}
 	}
 


### PR DESCRIPTION
## What?

Closes #81587

Gives the Social Icons label its own line height, so a label that wraps in a narrow container renders as stacked lines instead of every line being painted on top of the previous one.

## Why?

`social-links/style.scss` sets `line-height: 0` on the anchor so the icon contributes no vertical space:

```scss
.wp-block-social-link {
	a {
		align-items: center;
		display: flex;
		line-height: 0;
	}
}
```

The visible label is a `span` inside that anchor, so it inherits `line-height: 0` along with `white-space: normal`. Once the container is too narrow for the label to fit on one line the label wraps, and with a zero line height every wrapped line paints at the same vertical position. The result is illegible overlapping text, with the label element computing to `height: 0px` while the pill stays 36px tall.

A single-line label has nothing to overlap, which is why this only appears once the container gets small.

## How?

Adds `line-height: normal` to the existing label rule.

Reuse of the existing selector keeps the change scoped to the visible label — `span:not(.screen-reader-text)` — and leaves the anchor's `line-height: 0` in place, so the icon still contributes no extra vertical space.

Because the rule lives in the shared block stylesheet, this fixes the editor as well as the front end. The editor sets `line-height: 0` on `.wp-social-link` in `social-link/editor.scss` and had the same defect.

### Alternative considered

`white-space: nowrap` on the label would keep the pill a fixed height and let a long label overflow horizontally instead of wrapping. That trades one visual problem for another, so it is raised in the issue for maintainers to weigh rather than chosen here. Happy to switch if the overflow behaviour is preferred.

## Testing Instructions

Add a Social Icons block with **Show labels** enabled, inside a Columns block with **Stack on mobile** turned off, and set the first column to a narrow width (10–25%). View on the front end and in the editor.

```html
<!-- wp:columns {"isStackedOnMobile":false} -->
<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"10%"} -->
<div class="wp-block-column" style="flex-basis:10%"><!-- wp:social-links {"showLabels":true} -->
<ul class="wp-block-social-links has-visible-labels"><!-- wp:social-link {"url":"https://facebook.com","service":"facebook"} /-->
<!-- wp:social-link {"url":"https://instagram.com","service":"instagram"} /--></ul>
<!-- /wp:social-links --></div>
<!-- /wp:column -->
<!-- wp:column {"width":"90%"} -->
<div class="wp-block-column" style="flex-basis:90%"><!-- wp:paragraph --><p>Wide column.</p><!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

Paste this into the browser console to check whether any two rendered lines share the same vertical position:

```js
[ ...document.querySelectorAll( '.wp-social-link' ) ].map( ( a ) => {
	const label = a.querySelector( '.wp-block-social-link-label' );
	const range = document.createRange();
	range.selectNodeContents( label );
	const tops = [ ...range.getClientRects() ].map( ( r ) => Math.round( r.top ) );
	return {
		text: label.textContent,
		lines: tops.length,
		pillHeight: a.getBoundingClientRect().height,
		linesOverlap: tops.length !== new Set( tops ).size,
	};
} );
```

- [x] Before: the 10% column reports `linesOverlap: true` for both labels, 4 and 3 lines inside a 36px pill, and the text is illegible.
- [x] After: `linesOverlap: false` for every label; the pill grows to 96px and 75px and the text reads normally.
- [x] Single-line labels are unchanged before and after — same 36px pill height, no visual difference.
- [x] Same result in the editor canvas as on the front end.

### Testing Instructions for Keyboard

Not applicable — this is a CSS-only change with no interactive behaviour.

## Screenshots or screencast

| Before | After |
|-|-|
| Label wraps to 4 lines all drawn at the same position, rendering as illegible overlapping glyphs inside a 36px pill. | Label wraps to 4 readable stacked lines, pill grows to fit. |

## Use of AI Tools

AI tooling (Claude) was used to help investigate the cause and verify the fix. All changes and measurements have been reviewed and verified by me.
