### PR TITLE
Env: Fall back to cached docker images when the registry is unreachable

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Update git sources to the latest commit when `--update` is passed. Previously, a source pointing at a branch (such as `"core": "WordPress/WordPress"`) stayed at the commit it was first cloned at, no matter how many times it was updated.
+-   Do not fail `wp-env start` when docker images cannot be pulled (e.g., the Docker registry is unreachable); fall back to locally cached images and show a notice instead. ([#72477](https://github.com/WordPress/gutenberg/issues/72477))
 
 ## 11.13.0 (2026-08-12)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   Update git sources to the latest commit when `--update` is passed. Previously, a source pointing at a branch (such as `"core": "WordPress/WordPress"`) stayed at the commit it was first cloned at, no matter how many times it was updated.
--   Do not fail `wp-env start` when docker images cannot be pulled (e.g., the Docker registry is unreachable); fall back to locally cached images and show a notice instead. ([#72477](https://github.com/WordPress/gutenberg/issues/72477))
+-   Do not fail `wp-env start` when Docker images cannot be pulled (e.g., the Docker registry is unreachable); fall back to locally cached images and show a notice instead. ([#81631](https://github.com/WordPress/gutenberg/issues/81631))
 
 ## 11.13.0 (2026-08-12)
 

--- a/packages/env/lib/runtime/docker/index.js
+++ b/packages/env/lib/runtime/docker/index.js
@@ -162,7 +162,17 @@ class DockerRuntime {
 				// stop wp-env from working correctly.
 			}
 
-			await dockerCompose.pullAll( dockerComposeConfig );
+			try {
+				await dockerCompose.pullAll( dockerComposeConfig );
+			} catch {
+				// Note: pulling the images requires connecting to the Docker
+				// registry, which may be unavailable (e.g., offline or an
+				// outage). Locally cached images will be used instead, so this
+				// error should not stop wp-env from working correctly.
+				spinner.info(
+					'Could not pull docker images; using cached images instead.'
+				);
+			}
 			spinner.text = 'Downloading sources.';
 		}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/72477

Fixes `wp-env start` hard-failing when the Docker registry is down, even though all the required images are already cached locally.

When the configuration changes (or `--update` is passed) while wordpress.org is reachable but the Docker registry is not, `wp-env start` dies at the "Updating docker images." step: the `docker compose pull` call is the only network operation in the start sequence that is not guarded, so a registry outage aborts startup that could have completed fine with the cached images. To fix this we wrap the pull in a try/catch, mirroring the volume-removal handling just above it: when the pull fails, a notice is shown and startup continues using the locally cached images.

## Testing Instructions

1. Run `wp-env start` successfully once so the docker images are cached locally.
2. Simulate a registry outage while keeping normal internet access, e.g. add `127.0.0.1 registry-1.docker.io` to `/etc/hosts`.
3. Run `wp-env start --update`.
4. Verify the command no longer fails while updating the docker images: it prints "Could not pull docker images; using cached images instead." and the environment starts correctly.
5. Remove the `/etc/hosts` entry from step 2.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.