### PR TITLE
Real-time collaboration: Bundle @wordpress/sync instead of exposing as wp.sync

### DIFF
--- a/packages/e2e-tests/plugins/rtc-websocket-provider.php
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider.php
@@ -40,7 +40,7 @@ function gutenberg_test_rtc_websocket_provider_enqueue() {
 	wp_enqueue_script(
 		'gutenberg-test-rtc-websocket-provider',
 		plugins_url( 'rtc-websocket-provider/build/index.js', __FILE__ ),
-		array( 'wp-hooks', 'wp-sync' ),
+		array( 'wp-hooks' ),
 		filemtime( $script_path ),
 		true
 	);

--- a/packages/e2e-tests/plugins/rtc-websocket-provider/src/index.js
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider/src/index.js
@@ -9,6 +9,8 @@
 
 import { WebsocketProvider } from 'y-websocket';
 
+import { setYjs } from './yjs-external.js';
+
 const TEST_PROVIDER_NAMESPACE = 'gutenberg-test/rtc-websocket-provider';
 const DEFAULT_URL = 'ws://127.0.0.1:18991';
 
@@ -37,7 +39,11 @@ function updateDebugState( room, patch ) {
 }
 
 function createWebSocketProvider() {
-	return async ( { awareness, objectType, objectId, ydoc } ) => {
+	return async ( { awareness, objectType, objectId, Y, ydoc } ) => {
+		// Point the bundled y-websocket / y-protocols at the editor's Yjs
+		// instance before the provider touches any Yjs API.
+		setYjs( Y );
+
 		const room = objectId ? `${ objectType }:${ objectId }` : objectType;
 
 		updateDebugState( room, {

--- a/packages/e2e-tests/plugins/rtc-websocket-provider/src/yjs-external.js
+++ b/packages/e2e-tests/plugins/rtc-websocket-provider/src/yjs-external.js
@@ -1,15 +1,22 @@
 /**
- * Re-export Yjs symbols from wp.sync.Y so the bundled y-websocket and
- * y-protocols modules share the same Yjs instance as @wordpress/sync.
- * Two Yjs instances on the same page cause silent data corruption:
- * https://github.com/yjs/yjs/issues/438
+ * Re-exports the Yjs symbols of the instance `@wordpress/sync` hands to
+ * provider creators, so the bundled y-websocket and y-protocols modules share
+ * that instance. Two Yjs instances on the same page cause silent data
+ * corruption: https://github.com/yjs/yjs/issues/438
  *
- * Only the symbols actually referenced by y-websocket and y-protocols
- * need to be re-exported here.
+ * `@wordpress/sync` is bundled into its consumers, so there is no `wp.sync`
+ * global to read from. The bindings below are live: `setYjs()` must run before
+ * any y-websocket / y-protocols code that touches Yjs, which is guaranteed
+ * because the provider creator receives `Y` before constructing the provider.
+ *
+ * Only the symbols actually referenced by y-websocket and y-protocols need to
+ * be re-exported here.
  */
-const Y = window.wp.sync.Y;
+export let Doc;
+export let applyUpdate;
+export let encodeStateAsUpdate;
+export let encodeStateVector;
 
-export const Doc = Y.Doc;
-export const applyUpdate = Y.applyUpdate;
-export const encodeStateAsUpdate = Y.encodeStateAsUpdate;
-export const encodeStateVector = Y.encodeStateVector;
+export function setYjs( Y ) {
+	( { Doc, applyUpdate, encodeStateAsUpdate, encodeStateVector } = Y );
+}

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -30,33 +30,9 @@ Private @wordpress/sync APIs.
 
 ### Y
 
-Yjs should not be considered a public API. It is a third-party library that _will_ experience breaking changes in the future. However, in order to allow third-party plugins to provide their own Yjs providers / sync transport, they must import and consume **our instance** of Yjs due to this bug / feature:
+Yjs should not be considered a public API. It is a third-party library that _will_ experience breaking changes in the future. It is re-exported here so that internal `@wordpress/*` consumers of this bundled package have a single import path for Yjs.
 
-<https://github.com/yjs/yjs/issues/438>
-
-In other words, external code must be able to import Yjs from the `@wordpress/sync` package in their code, e.g.:
-
-```ts
-import { Y } from '@wordpress/sync';
-```
-
-Additionally, this import must resolve to `wp.sync` via `DependencyExtractionWebpackPlugin`. If you are using an older version of `@wordpress/scripts` that does not treat `@wordpress/sync` as an unbundled package, then you can use Webpack externals to manually resolve the package to the global `wp.sync` variable:
-
-```ts
-externals: {
-  ...existingConfig.externals,
-  // Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
-  '@wordpress/sync': 'wp.sync',
-
-  // Resolve Yjs to the global `wp.sync.Y` provided by the sync package.
-  // Since dependencies import 'yjs' directly, we need to avoid importing
-  // and packaging two different Yjs instances, which would result in this
-  // conflict:
-  //
-  // https://github.com/yjs/yjs/issues/438
-  yjs: 'wp.sync.Y',
-},
-```
+Note: this package is bundled into its consumers, so each consumer ends up with its own copy of Yjs. Sharing Yjs documents across separately-bundled scripts is not supported — see <https://github.com/yjs/yjs/issues/438>.
 
 ### YJS_VERSION
 

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -32,7 +32,7 @@ Private @wordpress/sync APIs.
 
 Yjs should not be considered a public API. It is a third-party library that _will_ experience breaking changes in the future. It is re-exported here so that internal `@wordpress/*` consumers of this bundled package have a single import path for Yjs.
 
-Note: this package is bundled into its consumers, so each consumer ends up with its own copy of Yjs. Sharing Yjs documents across separately-bundled scripts is not supported — see <https://github.com/yjs/yjs/issues/438>.
+Note: this package is bundled into its consumers, so each consumer ends up with its own copy of Yjs. A separately-bundled script must never import its own Yjs to work with a shared document — see <https://github.com/yjs/yjs/issues/438>. Sync providers receive the Yjs instance backing the document as the `Y` option of their creator function.
 
 ### YJS_VERSION
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -39,7 +39,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"wpScript": true,
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,38 +1,12 @@
 /**
  * Yjs should not be considered a public API. It is a third-party library that
- * _will_ experience breaking changes in the future. However, in order to allow
- * third-party plugins to provide their own Yjs providers / sync transport, they
- * must import and consume **our instance** of Yjs due to this bug / feature:
+ * _will_ experience breaking changes in the future. It is re-exported here so
+ * that internal `@wordpress/*` consumers of this bundled package have a single
+ * import path for Yjs.
  *
- * https://github.com/yjs/yjs/issues/438
- *
- * In other words, external code must be able to import Yjs from the
- * `@wordpress/sync` package in their code, e.g.:
- *
- * ```ts
- * import { Y } from '@wordpress/sync';
- * ```
- *
- * Additionally, this import must resolve to `wp.sync` via `DependencyExtractionWebpackPlugin`.
- * If you are using an older version of `@wordpress/scripts` that does not treat
- * `@wordpress/sync` as an unbundled package, then you can use Webpack externals
- * to manually resolve the package to the global `wp.sync` variable:
- *
- * ```ts
- * externals: {
- *   ...existingConfig.externals,
- *   // Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
- *   '@wordpress/sync': 'wp.sync',
- *
- *   // Resolve Yjs to the global `wp.sync.Y` provided by the sync package.
- *   // Since dependencies import 'yjs' directly, we need to avoid importing
- *   // and packaging two different Yjs instances, which would result in this
- *   // conflict:
- *   //
- *   // https://github.com/yjs/yjs/issues/438
- *   yjs: 'wp.sync.Y',
- * },
- * ```
+ * Note: this package is bundled into its consumers, so each consumer ends up
+ * with its own copy of Yjs. Sharing Yjs documents across separately-bundled
+ * scripts is not supported — see https://github.com/yjs/yjs/issues/438.
  */
 export * as Y from 'yjs';
 

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -5,8 +5,10 @@
  * import path for Yjs.
  *
  * Note: this package is bundled into its consumers, so each consumer ends up
- * with its own copy of Yjs. Sharing Yjs documents across separately-bundled
- * scripts is not supported — see https://github.com/yjs/yjs/issues/438.
+ * with its own copy of Yjs. A separately-bundled script must never import its
+ * own Yjs to work with a shared document — see
+ * https://github.com/yjs/yjs/issues/438. Sync providers receive the Yjs
+ * instance backing the document as the `Y` option of their creator function.
  */
 export * as Y from 'yjs';
 

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -298,6 +298,7 @@ export function createSyncManager( debug = false ): SyncManager {
 					objectId,
 					ydoc,
 					awareness,
+					Y,
 				} );
 
 				// Attach status listener after provider creation.
@@ -437,6 +438,7 @@ export function createSyncManager( debug = false ): SyncManager {
 					objectType,
 					objectId: null,
 					ydoc,
+					Y,
 				} );
 
 				// Attach status listener after provider creation.

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -151,6 +151,7 @@ describe( 'SyncManager', () => {
 				objectId: '123',
 				ydoc: expect.any( Y.Doc ),
 				awareness: expect.any( Awareness ),
+				Y,
 			} );
 		} );
 

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -107,6 +107,12 @@ export interface ProviderCreatorOptions {
 	objectId: ObjectID | null;
 	ydoc: Y.Doc;
 	awareness?: Awareness;
+
+	/**
+	 * The Yjs instance backing `ydoc`. Separately bundled providers must use
+	 * it instead of their own copy: https://github.com/yjs/yjs/issues/438
+	 */
+	Y: typeof Y;
 }
 
 export type ProviderCreator = (


### PR DESCRIPTION
## What?

Cherry-picks #78085 onto the `wp/7.1` branch, so that `wp.sync` is not exposed when Gutenberg is bundled into Core.

## Why?

Real-time collaboration was pulled from the 7.0 release. As part of that, #78085 landed on `wp/7.0` to stop exposing `wp.sync` in Core.

That change was never applied to `trunk`, so the 7.1 release re-exposes `wp.sync` and ships `sync.js` again.

## How?

Cherry-picks #78085: `wpScript: true` is removed from `@wordpress/sync`, so the package is bundled into its only consumer (`@wordpress/core-data`) instead of being registered as its own script handle.

As raised in https://github.com/WordPress/gutenberg/pull/78085#discussion_r3207513336, un-exposing the package on `trunk` carries risk for plugins that may already rely on `wp.sync` to provide their own transport layer. This PR therefore applies the change to `wp/7.1` only. The same problem will recur on every future WordPress release, so a proper fix still needs to be worked out.

## Testing Instructions

1. `npm install && npm run build`
2. Confirm `build/scripts/registry.php` no longer registers the `wp-sync` handle.
3. Confirm `build/scripts/sync/` no longer exists, and that `wp-sync` is absent from the dependencies in `build/scripts/core-data/index.min.asset.php`.
4. Load the editor and confirm `window.wp.sync` is `undefined` in the browser console.
5. Open the same post in two browser sessions and confirm real-time collaboration still works as before — typing syncs both ways, undo/redo behaves correctly, and peer presence/awareness is shown.

### Testing in WordPress Core

1. In a `wordpress-develop` checkout, set `gutenberg.sha` in `package.json` to `1f3a5262b46d4548e20c9475b1e04ac22f9c2037`.
2. Run `npm run gutenberg:download`, then `npm run build`.
3. Confirm `build/wp-includes/js/dist/sync.js` and `build/wp-includes/js/dist/sync.min.js` are not generated.
4. Load the editor and confirm `wp.sync` is not exposed.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Screenshots or screencast

N/A

## Use of AI Tools

Authored with Claude Code (Opus 5).
