### PR TITLE
Suggest mode: decline edits that would hide an inline marker

### DIFF
--- a/packages/editor/src/components/inline-suggestions/index.js
+++ b/packages/editor/src/components/inline-suggestions/index.js
@@ -57,6 +57,7 @@ export {
 	applyFormatPlan,
 } from './reconcile-format';
 export {
+	hasSuggestionMarkers,
 	stripSuggestionMarkers,
 	stripSuggestionMarkersFromAttributes,
 } from './strip-markers';

--- a/packages/editor/src/components/inline-suggestions/strip-markers.js
+++ b/packages/editor/src/components/inline-suggestions/strip-markers.js
@@ -8,6 +8,28 @@ import { SUGGESTION_FORMAT_NAME } from './format';
 const SUGGESTION_MARKER_CLASS = 'wp-suggestion';
 
 /**
+ * Whether an attribute value carries a live inline suggestion marker.
+ *
+ * A containment probe on the serialized marker class, not a rich-text parse:
+ * callers use it on every edit to decide whether the whole-content overlay
+ * fallback would strip a marker that is still rendering, so it has to be cheap.
+ * False positives are limited to values that mention the class in text, which
+ * would only cost an edit its overlay capture.
+ *
+ * @param {*} value Attribute value (string, RichTextData, or anything else).
+ * @return {boolean} True when the value contains a `core/suggestion` marker.
+ */
+export function hasSuggestionMarkers( value ) {
+	if ( typeof value === 'string' ) {
+		return value.includes( SUGGESTION_MARKER_CLASS );
+	}
+	if ( value instanceof RichTextData ) {
+		return value.toHTMLString().includes( SUGGESTION_MARKER_CLASS );
+	}
+	return false;
+}
+
+/**
  * Strip inline `core/suggestion` markers from a single attribute value,
  * unwrapping the `<mark class="wp-suggestion">` format while keeping the text
  * and every other format (bold, links, and nested notes markers included).

--- a/packages/editor/src/components/inline-suggestions/test/strip-markers.js
+++ b/packages/editor/src/components/inline-suggestions/test/strip-markers.js
@@ -5,6 +5,7 @@ import {
 } from '@wordpress/rich-text';
 import { select } from '@wordpress/data';
 import {
+	hasSuggestionMarkers,
 	stripSuggestionMarkers,
 	stripSuggestionMarkersFromAttributes,
 } from '../strip-markers';
@@ -26,6 +27,30 @@ afterAll( () => {
 	if ( getFormatType( SUGGESTION_FORMAT_NAME ) ) {
 		unregisterFormatType( SUGGESTION_FORMAT_NAME );
 	}
+} );
+
+describe( 'hasSuggestionMarkers', () => {
+	it( 'detects a marker in a string and in a RichTextData value', () => {
+		const html = `keep ${ del( 1, 'doomed' ) }`;
+		expect( hasSuggestionMarkers( html ) ).toBe( true );
+		expect(
+			hasSuggestionMarkers( RichTextData.fromHTMLString( html ) )
+		).toBe( true );
+	} );
+
+	it( 'is false for unmarked and non-string-like values', () => {
+		expect( hasSuggestionMarkers( 'plain <strong>text</strong>' ) ).toBe(
+			false
+		);
+		expect(
+			hasSuggestionMarkers( RichTextData.fromHTMLString( 'plain' ) )
+		).toBe( false );
+		expect( hasSuggestionMarkers( 3 ) ).toBe( false );
+		expect( hasSuggestionMarkers( undefined ) ).toBe( false );
+		expect( hasSuggestionMarkers( { content: del( 1, 'x' ) } ) ).toBe(
+			false
+		);
+	} );
 } );
 
 describe( 'stripSuggestionMarkers', () => {

--- a/packages/editor/src/components/suggestion-mode/refuse-edit.js
+++ b/packages/editor/src/components/suggestion-mode/refuse-edit.js
@@ -1,0 +1,52 @@
+/**
+ * The one place Suggest mode declines an edit outright.
+ *
+ * Suggest mode has two representations for a pending change: inline
+ * `core/suggestion` markers in the block's content, and the whole-attribute
+ * overlay that auto-save turns into an `attribute-set` operation. They are
+ * mutually exclusive on a given attribute — the overlay renders a clean value
+ * in place of the live one, so an overlay over a marked `content` value hides
+ * every marker in that block and leaves the marker's note describing text the
+ * reviewer can no longer see.
+ *
+ * Some edits can be expressed as neither: a delete straddling someone's pending
+ * marker, a type-over of a marked run, a second format toggle over a marked
+ * run. Those used to fall through to the overlay, which is exactly the case
+ * that breaks the invariant. They are now declined at the seam that saw them,
+ * and the user is told why.
+ */
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Fixed notice id so repeating a declined gesture (holding Backspace against a
+ * marker) replaces the snackbar instead of stacking a new one per keystroke.
+ */
+export const REFUSED_EDIT_NOTICE_ID = 'editor/suggestion-mode/edit-refused';
+
+/**
+ * Tell the user their edit was declined because it overlaps a pending
+ * suggestion, and what to do about it.
+ *
+ * Takes a registry rather than a bound `createNotice` so the per-block overlay
+ * HOC can call it without adding a `useDispatch` to every block's render; the
+ * dispatch is resolved at call time. Silently does nothing when the notices
+ * store isn't registered (isolated unit tests).
+ *
+ * @param {Object} registry Data registry.
+ */
+export function notifyEditRefused( registry ) {
+	registry
+		?.dispatch?.( noticesStore )
+		?.createNotice?.(
+			'warning',
+			__(
+				'This change overlaps a pending suggestion, so it was not captured. Accept or reject that suggestion first.'
+			),
+			{
+				id: REFUSED_EDIT_NOTICE_ID,
+				type: 'snackbar',
+				isDismissible: true,
+			}
+		);
+}

