### PR TITLE
Playlist: Add aria-label to prevent placeholder as label

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Bug Fixes
 
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
--   Playlist Track: Preserve the editor track button's accessible name while labeling editable track metadata fields.
 -   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
+-   Playlist Track: Preserve the editor track button's accessible name while labeling editable track metadata fields.
 -   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -270,6 +270,7 @@ const PlaylistTrackEdit = ( {
 							tagName="span"
 							className="wp-block-playlist-track__title"
 							value={ title }
+							aria-label={ __( 'Track title' ) }
 							placeholder={ __( 'Add title' ) }
 							onChange={ ( value ) => {
 								setAttributes( { title: value } );
@@ -281,6 +282,7 @@ const PlaylistTrackEdit = ( {
 								tagName="span"
 								className="wp-block-playlist-track__artist"
 								value={ artist }
+								aria-label={ __( 'Track artist' ) }
 								placeholder={ __( 'Add artist' ) }
 								onChange={ ( value ) =>
 									setAttributes( { artist: value } )

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -22,7 +22,7 @@ import {
 import { Link } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { PlaylistContext } from '../playlist/context';
@@ -53,12 +53,6 @@ const PlaylistTrackEdit = ( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
 	const hasTrackSource = !! src || !! temporaryURL;
-	const trackTitle = stripHTML( title || '' ) || __( 'Unknown title' );
-	const trackButtonLabel = sprintf(
-		/* translators: %s: track title. */
-		__( 'Play %s' ),
-		trackTitle
-	);
 
 	useEffect( () => {
 		if (
@@ -260,7 +254,6 @@ const PlaylistTrackEdit = ( {
 				<button
 					className="wp-block-playlist-track__button"
 					onClick={ () => setCurrentTrackClientId( clientId ) }
-					aria-label={ trackButtonLabel }
 					aria-current={
 						currentTrackClientId === clientId ? 'true' : 'false'
 					}

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -22,7 +22,7 @@ import {
 import { Link } from '@wordpress/ui';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { audio as icon } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { PlaylistContext } from '../playlist/context';
@@ -53,6 +53,12 @@ const PlaylistTrackEdit = ( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
 	const hasTrackSource = !! src || !! temporaryURL;
+	const trackTitle = stripHTML( title || '' ) || __( 'Unknown title' );
+	const trackButtonLabel = sprintf(
+		/* translators: %s: track title. */
+		__( 'Play %s' ),
+		trackTitle
+	);
 
 	useEffect( () => {
 		if (
@@ -254,6 +260,7 @@ const PlaylistTrackEdit = ( {
 				<button
 					className="wp-block-playlist-track__button"
 					onClick={ () => setCurrentTrackClientId( clientId ) }
+					aria-label={ trackButtonLabel }
 					aria-current={
 						currentTrackClientId === clientId ? 'true' : 'false'
 					}

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -6,44 +6,43 @@ import { useUploadMediaFromBlobURL } from '../../utils/hooks';
 
 let mockMediaReplaceFlowProps;
 
-jest.mock( '@wordpress/block-editor', () => ( {
-	BlockControls: ( { children } ) => <div>{ children }</div>,
-	BlockIcon: () => <span />,
-	InspectorControls: ( { children } ) => <div>{ children }</div>,
-	MediaPlaceholder: () => <div />,
-	MediaReplaceFlow: ( props ) => {
-		mockMediaReplaceFlowProps = props;
-		const { name, onSelect } = props;
-		return <button onClick={ () => onSelect( {} ) }>{ name }</button>;
-	},
-	MediaUpload: ( { render: renderMediaUpload } ) =>
-		renderMediaUpload( { open: jest.fn() } ),
-	MediaUploadCheck: ( { children } ) => <div>{ children }</div>,
-	PlainText: ( {
-		onChange,
-		placeholder,
-		tagName: TagName = 'div',
-		value,
-		__experimentalVersion,
-		...props
-	} ) => <TagName { ...props }>{ value || placeholder }</TagName>,
-	useBlockProps: jest.fn( () => ( {} ) ),
-} ) );
+jest.mock( '@wordpress/block-editor', () => {
+	const PlainText = jest.requireActual(
+		'../../../../block-editor/src/components/plain-text'
+	).default;
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-	combineReducers: jest.fn( ( reducers ) => ( state = {}, action ) => {
-		const newState = {};
-		Object.keys( reducers ).forEach( ( key ) => {
-			newState[ key ] = reducers[ key ]( state[ key ], action );
-		} );
-		return newState;
-	} ),
-	createRegistrySelector: jest.fn( ( fn ) => fn ),
-	createReduxStore: jest.fn( () => ( {} ) ),
-	createSelector: jest.fn( ( fn ) => fn ),
-	register: jest.fn(),
-} ) );
+	return {
+		BlockControls: ( { children } ) => <div>{ children }</div>,
+		BlockIcon: () => <span />,
+		InspectorControls: ( { children } ) => <div>{ children }</div>,
+		MediaPlaceholder: () => <div />,
+		MediaReplaceFlow: ( props ) => {
+			mockMediaReplaceFlowProps = props;
+			const { name, onSelect } = props;
+			return <button onClick={ () => onSelect( {} ) }>{ name }</button>;
+		},
+		MediaUpload: ( { render: renderMediaUpload } ) =>
+			renderMediaUpload( { open: jest.fn() } ),
+		MediaUploadCheck: ( { children } ) => <div>{ children }</div>,
+		PlainText,
+		useBlockProps: jest.fn( () => ( {} ) ),
+	};
+} );
+
+jest.mock( '@wordpress/data', () => {
+	const data = jest.requireActual( '@wordpress/data' );
+	const mockUseDispatch = jest.fn();
+
+	return new Proxy( data, {
+		get( target, property ) {
+			if ( property === 'useDispatch' ) {
+				return mockUseDispatch;
+			}
+
+			return target[ property ];
+		},
+	} );
+} );
 
 jest.mock( '@wordpress/notices', () => ( {
 	store: 'core/notices',

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -180,7 +180,7 @@ describe( 'PlaylistTrackEdit', () => {
 			} )
 		);
 		const trackButton = screen.getByRole( 'button', {
-			name: 'Play Song One',
+			name: /Song One/,
 		} );
 
 		expect(

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -180,7 +180,7 @@ describe( 'PlaylistTrackEdit', () => {
 			} )
 		);
 		const trackButton = screen.getByRole( 'button', {
-			name: /Song One/,
+			name: 'Play Song One',
 		} );
 
 		expect(


### PR DESCRIPTION
## What?

Gives the Playlist Track block's inline **title** and **artist** fields their own `aria-label`, so they are no longer announced as "Add title" and "Add artist" even when there is a value set for those textareas.

## Why?

`RichText` [falls back to using `placeholder` as the field's accessible name](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/index.js#L482):

```js
aria-label={ bindingsLabel || props[ 'aria-label' ] || placeholder }
```

That fallback is not conditional on the field being empty, so a Playlist Track that already has a title is still announced as "Add title", and one that already has an artist as "Add artist". 

## How?

Adds `aria-label` to the two `PlainText` fields.

## Testing Instructions

1. Insert a Playlist block and add a track that has a title and an artist
2. Inspect the track's title field in dev tools. It should be `aria-label="Track title"`, and the artist field `aria-label="Track artist"` — previously "Add title" / "Add artist".
3. With a screen reader running, move focus into the title field of a track that already has a title. It should be announced as "Track title" followed by the field's content, rather than "Add title".
4. Add an empty track and confirm the visible "Add title" and "Add artist" placeholders still render as before.

### Testing Instructions for Keyboard

No changes to keyboard behavior.

## Screenshots or screencast

Not applicable — there is no visual change.

## Use of AI Tools

Claude Code was used to investigate the cause, research the history and prior art (#1659, #5981, #26582, #33465), and draft this description. 
