### PR TITLE
Boot: Contain a surface failure to that surface

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Contain a failure to the surface it happened in, so a stage, inspector or canvas that throws leaves the rest of the screen working ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Contain a failure to the surface it happened in, so a stage, inspector or canvas that throws leaves the rest of the screen working ([#81622](https://github.com/WordPress/gutenberg/pull/81622)).
 
 ### Enhancements
 

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+-   Contain a failure to the surface it happened in, so a stage, inspector or canvas that throws leaves the rest of the screen working ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
+### Enhancements
+
 -   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.
 -   Pass the editor's entity navigation callbacks from the canvas, so a template part or synced pattern can be opened from the block inspector and navigated back out of, restoring the block that was selected ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).
 -   Add `registerEntityLinks` and `getEntityLink`, so an application declares where each post type is listed and edited and the canvas resolves every link through them ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).

--- a/packages/boot/src/components/app/router.tsx
+++ b/packages/boot/src/components/app/router.tsx
@@ -9,6 +9,7 @@ import {
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import Root from '../root';
+import ErrorBoundary from '../error-boundary';
 import type { Route, RouteConfig, RouteLoaderContext } from '../../store/types';
 import { unlock } from '../../lock-unlock';
 
@@ -129,12 +130,16 @@ function createRouteFromDefinition( route: Route, parentRoute: AnyRoute ) {
 					<>
 						{ Stage && showStage && (
 							<div className="boot-layout__stage">
-								<Stage />
+								<ErrorBoundary>
+									<Stage />
+								</ErrorBoundary>
 							</div>
 						) }
 						{ Inspector && showInspector && (
 							<div className="boot-layout__inspector">
-								<Inspector />
+								<ErrorBoundary>
+									<Inspector />
+								</ErrorBoundary>
 							</div>
 						) }
 					</>

--- a/packages/boot/src/components/error-boundary/index.tsx
+++ b/packages/boot/src/components/error-boundary/index.tsx
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { EmptyState } from '@wordpress/ui';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { caution } from '@wordpress/icons';
+import './style.scss';
 
 interface Props {
 	children: ReactNode;

--- a/packages/boot/src/components/error-boundary/index.tsx
+++ b/packages/boot/src/components/error-boundary/index.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { EmptyState } from '@wordpress/ui';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { caution } from '@wordpress/icons';
+
+interface Props {
+	children: ReactNode;
+}
+
+interface State {
+	error: Error | null;
+}
+
+function CopyErrorButton( { error }: { error: Error } ) {
+	const ref = useCopyToClipboard( () => error.stack ?? String( error ) );
+
+	return (
+		<Button __next40pxDefaultSize variant="secondary" ref={ ref }>
+			{ __( 'Copy error' ) }
+		</Button>
+	);
+}
+
+/**
+ * Contains a failure to one surface, so a screen keeps working around it.
+ *
+ * Wrapping each surface separately means a stage that throws leaves the
+ * navigation, the canvas and the way to save reachable, rather than taking the
+ * whole screen down with it.
+ */
+export default class ErrorBoundary extends Component< Props, State > {
+	constructor( props: Props ) {
+		super( props );
+		this.state = { error: null };
+	}
+
+	static getDerivedStateFromError( error: Error ): State {
+		return { error };
+	}
+
+	render() {
+		const { error } = this.state;
+
+		if ( ! error ) {
+			return this.props.children;
+		}
+
+		return (
+			<EmptyState.Root>
+				<EmptyState.Icon icon={ caution } />
+				<EmptyState.Title>
+					{ __( 'Something went wrong' ) }
+				</EmptyState.Title>
+				<EmptyState.Description>
+					{ __(
+						'This part of the screen could not be displayed. Reloading the page may help.'
+					) }
+				</EmptyState.Description>
+				<EmptyState.Actions>
+					<CopyErrorButton error={ error } />
+				</EmptyState.Actions>
+			</EmptyState.Root>
+		);
+	}
+}

--- a/packages/boot/src/components/error-boundary/index.tsx
+++ b/packages/boot/src/components/error-boundary/index.tsx
@@ -49,20 +49,22 @@ export default class ErrorBoundary extends Component< Props, State > {
 		}
 
 		return (
-			<EmptyState.Root>
-				<EmptyState.Icon icon={ caution } />
-				<EmptyState.Title>
-					{ __( 'Something went wrong' ) }
-				</EmptyState.Title>
-				<EmptyState.Description>
-					{ __(
-						'This part of the screen could not be displayed. Reloading the page may help.'
-					) }
-				</EmptyState.Description>
-				<EmptyState.Actions>
-					<CopyErrorButton error={ error } />
-				</EmptyState.Actions>
-			</EmptyState.Root>
+			<div className="boot-error-boundary">
+				<EmptyState.Root>
+					<EmptyState.Icon icon={ caution } />
+					<EmptyState.Title>
+						{ __( 'Something went wrong' ) }
+					</EmptyState.Title>
+					<EmptyState.Description>
+						{ __(
+							'This part of the screen could not be displayed. Reloading the page may help.'
+						) }
+					</EmptyState.Description>
+					<EmptyState.Actions>
+						<CopyErrorButton error={ error } />
+					</EmptyState.Actions>
+				</EmptyState.Root>
+			</div>
 		);
 	}
 }

--- a/packages/boot/src/components/error-boundary/style.scss
+++ b/packages/boot/src/components/error-boundary/style.scss
@@ -1,0 +1,13 @@
+@use "@wordpress/base-styles/variables";
+
+// The surfaces this sits in are sized by their container, so fill the height
+// available and centre the message in it rather than leaving it at the top of
+// an otherwise empty area.
+.boot-error-boundary {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	min-height: 100%;
+	padding: variables.$grid-unit-20;
+}

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -17,6 +17,7 @@ import { ThemeProvider } from '@wordpress/theme';
 import Sidebar from '../sidebar';
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
+import ErrorBoundary from '../error-boundary';
 import useRouteTitle from '../app/use-route-title';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
@@ -181,12 +182,14 @@ export default function Root() {
 														/>
 													</div>
 												) }
-											<CanvasRenderer
-												canvas={ canvas }
-												routeContentModule={
-													routeContentModule
-												}
-											/>
+											<ErrorBoundary>
+												<CanvasRenderer
+													canvas={ canvas }
+													routeContentModule={
+														routeContentModule
+													}
+												/>
+											</ErrorBoundary>
 										</div>
 									) }
 								</ThemeProvider>

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -1,6 +1,5 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
-@use "./components/error-boundary/style";
 
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke

