### PR TITLE
Admin UI: Fix the primary color of the Fresh admin color scheme

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `getAdminThemeColors`: Fix the primary color of the Fresh scheme ([#81618](https://github.com/WordPress/gutenberg/pull/81618)).
+
 ### New Features
 
 -   `Page`: Add a `navigation` prop (`{ items, currentHref }`) and a `components.link` override for link-based navigation between sections, rendered in the page header ([#79746](https://github.com/WordPress/gutenberg/pull/79746)).

--- a/packages/admin-ui/src/admin-theme-colors/index.ts
+++ b/packages/admin-ui/src/admin-theme-colors/index.ts
@@ -10,7 +10,7 @@ const DEFAULT_THEME_COLORS: AdminThemeColors = {
 
 const ADMIN_THEME_COLORS = new Map< string, AdminThemeColors >( [
 	[ 'modern', DEFAULT_THEME_COLORS ],
-	[ 'fresh', { primary: '#3858e9', background: '#25292b' } ],
+	[ 'fresh', { primary: '#007cba', background: '#25292b' } ],
 	[ 'midnight', { primary: '#cf4339', background: '#3d4042' } ],
 	[ 'coffee', { primary: '#916745', background: '#5b534d' } ],
 	[ 'ocean', { primary: '#567958', background: '#5f787f' } ],


### PR DESCRIPTION
## What?

Fixes #81607

The editors apply the Modern scheme's accent color when the user's admin color scheme is set to Fresh. This fixes that.

## Why?

`getAdminThemeColors()` mapped `fresh` to `#3858e9`, which is the Modern scheme's primary color.

Fresh has no `body.admin-color-fresh` rule in the `wordpress-admin-schemes()` Sass mixin, so its accent has always resolved to the `:root` fallback in `_default-custom-properties.scss`, which is `#007cba`. The map entry never matched that.

#78397 added the map and wired it into the site editor, and #81112, #81173, and #81174 did the same for the post editor, widgets editor, and Customizer widgets. `ThemeProvider` emits `--wp-admin-theme-color` as an inline style, which overrides the `:root` fallback, so Fresh users started seeing the Modern accent in those screens.

Every other scheme is unaffected because its map entry already matches the value in `wordpress-admin-schemes()`.

## How?

Map `fresh` to `#007cba` so the seed matches what the stylesheets have always produced.

Note that on `trunk`, `Popover` and `Modal` content in the site editor keeps the Modern accent even with this change. #81296 added the outer `isRoot` `ThemeProvider` that portaled UI needs, but only on the 7.1 release branch, so here that content still falls back to the hardcoded `#3858e9` in `@wordpress/theme`'s prebuilt `design-tokens.css`. This affects every scheme, not just Fresh.

<img width="1003" height="237" alt="image" src="https://github.com/user-attachments/assets/856822f9-8b6b-4e2b-ad85-c8e7e1a06b3c" />

#81183 is the general fix for that. Until it lands, porting #81296 to `trunk` as well may be worth doing.

## Testing Instructions

1. Go to **Users → Profile** and select the **Fresh** admin color scheme.
2. With a block theme active, open the post editor and the site editor. The accent color (Save button, inserter, focus rings) should be the classic WordPress blue `#007cba`, not `#3858e9`.
3. Activate a classic theme, then check **Appearance → Widgets** and the widgets panel in the Customizer.
4. Switch to another scheme such as **Ocean** and confirm nothing changed there.

### Testing Instructions for Keyboard

Not applicable. The change only alters a color value, with no effect on focus order or keyboard interaction.

## Use of AI Tools

The investigation, the code change, and the changelog entry were drafted with Claude Code and reviewed by the author.
