### PR TITLE
Theme: Avoid root-level relational selectors

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `ThemeProvider`: Avoid root-level relational selectors when forwarding `cornerRadius` presets to reduce style recalculation work. ([#81457](https://github.com/WordPress/gutenberg/pull/81457))
 -   Avoid `ThemeProvider` assigning CSS color properties when a seed value is not provided and there is no ancestor to inherit from. This is consistent with how `cursor` and `cornerRadius` behave, and resolves an issue where `ThemeProvider` may forcibly override colors to the default color scheme in situations where the admin color scheme properties may be provided elsewhere ([#80600](https://github.com/WordPress/gutenberg/pull/80600)).
 
 ## 1.0.0 (2026-07-14)

--- a/packages/theme/src/prebuilt/css/design-tokens.css
+++ b/packages/theme/src/prebuilt/css/design-tokens.css
@@ -351,7 +351,7 @@
 }
 
 [data-wpds-corner-radius='none'],
-:root:has( [data-wpds-root-provider='true'][data-wpds-corner-radius='none'] ) {
+:root[data-wpds-root-provider='true'][data-wpds-corner-radius='none'] {
 	/* Buttons and other elements nested inside controls. */
 	--wpds-border-radius-xs: 0px;
 	/* Standalone buttons, inputs, and compact controls. */
@@ -365,9 +365,7 @@
 }
 
 [data-wpds-corner-radius='subtle'],
-:root:has(
-		[data-wpds-root-provider='true'][data-wpds-corner-radius='subtle']
-	) {
+:root[data-wpds-root-provider='true'][data-wpds-corner-radius='subtle'] {
 	/* Buttons and other elements nested inside controls. */
 	--wpds-border-radius-xs: 1px;
 	/* Standalone buttons, inputs, and compact controls. */
@@ -381,9 +379,7 @@
 }
 
 [data-wpds-corner-radius='moderate'],
-:root:has(
-		[data-wpds-root-provider='true'][data-wpds-corner-radius='moderate']
-	) {
+:root[data-wpds-root-provider='true'][data-wpds-corner-radius='moderate'] {
 	/* Buttons and other elements nested inside controls. */
 	--wpds-border-radius-xs: 6px;
 	/* Standalone buttons, inputs, and compact controls. */
@@ -397,9 +393,7 @@
 }
 
 [data-wpds-corner-radius='pronounced'],
-:root:has(
-		[data-wpds-root-provider='true'][data-wpds-corner-radius='pronounced']
-	) {
+:root[data-wpds-root-provider='true'][data-wpds-corner-radius='pronounced'] {
 	/* Buttons and other elements nested inside controls. */
 	--wpds-border-radius-xs: 18px;
 	/* Standalone buttons, inputs, and compact controls. */

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -226,7 +226,11 @@ describe( 'ThemeProvider', () => {
 			iframeDoc.body.appendChild( mount );
 
 			const { unmount } = render(
-				<ThemeProvider isRoot color={ { primary: PRIMARY } }>
+				<ThemeProvider
+					isRoot
+					color={ { primary: PRIMARY } }
+					cornerRadius="moderate"
+				>
 					<div>x</div>
 				</ThemeProvider>,
 				{ container: mount }
@@ -235,7 +239,21 @@ describe( 'ThemeProvider', () => {
 			expect( readProp( iframeDoc.documentElement, BRAND_BG ) ).toBe(
 				PRIMARY
 			);
+			expect( iframeDoc.documentElement ).toHaveAttribute(
+				'data-wpds-root-provider',
+				'true'
+			);
+			expect( iframeDoc.documentElement ).toHaveAttribute(
+				'data-wpds-corner-radius',
+				'moderate'
+			);
 			expect( readProp( document.documentElement, BRAND_BG ) ).toBe( '' );
+			expect( document.documentElement ).not.toHaveAttribute(
+				'data-wpds-root-provider'
+			);
+			expect( document.documentElement ).not.toHaveAttribute(
+				'data-wpds-corner-radius'
+			);
 
 			unmount();
 			iframe.remove();
@@ -280,10 +298,10 @@ describe( 'ThemeProvider', () => {
 			warn.mockRestore();
 		} );
 
-		// `cornerRadius` forwards to `:root` through the prebuilt CSS's
-		// `:root:has( [data-wpds-root-provider='true']… )` rule (not the JS
-		// mirror used for color/cursor), so load that stylesheet to exercise
-		// it. Scoped to this block since it also defines base `:root` tokens.
+		// `cornerRadius` resolves through the prebuilt CSS after the root
+		// provider mirrors its preset attributes to the document element.
+		// Load that stylesheet to exercise the complete forwarding behavior.
+		// It is scoped to this block since it also defines base `:root` tokens.
 		describe( 'cornerRadius forwarding', () => {
 			let prebuiltStyle: HTMLStyleElement;
 
@@ -303,7 +321,7 @@ describe( 'ThemeProvider', () => {
 				prebuiltStyle.remove();
 			} );
 
-			it( 'forwards the preset to the document root when isRoot is set', () => {
+			it( 'forwards the preset attributes and tokens to the document root when isRoot is set', () => {
 				render(
 					<ThemeProvider isRoot cornerRadius="moderate">
 						<div data-testid="child">x</div>
@@ -318,11 +336,83 @@ describe( 'ThemeProvider', () => {
 					BORDER_RADIUS_SM
 				);
 
+				expect( document.documentElement ).toHaveAttribute(
+					'data-wpds-root-provider',
+					'true'
+				);
+				expect( document.documentElement ).toHaveAttribute(
+					'data-wpds-corner-radius',
+					'moderate'
+				);
+
 				// `:root` resolves to the same `moderate` value as the provider.
 				expect( forwarded ).toBeTruthy();
 				expect( forwarded ).toBe(
 					readProp( provider, BORDER_RADIUS_SM )
 				);
+			} );
+
+			it( 'updates the document-root attributes when the preset changes', () => {
+				const { rerender } = render(
+					<ThemeProvider isRoot cornerRadius="moderate">
+						<div>x</div>
+					</ThemeProvider>
+				);
+
+				rerender(
+					<ThemeProvider isRoot cornerRadius="pronounced">
+						<div>x</div>
+					</ThemeProvider>
+				);
+
+				expect( document.documentElement ).toHaveAttribute(
+					'data-wpds-root-provider',
+					'true'
+				);
+				expect( document.documentElement ).toHaveAttribute(
+					'data-wpds-corner-radius',
+					'pronounced'
+				);
+			} );
+
+			it( 'restores previous document-root attributes on unmount', () => {
+				const root = document.documentElement;
+				root.setAttribute( 'data-wpds-root-provider', 'previous' );
+				root.setAttribute( 'data-wpds-corner-radius', 'none' );
+				let unmount: undefined | ( () => void );
+
+				try {
+					( { unmount } = render(
+						<ThemeProvider isRoot cornerRadius="moderate">
+							<div>x</div>
+						</ThemeProvider>
+					) );
+
+					expect( root ).toHaveAttribute(
+						'data-wpds-root-provider',
+						'true'
+					);
+					expect( root ).toHaveAttribute(
+						'data-wpds-corner-radius',
+						'moderate'
+					);
+
+					unmount();
+					unmount = undefined;
+
+					expect( root ).toHaveAttribute(
+						'data-wpds-root-provider',
+						'previous'
+					);
+					expect( root ).toHaveAttribute(
+						'data-wpds-corner-radius',
+						'none'
+					);
+				} finally {
+					unmount?.();
+					root.removeAttribute( 'data-wpds-root-provider' );
+					root.removeAttribute( 'data-wpds-corner-radius' );
+				}
 			} );
 
 			it( 'does not forward the preset to the document root by default', () => {
@@ -341,6 +431,12 @@ describe( 'ThemeProvider', () => {
 				expect(
 					readProp( document.documentElement, BORDER_RADIUS_SM )
 				).not.toBe( readProp( provider, BORDER_RADIUS_SM ) );
+				expect( document.documentElement ).not.toHaveAttribute(
+					'data-wpds-root-provider'
+				);
+				expect( document.documentElement ).not.toHaveAttribute(
+					'data-wpds-corner-radius'
+				);
 			} );
 		} );
 	} );

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -39,12 +39,11 @@ export const ThemeProvider = ( {
 
 	const wrapperRef = useRef< HTMLDivElement >( null );
 
-	// For root providers, mirror the wrapper's custom properties onto the
-	// document element of the wrapper's own document (which may be an iframe)
-	// so they reach portals and content rendered outside the React subtree.
-	// `html` is shared, so set/remove individual properties (restoring any
-	// prior value) rather than assigning a whole style object. Preset settings
-	// like `cornerRadius` are forwarded by the prebuilt CSS instead.
+	// For root providers, mirror the wrapper's custom properties and preset
+	// attributes onto the document element of the wrapper's own document
+	// (which may be an iframe) so they reach portals and content rendered
+	// outside the React subtree. `html` is shared, so restore prior values on
+	// cleanup rather than replacing its complete style or attribute state.
 	useIsomorphicLayoutEffect( () => {
 		if ( ! isRoot ) {
 			return;
@@ -68,6 +67,15 @@ export const ThemeProvider = ( {
 
 		const previous = new Map< string, string >();
 		const applied: string[] = [];
+		const previousRootProvider = root.getAttribute(
+			'data-wpds-root-provider'
+		);
+		const previousCornerRadius = root.getAttribute(
+			'data-wpds-corner-radius'
+		);
+
+		root.setAttribute( 'data-wpds-root-provider', 'true' );
+		root.setAttribute( 'data-wpds-corner-radius', cornerRadiusPreset );
 
 		for ( const [ rawKey, rawValue ] of Object.entries(
 			themeProviderStyles
@@ -102,8 +110,26 @@ export const ThemeProvider = ( {
 					root.style.removeProperty( key );
 				}
 			}
+
+			if ( previousRootProvider === null ) {
+				root.removeAttribute( 'data-wpds-root-provider' );
+			} else {
+				root.setAttribute(
+					'data-wpds-root-provider',
+					previousRootProvider
+				);
+			}
+
+			if ( previousCornerRadius === null ) {
+				root.removeAttribute( 'data-wpds-corner-radius' );
+			} else {
+				root.setAttribute(
+					'data-wpds-corner-radius',
+					previousCornerRadius
+				);
+			}
 		};
-	}, [ isRoot, themeProviderStyles ] );
+	}, [ cornerRadiusPreset, isRoot, themeProviderStyles ] );
 
 	return (
 		<div

--- a/packages/theme/terrazzo.config.ts
+++ b/packages/theme/terrazzo.config.ts
@@ -48,39 +48,36 @@ const config: Config = {
 				},
 				// Each corner-radius preset is applied via the
 				// `data-wpds-corner-radius` attribute that `ThemeProvider`
-				// sets on its scoping element. The additional
-				// `:root:has([data-wpds-root-provider="true"]…)` selector lets
-				// a root `ThemeProvider` forward its preset to the document
-				// element, matching how `color` and `cursor` tokens already
-				// behave so the whole token surface stays consistent on
-				// `<html>` (e.g. for PHP-rendered admin UI outside the React
-				// app).
+				// sets on its scoping element. A root `ThemeProvider` mirrors
+				// its preset attributes directly to the document element so
+				// the whole token surface stays consistent on `<html>` (e.g.
+				// for PHP-rendered admin UI outside the React app).
 				{
 					mode: 'corner-radius-none',
 					selectors: [
 						'[data-wpds-corner-radius="none"]',
-						':root:has([data-wpds-root-provider="true"][data-wpds-corner-radius="none"])',
+						':root[data-wpds-root-provider="true"][data-wpds-corner-radius="none"]',
 					],
 				},
 				{
 					mode: 'corner-radius-subtle',
 					selectors: [
 						'[data-wpds-corner-radius="subtle"]',
-						':root:has([data-wpds-root-provider="true"][data-wpds-corner-radius="subtle"])',
+						':root[data-wpds-root-provider="true"][data-wpds-corner-radius="subtle"]',
 					],
 				},
 				{
 					mode: 'corner-radius-moderate',
 					selectors: [
 						'[data-wpds-corner-radius="moderate"]',
-						':root:has([data-wpds-root-provider="true"][data-wpds-corner-radius="moderate"])',
+						':root[data-wpds-root-provider="true"][data-wpds-corner-radius="moderate"]',
 					],
 				},
 				{
 					mode: 'corner-radius-pronounced',
 					selectors: [
 						'[data-wpds-corner-radius="pronounced"]',
-						':root:has([data-wpds-root-provider="true"][data-wpds-corner-radius="pronounced"])',
+						':root[data-wpds-root-provider="true"][data-wpds-corner-radius="pronounced"]',
 					],
 				},
 			],


### PR DESCRIPTION
## What?

Backports #81457 to the `wp/7.1` branch.element.

## Why?

This performance regression was introduced by #79153, which ships for the first time in 7.1 — so it is best fixed before the initial release rather than in a follow-up.

## How?

A straight cherry-pick of #81457. It conflicted on the generated `design-tokens.css` only, because #80213 moved that file from `src/prebuilt/` to `prebuilt/` on `trunk`, which also took it out of the lint/format scope and switched its generated quotes from single to double.

Resolved by keeping the `wp/7.1` path and formatting and taking the incoming selector change, which matches what Terrazzo generates from the backported `terrazzo.config.ts`. Every other file applied cleanly.

## Testing Instructions

1. Open the post editor and inspect its document element.
2. Confirm it has `data-wpds-root-provider="true"` and the active `data-wpds-corner-radius` preset.
3. Change the root provider's corner-radius preset and confirm the document attribute and resolved radius tokens update.
4. Record block selection with Chrome DevTools Selector Stats and confirm the previous `:root:has([data-wpds-root-provider...])` selectors are absent.

## Use of AI Tools

Claude Code was used to diagnose the cherry-pick conflict and resolve it. The backported change itself is #81457 as authored there.
