### PR TITLE
Suggest mode: strip suggestion markers and note ids from copied blocks

### DIFF
--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import {
 	serialize,
@@ -40,16 +41,28 @@ export function setClipboardBlocks( event, blocks, registry ) {
 			const wrapperBlockName = getBlockName( wrapperBlockClientId );
 
 			if ( wrapperBlockName ) {
-				_blocks = createBlock(
-					wrapperBlockName,
-					getBlockAttributes( wrapperBlockClientId ),
-					_blocks
-				);
+				_blocks = [
+					createBlock(
+						wrapperBlockName,
+						getBlockAttributes( wrapperBlockClientId ),
+						_blocks
+					),
+				];
 			}
 		}
 	}
 
-	const serialized = serialize( _blocks );
+	/*
+	 * Last chance for a feature to keep document-scoped data off the
+	 * clipboard. Anything that identifies a block by an id that is only
+	 * meaningful inside this post - a note id, a suggestion marker - is
+	 * meaningless (and actively misleading) once the blocks are pasted
+	 * somewhere else, and the clipboard is the one path out of the editor
+	 * that cannot be intercepted at the far end.
+	 */
+	const serialized = serialize(
+		applyFilters( 'blockEditor.copiedBlocks', _blocks )
+	);
 
 	event.clipboardData.setData( 'text/plain', toPlainText( serialized ) );
 	event.clipboardData.setData( 'text/html', serialized );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -53,6 +53,7 @@ import {
 	SuggestionFormatKeyboard,
 	SuggestionContentReconciler,
 	registerSuggestionOverlayFilter,
+	registerClipboardSuggestionStrip,
 	isSuggestionModeEnabled,
 	MoveGhostsProvider,
 } from '../suggestion-mode';
@@ -75,6 +76,12 @@ if ( isSuggestionModeEnabled() ) {
 // editing in Suggest mode, not from a control. Idempotent, so it's safe
 // globally.
 registerSuggestionFormat();
+
+// Keep suggestion markers, `metadata.suggestion` and `metadata.noteId` off the
+// clipboard. Registered unconditionally for the same reason as the format:
+// content that already carries markers outlives the experiment flag, and a
+// paste into another post has no way to resolve ids from this one.
+registerClipboardSuggestionStrip();
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );

