### PR TITLE
Media editor: keep initial modal focus on the dialog frame

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Keep initial focus on the modal dialog frame instead of moving it to the crop area once the image loads ([#81541](https://github.com/WordPress/gutenberg/pull/81541)).
+
 ## 0.14.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -19,8 +19,6 @@ import { Cropper } from '../../image-editor';
 import { useMediaEditor, resolveAspectRatio } from '../../state';
 
 export interface MediaEditorCanvasProps {
-	/** Focus the crop area when the canvas mounts. */
-	focusOnMount?: boolean;
 	/** Whether external placement activity should reveal the grid. */
 	isPlacementActive?: boolean;
 	/** Fires when a canvas cropper gesture begins. */
@@ -38,13 +36,11 @@ export interface MediaEditorCanvasProps {
  * guards can render a spinner or fall through to `<MediaPreview>`.
  *
  * @param props
- * @param props.focusOnMount
  * @param props.isPlacementActive
  * @param props.onGestureStart
  * @param props.onGestureEnd
  */
 export default function MediaEditorCanvas( {
-	focusOnMount,
 	isPlacementActive = false,
 	onGestureStart,
 	onGestureEnd,
@@ -154,10 +150,11 @@ export default function MediaEditorCanvas( {
 			 * The cropper stays mounted while loading (hidden behind the
 			 * spinner) so the image decodes off-screen and reveals in one paint
 			 * instead of streaming in top-to-bottom. Until it's revealed it's
-			 * non-interactive (`pointer-events: none` in CSS), and focus is
-			 * withheld by gating `focusOnMount` on the loaded state — the
-			 * cropper's focus effect keys off that prop, so focus lands on the
-			 * crop area only once it's visible.
+			 * non-interactive (`pointer-events: none` in CSS).
+			 *
+			 * The crop area is never focused programmatically: the modal keeps
+			 * initial focus on the dialog frame, and users reach the crop area
+			 * by tabbing to it.
 			 */ }
 			<div
 				className={ clsx( 'media-editor-canvas__cropper', {
@@ -169,7 +166,6 @@ export default function MediaEditorCanvas( {
 					controller={ controller }
 					aspectRatio={ aspectRatio }
 					freeformCrop
-					focusOnMount={ focusOnMount && status === 'loaded' }
 					showGrid="interactive"
 					isPlacementActive={ isPlacementActive }
 					onGestureStart={ handleGestureStart }

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -606,7 +606,6 @@ function MediaEditorContent( {
 								<div className="media-editor__canvas-area">
 									{ isImage ? (
 										<MediaEditorCanvas
-											focusOnMount
 											isPlacementActive={
 												isPlacementActive
 											}


### PR DESCRIPTION
## What?

Backports #81541 to the `wp/7.1` branch.

## Why?

The media editor ships in WordPress 7.1, so the fix needs to be on `wp/7.1`.

## How?

The cherry-pick of d033d614e57 conflicts because #81133 is not on `wp/7.1`. That PR moved `Tabs.Root` into `ComplementaryArea`'s `render` prop, which shifts the surrounding JSX in `media-editor/index.tsx`.

Backporting #81133 too felt like too much for this fix, so only the `focusOnMount` changes were applied, keeping the existing `wp/7.1` sidebar structure. The resulting diff matches d033d614e57 exactly.

## Testing Instructions

1. Add an Image block, select it, click Crop in the block toolbar.
2. Confirm focus is on the modal, not the crop area: the crop stencil shows no keyboard outline, and Tab moves to the first header control rather than a resize handle.
3. Tab to the crop area and confirm arrow keys still pan and `+`/`-` still zoom.

## Use of AI Tools

Claude Code was used to identify the cause of the cherry-pick conflict and to resolve it. The conflict resolution and this description were reviewed by me.