--- a/packages/editor/src/components/suggestion-mode/suggestion-addition-keyboard.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-addition-keyboard.js
@@ -1,4 +1,4 @@
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
@@ -22,6 +22,7 @@ import {
 	readEventRange,
 } from './keyboard-target';
 import { isPartOfPendingInsertion } from './store-interceptor';
+import { notifyEditRefused } from './refuse-edit';
 
 /**
  * Turn typing (and simple paste) in Suggest mode into an inline addition
@@ -81,6 +82,7 @@ export default function SuggestionAdditionKeyboard() {
 	const { getBlockName } = useSelect( blockEditorStore );
 	const { requestInterceptorBypass, isDeferredInsertion } =
 		useSuggestionOverlay();
+	const registry = useRegistry();
 
 	// The in-progress addition run. `id` is null while the suggestion note is
 	// being created; characters entered in that window queue in `pending` and
@@ -262,7 +264,9 @@ export default function SuggestionAdditionKeyboard() {
 	 * Returns whether the input was consumed. Callers must only cancel the
 	 * native edit when this returns true — when no valid single-attribute
 	 * anchor exists the input has to fall through to the native/overlay path
-	 * rather than being swallowed.
+	 * rather than being swallowed. A gesture this component owns but declines
+	 * (a type-over of a marked run) also counts as consumed: cancelling is the
+	 * refusal.
 	 *
 	 * `domRange` carries the DOM-derived offsets for the edit
 	 * (`readEventRange`); the store caret is only trusted for block/attribute
@@ -340,11 +344,15 @@ export default function SuggestionAdditionKeyboard() {
 				 * Type-over of a selection that overlaps an existing
 				 * suggestion marker: wrapping it in the `del` marker would
 				 * re-attribute part of that marker to the new id (see
-				 * `formatsRangeHasSuggestion`). Fall through to the
-				 * native/overlay path instead of intercepting.
+				 * `formatsRangeHasSuggestion`), and the overlay it used to
+				 * fall through to would hide that marker (#73411, F-09).
+				 * Neither representation fits, so the gesture is consumed and
+				 * declined — the caller cancels the native edit, leaving the
+				 * existing suggestion exactly as it was.
 				 */
 				resetRun();
-				return false;
+				notifyEditRefused( registry );
+				return true;
 			}
 			const run = runRef.current;
 			const isContiguous =
@@ -384,6 +392,7 @@ export default function SuggestionAdditionKeyboard() {
 			isDeferredInsertion,
 			beginInsertion,
 			commit,
+			registry,
 			resetRun,
 			authorId,
 		]

--- a/packages/editor/src/components/suggestion-mode/suggestion-deletion-keyboard.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-deletion-keyboard.js
@@ -1,4 +1,4 @@
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
@@ -26,6 +26,7 @@ import {
 	nextGraphemeBoundary,
 } from './grapheme-boundaries';
 import { isPartOfPendingInsertion } from './store-interceptor';