--- a/packages/editor/src/components/suggestion-mode/clipboard-strip.js
+++ b/packages/editor/src/components/suggestion-mode/clipboard-strip.js
@@ -1,0 +1,126 @@
+/**
+ * Keeps suggestion state off the clipboard.
+ *
+ * A suggestion is a proposal about *this* post: the inline `<mark
+ * class="wp-suggestion">` wrapper, the block-level `metadata.suggestion`
+ * marker and the `metadata.noteId` link all point at a note comment attached
+ * to this post's id. Copying blocks serializes those attributes verbatim, so
+ * pasting into a different post carries markers whose notes do not exist
+ * there: the text stays permanently highlighted with no Accept/Reject to
+ * clear it, and if a note with the same id ever exists on the destination
+ * post the marker silently binds to an unrelated suggestion.
+ *
+ * The clipboard is the one route out of the editor that cannot be
+ * intercepted at the far end - the paste may land in another site, another
+ * app, or a plain text file - so the strip runs on copy, via the
+ * `blockEditor.copiedBlocks` filter that `setClipboardBlocks` applies just
+ * before serializing.
+ *
+ * What survives the strip is the text a suggestion wraps, in every marker
+ * kind. A `del` run is content that is still in the document, a `format` run
+ * is unchanged text, and an `add` run is text the author can see and select
+ * on screen; dropping any of it would make copy return less than what was
+ * highlighted. Only the proposal *about* that text is removed.
+ */
+import { addFilter } from '@wordpress/hooks';
+import { stripSuggestionMarkersFromAttributes } from '../inline-suggestions';
+
+/**
+ * Drop the post-scoped `metadata` keys a suggestion writes: the note link and
+ * the block-level pending marker. Other metadata (a custom block name, a
+ * binding) describes the block itself and travels with it.
+ *
+ * @param {Object|undefined} attributes Block attributes.
+ * @return {Object|undefined} Attributes without suggestion metadata, returned
+ * by reference when there was none to remove.
+ */
+function stripSuggestionMetadata( attributes ) {
+	const metadata = attributes?.metadata;
+	if ( ! metadata || typeof metadata !== 'object' ) {
+		return attributes;
+	}
+	if ( metadata.noteId === undefined && metadata.suggestion === undefined ) {
+		return attributes;
+	}
+	const {
+		noteId: _noteId,
+		suggestion: _suggestion,
+		...remainingMetadata
+	} = metadata;
+	const next = { ...attributes };
+	if ( Object.keys( remainingMetadata ).length > 0 ) {
+		next.metadata = remainingMetadata;
+	} else {
+		// An empty object would serialize as `{"metadata":{}}` - noise on
+		// every copied block that ever carried a suggestion.
+		delete next.metadata;
+	}
+	return next;
+}
+
+/**
+ * Strip inline suggestion markers and suggestion metadata from a block and
+ * its descendants.
+ *
+ * @param {Object} block Block object.
+ * @return {Object} The block with suggestion state removed, returned by
+ * reference when nothing changed.
+ */
+export function stripSuggestionDataFromBlock( block ) {
+	if ( ! block || typeof block !== 'object' ) {
+		return block;
+	}
+	const attributes = stripSuggestionMetadata(
+		stripSuggestionMarkersFromAttributes( block.attributes )
+	);
+	const innerBlocks = stripSuggestionDataFromBlocks( block.innerBlocks );
+	if (
+		attributes === block.attributes &&
+		innerBlocks === block.innerBlocks
+	) {
+		return block;
+	}
+	return { ...block, attributes, innerBlocks };
+}
+
+/**
+ * Strip suggestion state from a list of blocks.
+ *
+ * @param {Object[]} blocks Blocks about to be serialized to the clipboard.
+ * @return {Object[]} Blocks without suggestion state, returned by reference
+ * when nothing changed.
+ */
+export function stripSuggestionDataFromBlocks( blocks ) {
+	if ( ! Array.isArray( blocks ) ) {
+		return blocks;
+	}
+	let changed = false;
+	const next = blocks.map( ( block ) => {
+		const stripped = stripSuggestionDataFromBlock( block );
+		if ( stripped !== block ) {
+			changed = true;
+		}
+		return stripped;
+	} );
+	return changed ? next : blocks;
+}
+
+let filterRegistered = false;
+
+/**
+ * Register the copy-time strip. Registered for every user rather than behind
+ * the Suggestion Mode experiment: content that already holds markers can
+ * outlive the flag being switched off, and the filter is a reference-returning
+ * no-op for blocks that carry no suggestion state.
+ */
+export function registerClipboardSuggestionStrip() {
+	if ( filterRegistered ) {
+		return;
+	}
+	filterRegistered = true;
+	addFilter(
+		'blockEditor.copiedBlocks',
+		'core/editor/strip-suggestions-on-copy',
+		stripSuggestionDataFromBlocks
+	);
+}

--- a/packages/editor/src/components/suggestion-mode/index.js
+++ b/packages/editor/src/components/suggestion-mode/index.js
@@ -9,6 +9,11 @@ export {
 	registerSuggestionOverlayFilter,
 } from './with-suggestion-overlay';
 export { MoveGhostsProvider } from './use-move-ghosts';
+export {
+	registerClipboardSuggestionStrip,
+	stripSuggestionDataFromBlock,
+	stripSuggestionDataFromBlocks,
+} from './clipboard-strip';
 export { default as SuggestionAutoSave } from './auto-save';
 export { default as SuggestionStoreInterceptor } from './store-interceptor';
 export { default as SuggestionUndoGuard } from './suggestion-undo-guard';

