### PR TITLE
Suggest mode: unwind suggestions in the order the user made them

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -496,18 +496,25 @@ export function getPostChangesFromCRDTDoc(
 	}
 
 	// When blocks changed but content didn't (the sender internally used a lazy
-	// serializer function), inject a closure that captures the synced blocks
-	// and serializes them on demand. Mirrors what useEntityBlockEditor does
-	// locally. A fresh function on every persistent edit marks the entity
-	// dirty (so the save button reactivates for peers), while serialization
-	// stays lazy (only runs when getEditedPostContent reads it). The closure
-	// captures `capturedBlocks` so the right content is returned even if the
-	// caller later clears `record.blocks` (e.g. the Code Editor re-parsing
-	// from content).
+	// serializer function), inject a closure that serializes the record's
+	// blocks on demand. Mirrors what useEntityBlockEditor does locally. A fresh
+	// function on every persistent edit marks the entity dirty (so the save
+	// button reactivates for peers), while serialization stays lazy (only runs
+	// when getEditedPostContent reads it).
+	//
+	// It reads the record it is handed rather than the synced blocks alone,
+	// because a later edit that writes `blocks` without writing `content` (any
+	// non-persistent block change - withdrawing a pending suggestion, say)
+	// would otherwise stay invisible to getEditedPostContent and to saving,
+	// which would put the stale blocks back on the server. `capturedBlocks` is
+	// the fallback for a caller that clears `record.blocks` (e.g. the Code
+	// Editor re-parsing from content).
 	if ( changes.blocks && ! changes.content ) {
 		const capturedBlocks = changes.blocks;
-		changes.content = () =>
-			__unstableSerializeAndClean( capturedBlocks as WPBlock[] );
+		changes.content = ( record?: { blocks?: Block[] } ) =>
+			__unstableSerializeAndClean(
+				( record?.blocks ?? capturedBlocks ) as WPBlock[]
+			);
 	}
 
 	// Meta changes must be merged with the edited record since not all meta

--- a/packages/core-data/src/utils/test/crdt.ts
+++ b/packages/core-data/src/utils/test/crdt.ts
@@ -1121,7 +1121,7 @@ describe( 'crdt', () => {
 			expect( typeof changes.content ).toBe( 'function' );
 		} );
 
