### PR TITLE
Editor: Fix partially obscured Back button with button text labels issue

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   Register the editor and block editor keyboard shortcuts from the editor provider, so shortcuts work for consumers that mount the editor without rendering `EditorKeyboardShortcutsRegister` themselves ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).
--   Header: Allow the back button column to grow when "Show button text labels" is enabled so the label is not obscured by the following controls ([#81680](https://github.com/WordPress/gutenberg/issues/81680)).
+-   Header: Allow the back button column to grow when "Show button text labels" is enabled so the label is not obscured by the following controls ([#81682](https://github.com/WordPress/gutenberg/pull/81682)).
 
 ## 14.53.0 (2026-08-12)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Register the editor and block editor keyboard shortcuts from the editor provider, so shortcuts work for consumers that mount the editor without rendering `EditorKeyboardShortcutsRegister` themselves ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).
+-   Header: Allow the back button column to grow when "Show button text labels" is enabled so the label is not obscured by the following controls ([#81680](https://github.com/WordPress/gutenberg/issues/81680)).
 
 ## 14.53.0 (2026-08-12)
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -10,11 +10,11 @@
 	background: $white;
 	display: grid;
 	grid-auto-flow: row;
-	grid-template: auto / $button-size-compact minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	grid-template: auto / auto minmax(0, max-content) minmax(min-content, 1fr) $header-height;
 	&:has(> .editor-header__center) {
-		grid-template: auto / $button-size-compact min-content 1fr min-content $header-height;
+		grid-template: auto / auto min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / $button-size-compact minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
+			grid-template: auto / auto minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {
@@ -127,15 +127,9 @@
  * Show icon labels.
  */
 
-// Grow the first track to the labeled back button so the toolbar does not overlap it.
-.show-icon-labels .editor-header:has(> .editor-header__back-button) {
-	grid-template: auto / max-content minmax(0, max-content) minmax(min-content, 1fr) $header-height;
-	&:has(> .editor-header__center) {
-		grid-template: auto / max-content min-content 1fr min-content $header-height;
-		@include break-medium {
-			grid-template: auto / max-content minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
-		}
-	}
+.show-icon-labels .editor-header__back-button {
+	// Include padding in the used width so the labeled control does not overflow.
+	width: max-content;
 }
 
 .show-icon-labels.interface-pinned-items,

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -10,15 +10,11 @@
 	background: $white;
 	display: grid;
 	grid-auto-flow: row;
-	// Compact by default so the first track matches the icon-only back button.
-	// Grow to the label when "Show button text labels" is on; a fixed track
-	// would clip the button and let the toolbar overlap it.
-	--wp-editor-header-start-column: #{$button-size-compact};
-	grid-template: auto / var(--wp-editor-header-start-column) minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	grid-template: auto / $button-size-compact minmax(0, max-content) minmax(min-content, 1fr) $header-height;
 	&:has(> .editor-header__center) {
-		grid-template: auto / var(--wp-editor-header-start-column) min-content 1fr min-content $header-height;
+		grid-template: auto / $button-size-compact min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / var(--wp-editor-header-start-column) minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
+			grid-template: auto / $button-size-compact minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {
@@ -131,8 +127,15 @@
  * Show icon labels.
  */
 
+// Grow the first track to the labeled back button so the toolbar does not overlap it.
 .show-icon-labels .editor-header:has(> .editor-header__back-button) {
-	--wp-editor-header-start-column: max-content;
+	grid-template: auto / max-content minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	&:has(> .editor-header__center) {
+		grid-template: auto / max-content min-content 1fr min-content $header-height;
+		@include break-medium {
+			grid-template: auto / max-content minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
+		}
+	}
 }
 
 .show-icon-labels.interface-pinned-items,

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -10,11 +10,15 @@
 	background: $white;
 	display: grid;
 	grid-auto-flow: row;
-	grid-template: auto / $button-size-compact minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	// Compact by default so the first track matches the icon-only back button.
+	// Grow to the label when "Show button text labels" is on; a fixed track
+	// would clip the button and let the toolbar overlap it.
+	--wp-editor-header-start-column: #{$button-size-compact};
+	grid-template: auto / var(--wp-editor-header-start-column) minmax(0, max-content) minmax(min-content, 1fr) $header-height;
 	&:has(> .editor-header__center) {
-		grid-template: auto / $button-size-compact min-content 1fr min-content $header-height;
+		grid-template: auto / var(--wp-editor-header-start-column) min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / $button-size-compact minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
+			grid-template: auto / var(--wp-editor-header-start-column) minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {
@@ -126,6 +130,10 @@
 /**
  * Show icon labels.
  */
+
+.show-icon-labels .editor-header:has(> .editor-header__back-button) {
+	--wp-editor-header-start-column: max-content;
+}
 
 .show-icon-labels.interface-pinned-items,
 .show-icon-labels .editor-header {

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -33,15 +33,6 @@ function getSiteEditorOpenNavigationButton( page ) {
 	} );
 }
 
-function getFirstDocumentTool( page ) {
-	// With "Show button text labels" on, the inserter's accessible name is
-	// "Add" rather than "Block Inserter".
-	return getEditorTopBar( page )
-		.getByRole( 'toolbar', { name: 'Document tools' } )
-		.getByRole( 'button' )
-		.first();
-}
-
 test.describe( 'Fullscreen Mode', () => {
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllPosts();
@@ -108,64 +99,5 @@ test.describe( 'Fullscreen Mode', () => {
 				getSiteEditorOpenNavigationButton( page )
 			).toBeVisible();
 		} );
-
-		test( 'should not obscure the back button when showing icon labels', async ( {
-			page,
-			admin,
-			editor,
-		} ) => {
-			await admin.visitSiteEditor( { canvas: 'edit' } );
-			await editor.setPreferences( 'core', {
-				showIconLabels: true,
-			} );
-
-			const backButton = getSiteEditorOpenNavigationButton( page );
-			await expect( backButton ).toBeVisible();
-
-			await expectBackButtonNotObscured(
-				backButton,
-				getFirstDocumentTool( page )
-			);
-		} );
-	} );
-
-	test( 'should not obscure the back button when showing icon labels', async ( {
-		page,
-		admin,
-		editor,
-	} ) => {
-		await admin.createNewPost();
-		await editor.setPreferences( 'core', {
-			showIconLabels: true,
-		} );
-		await enableFullscreenMode( page );
-
-		await expect( page.locator( 'body' ) ).toHaveClass(
-			/show-icon-labels/
-		);
-
-		const backLink = getPostEditorBackLink( page );
-		await expect( backLink ).toBeVisible();
-
-		await expectBackButtonNotObscured(
-			backLink,
-			getFirstDocumentTool( page )
-		);
 	} );
 } );
-
-/**
- * Assert that the back control is fully to the left of the following toolbar
- * control, so its label is not covered when "Show button text labels" is on.
- *
- * @param {import('@playwright/test').Locator} backControl
- * @param {import('@playwright/test').Locator} followingControl
- */
-async function expectBackButtonNotObscured( backControl, followingControl ) {
-	const backBox = await backControl.boundingBox();
-	const followingBox = await followingControl.boundingBox();
-
-	expect( backBox ).not.toBeNull();
-	expect( followingBox ).not.toBeNull();
-	expect( backBox.x + backBox.width ).toBeLessThanOrEqual( followingBox.x );
-}

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -99,5 +99,70 @@ test.describe( 'Fullscreen Mode', () => {
 				getSiteEditorOpenNavigationButton( page )
 			).toBeVisible();
 		} );
+
+		test( 'should not obscure the back button when showing icon labels', async ( {
+			page,
+			admin,
+			editor,
+		} ) => {
+			await admin.visitSiteEditor( { canvas: 'edit' } );
+			await editor.setPreferences( 'core', {
+				showIconLabels: true,
+			} );
+
+			const backButton = getSiteEditorOpenNavigationButton( page );
+			await expect( backButton ).toBeVisible();
+
+			await expectBackButtonNotObscured(
+				backButton,
+				getEditorTopBar( page ).getByRole( 'button', {
+					name: 'Block Inserter',
+					exact: true,
+				} )
+			);
+		} );
+	} );
+
+	test( 'should not obscure the back button when showing icon labels', async ( {
+		page,
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPost();
+		await editor.setPreferences( 'core', {
+			showIconLabels: true,
+		} );
+		await enableFullscreenMode( page );
+
+		await expect( page.locator( 'body' ) ).toHaveClass(
+			/show-icon-labels/
+		);
+
+		const backLink = getPostEditorBackLink( page );
+		await expect( backLink ).toBeVisible();
+
+		await expectBackButtonNotObscured(
+			backLink,
+			getEditorTopBar( page ).getByRole( 'button', {
+				name: 'Block Inserter',
+				exact: true,
+			} )
+		);
 	} );
 } );
+
+/**
+ * Assert that the back control is fully to the left of the following toolbar
+ * control, so its label is not covered when "Show button text labels" is on.
+ *
+ * @param {import('@playwright/test').Locator} backControl
+ * @param {import('@playwright/test').Locator} followingControl
+ */
+async function expectBackButtonNotObscured( backControl, followingControl ) {
+	const backBox = await backControl.boundingBox();
+	const followingBox = await followingControl.boundingBox();
+
+	expect( backBox ).not.toBeNull();
+	expect( followingBox ).not.toBeNull();
+	expect( backBox.x + backBox.width ).toBeLessThanOrEqual( followingBox.x );
+}

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -33,6 +33,15 @@ function getSiteEditorOpenNavigationButton( page ) {
 	} );
 }
 
+function getFirstDocumentTool( page ) {
+	// With "Show button text labels" on, the inserter's accessible name is
+	// "Add" rather than "Block Inserter".
+	return getEditorTopBar( page )
+		.getByRole( 'toolbar', { name: 'Document tools' } )
+		.getByRole( 'button' )
+		.first();
+}
+
 test.describe( 'Fullscreen Mode', () => {
 	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllPosts();
@@ -115,10 +124,7 @@ test.describe( 'Fullscreen Mode', () => {
 
 			await expectBackButtonNotObscured(
 				backButton,
-				getEditorTopBar( page ).getByRole( 'button', {
-					name: 'Block Inserter',
-					exact: true,
-				} )
+				getFirstDocumentTool( page )
 			);
 		} );
 	} );
@@ -143,10 +149,7 @@ test.describe( 'Fullscreen Mode', () => {
 
 		await expectBackButtonNotObscured(
 			backLink,
-			getEditorTopBar( page ).getByRole( 'button', {
-				name: 'Block Inserter',
-				exact: true,
-			} )
+			getFirstDocumentTool( page )
 		);
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes https://github.com/WordPress/gutenberg/issues/81680

When Show button text labels is on, the editor header Back control (post editor “View Posts” / site editor “Open Navigation”) is no longer covered by the Block Inserter and the rest of the toolbar.


<!-- In a few words, what is the PR actually doing? -->

## Why?
The header grid locked the first column to the compact icon width. Labels make the Back button wider (width: auto plus the aria-label as visible text), but the column did not grow, so the following controls overlapped it.

## How?
The first header track is a CSS custom property, still $button-size-compact by default. With .show-icon-labels and a .editor-header__back-button present, it becomes max-content so the column matches the labeled button.

## Testing Instructions
- Edit a post.
- Go to Options > Preferences > Accessibility > Show button text labels.
- Enable Show button text labels.
- Close the preferences modal dialog.
- Observe that the Back button is no longer obscured.


## Screenshots or screencast <!-- if applicable -->

After :
<img width="400" alt="after" src="https://github.com/user-attachments/assets/52fc92c9-ed41-4bb5-b9b0-319825fae2a8" />

## Use of AI Tools
- Yes (Cursor)
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