--- a/packages/boot/src/style.scss
+++ b/packages/boot/src/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
+@use "./components/error-boundary/style";
 
 .boot-layout-container .boot-layout {
 	// On mobile the main content area has to scroll, otherwise you can invoke

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -529,6 +529,11 @@
 			"count": 3
 		}
 	},
+	"packages/boot/src/components/error-boundary/index.tsx": {
+		"@wordpress/no-non-module-stylesheet-imports": {
+			"count": 1
+		}
+	},
 	"packages/boot/src/components/navigation/drilldown-item/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What?

Wraps each of the extensible site editor's surfaces — stage, inspector and canvas — in its own error boundary, so a failure in one leaves the rest of the screen usable.

## Why?

A throw anywhere in a surface took the whole router subtree with it: navigation, save button and all. What caught it was TanStack's own outermost boundary around the entire match tree, which renders the library's generic `ErrorComponent` and logs *"The following error wasn't caught by any route! At the very least, consider setting an 'errorComponent' in your RootRoute!"* — the router telling us the configuration wasn't intended.

Per-match boundaries weren't active either. TanStack resolves them conditionally:

```js
const ResolvedCatchBoundary = routeErrorComponent ? CatchBoundary : SafeFragment;
// routeErrorComponent = route.options.errorComponent ?? router.options.defaultErrorComponent
```

Neither is set here — the router configures `defaultNotFoundComponent` only — so every match resolves to a passthrough.

`edit-site` wraps each of its areas individually for exactly this reason: a broken inspector leaves the sidebar, the content and the preview working.

## How?

A small boundary in this package, following the pattern each editor package already has its own of (`editor`, `edit-widgets`), and rendered around each surface: the stage and inspector in the route component, the canvas in the root.

The fallback is `EmptyState` from `@wordpress/ui` — the design system's component for a region with nothing to show — with a **Copy error** action so the failure can be reported rather than just described. Copy follows the error-messaging guidance: it says what happened, offers a next step, and doesn't assume the reader knows which part of the screen failed.

Note this covers errors thrown while rendering a surface. Errors thrown in a route's loader still take TanStack's own path; setting `defaultErrorComponent` on the router would be a complementary one-liner if we want those styled too.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design**.
2. Temporarily make a surface throw — e.g. add `throw new Error( 'test' );` at the top of the stage component in `routes/post-list/stage.tsx`, and rebuild.
3. Open the Pages list and confirm the stage shows the error state while the sidebar, the canvas beside it and the save button all still work. On `trunk` the whole screen is replaced by the router's raw error output.
4. Confirm **Copy error** puts the stack on the clipboard.
5. Revert the throw and confirm everything renders normally.

### Testing Instructions for Keyboard

With a surface erroring, Tab through the screen and confirm focus still reaches the navigation and the **Copy error** button, and that the button can be activated with <kbd>Enter</kbd>.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0. Not verified: no browser pass, so the error state hasn't been seen rendered — in particular how `EmptyState` sizes inside a narrow inspector.
