### PR TITLE
Boot: Translate the canvas click-to-edit label

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#81620](https://github.com/WordPress/gutenberg/pull/81620)).
 
 ### Enhancements
 

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 ### Enhancements
 
 -   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { useNavigate } from '@wordpress/route';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as bootStore } from '../../store';
 import type { CanvasData } from '../../store/types';
@@ -131,7 +132,7 @@ export default function Canvas( { canvas }: CanvasProps ) {
 					} }
 					role="button"
 					tabIndex={ 0 }
-					aria-label="Click to edit"
+					aria-label={ __( 'Edit' ) }
 				/>
 			) }
 		</div>


### PR DESCRIPTION
## What?

Translates the accessible name on the extensible site editor's click-to-edit overlay, which was hardcoded English.

## Why?

A previewed canvas is covered by an overlay with `role="button"` that navigates into the editor. Its accessible name was the literal string `"Click to edit"` — not wrapped in `__()` — so anyone using a screen reader on a translated site heard English regardless of their locale. It's the only user-facing string in the package that wasn't translatable.

## How?

Uses `__( 'Edit' )`, the same string `edit-site` gives this affordance in `useEditorIframeProps`. Besides being translatable it's better copy for an accessible name: it names the action rather than the gesture, which `role="button"` already conveys, and it doesn't assume a pointer. It also keeps the two site editors announcing the same thing, and reuses a string that is already translated.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design**.
2. Land on a screen with a previewed canvas — Home, or a list route with a preview beside it.
3. With a screen reader running, move focus to the preview and confirm it announces as a button named "Edit".
4. With the site set to a non-English locale, confirm the name is translated rather than English.
5. Confirm activating it with <kbd>Enter</kbd> or <kbd>Space</kbd> still opens the editor.

### Testing Instructions for Keyboard

Tab to the preview canvas and activate it with <kbd>Enter</kbd> and with <kbd>Space</kbd>; both should open the entity for editing, unchanged by this PR.

## Screenshots or screencast

<!-- Not applicable — the change is an accessible name. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0. Not verified: no screen reader pass.
