### PR TITLE
Suggest mode: adopt externally-supplied content instead of capturing it as suggestions

### DIFF
--- a/packages/editor/src/components/suggestion-mode/store-interceptor.js
+++ b/packages/editor/src/components/suggestion-mode/store-interceptor.js
@@ -944,6 +944,18 @@ export default function SuggestionStoreInterceptor() {
 			// Externally-supplied content (see above): adopt it as the new
 			// capture baseline rather than diffing it as user intent.
 			if ( isExternalReset ) {
+				/*
+				 * An undo/redo lands here too: in the post editor it is
+				 * applied as a `resetBlocks`, so this branch — not the
+				 * drift branch below — is where the guard's armed adoption
+				 * token comes due. Consume it, because a token left armed
+				 * stays live for UNDO_ADOPTION_TTL_MS and the user's next
+				 * keystroke would spend it, adopting that edit as baseline
+				 * instead of capturing it as a suggestion. Resets that are
+				 * not an undo have no token armed, so this is a no-op for
+				 * them.
+				 */
+				consumeUndoRedoAdoptionRef.current?.();
 				adoptLiveTreeAsBaseline();
 				return;
 			}

--- a/packages/editor/src/components/suggestion-mode/store-interceptor.js
+++ b/packages/editor/src/components/suggestion-mode/store-interceptor.js
@@ -24,6 +24,10 @@
  *     provider after creating a note comment) is folded into the snapshot
  *     before diffing so it's invisible to the diff and never leaks into the
  *     user-pending overlay.
+ *   - A `resetBlocks` — content handed down by the controlling entity rather
+ *     than typed by this user — re-seeds the baseline instead of being
+ *     diffed, so another session's document isn't captured as a page of
+ *     insertions.
  *
  * Why subscribe rather than React state:
  *   - The interceptor must run after the dispatch lands but before any
@@ -898,8 +902,49 @@ export default function SuggestionStoreInterceptor() {
 			tree = captureTreeSnapshot( blockEditor );
 		};
 
+		/*
+		 * Content that did not come from this user replaces the whole block
+		 * tree through `resetBlocks`: the sync manager applying another
+		 * session's changes, a revision restore, a refetch. Every block in the
+		 * replacement carries a fresh clientId, so the diff below would read
+		 * the arriving document as "the local user inserted all of this" and
+		 * the previous document as "the local user removed all of that" —
+		 * duplicating the post in the canvas and opening a note per block.
+		 *
+		 * `resetBlocks` is the reliable signal because no editing action
+		 * dispatches it: in the post editor it is reached only from
+		 * `useBlockSync`, which calls it when the controlling entity hands
+		 * down a new value (and with `[]` on unmount), plus `synchronizeTemplate`,
+		 * which is a template resync rather than a content edit. Wrapping the
+		 * store's action object is the same interception `SuggestionUndoGuard`
+		 * uses for undo/redo; the original is restored on cleanup.
+		 *
+		 * Subscribers fire synchronously from within the dispatch, so the flag
+		 * is read by the very fire the reset triggers and needs no token
+		 * bookkeeping.
+		 */
+		let isExternalReset = false;
+		const originalResetBlocks = blockEditorDispatch.resetBlocks;
+		if ( originalResetBlocks ) {
+			blockEditorDispatch.resetBlocks = ( ...args ) => {
+				isExternalReset = true;
+				try {
+					return originalResetBlocks( ...args );
+				} finally {
+					isExternalReset = false;
+				}
+			};
+		}
+
 		const unsubscribe = registry.subscribe( () => {
 			if ( isDispatchingOwnWrite ) {
+				return;
+			}
+
+			// Externally-supplied content (see above): adopt it as the new
+			// capture baseline rather than diffing it as user intent.
+			if ( isExternalReset ) {
+				adoptLiveTreeAsBaseline();
 				return;
 			}
 
@@ -1386,7 +1431,12 @@ export default function SuggestionStoreInterceptor() {
 			tree = captureTreeSnapshot( blockEditor );
 		}, BLOCK_EDITOR_STORE_NAME );
 
-		return unsubscribe;
+		return () => {
+			unsubscribe();
+			if ( originalResetBlocks ) {
+				blockEditorDispatch.resetBlocks = originalResetBlocks;
+			}
+		};
 	}, [
 		isSuggestMode,
 		registry,

--- a/packages/editor/src/components/suggestion-mode/test/store-interceptor.js
+++ b/packages/editor/src/components/suggestion-mode/test/store-interceptor.js
@@ -661,6 +661,48 @@ describe( 'SuggestionStoreInterceptor (integration)', () => {
 		).toBe( 'Edited' );
 	} );
 
