### PR TITLE
Editor: Surface debugging details in the ErrorBoundary

### DIFF
--- a/docs/reference-guides/filters/editor-filters.md
+++ b/docs/reference-guides/filters/editor-filters.md
@@ -312,7 +312,7 @@ Opaque animated GIFs are converted client-side to a companion MP4/WebM video, an
 
 A JavaScript error in a part of the UI shouldn't break the whole app. To solve this problem for users, React library uses the concept of an ["error boundary"](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary). Error boundaries are React components that catch JavaScript errors anywhere in their child component tree and display a fallback UI instead of the component tree that crashed.
 
-The `editor.ErrorBoundary.errorLogged` action allows you to hook into the [Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) and gives you access to the error object.
+The `editor.ErrorBoundary.errorLogged` action allows you to hook into the [Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) and gives you access to the error object, along with React's error info object, whose `componentStack` property describes where in the component tree the error was thrown.
 
 You can use this action to get hold of the error object handled by the boundaries. For example, you may want to send them to an external error-tracking tool. Here's an example:
 
@@ -322,10 +322,10 @@ import { addAction } from '@wordpress/hooks';
 addAction(
 	'editor.ErrorBoundary.errorLogged',
 	'mu-plugin/error-capture-setup',
-	( error ) => {
-		// Error is the exception's error object. 
+	( error, errorInfo ) => {
+		// Error is the exception's error object.
 		// You can console.log it or send it to an external error-tracking tool.
-		console.log ( error );
+		console.log ( error, errorInfo?.componentStack );
 	}
 );
 ```

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -346,6 +346,29 @@ function MetaBoxesMain() {
 	);
 }
 
+// TEMP: remove. Stands in for a plugin panel that reads the store and throws
+// while rendering. Nested so the component stack has something to show.
+function TempCrashInner( { title } ) {
+	if ( title.toLowerCase().includes( 'crash' ) ) {
+		throw new TypeError(
+			`Cannot read properties of undefined (reading 'length')`
+		);
+	}
+
+	return null;
+}
+
+// TEMP: remove. Type "crash" in the post title to trigger it.
+function TempCrash() {
+	const title = useSelect(
+		( _select ) =>
+			_select( editorStore ).getEditedPostAttribute( 'title' ) ?? '',
+		[]
+	);
+
+	return <TempCrashInner title={ title } />;
+}
+
 function Layout( {
 	postId: initialPostId,
 	postType: initialPostType,
@@ -556,6 +579,7 @@ function Layout( {
 			<Tooltip.Provider>
 				<ThemeProvider isRoot color={ { primary: adminPrimary } }>
 					<ErrorBoundary canCopyContent>
+						<TempCrash />
 						<WelcomeGuide postType={ currentPostType } />
 						<div { ...navigateRegionsProps }>
 							<Editor

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -346,29 +346,6 @@ function MetaBoxesMain() {
 	);
 }
 
-// TEMP: remove. Stands in for a plugin panel that reads the store and throws
-// while rendering. Nested so the component stack has something to show.
-function TempCrashInner( { title } ) {
-	if ( title.toLowerCase().includes( 'crash' ) ) {
-		throw new TypeError(
-			`Cannot read properties of undefined (reading 'length')`
-		);
-	}
-
-	return null;
-}
-
-// TEMP: remove. Type "crash" in the post title to trigger it.
-function TempCrash() {
-	const title = useSelect(
-		( _select ) =>
-			_select( editorStore ).getEditedPostAttribute( 'title' ) ?? '',
-		[]
-	);
-
-	return <TempCrashInner title={ title } />;
-}
-
 function Layout( {
 	postId: initialPostId,
 	postType: initialPostType,
@@ -579,7 +556,6 @@ function Layout( {
 			<Tooltip.Provider>
 				<ThemeProvider isRoot color={ { primary: adminPrimary } }>
 					<ErrorBoundary canCopyContent>
-						<TempCrash />
 						<WelcomeGuide postType={ currentPostType } />
 						<div { ...navigateRegionsProps }>
 							<Editor

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -1,11 +1,12 @@
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { Collapsible, EmptyState, Stack, Text } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- The fallback UI renders outside the editor's notice system.
+import { Collapsible, Notice, Stack, Text } from '@wordpress/ui';
 import { select } from '@wordpress/data';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { doAction } from '@wordpress/hooks';
-import { caution, chevronDown } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 import { store as editorStore } from '../../store';
 
 function getContent() {
@@ -62,12 +63,12 @@ function getErrorReport( error, componentStack ) {
 	return sections.join( '\n\n' );
 }
 
-function CopyButton( { text, children, variant = 'secondary' } ) {
+function CopyButton( { text, children, variant = 'outline' } ) {
 	const ref = useCopyToClipboard( text );
 	return (
-		<Button __next40pxDefaultSize variant={ variant } ref={ ref }>
+		<Notice.ActionButton variant={ variant } ref={ ref }>
 			{ children }
-		</Button>
+		</Notice.ActionButton>
 	);
 }
 
@@ -143,34 +144,31 @@ class ErrorBoundary extends Component {
 				direction="column"
 				gap="lg"
 			>
-				<EmptyState.Root>
-					<EmptyState.Icon icon={ caution } />
-					<EmptyState.Title>
+				<Notice.Root intent="error">
+					<Notice.Title>
+						{ __( 'The editor has crashed' ) }
+					</Notice.Title>
+					<Notice.Description>
 						{ __(
-							'The editor has encountered an unexpected error.'
+							'An unknown error occurred. Reload your browser to try again, or copy the error to report the problem or search.'
 						) }
-					</EmptyState.Title>
-					<EmptyState.Description>
-						{ __(
-							'Reload the page to continue. Copy the error to report the problem.'
-						) }
-					</EmptyState.Description>
-					<EmptyState.Actions>
+					</Notice.Description>
+					<Notice.Actions>
 						{ canCopyContent && (
 							<CopyButton text={ getContent }>
 								{ __( 'Copy contents' ) }
 							</CopyButton>
 						) }
 						<CopyButton
-							variant="primary"
+							variant="solid"
 							text={ () =>
 								getErrorReport( error, componentStack )
 							}
 						>
 							{ __( 'Copy error' ) }
 						</CopyButton>
-					</EmptyState.Actions>
-				</EmptyState.Root>
+					</Notice.Actions>
+				</Notice.Root>
 				{ globalThis.SCRIPT_DEBUG ? (
 					<ErrorDetails
 						error={ error }

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -100,16 +100,10 @@ function ErrorReport( { error, componentStack } ) {
 			direction="column"
 			gap="md"
 		>
-			<Text
-				className="editor-error-boundary__report-title"
-				variant="body-sm"
-			>
-				{ __( 'Error report' ) }
-			</Text>
 			{ getErrorSections( error, componentStack ).map(
 				( { label, content } ) => (
 					<Stack key={ label } direction="column" gap="xs">
-						<Text variant="heading-sm">{ label }</Text>
+						<Text variant="heading-md">{ label }</Text>
 						<pre className="editor-error-boundary__report-section">
 							{ content }
 						</pre>

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -22,45 +22,66 @@ function getContent() {
 }
 
 // A boundary catches whatever was thrown, which is not always an `Error`.
+function getErrorName( error ) {
+	return ( error instanceof Error && error.name ) || 'Error';
+}
+
 function getErrorMessage( error ) {
-	if ( error instanceof Error ) {
-		const message = [ error.name, error.message ]
-			.filter( Boolean )
-			.join( ': ' );
-		if ( message ) {
-			return message;
-		}
-	} else if ( typeof error === 'string' && error ) {
+	if ( typeof error === 'string' && error ) {
 		return error;
-	} else if ( typeof error?.message === 'string' && error.message ) {
+	}
+
+	if ( typeof error?.message === 'string' && error.message ) {
 		return error.message;
 	}
 
-	return __( 'An unknown error occurred.' );
+	return 'An unknown error occurred.';
+}
+
+// The sections of the report, shared by the copied Markdown and the details
+// panel so that the two cannot drift apart. Deliberately untranslated: both
+// are developer-facing, and the report is pasted into a bug report.
+function getErrorSections( error, componentStack ) {
+	const sections = [
+		{ label: getErrorName( error ), content: getErrorMessage( error ) },
+	];
+
+	if ( componentStack ) {
+		sections.push( {
+			label: 'Component stack',
+			content: componentStack.trim(),
+			preformatted: true,
+		} );
+	}
+
+	if ( error?.stack ) {
+		sections.push( {
+			label: 'Stack',
+			content: error.stack.trim(),
+			preformatted: true,
+		} );
+	}
+
+	sections.push( {
+		label: 'Environment',
+		content: `User agent: ${ window.navigator.userAgent }`,
+		preformatted: true,
+	} );
+
+	return sections;
 }
 
 // Markdown, so the report stays readable as plain text and renders when pasted
-// into a bug report. Deliberately untranslated: the audience is a developer.
+// into a bug report.
 function getErrorReport( error, componentStack ) {
-	const sections = [ `### Editor error\n\n${ getErrorMessage( error ) }` ];
-
-	if ( error?.stack ) {
-		sections.push(
-			`#### Stack trace\n\n\`\`\`\n${ error.stack.trim() }\n\`\`\``
-		);
-	}
-
-	if ( componentStack ) {
-		sections.push(
-			`#### Component stack\n\n\`\`\`\n${ componentStack.trim() }\n\`\`\``
-		);
-	}
-
-	sections.push(
-		`#### Environment\n\n- User agent: ${ window.navigator.userAgent }`
+	const sections = getErrorSections( error, componentStack ).map(
+		( { label, content, preformatted } ) =>
+			`**${ label }**\n\n${
+				preformatted ? `\`\`\`\n${ content }\n\`\`\`` : content
+			}`
 	);
 
-	return sections.join( '\n\n' );
+	return [ '### Error report', ...sections ].join( '\n\n' );
 }
 
 function CopyButton( { text, children, variant = 'outline' } ) {
@@ -72,11 +93,29 @@ function CopyButton( { text, children, variant = 'outline' } ) {
 	);
 }
 
-function ErrorDetail( { label, children } ) {
+function ErrorReport( { error, componentStack } ) {
 	return (
-		<Stack direction="column" gap="xs">
-			<Text variant="heading-sm">{ label }</Text>
-			<pre className="editor-error-boundary__detail">{ children }</pre>
+		<Stack
+			className="editor-error-boundary__report"
+			direction="column"
+			gap="md"
+		>
+			<Text
+				className="editor-error-boundary__report-title"
+				variant="body-sm"
+			>
+				{ __( 'Error report' ) }
+			</Text>
+			{ getErrorSections( error, componentStack ).map(
+				( { label, content } ) => (
+					<Stack key={ label } direction="column" gap="xs">
+						<Text variant="heading-sm">{ label }</Text>
+						<pre className="editor-error-boundary__report-section">
+							{ content }
+						</pre>
+					</Stack>
+				)
+			) }
 		</Stack>
 	);
 }
@@ -97,16 +136,10 @@ function ErrorDetails( { error, componentStack } ) {
 				{ __( 'Show error details' ) }
 			</Collapsible.Trigger>
 			<Collapsible.Panel>
-				<Stack direction="column" gap="md">
-					<ErrorDetail label={ __( 'Error' ) }>
-						{ getErrorMessage( error ) }
-					</ErrorDetail>
-					{ componentStack && (
-						<ErrorDetail label={ __( 'Component stack' ) }>
-							{ componentStack.trim() }
-						</ErrorDetail>
-					) }
-				</Stack>
+				<ErrorReport
+					error={ error }
+					componentStack={ componentStack }
+				/>
 			</Collapsible.Panel>
 		</Collapsible.Root>
 	);

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -44,18 +44,18 @@ function getErrorSections( error, componentStack ) {
 		{ label: getErrorName( error ), content: getErrorMessage( error ) },
 	];
 
-	if ( componentStack ) {
-		sections.push( {
-			label: 'Component stack',
-			content: componentStack.trim(),
-			preformatted: true,
-		} );
-	}
-
 	if ( error?.stack ) {
 		sections.push( {
 			label: 'Stack',
 			content: error.stack.trim(),
+			preformatted: true,
+		} );
+	}
+
+	if ( componentStack ) {
+		sections.push( {
+			label: 'Component stack',
+			content: componentStack.trim(),
 			preformatted: true,
 		} );
 	}

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -1,12 +1,10 @@
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 // eslint-disable-next-line @wordpress/use-recommended-components -- The fallback UI renders outside the editor's notice system.
-import { Collapsible, Notice, Stack, Text } from '@wordpress/ui';
+import { Card, CollapsibleCard, Notice, Stack, Text } from '@wordpress/ui';
 import { select } from '@wordpress/data';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { doAction } from '@wordpress/hooks';
-import { chevronDown } from '@wordpress/icons';
 import { store as editorStore } from '../../store';
 
 function getContent() {
@@ -116,26 +114,17 @@ function ErrorReport( { error, componentStack } ) {
 
 function ErrorDetails( { error, componentStack } ) {
 	return (
-		<Collapsible.Root className="editor-error-boundary__details">
-			<Collapsible.Trigger
-				render={
-					<Button
-						variant="tertiary"
-						size="compact"
-						icon={ chevronDown }
-						iconPosition="right"
-					/>
-				}
-			>
-				{ __( 'Show error details' ) }
-			</Collapsible.Trigger>
-			<Collapsible.Panel>
+		<CollapsibleCard.Root className="editor-error-boundary__details">
+			<CollapsibleCard.Header>
+				<Card.Title>{ __( 'Error details' ) }</Card.Title>
+			</CollapsibleCard.Header>
+			<CollapsibleCard.Content>
 				<ErrorReport
 					error={ error }
 					componentStack={ componentStack }
 				/>
-			</Collapsible.Panel>
-		</Collapsible.Root>
+			</CollapsibleCard.Content>
+		</CollapsibleCard.Root>
 	);
 }
 

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -1,10 +1,11 @@
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { Stack, Text } from '@wordpress/ui';
+import { Collapsible, EmptyState, Stack, Text } from '@wordpress/ui';
 import { select } from '@wordpress/data';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { doAction } from '@wordpress/hooks';
+import { caution, chevronDown } from '@wordpress/icons';
 import { store as editorStore } from '../../store';
 
 function getContent() {
@@ -19,6 +20,48 @@ function getContent() {
 	} catch {}
 }
 
+// A boundary catches whatever was thrown, which is not always an `Error`.
+function getErrorMessage( error ) {
+	if ( error instanceof Error ) {
+		const message = [ error.name, error.message ]
+			.filter( Boolean )
+			.join( ': ' );
+		if ( message ) {
+			return message;
+		}
+	} else if ( typeof error === 'string' && error ) {
+		return error;
+	} else if ( typeof error?.message === 'string' && error.message ) {
+		return error.message;
+	}
+
+	return __( 'An unknown error occurred.' );
+}
+
+// Markdown, so the report stays readable as plain text and renders when pasted
+// into a bug report. Deliberately untranslated: the audience is a developer.
+function getErrorReport( error, componentStack ) {
+	const sections = [ `### Editor error\n\n${ getErrorMessage( error ) }` ];
+
+	if ( error?.stack ) {
+		sections.push(
+			`#### Stack trace\n\n\`\`\`\n${ error.stack.trim() }\n\`\`\``
+		);
+	}
+
+	if ( componentStack ) {
+		sections.push(
+			`#### Component stack\n\n\`\`\`\n${ componentStack.trim() }\n\`\`\``
+		);
+	}
+
+	sections.push(
+		`#### Environment\n\n- User agent: ${ window.navigator.userAgent }`
+	);
+
+	return sections.join( '\n\n' );
+}
+
 function CopyButton( { text, children, variant = 'secondary' } ) {
 	const ref = useCopyToClipboard( text );
 	return (
@@ -28,17 +71,59 @@ function CopyButton( { text, children, variant = 'secondary' } ) {
 	);
 }
 
+function ErrorDetail( { label, children } ) {
+	return (
+		<Stack direction="column" gap="xs">
+			<Text variant="heading-sm">{ label }</Text>
+			<pre className="editor-error-boundary__detail">{ children }</pre>
+		</Stack>
+	);
+}
+
+function ErrorDetails( { error, componentStack } ) {
+	return (
+		<Collapsible.Root className="editor-error-boundary__details">
+			<Collapsible.Trigger
+				render={
+					<Button
+						variant="tertiary"
+						size="compact"
+						icon={ chevronDown }
+						iconPosition="right"
+					/>
+				}
+			>
+				{ __( 'Show error details' ) }
+			</Collapsible.Trigger>
+			<Collapsible.Panel>
+				<Stack direction="column" gap="md">
+					<ErrorDetail label={ __( 'Error' ) }>
+						{ getErrorMessage( error ) }
+					</ErrorDetail>
+					{ componentStack && (
+						<ErrorDetail label={ __( 'Component stack' ) }>
+							{ componentStack.trim() }
+						</ErrorDetail>
+					) }
+				</Stack>
+			</Collapsible.Panel>
+		</Collapsible.Root>
+	);
+}
+
 class ErrorBoundary extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.state = {
 			error: null,
+			componentStack: null,
 		};
 	}
 
-	componentDidCatch( error ) {
-		doAction( 'editor.ErrorBoundary.errorLogged', error );
+	componentDidCatch( error, errorInfo ) {
+		this.setState( { componentStack: errorInfo?.componentStack } );
+		doAction( 'editor.ErrorBoundary.errorLogged', error, errorInfo );
 	}
 
 	static getDerivedStateFromError( error ) {
@@ -46,7 +131,7 @@ class ErrorBoundary extends Component {
 	}
 
 	render() {
-		const { error } = this.state;
+		const { error, componentStack } = this.state;
 		const { canCopyContent = false } = this.props;
 		if ( ! error ) {
 			return this.props.children;
@@ -55,24 +140,43 @@ class ErrorBoundary extends Component {
 		return (
 			<Stack
 				className="editor-error-boundary"
-				align="baseline"
+				direction="column"
 				gap="lg"
-				justify="space-between"
-				wrap="wrap"
 			>
-				<Text render={ <p /> }>
-					{ __( 'The editor has encountered an unexpected error.' ) }
-				</Text>
-				<Stack align="center" gap="sm">
-					{ canCopyContent && (
-						<CopyButton text={ getContent }>
-							{ __( 'Copy contents' ) }
+				<EmptyState.Root>
+					<EmptyState.Icon icon={ caution } />
+					<EmptyState.Title>
+						{ __(
+							'The editor has encountered an unexpected error.'
+						) }
+					</EmptyState.Title>
+					<EmptyState.Description>
+						{ __(
+							'Reload the page to continue. Copy the error to report the problem.'
+						) }
+					</EmptyState.Description>
+					<EmptyState.Actions>
+						{ canCopyContent && (
+							<CopyButton text={ getContent }>
+								{ __( 'Copy contents' ) }
+							</CopyButton>
+						) }
+						<CopyButton
+							variant="primary"
+							text={ () =>
+								getErrorReport( error, componentStack )
+							}
+						>
+							{ __( 'Copy error' ) }
 						</CopyButton>
-					) }
-					<CopyButton variant="primary" text={ error?.stack }>
-						{ __( 'Copy error' ) }
-					</CopyButton>
-				</Stack>
+					</EmptyState.Actions>
+				</EmptyState.Root>
+				{ globalThis.SCRIPT_DEBUG ? (
+					<ErrorDetails
+						error={ error }
+						componentStack={ componentStack }
+					/>
+				) : null }
 			</Stack>
 		);
 	}

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -26,15 +26,9 @@
 	padding: $grid-unit-15;
 	overflow: auto;
 	overflow-anchor: none;
-	color: $gray-900;
-	background-color: $gray-100;
-	border-radius: $radius-small;
-}
-
-.editor-error-boundary__report-title {
-	color: $gray-700;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	color: $gray-200;
+	background-color: $gray-800;
+	border-radius: $radius-medium;
 }
 
 .editor-error-boundary__report-section {

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -5,10 +5,39 @@
 	font-family: $default-font;
 	margin: auto;
 	max-width: 780px;
-	padding: 1em;
+	padding: $grid-unit-20;
 	margin-top: $header-height;
 	box-shadow: $elevation-large;
 	border: $border-width solid $gray-900;
 	border-radius: $radius-small;
 	background-color: $white;
+}
+
+.editor-error-boundary__details {
+	border-top: $border-width solid $gray-200;
+	padding-top: $grid-unit-15;
+}
+
+.editor-error-boundary__details [data-panel-open] svg {
+	transform: rotate(180deg);
+}
+
+.editor-error-boundary__details [data-open] {
+	padding-top: $grid-unit-15;
+}
+
+.editor-error-boundary__detail {
+	margin: 0;
+	padding: $grid-unit-10;
+	max-height: 180px;
+	overflow: auto;
+	overflow-anchor: none;
+	font-family: $font-family-mono;
+	font-size: $helptext-font-size;
+	line-height: 1.6;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+	color: $gray-900;
+	background-color: $gray-100;
+	border-radius: $radius-small;
 }

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -1,29 +1,26 @@
-@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 .editor-error-boundary {
-	font-family: $default-font;
+	font-family: var(--wpds-typography-font-family-body);
 	margin: auto;
-	max-width: 720px;
-	padding: $grid-unit-20;
+	width: 100%;
+	max-width: var(--wpds-dimension-surface-width-lg);
+	padding: var(--wpds-dimension-padding-xl);
 	margin-top: $header-height;
 }
 
 .editor-error-boundary__report {
-	max-height: 320px;
-	padding: $grid-unit-15;
+	max-height: 420px;
 	overflow: auto;
 	overflow-anchor: none;
-	color: $gray-200;
-	background-color: $gray-800;
-	border-radius: $radius-medium;
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .editor-error-boundary__report-section {
 	margin: 0;
-	font-family: $font-family-mono;
-	font-size: $helptext-font-size;
-	line-height: 1.6;
+	font-family: var(--wpds-typography-font-family-mono);
+	font-size: var(--wpds-typography-font-size-sm);
+	line-height: var(--wpds-typography-line-height-sm);
 	white-space: pre-wrap;
 	overflow-wrap: break-word;
 }

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -4,18 +4,13 @@
 .editor-error-boundary {
 	font-family: $default-font;
 	margin: auto;
-	max-width: 780px;
+	max-width: 720px;
 	padding: $grid-unit-20;
 	margin-top: $header-height;
 	box-shadow: $elevation-large;
 	border: $border-width solid $gray-900;
 	border-radius: $radius-small;
 	background-color: $white;
-}
-
-.editor-error-boundary__details {
-	border-top: $border-width solid $gray-200;
-	padding-top: $grid-unit-15;
 }
 
 .editor-error-boundary__details [data-panel-open] svg {

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -13,14 +13,10 @@
 	max-height: 420px;
 	overflow: auto;
 	overflow-anchor: none;
-	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .editor-error-boundary__report-section {
 	margin: 0;
-	font-family: var(--wpds-typography-font-family-mono);
-	font-size: var(--wpds-typography-font-size-sm);
-	line-height: var(--wpds-typography-line-height-sm);
 	white-space: pre-wrap;
 	overflow-wrap: break-word;
 }

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -21,18 +21,27 @@
 	padding-top: $grid-unit-15;
 }
 
-.editor-error-boundary__detail {
-	margin: 0;
-	padding: $grid-unit-10;
-	max-height: 180px;
+.editor-error-boundary__report {
+	max-height: 320px;
+	padding: $grid-unit-15;
 	overflow: auto;
 	overflow-anchor: none;
+	color: $gray-900;
+	background-color: $gray-100;
+	border-radius: $radius-small;
+}
+
+.editor-error-boundary__report-title {
+	color: $gray-700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.editor-error-boundary__report-section {
+	margin: 0;
 	font-family: $font-family-mono;
 	font-size: $helptext-font-size;
 	line-height: 1.6;
 	white-space: pre-wrap;
 	overflow-wrap: break-word;
-	color: $gray-900;
-	background-color: $gray-100;
-	border-radius: $radius-small;
 }

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -7,18 +7,6 @@
 	max-width: 720px;
 	padding: $grid-unit-20;
 	margin-top: $header-height;
-	box-shadow: $elevation-large;
-	border: $border-width solid $gray-900;
-	border-radius: $radius-small;
-	background-color: $white;
-}
-
-.editor-error-boundary__details [data-panel-open] svg {
-	transform: rotate(180deg);
-}
-
-.editor-error-boundary__details [data-open] {
-	padding-top: $grid-unit-15;
 }
 
 .editor-error-boundary__report {


### PR DESCRIPTION
## What?
Closes #34482.

The editor's error boundary showed a generic sentence and copied the raw `error.stack`, which contains mostly React internals and says nothing about where in the editor the crash occurred. React passes a second argument to `componentDidCatch` with a `componentStack` describing the component tree at the throw site, and the boundary was discarding it.

This captures that component stack and puts it to use in three places.

* The `editor.ErrorBoundary.errorLogged` action now receives React's error info object as a second argument, so error tracking tools can record it.
* The "Copy error" button now produces a Markdown report containing the message, the stack trace, the component stack, and the user agent, ready to paste into a bug report.
* When `SCRIPT_DEBUG` is on, a collapsible panel shows the message and the component stack directly in the UI, so a developer can identify the failing component without opening the console.

## Testing Instructions
1. Ensure `SCRIPT_DEBUG` is enabled.
2. Fake an error in the editor. See testing patch below.

<details><summary>Testing patch</summary>
<p>

```diff
diff --git a/packages/edit-post/src/components/layout/index.js b/packages/edit-post/src/components/layout/index.js
index 650683f3a0f..1b6da9a7f94 100644
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -346,6 +346,29 @@ function MetaBoxesMain() {
 	);
 }
 
+// TEMP: remove. Stands in for a plugin panel that reads the store and throws
+// while rendering. Nested so the component stack has something to show.
+function TempCrashInner( { title } ) {
+	if ( title.toLowerCase().includes( 'crash' ) ) {
+		throw new TypeError(
+			`Cannot read properties of undefined (reading 'length')`
+		);
+	}
+
+	return null;
+}
+
+// TEMP: remove. Type "crash" in the post title to trigger it.
+function TempCrash() {
+	const title = useSelect(
+		( _select ) =>
+			_select( editorStore ).getEditedPostAttribute( 'title' ) ?? '',
+		[]
+	);
+
+	return <TempCrashInner title={ title } />;
+}
+
 function Layout( {
 	postId: initialPostId,
 	postType: initialPostType,
@@ -556,6 +579,8 @@ function Layout( {
 			<Tooltip.Provider>
 				<ThemeProvider isRoot color={ { primary: adminPrimary } }>
 					<ErrorBoundary canCopyContent>
+						{ /* TEMP: remove. */ }
+						<TempCrash />
 						<WelcomeGuide postType={ currentPostType } />
 						<div { ...navigateRegionsProps }>
 							<Editor
```

</p>
</details> 


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

| Post Editor | Site Editor |
|--------|--------|
|<img width="732" height="787" alt="CleanShot 2026-08-20 at 12 49 36" src="https://github.com/user-attachments/assets/b4c8d425-d143-497a-9704-4fd25d6cdadf" />|<img width="537" height="692" alt="CleanShot 2026-08-20 at 12 57 46" src="https://github.com/user-attachments/assets/91fd4212-f598-4e56-bbbb-7c4f82a72efd" />|

## Use of AI Tools

Assisted by Claude.
