### PR TITLE
Block Fields: make the link field control configurable

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
+-   Block Fields: The link field control now follows the DataForm control conventions: it renders the field label, and fields can declare it as `Edit: { control: 'link' }` to configure the offered link settings and the search suggestions query ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
 
 ### Internal
 
@@ -23,6 +24,7 @@
 -   Element styles: Register each block's element-style CSS override with the block's `clientId`, so the editor orders them by block position instead of registration order. A parent's link color re-registered after a child's (e.g. by resetting and re-picking it) no longer overrides the child's own link color in the canvas ([#77833](https://github.com/WordPress/gutenberg/pull/77833)).
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 -   `BlockVariationPicker`: Set icon colors with `color` so stroke-based variation icons retain their intended unfilled appearance, while keeping a non-important `fill` fallback for third-party icons that do not use `currentColor`. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
+-   Block Fields: Read the link field's nofollow state from combined `rel` values such as `noopener nofollow`, so editing the URL no longer drops the token ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
 
 ### Internal
 
@@ -45,7 +47,6 @@
 -   Patterns explorer: Refactor the category sidebar to use `Tabs` ([#81807](https://github.com/WordPress/gutenberg/pull/81807)).
 -   `PublishDateTimePicker`: Add a `showPopoverHeader` prop so the picker can be rendered inline, without the popover title and close button. Rename the header's reset action from "Now" to "Reset", which reads as an action rather than a status ([#81806](https://github.com/WordPress/gutenberg/pull/81806)).
 -   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
--   Block Fields: The link field control now follows the DataForm control conventions: it renders the field label, and fields can declare it as `Edit: { control: 'link' }` to configure the offered link settings and the search suggestions query ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
 
 ### Bug Fixes
 
@@ -54,7 +55,6 @@
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
--   Block Fields: Read the link field's nofollow state from combined `rel` values such as `noopener nofollow`, so editing the URL no longer drops the token ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
 -   `ListView`: Only move focus into the list when the new `focusOnMount` prop is set, so that a list mounted as a side effect of a selection no longer pulls focus out of the editor canvas ([#81659](https://github.com/WordPress/gutenberg/pull/81659)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -45,6 +45,7 @@
 -   Patterns explorer: Refactor the category sidebar to use `Tabs` ([#81807](https://github.com/WordPress/gutenberg/pull/81807)).
 -   `PublishDateTimePicker`: Add a `showPopoverHeader` prop so the picker can be rendered inline, without the popover title and close button. Rename the header's reset action from "Now" to "Reset", which reads as an action rather than a status ([#81806](https://github.com/WordPress/gutenberg/pull/81806)).
 -   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
+-   Block Fields: The link field control now follows the DataForm control conventions: it renders the field label, and fields can declare it as `Edit: { control: 'link' }` to configure the offered link settings and the search suggestions query ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
 
 ### Bug Fixes
 
@@ -53,6 +54,7 @@
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
+-   Block Fields: Read the link field's nofollow state from combined `rel` values such as `noopener nofollow`, so editing the URL no longer drops the token ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
 -   `ListView`: Only move focus into the list when the new `focusOnMount` prop is set, so that a list mounted as a side effect of a selection no longer pulls focus out of the editor canvas ([#81659](https://github.com/WordPress/gutenberg/pull/81659)).

--- a/packages/block-editor/src/hooks/block-fields/index.jsx
+++ b/packages/block-editor/src/hooks/block-fields/index.jsx
@@ -159,7 +159,8 @@ function BlockFields( {
 			// These should be custom Edit components, not replaced here.
 			//
 			// - rich-text control: it needs clientId
-			// - link control: does not need anything extra
+			// - link control: accepts an optional Edit config
+			//   (settings, suggestionsQuery)
 			// - media control: needs the Edit config
 			if (
 				'string' === typeof fieldDef.Edit &&
@@ -169,10 +170,17 @@ function BlockFields( {
 					clientId,
 				} );
 			} else if (
-				'string' === typeof fieldDef.Edit &&
-				fieldDef.Edit === 'link'
+				( 'string' === typeof fieldDef.Edit &&
+					fieldDef.Edit === 'link' ) ||
+				( 'object' === typeof fieldDef.Edit &&
+					fieldDef.Edit.control === 'link' )
 			) {
-				field.Edit = createConfiguredControl( Link );
+				field.Edit = createConfiguredControl(
+					Link,
+					'object' === typeof fieldDef.Edit
+						? { ...fieldDef.Edit }
+						: {}
+				);
 			} else if (
 				'object' === typeof fieldDef.Edit &&
 				fieldDef.Edit.control === 'media'

--- a/packages/block-editor/src/hooks/block-fields/link/index.jsx
+++ b/packages/block-editor/src/hooks/block-fields/link/index.jsx
@@ -1,8 +1,10 @@
 import {
+	BaseControl,
 	Button,
 	Icon as WCIcon,
 	__experimentalGrid as Grid,
 	Popover,
+	useBaseControlProps,
 } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -14,6 +16,37 @@ import { useInspectorPopoverPlacement } from '../use-inspector-popover-placement
 export const NEW_TAB_REL = 'noopener';
 export const NEW_TAB_TARGET = '_blank';
 export const NOFOLLOW_REL = 'nofollow';
+
+/**
+ * The link settings the control knows how to map onto the block's `rel` and
+ * `linkTarget` attributes, keyed by the ids accepted in the field's
+ * `Edit.settings` config.
+ */
+const AVAILABLE_SETTINGS = [
+	...LinkControl.DEFAULT_LINK_SETTINGS,
+	{
+		id: 'nofollow',
+		title: __( 'Mark as nofollow' ),
+	},
+];
+
+const DEFAULT_SETTING_IDS = LinkControl.DEFAULT_LINK_SETTINGS.map(
+	( setting ) => setting.id
+);
+
+/**
+ * Resolves the setting ids declared in the field config into the settings
+ * passed to `LinkControl`.
+ *
+ * @param {string[]} settingIds Setting ids declared by the field.
+ *
+ * @return {Object[]} Settings for `LinkControl`.
+ */
+export function getLinkSettings( settingIds ) {
+	return AVAILABLE_SETTINGS.filter( ( setting ) =>
+		settingIds.includes( setting.id )
+	);
+}
 
 /**
  * Updates the link attributes.
@@ -60,10 +93,20 @@ export function getUpdatedLinkAttributes( {
 	};
 }
 
-export default function Link( { data, field, onChange } ) {
+export default function Link( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	config = {},
+} ) {
 	const [ isLinkControlOpen, setIsLinkControlOpen ] = useState( false );
 	const { popoverProps } = useInspectorPopoverPlacement( {
 		isControl: true,
+	} );
+	const { baseControlProps, controlProps } = useBaseControlProps( {
+		hideLabelFromVision: hideLabelFromVision ?? field.hideLabelFromVision,
+		label: field.label,
 	} );
 	const value = field.getValue( { item: data } );
 	const url = value?.url;
@@ -71,7 +114,13 @@ export default function Link( { data, field, onChange } ) {
 	const target = value?.linkTarget;
 
 	const opensInNewTab = target === NEW_TAB_TARGET;
-	const nofollow = rel === NOFOLLOW_REL;
+	const nofollow = rel.includes( NOFOLLOW_REL );
+
+	const { settings: settingIds, suggestionsQuery } = config;
+	const settings = useMemo(
+		() => getLinkSettings( settingIds ?? DEFAULT_SETTING_IDS ),
+		[ settingIds ]
+	);
 
 	// Memoize link value to avoid overriding the LinkControl's internal state.
 	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
@@ -81,13 +130,14 @@ export default function Link( { data, field, onChange } ) {
 	);
 
 	return (
-		<>
+		<BaseControl { ...baseControlProps }>
 			<Button
 				__next40pxDefaultSize
 				className="block-editor-content-only-controls__link"
 				onClick={ () => {
 					setIsLinkControlOpen( true );
 				} }
+				{ ...controlProps }
 			>
 				<Grid
 					rowGap={ 0 }
@@ -126,6 +176,8 @@ export default function Link( { data, field, onChange } ) {
 				>
 					<LinkControl
 						value={ linkValue }
+						settings={ settings }
+						suggestionsQuery={ suggestionsQuery }
 						onChange={ ( newValues ) => {
 							const updatedAttrs = getUpdatedLinkAttributes( {
 								rel,
@@ -150,6 +202,6 @@ export default function Link( { data, field, onChange } ) {
 					/>
 				</Popover>
 			) }
-		</>
+		</BaseControl>
 	);
 }

--- a/packages/block-editor/src/hooks/block-fields/test/link.js
+++ b/packages/block-editor/src/hooks/block-fields/test/link.js
@@ -1,0 +1,219 @@
+import { render as baseRender, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SlotFillProvider } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import Link, {
+	getLinkSettings,
+	getUpdatedLinkAttributes,
+	NEW_TAB_TARGET,
+} from '../link';
+
+const mockFetchSearchSuggestions = jest.fn( () => Promise.resolve( [] ) );
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test.
+	const mock = jest.fn();
+	return mock;
+} );
+useSelect.mockImplementation( () => ( {
+	fetchSearchSuggestions: mockFetchSearchSuggestions,
+	fetchRichUrlData: undefined,
+} ) );
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useReducedMotion: jest.fn( () => true ),
+} ) );
+
+function render( ui ) {
+	return baseRender( ui, { wrapper: SlotFillProvider } );
+}
+
+const linkField = {
+	id: 'link',
+	label: 'Link',
+	getValue: ( { item } ) => ( {
+		url: item.url,
+		rel: item.rel,
+		linkTarget: item.linkTarget,
+	} ),
+	setValue: ( { value } ) => ( {
+		url: value.url,
+		rel: value.rel,
+		linkTarget: value.linkTarget,
+	} ),
+};
+
+async function openLinkSettingsDrawer( user ) {
+	await user.click( screen.getByRole( 'button', { name: 'Link' } ) );
+	await user.click( screen.getByRole( 'button', { name: 'Edit link' } ) );
+	await user.click( screen.getByRole( 'button', { name: 'Advanced' } ) );
+}
+
+describe( 'getUpdatedLinkAttributes', () => {
+	it( 'adds the new tab target and rel when opening in a new tab', () => {
+		expect(
+			getUpdatedLinkAttributes( {
+				url: 'https://example.com',
+				opensInNewTab: true,
+				nofollow: false,
+			} )
+		).toEqual( {
+			url: 'https://example.com',
+			linkTarget: NEW_TAB_TARGET,
+			rel: 'noopener',
+		} );
+	} );
+
+	it( 'keeps combined rel tokens intact when both settings are enabled', () => {
+		expect(
+			getUpdatedLinkAttributes( {
+				url: 'https://example.com',
+				rel: 'noopener nofollow',
+				opensInNewTab: true,
+				nofollow: true,
+			} )
+		).toEqual( {
+			url: 'https://example.com',
+			linkTarget: NEW_TAB_TARGET,
+			rel: 'noopener nofollow',
+		} );
+	} );
+
+	it( 'removes only the managed tokens when settings are disabled', () => {
+		expect(
+			getUpdatedLinkAttributes( {
+				url: 'https://example.com',
+				rel: 'noopener nofollow sponsored',
+				opensInNewTab: false,
+				nofollow: false,
+			} )
+		).toEqual( {
+			url: 'https://example.com',
+			linkTarget: undefined,
+			rel: 'sponsored',
+		} );
+	} );
+
+	it( 'preserves custom rel tokens when adding nofollow', () => {
+		expect(
+			getUpdatedLinkAttributes( {
+				url: 'https://example.com',
+				rel: 'sponsored',
+				opensInNewTab: false,
+				nofollow: true,
+			} )
+		).toEqual( {
+			url: 'https://example.com',
+			linkTarget: undefined,
+			rel: 'sponsored nofollow',
+		} );
+	} );
+
+	it( 'prepends the protocol to bare domains', () => {
+		expect( getUpdatedLinkAttributes( { url: 'example.com' } ).url ).toBe(
+			'http://example.com'
+		);
+	} );
+
+	it( 'returns an undefined rel when no tokens remain', () => {
+		expect(
+			getUpdatedLinkAttributes( { url: 'https://example.com' } ).rel
+		).toBeUndefined();
+	} );
+} );
+
+describe( 'getLinkSettings', () => {
+	it( 'resolves known setting ids in a stable order', () => {
+		expect( getLinkSettings( [ 'nofollow', 'opensInNewTab' ] ) ).toEqual( [
+			{ id: 'opensInNewTab', title: 'Open in new tab' },
+			{ id: 'nofollow', title: 'Mark as nofollow' },
+		] );
+	} );
+
+	it( 'ignores unknown setting ids', () => {
+		expect( getLinkSettings( [ 'sponsored', 'nofollow' ] ) ).toEqual( [
+			{ id: 'nofollow', title: 'Mark as nofollow' },
+		] );
+	} );
+} );
+
+describe( 'Link field control', () => {
+	it( 'renders the field label and the current URL', () => {
+		render(
+			<Link
+				data={ { url: 'https://example.com' } }
+				field={ linkField }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Link' } ) ).toBeVisible();
+		expect( screen.getByText( 'https://example.com' ) ).toBeVisible();
+	} );
+
+	it( 'offers only the default link settings when the field declares none', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Link
+				data={ {
+					url: 'https://example.com',
+					rel: 'noopener',
+					linkTarget: NEW_TAB_TARGET,
+				} }
+				field={ linkField }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		await openLinkSettingsDrawer( user );
+
+		expect( screen.getAllByRole( 'checkbox' ) ).toHaveLength( 1 );
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Open in new tab',
+				checked: true,
+			} )
+		).toBeVisible();
+	} );
+
+	it( 'offers the settings declared by the field, reading their state from combined rel values', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Link
+				data={ {
+					url: 'https://example.com',
+					rel: 'noopener nofollow',
+					linkTarget: NEW_TAB_TARGET,
+				} }
+				field={ linkField }
+				onChange={ jest.fn() }
+				config={ {
+					settings: [ 'opensInNewTab', 'nofollow' ],
+				} }
+			/>
+		);
+
+		await openLinkSettingsDrawer( user );
+
+		expect( screen.getAllByRole( 'checkbox' ) ).toHaveLength( 2 );
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Open in new tab',
+				checked: true,
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Mark as nofollow',
+				checked: true,
+			} )
+		).toBeVisible();
+	} );
+} );

--- a/packages/block-editor/src/hooks/block-fields/test/link.jsdom.test.js
+++ b/packages/block-editor/src/hooks/block-fields/test/link.jsdom.test.js
@@ -2,32 +2,54 @@ import { render as baseRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SlotFillProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import Link, {
 	getLinkSettings,
 	getUpdatedLinkAttributes,
 	NEW_TAB_TARGET,
 } from '../link';
 
-const mockFetchSearchSuggestions = jest.fn( () => Promise.resolve( [] ) );
+const mockFetchSearchSuggestions = vi.fn( () => Promise.resolve( [] ) );
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
+// Mock the hook module itself so the returned value can be tweaked per test.
+vi.mock( '@wordpress/data/src/components/use-select', () => ( {
+	default: vi.fn(),
+} ) );
 useSelect.mockImplementation( () => ( {
 	fetchSearchSuggestions: mockFetchSearchSuggestions,
 	fetchRichUrlData: undefined,
 } ) );
 
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
-	useDispatch: () => ( { saveEntityRecords: jest.fn() } ),
+vi.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: () => ( { saveEntityRecords: vi.fn() } ),
 } ) );
 
-jest.mock( '@wordpress/compose', () => ( {
-	...jest.requireActual( '@wordpress/compose' ),
-	useReducedMotion: jest.fn( () => true ),
+vi.mock( import( '@wordpress/compose' ), async ( importOriginal ) => ( {
+	...( await importOriginal() ),
+	useReducedMotion: vi.fn( () => true ),
 } ) );
+
+beforeAll( () => {
+	// The link settings drawer reads `window.matchMedia`, which JSDOM lacks.
+	vi.stubGlobal(
+		'matchMedia',
+		vi.fn( ( query ) => ( {
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		} ) )
+	);
+} );
+
+afterAll( () => {
+	vi.unstubAllGlobals();
+} );
 
 function render( ui ) {
 	return baseRender( ui, { wrapper: SlotFillProvider } );
@@ -145,11 +167,11 @@ describe( 'getLinkSettings', () => {
 describe( 'Link field control', () => {
 	it( 'renders the field label and the current URL', () => {
 		render(
-			<Link
-				data={ { url: 'https://example.com' } }
-				field={ linkField }
-				onChange={ jest.fn() }
-			/>
+			createElement( Link, {
+				data: { url: 'https://example.com' },
+				field: linkField,
+				onChange: vi.fn(),
+			} )
 		);
 
 		expect( screen.getByRole( 'button', { name: 'Link' } ) ).toBeVisible();
@@ -160,15 +182,15 @@ describe( 'Link field control', () => {
 		const user = userEvent.setup();
 
 		render(
-			<Link
-				data={ {
+			createElement( Link, {
+				data: {
 					url: 'https://example.com',
 					rel: 'noopener',
 					linkTarget: NEW_TAB_TARGET,
-				} }
-				field={ linkField }
-				onChange={ jest.fn() }
-			/>
+				},
+				field: linkField,
+				onChange: vi.fn(),
+			} )
 		);
 
 		await openLinkSettingsDrawer( user );
@@ -186,18 +208,18 @@ describe( 'Link field control', () => {
 		const user = userEvent.setup();
 
 		render(
-			<Link
-				data={ {
+			createElement( Link, {
+				data: {
 					url: 'https://example.com',
 					rel: 'noopener nofollow',
 					linkTarget: NEW_TAB_TARGET,
-				} }
-				field={ linkField }
-				onChange={ jest.fn() }
-				config={ {
+				},
+				field: linkField,
+				onChange: vi.fn(),
+				config: {
 					settings: [ 'opensInNewTab', 'nofollow' ],
-				} }
-			/>
+				},
+			} )
 		);
 
 		await openLinkSettingsDrawer( user );

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).
 -   Query: Show a snackbar notice instead of a blocking modal when "Reload full page" is turned on automatically because a block inside the Query block doesn't support client-side navigation ([#82246](https://github.com/WordPress/gutenberg/pull/82246)).
 
+### Enhancements
+
+-   Button: Offer the "Mark as nofollow" setting in the content panel link field, matching the block's toolbar link popover ([#81636](https://github.com/WordPress/gutenberg/pull/81636)).
+
 ### Bug Fixes
 
 -   Image: Fix cropped galleries rendering images at their natural height in the editor canvas. The baseline inline `height: auto` is no longer emitted for images inside a cropped gallery, so the gallery's own cropping CSS applies ([#82318](https://github.com/WordPress/gutenberg/pull/82318)).

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -59,7 +59,13 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 			id: 'link',
 			label: __( 'Link' ),
 			type: 'url',
-			Edit: 'link', // TODO: replace with custom component
+			// TODO: replace with custom component
+			Edit: {
+				control: 'link',
+				// Match the settings offered by the block's toolbar link
+				// popover.
+				settings: [ 'opensInNewTab', 'nofollow' ],
+			},
 			getValue: ( { item } ) => ( {
 				url: item.url,
 				rel: item.rel,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/73261.

Makes the block fields link control (used by the DataForm-driven inspector fields experiment) a configurable control that follows the DataForm control conventions:

- The control renders the field label through `BaseControl`, respecting `hideLabelFromVision`, like its rich text sibling.
- Fields can declare the control as `Edit: { control: 'link', ... }`, mirroring how the media control is declared. The config accepts the link settings the popover offers, as setting ids (`opensInNewTab`, `nofollow`), and a `suggestionsQuery` to restrict search suggestions. The plain `Edit: 'link'` string keeps working and offers the default "Open in new tab" setting.
- The Button block declares `settings: [ 'opensInNewTab', 'nofollow' ]`, bringing the sidebar link field to parity with the block's toolbar link popover, which already offers both settings.

It also fixes a small bug: the nofollow state was detected with an exact comparison (`rel === 'nofollow'`), so a combined value like `noopener nofollow` was read as not-nofollow, and editing the URL dropped the token from `rel`. Detection now matches the toolbar popover's behavior.

Follow-ups planned per the tracking issue: adopting the config in the remaining blocks that use the link field (Image, Media & Text, Navigation Link, Navigation Submenu, Social Link), and registering the control through the DataForm custom controls API once https://github.com/WordPress/gutenberg/pull/74942 lands.

## Testing Instructions

1. Enable the "Block fields: Show dataform driven inspector fields on blocks that support them" experiment in Gutenberg > Experiments.
2. Insert a Button block, add some text, and select the block.
3. In the sidebar Content panel, click the Link field, pick or type a URL, then open "Edit link" > "Advanced": the drawer offers both "Open in new tab" and "Mark as nofollow", matching the toolbar link popover.
4. Enable both settings, apply, save the post, and confirm the button's markup contains `rel="noopener nofollow"` and `target="_blank"` on the front end.
5. Reopen the Link field settings: both settings remain checked.
6. `npm run test:unit -- packages/block-editor/src/hooks/block-fields/test/link.js` passes.

### Testing Instructions for Keyboard

Same as above; the Link field trigger, the link editing UI, and the settings drawer are reachable and operable with <kbd>Tab</kbd> and <kbd>Enter</kbd>.

## Use of AI Tools

This PR was developed with the assistance of AI tooling (implementation, tests, and description); the result was reviewed and tested by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Link fields now support configurable labels, visibility, link settings, and search suggestion queries.
  - Link controls preserve `nofollow` when multiple relationship values are present.
  - Button blocks now offer a **Mark as nofollow** option alongside opening links in a new tab.

- **Improvements**
  - Link field controls provide clearer labeling and more consistent configuration across editing contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->