### PR TITLE
Quote readable words in suggestion summaries

### DIFF
--- a/packages/editor/src/components/suggestion-mode/suggestion-summary.js
+++ b/packages/editor/src/components/suggestion-mode/suggestion-summary.js
@@ -20,6 +20,12 @@
  *                        Detected by tag-level diff of the serialized HTML
  *                        and de-duplicated by `joinLabels` so multiple span
  *                        edits don't list the same format twice.
+ *
+ * Quoted lines report what a reviewer would read on screen: the diff behind
+ * them runs on visible text, never on the raw content attribute, so no markup
+ * reaches the sidebar. Changed words keep the spaces that separated them, and
+ * runs that were not adjacent in the text are joined with an ellipsis rather
+ * than run together into a phrase nobody typed.
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalText as WCText } from '@wordpress/components';
@@ -97,10 +103,13 @@ const INLINE_FORMAT_TAG_LABELS = {
 
 const TAG_REGEX = /<\s*([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
 
+const LINE_BREAK_REGEX = /<\s*br\b[^>]*>/gi;
+
 /**
  * Strip HTML tags AND decode entities, leaving only the visible text. Used
  * to decide whether a content change is purely a formatting change (same
- * visible text wrapped in different markup) or a real text edit.
+ * visible text wrapped in different markup) or a real text edit, and to give
+ * the word diff plain text to work on.
  *
  * Wraps `__unstableStripHTML` so HTML entities such as `&amp;` and `&nbsp;`
  * are decoded by the DOM parser rather than via a hand-rolled regex — a
@@ -114,7 +123,15 @@ function stripTags( html ) {
 	if ( typeof html !== 'string' || html === '' ) {
 		return '';
 	}
-	return wpStripHTML( html ).replace( /\s+/g, ' ' ).trim();
+	/*
+	 * `textContent` drops a `<br>` without leaving anything in its place, so
+	 * the words on either side of a soft line break would run together in the
+	 * quoted summary. A line break separates words on screen, so give it a
+	 * separator here too before the tags come off.
+	 */
+	return wpStripHTML( html.replace( LINE_BREAK_REGEX, '\n' ) )
+		.replace( /\s+/g, ' ' )
+		.trim();
 }
 
 /**
@@ -201,27 +218,86 @@ function clampText( text ) {
 }
 
 /**
- * Derive the inserted and deleted text spans from a pair of before/after
- * strings by running the shared word-level diff and concatenating matching
- * segments. Whitespace-only runs are excluded from the counts so a pure
- * format change doesn't surface as "Add: ' '".
+ * Marker placed between two changed runs that are not next to each other in
+ * the text. Without it, "brave new" inserted in one place and "much longer"
+ * inserted three words later are concatenated into the phrase "brave new much
+ * longer", which is not a phrase anyone typed.
+ */
+const RUN_GAP = ' … ';
+
+/**
+ * Collect the changed runs of one side of a word diff, preserving the spaces
+ * that separated the changed words.
  *
- * @param {string} before Original text.
- * @param {string} after  Proposed text.
+ * `wordDiff` tokenizes on `\S+|\s+`, so the space between two changed words is
+ * its own token — and it matches a space on the other side of the diff, which
+ * makes it an `equal` segment sitting between two `delete` (or two `insert`)
+ * segments. Concatenating only the changed segments therefore glues the words
+ * together: "fox jumps over" comes out "foxjumpsover". Whitespace-only `equal`
+ * segments bridge a run instead of breaking it, so the quote reads the way the
+ * text does. An `equal` segment with visible characters is a genuine gap and
+ * does break the run.
+ *
+ * The opposite side of the diff neither bridges nor breaks: the two halves of
+ * a replacement are one edit that happens to interleave.
+ *
+ * @param {Array<{type: string, value: string}>} segments Word-diff segments.
+ * @param {string}                               type     `insert` or `delete`.
+ * @return {string[]} The changed runs, in document order.
+ */
+function changedRuns( segments, type ) {
+	const runs = [];
+	let current = '';
+	let gap = '';
+	for ( const seg of segments ) {
+		if ( seg.type === type ) {
+			if ( current !== '' ) {
+				current += gap;
+			}
+			gap = '';
+			current += seg.value;
+			continue;
+		}
+		if ( seg.type !== 'equal' ) {
+			continue;
+		}
+		if ( ! /\S/.test( seg.value ) ) {
+			gap += seg.value;
+			continue;
+		}
+		if ( current !== '' ) {
+			runs.push( current );
+			current = '';
+		}
+		gap = '';
+	}
+	if ( current !== '' ) {
+		runs.push( current );
+	}
+	return runs;
+}
+
+/**
+ * Derive the inserted and deleted text spans from a pair of before/after
+ * strings by running the shared word-level diff and joining the changed runs.
+ * Whitespace-only runs are excluded from the counts so a pure format change
+ * doesn't surface as "Add: ' '".
+ *
+ * Callers must pass *visible text*, not the raw content attribute: a tag is a
+ * token like any other to a whitespace tokenizer, so diffing markup puts
+ * `<strong>` and `</strong>` into the quoted summary as literal text. A
+ * reviewer wants to read the words being proposed, not the markup they arrive
+ * in — which formats changed is reported separately on the "Formatting:" line.
+ *
+ * @param {string} before Original visible text.
+ * @param {string} after  Proposed visible text.
  * @return {{inserted: string, deleted: string}} Aggregated insertions and
  * deletions, already trimmed and ellipsized.
  */
 function textDelta( before, after ) {
 	const segments = wordDiff( before, after );
-	let inserted = '';
-	let deleted = '';
-	for ( const seg of segments ) {
-		if ( seg.type === 'insert' ) {
-			inserted += seg.value;
-		} else if ( seg.type === 'delete' ) {
-			deleted += seg.value;
-		}
-	}
+	const inserted = changedRuns( segments, 'insert' ).join( RUN_GAP );
+	const deleted = changedRuns( segments, 'delete' ).join( RUN_GAP );
 	return {
 		inserted: inserted.trim() ? ellipsize( inserted ) : '',
 		deleted: deleted.trim() ? ellipsize( deleted ) : '',
@@ -340,11 +416,19 @@ export function summarizeOperations( operations ) {
 
 		const before = op.before ?? '';
 		const after = op.after ?? '';
+		/*
+		 * The quoted lines below report what a reviewer would read on screen,
+		 * so both the format check and the word diff work on visible text.
+		 * Strip once and share it — `stripTags` parses through the DOM, and a
+		 * sidebar can hold a lot of these cards.
+		 */
+		const beforeText = stripTags( before );
+		const afterText = stripTags( after );
 
 		// A pure inline-format change produces identical visible text with
 		// different markup — surface it as "Formatting: bold" rather than
 		// leaking raw `<strong>…</strong>` into an Add/Delete quote.
-		if ( stripTags( before ) === stripTags( after ) && before !== after ) {
+		if ( beforeText === afterText && before !== after ) {
 			const changedFormats = diffInlineFormats( before, after );
 			if ( changedFormats.length > 0 ) {
 				formattingLabels.push( ...changedFormats );
@@ -354,7 +438,7 @@ export function summarizeOperations( operations ) {
 			continue;
 		}
 
-		const { inserted, deleted } = textDelta( before, after );
+		const { inserted, deleted } = textDelta( beforeText, afterText );
 		if ( inserted ) {
 			lines.push( { label: __( 'Add:' ), value: `“${ inserted }”` } );
 		}

--- a/packages/editor/src/components/suggestion-mode/test/suggestion-summary.js
+++ b/packages/editor/src/components/suggestion-mode/test/suggestion-summary.js
@@ -170,6 +170,77 @@ describe( 'summarizeOperations', () => {
 		);
 	} );
 
+	it( 'keeps the spaces between consecutive changed words', () => {
+		// The word diff tokenizes whitespace separately, so a space between
+		// two changed words can match a space on the other side and land in
+		// the diff as an `equal` segment. Concatenating only the changed
+		// segments then glued the words together: a cross-block delete quoted
+		// "blackquartzjudgemyvow," in the sidebar (F-10).
+		const lines = summarizeOperations( [
+			{
+				type: 'attribute-set',
+				attribute: 'content',
+				before: 'alpha beta gamma delta epsilon',
+				after: 'alpha one two three four',
+			},
+		] );
+		expect( lines ).toEqual(
+			expect.arrayContaining( [
+				{ label: 'Add:', value: '“one two three four”' },
+				{ label: 'Delete:', value: '“beta gamma delta epsilon”' },
+			] )
+		);
+	} );
+
+	it( 'does not leak markup into a quoted Add: line', () => {
+		// Diffing the raw content attribute treats a tag as a token, so
+		// `<strong>` and `</strong>` were quoted to the reviewer as literal
+		// text alongside the words they wrap (F-10).
+		const lines = summarizeOperations( [
+			{
+				type: 'attribute-set',
+				attribute: 'content',
+				before: 'A short paragraph here.',
+				after: 'A short paragraph containing <strong>bold text</strong> here.',
+			},
+		] );
+		expect( lines ).toEqual( [
+			{ label: 'Add:', value: '“containing bold text”' },
+		] );
+		expect( lines[ 0 ].value ).not.toMatch( /</ );
+	} );
+
+	it( 'separates changed runs that were not adjacent in the text', () => {
+		// Two insertions three words apart are two proposals, not one phrase.
+		const lines = summarizeOperations( [
+			{
+				type: 'attribute-set',
+				attribute: 'content',
+				before: 'Hello world, this is a sentence.',
+				after: 'Hello brave new world, this is a much longer sentence.',
+			},
+		] );
+		expect( lines ).toEqual( [
+			{ label: 'Add:', value: '“brave new … much longer”' },
+		] );
+	} );
+
+	it( 'treats a line break as a word separator when quoting', () => {
+		// `textContent` drops a `<br>` without leaving a separator behind, so
+		// the words on either side of a soft line break ran together.
+		const lines = summarizeOperations( [
+			{
+				type: 'attribute-set',
+				attribute: 'content',
+				before: 'First line',
+				after: 'First line<br>second line',
+			},
+		] );
+		expect( lines ).toEqual( [
+			{ label: 'Add:', value: '“second line”' },
+		] );
+	} );
+
 	it( 'treats non-text content attributes as a format change', () => {
 		const lines = summarizeOperations( [
 			{

--- a/test/e2e/specs/editor/various/suggestion-mode-summary.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-summary.spec.js
@@ -1,0 +1,129 @@
+/**
+ * E2E coverage for what a suggestion's sidebar summary actually says (#73411).
+ *
+ * The sidebar precis is the only surface a reviewer has for a suggestion they
+ * do not want to hunt down in the canvas, so a quote they cannot read is a
+ * review failure. The summary's word diff used to run over the raw `content`
+ * attribute: a tag is a token like any other to a whitespace tokenizer, so
+ * markup was quoted at the reviewer as literal text, and the spaces separating
+ * the changed words were matched away as `equal` segments and dropped, gluing
+ * "jumps over the lazy dog." into "jumpsover the lazy dog." (F-10).
+ *
+ * The shapes of the summary lines themselves are unit-tested in
+ * `packages/editor/src/components/suggestion-mode/test/suggestion-summary.js`;
+ * this spec pins the end-to-end path, from a real capture in the editor to the
+ * text rendered in the notes sidebar.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` keeps its dropdown open on selection; close it so a
+	// later `Options` click reopens rather than toggles it shut.
+	await page.keyboard.press( 'Escape' );
+}
+
+/*
+ * Returns a promise for the debounced suggestion auto-save REST call. Call
+ * this BEFORE the edit that triggers it: attaching the listener afterwards
+ * races the debounce on slow CI.
+ */
+function suggestionSavedPromise( page ) {
+	return page.waitForResponse(
+		( response ) =>
+			/\/wp\/v2\/comments(\?|$|\/)/.test( response.url() ) &&
+			[ 'POST', 'PUT' ].includes( response.request().method() ) &&
+			response.ok()
+	);
+}
+
+async function openNotesSidebar( page ) {
+	const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
+	const allNotesToggle = topBar.getByRole( 'button', {
+		name: 'All notes',
+		exact: true,
+	} );
+	if (
+		( await allNotesToggle.getAttribute( 'aria-expanded' ) ) === 'false'
+	) {
+		await allNotesToggle.click();
+	}
+	return page.getByRole( 'region', { name: 'Editor settings' } );
+}
+
+test.describe( 'Suggest mode: sidebar summaries', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'a whole-content suggestion quotes readable words, not glued text or markup', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'The quick brown fox jumps over the <strong>lazy</strong> dog.',
+			},
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+
+		/*
+		 * Select the trailing "jumps over the lazy dog." and paste two lines
+		 * over it. A multi-line paste is declined by the addition keyboard, so
+		 * the editor's own paste pipeline commits the merged value and the
+		 * store interceptor diverts it into a whole-content `attribute-set`
+		 * suggestion — the path whose summary this test is about.
+		 */
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 24 } );
+
+		const saved = suggestionSavedPromise( page );
+		pageUtils.setClipboardData( { plainText: 'LINE ONE\nLINE TWO' } );
+		await pageUtils.pressKeys( 'primary+v' );
+		await saved;
+
+		const sidebar = await openNotesSidebar( page );
+		const summary = sidebar
+			.locator( '.editor-collab-sidebar-panel__suggestion-summary' )
+			.filter( { hasText: 'Delete:' } )
+			.first();
+
+		// Anchor on the summary existing before asserting what it says, so a
+		// slow sidebar render can't pass as a well-formed quote.
+		await expect( summary ).toBeVisible();
+
+		// Words keep the spaces that separated them...
+		await expect( summary ).toContainText( 'jumps over the lazy dog.' );
+		await expect( summary ).toContainText( 'LINE ONE' );
+		// ...and no markup is quoted at the reviewer.
+		await expect( summary ).not.toContainText( '<strong>' );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes finding **F-10** from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work tracked in #73411. Based on #80433 (`suggest/inline-wiring`), the top of the Suggest mode stack.

## The problem

The sidebar precis is the only surface a reviewer has for a suggestion they do not want to hunt down in the canvas, and a whole-content suggestion arrived there unreadable.

Paste two lines over a selection in Suggesting mode and the note reads:

```
Add:    “LINEONE<br>LINETWO”
Delete: “jumpsoverthe <strong>lazy</strong> dog.”
```

Markup quoted at the reader as literal text, and the spaces between the changed words gone. The testing pass hit the same thing on a cross-block delete (`Add: "hcontaining<strong>boldtext</strong>ateh..."`) and on a multi-line paste (`Delete: "jumpsover the lazy dog near the riverbank."`).

Both symptoms come from one decision: `textDelta` in `suggestion-summary.js` ran the word diff over the raw `content` attribute.

A tag is a token like any other to a whitespace tokenizer, so `<strong>` became a token and got quoted. And because whitespace is its own token, the space between two changed words matches a space on the other side of the diff and lands as an `equal` segment, which the aggregation dropped along with every other unchanged segment. That is why the gluing is intermittent in the report: it only shows up when the other side of the edit has spaces left over to match with, which is the replace-shaped case.

## The fix

Diff the visible text, and rebuild each quote from runs rather than by concatenating segments.

- `textDelta` now takes plain text. The call site strips once and shares the result with the format check that already sat above it, so no extra DOM parse per card.
- A new `changedRuns` walks the diff and preserves separators: a whitespace-only `equal` segment bridges a run, so consecutive changed words keep their spaces, while an `equal` segment with visible characters breaks it. Runs that were not adjacent in the text are joined with an ellipsis instead of being run together into a phrase nobody typed - "brave new" and "much longer" three words apart now read `“brave new … much longer”`, not `“brave new much longer”`.
- `stripTags` gives a `<br>` a separator before the tags come off. `textContent` drops it without leaving anything behind, so the words on either side of a soft line break were gluing too.

Narrow hunks in a hot file: `suggestion-summary.js` is also touched by #81677 and #81678. This PR changes `stripTags`, replaces the body of `textDelta`, adds `changedRuns` above it, and swaps two arguments at the call site. It does not touch the structural, inline-suggestion, or `Formatting:` branches that those two PRs edit.

One correction to the write-up in the testing doc. It lists a third symptom, "whitespace-only additions always read `Add: " "` regardless of how many spaces". Measured on this base, that comes from the inline-suggestion branch rather than this diff path - the attribute path drops a whitespace-only change to `Format: content` instead - and #81677 already answers it with `describeWhitespace`. Nothing here duplicates that.

## Screenshots

The same suggestion - two lines pasted over "jumps over the lazy dog." where "lazy" is bold - as the sidebar reports it.

Before:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f10-summary-before.png" alt="Sidebar note reading Add: LINEONE<br>LINETWO and Delete: jumpsoverthe <strong>lazy</strong> dog." width="420">

After:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f10-summary-after.png" alt="Sidebar note reading Add: LINE ONE LINE TWO and Delete: jumps over the lazy dog." width="420">

## Testing instructions

1. Enable the `gutenberg-suggestion-mode` experiment.
2. Create a post with one paragraph reading `The quick brown fox jumps over the lazy dog.` and bold the word "lazy".
3. Switch the editor to Suggesting from the Options menu.
4. Click into the paragraph, press End, then shift+left arrow 24 times to select `jumps over the lazy dog.`.
5. Paste two lines of text over the selection - `LINE ONE`, newline, `LINE TWO`.
6. Open the All notes sidebar and read the new note's summary.

Before: `Add: “LINEONE<br>LINETWO”` and `Delete: “jumpsoverthe <strong>lazy</strong> dog.”`

After: `Add: “LINE ONE LINE TWO”` and `Delete: “jumps over the lazy dog.”`

### Automated coverage

Four unit tests in `packages/editor/src/components/suggestion-mode/test/suggestion-summary.js`:

- `keeps the spaces between consecutive changed words`
- `does not leak markup into a quoted Add: line`
- `separates changed runs that were not adjacent in the text`
- `treats a line break as a word separator when quoting`

All four verified red against the unmodified base source (`4 failed, 24 passed`) and green with the fix (`28 passed`). The whole suggestion-mode and inline-suggestions unit set passes: 26 suites, 429 tests.

One e2e test in the new `test/e2e/specs/editor/various/suggestion-mode-summary.spec.js`:

- `Suggest mode: sidebar summaries › a whole-content suggestion quotes readable words, not glued text or markup`

Verified red against the base build with the received string `Add: “LINEONE<br>LINETWO”Delete: “jumpsoverthe <strong>lazy</strong> dog.”`, then green with the fix, five for five under `--repeat-each=5`.

The neighbouring suites were run too - `suggestion-mode`, `suggestion-mode-review`, `suggestion-mode-overlay-retirement`, `suggestion-mode-persistence`, `suggestion-mode-undo` - 63 passed, 1 failed. The failure is the known pre-existing F-17 case, "a closed sidebar stays closed when a suggestion is created", which #81671 fixes and is not on this base.

## AI Use

Claude Code did the typing here, I did the asking. I will review and test.
