### PR TITLE
Notes: Leave an already-closed sidebar closed when a suggestion note appears

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -518,9 +518,24 @@ export function useEnableFloatingSidebar( enabled = false ) {
 		const { disableComplementaryArea, enableComplementaryArea } =
 			registry.dispatch( interfaceStore );
 
+		/*
+		 * The floating board fills a slot the user vacates while notes are
+		 * on screen, but it must not claim one that was already empty when
+		 * the first note arrived: the user closed the sidebar before there
+		 * was anything to float, and opening it under them narrows the
+		 * canvas and reflows the block they are writing in. Wait until they
+		 * open a complementary area themselves before taking the slot back.
+		 */
+		let mayClaimEmptySlot = getActiveComplementaryArea( 'core' ) !== null;
+
 		const unsubscribe = registry.subscribe( () => {
-			// Return `null` to indicate the user hid the complementary area.
-			if ( getActiveComplementaryArea( 'core' ) === null ) {
+			// Returns `null` to indicate the user hid the complementary area.
+			if ( getActiveComplementaryArea( 'core' ) !== null ) {
+				mayClaimEmptySlot = true;
+				return;
+			}
+
+			if ( mayClaimEmptySlot ) {
 				enableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
 			}
 		} );

--- a/packages/editor/src/components/collab-sidebar/test/use-enable-floating-sidebar.js
+++ b/packages/editor/src/components/collab-sidebar/test/use-enable-floating-sidebar.js
@@ -1,0 +1,145 @@
+import { act, render } from '@testing-library/react';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useEnableFloatingSidebar } from '../hooks';
+import { FLOATING_NOTES_SIDEBAR } from '../constants';
+
+const DOCUMENT_SIDEBAR = 'edit-post/document';
+
+function setup( { activeArea, enabled = true } ) {
+	const registry = createRegistry();
+	registry.register( preferencesStore );
+	registry.register( interfaceStore );
+
+	if ( activeArea ) {
+		registry
+			.dispatch( interfaceStore )
+			.enableComplementaryArea( 'core', activeArea );
+	} else if ( activeArea === null ) {
+		/*
+		 * `disableComplementaryArea` is a no-op while the preference is
+		 * untouched, so the area has to be opened before it can be closed.
+		 * Only then does the selector report `null` - the user hid it - which
+		 * is what the hook keys off.
+		 */
+		registry
+			.dispatch( interfaceStore )
+			.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
+		registry.dispatch( interfaceStore ).disableComplementaryArea( 'core' );
+	}
+
+	function TestComponent( { isEnabled } ) {
+		useEnableFloatingSidebar( isEnabled );
+		return null;
+	}
+
+	const view = render(
+		<RegistryProvider value={ registry }>
+			<TestComponent isEnabled={ enabled } />
+		</RegistryProvider>
+	);
+
+	const getActiveArea = () =>
+		registry.select( interfaceStore ).getActiveComplementaryArea( 'core' );
+
+	return { registry, view, getActiveArea };
+}
+
+/**
+ * Nudges the registry so subscribers run, standing in for the constant store
+ * traffic of a live editor.
+ *
+ * @param {Object} registry Data registry.
+ */
+function tickRegistry( registry ) {
+	act( () => {
+		registry.dispatch( preferencesStore ).set( 'core', 'testTick', true );
+	} );
+}
+
+describe( 'useEnableFloatingSidebar', () => {
+	it( 'leaves a slot that was already closed alone', () => {
+		const { registry, getActiveArea } = setup( { activeArea: null } );
+
+		expect( getActiveArea() ).toBeNull();
+
+		tickRegistry( registry );
+
+		// The user closed the sidebar before there was a note to float, so
+		// the board must not take the vacated slot back from under them.
+		expect( getActiveArea() ).toBeNull();
+	} );
+
+	it( 'takes the slot when the user closes a sidebar while notes are shown', () => {
+		const { registry, getActiveArea } = setup( {
+			activeArea: DOCUMENT_SIDEBAR,
+		} );
+
+		expect( getActiveArea() ).toBe( DOCUMENT_SIDEBAR );
+
+		act( () => {
+			registry
+				.dispatch( interfaceStore )
+				.disableComplementaryArea( 'core' );
+		} );
+
+		expect( getActiveArea() ).toBe( FLOATING_NOTES_SIDEBAR );
+	} );
+
+	it( 'resumes claiming the slot once the user opens an area themselves', () => {
+		const { registry, getActiveArea } = setup( { activeArea: null } );
+
+		tickRegistry( registry );
+		expect( getActiveArea() ).toBeNull();
+
+		// Opening any area is the user re-engaging with the slot, so the
+		// board may fill it again when they next close one.
+		act( () => {
+			registry
+				.dispatch( interfaceStore )
+				.enableComplementaryArea( 'core', DOCUMENT_SIDEBAR );
+		} );
+		act( () => {
+			registry
+				.dispatch( interfaceStore )
+				.disableComplementaryArea( 'core' );
+		} );
+
+		expect( getActiveArea() ).toBe( FLOATING_NOTES_SIDEBAR );
+	} );
+
+	it( 'does nothing while disabled', () => {
+		const { registry, getActiveArea } = setup( {
+			activeArea: DOCUMENT_SIDEBAR,
+			enabled: false,
+		} );
+
+		act( () => {
+			registry
+				.dispatch( interfaceStore )
+				.disableComplementaryArea( 'core' );
+		} );
+
+		expect( getActiveArea() ).toBeNull();
+	} );
+
+	it( 'closes the floating board when it stops being enabled', () => {
+		const { registry, view, getActiveArea } = setup( {
+			activeArea: DOCUMENT_SIDEBAR,
+		} );
+
+		act( () => {
+			registry
+				.dispatch( interfaceStore )
+				.disableComplementaryArea( 'core' );
+		} );
+		expect( getActiveArea() ).toBe( FLOATING_NOTES_SIDEBAR );
+
+		act( () => {
+			view.unmount();
+		} );
+
+		expect( getActiveArea() ).toBeNull();
+	} );
+} );

--- a/test/e2e/specs/editor/various/suggestion-mode.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode.spec.js
@@ -934,6 +934,15 @@ test.describe( 'Suggestion mode', () => {
 				'mark.wp-suggestion[data-suggestion-type="add"]'
 			)
 		).toHaveAttribute( 'data-suggestion-id', /\d/ );
+		// The saved note still has to travel back through the notes query
+		// before the floating board would claim the vacated slot, and the
+		// "All notes" toggle only renders once it has. Waiting for it stops
+		// `toBeHidden` passing on a poll that lands before the board's turn.
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'All notes', exact: true } )
+		).toBeVisible();
 		await expect( sidebar ).toBeHidden();
 	} );
 