+	it( 'does not leave an undo adoption token armed after a resetBlocks', async () => {
+		// An undo/redo IS a `resetBlocks` in the post editor: the guard arms
+		// an adoption token, core-data reverts the `blocks` edit, and
+		// `useBlockSync` hands the result down. The external-reset branch
+		// adopts that landing, so it must also spend the token — a token left
+		// armed stays live for a second, and the user's very next keystroke
+		// would spend it and be adopted as baseline rather than captured.
+		const { registry, getOverlay } = setup();
+
+		await act( async () => {
+			getOverlay().armUndoRedoAdoption();
+		} );
+
+		const incoming = [
+			createBlock( TEST_BLOCK_NAME, { content: 'Undone' } ),
+		];
+		await act( async () => {
+			registry.dispatch( blockEditorStore ).resetBlocks( incoming );
+		} );
+		await flushSubscribers();
+
+		// The keystroke that follows the undo is an ordinary suggestion.
+		const incomingClientId = incoming[ 0 ].clientId;
+		await act( async () => {
+			registry
+				.dispatch( blockEditorStore )
+				.updateBlockAttributes( incomingClientId, {
+					content: 'Undone and typed',
+				} );
+		} );
+		await flushSubscribers();
+
+		expect(
+			registry
+				.select( blockEditorStore )
+				.getBlockAttributes( incomingClientId )?.content
+		).toBe( 'Undone' );
+		expect(
+			getOverlay().entries[ incomingClientId ]?.overlayAttributes?.content
+		).toBe( 'Undone and typed' );
+	} );
+
 	it( 'defers an empty default block, then registers a single insertion once it gains content', async () => {
 		// Regression: typing into a freshly-appended empty paragraph must
 		// produce ONE suggestion (the block insertion, content included) —

--- a/packages/editor/src/components/suggestion-mode/test/store-interceptor.js
+++ b/packages/editor/src/components/suggestion-mode/test/store-interceptor.js
@@ -594,6 +594,73 @@ describe( 'SuggestionStoreInterceptor (integration)', () => {
 		} );
 	} );
 
