### PR TITLE
Boot: Warn before leaving with unsaved changes

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Warn before leaving the page with unsaved changes ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Warn before leaving the page with unsaved changes ([#81625](https://github.com/WordPress/gutenberg/pull/81625)).
 
 -   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.
 -   Pass the editor's entity navigation callbacks from the canvas, so a template part or synced pattern can be opened from the block inspector and navigated back out of, restoring the block that was selected ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+-   Warn before leaving the page with unsaved changes ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 -   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.
 -   Pass the editor's entity navigation callbacks from the canvas, so a template part or synced pattern can be opened from the block inspector and navigated back out of, restoring the block that was selected ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).
 -   Add `registerEntityLinks` and `getEntityLink`, so an application declares where each post type is listed and edited and the canvas resolves every link through them ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -11,6 +11,7 @@ import {
 import { menu } from '@wordpress/icons';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { UnsavedChangesWarning } from '@wordpress/editor';
 import { Page, getAdminThemeColors } from '@wordpress/admin-ui';
 import { Tooltip } from '@wordpress/ui';
 import { ThemeProvider } from '@wordpress/theme';
@@ -67,6 +68,7 @@ export default function Root() {
 								'has-full-canvas': isFullScreen,
 							} ) }
 						>
+							<UnsavedChangesWarning />
 							<SavePanel />
 							<SnackbarNotices className="boot-notices__snackbar" />
 							{ isMobileViewport && (

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -5,6 +5,7 @@ import { SlotFillProvider } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
 import { getAdminThemeColors } from '@wordpress/admin-ui';
 import { ThemeProvider } from '@wordpress/theme';
+import { UnsavedChangesWarning } from '@wordpress/editor';
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
 import { unlock } from '../../lock-unlock';
@@ -53,6 +54,7 @@ export default function RootSinglePage() {
 							}
 						) }
 					>
+						<UnsavedChangesWarning />
 						<SavePanel />
 						<SnackbarNotices className="boot-notices__snackbar" />
 						<div className="boot-layout__surfaces">


### PR DESCRIPTION
## What?

Warns before leaving the page with unsaved changes in the extensible site editor, which discarded them silently.

## Why?

Both existing editors render `UnsavedChangesWarning`: `edit-post` and `edit-site` from their layouts. This shell didn't, so closing or reloading the tab with a dirty entity threw the work away without asking. It's a one-listener component that reads the dirty records from `core-data`, so nothing about it is specific to either editor.

## How?

Rendered in each root beside `<SavePanel />` — the roots are the only place always mounted, and it sits with the rest of the save handling. Both `Root` and `RootSinglePage` get it, since both render the save panel and both can hold unsaved changes.

Reuses the component from `@wordpress/editor` rather than adding one here: it's a public export, this package already depends on `@wordpress/editor`, and its behaviour is editor-agnostic — it only reads `__experimentalGetDirtyEntityRecords`.

**This covers leaving the page, not navigating within it.** `beforeunload` doesn't fire for a client-side route change, so moving between routes with unsaved changes still isn't guarded — and that's equally true in `edit-site` today, so it's a shared gap rather than something this shell regressed. Closing it needs the router's `useBlocker`, which `@wordpress/route` exposes but nothing calls, plus a confirmation dialog and its copy. Worth its own PR.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design**.
2. Open a page in the editor canvas and type something. Do not save.
3. Confirm the change registered, so a null result later means something:
   ```js
   wp.data.select( 'core' ).__experimentalGetDirtyEntityRecords().length
   ```
   It should be at least 1.
4. Reload the tab, or close it. Confirm the browser asks whether to leave. On `trunk` it closes silently.
5. Save, then reload again, and confirm there is no prompt.
6. Repeat on `site-editor.php` and confirm the behaviour now matches.

Note browsers only honour `beforeunload` after a real interaction with the page. Typing in the editor counts; dirtying state from the console alone will not produce a prompt in either editor.

### Testing Instructions for Keyboard

Make the edit by typing, then reload with <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd> and confirm the prompt appears.

## Screenshots or screencast

<!-- Not applicable — the prompt is rendered by the browser. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0. Not verified: no browser pass, so the prompt hasn't been seen.