### PR DESCRIPTION
## What

Fixes finding F-17 from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work tracked in #73411. Based on `suggest/inline-wiring` (#80433), the top of the seven-PR stack, so the diff here is only the fix.

This one also clears long-standing noise: the e2e test `a closed sidebar stays closed when a suggestion is created` has been failing intermittently on the base branch for the whole testing effort, and this is the finding behind it.

## The problem

Flow NS-03 asks that with the sidebar fully closed, making a suggestion leaves it closed. It does not. Type a suggestion with no complementary area open and `edit-post/collab-sidebar` - the floating notes board - opens by itself, narrowing the canvas and reflowing the block you are mid-sentence in.

One correction to the doc's proposed fix, which pointed at `getActiveComplementaryArea()` in the suggestion layer. That check is already there and already correct:

```js
const activeArea = getActiveComplementaryArea( 'core' );
if ( activeArea && ! SIDEBARS.includes( activeArea ) ) {
	enableComplementaryArea( 'core', ALL_NOTES_SIDEBAR );
}
```

The sidebar that pops open is a different one, opened by a different mechanism. `useEnableFloatingSidebar` in `packages/editor/src/components/collab-sidebar/hooks.js` subscribes to the registry and re-opens the floating notes board every time the active complementary area reads `null`:

```js
const unsubscribe = registry.subscribe( () => {
	// Return `null` to indicate the user hid the complementary area.
	if ( getActiveComplementaryArea( 'core' ) === null ) {
		enableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
	}
} );
```

