### PR TITLE
Perf: Measure block selection from input to paint

### DIFF
--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   `Metrics.getInteractionDurations()`: Return the input-to-next-paint duration of each traced interaction, read from the `EventTiming` records already present in the trace. Unlike `getSelectionEventDurations()`, it covers the render and the presentation delay, which is what INP measures.
+
 ## 1.53.0 (2026-08-12)
 
 ### Bug Fixes

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   `Metrics.getInteractionDurations()`: Return the input-to-next-paint duration of each traced interaction, read from the `EventTiming` records already present in the trace. Unlike `getSelectionEventDurations()`, it covers the render and the presentation delay, which is what INP measures.
+-   `Metrics.getInteractionDuration()`: New method returning the input-to-next-paint duration of the traced interaction, which is what INP measures ([#81623](https://github.com/WordPress/gutenberg/pull/81623)).
 
 ## 1.53.0 (2026-08-12)
 

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -37,6 +37,18 @@ type EventDispatch = TraceEvent & {
 	args: { data: { type: EventType } };
 };
 
+// A traced `EventTiming`, once filtered down to the entries that belong to an
+// interaction.
+interface InteractionTiming extends TraceEvent {
+	args: {
+		data: {
+			type: EventType;
+			duration: number;
+			interactionId: number;
+		};
+	};
+}
+
 interface Trace {
 	traceEvents: TraceEvent[];
 }
@@ -364,6 +376,57 @@ export class Metrics {
 		return [ ...durations.values() ].filter(
 			( eventDurations ) => eventDurations.length
 		);
+	}
+
+	/**
+	 * Measures from the input timestamp to the paint that follows, so unlike
+	 * `getSelectionEventDurations` it also covers the render and the
+	 * presentation delay. This is the quantity INP aggregates.
+	 *
+	 * Chromium emits one `EventTiming` entry per event of an interaction, all
+	 * carrying that same duration, so the entries are grouped by
+	 * `interactionId`. Entries outside an interaction have an `interactionId`
+	 * of `0`. The values come from the Event Timing API and are rounded to 8ms.
+	 *
+	 * A record only reaches the trace once the frame it measures has been
+	 * presented, so callers have to let the interaction paint before calling
+	 * `stopTracing()`. Stopping right after the input drops most of them.
+	 *
+	 * @return Input-to-next-paint duration of each traced interaction.
+	 */
+	getInteractionDurations() {
+		if ( this.trace.traceEvents.length === 0 ) {
+			throw new Error(
+				'No trace events found. Did you forget to call stopTracing()?'
+			);
+		}
+
+		const durations = new Map< number, number >();
+
+		for ( const item of this.trace.traceEvents ) {
+			if (
+				item.cat !== 'devtools.timeline' ||
+				item.name !== 'EventTiming'
+			) {
+				continue;
+			}
+
+			const data = ( item as InteractionTiming ).args.data;
+
+			if ( ! data?.interactionId ) {
+				continue;
+			}
+
+			durations.set(
+				data.interactionId,
+				Math.max(
+					durations.get( data.interactionId ) ?? 0,
+					data.duration
+				)
+			);
+		}
+
+		return [ ...durations.values() ];
 	}
 
 	/**

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -45,6 +45,7 @@ interface InteractionTiming extends TraceEvent {
 			type: EventType;
 			duration: number;
 			interactionId: number;
+			frame: string;
 		};
 	};
 }
@@ -383,25 +384,27 @@ export class Metrics {
 	 * `getSelectionEventDurations` it also covers the render and the
 	 * presentation delay. This is the quantity INP aggregates.
 	 *
-	 * Chromium emits one `EventTiming` entry per event of an interaction, all
-	 * carrying that same duration, so the entries are grouped by
-	 * `interactionId`. Entries outside an interaction have an `interactionId`
-	 * of `0`. The values come from the Event Timing API and are rounded to 8ms.
+	 * Chromium emits one `EventTiming` entry per event of the interaction.
+	 * They all end at the same paint but start at their own event, so the
+	 * longest is the one measured from the first input. Entries outside an
+	 * interaction have an `interactionId` of `0`.
 	 *
-	 * A record only reaches the trace once the frame it measures has been
-	 * presented, so callers have to let the interaction paint before calling
-	 * `stopTracing()`. Stopping right after the input drops most of them.
+	 * An entry only reaches the trace once the frame it measures has been
+	 * presented, so let the interaction paint before calling `stopTracing()`.
+	 * Stopping right after the input drops the entries, and losing them has to
+	 * fail the test rather than quietly leave a sample out.
 	 *
-	 * @return Input-to-next-paint duration of each traced interaction.
+	 * @throws If the trace does not hold exactly one interaction.
+	 * @return Input-to-next-paint duration of the traced interaction.
 	 */
-	getInteractionDurations() {
+	getInteractionDuration() {
 		if ( this.trace.traceEvents.length === 0 ) {
 			throw new Error(
 				'No trace events found. Did you forget to call stopTracing()?'
 			);
 		}
 
-		const durations = new Map< number, number >();
+		const durations = new Map< string, number >();
 
 		for ( const item of this.trace.traceEvents ) {
 			if (
@@ -411,22 +414,31 @@ export class Metrics {
 				continue;
 			}
 
-			const data = ( item as InteractionTiming ).args.data;
+			const data = ( item as InteractionTiming ).args?.data;
 
 			if ( ! data?.interactionId ) {
 				continue;
 			}
 
+			// Interaction ids are unique within a document, so a trace that
+			// spans several frames can repeat them.
+			const key = `${ data.frame }:${ data.interactionId }`;
+
 			durations.set(
-				data.interactionId,
-				Math.max(
-					durations.get( data.interactionId ) ?? 0,
-					data.duration
-				)
+				key,
+				Math.max( durations.get( key ) ?? 0, data.duration )
 			);
 		}
 
-		return [ ...durations.values() ];
+		if ( durations.size !== 1 ) {
+			throw new Error(
+				`Expected the trace to hold one interaction, found ${ durations.size }. An interaction is only traced once the frame it measures has been presented, so let it paint before calling stopTracing().`
+			);
+		}
+
+		const [ duration ] = durations.values();
+
+		return duration;
 	}
 
 	/**

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -331,15 +331,14 @@ test.describe( 'Post Editor Performance', () => {
 					i === Math.floor( iterations / 2 ) && 'post-editor-focus'
 				);
 
-				// Get the durations. A click is one interaction, so this is a
-				// single duration.
-				const durations = metrics.getInteractionDurations();
+				// Get the duration.
+				const duration = metrics.getInteractionDuration();
 
 				// Save the results.
 				if ( i === 1 ) {
-					results.firstFocus.push( ...durations );
+					results.firstFocus.push( duration );
 				} else {
-					results.focus.push( ...durations );
+					results.focus.push( duration );
 				}
 			}
 		} );

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -314,23 +314,32 @@ test.describe( 'Post Editor Performance', () => {
 				// Click the next paragraph.
 				await paragraph.click();
 
+				// An `EventTiming` record only reaches the trace once the frame
+				// it measures has been presented, so let the click paint before
+				// tracing stops.
+				await page.evaluate(
+					() =>
+						new Promise( ( resolve ) => {
+							window.requestAnimationFrame( () =>
+								window.requestAnimationFrame( resolve )
+							);
+						} )
+				);
+
 				// Stop tracing. Save just one representative sample.
 				await metrics.stopTracing(
 					i === Math.floor( iterations / 2 ) && 'post-editor-focus'
 				);
 
-				// Get the durations.
-				const allDurations = metrics.getSelectionEventDurations();
-				const duration = allDurations.reduce(
-					( acc, eventDurations ) => acc + sum( eventDurations ),
-					0
-				);
+				// Get the durations. A click is one interaction, so this is a
+				// single duration.
+				const durations = metrics.getInteractionDurations();
 
 				// Save the results.
 				if ( i === 1 ) {
-					results.firstFocus.push( duration );
+					results.firstFocus.push( ...durations );
 				} else {
-					results.focus.push( duration );
+					results.focus.push( ...durations );
 				}
 			}
 		} );


### PR DESCRIPTION
## What?

`focus` and `firstFocus` in the `Selecting blocks` spec now report the input-to-next-paint duration of the click instead of the sum of its event handler durations. The value comes from the `EventTiming` records already present in the trace, read through a new `Metrics.getInteractionDurations()`.

## Why?

The handler sum misses the render and presentation delays, so it does not reflect what the user waits for. It can also mislead in cases we care about here.

Example: the likely fix for a slow first click is to defer the block inspector fills, which moves work out of the handlers into a later render. That would shrink the handler sum whether or not paint arrives any sooner, so the old metric would credit a change it cannot verify.

The input to next paint is the quantity of INP aggregates, so the numbers can be read against the published thresholds.

## How?

* Add `Metrics.getInteractionDurations()`, which groups the trace's `EventTiming` records by `interactionId` and returns one duration per interaction.
* Read it in the spec in place of `getSelectionEventDurations()`.
* Wait two animation frames between the click and `stopTracing()`. An `EventTiming` record only reaches the trace once the frame it measures has been presented, and stopping right after the input drops it. Without the wait, only 1 of 11 iterations produced a sample, and it fails silently as short result arrays rather than an error.

## Notes

* The change means that our tracked measurements will jump a bit.
* `focus` keeps its name but no longer measures the same thing, so its recorded history is not comparable across this commit.
* `getSelectionEventDurations()` now has no callers in the repo. It is left in place because it is a public API on a published package, and removing it would be a breaking change.

## Testing Instructions

Run `npm run test:performance -- -g "Selecting blocks"` and check that `focus` reports 10 samples and `firstFocus` reports 1, with no missing metrics in the table.

Local results, 1000 paragraph post:

| | handler sum | input to paint |
| --- | --- | --- |
| `focus` | 24.79 ms | 32.45 ms |
| `firstFocus` | 55 ms | 87.3 ms |

Spec duration is 19.0 s before and 18.8 s after, so the job does not get slower.

## Use of AI Tools

Assisted by Claude.