### PR TITLE
Boot: Do not offer to edit a trashed entity

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Canvas: Do not offer to edit a trashed entity from its preview ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Canvas: Do not offer to edit a trashed entity from its preview ([#81632](https://github.com/WordPress/gutenberg/pull/81632)).
 -   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#81620](https://github.com/WordPress/gutenberg/pull/81620)).
 
 ### Enhancements

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,16 +4,13 @@
 
 ### Bug Fixes
 
+-   Canvas: Do not offer to edit a trashed entity from its preview ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
 -   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#81620](https://github.com/WordPress/gutenberg/pull/81620)).
 
 ### Enhancements
 
 -   Contain a failure to the surface it happened in, so a stage, inspector or canvas that throws leaves the rest of the screen working ([#81622](https://github.com/WordPress/gutenberg/pull/81622)).
-
-### Enhancements
-
 -   Warn before leaving the page with unsaved changes ([#81625](https://github.com/WordPress/gutenberg/pull/81625)).
-
 -   Add a `stage` visibility function to a route's config, mirroring `inspector`, so a route can hide its stage and leave the canvas to fill the surfaces area.
 -   Pass the editor's entity navigation callbacks from the canvas, so a template part or synced pattern can be opened from the block inspector and navigated back out of, restoring the block that was selected ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).
 -   Add `registerEntityLinks` and `getEntityLink`, so an application declares where each post type is listed and edited and the canvas resolves every link through them ([#81590](https://github.com/WordPress/gutenberg/pull/81590)).

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -3,6 +3,7 @@ import { Spinner } from '@wordpress/components';
 import { useNavigate } from '@wordpress/route';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as bootStore } from '../../store';
 import type { CanvasData } from '../../store/types';
 import BootBackButton from './back-button';
@@ -28,16 +29,35 @@ export default function Canvas( { canvas }: CanvasProps ) {
 		useNavigateToEntityRecord();
 	const onActionPerformed = useActionPerformed( canvas.postType );
 
-	// Where clicking a previewed canvas goes, resolved the same way the editor
-	// resolves anywhere else it sends you to edit an entity.
-	const editLink = useSelect(
-		( select ) =>
-			canvas.postType && canvas.postId
-				? select( bootStore ).getEntityLink(
-						canvas.postType,
-						canvas.postId
-				  )
-				: undefined,
+	/*
+	 * Where clicking a previewed canvas goes, resolved the same way the editor
+	 * resolves anywhere else it sends you to edit an entity, and whether it
+	 * should go anywhere at all: a trashed entity has to be restored before it
+	 * can be edited.
+	 *
+	 * The record is the one the editor loads for this canvas, so reading it
+	 * here costs no request of its own.
+	 */
+	const { editLink, isTrashed } = useSelect(
+		( select ) => {
+			if ( ! canvas.postType || ! canvas.postId ) {
+				return { editLink: undefined, isTrashed: false };
+			}
+
+			const record = select( coreStore ).getEntityRecord(
+				'postType',
+				canvas.postType,
+				canvas.postId
+			) as { status?: string } | undefined;
+
+			return {
+				editLink: select( bootStore ).getEntityLink(
+					canvas.postType,
+					canvas.postId
+				),
+				isTrashed: record?.status === 'trash',
+			};
+		},
 		[ canvas.postType, canvas.postId ]
 	);
 
@@ -117,8 +137,15 @@ export default function Canvas( { canvas }: CanvasProps ) {
 			</div>
 			{ canvas.isPreview && editLink && (
 				<div
-					onClick={ () => navigate( { to: editLink } ) }
+					onClick={
+						isTrashed
+							? undefined
+							: () => navigate( { to: editLink } )
+					}
 					onKeyDown={ ( e ) => {
+						if ( isTrashed ) {
+							return;
+						}
 						if ( e.key === 'Enter' || e.key === ' ' ) {
 							e.preventDefault();
 							navigate( { to: editLink } );
@@ -127,11 +154,12 @@ export default function Canvas( { canvas }: CanvasProps ) {
 					style={ {
 						position: 'absolute',
 						inset: 0,
-						cursor: 'pointer',
+						cursor: isTrashed ? 'default' : 'pointer',
 						zIndex: 1,
 					} }
 					role="button"
 					tabIndex={ 0 }
+					aria-disabled={ isTrashed }
 					aria-label={ __( 'Edit' ) }
 				/>
 			) }

--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -382,6 +382,12 @@ function PostList() {
 						},
 					} );
 				} }
+				isItemClickable={ ( item: Post ) =>
+					// Restoring comes before editing, so a trashed post's title
+					// does not link to the editor. Cast because the assignable
+					// statuses `status` is typed as exclude 'trash'.
+					( item.status as string ) !== 'trash'
+				}
 				renderItemLink={ ( { item, ...props }: { item: Post } ) => (
 					<Link
 						to={ `/types/${ postType }/edit/${ encodeURIComponent(


### PR DESCRIPTION
## What?

Stops the extensible site editor offering to edit a post that is in the trash, closing a gap with `edit-site`.

## Why?

A trashed post has to be restored before WordPress will let it be edited, so every route into the editor for one is a dead end. `edit-site` blocks all of them; v2 blocked none.

Two ways in today:

- **The post list title**, which `renderItemLink` renders as a link straight to `/types/{postType}/edit/{id}`.
- **The preview canvas**, whose click overlay navigates on click and on <kbd>Enter</kbd>/<kbd>Space</kbd>, with `cursor: pointer` to advertise it.

`edit-site` guards the equivalents in three places — [`isItemClickable`](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/post-list/index.js) on the list, `aria-disabled` plus an `onClickCapture` that swallows the click on the canvas iframe, and omitting the `cursor: pointer` it injects into the preview.

## How?

- `routes/post-list`: `isItemClickable` returns `false` for a trashed post, so DataViews renders the title as plain text instead of a link. Row selection is separate, so a trashed post can still be selected and previewed — only the way into the editor closes.
- `packages/boot` canvas: the overlay drops its click and key handlers, gains `aria-disabled`, and drops the pointer cursor.

The canvas reads `status` from `getEntityRecord( 'postType', … )` — the same call with the same cache key that the editor already makes for this canvas ([editor/index.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/components/editor/index.js)), so the check adds no request. Reading it from `core-data` rather than `core/editor` also avoids depending on the editor being mounted, and on which post it currently holds mid-transition.

Also merges a duplicate `### Enhancements` heading I left in the boot changelog in #81625.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design → Pages**.
2. Trash a page, then switch to the **Trash** filter.
3. Confirm the page's title is no longer a link. On `trunk` it links into the editor.
4. Select the row so it previews in the canvas. Confirm hovering the preview shows the normal arrow cursor, and clicking it does nothing. On `trunk` it navigates into the editor.
5. Restore the page and confirm the title links and the preview is clickable again.

### Testing Instructions for Keyboard

With a trashed page previewed, tab to the canvas and press <kbd>Enter</kbd> and <kbd>Space</kbd>; neither should navigate. A screen reader should announce the canvas as a disabled button.

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0; `routes/post-list` type-checks clean under a throwaway tsconfig copied from `routes/dashboard` (routes are outside the project graph, so nothing checks them in CI). Not verified: no browser pass.

One thing I did not chase: what actually happens if you *do* reach the editor for a trashed post — whether saving restores it, fails, or writes to a trashed row. This PR removes the ways in rather than making that path safe, so if it turns out to corrupt state there may be more to do.
