### PR TITLE
Site Editor: Use inverted ThemeProvider seed for portaled UI

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Seed the root `ThemeProvider` with the admin color scheme primary color so portaled popovers and modals receive the scheme's accent colors.
+-   Seed the root `ThemeProvider` with the admin color scheme primary color so portaled popovers and modals receive the scheme's accent colors ([#81653](https://github.com/WordPress/gutenberg/pull/81653)).
 
 ### Internal
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Seed the root `ThemeProvider` with the admin color scheme primary color so portaled popovers and modals receive the scheme's accent colors.
+
 ### Internal
 
 -   Stop rendering `EditorKeyboardShortcutsRegister`, which the editor provider now renders itself ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -313,8 +313,16 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 			<Tooltip.Provider>
 				{ /** This needs to be within the SlotFillProvider */ }
 				<PluginArea onError={ onPluginAreaError } />
-				<ThemeProvider color={ themeColors }>
-					<Layout { ...props } />
+				<ThemeProvider
+					isRoot
+					color={ {
+						primary: themeColors.primary,
+						...CONTENT_COLOR,
+					} }
+				>
+					<ThemeProvider color={ themeColors }>
+						<Layout { ...props } />
+					</ThemeProvider>
 				</ThemeProvider>
 			</Tooltip.Provider>
 		</SlotFillProvider>


### PR DESCRIPTION
## What?

Backports the inverted `ThemeProvider` layout from #81296 (merged to `wp/7.1`) to trunk.

## Why?

Portaled popovers and modals render outside their ancestor `ThemeProvider` wrapper in the DOM, so they do not receive the CSS custom properties on that wrapper. In the Site Editor, WPDS-styled UI inside popovers and modals can miss the chosen admin color scheme's primary/accent colors.

#81183 fixes this at the `Popover`/`Modal` level by wrapping portaled content in `ThemeProvider`. That is the more general long-term fix, but many legacy components inside portaled UI are not yet theme-ready on dark sidebar surfaces. Until that migration is further along, the inverted seed pattern provides broad coverage with a single layout change.

This follows the inverted seed pattern already used in `@wordpress/boot`: an outer `isRoot` provider seeds accent + content background for portaled UI, while an inner provider applies the full admin scheme to the editor chrome.

## How?

- Add an outer `ThemeProvider` with `isRoot`, seeding `primary` from the admin color scheme and a white content background (`CONTENT_COLOR`).
- Nest the existing `ThemeProvider color={ themeColors }` inside it for the site editor chrome.

## Testing Instructions

1. Start wp-env and build the branch (`npm start`).
2. Open the Site Editor (`/wp-admin/site-editor.php`).
3. Switch admin color schemes under **Users → Profile** (e.g. Ocean, Midnight, Sunrise, Light).
4. Reload the Site Editor and open a popover or modal, e.g. DataViews "View options" dropdown in Pages, dropdown menus or font modal in Styles, Navigation section action menus, or the "Add page" link control.
5. Confirm WPDS-styled UI inside the popover or modal reflects the chosen scheme's primary/accent colors.
6. Confirm the site editor chrome still uses the admin scheme background color (not white).
7. Smoke test the post editor for regressions.