### PR TITLE
Perf: Report the first block selection as its own metric

### DIFF
--- a/test/performance/config/performance-reporter.ts
+++ b/test/performance/config/performance-reporter.ts
@@ -23,6 +23,7 @@ export interface WPRawPerformanceResults {
 	typeWithTopToolbar: number[];
 	typeContainer: number[];
 	focus: number[];
+	firstFocus: number[];
 	selectAll: number[];
 	inserterOpen: number[];
 	inserterSearch: number[];
@@ -67,6 +68,7 @@ export interface WPPerformanceResults {
 	typeWithTopToolbar?: PerformanceStats;
 	typeContainer?: PerformanceStats;
 	focus?: PerformanceStats;
+	firstFocus?: PerformanceStats;
 	selectAll?: PerformanceStats;
 	inserterOpen?: PerformanceStats;
 	inserterSearch?: PerformanceStats;
@@ -113,6 +115,7 @@ export function curateResults(
 		typeWithTopToolbar: stats( results.typeWithTopToolbar ),
 		typeContainer: stats( results.typeContainer ),
 		focus: stats( results.focus ),
+		firstFocus: stats( results.firstFocus ),
 		selectAll: stats( results.selectAll ),
 		inserterOpen: stats( results.inserterOpen ),
 		inserterSearch: stats( results.inserterSearch ),

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -20,6 +20,7 @@ const results = {
 	typeWithTopToolbar: [],
 	typeContainer: [],
 	focus: [],
+	firstFocus: [],
 	selectAll: [],
 	listViewOpen: [],
 	inserterOpen: [],
@@ -292,10 +293,17 @@ test.describe( 'Post Editor Performance', () => {
 				name: /Block: Paragraph/i,
 			} );
 
+			// The first click also mounts the block inspector, so it costs
+			// about twice a later one and gets its own metric.
 			const samples = 10;
-			const throwaway = 1;
-			const iterations = samples + throwaway;
+			const iterations = samples + 1;
 			for ( let i = 1; i <= iterations; i++ ) {
+				const paragraph = paragraphs.nth( i );
+
+				// Scroll first, so Playwright's auto-scroll on click stays
+				// out of the trace.
+				await paragraph.scrollIntoViewIfNeeded();
+
 				// Wait for the browser to be idle before starting the monitoring.
 				// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
 				await page.waitForTimeout( BROWSER_IDLE_WAIT );
@@ -304,7 +312,7 @@ test.describe( 'Post Editor Performance', () => {
 				await metrics.startTracing();
 
 				// Click the next paragraph.
-				await paragraphs.nth( i ).click();
+				await paragraph.click();
 
 				// Stop tracing. Save just one representative sample.
 				await metrics.stopTracing(
@@ -313,14 +321,16 @@ test.describe( 'Post Editor Performance', () => {
 
 				// Get the durations.
 				const allDurations = metrics.getSelectionEventDurations();
+				const duration = allDurations.reduce(
+					( acc, eventDurations ) => acc + sum( eventDurations ),
+					0
+				);
 
 				// Save the results.
-				if ( i > throwaway ) {
-					results.focus.push(
-						allDurations.reduce( ( acc, eventDurations ) => {
-							return acc + sum( eventDurations );
-						}, 0 )
-					);
+				if ( i === 1 ) {
+					results.firstFocus.push( duration );
+				} else {
+					results.focus.push( duration );
 				}
 			}
 		} );

--- a/test/performance/utils.js
+++ b/test/performance/utils.js
@@ -60,6 +60,11 @@ export function quartiles( array ) {
 
 	const q50 = med( 0, numbers.length );
 
+	// A single value has no halves, and `med()` would read past the array.
+	if ( numbers.length === 1 ) {
+		return { q25: q50, q50, q75: q50 };
+	}
+
 	let q25, q75;
 	if ( numbers.length % 2 === 0 ) {
 		// medians of two exact halves

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -96,6 +96,11 @@ function quartiles( array ) {
 
 	const q50 = med( 0, numbers.length );
 
+	// A single value has no halves, and `med()` would read past the array.
+	if ( numbers.length === 1 ) {
+		return { q25: q50, q50, q75: q50 };
+	}
+
 	let q25, q75;
 	if ( numbers.length % 2 === 0 ) {
 		// medians of two exact halves


### PR DESCRIPTION
## What?

The `Selecting blocks` spec discarded its first iteration as a throwaway. That iteration is now recorded as a separate `firstFocus` metric, and the scroll that brings each paragraph into view happens before tracing starts.

## Why?

The first click is the one that also mounts the block inspector, so it costs about twice as much as a later click: locally, 53 to 56 ms versus 24.79 ms in the steady state. Throwing it away meant the most expensive selection in the run was never measured, and a regression confined to inspector mount would not show up in `focus`.

The scroll change removes a confound. Playwright auto-scrolls inside `click()`, so later iterations could carry scroll work that earlier ones did not.

## Testing Instructions

Run `npm run test:performance -- -g "Selecting blocks"` and check that the results table lists both `focus` and `firstFocus` with no `NaN`. Or wait for CI to finish the perf job and check the summary.
## Use of AI Tools

Assisted by Claude.
