### PR TITLE
Suggest mode: reveal a selected suggestion's marker, and stop unplaced note cards eating clicks

### DIFF
--- a/packages/editor/src/components/collab-sidebar/floating-container.js
+++ b/packages/editor/src/components/collab-sidebar/floating-container.js
@@ -9,12 +9,42 @@ export function FloatingContainer( {
 	...props
 } ) {
 	const isFloating = !! floating;
+	/*
+	 * The board resolves a thread's `y` from its anchor's measured rect, so
+	 * there is a beat after mount — and after any change that invalidates the
+	 * anchors — where a thread has no position yet. An absolutely positioned
+	 * card with no `top` does not stay put: it falls back to its static
+	 * position, which is the panel's origin, so every unpositioned card piles
+	 * up there on top of whichever card legitimately sits at the top of the
+	 * board and, being later in tree order, wins the hit test and swallows
+	 * clicks meant for it — including a suggestion's Accept button.
+	 *
+	 * Take it out of the hit test until the board has placed it, and fade it
+	 * so the pile never paints. Deliberately not `visibility` or `display`:
+	 * the board's ResizeObserver still has to measure the card's height to
+	 * work out where it goes, and the card still has to be focusable — the
+	 * pending new-note form is focused the moment it mounts.
+	 */
+	const isPlaced = ! isFloating || floating.y !== undefined;
 	return (
 		<Stack
 			direction="column"
 			className={ clsx( className, { 'is-floating': isFloating } ) }
 			ref={ isFloating ? floating.ref : undefined }
-			style={ isFloating ? { top: floating.y, ...style } : style }
+			style={
+				isFloating
+					? {
+							top: floating.y,
+							...( isPlaced
+								? undefined
+								: {
+										opacity: 0,
+										pointerEvents: 'none',
+								  } ),
+							...style,
+					  }
+					: style
+			}
 			{ ...props }
 		>
 			{ children }

--- a/packages/editor/src/components/collab-sidebar/test/floating-container.js
+++ b/packages/editor/src/components/collab-sidebar/test/floating-container.js
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { FloatingContainer } from '../floating-container';
+
+describe( 'FloatingContainer', () => {
+	it( 'stays out of the way until the board has placed it', () => {
+		// An absolutely positioned card with no `top` falls back to the
+		// panel's origin, where every unplaced card lands on top of the one
+		// that legitimately sits there and swallows its clicks.
+		render(
+			<FloatingContainer
+				floating={ { y: undefined } }
+				data-testid="card"
+			/>
+		);
+		const card = screen.getByTestId( 'card' );
+		expect( card ).toHaveStyle( { opacity: '0' } );
+		expect( card ).toHaveStyle( { pointerEvents: 'none' } );
+	} );
+
+	it( 'is visible and clickable once the board reports a position', () => {
+		render(
+			<FloatingContainer floating={ { y: 120 } } data-testid="card" />
+		);
+		const card = screen.getByTestId( 'card' );
+		expect( card ).toHaveStyle( { top: '120px' } );
+		expect( card ).not.toHaveStyle( { opacity: '0' } );
+		expect( card ).not.toHaveStyle( { pointerEvents: 'none' } );
+	} );
+
+	it( 'leaves a non-floating card alone', () => {
+		render( <FloatingContainer data-testid="card" /> );
+		const card = screen.getByTestId( 'card' );
+		expect( card ).not.toHaveStyle( { opacity: '0' } );
+		expect( card ).not.toHaveClass( 'is-floating' );
+	} );
+} );

--- a/packages/editor/src/components/collab-sidebar/test/utils.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.js
@@ -365,6 +365,45 @@ describe( 'calculateNotePositions', () => {
 		expect( positions ).toEqual( { 1: 84, 2: 284, 3: 484 } );
 	} );
 
+	it( 'anchors on a measured thread when the selected one has no rect', () => {
+		// A selected thread whose anchor has not been measured yet used to
+		// abandon the whole sweep, leaving every card without a position —
+		// and an unpositioned floating card falls back to the panel's origin,
+		// where the cards pile up on each other.
+		const threads = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+		// Thread 2 is selected but its anchor has not been measured.
+		const blockRects = { 1: makeRect( 100 ), 3: makeRect( 300 ) };
+		const heights = { 1: 50, 2: 50, 3: 50 };
+
+		const { positions } = calculateNotePositions( {
+			threads,
+			selectedNoteId: 2,
+			blockRects,
+			heights,
+			scrollTop: 0,
+		} );
+
+		expect( positions ).toEqual( { 1: 84, 3: 284 } );
+	} );
+
+	it( 'holds every position back until the cards have been measured', () => {
+		// Sweeping with an unmeasured card treats it as zero-height, so the
+		// card after it lands on its anchor — on top of the card it was
+		// supposed to clear.
+		const threads = [ { id: 1 }, { id: 2 } ];
+		const blockRects = { 1: makeRect( 100 ), 2: makeRect( 140 ) };
+
+		const { positions } = calculateNotePositions( {
+			threads,
+			selectedNoteId: 1,
+			blockRects,
+			heights: { 1: 90 },
+			scrollTop: 0,
+		} );
+
+		expect( positions ).toEqual( {} );
+	} );
+
 	it( 'pushes an overlapping thread above the anchor upward', () => {
 		const threads = [ { id: 1 }, { id: 2 } ];
 		const blockRects = {

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -1,6 +1,7 @@
 import { _x } from '@wordpress/i18n';
 import { create, RichTextData } from '@wordpress/rich-text';
 import { getRectangleFromRange } from '@wordpress/dom';
+import { getMarkerSelector } from '../inline-markers/marker-selector';
 
 /**
  * Sanitizes a note string by trimming leading and trailing whitespace.
@@ -214,23 +215,7 @@ export function findNoteInBlock( attributes, noteId ) {
  * @return {string} Selector for the note's marker element(s).
  */
 export function getNoteMarkerSelector( noteId ) {
-	/*
-	 * `noteId` is a server comment ID (always a positive integer), but the
-	 * value composes a selector from stored data, so escape it defensively.
-	 *
-	 * Deliberately not `CSS.escape`: that escapes for *identifier* context,
-	 * where a leading digit is illegal, so it renders the id 7 as `\37 `.
-	 * That is valid, and matches, but it makes every rule
-	 * `buildHighlightCss` generates unreadable. Inside a quoted attribute
-	 * value the only characters that need escaping are the quote, the
-	 * backslash, and raw line breaks (a parse error in a CSS string).
-	 */
-	const escapedId = String( noteId ).replace( /["\\\n\r\f]/g, ( char ) =>
-		char === '"' || char === '\\'
-			? `\\${ char }`
-			: `\\${ char.codePointAt( 0 ).toString( 16 ) } `
-	);
-	return `mark.wp-note[data-id="${ escapedId }"]`;
+	return getMarkerSelector( 'wp-note', 'data-id', noteId );
 }
 
 /**
@@ -482,14 +467,40 @@ export function calculateNotePositions( {
 			( blockRects[ b.id ]?.top ?? Number.MAX_VALUE )
 	);
 
-	const anchorIndex = Math.max(
-		0,
-		orderedThreads.findIndex( ( thread ) => thread.id === selectedNoteId )
+	// The sweep runs outward from the selected thread so its card stays put
+	// while its neighbours give way. A thread whose anchor has not been
+	// measured yet cannot hold that role: rect-less threads sort last, so
+	// fall back to the first thread that does have a rect rather than
+	// abandoning the whole board — leaving every card unpositioned stacks
+	// them all at the panel's origin.
+	let anchorIndex = orderedThreads.findIndex(
+		( thread ) => thread.id === selectedNoteId
 	);
+	if (
+		anchorIndex < 0 ||
+		! blockRects[ orderedThreads[ anchorIndex ]?.id ]
+	) {
+		anchorIndex = orderedThreads.findIndex(
+			( thread ) => !! blockRects[ thread.id ]
+		);
+	}
 
 	const anchorThread = orderedThreads[ anchorIndex ];
 
-	if ( ! anchorThread || ! blockRects[ anchorThread.id ] ) {
+	if ( ! anchorThread ) {
+		return { positions: {} };
+	}
+
+	// Where a card lands depends on the measured height of the cards it has to
+	// clear, so sweeping before the ResizeObserver has reported treats every
+	// card as zero-height and drops them all on their anchors, on top of each
+	// other. Hold the positions back for that frame: an unplaced card sits out
+	// the hit test (see `FloatingContainer`) rather than landing in the wrong
+	// place and taking its neighbour's clicks.
+	const placeable = orderedThreads.filter(
+		( thread ) => !! blockRects[ thread.id ]
+	);
+	if ( placeable.some( ( thread ) => heights[ thread.id ] === undefined ) ) {
 		return { positions: {} };
 	}
 

--- a/packages/editor/src/components/inline-markers/index.js
+++ b/packages/editor/src/components/inline-markers/index.js
@@ -13,6 +13,7 @@
  */
 
 export { findMarkerRange, findMarkerText } from './find-marker-range';
+export { getMarkerSelector } from './marker-selector';
 export { wrapInlineMarker } from './wrap-inline-marker';
 export { readInlineSelection } from './read-inline-selection';
 export { readInlineCaret } from './read-inline-caret';

--- a/packages/editor/src/components/inline-markers/marker-selector.js
+++ b/packages/editor/src/components/inline-markers/marker-selector.js
@@ -1,0 +1,33 @@
+/**
+ * Build the CSS selector that matches an in-content `<mark>` marker by its id.
+ *
+ * Both consumers of the inline-markers primitive serialize their marker as a
+ * `<mark>` carrying a class token and an id attribute (`wp-note` /`data-id` for
+ * Notes, `wp-suggestion` / `data-suggestion-id` for Suggestions), so resolving
+ * a marker element from the DOM — to tint it, to scroll to it, or to anchor a
+ * floating card to it — is the same operation for both.
+ *
+ * @param {string}        className   Exact class token on the marker.
+ * @param {string}        idAttribute Attribute holding the marker id.
+ * @param {number|string} id          Marker id to match.
+ * @return {string} Selector for the marker element(s).
+ */
+export function getMarkerSelector( className, idAttribute, id ) {
+	/*
+	 * The id is a server comment ID (always a positive integer), but the value
+	 * composes a selector from stored data, so escape it defensively.
+	 *
+	 * Deliberately not `CSS.escape`: that escapes for *identifier* context,
+	 * where a leading digit is illegal, so it renders the id 7 as `\37 `. That
+	 * is valid, and matches, but it makes every generated rule unreadable.
+	 * Inside a quoted attribute value the only characters that need escaping
+	 * are the quote, the backslash, and raw line breaks (a parse error in a
+	 * CSS string).
+	 */
+	const escapedId = String( id ).replace( /["\\\n\r\f]/g, ( char ) =>
+		char === '"' || char === '\\'
+			? `\\${ char }`
+			: `\\${ char.codePointAt( 0 ).toString( 16 ) } `
+	);
+	return `mark.${ className }[${ idAttribute }="${ escapedId }"]`;
+}

--- a/packages/editor/src/components/inline-markers/test/marker-selector.js
+++ b/packages/editor/src/components/inline-markers/test/marker-selector.js
@@ -1,0 +1,32 @@
+import { getMarkerSelector } from '../marker-selector';
+
+describe( 'getMarkerSelector', () => {
+	it( 'matches a marker by class token and id attribute', () => {
+		expect( getMarkerSelector( 'wp-note', 'data-id', 12 ) ).toBe(
+			'mark.wp-note[data-id="12"]'
+		);
+		expect(
+			getMarkerSelector( 'wp-suggestion', 'data-suggestion-id', 12 )
+		).toBe( 'mark.wp-suggestion[data-suggestion-id="12"]' );
+	} );
+
+	it( 'leaves a numeric id readable rather than identifier-escaped', () => {
+		// `CSS.escape` would render 7 as `\37 `, which matches but makes every
+		// generated rule unreadable.
+		expect( getMarkerSelector( 'wp-note', 'data-id', 7 ) ).toBe(
+			'mark.wp-note[data-id="7"]'
+		);
+	} );
+
+	it( 'escapes characters that would break out of the attribute value', () => {
+		expect( getMarkerSelector( 'wp-note', 'data-id', 'a"b' ) ).toBe(
+			'mark.wp-note[data-id="a\\"b"]'
+		);
+		expect( getMarkerSelector( 'wp-note', 'data-id', 'a\\b' ) ).toBe(
+			'mark.wp-note[data-id="a\\\\b"]'
+		);
+		expect( getMarkerSelector( 'wp-note', 'data-id', 'a\nb' ) ).toBe(
+			'mark.wp-note[data-id="a\\a b"]'
+		);
+	} );
+} );

--- a/packages/editor/src/components/inline-suggestions/format.js
+++ b/packages/editor/src/components/inline-suggestions/format.js
@@ -4,7 +4,11 @@ import {
 	registerFormatType,
 	store as richTextStore,
 } from '@wordpress/rich-text';
-import { findMarkerRange, findMarkerText } from '../inline-markers';
+import {
+	findMarkerRange,
+	findMarkerText,
+	getMarkerSelector,
+} from '../inline-markers';
 
 export const SUGGESTION_FORMAT_NAME = 'core/suggestion';
 
@@ -177,6 +181,19 @@ export function registerSuggestionFormat( edit ) {
 		SUGGESTION_FORMAT_NAME,
 		edit ? { ...suggestionFormat, edit } : suggestionFormat
 	);
+}
+
+/**
+ * Build the CSS selector matching a suggestion's in-content marker in the
+ * editor canvas. The format serializes as `<mark class="wp-suggestion">` with
+ * the suggestion id in `data-suggestion-id`, so the marker element can be
+ * targeted directly — no separate annotation layer needed.
+ *
+ * @param {number|string} id Suggestion id the marker carries.
+ * @return {string} Selector for the suggestion's marker element(s).
+ */
+export function getSuggestionMarkerSelector( id ) {
+	return getMarkerSelector( SUGGESTION_CLASS, SUGGESTION_ID_ATTRIBUTE, id );
 }
 
 /**

--- a/packages/editor/src/components/inline-suggestions/index.js
+++ b/packages/editor/src/components/inline-suggestions/index.js
@@ -30,6 +30,7 @@ export {
 	registerSuggestionFormat,
 	findSuggestionRange,
 	findSuggestionText,
+	getSuggestionMarkerSelector,
 } from './format';
 export { useAnnotateSuggestions } from './use-annotate-suggestions';
 export {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -48,6 +48,7 @@ import {
 	SuggestionNoteGC,
 	SuggestionAnnotations,
 	SuggestionAuthorColors,
+	RevealSelectedSuggestion,
 	SuggestionDeletionKeyboard,
 	SuggestionAdditionKeyboard,
 	SuggestionFormatKeyboard,
@@ -498,6 +499,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 													<SuggestionAutoSave />
 													<SuggestionAnnotations />
 													<SuggestionAuthorColors />
+													<RevealSelectedSuggestion />
 													<SuggestionDeletionKeyboard />
 													<SuggestionAdditionKeyboard />
 													<SuggestionFormatKeyboard />

--- a/packages/editor/src/components/suggestion-mode/index.js
+++ b/packages/editor/src/components/suggestion-mode/index.js
@@ -27,6 +27,10 @@ export {
 	buildSuggestionAuthorColorCss,
 } from './suggestion-author-colors';
 export {
+	default as RevealSelectedSuggestion,
+	buildSelectedSuggestionCss,
+} from './reveal-selected-suggestion';
+export {
 	useSuggestionsProvider,
 	operationsFromOverlay,
 	applyOperations,

--- a/packages/editor/src/components/suggestion-mode/reveal-selected-suggestion.js
+++ b/packages/editor/src/components/suggestion-mode/reveal-selected-suggestion.js
@@ -1,0 +1,120 @@
+import { useEffect, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import {
+	useStyleOverride,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { getSuggestionMarkerSelector } from '../inline-suggestions';
+import { getAvatarBorderColor } from '../collab-sidebar/utils';
+import { useNoteThreads } from '../collab-sidebar/hooks';
+import { parseSuggestionPayload } from './provider';
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { useBlockElement } = unlock( blockEditorPrivateApis );
+
+// Hex alpha suffix for the active marker's tint. Deliberately lighter than the
+// `NoteHighlightStyles` active state (0x80): a suggestion marker already
+// carries a strikethrough or underline in the author's color, so a heavy wash
+// behind it competes with the decoration instead of pointing at it.
+// (0x33 = 20%.)
+const ACTIVE_ALPHA = '33';
+
+/**
+ * Build the CSS that gives the selected suggestion's in-content marker an
+ * active treatment: a tint and a ring in the suggester's color, so a reviewer
+ * can tell at a glance *which* run a note is about. Block selection alone is
+ * the wrong granularity, because one block can hold several markers.
+ *
+ * Pure so it can be unit-tested without React.
+ *
+ * @param {?number|string} selectedId Suggestion (note) id to reveal, if any.
+ * @param {?number}        author     Author id the marker's color derives from.
+ * @return {string} Serialized CSS, or '' when nothing is selected.
+ */
+export function buildSelectedSuggestionCss( selectedId, author ) {
+	if ( ! selectedId ) {
+		return '';
+	}
+	const color = getAvatarBorderColor( author ?? 0 );
+	const selector = getSuggestionMarkerSelector( selectedId );
+	return (
+		`${ selector }{background-color:${ color }${ ACTIVE_ALPHA };` +
+		`border-radius:2px;outline:2px solid ${ color };outline-offset:1px;}`
+	);
+}
+
+/**
+ * Reveal the in-content marker belonging to the selected note.
+ *
+ * Selecting a note in the sidebar selects its block, which is as far as the
+ * link went: the marker itself kept its resting treatment and the canvas never
+ * moved, so on a long post the reviewer had to hunt for the run the note was
+ * about — and on a block holding several markers, block selection could not
+ * point at one of them at all.
+ *
+ * Both halves are keyed off the note the editor considers selected, rather
+ * than off a click handler, so every route into a selection behaves the same:
+ * clicking a card, arrowing through the sidebar, or the List View's
+ * "focus note" path.
+ *
+ * @return {null} Renders nothing; styles are applied via `useStyleOverride`.
+ */
+export default function RevealSelectedSuggestion() {
+	const { postId, selectedNoteId } = useSelect( ( select ) => {
+		const { getCurrentPostId, getSelectedNote } = unlock(
+			select( editorStore )
+		);
+		return {
+			postId: getCurrentPostId(),
+			selectedNoteId: getSelectedNote(),
+		};
+	}, [] );
+	const { unresolvedNotes } = useNoteThreads( postId );
+
+	// Only threads that actually carry an inline marker can be revealed;
+	// structural and whole-attribute suggestions have nothing in content to
+	// point at, and plain notes are handled by `NoteHighlightStyles`.
+	const thread = useMemo( () => {
+		if ( ! selectedNoteId ) {
+			return undefined;
+		}
+		const match = unresolvedNotes?.find(
+			( candidate ) => String( candidate.id ) === String( selectedNoteId )
+		);
+		const payload = parseSuggestionPayload( match?.meta?._wp_suggestion );
+		const hasInline = payload?.operations?.some(
+			( op ) => op.type === 'inline-suggestion'
+		);
+		return hasInline ? match : undefined;
+	}, [ unresolvedNotes, selectedNoteId ] );
+
+	const css = useMemo(
+		() => buildSelectedSuggestionCss( thread?.id, thread?.author ),
+		[ thread?.id, thread?.author ]
+	);
+	useStyleOverride( { id: 'core-suggestion-selected', css } );
+
+	const blockElement = useBlockElement( thread?.blockClientId );
+	const markerId = thread?.id;
+
+	useEffect( () => {
+		if ( ! blockElement || ! markerId ) {
+			return;
+		}
+		/*
+		 * A marker split across several runs (crossing overlaps) resolves to
+		 * its first run, which is where the note's text begins — the same
+		 * choice the floating board makes when anchoring a card.
+		 *
+		 * `block: 'nearest'` leaves an already-visible marker alone instead of
+		 * yanking the canvas to center it, so selecting notes one after
+		 * another does not make the page jump.
+		 */
+		blockElement
+			.querySelector( getSuggestionMarkerSelector( markerId ) )
+			?.scrollIntoView( { block: 'nearest' } );
+	}, [ blockElement, markerId ] );
+
+	return null;
+}

--- a/packages/editor/src/components/suggestion-mode/test/reveal-selected-suggestion.js
+++ b/packages/editor/src/components/suggestion-mode/test/reveal-selected-suggestion.js
@@ -1,0 +1,28 @@
+import { buildSelectedSuggestionCss } from '../reveal-selected-suggestion';
+
+describe( 'buildSelectedSuggestionCss', () => {
+	it( 'emits nothing when no note is selected', () => {
+		expect( buildSelectedSuggestionCss() ).toBe( '' );
+		expect( buildSelectedSuggestionCss( undefined, 1 ) ).toBe( '' );
+		expect( buildSelectedSuggestionCss( null, 1 ) ).toBe( '' );
+	} );
+
+	it( 'targets the selected suggestion marker by id', () => {
+		const css = buildSelectedSuggestionCss( 42, 1 );
+		expect( css ).toContain(
+			'mark.wp-suggestion[data-suggestion-id="42"]{'
+		);
+	} );
+
+	it( 'tints and rings the marker in the suggester colour', () => {
+		// Author 1 → index 1 (#D94145).
+		const css = buildSelectedSuggestionCss( 7, 1 );
+		expect( css ).toContain( 'background-color:#D9414533;' );
+		expect( css ).toContain( 'outline:2px solid #D94145;' );
+	} );
+
+	it( 'only ever styles the selected marker', () => {
+		const css = buildSelectedSuggestionCss( 7, 1 );
+		expect( css.match( /mark\.wp-suggestion/g ) ).toHaveLength( 1 );
+	} );
+} );

--- a/test/e2e/specs/editor/various/suggestion-mode-marker-reveal.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-marker-reveal.spec.js
@@ -1,0 +1,192 @@
+/**
+ * E2E coverage for revealing a suggestion's in-content marker (#73411, F-31).
+ *
+ * Selecting a note in the sidebar used to stop at selecting its block: the
+ * marker itself kept its resting treatment and the canvas never moved, so on a
+ * long post the reviewer had to hunt for the run the note was about. The
+ * second test covers the other half of the same finding — a floating note card
+ * landing on top of another card's review controls and swallowing the click.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection.
+	await page.keyboard.press( 'Escape' );
+}
+
+/**
+ * Type a suggested addition at the end of the nth paragraph and wait for the
+ * marker to pick up its server-minted id.
+ *
+ * @param {import('@playwright/test').Page} page   Playwright page.
+ * @param {Object}                          editor Editor fixture.
+ * @param {number}                          index  Paragraph index.
+ * @return {Promise<import('@playwright/test').Locator>} The marker locator.
+ */
+async function suggestAdditionIn( page, editor, index ) {
+	const paragraph = editor.canvas
+		.getByRole( 'document', { name: 'Block: Paragraph' } )
+		.nth( index );
+	await paragraph.click();
+	await page.keyboard.press( 'End' );
+	await page.keyboard.type( ' edit' );
+	const marker = paragraph.locator(
+		'mark.wp-suggestion[data-suggestion-type="add"]'
+	);
+	await expect( marker ).toHaveAttribute( 'data-suggestion-id', /\d/ );
+	return marker;
+}
+
+test.describe( 'Suggestion marker reveal', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'selecting a note scrolls to its marker and marks it active', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello' },
+		} );
+		// Enough content below the marker that it leaves the viewport.
+		for ( let i = 0; i < 30; i++ ) {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: `Filler paragraph number ${ i }` },
+			} );
+		}
+
+		await switchIntent( page, 'Suggesting' );
+		const marker = await suggestAdditionIn( page, editor, 0 );
+
+		// Open "All notes" and scroll the marker out of sight.
+		const allNotesToggle = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'All notes', exact: true } );
+		if (
+			( await allNotesToggle.getAttribute( 'aria-expanded' ) ) === 'false'
+		) {
+			await allNotesToggle.click();
+		}
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.last()
+			.scrollIntoViewIfNeeded();
+		await expect( marker ).not.toBeInViewport();
+
+		// Clicking the note brings its marker back into view…
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'treeitem' )
+			.first()
+			.click();
+		await expect( marker ).toBeInViewport();
+
+		// …and gives the marker itself an active treatment, so a block
+		// holding several markers still points at the right one.
+		await expect( marker ).toHaveCSS( 'outline-style', 'solid' );
+		await expect( marker ).not.toHaveCSS(
+			'background-color',
+			'rgba(0, 0, 0, 0)'
+		);
+	} );
+
+	test( 'floating note cards never stack on top of one another', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.setViewportSize( { width: 1600, height: 900 } );
+		for ( let i = 0; i < 3; i++ ) {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: `Paragraph ${ i }` },
+			} );
+		}
+
+		await switchIntent( page, 'Suggesting' );
+		for ( let i = 0; i < 3; i++ ) {
+			await suggestAdditionIn( page, editor, i );
+		}
+
+		/*
+		 * Sample every frame while the floating board mounts, counting only
+		 * the cards that can take a click. A card the board has not placed
+		 * yet used to fall back to the panel's origin, where it covered
+		 * whichever card legitimately sat at the top — and being later in
+		 * tree order, it took that card's clicks with it.
+		 */
+		await page.evaluate( () => {
+			window.__f31Overlaps = [];
+			const deadline = Date.now() + 4000;
+			const tick = () => {
+				const boxes = Array.from(
+					document.querySelectorAll(
+						'.editor-collab-sidebar-panel__thread.is-floating'
+					)
+				)
+					.filter(
+						( el ) =>
+							window.getComputedStyle( el ).pointerEvents !==
+							'none'
+					)
+					.map( ( el ) => el.getBoundingClientRect() )
+					.sort( ( a, b ) => a.top - b.top );
+				for ( let i = 1; i < boxes.length; i++ ) {
+					if ( boxes[ i ].top < boxes[ i - 1 ].bottom ) {
+						window.__f31Overlaps.push(
+							`${ Math.round(
+								boxes[ i - 1 ].top
+							) }-${ Math.round(
+								boxes[ i - 1 ].bottom
+							) } over ${ Math.round(
+								boxes[ i ].top
+							) }-${ Math.round( boxes[ i ].bottom ) }`
+						);
+					}
+				}
+				if ( Date.now() < deadline ) {
+					window.requestAnimationFrame( tick );
+				}
+			};
+			tick();
+		} );
+
+		// Closing the docked sidebar hands the notes over to the floating
+		// board, which mounts all three cards at once.
+		await page.getByRole( 'button', { name: 'Close Notes' } ).click();
+		const cards = page.locator(
+			'.editor-collab-sidebar-panel__thread.is-floating'
+		);
+		await expect( cards ).toHaveCount( 3 );
+		// Anchor on a positive signal: all three cards placed and visible.
+		await expect( cards.nth( 2 ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: 'Accept suggestion' } )
+		).toHaveCount( 3 );
+
+		const overlaps = await page.evaluate( () => window.__f31Overlaps );
+		expect( overlaps ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes finding F-31 from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work in https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433).

