### PR TITLE
Editor: Refactor 'ErrorBoundary' to use the new recommended components

### DIFF
--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -1,10 +1,7 @@
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	__experimentalHStack as HStack,
-	__experimentalText as WCText,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
 import { select } from '@wordpress/data';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { doAction } from '@wordpress/hooks';
@@ -56,18 +53,17 @@ class ErrorBoundary extends Component {
 		}
 
 		return (
-			<HStack
+			<Stack
 				className="editor-error-boundary"
-				alignment="baseline"
-				spacing={ 4 }
+				align="baseline"
+				gap="lg"
 				justify="space-between"
-				expanded={ false }
-				wrap
+				wrap="wrap"
 			>
-				<WCText as="p">
+				<Text render={ <p /> }>
 					{ __( 'The editor has encountered an unexpected error.' ) }
-				</WCText>
-				<HStack expanded={ false }>
+				</Text>
+				<Stack align="center" gap="sm">
 					{ canCopyContent && (
 						<CopyButton text={ getContent }>
 							{ __( 'Copy contents' ) }
@@ -76,8 +72,8 @@ class ErrorBoundary extends Component {
 					<CopyButton variant="primary" text={ error?.stack }>
 						{ __( 'Copy error' ) }
 					</CopyButton>
-				</HStack>
-			</HStack>
+				</Stack>
+			</Stack>
 		);
 	}
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1197,11 +1197,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/error-boundary/index.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 2
-		}
-	},
 	"packages/editor/src/components/global-styles-sidebar/welcome-guide.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?

PR refactors `ErrorBoundary` to use new recommended `@wordpress/ui` components.

## Testing Instructions
No behavior change, but comment error check condition to see the returned component.

## Screenshot
<img width="1454" height="526" alt="CleanShot 2026-08-14 at 19 01 13" src="https://github.com/user-attachments/assets/931ec2ca-0f09-429f-a19c-e12e30ba05e8" />


## Use of AI Tools

Assisted by Claude.
