### PR TITLE
Admin UI: Fix the primary color of the Fresh admin color scheme

### DIFF
--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `getAdminThemeColors`: Fix the primary color of the Fresh scheme ([#81618](https://github.com/WordPress/gutenberg/pull/81618)).
+
 ## 2.6.0 (2026-07-14)
 
 ### Enhancements

--- a/packages/admin-ui/src/admin-theme-colors/index.ts
+++ b/packages/admin-ui/src/admin-theme-colors/index.ts
@@ -10,7 +10,7 @@ const DEFAULT_THEME_COLORS: AdminThemeColors = {
 
 const ADMIN_THEME_COLORS = new Map< string, AdminThemeColors >( [
 	[ 'modern', DEFAULT_THEME_COLORS ],
-	[ 'fresh', { primary: '#3858e9', background: '#25292b' } ],
+	[ 'fresh', { primary: '#007cba', background: '#25292b' } ],
 	[ 'midnight', { primary: '#cf4339', background: '#3d4042' } ],
 	[ 'coffee', { primary: '#916745', background: '#5b534d' } ],
 	[ 'ocean', { primary: '#567958', background: '#5f787f' } ],


### PR DESCRIPTION
## What?

Backports #81618 to the `wp/7.1` branch.

## Why?

The cherry-pick did not apply cleanly, so it needs a dedicated PR rather than an automated backport.

## How?

Cherry-picked `d3c65d3a7ed` and resolved the conflict. Only `packages/admin-ui/CHANGELOG.md` conflicted.

## Testing Instructions

See #81618.

## Use of AI Tools

Claude Code was used to resolve the cherry-pick conflict and draft this description. The resulting diff was reviewed locally.