## The problem

F-31 recorded two things.

First: clicking a note card selects the right block, but the marker in the canvas gets no active treatment - its class stays the bare `wp-suggestion` - and nothing scrolls. Block selection is the wrong granularity here. A paragraph can hold several markers, so selecting the block cannot say which run the note is about, and on a long post the marker can be nowhere near the viewport.

Second: during the MU-09 run a floating note card sat on top of a suggestion's Accept button and swallowed the click, which had to be forced through.

The second half turned out to be reproducible, just not where the write-up guessed. It is not a z-index problem. A floating card is `position: absolute` and gets its `top` from the board, and the board resolves that from the anchor's measured rect - so there is a frame after mount where a card has no position. An absolutely positioned card with no `top` does not stay put: it falls back to its static position, which is the panel's origin, on top of whichever card legitimately sits at the top of the board. Being later in tree order, it wins the hit test and takes that card's clicks. Sampling every frame while the board mounts shows two cards landing on the exact same box (`129-229` twice), and a second, longer overlap right after: `calculateNotePositions` reads `heights[ id ] || 0`, so the first sweep - run before the ResizeObserver has reported anything - treats every card as zero-height and drops them all on their anchors, 64px apart with 100px cards.

## The fix

**Revealing the marker.** A new `RevealSelectedSuggestion` keys off the note the editor considers selected rather than off a click handler, so every route in behaves the same - clicking a card, arrowing through the sidebar, the List View's focus-note path. It injects a rule for `mark.wp-suggestion[data-suggestion-id="N"]` through `useStyleOverride` (the same mechanism `NoteHighlightStyles` uses for `wp-note`, and the reason the treatment survives a rich-text re-render that replaces the marker element), tinting and ringing that one marker in the suggester's colour, and scrolls the marker into view with `block: 'nearest'` so an already-visible marker is left alone. Only threads carrying an `inline-suggestion` op are revealed; structural and whole-attribute suggestions have nothing in content to point at.

