### PR TITLE
Fix playlist track toolbar insertion

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
+-   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 
 ## 10.4.0 (2026-08-12)

--- a/packages/block-library/src/playlist-track/README.md
+++ b/packages/block-library/src/playlist-track/README.md
@@ -21,15 +21,15 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
 |-----------|------|---------|-------------|
 | `blob` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `local` |
-| `id` | `number` | — | — |
-| `src` | `string` | — | — |
+| `id` | `number` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `src` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 | `type` | `string` | `"audio"` | — |
-| `album` | `string` | — | — |
-| `artist` | `string` | — | — |
-| `image` | `string` | — | — |
-| `imageAlt` | `string` | — | — |
-| `length` | `string` | — | — |
-| `title` | `string` | — | — |
+| `album` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `artist` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `image` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `imageAlt` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `length` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
+| `title` | `string` | — | [Role](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#role): `content` |
 
 ## Supports
 

--- a/packages/block-library/src/playlist-track/block.json
+++ b/packages/block-library/src/playlist-track/block.json
@@ -15,32 +15,40 @@
 			"role": "local"
 		},
 		"id": {
-			"type": "number"
+			"type": "number",
+			"role": "content"
 		},
 		"src": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"type": {
 			"type": "string",
 			"default": "audio"
 		},
 		"album": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"artist": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"image": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"imageAlt": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"length": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"title": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"supports": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #81532.

Marks Playlist Track media attributes as `content` and updates the generated block docs.

## Why?
The parent selector toolbar inserter can insert the only allowed child block for Playlist. In that direct-insert path, the generic `Inserter` creates a new same-type child with attributes copied from an adjacent sibling:

```js
const newAttributes = getAdjacentBlockAttributes();

const newBlock = createBlock( blockName, {
	...blockToInsert?.attributes,
	...newAttributes,
} );
```

That sibling-attribute copying was added so newly inserted siblings preserve useful non-content settings, such as style/layout attributes. For Playlist Track, though, the unmarked attributes are the actual track payload: media ID, source URL, title, artist, artwork, duration, and related metadata. Copying those values makes the toolbar inserter look like it duplicated the selected track instead of inserting a new empty track.

`isAppender` is not the root cause. It controls the insertion position, not whether adjacent attributes are copied. Even when appending to the end, the inserter can still copy attributes from the last child of the same type.

## How?
Adds the `content` role to Playlist Track attributes that represent track media data, so the existing sibling-attribute copying logic excludes them when creating a new track.

This follows the current generic contract in `getSiblingBlockAttributes()`: content-role attributes are not inherited by newly inserted sibling blocks, while non-content settings can still be copied.

A possible higher-level alternative would be to let this parent-selector toolbar inserter opt out of adjacent attribute copying entirely, so it always creates a fresh child block. That would target the surprising inserter behavior directly, but it would require a generic `Inserter` API/behavior change rather than a Playlist Track metadata fix.

## Testing Instructions
1. Open a post or page.
2. Insert a Playlist block with at least one track.
3. Select a Playlist Track block.
4. Use the toolbar parent selector inserter to add another track.
5. Confirm the new track does not duplicate the selected track's media data.

### Testing Instructions for Keyboard
1. Select a Playlist Track block.
2. Move focus to the block toolbar.
3. Use the parent selector toolbar inserter to add another track.
4. Confirm the inserted track is empty rather than a duplicate of the selected track.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Created with assistance from OpenAI Codex. The changes and PR description were reviewed before publishing.
