### PR TITLE
Editor: Announce publish date changes to screen readers

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Header: Allow the Back button column to grow when "Show button text labels" is enabled so the label is not obscured by the following controls ([#81701](https://github.com/WordPress/gutenberg/pull/81701)).
 -   Notes: Stop forcing capitalization of the user name in a note byline, so the name is shown as the user set it ([#81788](https://github.com/WordPress/gutenberg/pull/81788)).
 -   Device Preview: Center the editor canvas with the canvas container's own flex alignment rather than the canvas's auto margins, which were conditional on the resize handles being active. Switching from the mobile or tablet preview back to desktop no longer expands the canvas from the left edge ([#81484](https://github.com/WordPress/gutenberg/pull/81484)).
+-   `PostSchedule`: Announce the new publish date to screen readers when the date is changed ([#81629](https://github.com/WordPress/gutenberg/pull/81629)).
 
 ### Internal
 

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -1,11 +1,13 @@
 import { parseISO, endOfMonth, startOfMonth } from 'date-fns';
+import { speak } from '@wordpress/a11y';
 import { getSettings } from '@wordpress/date';
-import { _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useState, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
+import { getFullPostScheduleLabel } from './label';
 import { unlock } from '../../lock-unlock';
 
 const { PrivatePublishDateTimePicker } = unlock( blockEditorPrivateApis );
@@ -42,7 +44,19 @@ export function PrivatePostSchedule( {
 	);
 
 	const { editPost } = useDispatch( editorStore );
-	const onUpdateDate = ( date ) => editPost( { date } );
+	const onUpdateDate = ( date ) => {
+		editPost( { date } );
+		speak(
+			date
+				? sprintf(
+						// translators: %s: The new publish date and time, e.g. "June 3, 2025 12:00 pm UTC+0".
+						__( 'Publish date set to %s.' ),
+						getFullPostScheduleLabel( date )
+				  )
+				: __( 'Publish date set to now.' ),
+			'assertive'
+		);
+	};
 
 	const [ previewedMonth, setPreviewedMonth ] = useState(
 		startOfMonth( new Date( postDate ) )


### PR DESCRIPTION
Fixes #15398.

When the publish date of a post is changed in the date picker, there is no audible confirmation for screen reader users. The button previously relied on an `aria-live` attribute that was removed in #15381, and as noted in the issue, an explicit `speak()` message is the recommended replacement.

This PR adds a `speak()` call to the `onUpdateDate` handler of the `PostSchedule` component, the approach suggested by @Mamaduka in the issue. The announcement uses the wording proposed by @afercia, e.g., "Publish date set to June 3, 2025 12:00 pm UTC+0.", reusing the existing `getFullPostScheduleLabel` helper so the date is localized and includes the timezone. When the date is reset via the "Now" action in the popover header, "Publish date set to now." is announced instead.

## Testing Instructions

1. Open the post editor and open the Settings sidebar.
2. Start a screen reader (e.g., VoiceOver or NVDA).
3. In the Summary panel, click the publish date button (labeled "Immediately" on a new draft) to open the date picker.
4. Choose a different day or change the time, and verify the screen reader announces "Publish date set to [date]."
5. Click "Now" in the popover header and verify "Publish date set to now." is announced.

Without a screen reader, the same can be verified by inspecting the content of the `#a11y-speak-assertive` region in the DOM after changing the date.

AI assistance was used in the creation of this PR.