The `<mark>` selector both features build was duplicated between Notes and Suggestions, so it moved down to `inline-markers` as `getMarkerSelector( className, idAttribute, id )` - the format-agnostic primitive both already sit on. `getNoteMarkerSelector` now delegates to it and `getSuggestionMarkerSelector` is new.

**The click theft.** Two changes, both "don't act on a measurement you don't have yet":

- `FloatingContainer` fades an unplaced card and takes it out of the hit test until the board reports a position. Deliberately `opacity` and `pointer-events` rather than `visibility` or `display` - the board's ResizeObserver still has to measure the card's height to work out where it goes, and the card still has to be focusable, since the pending new-note form is focused the moment it mounts.
- `calculateNotePositions` holds every position back until the cards it has to place have been measured, so no card is ever placed from a zero-height sweep. Its anchor pick also falls back to the first thread that has a rect instead of abandoning the whole board when the selected thread's anchor has not been measured - that early return used to leave every card unpositioned, which is the pile-up in its worst form.

One correction to the write-up: the interception is not a z-order bug, and there is no fix in the stacking context. It is a placement race, and the cards that pile up are ones the board has not placed at all.

## Screenshots

**Selecting a note.** Two additions in the same paragraph, with the second note selected in the sidebar. Before, both markers look identical and nothing says which one the note is about. After, " Twice." carries the ring and tint.

