### PR TITLE
List View: Make focus on mount opt in

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
+-   `ListView`: Only move focus into the list when the new `focusOnMount` prop is set, so that a list mounted as a side effect of a selection no longer pulls focus out of the editor canvas ([#81659](https://github.com/WordPress/gutenberg/pull/81659)).
 
 ## 16.2.0 (2026-08-12)
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import {
 	useInstanceId,
 	useMergeRefs,
+	useRefEffect,
 	__experimentalUseFixedWindowList as useFixedWindowList,
 } from '@wordpress/compose';
 import { isShallowEqual } from '@wordpress/is-shallow-equal';
@@ -80,6 +81,7 @@ const expansion = ( state, action ) => {
  * @param {?boolean}       props.showBlockMovers        Flag to enable block movers. Defaults to `false`.
  * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `false`.
  * @param {?boolean}       props.showAppender           Flag to show or hide the block appender. Defaults to `false`.
+ * @param {?boolean}       props.focusOnMount           Flag to move focus into the list when it mounts. Defaults to `false`.
  * @param {?ComponentType} props.blockSettingsMenu      Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
  * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.
  * @param {string}         props.description            Optional accessible description for the tree grid component.
@@ -95,6 +97,7 @@ function ListViewComponent(
 		showBlockMovers = false,
 		isExpanded = false,
 		showAppender = false,
+		focusOnMount = false,
 		blockSettingsMenu: BlockSettingsMenu = BlockSettingsDropdown,
 		rootClientId,
 		description,
@@ -174,21 +177,61 @@ function ListViewComponent(
 		selectBlock: selectEditorBlock,
 	} );
 
-	const focusSelectedBlock = useCallback(
+	const focusOnMountRef = useRefEffect(
 		( node ) => {
-			const [ firstSelectedClientId ] = getSelectedBlockClientIds();
-			// If a blocks are already selected when the list view is initially
-			// mounted, shift focus to the first selected block.
-			if ( firstSelectedClientId && node ) {
-				focusListItem( firstSelectedClientId, node );
+			// A list that mounts as a side effect of selecting a block, the
+			// block inspector's for one, would pull focus out of whatever the
+			// user is editing, so taking focus is opt-in.
+			if ( ! focusOnMount ) {
+				return;
 			}
+
+			const controller = new window.AbortController();
+			const focusRow = ( clientId ) =>
+				focusListItem( clientId, node, controller.signal ).then( () =>
+					controller.abort()
+				);
+
+			// Anything that takes focus first has a better claim to it. The row
+			// is not always there yet either, because a nested block waits on
+			// its ancestors expanding.
+			node.ownerDocument.addEventListener(
+				'focusin',
+				() => controller.abort(),
+				{ once: true, signal: controller.signal }
+			);
+
+			const [ firstSelectedClientId ] = getSelectedBlockClientIds();
+
+			if ( firstSelectedClientId ) {
+				focusRow( firstSelectedClientId );
+				return () => controller.abort();
+			}
+
+			// With nothing selected the top of the list gets focus, but only
+			// once the click that opened the list is over. Focusing a row costs
+			// a style and layout pass, and inside that commit it lands on a
+			// document that is still dirty.
+			const timerId = setTimeout( () => {
+				const firstClientId = node.querySelector(
+					'[role=row][data-block]'
+				)?.dataset.block;
+				if ( firstClientId ) {
+					focusRow( firstClientId );
+				}
+			}, 0 );
+
+			return () => {
+				clearTimeout( timerId );
+				controller.abort();
+			};
 		},
-		[ getSelectedBlockClientIds ]
+		[ focusOnMount, getSelectedBlockClientIds ]
 	);
 
 	const treeGridRef = useMergeRefs( [
 		clipBoardRef,
-		focusSelectedBlock,
+		focusOnMountRef,
 		elementRef,
 		dropZoneRef,
 		ref,

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -80,8 +80,9 @@ export function getCommonDepthClientIds(
  *
  * @param {string}       focusClientId   The client ID of the block to focus.
  * @param {?HTMLElement} treeGridElement The container element to search within.
+ * @param {?AbortSignal} signal          Optional signal to stop waiting for the row and leave focus alone.
  */
-export function focusListItem( focusClientId, treeGridElement ) {
+export function focusListItem( focusClientId, treeGridElement, signal ) {
 	if ( ! treeGridElement ) {
 		return;
 	}
@@ -108,12 +109,26 @@ export function focusListItem( focusClientId, treeGridElement ) {
 			subtree: true,
 		} );
 
+		signal?.addEventListener(
+			'abort',
+			() => {
+				clearTimeout( timer );
+				observer.disconnect();
+				resolve( null );
+			},
+			{ once: true }
+		);
+
 		// Stop trying after 3 seconds.
 		timer = setTimeout( () => {
 			observer.disconnect();
 			resolve( null );
 		}, 3000 );
 	} ).then( ( element ) => {
+		if ( signal?.aborted ) {
+			return;
+		}
+
 		if ( element && element.isConnected ) {
 			// Focus the first focusable in the row, which is the ListViewBlockSelectButton.
 			focus.focusable.find( element )?.[ 0 ]?.focus();

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -1,6 +1,5 @@
 import { __experimentalListView as ListView } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,8 +15,6 @@ export default function ListViewSidebar() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the dropZoneElement updates.
 	const [ dropZoneElement, setDropZoneElement ] = useState( null );
-
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	// When closing the list view, focus should return to the toggle button.
 	const closeListView = useCallback( () => {
@@ -52,9 +49,9 @@ export default function ListViewSidebar() {
 			</div>
 			<div
 				className="edit-widgets-editor__list-view-panel-content"
-				ref={ useMergeRefs( [ focusOnMountRef, setDropZoneElement ] ) }
+				ref={ setDropZoneElement }
 			>
-				<ListView dropZoneElement={ dropZoneElement } />
+				<ListView dropZoneElement={ dropZoneElement } focusOnMount />
 			</div>
 		</div>
 	);

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -2,7 +2,7 @@ import {
 	__experimentalListView as ListView,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
+import { useMergeRefs } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import { useCallback, useRef, useState } from '@wordpress/element';
@@ -18,9 +18,6 @@ const { TabbedSidebar } = unlock( blockEditorPrivateApis );
 export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editorStore );
 	const { getListViewToggleRef } = unlock( useSelect( editorStore ) );
-
-	// This hook handles focus when the sidebar first renders.
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	// When closing the list view, focus should return to the toggle button.
 	const closeListView = useCallback( () => {
@@ -53,7 +50,6 @@ export default function ListViewSidebar() {
 
 	// Must merge the refs together so focus can be handled properly in the next function.
 	const listViewContainerRef = useMergeRefs( [
-		focusOnMountRef,
 		listViewRef,
 		setDropZoneElement,
 	] );
@@ -121,6 +117,7 @@ export default function ListViewSidebar() {
 								<div className="editor-list-view-sidebar__list-view-panel-content">
 									<ListView
 										dropZoneElement={ dropZoneElement }
+										focusOnMount
 									/>
 								</div>
 							</div>

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -496,6 +496,33 @@ test.describe( 'List View', () => {
 		).toBeFocused();
 	} );
 
+	test( 'should place focus on the first block when no block is selected', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'First' },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
+
+		// Clicking the title deselects the blocks.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.click();
+
+		// Open List View.
+		await pageUtils.pressKeys( 'access+o' );
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		await expect(
+			listView.getByRole( 'link', { name: 'First' } )
+		).toBeFocused();
+	} );
+
 	test( 'should duplicate block using keyboard', async ( {
 		editor,
 		pageUtils,


### PR DESCRIPTION
## What?

The List View moved focus to the selected block whenever its tree grid was attached, regardless of why. A List View that mounts as a side effect of selecting a block, such as the one the block inspector renders for blocks with List View support, therefore pulled focus out of the editor canvas. The Navigation block's inspector list remounts on every expand, so it did this repeatedly.

Focus is now opt-in through a new `focusOnMount` prop, which only the two List View sidebars the user opens pass (post/site editor and widgets). Those sidebars no longer run `useFocusOnMount` themselves, so the List View is the single owner of where focus lands: the selected block, or the first block when nothing is selected.

Removing the sidebar hook also eliminates a race condition, since the two mechanisms previously competed, and the winner depended on whether the selected row rendered in the first commit.

The wait for a row that has not rendered yet, which happens when a nested block needs its ancestors expanded, is now canceled on unmount and once focus moves outside the list, so it can no longer pull the user back after they have moved on.

## Testing Instructions
* Open List View from the toolbar or with `access+o` and confirm focus lands on the selected block, or on the first block when nothing is selected.
* Select a block, open List View and confirm that the correct block receives focus.
* Repeat the same step with inner blocks.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
