### PR TITLE
Global Styles: Add pseudo-selector support for select elements

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -613,10 +613,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.1.0
 	 * @since 6.2.0 Added support for `:link` and `:any-link`.
 	 * @since 6.8.0 Added support for `:focus-visible`.
+	 * @since 7.2.0 Added support for select pseudo-selectors.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
 		'link'   => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':focus-visible', ':active' ),
 		'button' => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':focus-visible', ':active' ),
+		'select' => array( ':hover', ':focus', ':focus-visible', ':active' ),
 	);
 
 	/**

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add pseudo-selector support for select elements.
+
 ## 1.20.0 (2026-08-12)
 
 ### Bug Fixes

--- a/packages/global-styles-engine/src/core/render.tsx
+++ b/packages/global-styles-engine/src/core/render.tsx
@@ -220,6 +220,7 @@ const VALID_ELEMENT_PSEUDO_SELECTORS: Record< string, string[] > = {
 		':focus-visible',
 		':active',
 	],
+	select: [ ':hover', ':focus', ':focus-visible', ':active' ],
 };
 
 /**

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2165,6 +2165,26 @@
 				":visited"
 			]
 		},
+		"stylesSelectPseudoSelectorsProperties": {
+			"type": "object",
+			"properties": {
+				":active": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus-visible": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":hover": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
+		"stylesSelectPseudoSelectorsPropertyNames": {
+			"enum": [ ":active", ":focus", ":focus-visible", ":hover" ]
+		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
 			"type": "object",
@@ -2374,11 +2394,17 @@
 							"$ref": "#/definitions/stylesProperties"
 						},
 						{
+							"$ref": "#/definitions/stylesSelectPseudoSelectorsProperties"
+						},
+						{
 							"type": "object",
 							"propertyNames": {
 								"anyOf": [
 									{
 										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesSelectPseudoSelectorsPropertyNames"
 									}
 								]
 							}


### PR DESCRIPTION
## What?

Adds `:hover`, `:focus`, `:focus-visible`, and `:active` support for the `select` element in Global Styles.

Part of #34198. Addresses the select element portion of #76534.

## Why?

Themes should be able to style common interactive states for select controls through `theme.json`.

## How?

Adds the four states to the PHP and client-side element allowlists and updates the `theme.json` schema.

## Testing Instructions

Add the following styles to the active theme's `theme.json`:

```json
{
	"version": 3,
	"styles": {
		"elements": {
			"select": {
				":hover": {
					"color": { "background": "#bde3ff" }
				},
				":focus": {
					"outline": {
						"color": "#f97316",
						"style": "solid",
						"width": "3px"
					}
				},
				":focus-visible": {
					"outline": {
						"color": "#7c3aed",
						"style": "dashed",
						"width": "4px"
					}
				},
				":active": {
					"color": { "background": "#ffb3b3" }
				}
			}
		}
	}
}
```

### Custom HTML

1. Add a Custom HTML block with:

```html
<label for="test-select">Choose an option</label>
<select id="test-select">
	<option>First option</option>
	<option>Second option</option>
	<option>Third option</option>
</select>
```

2. Preview the page.
3. Hover the select, focus it with the mouse, tab to it with the keyboard, and hold the mouse button down on it.
4. Confirm each state uses the configured styles.

### Categories block

1. Add a Categories block and enable **Display as dropdown**.
2. Preview the page.
3. Repeat the hover, mouse focus, keyboard focus, and active-state checks above.

## Screenshots or screencast

### Default

![Categories block dropdown in its default state](https://github.com/user-attachments/assets/5dd694d0-e1d5-4d89-885a-b341f54db5e7)

### Hover and focus visible

![Categories block dropdown with the hover background and focus-visible outline](https://github.com/user-attachments/assets/4b1cae6e-a14e-4b2a-bc2c-e9a40461a995)

## Use of AI Tools

AI assistance: Yes  
Tool: OpenAI Codex  
Model: GPT-5  
Used for: Implementing the change, running validation, and drafting the pull request.
