### PR TITLE
Site editor: update template section description.

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Explain what templates are in the Templates sidebar description. ([#60304](https://github.com/WordPress/gutenberg/issues/60304))
+-   Unify the Site Editor sidebar section descriptions for Templates, Pages, Navigation, and Patterns. ([#60304](https://github.com/WordPress/gutenberg/issues/60304))
 
 ### Internal
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Seed the root `ThemeProvider` with the admin color scheme primary color so portaled popovers and modals receive the scheme's accent colors ([#81653](https://github.com/WordPress/gutenberg/pull/81653)).
 
+### Enhancements
+
+-   Explain what templates are in the Templates sidebar description. ([#60304](https://github.com/WordPress/gutenberg/issues/60304))
+
 ### Internal
 
 -   Stop rendering `EditorKeyboardShortcutsRegister`, which the editor provider now renders itself ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -135,7 +135,12 @@ export function SidebarNavigationScreenWrapper( {
 		<SidebarNavigationScreen
 			title={ title || __( 'Navigation' ) }
 			actions={ actions }
-			description={ description || __( 'Manage your Navigation Menus.' ) }
+			description={
+				description ||
+				__(
+					'Manage the menus that help visitors find their way around your site.'
+				)
+			}
 			backPath={ backPath }
 			content={ children }
 		/>

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/index.js
@@ -121,7 +121,7 @@ export default function SidebarNavigationScreenPatterns( { backPath } ) {
 		<SidebarNavigationScreen
 			title={ __( 'Patterns' ) }
 			description={ __(
-				'Manage what patterns are available when editing the site.'
+				'Manage what patterns are available when editing your site.'
 			) }
 			isRoot={ ! backPath }
 			backPath={ backPath }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -8,7 +8,7 @@ export default function SidebarNavigationScreenTemplatesBrowse( { backPath } ) {
 		<SidebarNavigationScreen
 			title={ __( 'Templates' ) }
 			description={ __(
-				'Create new templates, or reset any customizations made to the templates supplied by your theme.'
+				'A template specifies the structure of a page. Here, you can add new templates, or reset any customizations made to the templates supplied by your theme.'
 			) }
 			backPath={ backPath }
 			content={

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/index.js
@@ -8,7 +8,7 @@ export default function SidebarNavigationScreenTemplatesBrowse( { backPath } ) {
 		<SidebarNavigationScreen
 			title={ __( 'Templates' ) }
 			description={ __(
-				'A template specifies the structure of a page. Here, you can add new templates, or reset any customizations made to the templates supplied by your theme.'
+				'Manage the templates that define the structure of your pages, or reset any customizations made to those supplied by your theme.'
 			) }
 			backPath={ backPath }
 			content={

--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -41,6 +41,9 @@ export const pagesRoute = {
 			return siteData.currentTheme.is_block_theme ? (
 				<SidebarNavigationScreen
 					title={ __( 'Pages' ) }
+					description={ __(
+						'Manage or edit the pages that make up your site, and their appearance.'
+					) }
 					backPath="/"
 					content={ <DataViewsSidebarContent postType="page" /> }
 				/>


### PR DESCRIPTION
## What?

Closes #60304.

Before:

<img width="288" height="251" alt="Skærmbillede 2026-08-14 kl  11 33 49" src="https://github.com/user-attachments/assets/d0ea5a4b-9773-4c05-bf01-2d9cecaff3f1" />

After:

<img width="293" height="275" alt="Skærmbillede 2026-08-14 kl  11 34 53" src="https://github.com/user-attachments/assets/a7399a87-05d9-4ffc-ac71-335c61ee3a73" />

## Testing Instructions

Open Site Editor > Templates, observe the new description.

## Use of AI Tools

A little help from Claude Sonnet 5.