<a href="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-reveal-before.png"><img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-reveal-before.png" alt="Before: the selected note's marker looks the same as the other marker in the paragraph" width="440"></a> <a href="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-reveal-after.png"><img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-reveal-after.png" alt="After: the selected note's marker carries a tint and a ring in the author's colour" width="440"></a>

**The floating board.** The first frame each build paints, with the card measurements held back so the frame lasts long enough to photograph. Before, three cards land on top of each other. After, nothing is painted until the board knows where the cards go.

<a href="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-board-before.png"><img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-board-before.png" alt="Before: three floating note cards stacked on top of each other at the top of the panel" width="260"></a> <a href="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-board-after.png"><img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f31-board-after.png" alt="After: the same three cards laid out down the board with no overlap" width="260"></a>

## Testing instructions

Enable the `gutenberg-suggestion-mode` experiment first.

Revealing the marker:

1. Create a post with one paragraph and 30 or so filler paragraphs after it.
2. Switch the editor intent to Suggesting.
3. Put the caret at the end of the first paragraph and type some text. Wait for the add marker to pick up a `data-suggestion-id`.
4. Open "All notes", then scroll the canvas to the bottom so the marker leaves the viewport.
5. Click the note card.
6. **Before:** nothing moves and the marker keeps its resting underline. **After:** the canvas scrolls the marker back into view and the marker takes a tinted background and a ring in the author's colour.
7. For the granularity half, put two additions in the same paragraph and select each note in turn. **Before:** both markers look identical whichever note is selected. **After:** only the selected note's marker is ringed.