+	it( 'adopts a resetBlocks as the new baseline instead of capturing it', async () => {
+		// A `resetBlocks` is content handed down by the controlling entity —
+		// the sync manager applying another session's changes, a revision
+		// restore, a refetch. Every block in it carries a fresh clientId, so
+		// without the external-reset check the interceptor read the arriving
+		// document as a page of insertions and the outgoing one as a page of
+		// removals, doubling the post in the canvas and opening a note per
+		// block (issue #73411, finding F-21).
+		const { registry, getOverlay } = setup();
+
+		const incoming = [
+			createBlock( TEST_BLOCK_NAME, { content: 'Hello' } ),
+			createBlock( TEST_BLOCK_NAME, { content: 'From the server' } ),
+		];
+		await act( async () => {
+			registry.dispatch( blockEditorStore ).resetBlocks( incoming );
+		} );
+		await flushSubscribers();
+
+		const liveBlocks = registry.select( blockEditorStore ).getBlocks();
+		expect( liveBlocks.map( ( block ) => block.clientId ) ).toEqual(
+			incoming.map( ( block ) => block.clientId )
+		);
+		expect(
+			liveBlocks.map(
+				( block ) => block.attributes?.metadata?.suggestion
+			)
+		).toEqual( [ undefined, undefined ] );
+		expect( Object.keys( getOverlay().entries ) ).toEqual( [] );
+	} );
+
+	it( 'still captures an edit made after a resetBlocks', async () => {
+		// The adoption above must re-seed the baseline, not switch capture
+		// off: the next real edit — on a block that only exists because of
+		// the reset — is still a suggestion.
+		const { registry, getOverlay } = setup();
+
+		const incoming = [
+			createBlock( TEST_BLOCK_NAME, { content: 'From the server' } ),
+		];
+		await act( async () => {
+			registry.dispatch( blockEditorStore ).resetBlocks( incoming );
+		} );
+		await flushSubscribers();
+
+		const incomingClientId = incoming[ 0 ].clientId;
+		await act( async () => {
+			registry
+				.dispatch( blockEditorStore )
+				.updateBlockAttributes( incomingClientId, {
+					content: 'Edited',
+				} );
+		} );
+		await flushSubscribers();
+
+		// Reverted on the live block, captured in the overlay — the ordinary
+		// attribute-suggestion path.
+		expect(
+			registry
+				.select( blockEditorStore )
+				.getBlockAttributes( incomingClientId )?.content
+		).toBe( 'From the server' );
+		expect(
+			getOverlay().entries[ incomingClientId ]?.overlayAttributes?.content
+		).toBe( 'Edited' );
+	} );
+
 	it( 'defers an empty default block, then registers a single insertion once it gains content', async () => {
 		// Regression: typing into a freshly-appended empty paragraph must
 		// produce ONE suggestion (the block insertion, content included) —

--- a/test/e2e/specs/editor/various/suggestion-mode-external-content.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-external-content.spec.js
@@ -72,6 +72,30 @@ async function receiveExternalContent( page, content ) {
 }
 
 /**
+ * Counts the post's note comments, pending ones included.
+ *
+ * `status` has to be spelled out: pending suggestion notes are `hold`, and the
+ * comments endpoint defaults to `approve`, so the default query would report
+ * zero however many notes a bug manufactured.
+ *
+ * @param {Object} requestUtils Playwright request utils.
+ * @param {number} postId       Post whose notes are counted.
+ * @return {Promise<number>} Number of notes on the post.
+ */
+async function countNotes( requestUtils, postId ) {
+	const notes = await requestUtils.rest( {
+		path: '/wp/v2/comments',
+		params: {
+			type: 'note',
+			post: postId,
+			per_page: 100,
+			status: 'all',
+		},
+	} );
+	return notes.length;
+}
+
+/**
  * Reads every block's pending-suggestion marker type.
  *
  * @param {import('@playwright/test').Page} page Playwright page.
@@ -139,12 +163,25 @@ test.describe( 'Suggestion mode and externally-supplied content', () => {
 		const postId = await page.evaluate( () =>
 			window.wp.data.select( 'core/editor' ).getCurrentPostId()
 		);
-		const notesBefore = await requestUtils.rest( {
-			path: '/wp/v2/comments',
-			params: { type: 'note', post: postId, per_page: 100 },
-		} );
+		const notesBefore = await countNotes( requestUtils, postId );
 
-		await receiveExternalContent( page, INCOMING_CONTENT );
+		/*
+		 * The other session edits the shared document, so what comes back
+		 * carries this user's pending suggestion untouched and differs only
+		 * where the other author typed. Deriving the incoming markup from the
+		 * live content models that faithfully: a hardcoded replacement would
+		 * drop the suggestion's inline marker, and the note would be collected
+		 * as a genuine orphan rather than by the bug under test.
+		 */
+		const shared = await editor.getEditedPostContent();
+		expect( shared ).toContain( 'plus a word' );
+		const incoming = shared.replace(
+			'<p>Beta</p>',
+			'<p>Beta, edited by someone else</p>'
+		);
+		expect( incoming ).not.toBe( shared );
+
+		await receiveExternalContent( page, incoming );
 
 		// The incoming document replaces the tree; it is not duplicated, and
 		// nothing in it is marked as this user's pending change.
@@ -160,11 +197,8 @@ test.describe( 'Suggestion mode and externally-supplied content', () => {
 		// window and round-trips to the server, so any note opened for the
 		// incoming document exists by the time the count is read.
 		await editor.saveDraft();
-		const notesAfter = await requestUtils.rest( {
-			path: '/wp/v2/comments',
-			params: { type: 'note', post: postId, per_page: 100 },
-		} );
-		expect( notesAfter ).toHaveLength( notesBefore.length );
+		const notesAfter = await countNotes( requestUtils, postId );
+		expect( notesAfter ).toBe( notesBefore );
 
 		// And the reconciled document is what gets saved: three paragraphs,
 		// no pending markers manufactured for them.

--- a/test/e2e/specs/editor/various/suggestion-mode-external-content.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-external-content.spec.js
@@ -1,0 +1,204 @@
+/**
+ * E2E coverage for content that reaches the editor from somewhere other than
+ * this user's keyboard while Suggest mode is active.
+ *
+ * The sync manager applies another session's changes by dispatching
+ * `editEntityRecord` with a fresh `blocks` array (see the `editRecord` handler
+ * in core-data's resolvers); `useBlockSync` turns that into `resetBlocks`. A
+ * revision restore and a refetch arrive the same way. Every block in the
+ * replacement carries a new clientId, so the suggestion capture layer used to
+ * read the arriving document as "this user inserted all of this" and the
+ * outgoing one as "this user removed all of that" — the post doubled in the
+ * canvas, every block wore a pending marker, and auto-save opened a note for
+ * each one (issue #73411, finding F-21).
+ *
+ * These tests pin both halves: the reconcile is adopted silently, and capture
+ * is still live afterwards.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const INCOMING_CONTENT = `<!-- wp:paragraph --><p>Alpha</p><!-- /wp:paragraph -->
+
+<!-- wp:paragraph --><p>Beta, edited by someone else</p><!-- /wp:paragraph -->
+
+<!-- wp:paragraph --><p>Gamma</p><!-- /wp:paragraph -->`;
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection.
+	await page.keyboard.press( 'Escape' );
+}
+
+/*
+ * Returns a promise for the debounced suggestion auto-save REST call. Call
+ * this BEFORE performing the edit that triggers the auto-save.
+ */
+function suggestionSavedPromise( page ) {
+	return page.waitForResponse(
+		( response ) =>
+			/\/wp\/v2\/comments(\?|$|\/)/.test( response.url() ) &&
+			[ 'POST', 'PUT' ].includes( response.request().method() ) &&
+			response.ok()
+	);
+}
+
+/**
+ * Hands the editor a replacement document the way the sync manager does: an
+ * `editEntityRecord` carrying a `blocks` array parsed elsewhere, which
+ * `useBlockSync` applies to the store as a `resetBlocks`.
+ *
+ * @param {import('@playwright/test').Page} page    Playwright page.
+ * @param {string}                          content Serialized block markup.
+ */
+async function receiveExternalContent( page, content ) {
+	await page.evaluate( ( markup ) => {
+		const postId = window.wp.data
+			.select( 'core/editor' )
+			.getCurrentPostId();
+		window.wp.data
+			.dispatch( 'core' )
+			.editEntityRecord( 'postType', 'post', postId, {
+				blocks: window.wp.blocks.parse( markup ),
+			} );
+	}, content );
+}
+
+/**
+ * Reads every block's pending-suggestion marker type.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page.
+ * @return {Promise<Array<string|null>>} One entry per top-level block.
+ */
+function getMarkerTypes( page ) {
+	return page.evaluate( () =>
+		window.wp.data
+			.select( 'core/block-editor' )
+			.getBlocks()
+			.map(
+				( block ) =>
+					block.attributes?.metadata?.suggestion?.type ?? null
+			)
+	);
+}
+
+test.describe( 'Suggestion mode and externally-supplied content', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Alpha' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Beta' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Gamma' },
+		} );
+		await editor.saveDraft();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( "another session's content is not captured as suggested insertions", async ( {
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await switchIntent( page, 'Suggesting' );
+
+		// This user makes one real suggestion first, so the note count below
+		// measures manufactured notes against a known baseline.
+		const first = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Alpha' } );
+		await first.click();
+		await page.keyboard.press( 'End' );
+		const suggestionSaved = suggestionSavedPromise( page );
+		await page.keyboard.type( ' plus a word' );
+		await suggestionSaved;
+
+		const postId = await page.evaluate( () =>
+			window.wp.data.select( 'core/editor' ).getCurrentPostId()
+		);
+		const notesBefore = await requestUtils.rest( {
+			path: '/wp/v2/comments',
+			params: { type: 'note', post: postId, per_page: 100 },
+		} );
+
+		await receiveExternalContent( page, INCOMING_CONTENT );
+
+		// The incoming document replaces the tree; it is not duplicated, and
+		// nothing in it is marked as this user's pending change.
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toHaveCount( 3 );
+		await expect(
+			editor.canvas.getByText( 'Beta, edited by someone else' )
+		).toBeVisible();
+		expect( await getMarkerTypes( page ) ).toEqual( [ null, null, null ] );
+
+		// The suggestion auto-save is debounced; saving the draft gives it its
+		// window and round-trips to the server, so any note opened for the
+		// incoming document exists by the time the count is read.
+		await editor.saveDraft();
+		const notesAfter = await requestUtils.rest( {
+			path: '/wp/v2/comments',
+			params: { type: 'note', post: postId, per_page: 100 },
+		} );
+		expect( notesAfter ).toHaveLength( notesBefore.length );
+
+		// And the reconciled document is what gets saved: three paragraphs,
+		// no pending markers manufactured for them.
+		const saved = await editor.getEditedPostContent();
+		expect( saved ).toContain( 'Beta, edited by someone else' );
+		expect( saved ).not.toContain( 'pending-insert' );
+		expect( saved ).not.toContain( 'pending-remove' );
+	} );
+
+	test( 'an edit made after the reconcile is still captured as a suggestion', async ( {
+		editor,
+		page,
+	} ) => {
+		await switchIntent( page, 'Suggesting' );
+
+		await receiveExternalContent( page, INCOMING_CONTENT );
+		await expect(
+			editor.canvas.getByText( 'Beta, edited by someone else' )
+		).toBeVisible();
+
+		// Adopting the reconcile re-seeds the capture baseline; it must not
+		// switch capture off. Editing a block that only exists because of the
+		// reconcile still produces a marker rather than a direct edit.
+		const incoming = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Beta, edited by someone else' } );
+		await incoming.click();
+		await page.keyboard.press( 'End' );
+		const suggestionSaved = suggestionSavedPromise( page );
+		await page.keyboard.type( ' and by me' );
+		await suggestionSaved;
+
+		await expect(
+			editor.canvas.locator( 'mark.wp-suggestion' )
+		).toContainText( ' and by me' );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes **F-21** from the [Suggest mode guided testing results](https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md) - a P1 in Table 1, and the one finding where the editor briefly shows a document that does not exist.

Part of the Suggest mode stack for [#73411](https://github.com/WordPress/gutenberg/issues/73411). Based on `suggest/inline-wiring` ([#80433](https://github.com/WordPress/gutenberg/pull/80433)).

## The problem

Two sessions open on the same post. User B suggests and saves; user A, still holding pre-B content, suggests and saves. The server converges correctly and nothing is lost, but A's live editor expands to **13 blocks** - the whole document duplicated - with **12 of the 13** flagged `metadata.suggestion.type = "pending-insert"`, and the note count runs to 15 for what should be 2 suggestions (MU-08). No errors are thrown, which is part of the problem: a user who saves from that state, or simply believes what they see, is in trouble.

The capture layer is the cause. Content that did not come from this user reaches the editor as a whole new block tree: the sync manager applies another session's changes by dispatching `editEntityRecord` with a fresh `blocks` array (the `editRecord` handler in core-data's resolvers), and `useBlockSync` turns that into `resetBlocks`. A revision restore and a refetch arrive the same way. Every block in the replacement carries a brand-new client ID, so `SuggestionStoreInterceptor` - which keys its baseline snapshot by client ID - reads the arriving document as "this user inserted all of this" and the outgoing one as "this user removed all of that". It tags the new blocks `pending-insert`, re-inserts the old ones and tags them `pending-remove`, and auto-save opens a note for each.

Reduced to three paragraphs, the before/after is stark:

| | blocks | markers | notes |
|---|---|---|---|
| Before | 6 | `pending-remove` ×3, `pending-insert` ×3 | 1 → 7 |
| After | 3 | none | 1 → 1 |

## The fix

Recognise the reset and re-seed the capture baseline from it, exactly the way an undo landing is already adopted by `adoptLiveTreeAsBaseline()`.

`resetBlocks` is the signal to key on because no editing action dispatches it. In the post editor it is reached only from `useBlockSync` - when the controlling entity hands down a new value, and with `[]` on unmount - plus `synchronizeTemplate`, which is a template resync rather than a content edit. The interceptor wraps the store's `resetBlocks` while Suggest intent is active and restores the original on cleanup, the same interception `SuggestionUndoGuard` already uses for undo and redo. Subscribers fire synchronously from inside the dispatch, so the flag is read by the very fire the reset triggers and needs no token bookkeeping.

Capture is re-seeded, not switched off: an edit made after the reconcile is still captured as a suggestion, including an edit to a block that only exists because of it.

**Out of scope:** overlay entries keyed by client IDs the reset retired are left alone here. They no longer manufacture markers or notes, and untangling them is a separate question from the corruption this fixes.

## Screenshots

Three paragraphs, one real suggestion of this user's own (`Alpha plus a word`, one note), then another session's content arrives carrying that suggestion plus their own edit to the second paragraph.

**Before** - the document is duplicated: the original three struck through as pending removals, the incoming three dashed as pending insertions, and the sidebar fills with manufactured notes (three "Remove block", three "Insert block", and a second copy of the real "Add" note).

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/gb-81657-f21-before-duplicated.png" alt="Editor showing six blocks, three struck through as pending removals and three outlined as pending insertions, with a sidebar of seven notes" width="900">

**After** - the reconcile is adopted: three blocks, the incoming edit visible, this user's own marker and its single note untouched.

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/gb-81657-f21-after-adopted.png" alt="Editor showing three blocks with the incoming edit and one suggestion note in the sidebar" width="900">

## Testing instructions

1. Enable the Suggest mode experiment, create a post with three paragraphs (`Alpha`, `Beta`, `Gamma`), and save.
2. Switch Options → Mode → Suggesting, and make one suggestion - type a few words at the end of `Alpha`. One marker, one note.
3. Simulate another session's content arriving, from the browser console:

```js
wp.data.dispatch( 'core' ).editEntityRecord(
	'postType',
	'post',
	wp.data.select( 'core/editor' ).getCurrentPostId(),
	{ blocks: wp.blocks.parse( '<!-- wp:paragraph --><p>Alpha</p><!-- /wp:paragraph -->\n\n<!-- wp:paragraph --><p>Beta, edited by someone else</p><!-- /wp:paragraph -->\n\n<!-- wp:paragraph --><p>Gamma</p><!-- /wp:paragraph -->' ) }
);
```

   - **Before:** six blocks - the old three dimmed as pending removals, the new three as pending insertions - and the notes sidebar fills with new cards.
   - **After:** three blocks, the incoming text, no markers, and the note count unchanged.
4. Type into `Beta, edited by someone else` and confirm it still produces a marker and a note - the reconcile must not turn capture off.

The same shape reproduces without the console by opening the post in two browsers as two users, suggesting and saving in each; the console version just makes it deterministic.

### Automated coverage

Two new e2e cases in `test/e2e/specs/editor/various/suggestion-mode-external-content.spec.js`. Both verified red on `suggest/inline-wiring` before the fix and green after:

```
✓ another session's content is not captured as suggested insertions
✓ an edit made after the reconcile is still captured as a suggestion
```

Two new unit cases in `packages/editor/src/components/suggestion-mode/test/store-interceptor.js`, also red before and green after:

```
✓ adopts a resetBlocks as the new baseline instead of capturing it
✓ still captures an edit made after a resetBlocks
```

The suggestion-mode unit suites are green (19 suites, 306 tests). The five `suggestion-mode*` e2e specs run 66 cases with one failure, `a closed sidebar stays closed when a suggestion is created`, which fails the same way on the unmodified base branch.

## AI Use

Claude Code did the typing here, I did the asking. I will review and test.

