### PR TITLE
Suggest mode: extend your own pending addition when typing inside it

### DIFF
--- a/packages/editor/src/components/inline-suggestions/index.js
+++ b/packages/editor/src/components/inline-suggestions/index.js
@@ -44,6 +44,8 @@ export {
 	buildSuggestionMarkerAttributes,
 	formatsRangeHasSuggestion,
 	valueRangeHasSuggestion,
+	formatsAdditionRunToExtend,
+	valueAdditionRunToExtend,
 } from './operations';
 export { computeDeleteRange } from './delete-range';
 export {

--- a/packages/editor/src/components/inline-suggestions/operations.js
+++ b/packages/editor/src/components/inline-suggestions/operations.js
@@ -110,13 +110,15 @@ function suggestionFormatAt( formats, index ) {
  * Conservative elsewhere too. The marker has to be an `add` marker (typing
  * inside someone's proposed deletion is a different, unsettled gesture),
  * authored by the person making this edit, and unfragmented — a marker whose id
- * also appears elsewhere in the value cannot be re-stamped as one range.
+ * also appears elsewhere in the value cannot be re-stamped as one range. An
+ * editor whose own id is unknown counts as unauthored, matching only a marker
+ * that carries no author either.
  *
  * @param {Array}   formats       Per-character format stacks (from `create()`).
  * @param {number}  offset        Caret offset.
  * @param {?string} [authorToken] Id of the author making the edit, as a
- *                                string; `null`/omitted skips the author
- *                                check.
+ *                                string; `null`/omitted matches only a marker
+ *                                with no author.
  * @return {?{id: string, start: number, end: number}} The marker's range, or null.
  */
 export function formatsAdditionRunToExtend( formats, offset, authorToken ) {
@@ -137,13 +139,16 @@ export function formatsAdditionRunToExtend( formats, offset, authorToken ) {
 	if ( rawId === undefined || rawId === null || rawId === '' ) {
 		return null;
 	}
-	// Extending re-attributes nothing: the marker and its note stay the
-	// original author's, so only that author may grow it.
+	/*
+	 * Extending re-attributes nothing: the marker and its note stay the
+	 * original author's, so only that author may grow it. An unknown editor
+	 * therefore matches an unauthored marker only — growing someone else's
+	 * would re-stamp their span with no `data-author` and fold this text into
+	 * their note.
+	 */
 	if (
-		authorToken !== null &&
-		authorToken !== undefined &&
 		String( attributes[ SUGGESTION_AUTHOR_ATTRIBUTE ] ?? '' ) !==
-			authorToken
+		( authorToken ?? '' )
 	) {
 		return null;
 	}

--- a/packages/editor/src/components/inline-suggestions/operations.js
+++ b/packages/editor/src/components/inline-suggestions/operations.js
@@ -7,10 +7,12 @@ import {
 	applyFormat,
 } from '@wordpress/rich-text';
 import {
+	SUGGESTION_CLASS,
 	SUGGESTION_FORMAT_NAME,
 	SUGGESTION_ID_ATTRIBUTE,
 	SUGGESTION_TYPE_ATTRIBUTE,
 	SUGGESTION_AUTHOR_ATTRIBUTE,
+	SUGGESTION_TYPE_ADDITION,
 	findSuggestionRange,
 } from './format';
 
@@ -72,6 +74,105 @@ export function formatsRangeHasSuggestion( formats, start, end ) {
 }
 
 /**
+ * The `core/suggestion` format covering a character in a per-character format
+ * stack array, or undefined.
+ *
+ * @param {Array}  formats Per-character format stacks (from `create()`).
+ * @param {number} index   Character index.
+ * @return {Object|undefined} The suggestion format at that character.
+ */
+function suggestionFormatAt( formats, index ) {
+	const stack = formats[ index ];
+	return Array.isArray( stack )
+		? stack.find( ( f ) => f.type === SUGGESTION_FORMAT_NAME )
+		: undefined;
+}
+
+/**
+ * The pending `add` marker that text entered at `offset` should extend, rather
+ * than opening a second suggestion nested inside the first.
+ *
+ * A caret sitting inside — or at the trailing edge of — the suggester's own
+ * pending addition is a caret inside text that is already proposed. More typed
+ * there is more of the same proposal, so it belongs to the same marker and the
+ * same note. Inserting a *new* marker at that offset instead splits the
+ * enclosing one into two disjoint `<mark>` elements sharing one id, leaves two
+ * notes claiming the same characters, and makes accept/reject incoherent —
+ * accepting the inner note while rejecting the outer keeps the new text and
+ * drops the text it was typed into (#73411, finding F-06).
+ *
+ * The marker to the LEFT of the caret is the one that grows, which covers both
+ * a caret strictly inside the run and one at its trailing edge. A caret at the
+ * marker's *leading* edge is deliberately not matched: the character before it
+ * is unmarked, so the new text is as plausibly a fresh addition, and starting a
+ * separate marker there fragments nothing.
+ *
+ * Conservative elsewhere too. The marker has to be an `add` marker (typing
+ * inside someone's proposed deletion is a different, unsettled gesture),
+ * authored by the person making this edit, and unfragmented — a marker whose id
+ * also appears elsewhere in the value cannot be re-stamped as one range.
+ *
+ * @param {Array}   formats       Per-character format stacks (from `create()`).
+ * @param {number}  offset        Caret offset.
+ * @param {?string} [authorToken] Id of the author making the edit, as a
+ *                                string; `null`/omitted skips the author
+ *                                check.
+ * @return {?{id: string, start: number, end: number}} The marker's range, or null.
+ */
+export function formatsAdditionRunToExtend( formats, offset, authorToken ) {
+	if (
+		! Array.isArray( formats ) ||
+		offset <= 0 ||
+		offset > formats.length
+	) {
+		return null;
+	}
+	const attributes = suggestionFormatAt( formats, offset - 1 )?.attributes;
+	if (
+		attributes?.[ SUGGESTION_TYPE_ATTRIBUTE ] !== SUGGESTION_TYPE_ADDITION
+	) {
+		return null;
+	}
+	const rawId = attributes[ SUGGESTION_ID_ATTRIBUTE ];
+	if ( rawId === undefined || rawId === null || rawId === '' ) {
+		return null;
+	}
+	// Extending re-attributes nothing: the marker and its note stay the
+	// original author's, so only that author may grow it.
+	if (
+		authorToken !== null &&
+		authorToken !== undefined &&
+		String( attributes[ SUGGESTION_AUTHOR_ATTRIBUTE ] ?? '' ) !==
+			authorToken
+	) {
+		return null;
+	}
+	const id = String( rawId );
+	const idAt = ( index ) => {
+		const value = suggestionFormatAt( formats, index )?.attributes?.[
+			SUGGESTION_ID_ATTRIBUTE
+		];
+		return value === undefined || value === null ? null : String( value );
+	};
+	let start = offset - 1;
+	while ( start > 0 && idAt( start - 1 ) === id ) {
+		start--;
+	}
+	let end = offset;
+	while ( end < formats.length && idAt( end ) === id ) {
+		end++;
+	}
+	// A marker already split into fragments (an earlier nested insert, a
+	// copy/paste) has no single range to grow.
+	for ( let i = 0; i < formats.length; i++ ) {
+		if ( ( i < start || i >= end ) && idAt( i ) === id ) {
+			return null;
+		}
+	}
+	return { id, start, end };
+}
+
+/**
  * Whether any character in `[start, end)` of a block attribute value already
  * carries a `core/suggestion` marker. Value-level convenience wrapper around
  * `formatsRangeHasSuggestion` tolerating plain strings and non-rich values.
@@ -94,6 +195,34 @@ export function valueRangeHasSuggestion( value, start, end ) {
 	}
 	const record = create( { html } );
 	return formatsRangeHasSuggestion( record.formats, start, end );
+}
+
+/**
+ * The pending `add` marker in a block attribute value that text entered at
+ * `offset` should extend. Value-level convenience wrapper around
+ * `formatsAdditionRunToExtend` tolerating plain strings and non-rich values.
+ *
+ * @param {*}       value         Block attribute value (RichTextData, string, or other).
+ * @param {number}  offset        Caret offset.
+ * @param {?string} [authorToken] Id of the author making the edit, as a string.
+ * @return {?{id: string, start: number, end: number}} The marker's range, or null.
+ */
+export function valueAdditionRunToExtend( value, offset, authorToken ) {
+	let html = null;
+	if ( value && typeof value.toHTMLString === 'function' ) {
+		html = value.toHTMLString();
+	} else if ( typeof value === 'string' ) {
+		html = value;
+	}
+	if ( html === null || false === html.includes( SUGGESTION_CLASS ) ) {
+		// Quick reject: no marker markup, nothing to extend.
+		return null;
+	}
+	return formatsAdditionRunToExtend(
+		create( { html } ).formats,
+		offset,
+		authorToken
+	);
 }
 
 /**
@@ -305,27 +434,31 @@ export function insertInlineAddition(
 }
 
 /**
- * Extend an existing `add` marker by inserting more proposed text at the
- * marker's trailing edge and re-stamping the marker format over the *entire*
- * grown span. Re-stamping the whole span (rather than only the new run) keeps
- * one format instance across it, so the marker serializes as a single `<mark>`
- * as the user keeps typing rather than fragmenting into one tag per keystroke.
+ * Extend an existing `add` marker by inserting more proposed text into it and
+ * re-stamping the marker format over the *entire* grown span. Re-stamping the
+ * whole span (rather than only the new run) keeps one format instance across it,
+ * so the marker serializes as a single `<mark>` as the user keeps typing rather
+ * than fragmenting into one tag per keystroke.
  *
  * Used by the typing-creation trigger to grow a contiguous addition without a
- * round-trip per character: the caret-driven insertion point is `markerEnd`,
- * the new span becomes `[markerStart, markerEnd + text.length]`.
+ * round-trip per character: the caret-driven insertion point defaults to
+ * `markerEnd`, and the new span becomes `[markerStart, markerEnd + text.length]`.
+ *
+ * `at` moves that insertion point anywhere within the marker, so resuming inside
+ * a pending addition grows the one marker instead of nesting a second one in it.
  *
  * @param {*}      value               Block attribute value (RichTextData or other).
  * @param {Object} options
  * @param {string} options.text        Proposed text to append to the marker.
  * @param {Object} options.attributes  Marker attributes (see `buildSuggestionMarkerAttributes`).
  * @param {number} options.markerStart Current marker start offset.
- * @param {number} options.markerEnd   Current marker end offset (insertion point).
+ * @param {number} options.markerEnd   Current marker end offset.
+ * @param {number} [options.at]        Insertion point within the marker; defaults to `markerEnd`.
  * @return {*} New RichTextData with the marker grown, or the original value.
  */
 export function growInlineAddition(
 	value,
-	{ text, attributes, markerStart, markerEnd }
+	{ text, attributes, markerStart, markerEnd, at }
 ) {
 	if ( ! ( value instanceof RichTextData ) ) {
 		return value;
@@ -334,7 +467,14 @@ export function growInlineAddition(
 		return value;
 	}
 	const record = create( { html: value.toHTMLString() } );
-	const inserted = insert( record, text, markerEnd, markerEnd );
+	// An insertion point outside the marker would leave text unmarked between
+	// the marker and the re-stamped span, or absorb text that was never part of
+	// the proposal.
+	const insertAt = Math.min(
+		Math.max( at ?? markerEnd, markerStart ),
+		markerEnd
+	);
+	const inserted = insert( record, text, insertAt, insertAt );
 	const formatted = applyFormat(
 		inserted,
 		{ type: SUGGESTION_FORMAT_NAME, attributes },

--- a/packages/editor/src/components/inline-suggestions/reconcile-edit.js
+++ b/packages/editor/src/components/inline-suggestions/reconcile-edit.js
@@ -10,6 +10,7 @@ import {
 } from './format';
 import {
 	buildSuggestionMarkerAttributes,
+	formatsAdditionRunToExtend,
 	insertInlineAddition,
 	growInlineAddition,
 	rejectInlineAddition,
@@ -149,7 +150,7 @@ function markerType( format ) {
  * @typedef {Object} MarkerAction
  * @property {'insert-add'|'grow-add'|'wrap-del'|'remove-add'} type      Action kind.
  * @property {string}                                          [text]    Text to insert/append (insert-add, grow-add).
- * @property {number}                                          [at]      Insertion offset (insert-add).
+ * @property {number}                                          [at]      Insertion offset (insert-add, grow-add).
  * @property {number}                                          [start]   Range start (wrap-del).
  * @property {number}                                          [end]     Range end (wrap-del).
  * @property {string}                                          [id]      Existing marker id to reuse (grow-add, remove-add).
@@ -164,8 +165,8 @@ function markerType( format ) {
  *
  * Handled cleanly:
  *   - insert into unmarked text                       -> new `add` marker
- *   - insert at the trailing edge of the author's own
- *     open `add` marker                               -> grow that marker
+ *   - insert inside, or at the trailing edge of, the
+ *     author's own `add` marker                       -> grow that marker
  *   - delete unmarked text                            -> new `del` marker (kept, struck through)
  *   - delete text already inside a `del` marker       -> no-op (already proposed for deletion)
  *   - delete the author's own `add` text              -> remove that marker (un-add)
@@ -234,36 +235,42 @@ export function planEditMarkers( prevValue, nextValue, { authorId } = {} ) {
 	};
 
 	if ( edit.kind === 'insert' ) {
-		const left =
-			edit.start > 0 ? suggestionAt( record, edit.start - 1 ) : null;
-		const right = suggestionAt( record, edit.start );
-		const sameMarker =
-			left && right && markerId( left ) === markerId( right );
-
-		// Grow the author's own open addition when typing at its trailing edge
-		// (left edge is that marker, the insertion point is past its end).
-		const atAddTrailingEdge =
-			left &&
-			markerType( left ) === SUGGESTION_TYPE_ADDITION &&
-			! sameMarker;
-		if (
-			atAddTrailingEdge &&
-			( authorToken === null ||
-				left.attributes?.[ 'data-author' ] === authorToken )
-		) {
+		/*
+		 * Grow the author's own pending addition when the insertion point sits
+		 * inside it or at its trailing edge, rather than opening a second
+		 * suggestion over the same words. Nesting a new marker inside an
+		 * existing one splits it into two disjoint `<mark>` elements sharing an
+		 * id and leaves two notes claiming the same characters (#73411, finding
+		 * F-06).
+		 */
+		const extendable = formatsAdditionRunToExtend(
+			record.formats,
+			edit.start,
+			authorToken
+		);
+		if ( extendable ) {
 			return {
 				kind: 'insert',
 				actions: [
 					{
 						type: 'grow-add',
-						id: markerId( left ),
+						id: extendable.id,
 						text: edit.insertedText,
+						at: edit.start,
 					},
 				],
 			};
 		}
-		// Typing in the middle of an existing marker: leave to a later phase.
-		if ( sameMarker ) {
+		/*
+		 * Inside a marker this edit may not extend — a run proposed for
+		 * deletion, or someone else's addition. Splitting it would fragment a
+		 * marker whose accept/reject then acts on a partial range, so plan
+		 * nothing and leave the call to the caller.
+		 */
+		const left =
+			edit.start > 0 ? suggestionAt( record, edit.start - 1 ) : null;
+		const right = suggestionAt( record, edit.start );
+		if ( left && right && markerId( left ) === markerId( right ) ) {
 			return { kind: 'insert', actions: [] };
 		}
 		return {
@@ -391,6 +398,7 @@ export function applyEditPlan( value, actions, { authorId, ids = [] } = {} ) {
 					} ),
 					markerStart: range.start,
 					markerEnd: range.end,
+					at: action.at,
 				} );
 				break;
 			}

--- a/packages/editor/src/components/inline-suggestions/test/operations.js
+++ b/packages/editor/src/components/inline-suggestions/test/operations.js
@@ -539,13 +539,19 @@ describe( 'formatsAdditionRunToExtend / valueAdditionRunToExtend', () => {
 		expect( formatsAdditionRunToExtend( undefined, 4, '2' ) ).toBeNull();
 	} );
 
-	it( 'skips the author check when no author is supplied', () => {
+	it( 'matches an unauthored marker when the editor author is unknown', () => {
 		const value = RichTextData.fromHTMLString( add( 41, 'ADDED' ) );
 		expect( valueAdditionRunToExtend( value, 3, null ) ).toEqual( {
 			id: '41',
 			start: 0,
 			end: 5,
 		} );
+	} );
+
+	it( 'does not match an authored marker when the editor author is unknown', () => {
+		const value = RichTextData.fromHTMLString( mine( 41, 'ADDED' ) );
+		expect( valueAdditionRunToExtend( value, 3, null ) ).toBeNull();
+		expect( valueAdditionRunToExtend( value, 3, undefined ) ).toBeNull();
 	} );
 } );
 

--- a/packages/editor/src/components/inline-suggestions/test/operations.js
+++ b/packages/editor/src/components/inline-suggestions/test/operations.js
@@ -17,8 +17,14 @@ import {
 	buildSuggestionMarkerAttributes,
 	formatsRangeHasSuggestion,
 	valueRangeHasSuggestion,
+	formatsAdditionRunToExtend,
+	valueAdditionRunToExtend,
 } from '../operations';
-import { registerSuggestionFormat, SUGGESTION_FORMAT_NAME } from '../format';
+import {
+	registerSuggestionFormat,
+	findSuggestionText,
+	SUGGESTION_FORMAT_NAME,
+} from '../format';
 
 const getFormatType = ( name ) => select( richTextStore ).getFormatType( name );
 
@@ -403,6 +409,142 @@ describe( 'inline addition operations', () => {
 					markerEnd: 0,
 				} ).toHTMLString()
 			).toBe( 'unchanged' );
+		} );
+
+		it( 'inserts at `at` inside the marker, still as one run', () => {
+			const value = growInlineAddition(
+				RichTextData.fromHTMLString( `Hello ${ add( 9, 'ADDED' ) }` ),
+				{
+					text: 'XX',
+					attributes: attrs,
+					markerStart: 6,
+					markerEnd: 11,
+					at: 9,
+				}
+			);
+			const html = value.toHTMLString();
+			expect( stripTags( html ) ).toBe( 'Hello ADDXXED' );
+			expect( html.match( /<mark/g ) ).toHaveLength( 1 );
+			expect( findSuggestionText( value, 9 ) ).toBe( 'ADDXXED' );
+			// Rejecting still restores the original text exactly.
+			expect( rejectInlineAddition( value, 9 ).toHTMLString() ).toBe(
+				'Hello '
+			);
+		} );
+
+		it( 'clamps an `at` outside the marker into it', () => {
+			const value = growInlineAddition(
+				RichTextData.fromHTMLString( `Hello ${ add( 9, 'ADDED' ) }` ),
+				{
+					text: 'X',
+					attributes: attrs,
+					markerStart: 6,
+					markerEnd: 11,
+					at: 0,
+				}
+			);
+			expect( stripTags( value.toHTMLString() ) ).toBe( 'Hello XADDED' );
+			expect( findSuggestionText( value, 9 ) ).toBe( 'XADDED' );
+		} );
+	} );
+} );
+
+describe( 'formatsAdditionRunToExtend / valueAdditionRunToExtend', () => {
+	beforeAll( () => {
+		registerSuggestionFormat();
+	} );
+
+	afterAll( () => {
+		if ( getFormatType( SUGGESTION_FORMAT_NAME ) ) {
+			unregisterFormatType( SUGGESTION_FORMAT_NAME );
+		}
+	} );
+
+	// A pending `add` marker authored by user 2.
+	const mine = ( id, text ) =>
+		`<mark class="wp-suggestion" data-suggestion-id="${ id }" data-suggestion-type="add" data-author="2">${ text }</mark>`;
+
+	it( 'matches a caret inside the author own addition', () => {
+		const value = RichTextData.fromHTMLString(
+			`Hello ${ mine( 41, 'ADDED' ) }`
+		);
+		expect( valueAdditionRunToExtend( value, 9, '2' ) ).toEqual( {
+			id: '41',
+			start: 6,
+			end: 11,
+		} );
+	} );
+
+	it( 'matches a caret at the trailing edge', () => {
+		const value = RichTextData.fromHTMLString(
+			`Hello ${ mine( 41, 'ADDED' ) } tail`
+		);
+		expect( valueAdditionRunToExtend( value, 11, '2' ) ).toEqual( {
+			id: '41',
+			start: 6,
+			end: 11,
+		} );
+	} );
+
+	it( 'does not match a caret at the leading edge', () => {
+		const value = RichTextData.fromHTMLString(
+			`Hello ${ mine( 41, 'ADDED' ) }`
+		);
+		expect( valueAdditionRunToExtend( value, 6, '2' ) ).toBeNull();
+	} );
+
+	it( 'does not match another author addition', () => {
+		const value = RichTextData.fromHTMLString(
+			`Hello ${ mine( 41, 'ADDED' ) }`
+		);
+		expect( valueAdditionRunToExtend( value, 9, '7' ) ).toBeNull();
+	} );
+
+	it( 'does not match a deletion or a format marker', () => {
+		expect(
+			valueAdditionRunToExtend(
+				RichTextData.fromHTMLString( del( 41, 'gone' ) ),
+				2,
+				null
+			)
+		).toBeNull();
+		expect(
+			valueAdditionRunToExtend(
+				RichTextData.fromHTMLString(
+					fmt( 41, '<strong>bold</strong>' )
+				),
+				2,
+				null
+			)
+		).toBeNull();
+	} );
+
+	it( 'does not match a marker already fragmented across the value', () => {
+		// The shape F-06 used to produce: one id, two disjoint <mark>s.
+		const value = RichTextData.fromHTMLString(
+			`${ mine( 41, 'ADD' ) }${ add( 42, 'XX' ) }${ mine( 41, 'ED' ) }`
+		);
+		expect( valueAdditionRunToExtend( value, 2, '2' ) ).toBeNull();
+	} );
+
+	it( 'returns null for unmarked text and non-rich values', () => {
+		expect(
+			valueAdditionRunToExtend(
+				RichTextData.fromHTMLString( 'plain text' ),
+				4,
+				'2'
+			)
+		).toBeNull();
+		expect( valueAdditionRunToExtend( undefined, 4, '2' ) ).toBeNull();
+		expect( formatsAdditionRunToExtend( undefined, 4, '2' ) ).toBeNull();
+	} );
+
+	it( 'skips the author check when no author is supplied', () => {
+		const value = RichTextData.fromHTMLString( add( 41, 'ADDED' ) );
+		expect( valueAdditionRunToExtend( value, 3, null ) ).toEqual( {
+			id: '41',
+			start: 0,
+			end: 5,
 		} );
 	} );
 } );

--- a/packages/editor/src/components/inline-suggestions/test/reconcile-edit.js
+++ b/packages/editor/src/components/inline-suggestions/test/reconcile-edit.js
@@ -153,7 +153,7 @@ describe( 'planEditMarkers', () => {
 		const next = rtd( add( 7, 'new', 2 ) + 's' );
 		expect( planEditMarkers( prev, next, { authorId: 2 } ) ).toEqual( {
 			kind: 'insert',
-			actions: [ { type: 'grow-add', id: '7', text: 's' } ],
+			actions: [ { type: 'grow-add', id: '7', text: 's', at: 3 } ],
 		} );
 	} );
 
@@ -168,10 +168,34 @@ describe( 'planEditMarkers', () => {
 		} );
 	} );
 
-	it( 'does not act when typing inside an existing marker', () => {
+	/*
+	 * #73411 finding F-06. Typing inside the author's own pending addition used
+	 * to plan nothing, so the edit fell through to the whole-content overlay (or,
+	 * on the typing seam, nested a second marker inside the first). It extends
+	 * the one marker now.
+	 */
+	it( 'grows the author own addition when typing inside it', () => {
 		// Insert between the two characters of an existing add marker.
 		const prev = rtd( add( 7, 'ab', 2 ) );
 		const next = rtd( add( 7, 'aXb', 2 ) );
+		expect( planEditMarkers( prev, next, { authorId: 2 } ) ).toEqual( {
+			kind: 'insert',
+			actions: [ { type: 'grow-add', id: '7', text: 'X', at: 1 } ],
+		} );
+	} );
+
+	it( 'does not act when typing inside another author addition', () => {
+		const prev = rtd( add( 7, 'ab', 2 ) );
+		const next = rtd( add( 7, 'aXb', 2 ) );
+		expect( planEditMarkers( prev, next, { authorId: 9 } ) ).toEqual( {
+			kind: 'insert',
+			actions: [],
+		} );
+	} );
+
+	it( 'does not act when typing inside a pending deletion', () => {
+		const prev = rtd( del( 7, 'ab', 2 ) );
+		const next = rtd( del( 7, 'aXb', 2 ) );
 		expect( planEditMarkers( prev, next, { authorId: 2 } ) ).toEqual( {
 			kind: 'insert',
 			actions: [],
@@ -261,6 +285,24 @@ describe( 'applyEditPlan', () => {
 			ids: [],
 		} );
 		expect( findSuggestionText( result, 7 ) ).toBe( 'news' );
+	} );
+
+	it( 'grows an existing add marker from inside, as one marker', () => {
+		const prev = rtd( 'Hello ' + add( 41, 'ADDED', 2 ) );
+		const { actions } = planEditMarkers(
+			prev,
+			rtd( 'Hello ' + add( 41, 'ADDXXED', 2 ) ),
+			{ authorId: 2 }
+		);
+		const result = applyEditPlan( prev, actions, {
+			authorId: 2,
+			ids: [],
+		} );
+		const html = result.toHTMLString();
+		// One marker, one id, the typed text inside it.
+		expect( html.match( /<mark/g ) ).toHaveLength( 1 );
+		expect( findSuggestionText( result, 41 ) ).toBe( 'ADDXXED' );
+		expect( html ).toContain( 'data-author="2"' );
 	} );
 
 	it( 'wraps a deletion, keeping the text struck through', () => {

--- a/packages/editor/src/components/suggestion-mode/suggestion-addition-keyboard.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-addition-keyboard.js
@@ -14,6 +14,7 @@ import {
 	buildSuggestionMarkerAttributes,
 	insertInlineAddition,
 	growInlineAddition,
+	valueAdditionRunToExtend,
 	valueRangeHasSuggestion,
 } from '../inline-suggestions';
 import {
@@ -38,7 +39,10 @@ import { isPartOfPendingInsertion } from './store-interceptor';
  *   via `selectionChange`. A contiguous run grows one marker: the first
  *   character opens the note (async; characters typed meanwhile buffer and
  *   flush once the id resolves), and each subsequent character re-stamps the
- *   whole marker span so it stays one `<mark>` (`growInlineAddition`).
+ *   whole marker span so it stays one `<mark>` (`growInlineAddition`). Typing
+ *   back inside a pending addition of the author's own grows that marker the
+ *   same way, wherever the caret sits in it, so one proposal stays one marker
+ *   and one note.
  * - Type-over (entering text with a non-collapsed selection) proposes deleting
  *   the selected text (a `del` marker) and adds the replacement (an `add` run
  *   at the selection end), as two independent notes.
@@ -85,7 +89,8 @@ export default function SuggestionAdditionKeyboard() {
 	// The in-progress addition run. `id` is null while the suggestion note is
 	// being created; characters entered in that window queue in `pending` and
 	// are flushed when the id resolves. `start`/`end` track the marker's live
-	// span; the caret sits at `end`.
+	// span and `caret` the insertion point within it — the two only differ when
+	// the author resumed typing inside the marker rather than at its end.
 	const runRef = useRef( null );
 
 	const resetRun = useCallback( () => {
@@ -139,6 +144,7 @@ export default function SuggestionAdditionKeyboard() {
 				id: null,
 				start: markerStart,
 				end: markerStart,
+				caret: markerStart,
 				pending: text,
 			};
 			runRef.current = run;
@@ -233,7 +239,8 @@ export default function SuggestionAdditionKeyboard() {
 					end: run.start,
 				} );
 				run.end = run.start + buffered.length;
-				commit( clientId, attributeKey, inserted, run.end );
+				run.caret = run.end;
+				commit( clientId, attributeKey, inserted, run.caret );
 			} catch {
 				// `createSuggestion` already surfaces a notice on failure; drop
 				// the run so the next edit starts clean.
@@ -354,7 +361,7 @@ export default function SuggestionAdditionKeyboard() {
 				run.id !== null &&
 				run.clientId === clientId &&
 				run.attributeKey === attributeKey &&
-				run.end === start;
+				run.caret === start;
 
 			if ( isContiguous ) {
 				const value = getBlockAttributes( clientId )?.[ attributeKey ];
@@ -367,10 +374,66 @@ export default function SuggestionAdditionKeyboard() {
 					} ),
 					markerStart: run.start,
 					markerEnd: run.end,
+					at: run.caret,
 				} );
 				run.end += text.length;
-				commit( clientId, attributeKey, grown, run.end );
+				run.caret += text.length;
+				commit( clientId, attributeKey, grown, run.caret );
 				return true;
+			}
+
+			/*
+			 * Resuming inside the author's own pending addition — clicking back
+			 * into text they already proposed and typing more. Grow that marker
+			 * in place: a fresh marker at that offset would split the enclosing
+			 * one into two `<mark>` elements sharing an id and leave a second
+			 * note claiming characters the first note also reports (#73411,
+			 * finding F-06). The marker is resolved from the block's live value
+			 * rather than from `runRef`, so it works after a click, a
+			 * reload or a caret move away and back.
+			 *
+			 * Paste merges only when the caret is strictly inside the marker,
+			 * where the alternative is that split. At the trailing edge a pasted
+			 * run stays its own marker, as `allowGrow` intends.
+			 */
+			if ( start === end ) {
+				const value = getBlockAttributes( clientId )?.[ attributeKey ];
+				const extendable = valueAdditionRunToExtend(
+					value,
+					start,
+					authorId === null || authorId === undefined
+						? null
+						: String( authorId )
+				);
+				if ( extendable && ( allowGrow || start < extendable.end ) ) {
+					const grown = growInlineAddition( value, {
+						text,
+						attributes: buildSuggestionMarkerAttributes( {
+							id: extendable.id,
+							type: SUGGESTION_TYPE_ADDITION,
+							authorId,
+						} ),
+						markerStart: extendable.start,
+						markerEnd: extendable.end,
+						at: start,
+					} );
+					runRef.current = {
+						clientId,
+						attributeKey,
+						id: extendable.id,
+						start: extendable.start,
+						end: extendable.end + text.length,
+						caret: start + text.length,
+						pending: '',
+					};
+					commit(
+						clientId,
+						attributeKey,
+						grown,
+						runRef.current.caret
+					);
+					return true;
+				}
 			}
 
 			beginInsertion( clientId, attributeKey, start, end, text );

--- a/packages/editor/src/components/suggestion-mode/suggestion-content-reconciler.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-content-reconciler.js
@@ -48,10 +48,11 @@ export function contentKey( value ) {
  * `useSuggestionsProvider` in one component rather than every block's render is
  * why this is a singleton, mirroring `SuggestionFormatKeyboard`.
  *
- * Only plans whose actions all open a fresh note (`insert-add`, `wrap-del`) are
- * routed here by the HOC; plans that edit an existing marker or that the diff
- * can't resolve are left to the overlay path, so this handler always has a note
- * to create for every id the plan consumes.
+ * Only plans this handler can execute end to end are routed here by the HOC:
+ * every action either opens a fresh note (`insert-add`, `wrap-del`) or grows a
+ * marker that already has one (`grow-add`, which needs no note work at all).
+ * Plans that would retire a note, or that the diff can't resolve, are left to
+ * the overlay path.
  *
  * Writes are serialized per block through the overlay context's shared write
  * queue (shared with `SuggestionFormatKeyboard`), and every write re-validates
@@ -221,7 +222,9 @@ export default function SuggestionContentReconciler() {
 			if (
 				! request?.clientId ||
 				actions.length === 0 ||
-				! actions.every( ( action ) => action.newNote ) ||
+				! actions.every(
+					( action ) => action.newNote || action.type === 'grow-add'
+				) ||
 				contentKey( request.prevContent ) === null
 			) {
 				return false;

--- a/packages/editor/src/components/suggestion-mode/test/suggestion-content-reconciler.js
+++ b/packages/editor/src/components/suggestion-mode/test/suggestion-content-reconciler.js
@@ -169,6 +169,33 @@ describe( 'SuggestionContentReconciler', () => {
 		expect( getContent() ).toContain( ' world' );
 	} );
 
+	it( 'grows an existing marker without opening a note', async () => {
+		const marked =
+			'Hi <mark class="wp-suggestion" data-suggestion-id="9" data-suggestion-type="add">new</mark>';
+		const { clientId, getContent } = setup( { content: marked } );
+
+		let accepted;
+		act( () => {
+			accepted = overlayRef.current.requestContentSuggestion( {
+				clientId,
+				blockName: TEST_BLOCK_NAME,
+				prevContent: RichTextData.fromHTMLString( marked ),
+				plan: {
+					kind: 'edit',
+					// A revision of a proposal that already has a note.
+					actions: [
+						{ type: 'grow-add', text: 'er', id: '9', at: 6 },
+					],
+				},
+			} );
+		} );
+		expect( accepted ).toBe( true );
+		await flushPromises();
+
+		expect( createSuggestion ).not.toHaveBeenCalled();
+		expect( getContent() ).toContain( '>newer</mark>' );
+	} );
+
 	it( 'declines synchronously when the plan is not executable', () => {
 		const { clientId } = setup();
 
@@ -180,8 +207,8 @@ describe( 'SuggestionContentReconciler', () => {
 				prevContent: RichTextData.fromHTMLString( 'Hello' ),
 				plan: {
 					kind: 'edit',
-					// `grow-add` reuses an existing note: not this handler's job.
-					actions: [ { type: 'grow-add', text: 'x', id: '9' } ],
+					// `remove-add` retires a note: not this handler's job.
+					actions: [ { type: 'remove-add', id: '9' } ],
 				},
 			} );
 		} );

--- a/packages/editor/src/components/suggestion-mode/with-suggestion-overlay.js
+++ b/packages/editor/src/components/suggestion-mode/with-suggestion-overlay.js
@@ -248,7 +248,19 @@ function SuggestingBlockEdit( { BlockEdit, props } ) {
 			if ( actions.length === 0 ) {
 				return false;
 			}
-			if ( ! actions.every( ( action ) => action.newNote ) ) {
+			/*
+			 * Only plans this seam can carry out end to end. Every action
+			 * either opens its own note (`newNote`) or grows a marker that
+			 * already has one (`grow-add`) — a `grow-add` is a revision of an
+			 * existing proposal, so it needs no note work at all. An action
+			 * that would retire a note (`remove-add`) is left to the paths that
+			 * own that cleanup.
+			 */
+			if (
+				! actions.every(
+					( action ) => action.newNote || action.type === 'grow-add'
+				)
+			) {
 				return false;
 			}
 			return requestContentSuggestion( {

--- a/test/e2e/specs/editor/various/suggestion-mode.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode.spec.js
@@ -318,6 +318,110 @@ test.describe( 'Suggestion mode', () => {
 		await expect( summary ).not.toContainText( 'Format:' );
 	} );
 
+	/*
+	 * #73411 finding F-06. Typing back inside a pending addition used to insert
+	 * a marker with a FRESH id at the caret, splitting the enclosing marker into
+	 * two disjoint `<mark>` elements sharing one id — `add:41:"ADD"`,
+	 * `add:42:"XX"`, `add:41:"ED"` — backed by two notes that both claimed the
+	 * typed characters (note 41 summarised `Add: "ADDXXED"` because it reads
+	 * across its fragments, note 42 `Add: "XX"`). Accepting one while rejecting
+	 * the other kept the new text and dropped the text it was typed into. The
+	 * addition now grows the marker already under the caret.
+	 */
+	test( 'add — typing inside your own pending addition extends that marker, not a second one', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello ' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( 'ADDED' );
+
+		const markers = paragraph.locator(
+			'mark.wp-suggestion[data-suggestion-type="add"]'
+		);
+		await expect( markers ).toHaveText( [ 'ADDED' ] );
+		const firstId = await markers.getAttribute( 'data-suggestion-id' );
+		expect( firstId ).toMatch( /\d/ );
+
+		/*
+		 * Put the caret between "ADD" and "ED", inside the author's own
+		 * pending addition. Placed as a DOM range rather than with ArrowLeft:
+		 * rich-text absorbs the first presses at a format boundary, so the
+		 * number of keystrokes needed to reach a given character is not fixed.
+		 */
+		await markers.first().evaluate( ( mark ) => {
+			const doc = mark.ownerDocument;
+			// The marker wraps its text in the editor-only a11y role element,
+			// so walk to the text node itself.
+			const text = doc
+				.createTreeWalker( mark, NodeFilter.SHOW_TEXT )
+				.nextNode();
+			const range = doc.createRange();
+			range.setStart( text, 3 );
+			range.collapse( true );
+			const selection = doc.getSelection();
+			selection.removeAllRanges();
+			selection.addRange( range );
+		} );
+		// Wait for the store to agree with the DOM caret: while it lags, a
+		// re-render would re-apply the stale selection and snap the caret back
+		// to the end of the marker.
+		await expect
+			.poll( () =>
+				page.evaluate(
+					() =>
+						window.wp.data
+							.select( 'core/block-editor' )
+							.getSelectionStart().offset
+				)
+			)
+			.toBe( 9 );
+
+		await page.keyboard.type( 'XX' );
+
+		// One marker, still the original note's id, holding the whole run.
+		await expect( markers ).toHaveText( [ 'ADDXXED' ] );
+		await expect( markers ).toHaveAttribute(
+			'data-suggestion-id',
+			firstId
+		);
+		await expect( paragraph ).toHaveText( 'Hello ADDXXED' );
+
+		// The serialized post carries one marker and one id, so no second note
+		// claims the typed characters.
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized.match( /data-suggestion-id="\d+"/g ) ).toEqual( [
+			`data-suggestion-id="${ firstId }"`,
+		] );
+
+		// And the sidebar lists exactly one suggestion for the run.
+		const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
+		const allNotesToggle = topBar.getByRole( 'button', {
+			name: 'All notes',
+			exact: true,
+		} );
+		if (
+			( await allNotesToggle.getAttribute( 'aria-expanded' ) ) === 'false'
+		) {
+			await allNotesToggle.click();
+		}
+		const summaries = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.locator( '.editor-collab-sidebar-panel__suggestion-summary' );
+		await expect( summaries ).toHaveCount( 1 );
+		await expect( summaries.first() ).toContainText( 'ADDXXED' );
+	} );
+
 	test( 'delete — golden path: deleting a selection becomes an in-content del marker', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What

Fixes finding F-06 from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work in https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), so review the last commit only.

## The problem

F-06 (flow IA-06) is what happens when you go back and add to something you already suggested. Type "ADDED" in Suggesting mode and you get one `add` marker and one note. Put the caret between "ADD" and "ED", type "XX", and the one proposal becomes two.

The addition path never asks whether the caret is already inside a pending addition. `insertInlineAddition` mints a fresh note id and stamps it over the two new characters, which splits the marker it landed in. Measured on the base branch, the paragraph serializes as three `<mark>` elements for two suggestions:

```
<mark data-suggestion-id="11" …>ADD</mark><mark data-suggestion-id="12" …>XX</mark><mark data-suggestion-id="11" …>ED</mark>
```

Note 11 summarises `Add: "ADDXXED"`, because the marker lookup spans first-to-last hit of the id and reads straight across the gap. Note 12 summarises `Add: "XX"`. Both notes claim the same two characters, and resolving them separately is incoherent: accept 12 and reject 11 and you keep "XX" and lose the text it was typed into.

Same gesture arriving at the value-level seam (IME, autocorrect, drag-drop) took a different bad path - `planEditMarkers` deliberately planned nothing for an insert inside a marker, so the edit fell through to the whole-content overlay, which is finding F-09.

## The fix

Recognise the suggester's own addition under the caret and grow that marker instead of nesting a new one in it.

`formatsAdditionRunToExtend` resolves the `add` marker carrying the character to the left of the insertion point, which covers a caret strictly inside the run and one at its trailing edge. `growInlineAddition` takes an `at` offset now, so the addition keyboard inserts at the caret and re-stamps the whole span - the existing "keep it one `<mark>` while you type" mechanism, just no longer pinned to the end of the marker. No second note is created, and the existing note keeps summarising the run because the run is what it always described.

The match is deliberately narrow. It only extends an `add` marker, authored by the person making this edit, that is not already fragmented. Someone else's addition, a run proposed for deletion, or a caret at the marker's *leading* edge (where the character before it is unmarked, so a separate marker fragments nothing) all take the old path.

`planEditMarkers` learns the same rule, so the value-level seam plans a `grow-add` for an insert inside the marker as well as at its trailing edge, and the overlay HOC will now carry out a plan that only grows a marker rather than declining it into the fallback. It still declines to plan anything when the caret is inside a marker it may not extend, so nothing that used to reach the overlay gets split instead.

Two things this does not do. A marker that is *already* fragmented - a document that hit this bug before the fix - is left alone rather than re-stamped across the gap, so existing damaged content is not silently rewritten. And typing inside another author's addition still splits their marker; declining that edit means falling through to the overlay, which is https://github.com/WordPress/gutenberg/pull/81655's territory.

One thing turned up while writing the e2e test that is worth recording but is not fixed here: after the marker write, an arrow-key caret move inside the marker gets snapped back to the end of the marker by the next re-render, because RichText re-applies the store selection and the store lags the DOM. It is the same hazard the format keyboard already works around with `readLiveInlineSelection`. It does not affect this fix (the addition keyboard reads the DOM range at input time), and the test places the caret as a DOM range to sidestep it.

## Screenshots

Both captured after typing "ADDED" in Suggesting mode, putting the caret between "ADD" and "ED", and typing "XX", with the notes sidebar open.

**Before** - two notes for one run, `Add: "ADDXXED"` above `Add: "XX"`, and the canvas showing three separately underlined fragments. Saved content is `metadata.noteId: [11,12]` and three `<mark>` elements:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/F06-before.png" width="900">

**After** - one note reading `Add: "ADDXXED"`, one marker across the whole run. Saved content is `metadata.noteId: [13]` and a single `<mark>`:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/F06-after.png" width="900">

## Testing instructions

1. Enable the **Suggestion Mode** experiment in Gutenberg → Experiments.
2. Create a post with one paragraph reading `Hello ` (with the trailing space).
3. Switch to **Suggesting** through the Options menu (top right).
4. Click into the paragraph, press End, and type `ADDED`. Wait for the marker to appear.
5. Click between the "D" and the "E" of "ADDED", so the caret sits inside the marker. Note that arrow keys are unreliable here - the caret gets pulled back to the end of the marker by the next re-render - so click.
6. Type `XX`.
7. **Before:** the canvas shows three separately underlined fragments; the notes sidebar lists two notes, `Add: "ADDXXED"` and `Add: "XX"`; the code editor (⌘⇧⌥M) shows `"noteId":[N,M]` and three `<mark>` elements. **After:** one continuous marker over `ADDXXED`, one note, and one `<mark>` carrying the original id.
8. Open the note and press Reject: the whole run including "XX" disappears and the paragraph is back to `Hello `. Repeat from step 3 and press Accept instead: `ADDXXED` stays and the marker is unwrapped.
9. Regression: type an addition, click to the very *start* of the marker and type. That still opens its own marker and note, which is intended - the character before the caret is not part of the proposal.
10. Regression: with two users, have one type an addition and the other click inside it and type. Behaviour is unchanged from the base branch (it still splits); that case is left to #81655.

### Automated coverage

Unit, `packages/editor/src/components/inline-suggestions/test/operations.js`:

- `growInlineAddition › inserts at 'at' inside the marker, still as one run`
- `growInlineAddition › clamps an 'at' outside the marker into it`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › matches a caret inside the author own addition`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › matches a caret at the trailing edge`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › does not match a caret at the leading edge`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › does not match another author addition`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › does not match a deletion or a format marker`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › does not match a marker already fragmented across the value`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › returns null for unmarked text and non-rich values`
- `formatsAdditionRunToExtend / valueAdditionRunToExtend › skips the author check when no author is supplied`

Unit, `packages/editor/src/components/inline-suggestions/test/reconcile-edit.js`:

- `planEditMarkers › grows the author own addition when typing inside it`
- `planEditMarkers › does not act when typing inside another author addition`
- `planEditMarkers › does not act when typing inside a pending deletion`
- `applyEditPlan › grows an existing add marker from inside, as one marker`

E2E, `test/e2e/specs/editor/various/suggestion-mode.spec.js`:

- `Suggestion mode › add — typing inside your own pending addition extends that marker, not a second one`

All 13 new/changed unit assertions were verified red against the unmodified base (13 failed, 70 passed) and green with the fix. The e2e test was verified red against a build of the unmodified base - it reported the markers as `["ADD", "XX", "ED"]` against the expected `["ADDXXED"]`, which is F-06 exactly - and green with the fix.

Regression runs with the fix in: `suggestion-mode.spec.js` 22 passed, 1 failed, the failure being the known `a closed sidebar stays closed when a suggestion is created` (finding F-17, still open, and it fails on the base branch too). `suggestion-mode-overlay-retirement.spec.js`, `suggestion-mode-persistence.spec.js`, `suggestion-mode-review.spec.js` and `suggestion-mode-undo.spec.js` together: 42 passed. The 438 unit tests under `inline-suggestions` and `suggestion-mode` pass.

## AI Use

Claude Code did the typing here, I did the asking - both the code and this description. I will review and test.