-		it( 'injected content function captures the synced blocks and ignores its caller-supplied argument', () => {
+		it( 'injected content function serializes the record it is handed, falling back to the synced blocks', () => {
 			addBlockToDoc( map, 'block-1', 'Hello world' );
 
 			const editedRecord = {
@@ -1137,21 +1137,27 @@ describe( 'crdt', () => {
 				defaultSyncedProperties
 			);
 
-			// The injected function takes no parameters and serializes the
-			// captured (synced) blocks. This is what makes getEditedPostContent
-			// keep working after the Code Editor clears `record.blocks` to force
-			// a re-parse: the closure already has the right blocks on hand.
-			//
 			// The mocked __unstableSerializeAndClean returns "serialized:<n>"
-			// where n is the length of the blocks it was called with. The
-			// captured blocks have one entry, so both calls below should yield
-			// "serialized:1" (proving the closure ignores its argument and
-			// uses the captured blocks instead).
+			// where n is the length of the blocks it was called with, and the
+			// captured (synced) blocks have one entry.
 			const contentFn = changes.content as ( args?: {
-				blocks: Block[];
+				blocks?: Block[];
 			} ) => string;
+
+			// A record with blocks wins: a later edit that writes `blocks`
+			// without writing `content` (any non-persistent block change) has
+			// to be what getEditedPostContent and saving see.
+			expect( contentFn( { blocks: [ {}, {}, {} ] as Block[] } ) ).toBe(
+				'serialized:3'
+			);
+			// Including an emptied one — no blocks left means no content.
+			expect( contentFn( { blocks: [] } ) ).toBe( 'serialized:0' );
+
+			// No blocks on the record: fall back to the captured ones. This is
+			// what makes getEditedPostContent keep working after the Code
+			// Editor clears `record.blocks` to force a re-parse.
 			expect( contentFn() ).toBe( 'serialized:1' );
-			expect( contentFn( { blocks: [] } ) ).toBe( 'serialized:1' );
+			expect( contentFn( {} ) ).toBe( 'serialized:1' );
 		} );
 
 		it( 'does not inject a content function when content also changed in the doc', () => {

--- a/packages/editor/src/components/suggestion-mode/suggestion-undo-guard.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-undo-guard.js
@@ -32,7 +32,9 @@
  *     marker), as history-ignored writes so the withdrawal can't itself be
  *     undone into a resurrected marker. `SuggestionNoteGC` observes the
  *     anchor disappearing and trashes the note. Suggested removals instead
- *     revert cleanly through the real undo stack (see PENDING_MARKER_BY_OP).
+ *     revert cleanly through the real undo stack (see HISTORY_OWNED_OPS), and
+ *     while one is pending and newest the guard stands aside entirely so undo
+ *     keeps running newest-first.
  *   - Otherwise (inline text/format markers live in block content and undo
  *     cleanly) it arms an "adoption token" (see overlay-context) and lets
  *     the real undo run. The store interceptor consumes the token when the
@@ -62,35 +64,51 @@ import { EDITOR_STORE_NAME, SUGGEST_INTENT } from './constants';
 import { unlock } from '../../lock-unlock';
 
 /*
- * Structural ops the guard withdraws itself. `block-remove` is deliberately
- * absent: undoing a suggested removal reverts cleanly through the real undo
- * stack — the history transaction replaces the re-inserted block wholesale,
- * taking the marker and the async note linkage with it, and consuming the
- * history item keeps a follow-up undo stepping into older changes. Moves and
- * insertions leave the block alive across the transaction, where the
- * history-ignored linkage write resurrects the marker — those are withdrawn
- * here instead.
+ * The pending marker each structural op leaves on its block. A candidate whose
+ * marker is gone has already been resolved or withdrawn, so the overlay entry
+ * behind it is stale.
  */
 const PENDING_MARKER_BY_OP = {
 	'block-insert-after': 'pending-insert',
 	'block-move': 'pending-move',
+	'block-remove': 'pending-remove',
 };
 
+/*
+ * Structural ops the real undo stack owns rather than the guard. Undoing a
+ * suggested removal reverts cleanly through history - the transaction replaces
+ * the re-inserted block wholesale, taking the marker and the async note linkage
+ * with it, and leaving the history item unconsumed keeps a follow-up undo
+ * stepping into older changes. Moves and insertions leave the block alive
+ * across the transaction, where the history-ignored linkage write resurrects
+ * the marker, so the guard withdraws those itself.
+ *
+ * These still take part in the newest-first ordering below: a pending removal
+ * that is newer than every withdrawable suggestion has to reach undo first, or
+ * an older suggestion jumps the queue and the stack stops matching the order
+ * the user worked in.
+ */
+const HISTORY_OWNED_OPS = new Set( [ 'block-remove' ] );
+
 /**
- * Find the pending suggestion the guard should withdraw on undo: the overlay
- * entry (attribute edit or structural op) with the highest capture sequence.
+ * Find the newest pending suggestion the overlay is holding: the entry
+ * (attribute edit or structural op) with the highest capture sequence.
  * Attribute candidates need a pending baseline-vs-overlay diff; structural
- * candidates need their pending marker still live on the block (an already
- * resolved or withdrawn op is stale overlay state, not a candidate).
+ * candidates need their pending marker still live on the block.
+ *
+ * The `kind` says who reverts it. `attribute` and `structural` are withdrawn by
+ * the guard; `history` means the newest suggestion belongs to the real undo
+ * stack, so the guard must stand aside rather than reach past it for an older
+ * one it could withdraw.
  *
  * @param {Object}      entries     Overlay entries keyed by clientId.
  * @param {Object|null} blockEditor Block-editor selectors; without them (unit
  *                                  tests, standalone) structural candidates
  *                                  are skipped.
- * @return {{kind: 'attribute'|'structural', clientId: string, entry: Object,
- * seq: number}|null} Newest withdrawable suggestion.
+ * @return {{kind: 'attribute'|'structural'|'history', clientId: string,
+ * entry: Object, seq: number}|null} Newest pending suggestion.
  */
-export function findNewestWithdrawableSuggestion( entries, blockEditor ) {
+export function findNewestPendingSuggestion( entries, blockEditor ) {
 	let newest = null;
 	for ( const [ clientId, entry ] of Object.entries( entries ?? {} ) ) {
 		if (
@@ -123,7 +141,9 @@ export function findNewestWithdrawableSuggestion( entries, blockEditor ) {
 				markerType === PENDING_MARKER_BY_OP[ entry.structuralOp.type ]
 			) {
 				newest = {
-					kind: 'structural',
+					kind: HISTORY_OWNED_OPS.has( entry.structuralOp.type )
+						? 'history'
+						: 'structural',
 					clientId,
 					entry,
 					seq: entry.structuralOpSeq,
@@ -274,11 +294,21 @@ export default function SuggestionUndoGuard() {
 		 * @return {boolean} True when the undo was consumed.
 		 */
 		const withdrawNewestSuggestion = () => {
-			const newest = findNewestWithdrawableSuggestion(
+			const newest = findNewestPendingSuggestion(
 				entriesRef.current,
 				registry.select( blockEditorStore )
 			);
-			if ( ! newest || newest.seq <= getLastContentCaptureSeq() ) {
+			/*
+			 * `history` kind: the newest suggestion is one the real undo stack
+			 * reverts. Standing aside is what keeps undo newest-first - reaching
+			 * past it for an older withdrawable suggestion would unwind the
+			 * user's actions out of order.
+			 */
+			if (
+				! newest ||
+				newest.kind === 'history' ||
+				newest.seq <= getLastContentCaptureSeq()
+			) {
 				return false;
 			}
 			if ( newest.kind === 'structural' ) {

--- a/packages/editor/src/components/suggestion-mode/test/suggestion-undo-guard.js
+++ b/packages/editor/src/components/suggestion-mode/test/suggestion-undo-guard.js
@@ -1,11 +1,9 @@
-import { findNewestWithdrawableSuggestion } from '../suggestion-undo-guard';
+import { findNewestPendingSuggestion } from '../suggestion-undo-guard';
 
-describe( 'findNewestWithdrawableSuggestion', () => {
+describe( 'findNewestPendingSuggestion', () => {
 	it( 'returns null when nothing is pending', () => {
-		expect( findNewestWithdrawableSuggestion( {}, null ) ).toBeNull();
-		expect(
-			findNewestWithdrawableSuggestion( undefined, null )
-		).toBeNull();
+		expect( findNewestPendingSuggestion( {}, null ) ).toBeNull();
+		expect( findNewestPendingSuggestion( undefined, null ) ).toBeNull();
 	} );
 
 	it( 'ignores entries whose overlay equals their baseline', () => {
@@ -16,7 +14,7 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 				lastEditSeq: 5,
 			},
 		};
-		expect( findNewestWithdrawableSuggestion( entries, null ) ).toBeNull();
+		expect( findNewestPendingSuggestion( entries, null ) ).toBeNull();
 	} );
 
 	it( 'ignores unstamped attribute entries', () => {
@@ -26,7 +24,7 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 				overlayAttributes: { level: 3 },
 			},
 		};
-		expect( findNewestWithdrawableSuggestion( entries, null ) ).toBeNull();
+		expect( findNewestPendingSuggestion( entries, null ) ).toBeNull();
 	} );
 
 	it( 'picks the most recently edited pending attribute entry', () => {
@@ -42,7 +40,7 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 				lastEditSeq: 8,
 			},
 		};
-		expect( findNewestWithdrawableSuggestion( entries, null ) ).toEqual( {
+		expect( findNewestPendingSuggestion( entries, null ) ).toEqual( {
 			kind: 'attribute',
 			clientId: 'block-2',
 			entry: entries[ 'block-2' ],
@@ -64,9 +62,7 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 				metadata: { suggestion: { type: 'pending-move' } },
 			} ),
 		};
-		expect(
-			findNewestWithdrawableSuggestion( entries, withMarker )
-		).toEqual( {
+		expect( findNewestPendingSuggestion( entries, withMarker ) ).toEqual( {
 			kind: 'structural',
 			clientId: 'block-1',
 			entry: entries[ 'block-1' ],
@@ -79,11 +75,11 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 			getBlockAttributes: () => ( { metadata: {} } ),
 		};
 		expect(
-			findNewestWithdrawableSuggestion( entries, withoutMarker )
+			findNewestPendingSuggestion( entries, withoutMarker )
 		).toBeNull();
 	} );
 
-	it( 'leaves block-remove suggestions to the real undo stack', () => {
+	it( 'marks a block-remove as owned by the real undo stack', () => {
 		const entries = {
 			'block-1': {
 				baselineAttributes: {},
@@ -98,8 +94,40 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 			} ),
 		};
 		expect(
-			findNewestWithdrawableSuggestion( entries, blockEditor )
-		).toBeNull();
+			findNewestPendingSuggestion( entries, blockEditor )
+		).toMatchObject( { kind: 'history', clientId: 'block-1', seq: 9 } );
+	} );
+
+	it( 'lets a stale block-remove fall away once its marker is gone', () => {
+		const entries = {
+			'block-1': {
+				baselineAttributes: {},
+				overlayAttributes: {},
+				structuralOp: { type: 'block-remove' },
+				structuralOpSeq: 9,
+			},
+			'block-2': {
+				baselineAttributes: {},
+				overlayAttributes: {},
+				structuralOp: { type: 'block-insert-after' },
+				structuralOpSeq: 4,
+			},
+		};
+		// The removal has already been reverted through history; only the
+		// insertion still carries a live marker.
+		const blockEditor = {
+			getBlockAttributes: ( clientId ) =>
+				clientId === 'block-2'
+					? {
+							metadata: {
+								suggestion: { type: 'pending-insert' },
+							},
+					  }
+					: { metadata: {} },
+		};
+		expect(
+			findNewestPendingSuggestion( entries, blockEditor )
+		).toMatchObject( { kind: 'structural', clientId: 'block-2', seq: 4 } );
 	} );
 
 	it( 'orders attribute and structural candidates by capture sequence', () => {
@@ -122,7 +150,69 @@ describe( 'findNewestWithdrawableSuggestion', () => {
 			} ),
 		};
 		expect(
-			findNewestWithdrawableSuggestion( entries, blockEditor )
+			findNewestPendingSuggestion( entries, blockEditor )
 		).toMatchObject( { kind: 'attribute', clientId: 'block-1' } );
+	} );
+
+	it( 'lets a newer block-remove shadow an older withdrawable suggestion', () => {
+		const entries = {
+			'inserted-block': {
+				baselineAttributes: {},
+				overlayAttributes: {},
+				structuralOp: { type: 'block-insert-after' },
+				structuralOpSeq: 4,
+			},
+			'doomed-block': {
+				baselineAttributes: {},
+				overlayAttributes: {},
+				structuralOp: { type: 'block-remove' },
+				structuralOpSeq: 5,
+			},
+		};
+		const blockEditor = {
+			getBlockAttributes: ( clientId ) => ( {
+				metadata: {
+					suggestion: {
+						type:
+							clientId === 'doomed-block'
+								? 'pending-remove'
+								: 'pending-insert',
+					},
+				},
+			} ),
+		};
+		// Newest-first: the removal is the newer action, so the guard must
+		// report it rather than the insertion it could withdraw itself.
+		expect(
+			findNewestPendingSuggestion( entries, blockEditor )
+		).toMatchObject( {
+			kind: 'history',
+			clientId: 'doomed-block',
+			seq: 5,
+		} );
+	} );
+
+	it( 'lets a newer block-remove shadow an older attribute suggestion', () => {
+		const entries = {
+			'heading-block': {
+				baselineAttributes: { level: 2 },
+				overlayAttributes: { level: 3 },
+				lastEditSeq: 4,
+			},
+			'doomed-block': {
+				baselineAttributes: {},
+				overlayAttributes: {},
+				structuralOp: { type: 'block-remove' },
+				structuralOpSeq: 5,
+			},
+		};
+		const blockEditor = {
+			getBlockAttributes: () => ( {
+				metadata: { suggestion: { type: 'pending-remove' } },
+			} ),
+		};
+		expect(
+			findNewestPendingSuggestion( entries, blockEditor )
+		).toMatchObject( { kind: 'history', clientId: 'doomed-block' } );
 	} );
 } );

--- a/test/e2e/specs/editor/various/suggestion-mode-undo.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-undo.spec.js
@@ -510,4 +510,71 @@ test.describe( 'Suggestion mode undo', () => {
 		expect( serialized ).not.toContain( 'data-suggestion' );
 		expect( serialized ).not.toContain( '"suggestion"' );
 	} );
+
+	test( 'undo unwinds a block insertion and a block removal in the order they were made', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Alpha' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Beta' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		// Suggestion 1: a brand new block after the first paragraph.
+		const alpha = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Alpha' } );
+		await editor.selectBlocks( alpha );
+		await alpha.click();
+		await page.keyboard.press( 'End' );
+		const insertSaved = suggestionSavedPromise( page );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Gamma' );
+		const inserted = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Gamma' } );
+		await expect( inserted ).toHaveClass( /is-suggestion-pending-insert/ );
+		await insertSaved;
+
+		// Suggestion 2: remove the last paragraph.
+		const beta = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Beta' } );
+		await beta.click();
+		const removeSaved = suggestionSavedPromise( page );
+		await editor.clickBlockOptionsMenuItem( 'Delete' );
+		await expect( beta ).toHaveClass( /is-suggestion-pending-remove/ );
+		await removeSaved;
+
+		const summaries = await openSuggestionSummaries( page );
+		await expect( summaries ).toHaveCount( 2 );
+
+		/*
+		 * The removal was the newer action, so it has to come off first - even
+		 * though the guard could withdraw the insertion itself while the real
+		 * undo stack owns the removal. Unwinding out of order is how a pair of
+		 * interacting steps lands the document in a state that never existed.
+		 */
+		await pageUtils.pressKeys( 'primary+z' );
+		await expect( beta ).not.toHaveClass( /is-suggestion-pending-remove/ );
+		await expect( inserted ).toHaveClass( /is-suggestion-pending-insert/ );
+		await expect( summaries ).toHaveCount( 1 );
+
+		// The insertion goes on the next undo.
+		await pageUtils.pressKeys( 'primary+z' );
+		await expect( inserted ).toHaveCount( 0 );
+		await expect( summaries ).toHaveCount( 0 );
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized ).toContain( 'Alpha' );
+		expect( serialized ).toContain( 'Beta' );
+		expect( serialized ).not.toContain( 'Gamma' );
+		expect( serialized ).not.toContain( '"suggestion"' );
+	} );
 } );


### PR DESCRIPTION
## What

Fixes F-33 from the Suggest mode guided testing round: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of Suggest mode, https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), the top of the Suggest mode stack.

## The problem

The UN-06 flow made five suggestions in the order add, delete, format, insert-block, remove-block, then pressed Ctrl+Z five times. They came off as insert-block, remove-block, format, delete, add - the fourth action unwound before the fifth. The end state was right in that run because every step reversed cleanly, but the undo stack was no longer a faithful history.

The cause is in `SuggestionUndoGuard`. On undo it looks for the newest suggestion it can withdraw itself and consumes the keystroke if it finds one. `block-remove` was left out of that search on purpose, because a suggested removal reverts cleanly through the real undo stack. The trouble is that leaving it out of the search also left it out of the *ordering*: a pending removal, however recent, was invisible to the comparison, so the guard reached past it for an older insertion, move, or attribute suggestion and withdrew that instead. The removal then came off on the next Ctrl+Z, one step late.

Where the two steps do not interact this only looks odd. Where they do - a block inserted and then removed, say - unwinding out of order lands the document in a state that never existed.

Measuring it turned up a second problem underneath. Once the ordering was corrected, the withdrawal that follows a real undo left `getEditedPostContent` behind: the editor showed the right blocks but a save put the withdrawn block back on the server. That traces to `getPostChangesFromCRDTDoc`, which installs a lazy content serializer on the entity when a synced change carries blocks but no content. It captured the synced blocks, so every later edit that writes `blocks` without writing `content` - which is every non-persistent block change, withdrawals included - stayed invisible to reads and to saving.

## The fix

Two commits.

Keep pending removals in the guard's newest-first ordering and give them their own kind, `history`, meaning the real undo stack owns them. When the newest pending suggestion is one of those, the guard stands aside and lets Ctrl+Z run, so the removal reverts first and the older suggestion waits its turn. The marker check that already filtered stale structural candidates now covers removals too, so a removal that has already been reverted drops out of the ordering and the next undo withdraws the insertion as it should.

In `crdt.ts`, serialize the record the closure is handed rather than the captured blocks alone, keeping the capture as the fallback for a caller that clears `record.blocks` (the Code Editor re-parsing from content). That keeps the Code Editor guarantee the capture was written for while letting later local edits through.

One correction to the write-up in the testing doc: it suspected block-level suggestion actions were being pushed onto the history differently from inline ones. They are not. Inline captures were already part of the comparison through `getLastContentCaptureSeq`; the only capture missing from it was the block removal, and it was missing because the guard's candidate search doubled as its ordering.

## Screenshots

Two suggestions made in order - a new block inserted after "Alpha", then "Beta" removed - and one Ctrl+Z.

Before: the older insertion was withdrawn, leaving the newer removal pending. "Gamma" is gone and "Beta" is still struck through with its "Remove block" note.

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f33-before.png" alt="Before: after one undo the inserted block is gone and the block removal is still pending" width="620">

After: the newer removal comes off first. "Beta" is back to plain text, and the insertion is still pending with its "Insert block" note, waiting for the next undo.

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f33-after.png" alt="After: after one undo the removal is withdrawn and the insertion is still pending" width="620">

## Testing instructions

1. Enable the `gutenberg-suggestion-mode` experiment and create a post with two paragraphs, "Alpha" and "Beta".
2. Switch the editor to Suggesting from the Options menu.
3. Click at the end of "Alpha", press Enter, and type "Gamma". It gets the pending-insert treatment and an "Insert block" note.
4. Click "Beta" and delete it from the block options menu. It gets the pending-remove treatment and a "Remove block" note.
5. Press Ctrl+Z (Cmd+Z) once.
   - Before: "Gamma" disappears and "Beta" stays struck through. The older of the two suggestions was withdrawn.
   - After: "Beta" goes back to plain text and "Gamma" is still pending. The newer suggestion was withdrawn.
6. Press Ctrl+Z again. "Gamma" goes, both notes are gone.
7. Save the draft and reload. The post holds "Alpha" and "Beta" with no suggestion markup. Before the `crdt.ts` change the withdrawn "Gamma" block came back on reload.

### Automated coverage

- `packages/editor/src/components/suggestion-mode/test/suggestion-undo-guard.js` - `findNewestPendingSuggestion` (renamed from `findNewestWithdrawableSuggestion`, since it now reports candidates the guard does not withdraw). New cases: `lets a newer block-remove shadow an older withdrawable suggestion`, `lets a newer block-remove shadow an older attribute suggestion`, `marks a block-remove as owned by the real undo stack`, `lets a stale block-remove fall away once its marker is gone`. Verified red against the base implementation first, which returned the older insertion at seq 4 rather than the removal at seq 5.
- `test/e2e/specs/editor/various/suggestion-mode-undo.spec.js` - `undo unwinds a block insertion and a block removal in the order they were made`. Red on the base build (the removal was still pending after the first undo), green with the fix, and green through `--repeat-each=5`. The serialized-content assertion at the end of that test is what covers the `crdt.ts` change.
- `packages/core-data/src/utils/test/crdt.ts` - `injected content function serializes the record it is handed, falling back to the synced blocks`, replacing the case that pinned the old capture-only contract.
- No regressions in the neighbouring suites: all 10 tests in `suggestion-mode-undo.spec.js`, all 55 across `suggestion-mode.spec.js`, `suggestion-mode-review.spec.js`, `suggestion-mode-persistence.spec.js` and `suggestion-mode-overlay-retirement.spec.js`, all 48 in `block-notes.spec.js`, and the 1206 unit tests in `packages/core-data` and `packages/editor/src/components/suggestion-mode`.

### Known gap

The pre-existing limitation noted at the top of `suggestion-undo-guard.js` still stands: a swallowed undo does not consume the history item of the original structural dispatch, so a later Ctrl+Z can replay it against already-withdrawn state. Reordering does not change that, and undoing past the last suggestion still steps into whatever history sits below.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
