### PR TITLE
Boot: Sync the editor's device preview with the URL

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 -   Contain a failure to the surface it happened in, so a stage, inspector or canvas that throws leaves the rest of the screen working ([#81622](https://github.com/WordPress/gutenberg/pull/81622)).
 -   Warn before leaving the page with unsaved changes ([#81625](https://github.com/WordPress/gutenberg/pull/81625)).
+-   Keep the editor's device preview in step with a `viewport` search param, so an entity that asks to be edited at a particular width — a navigation overlay meant for mobile — opens there and restores the previous width on the way back ([#81617](https://github.com/WordPress/gutenberg/pull/81617)).
 -   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.
 -   Pass the editor's entity navigation callbacks from the canvas, so a template part or synced pattern can be opened from the block inspector and navigated back out of, restoring the block that was selected ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).
 -   Add `registerEntityLinks` and `getEntityLink`, so an application declares where each post type is listed and edited and the canvas resolves every link through them ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -10,6 +10,7 @@ import BootBackButton from './back-button';
 import useNavigateToEntityRecord, {
 	useActionPerformed,
 } from './use-navigate-to-entity-record';
+import useViewportSync from './use-viewport-sync';
 
 interface CanvasProps {
 	canvas: CanvasData;
@@ -28,6 +29,8 @@ export default function Canvas( { canvas }: CanvasProps ) {
 	const { onNavigateToEntityRecord, onNavigateToPreviousEntityRecord } =
 		useNavigateToEntityRecord();
 	const onActionPerformed = useActionPerformed( canvas.postType );
+
+	useViewportSync();
 
 	/*
 	 * Where clicking a previewed canvas goes, resolved the same way the editor

--- a/packages/boot/src/components/canvas/use-navigate-to-entity-record.ts
+++ b/packages/boot/src/components/canvas/use-navigate-to-entity-record.ts
@@ -11,6 +11,7 @@ import {
 	privateApis as routePrivateApis,
 } from '@wordpress/route';
 import { store as bootStore } from '../../store';
+import { DEFAULT_DEVICE_TYPE } from './use-viewport-sync';
 import { unlock } from '../../lock-unlock';
 
 const { useCanGoBack, useRouter } = unlock( routePrivateApis );
@@ -31,7 +32,10 @@ type Navigate = ( options: {
 interface NavigateParams {
 	postType: string;
 	postId: string;
+	viewport?: string;
 }
+
+const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
 
 /**
  * Builds the editor's entity navigation callbacks.
@@ -77,11 +81,33 @@ export default function useNavigateToEntityRecord() {
 				) as { selection?: { selectionStart?: { clientId?: string } } };
 			const selectedBlock = edits?.selection?.selectionStart?.clientId;
 
-			if ( selectedBlock ) {
+			/*
+			 * An entity can ask to be edited at a particular width — a
+			 * navigation overlay meant for mobile. Leave the width this entity
+			 * is being viewed at behind, so returning restores it.
+			 */
+			const requestedViewport = params.viewport?.toLowerCase();
+			const hasRequestedViewport =
+				!! requestedViewport &&
+				VALID_VIEWPORTS.includes( requestedViewport );
+			const currentViewport = hasRequestedViewport
+				? (
+						(
+							registry.select( editorStore ) as any
+						 ).getDeviceType() ?? DEFAULT_DEVICE_TYPE
+				  ).toLowerCase()
+				: undefined;
+
+			if ( selectedBlock || currentViewport ) {
 				navigate( {
 					search: ( previous: Record< string, unknown > ) => ( {
 						...previous,
-						selectedBlock,
+						...( selectedBlock ? { selectedBlock } : {} ),
+						// The default needs no entry; its absence means it.
+						...( currentViewport &&
+						currentViewport !== DEFAULT_DEVICE_TYPE.toLowerCase()
+							? { viewport: currentViewport }
+							: {} ),
 					} ),
 					replace: true,
 				} );
@@ -96,7 +122,15 @@ export default function useNavigateToEntityRecord() {
 			const to = getEntityLink( params.postType, params.postId );
 
 			if ( to ) {
-				navigate( { to, search: () => ( { focusMode: true } ) } );
+				navigate( {
+					to,
+					search: () => ( {
+						focusMode: true,
+						...( hasRequestedViewport
+							? { viewport: requestedViewport }
+							: {} ),
+					} ),
+				} );
 			}
 		},
 		[ navigate, registry, getEntityLink ]

--- a/packages/boot/src/components/canvas/use-viewport-sync.ts
+++ b/packages/boot/src/components/canvas/use-viewport-sync.ts
@@ -1,0 +1,39 @@
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useSearch } from '@wordpress/route';
+
+export const DEFAULT_DEVICE_TYPE = 'Desktop';
+
+// Lowercase in the URL, PascalCase in the editor store.
+const VALID_VIEWPORTS = [ 'desktop', 'tablet', 'mobile' ];
+
+const capitalize = ( value: string ) =>
+	value.charAt( 0 ).toUpperCase() + value.slice( 1 );
+
+/**
+ * Keeps the editor's device preview in step with the `viewport` search param.
+ *
+ * Set when navigating into an entity that asks to be edited at a particular
+ * width — a navigation overlay meant for mobile — and read back on the way out,
+ * where the entity being returned to carries the width it was left at.
+ *
+ * Runs on every change rather than only on mount, because returning to an entity
+ * changes the param without remounting the canvas.
+ */
+export default function useViewportSync() {
+	const { viewport } = useSearch( { strict: false } ) as {
+		viewport?: string;
+	};
+	const { setDeviceType } = useDispatch( editorStore );
+
+	useEffect( () => {
+		const requested = viewport?.toLowerCase();
+
+		setDeviceType(
+			requested && VALID_VIEWPORTS.includes( requested )
+				? capitalize( requested )
+				: DEFAULT_DEVICE_TYPE
+		);
+	}, [ viewport, setDeviceType ] );
+}


### PR DESCRIPTION
## What?

Ports the viewport handling from #75386 to the extensible site editor's canvas, so a navigation overlay meant for mobile opens at mobile width and the previous width is restored on the way back.

## Why?

A block can ask for an entity to be edited at a particular width. The navigation block does this when its overlay is set to `mobile`, passing `viewport: 'mobile'` alongside the entity in `onNavigateToEntityRecord`. The canvas dropped that parameter, so overlays opened at desktop width and nothing was restored on return.

## How?

Same mechanism as `edit-site`, kept to two small pieces:

- **`use-viewport-sync`** applies whichever viewport the current URL carries, falling back to Desktop when there is none. It runs on every change rather than only on mount, because returning to an entity changes the param without remounting the canvas.
- **`onNavigateToEntityRecord`** puts the requested viewport on the entity being opened, and the current viewport on the entity being left, so returning restores it. The default is expressed by absence rather than by `?viewport=desktop`.

Worth noting the canvas has no equivalent of `edit-site`'s `useAdaptEditorToCanvas`, which resets the device type on every canvas-mode change. `canvasWidth` therefore persists across navigation here, and the fallback in the sync hook is what returns an entity opened directly to Desktop.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**, with a block theme active.
2. Open a template containing a Navigation block in the editor canvas.
3. Select the Navigation block and set **Overlay Menu** to **Mobile**.
4. From the overlay panel, open the overlay's template part for editing.
5. Confirm the canvas switches to the mobile device preview, and that the URL carries `viewport=mobile`.
6. Use the document bar's back button and confirm the canvas returns to the width you were at before.
7. Set **Overlay Menu** to **Always**, open the overlay template part again, and confirm the canvas stays at the current width — no viewport is requested in that case.
8. Open an entity directly from a list and confirm it opens at Desktop.

### Testing Instructions for Keyboard

Reach the overlay panel's edit affordance by keyboard and activate it with Enter, then return with the document bar's back button. The viewport should change and restore identically.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0. Not verified: no browser pass, so the steps above still need a manual run — in particular that `setDeviceType` resolves the right width when dispatched from the canvas, which sits outside the editor provider. It reads the theme's viewport breakpoints from the block editor settings, so a theme that customises them could resolve against defaults if the effect runs before the provider has mounted. `edit-site` avoids that by rendering its equivalent inside the editor tree; if it proves to matter here, the hook can move behind the same gate.