The floating cards:

1. In a post with three paragraphs, in Suggesting intent, make an addition in each one.
2. Close the "All notes" sidebar with its X so the floating board takes over.
3. Watch the moment the cards appear, and click Accept on the topmost one.
4. **Before:** the cards flash stacked on each other, and a click on the top card's Accept during that frame lands on the card covering it. **After:** the cards fade in already laid out, and the click lands where it was aimed.

### Automated coverage

New e2e spec `test/e2e/specs/editor/various/suggestion-mode-marker-reveal.spec.js`:

- "selecting a note scrolls to its marker and marks it active"
- "floating note cards never stack on top of one another" - samples every frame while the board mounts and asserts no two cards that can take a click ever overlap

New unit tests:

- `collab-sidebar/test/floating-container.js` - three cases covering the unplaced, placed, and non-floating states
- `collab-sidebar/test/utils.js` - "anchors on a measured thread when the selected one has no rect" and "holds every position back until the cards have been measured"
- `inline-markers/test/marker-selector.js` - the shared selector, including the escaping it inherited from `getNoteMarkerSelector`
- `suggestion-mode/test/reveal-selected-suggestion.js` - `buildSelectedSuggestionCss`

Both e2e tests were verified red on the unmodified base branch and green with the fix, 10 runs each (`--repeat-each=5`): 10 failed before, 10 passed after. The three unit tests that pin new behaviour were each confirmed failing with their production hunk stashed.

No regressions: the five existing `suggestion-mode*` specs pass (64 tests), `block-notes.spec.js` passes (48 tests), and the `packages/editor` unit suite passes (1283 tests). An earlier draft of the `FloatingContainer` change used `visibility: hidden` and broke six `block-notes` tests that focus a card the moment it mounts, which is why it fades instead.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
