### PR TITLE
Block Editor: Never spotlight blocks in a preview

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -55,7 +55,13 @@ function Root( { className, ...settings } ) {
 		} = getSettings();
 		return {
 			isOutlineMode: outlineMode && ! isTyping(),
-			isFocusMode: focusMode || hasBlockSpotlight(),
+			/*
+			 * Spotlight fades everything but the block being worked on, which
+			 * has nothing to offer a canvas that cannot be edited — a preview
+			 * would just render most of its content faded out.
+			 */
+			isFocusMode:
+				! _isPreviewMode && ( focusMode || hasBlockSpotlight() ),
 			isPreviewMode: _isPreviewMode,
 			editedContentOnlySection: getEditedContentOnlySection(),
 		};

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -48,7 +48,6 @@ export function BlockPreview( {
 	const settings = useMemo(
 		() => ( {
 			...originalSettings,
-			focusMode: false, // Disable "Spotlight mode".
 			isPreviewMode: true,
 		} ),
 		[ originalSettings ]
@@ -117,7 +116,6 @@ export function useBlockPreview( { blocks, props = {}, layout } ) {
 		() => ( {
 			...originalSettings,
 			styles: undefined, // Clear styles included by the parent settings, as they are already output by the parent's EditorStyles.
-			focusMode: false, // Disable "Spotlight mode".
 			isPreviewMode: true,
 		} ),
 		[ originalSettings ]

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -91,7 +91,6 @@ export function useSpecificEditorSettings() {
 			__experimentalFeatures: globalSettings,
 			richEditingEnabled: true,
 			supportsTemplateMode: true,
-			focusMode: canvas !== 'view',
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
 			isPreviewMode: canvas === 'view',

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -345,8 +345,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		return settings.allowedBlockTypes;
 	}, [ settings.allowedBlockTypes, hiddenBlockTypes, blockTypes ] );
 
-	const forceDisableFocusMode = settings.focusMode === false;
-
 	// The "Attachments" media category depends on the edited post and its post
 	// type label (which gates whether it's offered and words its copy), so the
 	// categories are derived rather than being a static list.
@@ -371,7 +369,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			imageMaxBitDepth,
 			allowedBlockTypes,
 			allowRightClickOverrides,
-			focusMode: focusMode && ! forceDisableFocusMode,
+			focusMode,
 			hasFixedToolbar,
 			isDistractionFree,
 			keepCaretInsideBlock,
@@ -467,7 +465,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		allowedBlockTypes,
 		allowRightClickOverrides,
 		focusMode,
-		forceDisableFocusMode,
 		hasFixedToolbar,
 		isDistractionFree,
 		keepCaretInsideBlock,

--- a/packages/editor/src/components/style-book/index.js
+++ b/packages/editor/src/components/style-book/index.js
@@ -709,7 +709,6 @@ const Example = ( { id, title, blocks, isSelected, onClick, content } ) => {
 	const settings = useMemo(
 		() => ( {
 			...originalSettings,
-			focusMode: false, // Disable "Spotlight mode".
 			isPreviewMode: true,
 		} ),
 		[ originalSettings ]


### PR DESCRIPTION
## What?

Stops Spotlight mode fading blocks in a preview canvas, deriving it from `isPreviewMode` where it's consumed rather than leaving each host to disable it.

## Why?

Spotlight fades every block that doesn't contain the selection to `opacity: 0.2`. A preview can't be edited and has no selection, so most of its content just renders faded for anyone who has the preference on.

Hosts have been suppressing this by hand, and the duplication shows the intent is already settled:

- `BlockPreview` passes `focusMode: false, // Disable "Spotlight mode".` alongside `isPreviewMode: true` — in both of its setting objects.
- `edit-site` computes `focusMode: canvas !== 'view'`, whose only meaningful value is the `false` it produces in view mode.

A host that doesn't know to do this gets faded previews. The extensible site editor's list previews are the case that surfaced it.

## How?

`isFocusMode` is computed in one place, [block-list/index.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/index.js), from a `useSelect` that already reads `isPreviewMode`. Gating it there covers every preview at once.

With that in place the `focusMode` **editor setting** has nothing left to do, so it goes too. It could only ever force Spotlight *off* — `useBlockEditorSettings` tested it with a strict `settings.focusMode === false` — which was exactly the workaround being centralised. Removed along with its three producers:

- `BlockPreview`, both settings objects
- `StyleBook`, which sets `isPreviewMode: true` beside it
- `edit-site`'s `focusMode: canvas !== 'view'`

The **preference** is untouched and remains the only thing that turns Spotlight on: `useBlockEditorSettings` still reads `get( 'core', 'focusMode' )` and passes it to the block editor, the Options toggle still writes it, and `edit-site`'s `setDefaults( 'core', { focusMode: false } )` still seeds it. `edit-site`'s `?focusMode` URL parameter is a separate concept and is also untouched.

Net effect: Spotlight is on when the user asks for it and off in previews, with no host able to get that wrong.

## Testing Instructions

1. Enable **Spotlight mode** in the editor's preferences (Options → Spotlight mode).
2. Open a preview canvas — with the Extensible Site Editor experiment on, the Pages list at **Appearance → Design** shows one; block previews in the inserter and pattern lists are also previews.
3. Confirm the previewed content renders at full opacity throughout. On `trunk` the list preview fades everything but one block.
4. Open a page in an editable canvas and confirm Spotlight still works there — only the block being edited stays at full opacity.
5. Turn Spotlight off and confirm nothing is faded anywhere.

### Testing Instructions for Keyboard

Not applicable — this is presentational and changes no interaction.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: the `@wordpress/block-editor`, `@wordpress/editor` and `@wordpress/edit-site` unit suites pass (199 suites, 2980 tests); lint reports no errors across the three packages, only pre-existing warnings in files this PR doesn't touch. Not verified: no browser pass, so the testing steps above still need a manual run.
