### PR TITLE
Suggest mode: keep a block's attribute suggestion alive through an inline decision

### DIFF
--- a/packages/editor/src/components/suggestion-mode/overlay-context.js
+++ b/packages/editor/src/components/suggestion-mode/overlay-context.js
@@ -87,6 +87,18 @@ const UNDO_ADOPTION_TTL_MS = 1000;
  *                                                               overlay attributes.
  */
 
+/**
+ * A block can hold more than one pending suggestion at a time — an
+ * attribute-set overlay (heading level) alongside inline markers in the same
+ * block's content, which is a legitimate combination because the two describe
+ * disjoint parts of the block. The overlay entry belongs to whichever
+ * suggestion opened it, so a decision on one of the block's other suggestions
+ * must leave it alone. `clearOverlayForComment` is the guarded clear used by
+ * those paths: it removes the entry only when the entry is the one linked to
+ * the comment being resolved. See finding F-14 in the Suggest mode testing
+ * document.
+ */
+
 const EMPTY_ENTRIES = Object.freeze( {} );
 
 const OverlayContext = createContext( {
@@ -94,6 +106,7 @@ const OverlayContext = createContext( {
 	captureBaseline: () => {},
 	setOverlayAttributes: () => {},
 	clearOverlay: () => {},
+	clearOverlayForComment: () => {},
 	setCommentId: () => {},
 	setSyncedOpsKey: () => {},
 	setStructuralOp: () => {},
@@ -166,6 +179,25 @@ export function overlayReducer( state, action ) {
 			}
 			const { [ action.clientId ]: _removed, ...rest } = state;
 			return rest;
+		}
+		case 'CLEAR_OVERLAY_FOR_COMMENT': {
+			/*
+			 * Guarded clear for decision paths that act on a suggestion which
+			 * does not live in the overlay (an inline marker). The block may
+			 * still hold an unrelated pending attribute suggestion, and that
+			 * entry is the only anchor keeping its note alive — dropping it
+			 * would send the note to the garbage collector and take the
+			 * proposed value off the canvas with it.
+			 */
+			const entry = state[ action.clientId ];
+			if ( entry?.commentId === null || entry?.commentId === undefined ) {
+				return state;
+			}
+			if ( String( entry.commentId ) !== String( action.commentId ) ) {
+				return state;
+			}
+			const { [ action.clientId ]: _dropped, ...remaining } = state;
+			return remaining;
 		}
 		case 'SET_COMMENT_ID': {
 			const entry = state[ action.clientId ];
@@ -277,6 +309,16 @@ export function SuggestionOverlayProvider( { children } ) {
 
 	const clearOverlay = useCallback(
 		( clientId ) => dispatch( { type: 'CLEAR_OVERLAY', clientId } ),
+		[]
+	);
+
+	const clearOverlayForComment = useCallback(
+		( clientId, commentId ) =>
+			dispatch( {
+				type: 'CLEAR_OVERLAY_FOR_COMMENT',
+				clientId,
+				commentId,
+			} ),
 		[]
 	);
 
@@ -544,6 +586,7 @@ export function SuggestionOverlayProvider( { children } ) {
 			captureBaseline,
 			setOverlayAttributes,
 			clearOverlay,
+			clearOverlayForComment,
 			setCommentId,
 			setSyncedOpsKey,
 			setStructuralOp,
@@ -568,6 +611,7 @@ export function SuggestionOverlayProvider( { children } ) {
 			captureBaseline,
 			setOverlayAttributes,
 			clearOverlay,
+			clearOverlayForComment,
 			setCommentId,
 			setSyncedOpsKey,
 			setStructuralOp,

--- a/packages/editor/src/components/suggestion-mode/provider.js
+++ b/packages/editor/src/components/suggestion-mode/provider.js
@@ -478,7 +478,8 @@ export function useSuggestionsProvider() {
 		getBlockRootClientId: selectBlockRootClientId,
 		getClientIdsWithDescendants: selectClientIdsWithDescendants,
 	} = useSelect( blockEditorStore );
-	const { requestInterceptorBypass, clearOverlay } = useSuggestionOverlay();
+	const { requestInterceptorBypass, clearOverlay, clearOverlayForComment } =
+		useSuggestionOverlay();
 	const registry = useRegistry();
 
 	const createSuggestion = useCallback(
@@ -772,7 +773,15 @@ export function useSuggestionsProvider() {
 				}
 				try {
 					requestInterceptorBypass( targetClientId );
-					clearOverlay( targetClientId );
+					/*
+					 * An inline suggestion never lives in the overlay, but the
+					 * same block can hold a pending attribute suggestion that
+					 * does. Clear only an entry this comment owns: the entry is
+					 * the attribute note's sole anchor, so an unconditional
+					 * clear here hands that note to the orphan collector and
+					 * wipes the proposed value off the canvas (F-14).
+					 */
+					clearOverlayForComment( targetClientId, commentId );
 					updateBlockAttributes( targetClientId, {
 						[ attributeKey ]: nextValue,
 					} );
@@ -975,6 +984,7 @@ export function useSuggestionsProvider() {
 			createNotice,
 			requestInterceptorBypass,
 			clearOverlay,
+			clearOverlayForComment,
 		]
 	);
 
@@ -1120,7 +1130,10 @@ export function useSuggestionsProvider() {
 					}
 					try {
 						requestInterceptorBypass( targetClientId );
-						clearOverlay( targetClientId );
+						// Guarded for the same reason as the apply path above:
+						// a co-resident attribute suggestion owns this block's
+						// overlay entry and must survive an inline decision.
+						clearOverlayForComment( targetClientId, commentId );
 						updateBlockAttributes( targetClientId, {
 							[ attributeKey ]: nextValue,
 						} );
@@ -1196,6 +1209,7 @@ export function useSuggestionsProvider() {
 			moveBlockToPosition,
 			requestInterceptorBypass,
 			clearOverlay,
+			clearOverlayForComment,
 			registry,
 		]
 	);

--- a/packages/editor/src/components/suggestion-mode/test/overlay-context.js
+++ b/packages/editor/src/components/suggestion-mode/test/overlay-context.js
@@ -83,6 +83,77 @@ describe( 'overlayReducer', () => {
 		expect( cleared ).not.toBe( withEntry );
 	} );
 
+	describe( 'CLEAR_OVERLAY_FOR_COMMENT', () => {
+		const withComment = ( commentId ) => {
+			const withEntry = overlayReducer( INITIAL, {
+				type: 'CAPTURE_BASELINE',
+				clientId: CLIENT_ID,
+				blockName: 'core/heading',
+				attributes: { level: 2 },
+			} );
+			return overlayReducer( withEntry, {
+				type: 'SET_COMMENT_ID',
+				clientId: CLIENT_ID,
+				commentId,
+			} );
+		};
+
+		it( 'removes the entry when the comment owns it', () => {
+			const state = withComment( 42 );
+			const cleared = overlayReducer( state, {
+				type: 'CLEAR_OVERLAY_FOR_COMMENT',
+				clientId: CLIENT_ID,
+				commentId: 42,
+			} );
+			expect( cleared ).toEqual( {} );
+		} );
+
+		it( 'matches across the string/number boundary', () => {
+			const state = withComment( 42 );
+			const cleared = overlayReducer( state, {
+				type: 'CLEAR_OVERLAY_FOR_COMMENT',
+				clientId: CLIENT_ID,
+				commentId: '42',
+			} );
+			expect( cleared ).toEqual( {} );
+		} );
+
+		it( 'keeps an entry that belongs to another suggestion', () => {
+			const state = withComment( 42 );
+			const next = overlayReducer( state, {
+				type: 'CLEAR_OVERLAY_FOR_COMMENT',
+				clientId: CLIENT_ID,
+				commentId: 43,
+			} );
+			expect( next ).toBe( state );
+			expect( next[ CLIENT_ID ].commentId ).toBe( 42 );
+		} );
+
+		it( 'keeps an entry that has no comment yet', () => {
+			const state = overlayReducer( INITIAL, {
+				type: 'CAPTURE_BASELINE',
+				clientId: CLIENT_ID,
+				blockName: 'core/heading',
+				attributes: { level: 2 },
+			} );
+			const next = overlayReducer( state, {
+				type: 'CLEAR_OVERLAY_FOR_COMMENT',
+				clientId: CLIENT_ID,
+				commentId: 42,
+			} );
+			expect( next ).toBe( state );
+		} );
+
+		it( 'is a no-op when the block has no entry', () => {
+			const next = overlayReducer( INITIAL, {
+				type: 'CLEAR_OVERLAY_FOR_COMMENT',
+				clientId: CLIENT_ID,
+				commentId: 42,
+			} );
+			expect( next ).toBe( INITIAL );
+		} );
+	} );
+
 	it( 'returns the same reference for unknown actions', () => {
 		const next = overlayReducer( INITIAL, { type: 'UNKNOWN' } );
 		expect( next ).toBe( INITIAL );

--- a/test/e2e/specs/editor/various/suggestion-mode-review.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-review.spec.js
@@ -982,4 +982,103 @@ test.describe( 'Suggestion mode review flows', () => {
 			sidebar.getByText( 'Rejected', { exact: true } )
 		).toBeVisible();
 	} );
+
+	test( 'an inline decision leaves a co-resident attribute suggestion pending', async ( {
+		editor,
+		page,
+	} ) => {
+		// A heading can hold two independent suggestions at once: an
+		// attribute-set overlay for its level, and an inline marker in its
+		// text. They describe disjoint parts of the block, so deciding one
+		// must not disturb the other. The apply/reject paths for an inline
+		// marker used to clear the block's whole overlay entry, which is the
+		// attribute note's only anchor — the note was collected as an orphan
+		// and its proposed level vanished from the canvas. See F-14.
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: { content: 'My Heading', level: 2 },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const heading = editor.canvas
+			.getByRole( 'document', { name: 'Block: Heading' } )
+			.first();
+		await heading.click();
+
+		// Suggestion one: heading level, captured into the overlay.
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: /^Heading 2$/ } )
+			.click();
+		const attributeSaved = suggestionSavedPromise( page );
+		await page.getByRole( 'menuitem', { name: /^Heading 3/ } ).click();
+		await attributeSaved;
+		await expect( heading ).toHaveJSProperty( 'tagName', 'H3' );
+
+		// Suggestion two: typed text in the same heading, captured as a marker.
+		await heading.click();
+		await page.keyboard.press( 'End' );
+		const inlineSaved = suggestionSavedPromise( page );
+		await page.keyboard.type( ' XYZ' );
+		await inlineSaved;
+		await expect(
+			heading.locator( 'mark.wp-suggestion[data-suggestion-type="add"]' )
+		).toHaveAttribute( 'data-suggestion-id', /\d/ );
+
+		// Both suggestions are listed as their own threads.
+		const sidebar = await openNotesSidebar( page );
+		const threads = sidebar.locator(
+			'.editor-collab-sidebar-panel__thread'
+		);
+		await expect( threads ).toHaveCount( 2 );
+
+		// Accept the inline one, picked by the thread carrying its summary —
+		// thread order is not guaranteed, so index-based selection would
+		// silently decide the wrong suggestion.
+		await threads
+			.filter( { hasText: 'XYZ' } )
+			.getByRole( 'button', { name: 'Accept suggestion' } )
+			.click();
+		await expect(
+			page
+				.locator( '.components-snackbar-list' )
+				.getByText( 'Suggestion applied.' )
+		).toBeVisible();
+
+		// The addition landed: marker unwrapped, text kept.
+		await expect( heading.locator( 'mark.wp-suggestion' ) ).toHaveCount(
+			0
+		);
+		await expect( heading ).toHaveText( 'My Heading XYZ' );
+
+		/*
+		 * Let the state settle before judging the level suggestion. Both
+		 * failure modes are asynchronous — the orphan collector waits out its
+		 * 500ms grace period and then round-trips a status write — so an
+		 * assertion that retries until it passes would go green on the state
+		 * before the damage, not after it.
+		 */
+		// eslint-disable-next-line no-restricted-syntax, playwright/no-wait-for-timeout
+		await page.waitForTimeout( 3000 );
+
+		// The level suggestion is untouched: still previewed on the canvas,
+		// still listed in the sidebar, still pending on the server.
+		await expect( heading ).toHaveJSProperty( 'tagName', 'H3' );
+		await expect( sidebar.getByText( /heading level/ ) ).toBeVisible();
+		const attributeNoteStatuses = await page.evaluate( async () => {
+			const postId = window.wp.data
+				.select( 'core/editor' )
+				.getCurrentPostId();
+			const comments = await window.wp.apiFetch( {
+				path: `/wp/v2/comments?type=note&status=any&per_page=50&context=edit&post=${ postId }`,
+			} );
+			return comments
+				.filter( ( comment ) =>
+					/attribute-set/.test( comment.meta?._wp_suggestion ?? '' )
+				)
+				.map( ( comment ) => comment.status );
+		} );
+		expect( attributeNoteStatuses ).toEqual( [ 'hold' ] );
+	} );
 } );


### PR DESCRIPTION
## What

Fixes finding **F-14** from the Suggest mode guided testing document: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), like the other fixes in this round.

## The problem

F-14 reported that a heading can end up carrying both an attribute suggestion and an inline suggestion at once - `metadata.noteId: [142, 143]`, one `attribute-set` and one `inline-suggestion` - and asked whether that breaks the stack's "no block holds both a marker and an overlay" invariant.

Measuring it says the coexistence itself is fine, and the finding's own note that "the coexistence is not visually destructive" turns out to be the important half. The two suggestions describe disjoint parts of the block: one changes `level`, the other adds a run of text. Both payloads are well formed, both summaries read correctly, the marker renders, and the front end is unaffected. The invariant as written is broader than the thing it protects, which is an overlay that captures the block's whole `content` and so replaces marker rendering. https://github.com/WordPress/gutenberg/pull/81655 already blocks that destructive direction, so blocking this one too would only take away a combination that works.

What is broken is that the two are not independent when one of them is decided. Accepting or rejecting an inline marker ran `clearOverlay( targetClientId )`, which drops the block's entire overlay entry. An inline suggestion never has an entry of its own, so on its own that call does nothing - but when the block also holds a pending attribute suggestion, that entry is the attribute note's only anchor. The orphan collector notices the anchor is gone, waits out its 500ms grace period and trashes the note. Measured on the base branch, accepting the addition on a heading that also had a pending H2 to H3 change left:

- the heading back at H2 on the canvas, with no way to get the proposal back
- the level note gone from the sidebar entirely
- the comment moved to `trash` on the server, with the block still linking to it in `metadata.noteId`

Reject had the same defect.

## The fix

Clear the overlay entry only when it belongs to the comment being decided. A new `clearOverlayForComment( clientId, commentId )` action compares the entry's `commentId` before removing it, and the two inline decision paths in `provider.js` call that instead of the unconditional clear. Everywhere the overlay entry genuinely is the suggestion being resolved - attribute-set, block-remove, block-insert-after, block-move - keeps using `clearOverlay` unchanged.

The comparison is string-based so a numeric entry id and a string comment id still match, and an entry with no comment yet is left alone.

Note for anyone merging this round: https://github.com/WordPress/gutenberg/pull/81684 also edits `provider.js`, in the same two functions but on different lines (it is adding a `silent` flag to the snackbars). The hunks here are two one-line call swaps plus dependency-array entries, so they should merge, but worth a look.

## Screenshots

Both taken at the same moment: right after accepting the typed addition on a heading that also has a pending heading-level suggestion, with the state settled past the orphan collector's grace period.

Before - the heading has snapped back to H2 and the "Format: heading level" note has been trashed out of the sidebar, leaving only the applied addition:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f14-before.png" alt="After accepting the addition, the heading renders at H2 and the sidebar shows only the resolved note" width="900">

After - the addition is applied and resolved, and the level suggestion is still pending: still previewed on the canvas, still listed with its Accept and Reject buttons:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f14-after.png" alt="After accepting the addition, the heading still previews at H3 and the level suggestion is still pending in the sidebar" width="900">

## Testing instructions

1. Enable the Suggest mode experiment (Gutenberg > Experiments > "Suggestion mode").
2. Create a post with a Heading block reading "My Heading" at level 2.
3. Switch the editor to Suggesting from the Options menu.
4. Select the heading, open the block switcher and pick Heading 3. Wait for the note to save. The heading now previews as H3 and the sidebar lists "Format: heading level".
5. Click into the same heading, press End and type " XYZ". Wait for the second note to save. The sidebar now lists two suggestions and the typed text carries a marker.
6. Accept the addition - the "Add: XYZ" thread, not the other one.
7. Wait a few seconds for things to settle.

Before: the heading drops back to H2 and the heading-level suggestion disappears from the sidebar. Its comment is in the trash and there is no way to accept or reject it.

After: the addition is applied, the heading stays at H3, and the heading-level suggestion is still pending with its decision buttons intact.

Rejecting the addition instead of accepting it behaves the same way in both builds.

### Automated coverage

E2E, in `test/e2e/specs/editor/various/suggestion-mode-review.spec.js`:

- `Suggestion mode review flows > an inline decision leaves a co-resident attribute suggestion pending`

Verified 5/5 red on the unmodified base branch, failing on `expect(locator).toHaveJSProperty` with `Expected: "H3"` / `Received: "H2"`, and 5/5 green with the fix. The test waits out the collector's grace period before asserting, so it judges the settled state rather than going green on the moment before the damage lands. The full `suggestion-mode-review.spec.js` file is 20/20 green.

Unit, in `packages/editor/src/components/suggestion-mode/test/overlay-context.js`:

- `overlayReducer > CLEAR_OVERLAY_FOR_COMMENT > removes the entry when the comment owns it`
- `overlayReducer > CLEAR_OVERLAY_FOR_COMMENT > matches across the string/number boundary`
- `overlayReducer > CLEAR_OVERLAY_FOR_COMMENT > keeps an entry that belongs to another suggestion`
- `overlayReducer > CLEAR_OVERLAY_FOR_COMMENT > keeps an entry that has no comment yet`
- `overlayReducer > CLEAR_OVERLAY_FOR_COMMENT > is a no-op when the block has no entry`

Red on base (2 failed, 18 passed - the guard cases pass vacuously there because an unknown action returns state unchanged), green with the fix.

Neighbouring suites were run against the fixed build too: `suggestion-mode.spec.js`, `suggestion-mode-undo.spec.js`, `suggestion-mode-persistence.spec.js` and `suggestion-mode-overlay-retirement.spec.js` are 44/45, and `block-notes.spec.js` is 48/48. The one failure is the known pre-existing `a closed sidebar stays closed when a suggestion is created`, which is F-17 and is fixed in https://github.com/WordPress/gutenberg/pull/81671. All 444 unit tests under `suggestion-mode`, `inline-suggestions` and `attribute-suggestions` pass.

### Remaining gap

The two suggestions are independent now, but nothing yet merges them for a reviewer who wants to take both in one gesture - they are two threads and two clicks. https://github.com/WordPress/gutenberg/pull/81684 is the PR working on grouped decisions, so that belongs there rather than here.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
