### PR TITLE
Lazy Editor: Render the editor preferences modal

### DIFF
--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Render the editor preferences modal, so the Preferences menu item and command open it ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 ## 1.19.0 (2026-08-12)
 
 

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Render the editor preferences modal, so the Preferences menu item and command open it ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Render the editor preferences modal, so the Preferences menu item and command open it ([#81630](https://github.com/WordPress/gutenberg/pull/81630)).
 
 ## 1.19.0 (2026-08-12)
 

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -9,7 +9,11 @@ import { useEditorSettings } from '../../hooks/use-editor-settings';
 import { useEditorAssets } from '../../hooks/use-editor-assets';
 import { unlock } from '../../lock-unlock';
 
-const { Editor: PrivateEditor, BackButton } = unlock( editorPrivateApis );
+const {
+	Editor: PrivateEditor,
+	BackButton,
+	PreferencesModal,
+} = unlock( editorPrivateApis );
 
 interface EditorProps {
 	postType?: string;
@@ -115,6 +119,12 @@ export function Editor( {
 			onActionPerformed={ onActionPerformed }
 		>
 			{ backButton && <BackButton>{ backButton }</BackButton> }
+			{ /*
+			   Opened from the editor's own menu and from the command the editor
+			   registers, both of which exist only while it is mounted. Renders
+			   nothing until one of them opens it.
+			 */ }
+			<PreferencesModal />
 		</PrivateEditor>
 	);
 }


### PR DESCRIPTION
## What?

Renders the editor preferences modal from `@wordpress/lazy-editor`, so choosing **Preferences** in the extensible site editor opens it instead of doing nothing.

## Why?

Opening and rendering are separate responsibilities. Two things open the modal, and both come from the editor itself:

- the **Preferences** item in the editor's own menu, which `EditorInterface` renders
- the `core/open-preferences` command, registered by `useCommands()` from the editor provider

Both just dispatch `openModal( 'editor/preferences' )` against the `interface` store, which succeeds. But `PreferencesModal` is a private export that whoever mounts the editor has to render — `edit-post` and `edit-site` each do it from their more-menus. Nothing did here, so the flag flipped and no UI appeared.

## How?

Rendered next to the editor. Both entry points exist exactly while the editor is mounted — the menu comes from `EditorInterface`, the command from the provider — so this covers both, and there is no state where one is reachable and the modal isn't. The component is internally gated on `isModalActive`, so it renders nothing until opened.

Passes no `extraSections`, matching `edit-site`. That prop is how `edit-post` contributes its meta boxes section and the `core/edit-post` theme styles toggle; neither applies here.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design**.
2. Open a page in the editor canvas.
3. Open the editor's ⋮ menu and choose **Preferences**. Confirm the modal opens. On `trunk` nothing happens.
4. Confirm the toggles work and persist across a reload.
5. Open the command palette, run **Editor preferences**, and confirm it opens the same modal.
6. Close it and confirm the flag clears:
   ```js
   wp.data.select( 'core/interface' ).isModalActive( 'editor/preferences' )
   ```
   It should be `false`; on `trunk` it goes `true` and stays there with nothing on screen.

### Testing Instructions for Keyboard

Reach the ⋮ menu by keyboard, activate **Preferences** with <kbd>Enter</kbd>, confirm focus moves into the modal, and that <kbd>Esc</kbd> closes it and returns focus sensibly.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/lazy-editor --force` exits 0. Not verified: no browser pass, so the modal hasn't been seen opening.