The hook turns on when unresolved notes exist. That is deliberate for Notes and worth keeping: with notes on screen, closing the settings sidebar hands the vacated slot to the floating board rather than leaving it blank. But `null` is precisely the value that means *the user hid it*, so the rule also fires on a slot that was already empty before there was anything to float. That is every Suggest mode session where the writer closed the sidebar first: the note lands, the hook turns on, and the board takes a slot the user had deliberately emptied.

Worth noting the same code makes the board effectively unclosable while unresolved notes exist, since closing it is what triggers the re-open.

## The fix

Latch it. Read the active area once as the hook turns on. If the slot is already `null` then it belongs to the user - they closed it before there was a note to float - so leave it alone. Any complementary area the user opens afterwards re-arms the behaviour, and closing one from then on hands the slot to the board as before.

```js
let mayClaimEmptySlot = getActiveComplementaryArea( 'core' ) !== null;

const unsubscribe = registry.subscribe( () => {
	if ( getActiveComplementaryArea( 'core' ) !== null ) {
		mayClaimEmptySlot = true;
		return;
	}

	if ( mayClaimEmptySlot ) {
		enableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
	}
} );
```

NS-02 is untouched. A *different* sidebar being open still switches to All notes, which is the suggestion layer's own code and was already right.

The fix lives in the Notes layer, not the suggestion layer, so it changes plain Notes too. One behaviour changes there: loading a post that already has unresolved notes with the sidebar preference persisted closed now leaves it closed instead of opening the board. That reads like the better answer - a persisted close is still the user's choice - but it is a real change and worth a look from whoever owns Notes.

## Screenshots

Same flow both times: close the settings sidebar, switch to Suggesting, type an addition at the end of the paragraph.

**Before** - the floating notes board takes the empty slot on its own and the canvas narrows:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f17-sidebar-before.png" width="900">

**After** - the sidebar stays closed and the canvas keeps its width. The suggestion is still created; the marker is there and the note is waiting in All notes when the user asks for it:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f17-sidebar-after.png" width="900">

## Testing instructions

1. Enable **Gutenberg → Experiments → Suggestion mode** and hard-reload the editor.
2. Create a post with one paragraph, eg. "The quick brown fox jumps over the lazy dog."
3. Close the settings sidebar with the **Settings** button in the top bar. The canvas should now be full width.
4. Options (⋮) → Mode → **Suggesting**.
5. Click at the end of the paragraph and type ` Onward!`.

**Before:** after a second or two the floating notes board slides in on the right, the canvas narrows, and the paragraph reflows under the caret.

**After:** nothing moves. The addition marker appears in the paragraph and the sidebar stays closed. Open **All notes** from the top bar and the note is there.

Also worth checking the two behaviours that should not change:

- NS-02: repeat the steps with the **settings** sidebar left open. It should switch to All notes and show the new suggestion.
- Notes: in Editing mode add a note to a block, leave the sidebar open, then close it with the Settings button. The floating notes board should take the vacated slot, as it does today.

### Automated coverage

- `test/e2e/specs/editor/various/suggestion-mode.spec.js` › `a closed sidebar stays closed when a suggestion is created` - the existing test, and a correct expression of NS-03. It was also the source of the intermittency: `toBeHidden` passes on the first poll where the sidebar is hidden, so it could land before the note had travelled back through the notes query and the board had its turn. It now waits for the "All notes" toggle, which only renders once the note has loaded, before asserting. With that anchor it fails 5/5 on the base build and passes 5/5 with the fix, where before it was 3/5 red and 2/5 green on the same build.
- `packages/editor/src/components/collab-sidebar/test/use-enable-floating-sidebar.js` - new unit coverage for the hook. Two cases pin the new rule (an already-closed slot is left alone; it re-arms once the user opens an area themselves) and three pin what must not change (the board still takes a slot the user vacates, the hook is inert while disabled, and it closes the board on cleanup). The two new cases fail on the base branch, the other three pass there.

`suggestion-mode.spec.js`, `suggestion-mode-review.spec.js`, `suggestion-mode-undo.spec.js` and `suggestion-mode-persistence.spec.js` pass together (56), and `block-notes.spec.js` passes (48) so the Notes side is covered too.

## AI Use

Claude Code did the typing here, I did the asking, and it wrote the description as well. I will review and test.
