### PR TITLE
Suggest mode: make the Viewing intent actually read-only

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -28,6 +28,7 @@ export default function useInput() {
 		getSelectionStart,
 		getSelectionEnd,
 		getBlockAttributes,
+		getSettings,
 	} = useSelect( blockEditorStore );
 	const {
 		replaceBlocks,
@@ -39,7 +40,23 @@ export default function useInput() {
 	} = useDispatch( blockEditorStore );
 
 	return useRefEffect( ( node ) => {
+		/*
+		 * A preview canvas is read-only, so none of the cross-block input
+		 * handling below applies: every branch of it writes to the store.
+		 * Preview mode is checked per event rather than once, because the
+		 * editor intent can turn it on and off while this effect stays
+		 * mounted.
+		 */
+		function isReadOnly() {
+			return !! getSettings().isPreviewMode;
+		}
+
 		function onBeforeInput( event ) {
+			if ( isReadOnly() ) {
+				event.preventDefault();
+				return;
+			}
+
 			// If writing flow is editable, never allow the browser to alter
 			// the DOM outside of an editable element within a block. This
 			// will cause React errors (and the DOM should only be altered in
@@ -64,7 +81,7 @@ export default function useInput() {
 		}
 
 		function onKeyDown( event ) {
-			if ( event.defaultPrevented ) {
+			if ( event.defaultPrevented || isReadOnly() ) {
 				return;
 			}
 
@@ -182,6 +199,11 @@ export default function useInput() {
 		}
 
 		function onCompositionStart( event ) {
+			if ( isReadOnly() ) {
+				event.preventDefault();
+				return;
+			}
+
 			if ( ! hasMultiSelection() ) {
 				return;
 			}

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2882,6 +2882,37 @@ describe( 'selectors', () => {
 			);
 		} );
 
+		it( 'should stop allowing blocks once preview mode is turned on', () => {
+			const blocks = {
+				byClientId: new Map(),
+				attributes: new Map(),
+				order: new Map(),
+				parents: new Map(),
+				blockEditingModes: new Map(),
+			};
+			const editing = {
+				blocks,
+				blockListSettings: new Map(),
+				settings: {},
+			};
+			// Ask once while the canvas is editable, so the answer is
+			// memoized, then turn preview mode on. The editor intent flips
+			// this setting at runtime, so a stale `true` here is what lets a
+			// read-only canvas split blocks and open a working inserter.
+			expect( canInsertBlockType( editing, 'core/test-block-a' ) ).toBe(
+				true
+			);
+
+			const previewing = {
+				blocks,
+				blockListSettings: new Map(),
+				settings: { isPreviewMode: true },
+			};
+			expect(
+				canInsertBlockType( previewing, 'core/test-block-a' )
+			).toBe( false );
+		} );
+
 		it( 'should deny blocks when the editor has a template lock', () => {
 			const state = {
 				blocks: {

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -140,6 +140,14 @@ export const getInsertBlockTypeDependants = () => ( state, rootClientId ) => {
 		state.blocks.order.get( rootClientId || '' ),
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
+		/*
+		 * Preview mode refuses insertion outright, and unlike the settings
+		 * above it flips while the editor is running - switching the editor
+		 * intent to "view" turns it on and back off again. Without it here,
+		 * every answer cached before the switch survives it, so the editor
+		 * goes on believing it can insert blocks in a read-only canvas.
+		 */
+		state.settings.isPreviewMode,
 		getBlockEditingMode( state, rootClientId ),
 		getSectionRootClientId( state ),
 		isSectionBlock( state, rootClientId ),

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -2,7 +2,10 @@ import clsx from 'clsx';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
-import { NavigableToolbar } from '@wordpress/block-editor';
+import {
+	NavigableToolbar,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
@@ -24,6 +27,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		inserterSidebarToggleRef,
 		listViewToggleRef,
 		showIconLabels,
+		isPreviewMode,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const {
@@ -33,8 +37,13 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			getListViewToggleRef,
 		} = unlock( select( editorStore ) );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		const { getSettings } = select( blockEditorStore );
 
 		return {
+			// A preview canvas can't take a block. The read-only intents use
+			// it, so the control that adds blocks has to read as unavailable
+			// rather than open onto an empty library.
+			isPreviewMode: !! getSettings().isPreviewMode,
 			isInserterOpened: select( editorStore ).isInserterOpened(),
 			isListViewOpen: isListViewOpened(),
 			listViewShortcut: getShortcutRepresentation(
@@ -106,7 +115,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 						isPressed={ isInserterOpened }
 						onMouseDown={ preventDefault }
 						onClick={ toggleInserter }
-						disabled={ disableBlockTools }
+						disabled={ disableBlockTools || isPreviewMode }
 						icon={ plus }
 						label={ showIconLabels ? shortLabel : longLabel }
 						showTooltip={ ! showIconLabels }

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -799,6 +799,13 @@ export const setEditorIntent =
 
 		dispatch( { type: 'SET_EDITOR_INTENT', intent } );
 
+		// The view intent puts the canvas in preview mode, where nothing can
+		// be inserted. An inserter left open over it offers a library that
+		// can't do anything, so close it on the way in.
+		if ( intent === EDITOR_INTENT_VIEW && select.isInserterOpened() ) {
+			dispatch.setIsInserterOpened( false );
+		}
+
 		// Skip the snackbar/announcement on the initial set (when there is no
 		// previous intent, e.g. during editor boot) so the user isn't greeted
 		// with a mode notice they didn't trigger.

--- a/test/e2e/specs/editor/various/suggestion-mode-view-readonly.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-view-readonly.spec.js
@@ -49,13 +49,34 @@ test.describe( 'Suggestion mode - Viewing intent is read-only', () => {
 		editor,
 		page,
 	} ) => {
+		// F-01 was reported as the post going dirty, so start from a clean one.
+		await editor.saveDraft();
+
+		/*
+		 * Select across both paragraphs before switching. Preview mode drops
+		 * the per-block selection state, so a click in the read-only canvas
+		 * places no caret and a keystroke reaches no handler at all. A
+		 * selection carried in from Editing is what keeps the cross-block
+		 * branch of `useInput` live, and on Enter that branch hands the whole
+		 * selection to `replaceBlocks` - which is exactly what a stale
+		 * `canInsertBlockType` lets through.
+		 */
+		const paragraphs = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		await editor.selectBlocks( paragraphs.first(), paragraphs.last() );
+
 		await switchIntent( page, 'Viewing' );
 
-		const paragraph = editor.canvas
-			.getByRole( 'document', { name: 'Block: Paragraph' } )
-			.first();
-		await paragraph.click();
-		for ( const key of [ 'Enter', 'a', 'Backspace', 'Delete', 'Enter' ] ) {
+		// The writing flow ref lands on the iframed canvas' body element.
+		const writingFlow = editor.canvas.locator( 'body' );
+		await expect( writingFlow ).toHaveAttribute(
+			'data-has-multi-selection',
+			'true'
+		);
+		await writingFlow.focus();
+
+		for ( const key of [ 'Enter', 'a', 'Backspace', 'Delete' ] ) {
 			await page.keyboard.press( key );
 		}
 
@@ -63,6 +84,13 @@ test.describe( 'Suggestion mode - Viewing intent is read-only', () => {
 		expect( blocks ).toHaveLength( 2 );
 		expect( blocks[ 0 ].attributes.content ).toBe( 'First paragraph' );
 		expect( blocks[ 1 ].attributes.content ).toBe( 'Second paragraph' );
+		await expect
+			.poll( () =>
+				page.evaluate( () =>
+					window.wp.data.select( 'core/editor' ).isEditedPostDirty()
+				)
+			)
+			.toBe( false );
 	} );
 
 	test( 'the block inserter is disabled in Viewing mode', async ( {

--- a/test/e2e/specs/editor/various/suggestion-mode-view-readonly.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-view-readonly.spec.js
@@ -1,0 +1,120 @@
+/**
+ * E2E coverage for the Viewing intent being genuinely read-only (#73411,
+ * findings F-01 and F-02). Viewing is described in the Mode menu as a
+ * "Read-only preview of the content", so no keystroke and no header control
+ * may mutate blocks or dirty the post.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection, so
+	// leaving the menu open would make a subsequent `Options` click toggle
+	// it closed instead of reopening it.
+	await page.keyboard.press( 'Escape' );
+}
+
+test.describe( 'Suggestion mode - Viewing intent is read-only', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First paragraph' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second paragraph' },
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'no keystroke changes the blocks in Viewing mode', async ( {
+		editor,
+		page,
+	} ) => {
+		await switchIntent( page, 'Viewing' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		for ( const key of [ 'Enter', 'a', 'Backspace', 'Delete', 'Enter' ] ) {
+			await page.keyboard.press( key );
+		}
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 2 );
+		expect( blocks[ 0 ].attributes.content ).toBe( 'First paragraph' );
+		expect( blocks[ 1 ].attributes.content ).toBe( 'Second paragraph' );
+	} );
+
+	test( 'the block inserter is disabled in Viewing mode', async ( {
+		page,
+	} ) => {
+		const inserterToggle = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } );
+
+		await expect( inserterToggle ).toBeEnabled();
+
+		await switchIntent( page, 'Viewing' );
+		await expect( inserterToggle ).toBeDisabled();
+
+		// Returning to Editing restores it: the read-only state follows the
+		// intent rather than being a one-way trip.
+		await switchIntent( page, 'Editing' );
+		await expect( inserterToggle ).toBeEnabled();
+	} );
+
+	test( 'an inserter opened over a Viewing canvas offers nothing', async ( {
+		editor,
+		page,
+	} ) => {
+		await switchIntent( page, 'Viewing' );
+
+		// The header toggle is disabled by now, so drive the inserter open
+		// through the store: that proves insertion is refused by the editor
+		// itself and not only hidden behind a disabled control.
+		await page.evaluate( () =>
+			window.wp.data.dispatch( 'core/editor' ).setIsInserterOpened( true )
+		);
+
+		const library = page.getByRole( 'region', { name: 'Block Library' } );
+		await expect( library ).toBeVisible();
+		await expect( library.getByRole( 'option' ) ).toHaveCount( 0 );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 2 );
+	} );
+
+	test( 'switching to Viewing closes an open inserter', async ( {
+		page,
+	} ) => {
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
+			.click();
+		const library = page.getByRole( 'region', { name: 'Block Library' } );
+		await expect( library ).toBeVisible();
+
+		await switchIntent( page, 'Viewing' );
+		await expect( library ).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
## What

Fixes findings **F-01** and **F-02** from the Suggest mode guided testing run: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode stack for https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), the top of the stack.

The testing doc lists these two as one fix ("Fix with F-02 as one editor-level read-only"), and they do turn out to share a root cause, so they are handled together here.

## The problem

The Viewing intent is described in the Mode menu as a "Read-only preview of the content", and it does put the block editor canvas into preview mode. But the read-only part only half lands:

- **F-01:** pressing Enter with the caret in a paragraph splits the block. Block count goes 7 to 8, the paragraph's text is emptied, and the post goes dirty.
- **F-02:** the header's Block Inserter is neither hidden nor disabled. It opens, lists every block type, and picking one actually inserts a block and dirties the post.

The block editor already refuses insertion in preview mode - `canInsertBlockType` bails out at the top when `settings.isPreviewMode` is set. The catch is that `canInsertBlockType`, `getInserterItems`, `getAllowedBlocks` and friends are all memoized through `createSelector`, and the shared dependants list in `getInsertBlockTypeDependants` does not include `state.settings.isPreviewMode`:

```js
state.settings.allowedBlockTypes,
state.settings.templateLock,
```

That was fine while preview mode only ever applied to an editor that mounted in it, like the Revisions UI. The editor intent is the first thing to flip it at runtime, and nothing in that list changes when it flips - so every answer cached before the switch survives it.

Measured in the browser after switching to Viewing:

```
isPreviewMode: true
canInsertBlockType( 'core/paragraph', '' ): true      <- stale
getInserterItems( '' ).length: 118                    <- stale
```

That single stale `true` is what both findings run on. `useInput` asks `canInsertBlockType` before it splits on Enter (F-01), and the inserter's block list is built from `getInserterItems` (F-02).

## The fix

Three changes, smallest first:

1. **`getInsertBlockTypeDependants` gains `state.settings.isPreviewMode`.** Flipping preview mode now invalidates every insertion answer, which is what closes the bypass for both findings.
2. **The writing flow's cross-block input handling bails out in preview mode.** Every branch of `useInput` writes to the store, so rather than leaning on the insertion check alone, `onKeyDown`, `onBeforeInput` and `onCompositionStart` return early while the canvas is a preview. No keystroke reaches a store write regardless of which branch it would have taken - including the Enter-transform branch, which runs before the insertion check.
3. **The header Block Inserter is disabled while the canvas is in preview mode**, and an inserter that is already open is closed on the way into the view intent. Without this the toggle still opens, just onto an empty library, which reads as a broken editor rather than a read-only one.

Gating on `isPreviewMode` rather than on the intent directly keeps it the single editor-wide read-only switch the testing doc asked for, and it covers the Revisions canvas at the same time.

Note that the block toolbar in Viewing mode is untouched here - it was mentioned in the doc's proposed fix but not reported as a defect of its own, so it is left for whoever picks it up.

## Screenshots

Both taken in Viewing mode on the same post. Before, the block library is fully populated and every entry inserts. After, the header toggle is disabled, and forcing the panel open through the store shows there is nothing to insert.

**Before**

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f01-f02-before-viewing-inserter.png" width="900">

**After**

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f01-f02-after-viewing-inserter.png" width="900">

The header toolbar on its own, before and after, showing the inserter toggle going from available to disabled:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f01-f02-before-header.png" width="700">

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f01-f02-after-header.png" width="700">

## Testing instructions

Enable the Suggest mode experiment (Gutenberg → Experiments → Suggest mode), then open a post with a few paragraphs.

1. Options → Mode → **Viewing**.
2. Look at the Block Inserter (the `+` in the top bar).
   - **Before:** it is enabled. Clicking it opens a full block library.
   - **After:** it is disabled.
3. Still in Viewing, click one of the blocks in the library.
   - **Before:** the block is inserted. Block count goes up and the post goes dirty.
   - **After:** there is no library entry to click. Forcing the panel open with `wp.data.dispatch( 'core/editor' ).setIsInserterOpened( true )` shows "No results found."
4. Open the inserter first while in Editing, then switch to Viewing.
   - **Before:** the inserter stays open over the read-only canvas.
   - **After:** it closes.
5. Switch back to Editing, click the first paragraph and shift-click the last one so the selection spans both, then switch to Viewing and press Enter.
   - **Before:** the whole selection is replaced and the post goes dirty.
   - **After:** the block list is unchanged and the post stays clean.
6. Switch back to Editing and confirm the inserter works normally again.

### Automated coverage

New e2e spec `test/e2e/specs/editor/various/suggestion-mode-view-readonly.spec.js`:

- `no keystroke changes the blocks in Viewing mode`
- `the block inserter is disabled in Viewing mode`
- `an inserter opened over a Viewing canvas offers nothing`
- `switching to Viewing closes an open inserter`

New unit test in `packages/block-editor/src/store/test/selectors.js`:

- `canInsertBlockType › should stop allowing blocks once preview mode is turned on`

The unit test and all four e2e tests were verified red on the unmodified base branch and green with the fix. Red output on the base:

```
canInsertBlockType › should stop allowing blocks once preview mode is turned on
  Expected: false
  Received: true

no keystroke changes the blocks in Viewing mode
  Expected length: 2 / Received length: 0
the block inserter is disabled in Viewing mode
  Expected: disabled / Received: enabled
an inserter opened over a Viewing canvas offers nothing
  Expected: 0 / Received: 11
switching to Viewing closes an open inserter
  Expected: hidden / Received: visible
```

All five pass with the fix.

**A note on how the keystroke test gets there.** Preview mode drops the per-block selection state, so clicking a block in the Viewing canvas places no caret and the keystroke lands on nothing - which is why the first shape of this test (click a paragraph, then mash keys) passed on the base too. The reproduction that does work is a selection carried in from Editing: select across the blocks, then switch. Enter still reaches `useInput`'s cross-block branch, which hands the whole selection to `replaceBlocks`, and on the base that walks straight through the stale `canInsertBlockType` and empties the post. The test now does that and also asserts the post stays clean, which was F-01's reported symptom.

Worth noting while reading change 2: `canRemoveBlock`, `canMoveBlock` and `canEditBlock` are plain selectors rather than memoized ones, and they already bail on `isPreviewMode` - so the Backspace and Delete branches of `useInput` were never getting through in the first place. `canInsertBlockType` was the only hole, and change 1 closes it. That makes the `useInput` bail-out defense in depth rather than the thing this test distinguishes.

Also ran, with no regressions: the full `suggestion-mode*` e2e set (67 passed, plus the known pre-existing failure of "a closed sidebar stays closed when a suggestion is created", which fails on the base branch too), `writing-flow.spec.js` and `multi-block-selection.spec.js` across all three browsers (257 passed), and the block-editor and editor store unit suites (869 passed).

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.