--- a/packages/editor/src/components/suggestion-mode/test/clipboard-strip.js
+++ b/packages/editor/src/components/suggestion-mode/test/clipboard-strip.js
@@ -1,0 +1,180 @@
+import {
+	unregisterFormatType,
+	store as richTextStore,
+} from '@wordpress/rich-text';
+import { select } from '@wordpress/data';
+import { applyFilters, removeFilter } from '@wordpress/hooks';
+import {
+	registerClipboardSuggestionStrip,
+	stripSuggestionDataFromBlock,
+	stripSuggestionDataFromBlocks,
+} from '../clipboard-strip';
+import {
+	registerSuggestionFormat,
+	SUGGESTION_FORMAT_NAME,
+} from '../../inline-suggestions/format';
+
+const getFormatType = ( name ) => select( richTextStore ).getFormatType( name );
+
+const marker = ( id, type, text ) =>
+	`<mark class="wp-suggestion" data-suggestion-id="${ id }" data-suggestion-type="${ type }" data-author="1">${ text }</mark>`;
+
+beforeAll( () => {
+	registerSuggestionFormat();
+} );
+
+afterAll( () => {
+	if ( getFormatType( SUGGESTION_FORMAT_NAME ) ) {
+		unregisterFormatType( SUGGESTION_FORMAT_NAME );
+	}
+} );
+
+describe( 'stripSuggestionDataFromBlock', () => {
+	it( 'unwraps inline suggestion markers, keeping the text of every kind', () => {
+		const block = {
+			name: 'core/paragraph',
+			attributes: {
+				content: `keep ${ marker( 7, 'del', 'doomed' ) } and ${ marker(
+					8,
+					'add',
+					'COPIED'
+				) } and ${ marker( 9, 'format', 'styled' ) }`,
+			},
+			innerBlocks: [],
+		};
+
+		const result = stripSuggestionDataFromBlock( block );
+
+		expect( result.attributes.content ).toBe(
+			'keep doomed and COPIED and styled'
+		);
+		expect( result.attributes.content ).not.toContain( 'wp-suggestion' );
+	} );
+
+	it( 'drops metadata.noteId and metadata.suggestion but keeps other metadata', () => {
+		const block = {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'plain',
+				metadata: {
+					noteId: [ 192 ],
+					suggestion: { type: 'pending-insert' },
+					name: 'Intro',
+				},
+			},
+			innerBlocks: [],
+		};
+
+		const result = stripSuggestionDataFromBlock( block );
+
+		expect( result.attributes.metadata ).toEqual( { name: 'Intro' } );
+	} );
+
+	it( 'removes the metadata object entirely when only suggestion keys were in it', () => {
+		const block = {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'plain',
+				metadata: { noteId: [ 192 ] },
+			},
+			innerBlocks: [],
+		};
+
+		expect(
+			stripSuggestionDataFromBlock( block ).attributes
+		).not.toHaveProperty( 'metadata' );
+	} );
+
+	it( 'strips inner blocks recursively', () => {
+		const block = {
+			name: 'core/group',
+			attributes: {},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: marker( 3, 'add', 'nested' ),
+						metadata: { noteId: [ 3 ] },
+					},
+					innerBlocks: [],
+				},
+			],
+		};
+
+		const result = stripSuggestionDataFromBlock( block );
+
+		expect( result.innerBlocks[ 0 ].attributes.content ).toBe( 'nested' );
+		expect( result.innerBlocks[ 0 ].attributes ).not.toHaveProperty(
+			'metadata'
+		);
+	} );
+
+	it( 'returns the same reference when there is no suggestion state', () => {
+		const block = {
+			name: 'core/paragraph',
+			attributes: { content: 'nothing to strip' },
+			innerBlocks: [],
+		};
+
+		expect( stripSuggestionDataFromBlock( block ) ).toBe( block );
+	} );
+
+	it( 'does not mutate the source block', () => {
+		const attributes = {
+			content: marker( 1, 'del', 'gone' ),
+			metadata: { noteId: [ 1 ] },
+		};
+		const block = { name: 'core/paragraph', attributes, innerBlocks: [] };
+
+		stripSuggestionDataFromBlock( block );
+
+		expect( block.attributes ).toBe( attributes );
+		expect( attributes.content ).toContain( 'wp-suggestion' );
+		expect( attributes.metadata.noteId ).toEqual( [ 1 ] );
+	} );
+} );
+
+describe( 'stripSuggestionDataFromBlocks', () => {
+	it( 'returns the same array reference when nothing changed', () => {
+		const blocks = [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'clean' },
+				innerBlocks: [],
+			},
+		];
+
+		expect( stripSuggestionDataFromBlocks( blocks ) ).toBe( blocks );
+	} );
+
+	it( 'passes non-array input through', () => {
+		expect( stripSuggestionDataFromBlocks( undefined ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'registerClipboardSuggestionStrip', () => {
+	afterEach( () => {
+		removeFilter(
+			'blockEditor.copiedBlocks',
+			'core/editor/strip-suggestions-on-copy'
+		);
+	} );
+
+	it( 'strips suggestion state through the blockEditor.copiedBlocks filter', () => {
+		registerClipboardSuggestionStrip();
+
+		const [ filtered ] = applyFilters( 'blockEditor.copiedBlocks', [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: marker( 192, 'add', 'COPIED ' ),
+					metadata: { noteId: [ 192 ] },
+				},
+				innerBlocks: [],
+			},
+		] );
+
+		expect( filtered.attributes.content ).toBe( 'COPIED ' );
+		expect( filtered.attributes ).not.toHaveProperty( 'metadata' );
+	} );
+} );

--- a/test/e2e/specs/editor/various/suggestion-mode-clipboard.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-clipboard.spec.js
@@ -1,0 +1,108 @@
+/**
+ * E2E coverage for F-34: copying blocks out of a post must not carry that
+ * post's suggestion state with them.
+ *
+ * A suggestion is a proposal about one post. Its inline `wp-suggestion`
+ * marker and the `metadata.noteId` link both point at a note comment attached
+ * to that post's id, so pasting the blocks into a different post produces
+ * permanently highlighted text with no note behind it and no Accept/Reject to
+ * clear it. `setClipboardBlocks` runs the blocks through the
+ * `blockEditor.copiedBlocks` filter, where the suggestion layer unwraps the
+ * markers and drops the note link.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection.
+	await page.keyboard.press( 'Escape' );
+}
+
+test.describe( 'Suggestion mode clipboard', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'copied blocks carry no suggestion markers or note ids into another post', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Original content' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( ' COPIED' );
+
+		/*
+		 * A populated `data-suggestion-id` is race-free proof the note
+		 * exists: the marker is only written once the note comment's id
+		 * comes back.
+		 */
+		const marker = paragraph.locator(
+			'mark.wp-suggestion[data-suggestion-type="add"]'
+		);
+		await expect( marker ).toContainText( 'COPIED' );
+		await expect( marker ).toHaveAttribute( 'data-suggestion-id', /\d/ );
+
+		// The source post holds the marker and the note link, as it should.
+		const sourceContent = await editor.getEditedPostContent();
+		expect( sourceContent ).toContain( 'wp-suggestion' );
+		expect( sourceContent ).toContain( 'noteId' );
+
+		await editor.saveDraft();
+
+		// Collapsed selection inside the block copies the whole block.
+		await paragraph.click();
+		await pageUtils.pressKeys( 'primary+c' );
+
+		await admin.createNewPost();
+		await editor.canvas
+			.locator( 'role=document[name="Add default block"i]' )
+			.click();
+		await pageUtils.pressKeys( 'primary+v' );
+
+		const pastedParagraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await expect( pastedParagraph ).toContainText(
+			'Original content COPIED'
+		);
+
+		const pastedContent = await editor.getEditedPostContent();
+		expect( pastedContent ).toContain( 'Original content COPIED' );
+		expect( pastedContent ).not.toContain( 'wp-suggestion' );
+		expect( pastedContent ).not.toContain( 'data-suggestion-id' );
+		expect( pastedContent ).not.toContain( 'noteId' );
+
+		// Nothing marked means nothing to review: no orphaned markers render.
+		await expect(
+			editor.canvas.locator( 'mark.wp-suggestion' )
+		).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes finding F-34 from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work tracked in #73411. Based on `suggest/inline-wiring` (#80433), the top of the seven-PR stack, so the diff here is only the fix.

## The problem

A suggestion is a proposal about one specific post. The inline `<mark class="wp-suggestion" data-suggestion-id="192">` wrapper and the `metadata.noteId: [192]` link both resolve against a note comment attached to that post.

Copying blocks serializes those attributes verbatim onto the clipboard, so pasting into a different post carries them along. The destination post has zero notes, which leaves two bad outcomes:

- the pasted text stays permanently highlighted with no note behind it, and so no Accept or Reject to clear it - the same dead end as F-22
- if the destination post ever mints a note numbered 192, the stale marker silently binds to a completely unrelated suggestion

Reproduced on the base build. Select-all-and-copy in a post with one pending addition, paste into a new post, and the new post's content reads:

```
<!-- wp:paragraph {"metadata":{"noteId":[3]}} -->
<p>The quick brown fox jumps over the lazy dog.<mark data-suggestion-id="3" data-suggestion-type="add" data-author="1" class="wp-suggestion"> COPIED</mark></p>
<!-- /wp:paragraph -->
```

One correction to the doc's description: block-level `metadata.suggestion` was recorded as not carrying over. Since it is serialized the same way, it is stripped here too rather than left to chance.

## The fix

The clipboard is the one route out of the editor that cannot be intercepted at the far end - a paste can land in another site, another app, or a text file - so the strip runs on copy.

`setClipboardBlocks` now passes the blocks through a `blockEditor.copiedBlocks` filter just before serializing. That keeps `block-editor` WordPress-agnostic: it offers the seam, and `editor` fills it. The suggestion layer registers a handler in `packages/editor/src/components/suggestion-mode/clipboard-strip.js` that walks the blocks and their inner blocks and:

- unwraps every `wp-suggestion` marker, keeping the text
- drops `metadata.noteId` and `metadata.suggestion`, removing `metadata` entirely if nothing else was in it

Text survives in all three marker kinds. A `del` run is content still in the document, a `format` run is unchanged text, and an `add` run is text the author can see and select on screen - dropping any of it would make copy return less than what was highlighted. Only the proposal *about* the text is removed.

The filter is registered for every user rather than behind the experiment flag, matching how `registerSuggestionFormat` is already handled. Content that carries markers outlives the flag being switched off, and the handler returns the input array by reference when there is no suggestion state to strip.

Copying inside the same post is stripped too, which is deliberate: a duplicate marker pointing at one note is just as incoherent as a cross-post one.

## Screenshots

Same flow both times: type a suggested addition in Suggesting mode, copy the block, paste it into a brand new post.

**Before** - the pasted paragraph in the new post still renders " COPIED" as a live addition marker, green and underlined, in a post with no notes at all:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f34-before.png" width="900">

**After** - the same paste lands as plain text, and the serialized block is `<!-- wp:paragraph -->` with no `noteId`:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f34-after.png" width="900">

## Testing instructions

1. Enable **Gutenberg → Experiments → Suggestion mode** and hard-reload the editor.
2. Create a post with one paragraph, eg. "The quick brown fox jumps over the lazy dog."
3. Options (⋮) → Mode → **Suggesting**.
4. Click at the end of the paragraph and type ` COPIED`. Confirm the green addition marker appears and a note shows in the sidebar.
5. Save the draft, click in the paragraph to place a collapsed caret, and press `Ctrl/Cmd + C`.
6. Create a new post, click the empty block, and press `Ctrl/Cmd + V`.
7. Open the code editor (or check the saved markup) for the new post.

**Before:** the pasted paragraph carries `{"metadata":{"noteId":[N]}}` and a `<mark class="wp-suggestion" data-suggestion-id="N">` around " COPIED". The text renders highlighted with no note to act on.

**After:** the pasted paragraph is `<!-- wp:paragraph --><p>The quick brown fox jumps over the lazy dog. COPIED</p>`, with no marker, no `data-suggestion-id`, and no `noteId`.

Also worth checking that ordinary copy/paste is unaffected: copy and paste a plain paragraph, a group with inner blocks, and a list item, in and out of Suggesting mode.

### Automated coverage

New e2e spec `test/e2e/specs/editor/various/suggestion-mode-clipboard.spec.js`:

- `Suggestion mode clipboard › copied blocks carry no suggestion markers or note ids into another post`

Verified red on the unmodified base branch, where it fails with the pasted content still holding `{"metadata":{"noteId":[2]}}` and the `wp-suggestion` mark, and green with the fix.

New unit tests in `packages/editor/src/components/suggestion-mode/test/clipboard-strip.js`, 9 cases covering marker unwrapping for all three types, metadata removal, recursion into inner blocks, reference identity when nothing changed, non-mutation of the source block, and the registered filter end to end.

No regressions in the surrounding suites, all run against the built plugin:

- `copy-cut-paste.spec.js` + `list-view.spec.js`: 48 passed, 1 skipped
- the five `suggestion-mode*.spec.js` suites: 64 passed
- `packages/block-editor/src/components/writing-flow` and `packages/editor/src/components/suggestion-mode` unit tests: 319 passed

## Remaining gap

Content that already holds markers - pasted from an older build, or hand-authored - is not cleaned on the way in. A paste-side check against the destination post id would cover that, and it is the more thorough half of what the finding proposes. It is left out here to keep the change to one choke point. Inline `wp-note` markers are also untouched; block-level `metadata.noteId` is stripped, which covers the notes case at block granularity.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
