### PR TITLE
Edit Site Init: Seed the editor preferences the editor expects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52527,7 +52527,8 @@
 			"dependencies": {
 				"@wordpress/boot": "file:../boot",
 				"@wordpress/data": "file:../data",
-				"@wordpress/icons": "file:../icons"
+				"@wordpress/icons": "file:../icons",
+				"@wordpress/preferences": "file:../preferences"
 			},
 			"engines": {
 				"node": ">=20.10.0",

--- a/packages/edit-site-init/package.json
+++ b/packages/edit-site-init/package.json
@@ -34,7 +34,8 @@
 	"dependencies": {
 		"@wordpress/boot": "file:../boot",
 		"@wordpress/data": "file:../data",
-		"@wordpress/icons": "file:../icons"
+		"@wordpress/icons": "file:../icons",
+		"@wordpress/preferences": "file:../preferences"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -58,15 +58,7 @@ export async function init() {
 		} );
 	} );
 
-	/*
-	 * Editor preferences that are off unless something seeds them. Both the
-	 * post editor and the site editor seed the same values, because they are
-	 * what the editor expects rather than anything this application prefers —
-	 * they belong in the editor itself, and this is a copy until they move.
-	 *
-	 * Only these three matter: every other preference those editors seed is
-	 * either falsy anyway, or read with a fallback at the point of use.
-	 */
+	// Read without a fallback where they are used, so they are off unless seeded.
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
 		enableChoosePatternModal: true,

--- a/packages/edit-site-init/src/index.ts
+++ b/packages/edit-site-init/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/icons';
 import { dispatch } from '@wordpress/data';
 import { store as bootStore } from '@wordpress/boot';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Initialize edit-site menu items with icons.
@@ -55,5 +56,20 @@ export async function init() {
 			...entityLinks.default,
 			...links,
 		} );
+	} );
+
+	/*
+	 * Editor preferences that are off unless something seeds them. Both the
+	 * post editor and the site editor seed the same values, because they are
+	 * what the editor expects rather than anything this application prefers —
+	 * they belong in the editor itself, and this is a copy until they move.
+	 *
+	 * Only these three matter: every other preference those editors seed is
+	 * either falsy anyway, or read with a fallback at the point of use.
+	 */
+	dispatch( preferencesStore ).setDefaults( 'core', {
+		allowRightClickOverrides: true,
+		enableChoosePatternModal: true,
+		showBlockBreadcrumbs: true,
 	} );
 }


### PR DESCRIPTION
## What?

Seeds the editor preferences the extensible site editor was missing, so block breadcrumbs, right-click block menus and the start-page pattern chooser work there.

## Why?

Three `core` preferences are read without a fallback, so they're off unless something calls `setDefaults`:

| Preference | Read at | Effect when unset |
| --- | --- | --- |
| `showBlockBreadcrumbs` | `editor-interface/index.js` | Breadcrumbs hidden below the canvas |
| `allowRightClickOverrides` | `provider/use-block-editor-settings.js` | Right-clicking a block gives the browser menu |
| `enableChoosePatternModal` | `start-page-options/index.js` | No pattern chooser when starting an empty page |

`edit-post` and `edit-site` both seed them at startup; this application seeded nothing, so all three were off.

**Only these three matter.** Every other preference those two editors seed is either falsy anyway — indistinguishable from unset — or read with a fallback at the point of use: `editorMode` via `?? 'visual'`, `openPanels` and `inactivePanels` via `??` and optional chaining, `hiddenBlockTypes` behind a `&& length > 0` guard. So the other thirteen are no-ops here and copying them would just be noise.

## How?

A `setDefaults` call in the init module, next to the menu icons and entity links that already live there.

Worth flagging for a follow-up: `edit-post` and `edit-site` seed these same three with the same values, because they describe what the editor expects rather than anything an application prefers. They arguably belong in `@wordpress/editor`, seeded once, at which point all three copies could go and the consumers would no longer need their fallbacks. This PR adds a third copy rather than making that move, and the comment in the code says so.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design**.
2. Open a page in the editor canvas and select a nested block. Confirm the block breadcrumbs appear along the bottom. On `trunk` they don't.
3. Right-click a block and confirm the block's own menu opens rather than the browser's.
4. Create a new page with no content and confirm the pattern chooser is offered.
5. Compare each against `site-editor.php`; they should now match.

Note these are *defaults*, so they only apply if you have not set the preference yourself. If any of the three already has a stored value in `wp_persisted_preferences`, that wins in both editors and the comparison will show no difference. Checking is one line:

```js
wp.data.select( 'core/preferences' ).get( 'core', 'showBlockBreadcrumbs' )
```

### Testing Instructions for Keyboard

With a nested block selected by keyboard, confirm the breadcrumb trail is reachable by Tab and that activating an entry selects that ancestor.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; the package type-checks (it has no tsconfig of its own, so this was an ad-hoc `tsc -p` over its sources); lockfile updated for the new `@wordpress/preferences` dependency. Not verified: no browser pass, so the three behavioural checks above still need a manual run.