+import { notifyEditRefused } from './refuse-edit';
 
 /**
  * Read a rich-text value's plain text and its per-character format stacks,
@@ -139,6 +140,24 @@ export default function SuggestionDeletionKeyboard() {
 	const { createSuggestion } = useSuggestionsProvider();
 	const { requestInterceptorBypass, isDeferredInsertion } =
 		useSuggestionOverlay();
+	const registry = useRegistry();
+
+	/*
+	 * A deletion whose range overlaps an existing marker can be expressed
+	 * neither as a marker (`applyFormat` over the range would re-attribute
+	 * part of the existing marker to the new id, so its accept/reject would
+	 * act on a partial range) nor as an overlay (a whole-attribute snapshot
+	 * is marker-free, so it would hide the existing marker — #73411, F-09).
+	 * Cancel the native edit and say so, rather than letting the browser
+	 * apply it and the overlay swallow the result.
+	 */
+	const refuseDeletion = useCallback(
+		( event ) => {
+			event.preventDefault();
+			notifyEditRefused( registry );
+		},
+		[ registry ]
+	);
 
 	// The in-progress collapsed-cursor deletion run. `id` is null while the note
 	// is being created; repeats in that window accumulate in `steps`. `start`/
@@ -392,12 +411,8 @@ export default function SuggestionDeletionKeyboard() {
 
 			// Selection delete (any delete input type over a range).
 			if ( start !== end ) {
-				/*
-				 * Leave a selection that overlaps an existing suggestion
-				 * marker to the default path: `applyFormat` over the range
-				 * would re-attribute part of that marker to the new id and
-				 * its accept/reject would then act on a partial range.
-				 */
+				// A selection overlapping an existing marker is declined; see
+				// `refuseDeletion`.
 				if (
 					valueRangeHasSuggestion(
 						getBlockAttributes( clientId )?.[ attributeKey ],
@@ -406,6 +421,7 @@ export default function SuggestionDeletionKeyboard() {
 					)
 				) {
 					resetRun();
+					refuseDeletion( event );
 					return;
 				}
 				event.preventDefault();
@@ -434,8 +450,8 @@ export default function SuggestionDeletionKeyboard() {
 					return;
 				}
 				/*
-				 * Leave edits inside an existing suggestion marker to the
-				 * default path rather than nesting marks. The target is the
+				 * A delete aimed inside an existing marker is declined rather
+				 * than nesting marks; see `refuseDeletion`. The target is the
 				 * whole grapheme next to the caret, not a single code unit.
 				 */
 				const targetStart = isBackward
@@ -448,6 +464,7 @@ export default function SuggestionDeletionKeyboard() {
 					formatsRangeHasSuggestion( formats, targetStart, targetEnd )
 				) {
 					resetRun();
+					refuseDeletion( event );
 					return;
 				}
 				event.preventDefault();
@@ -469,12 +486,13 @@ export default function SuggestionDeletionKeyboard() {
 				resetRun();
 				return;
 			}
-			// Leave a range overlapping an existing suggestion marker to the
-			// default path rather than nesting marks.
+			// A word/line range overlapping an existing marker is declined
+			// rather than nesting marks; see `refuseDeletion`.
 			if (
 				formatsRangeHasSuggestion( formats, range.start, range.end )
 			) {
 				resetRun();
+				refuseDeletion( event );
 				return;
 			}
 			event.preventDefault();
@@ -493,6 +511,7 @@ export default function SuggestionDeletionKeyboard() {
 			isDeferredInsertion,
 			deleteSelection,
 			deleteCharacter,
+			refuseDeletion,
 			resetRun,
 		]
 	);
@@ -542,17 +561,13 @@ export default function SuggestionDeletionKeyboard() {
 			}
 			const value = getBlockAttributes( clientId )?.[ attributeKey ];
 			const { formats, text } = readValueMetrics( value );
-			// Leave a selection overlapping an existing suggestion marker to the
-			// default path rather than nesting marks.
-			if ( formatsRangeHasSuggestion( formats, start, end ) ) {
-				resetRun();
-				return;
-			}
 			/*
 			 * Preserve the copy half of cut: put the selected run on the
 			 * clipboard as plain text AND as HTML (so pasting elsewhere keeps
 			 * bold/links/other inline formatting), then cancel the browser's
 			 * delete so the text is marked for deletion instead of removed.
+			 * The copy half runs even when the delete half is declined below,
+			 * so a cut over a marker still behaves as a copy.
 			 */
 			event.clipboardData?.setData?.(
 				'text/plain',
@@ -564,6 +579,14 @@ export default function SuggestionDeletionKeyboard() {
 			}
 			event.preventDefault();
 			event.stopImmediatePropagation();
+			// A selection overlapping an existing marker is declined rather
+			// than nesting marks; see `refuseDeletion`. The `preventDefault`
+			// above already cancelled the removal.
+			if ( formatsRangeHasSuggestion( formats, start, end ) ) {
+				resetRun();
+				notifyEditRefused( registry );
+				return;
+			}
 			deleteSelection( { clientId, attributeKey, start, end } );
 		},
 		[
@@ -571,6 +594,7 @@ export default function SuggestionDeletionKeyboard() {
 			getSelectionEnd,
 			getBlockAttributes,
 			deleteSelection,
+			registry,
 			resetRun,
 		]
 	);

--- a/packages/editor/src/components/suggestion-mode/test/with-suggestion-overlay.js
+++ b/packages/editor/src/components/suggestion-mode/test/with-suggestion-overlay.js
@@ -75,11 +75,18 @@ function FakeBlock( { attributes, setAttributes } ) {
 	return (
 		<>
 			<div data-testid="content">{ attributes?.content ?? '' }</div>
+			<div data-testid="level">{ attributes?.level ?? '' }</div>
 			<button
 				type="button"
 				onClick={ () => setAttributes( { content: 'proposed' } ) }
 			>
 				edit
+			</button>
+			<button
+				type="button"
+				onClick={ () => setAttributes( { level: 3 } ) }
+			>
+				edit level
 			</button>
 		</>
 	);
@@ -182,12 +189,67 @@ describe( 'withSuggestionOverlay', () => {
 		expect( screen.getByTestId( 'content' ) ).toHaveTextContent( 'Hello' );
 	} );
 
-	it( 'strips live suggestion markers from overlay baseline and after snapshots', () => {
-		// Another author's pending marker lives in the block content. When an
-		// edit falls through to the attribute overlay, neither the baseline
-		// nor the proposed value may capture that marker - replaying `after`
-		// on accept would otherwise resurrect a marker whose suggestion was
-		// resolved in the interim.
+	it( 'declines an edit that would bury a live marker under an overlay', () => {
+		// An overlay snapshot is marker-free by construction and renders in
+		// place of the block's live value, so capturing one for an attribute
+		// that still holds a marker hides that marker while its note keeps
+		// describing it - the block would carry both representations of a
+		// pending change at once (#73411, F-09). The edit is declined instead.
+		registerSuggestionFormat();
+		try {
+			const marked =
+				'Hello <mark class="wp-suggestion" data-suggestion-id="9" data-suggestion-type="del">doomed</mark>';
+			let overlayHandle;
+			function CaptureOverlay() {
+				const overlay = useSuggestionOverlay();
+				useEffect( () => {
+					overlayHandle = overlay;
+				}, [ overlay ] );
+				return null;
+			}
+
+			const setAttributes = jest.fn();
+			const { registry } = renderWithProviders(
+				<>
+					<CaptureOverlay />
+					<Wrapped
+						clientId="a"
+						name="core/paragraph"
+						attributes={ { content: marked } }
+						setAttributes={ setAttributes }
+					/>
+				</>,
+				{ intent: 'suggest' }
+			);
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'edit' } ) );
+
+			// No overlay entry, and the block was not written through either:
+			// the marker and its note are left exactly as they were.
+			expect( overlayHandle.entries.a ).toBeUndefined();
+			expect( setAttributes ).not.toHaveBeenCalled();
+			// The user is told why, rather than the edit vanishing silently.
+			// (The intent switch itself announces a snackbar, hence the find.)
+			const refusal = registry
+				.select( noticesStore )
+				.getNotices()
+				.find( ( notice ) =>
+					notice.content.includes( 'overlaps a pending suggestion' )
+				);
+			expect( refusal ).toBeDefined();
+			expect( refusal.status ).toBe( 'warning' );
+		} finally {
+			unregisterFormatType( SUGGESTION_FORMAT_NAME );
+		}
+	} );
+
+	it( 'strips live suggestion markers from an attribute-only overlay baseline', () => {
+		// An attribute suggestion that leaves the marked attribute alone (a
+		// heading level change on a block whose content holds someone's
+		// marker) still goes to the overlay - it neither hides the marker nor
+		// competes with it. The baseline snapshot must still be marker-free:
+		// replaying it on accept would otherwise resurrect a marker whose
+		// suggestion was resolved in the interim.
 		registerSuggestionFormat();
 		try {
 			const marked =
@@ -206,15 +268,17 @@ describe( 'withSuggestionOverlay', () => {
 					<CaptureOverlay />
 					<Wrapped
 						clientId="a"
-						name="core/paragraph"
-						attributes={ { content: marked } }
+						name="core/heading"
+						attributes={ { content: marked, level: 2 } }
 						setAttributes={ jest.fn() }
 					/>
 				</>,
 				{ intent: 'suggest' }
 			);
 
-			fireEvent.click( screen.getByRole( 'button', { name: 'edit' } ) );
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'edit level' } )
+			);
 
 			const entry = overlayHandle.entries.a;
 			expect( entry ).toBeDefined();
@@ -223,8 +287,15 @@ describe( 'withSuggestionOverlay', () => {
 			expect( entry.baselineAttributes.content ).not.toContain(
 				'wp-suggestion'
 			);
-			// The proposed value is clean too.
-			expect( entry.overlayAttributes.content ).toBe( 'proposed' );
+			// Only the attribute the user actually changed is proposed, so the
+			// marked content is never replayed on accept.
+			expect( entry.overlayAttributes ).toEqual( { level: 3 } );
+			// The block renders the proposed level over its still-marked
+			// content: the overlay covers one attribute, not the whole block.
+			expect( screen.getByTestId( 'level' ) ).toHaveTextContent( '3' );
+			expect( screen.getByTestId( 'content' ) ).toHaveTextContent(
+				'wp-suggestion'
+			);
 		} finally {
 			unregisterFormatType( SUGGESTION_FORMAT_NAME );
 		}

--- a/packages/editor/src/components/suggestion-mode/with-suggestion-overlay.js
+++ b/packages/editor/src/components/suggestion-mode/with-suggestion-overlay.js
@@ -9,6 +9,12 @@
  * the suggestion's operations. The block-editor store stays at the baseline
  * until Accept/Reject, so the document is never mutated in place.
  *
+ * The overlay and inline markers are mutually exclusive per attribute: an
+ * overlay snapshot is marker-free by construction, so it renders in place of —
+ * and hides — any marker living in that attribute. An edit that would do that
+ * is declined at this seam rather than captured (`notifyEditRefused`), which is
+ * what keeps a block from carrying both representations at once.
+ *
  * Text and formatting edits never reach the overlay: typing, deletion, cut,
  * and single-line paste are caught on `beforeinput`/`cut`/`paste` by the
  * suggestion keyboards, and the remaining seams (committed IME composition,
@@ -35,9 +41,11 @@ import useMoveGhosts from './use-move-ghosts';
 import {
 	planFormatMarkers,
 	planEditMarkers,
+	hasSuggestionMarkers,
 	stripSuggestionMarkersFromAttributes,
 } from '../inline-suggestions';
 import { isPartOfPendingInsertion } from './store-interceptor';
+import { notifyEditRefused } from './refuse-edit';
 
 /**
  * True for plain strings and for objects that stringify to a meaningful HTML
@@ -67,6 +75,35 @@ function isStringLike( value ) {
  * semantics for primitive and array values).
  */
 const DEEP_MERGE_KEYS = new Set( [ 'style', 'metadata' ] );
+
+/**
+ * Would routing this edit into the overlay hide a marker that is currently
+ * rendering?
+ *
+ * The overlay stores marker-free snapshots (see
+ * `stripSuggestionMarkersFromAttributes`) and renders them in place of the
+ * block's live values, so an overlay entry for an attribute whose live value
+ * carries `<mark class="wp-suggestion">` suppresses every marker in it — the
+ * earlier suggestion's note survives in the sidebar describing text the
+ * reviewer can no longer see, and the block ends up carrying both
+ * representations of a pending change at once (#73411, finding F-09).
+ *
+ * Compared per attribute rather than per block: an attribute-only suggestion
+ * (heading level, alignment) on a block whose `content` holds a marker touches
+ * neither the marked value nor its rendering, and still goes to the overlay.
+ *
+ * @param {Object} nextAttributes Attributes the block is trying to set.
+ * @param {Object} prevAttributes The block's current attributes.
+ * @return {boolean} True when the overlay would strip a live marker.
+ */
+function overlayWouldHideMarkers( nextAttributes, prevAttributes ) {
+	for ( const key of Object.keys( nextAttributes ?? {} ) ) {
+		if ( hasSuggestionMarkers( prevAttributes?.[ key ] ) ) {
+			return true;
+		}
+	}
+	return false;
+}
 
 /**
  * Apply an overlay attribute set on top of the block's real attributes for
@@ -303,6 +340,21 @@ function SuggestingBlockEdit( { BlockEdit, props } ) {
 			if (
 				maybeHandleContentEdit( nextAttributes, attributesRef.current )
 			) {
+				return;
+			}
+			/*
+			 * Last stop before the overlay: an edit that would bury a live
+			 * marker under a clean whole-attribute snapshot is declined
+			 * instead. The keyboards decline the gestures they own before the
+			 * browser applies them; this covers every other way an edit can
+			 * reach a marked attribute (a format toggle over a marked run, a
+			 * paste or IME commit the marker plan can't resolve), so the
+			 * invariant holds however the edit arrived.
+			 */
+			if (
+				overlayWouldHideMarkers( nextAttributes, attributesRef.current )
+			) {
+				notifyEditRefused( registry );
 				return;
 			}
 			/*

--- a/test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js
@@ -10,8 +10,10 @@
  *      AND an overlay `<del>/<ins class="has-suggestion-*">` diff. This holds
  *      now that Phase 2 moved formatting to markers, including when a formatting
  *      change and a text addition coexist on one block (non-overlapping runs).
- *      A formatting change whose run overlaps an existing marker still declines
- *      to the overlay; that narrower case is not yet exercised here.
+ *      An edit that can be expressed as neither — a delete straddling a marker,
+ *      a type-over of a marked run, a second format toggle over one — is
+ *      declined outright rather than falling through to the overlay, which
+ *      would hide the marker it landed on top of.
  *
  *   2. SEAMS - edits that used to fall through to the overlay diff path instead
  *      of producing a marker, because marker creation keys off a narrow set of
@@ -466,7 +468,7 @@ test.describe( 'Suggest mode: overlay-retirement safety net (Phase 0)', () => {
 		expect( serialized ).toContain( 'data-suggestion-type="add"' );
 	} );
 
-	test( 'seam: a delete straddling an existing marker never corrupts it', async ( {
+	test( 'invariant: a delete straddling an existing marker is declined, not swallowed by an overlay', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -491,30 +493,140 @@ test.describe( 'Suggest mode: overlay-retirement safety net (Phase 0)', () => {
 
 		/*
 		 * Select "ld NEW" — a range straddling the add marker's boundary —
-		 * and delete it. The deletion keyboard declines ranges overlapping an
-		 * existing suggestion (no nested marks), and the reconciler's diff
-		 * declares the straddling edit unresolvable, so the store interceptor
-		 * captures it as a whole-attribute suggestion. The one behavior this
-		 * seam pins: the existing suggestion is never corrupted.
+		 * and delete it. Neither representation fits: a `del` marker over the
+		 * range would re-attribute half of the existing marker to a new note,
+		 * and the whole-content overlay this used to fall through to renders a
+		 * marker-free snapshot, which hid every marker in the block while the
+		 * earlier note kept describing them (#73411, F-09). The gesture is
+		 * declined instead.
 		 */
-		const saved = waitForSuggestionSaved( page );
 		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 6 } );
 		await page.keyboard.press( 'Backspace' );
-		await saved;
+
+		// The user is told why the edit did not take.
+		await expect(
+			page
+				.locator( '.components-snackbar-list' )
+				.getByText( 'overlaps a pending suggestion' )
+		).toBeVisible();
+
 		await deselect( page );
 
 		// Never nested: a marker inside a marker would corrupt both.
 		await expect(
 			paragraph.locator( `${ SUGGESTION_MARK } ${ SUGGESTION_MARK }` )
 		).toHaveCount( 0 );
-		// The straddling edit fell back to an attribute suggestion…
-		await expect( paragraph ).toHaveClass( /is-suggestion-pending/ );
-		// …and the baseline — including the earlier add suggestion, intact —
-		// is what serializes.
+		// The invariant: no overlay landed on this block, so the marker is
+		// still the block's rendered state and still the only suggestion on it.
+		await expect( paragraph ).not.toHaveClass( /is-suggestion-pending/ );
+		await expect( paragraph.locator( OVERLAY_ADD ) ).toHaveCount( 0 );
+		await expect( paragraph.locator( OVERLAY_DEL ) ).toHaveCount( 0 );
+		await expect( addMarker ).toBeVisible();
+		await expect( paragraph.locator( SUGGESTION_MARK ) ).toHaveCount( 1 );
+		// Nothing was removed, and the earlier suggestion survives verbatim.
+		await expect
+			.poll( () => paragraph.textContent() )
+			.toBe( 'Hello world NEW' );
 		const serialized = await editor.getEditedPostContent();
 		expect( serialized ).toContain( 'Hello world' );
 		expect( serialized ).toContain( 'data-suggestion-type="add"' );
 		expect( serialized ).toContain( 'NEW' );
+	} );
+
+	test( 'invariant: a format toggle over a marked run is declined, not swallowed by an overlay', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello world' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+
+		// Bold "world" — the golden path, one `format` marker.
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 5 } );
+		await pageUtils.pressKeys( 'primary+b' );
+		const formatMark = paragraph.locator(
+			`${ SUGGESTION_MARK }[data-suggestion-type="format"]`
+		);
+		await expect( formatMark ).toContainText( 'world' );
+
+		/*
+		 * Italicise the same run. `planFormatMarkers` declines a run that
+		 * overlaps an existing marker, and the overlay it used to fall through
+		 * to recorded a suggestion carrying no change at all while hiding the
+		 * bold marker (#73411, F-12). Declined at the seam instead.
+		 */
+		await pageUtils.pressKeys( 'primary+i' );
+
+		await expect(
+			page
+				.locator( '.components-snackbar-list' )
+				.getByText( 'overlaps a pending suggestion' )
+		).toBeVisible();
+
+		await deselect( page );
+
+		// The bold marker still renders, alone, with no overlay over it.
+		await expect( paragraph ).not.toHaveClass( /is-suggestion-pending/ );
+		await expect( paragraph.locator( SUGGESTION_MARK ) ).toHaveCount( 1 );
+		await expect( formatMark ).toHaveText( 'world' );
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized ).toContain( 'data-suggestion-type="format"' );
+	} );
+
+	test( 'invariant: typing over a marked run is declined, not swallowed by an overlay', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello world' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( ' NEW' );
+		const addMarker = paragraph.locator(
+			`${ SUGGESTION_MARK }[data-suggestion-type="add"]`
+		);
+		await expect( addMarker ).toHaveAttribute( 'data-suggestion-id', /\d/ );
+
+		/*
+		 * Select the pending addition and type over it. The type-over would
+		 * wrap the selection in a `del` marker, re-attributing the existing
+		 * marker's text to a second note; the fallback hid the marker instead.
+		 */
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 3 } );
+		await page.keyboard.type( 'X' );
+
+		await expect(
+			page
+				.locator( '.components-snackbar-list' )
+				.getByText( 'overlaps a pending suggestion' )
+		).toBeVisible();
+
+		await deselect( page );
+
+		await expect( paragraph ).not.toHaveClass( /is-suggestion-pending/ );
+		await expect( paragraph.locator( SUGGESTION_MARK ) ).toHaveCount( 1 );
+		await expect
+			.poll( () => paragraph.textContent() )
+			.toBe( 'Hello world NEW' );
 	} );
 
 	/*


### PR DESCRIPTION
## What

Fixes **F-09** from the [Suggest mode guided testing results](https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md) - the top P1 in Table 1, and the shared root cause behind ID-03, ID-11, ID-12, FS-05, FS-06 and IR-10.

Part of the Suggest mode stack for [#73411](https://github.com/WordPress/gutenberg/issues/73411). Based on `suggest/inline-wiring` ([#80433](https://github.com/WordPress/gutenberg/pull/80433)).

## The problem

Suggest mode has two representations for a pending change: inline `core/suggestion` markers in the block's content, and a whole-attribute overlay that auto-save turns into an `attribute-set` operation. They are mutually exclusive per attribute - an overlay snapshot is marker-free by construction (`stripSuggestionMarkersFromAttributes`) and renders in place of the block's live value, so an overlay over a marked `content` value hides every marker in that block.

Several gestures can be expressed as neither: a delete straddling a marker, a type-over of a marked run, a second format toggle over one. Each of those had a bail-out that "left the edit to the default path" - which meant the browser applied it and the whole-content overlay swallowed the result. Measured in the testing pass (IR-10): a block ended up with `metadata.noteId: [92, 96]`, note 92 an `inline-suggestion` whose `<mark>` was still in the saved content and note 96 an `attribute-set` overlay. Every `<mark>` in the block stopped rendering, the earlier note was orphaned but still listed, and the sidebar showed two contradictory descriptions of the same text (`Add: "ADDED "` next to `Add: "ADD" / Delete: "ADDED"`).

## The fix

Decline those edits instead of letting them fall through.

- **The keyboards decline at the seam they own.** `SuggestionDeletionKeyboard`'s three marker-overlap bail-outs (selection delete, collapsed-cursor delete, word/line delete) and the `cut` handler now `preventDefault()` and explain, so nothing diverges between the DOM and the store. Cut still writes the clipboard first, so a cut over a marker behaves as a copy. `SuggestionAdditionKeyboard`'s type-over bail-out does the same.
- **The overlay HOC is the backstop.** `wrappedSetAttributes` refuses any overlay write whose target attribute still holds a marker, covering every path with no interceptable event - a format toggle over a marked run, an IME commit or paste the marker plan can't resolve. The invariant now holds however the edit arrived.
- **Attribute suggestions are unaffected.** The check is per attribute, not per block: a heading-level or alignment suggestion on a block whose `content` holds someone's marker neither hides the marker nor competes with it, and still goes to the overlay.

A declined edit gets a snackbar: "This change overlaps a pending suggestion, so it was not captured. Accept or reject that suggestion first." It carries a fixed notice id, so holding Backspace against a marker replaces the snackbar rather than stacking one per keystroke.

### On D-1

The testing punch list flags **D-1** ("is the marker/overlay invariant real?") as gating this fix. This PR implements the *no* branch, which is the invariant the stack already states and the one the existing e2e safety net already pins. If the answer turns out to be *yes* - a block may hold both - the shape of the follow-up is to make the fallback preserve marker rendering, and this refusal becomes the thing to relax. Nothing here forecloses that.

## Screenshots

A paragraph with one pending addition (`ADDED`), then a Backspace over a selection that half-overlaps that marker.

**Before** - the block ends up carrying both representations. `metadata.noteId` holds `[115, 116]`, the original marker stops rendering, and the sidebar describes the same text twice and contradicts itself: `Add: " ADDED"` next to `Add: "ED" / Delete: "paragraph. ADDED"`.

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/gb-81655-f09-before-both-representations.png" alt="Editor showing the marker gone from the canvas and two contradictory notes in the sidebar" width="900">

**After** - the edit is declined at the seam that saw it. The marker still renders, the note is still the one note that exists, and a snackbar says why: "This change overlaps a pending suggestion, so it was not captured. Accept or reject that suggestion first."

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/gb-81655-f09-after-declined.png" alt="Editor showing the marker intact, one note, and a snackbar explaining the edit was not captured" width="900">

## What this does not fix

The other half of F-09's proposed fix - "reach the fallback less often" - is deliberately left out, so the invariant fix stays reviewable on its own:

- **F-06 / ID-12:** typing or deleting inside your *own* pending addition should extend or shrink that marker rather than being declined. This is the most common refusal a suggester will hit, and it deserves its own change.
- **F-08 / ID-03:** the forward-delete direction still misses the marker-extension path that Backspace has.
- **F-12:** the empty `beforeHTML`/`afterHTML` payload is gone as a side effect (no note is created at all now), but the underlying "extend the existing format marker" improvement is still open.

## Testing instructions

1. Enable the Suggest mode experiment, create a post with a paragraph reading `Hello world`, switch Options → Mode → Suggesting.
2. Put the caret at the end and type ` NEW`. An `add` marker appears.
3. Select a range that half-overlaps the marker (`Shift+Left` six times) and press Backspace.
   - **Before:** the text is deleted, every marker in the block stops rendering, the block picks up the green attribute-suggestion treatment, and a second contradictory note appears in the sidebar.
   - **After:** nothing is removed, the marker still renders, one note, and a snackbar explains why.
4. Repeat with a type-over (select part of the marker and type), and with a format toggle over a marked run (bold a word, then italicise the same word).
5. Confirm the untouched paths still work: bold one word and add text elsewhere in the same block (two markers, no overlay); change the heading level on a block that carries a marker (attribute suggestion captured, marker still rendering).

### Automated coverage

Three new e2e cases in `suggestion-mode-overlay-retirement.spec.js` (the file's own header called this gap out). They were verified red on `suggest/inline-wiring` before the fix and green after:

```
✓ invariant: a delete straddling an existing marker is declined, not swallowed by an overlay
✓ invariant: a format toggle over a marked run is declined, not swallowed by an overlay
✓ invariant: typing over a marked run is declined, not swallowed by an overlay
```

The existing `seam: a delete straddling an existing marker never corrupts it` case pinned the old fallback behaviour (it asserted the block *did* pick up an overlay); it is replaced by the first of the three above.

Unit tests: a refusal case and an attribute-only-overlay case in `test/with-suggestion-overlay.js`, plus `hasSuggestionMarkers` coverage in `test/strip-markers.js`. The full Suggest mode e2e suite is green apart from `a closed sidebar stays closed when a suggestion is created`, which fails identically on the base branch (that is F-17, still open).

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.

