### PR TITLE
Terms Query: Support custom query args in the editor

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Terms Query: Pass custom `termQuery` args through to the REST API call in the editor, matching the Query Loop block's `restQueryArgs` pattern, so editor previews can reflect custom query args ([#81300](https://github.com/WordPress/gutenberg/issues/81300)).
+
 ### Internal
 
 -   Heading: Declare the heading level and paragraph keyboard shortcuts on the block's variations and transforms, rather than in a `BlockKeyboardShortcuts` component that every editor had to render. The `BlockKeyboardShortcuts` private export has been removed ([#81588](https://github.com/WordPress/gutenberg/pull/81588)).

--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -73,6 +73,12 @@ export default function TermTemplateEdit( {
 			showNested = false,
 			perPage,
 			include,
+			// We gather extra query args to pass to the REST API call.
+			// This way extenders of Terms Query can add their own query args,
+			// and have accurate previews in the editor.
+			// Noting though that these args should either be supported by the
+			// REST API or be handled by custom REST filters like `rest_{$taxonomy}_query`.
+			...restQueryArgs
 		} = {},
 	},
 	__unstableLayoutClassNames,
@@ -103,11 +109,10 @@ export default function TermTemplateEdit( {
 		queryArgs.order = 'asc';
 	}
 
-	const { records: terms } = useEntityRecords(
-		'taxonomy',
-		taxonomy,
-		queryArgs
-	);
+	const { records: terms } = useEntityRecords( 'taxonomy', taxonomy, {
+		...queryArgs,
+		...restQueryArgs,
+	} );
 
 	const blocks = useSelect(
 		( select ) => select( blockEditorStore ).getBlocks( clientId ),


### PR DESCRIPTION
## What?

Closes #81300

## Why?

The Terms Query block accepts custom args on its `termQuery` attribute (e.g. via block variations), but the editor discards them when fetching terms for the preview. The Query Loop block solves this for posts by spreading any extra `query` keys into the `useEntityRecords` call. Term Template didn't have the equivalent, so a custom arg could shape the front end (through custom REST filters like `rest_{$taxonomy}_query`) without the editor preview ever reflecting it.

## How?

Mirrors the exact pattern already used in `post-template/edit.js`:

- Destructure the known `termQuery` context keys and collect the rest into a `...restQueryArgs` rest parameter.
- Spread `restQueryArgs` after the existing `queryArgs` when calling `useEntityRecords( 'taxonomy', taxonomy, { ...queryArgs, ...restQueryArgs } )`, so custom args win over (or extend) the block's own computed args, same as Query Loop.

No PHP changes: `core/terms-query`'s `termQuery` attribute is already a plain object with no schema restrictions, so custom keys already pass through to the front end. This PR only closes the editor-preview parity gap described in the issue.

## Testing Instructions

1. Add a Terms Query block, and give its Term Template block context a custom `termQuery` arg not covered by the block's UI (e.g. via a block variation or the code editor), such as a `meta_key`/`meta_query`-style arg supported by a custom `rest_{$taxonomy}_query` filter.
2. Confirm the editor preview now reflects the filtered/custom result set instead of ignoring the extra arg.
3. Confirm existing Terms Query usage (no custom args) is unaffected — order, pagination, nested terms, and the `include` override still behave the same.

```
npm run lint:js -- packages/block-library/src/term-template/edit.js
npm run test:unit -- packages/block-library
```

Both pass locally (679/679 block-library unit tests).

## Use of AI Tools

Used Claude Code to help draft this change and verify it against the existing Query Loop pattern.