### PR TITLE
List View: show pending block suggestions on the row

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -30,6 +30,7 @@ import { useListViewContext } from './context';
 import {
 	getBlockPositionDescription,
 	getBlockPropertiesDescription,
+	getBlockSuggestionTreatment,
 	focusListItem,
 } from './utils';
 import { store as blockEditorStore } from '../../store';
@@ -119,6 +120,7 @@ function ListViewBlock( {
 		positionLabel,
 		isSynced,
 		isLocked,
+		suggestion,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -146,6 +148,7 @@ function ListViewBlock( {
 				positionLabel: getPositionTypeLabel( attributes ),
 				isSynced: isSyncedBlock( clientId ),
 				isLocked: isLockedBlock( clientId ),
+				suggestion: attributes?.metadata?.suggestion,
 			};
 		},
 		[ clientId ]
@@ -556,6 +559,13 @@ function ListViewBlock( {
 		viewportSettings
 	);
 
+	// Pending structural suggestions (insert / remove / move) are shown on the
+	// canvas but were invisible here, so a reviewer navigating by List View —
+	// including anyone reading it with assistive technology — had no way to
+	// tell that a block is proposed for removal. Both halves matter: the class
+	// drives the row treatment, the label joins the row's description.
+	const blockSuggestionTreatment = getBlockSuggestionTreatment( suggestion );
+
 	const hasSiblings = siblingBlockCount > 0;
 	const canShowBlockActions = showBlockActions && ! isDisabled;
 	const hasRenderedMovers = showBlockMovers && hasSiblings && ! isDisabled;
@@ -576,7 +586,7 @@ function ListViewBlock( {
 		colSpan = 3;
 	}
 
-	const classes = clsx( {
+	const classes = clsx( blockSuggestionTreatment?.className, {
 		'is-selected': isSelected,
 		'is-first-selected': isFirstSelectedBlock,
 		'is-last-selected': isLastSelectedBlock,
@@ -665,6 +675,7 @@ function ListViewBlock( {
 								blockPositionDescription,
 								blockPropertiesDescription,
 								blockVisibilityDescription,
+								blockSuggestionTreatment?.label,
 							]
 								.filter( Boolean )
 								.join( ' ' ) }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -466,6 +466,55 @@
 		}
 	}
 
+	// Pending structural suggestions. On the canvas these read as an outline,
+	// a strikethrough or a "Suggested move" tab; List View showed nothing at
+	// all, which is the surface where structural change is easiest to take in.
+	// Mirror the canvas semantics — strikethrough for a proposed removal,
+	// underline for a proposed insertion, a dashed underline for a proposed
+	// move. Colour never carries this alone: the row's accessible description
+	// says the same thing in words (see `getBlockSuggestionTreatment`).
+	//
+	// The values repeat `block-list/content-suggestion.scss` rather than
+	// sharing with it, because that stylesheet is compiled into the canvas
+	// iframe and List View lives in the editor chrome.
+	&.is-suggestion-pending-insert,
+	&.is-suggestion-pending-remove,
+	&.is-suggestion-pending-move {
+		.block-editor-list-view-block-select-button__title {
+			text-decoration-thickness: 1px;
+			text-underline-offset: 2px;
+		}
+	}
+
+	&.is-suggestion-pending-remove .block-editor-list-view-block-select-button__title {
+		text-decoration-line: line-through;
+	}
+
+	&.is-suggestion-pending-insert .block-editor-list-view-block-select-button__title,
+	&.is-suggestion-pending-move .block-editor-list-view-block-select-button__title {
+		text-decoration-line: underline;
+	}
+
+	&.is-suggestion-pending-move .block-editor-list-view-block-select-button__title {
+		text-decoration-style: dashed;
+	}
+
+	// Tint only when the row isn't selected — a selected row paints its cells
+	// with the admin theme colour and its text white.
+	&:not(.is-selected) {
+		&.is-suggestion-pending-remove .block-editor-list-view-block-select-button__title {
+			color: $alert-red;
+		}
+
+		&.is-suggestion-pending-insert .block-editor-list-view-block-select-button__title {
+			color: #007017;
+		}
+
+		&.is-suggestion-pending-move .block-editor-list-view-block-select-button__title {
+			color: #188038;
+		}
+	}
+
 	&.is-disabled {
 		opacity: 0.2;
 		@media not ( prefers-reduced-motion ) {

--- a/packages/block-editor/src/components/list-view/test/utils.js
+++ b/packages/block-editor/src/components/list-view/test/utils.js
@@ -1,4 +1,43 @@
-import { getCommonDepthClientIds, getDragDisplacementValues } from '../utils';
+import {
+	getBlockSuggestionTreatment,
+	getCommonDepthClientIds,
+	getDragDisplacementValues,
+} from '../utils';
+
+describe( 'getBlockSuggestionTreatment', () => {
+	it( 'returns nothing for a block with no structural suggestion', () => {
+		expect( getBlockSuggestionTreatment( undefined ) ).toBe( undefined );
+		expect( getBlockSuggestionTreatment( null ) ).toBe( undefined );
+		expect( getBlockSuggestionTreatment( {} ) ).toBe( undefined );
+	} );
+
+	it( 'ignores a marker type it does not recognize rather than inventing a class', () => {
+		expect( getBlockSuggestionTreatment( { type: 'pending-shrug' } ) ).toBe(
+			undefined
+		);
+	} );
+
+	it( 'describes each structural marker with a class and a spoken label', () => {
+		expect(
+			getBlockSuggestionTreatment( { type: 'pending-insert' } )
+		).toEqual( {
+			className: 'is-suggestion-pending-insert',
+			label: 'Suggested insertion.',
+		} );
+		expect(
+			getBlockSuggestionTreatment( { type: 'pending-remove' } )
+		).toEqual( {
+			className: 'is-suggestion-pending-remove',
+			label: 'Suggested removal.',
+		} );
+		expect(
+			getBlockSuggestionTreatment( { type: 'pending-move' } )
+		).toEqual( {
+			className: 'is-suggestion-pending-move',
+			label: 'Suggested move destination.',
+		} );
+	} );
+} );
 
 describe( 'getCommonDepthClientIds', () => {
 	it( 'should return start and end when no depth is provided', () => {

--- a/packages/block-editor/src/components/list-view/utils.js
+++ b/packages/block-editor/src/components/list-view/utils.js
@@ -29,6 +29,50 @@ export const getBlockPropertiesDescription = ( positionLabel, isLocked ) =>
 		.join( ' ' );
 
 /**
+ * Describe a block's pending structural suggestion for List View.
+ *
+ * A structural suggestion lives on the block as `metadata.suggestion` and, on
+ * the canvas, is conveyed entirely by colour and text-decoration: an outline
+ * for an insertion, a strikethrough for a removal, a tab for a move. None of
+ * that reaches List View, which is both the primary way to perceive
+ * *structural* change and a key non-visual navigation surface — so a row whose
+ * block is slated for removal has to carry the same information, in a form
+ * that survives having no sight of the canvas.
+ *
+ * The class names match the canvas treatment on purpose (see
+ * `block-list/content-suggestion.scss`), so the two surfaces stay in step.
+ * Unrecognized marker types return nothing rather than an invented class.
+ *
+ * @param {?Object} suggestion Value of the block's `metadata.suggestion`.
+ * @return {?{className: string, label: string}} Row class and the sentence
+ * appended to the row's accessible description, or undefined when the block
+ * carries no structural suggestion.
+ */
+export const getBlockSuggestionTreatment = ( suggestion ) => {
+	switch ( suggestion?.type ) {
+		case 'pending-insert':
+			return {
+				className: 'is-suggestion-pending-insert',
+				label: __( 'Suggested insertion.' ),
+			};
+		case 'pending-remove':
+			return {
+				className: 'is-suggestion-pending-remove',
+				label: __( 'Suggested removal.' ),
+			};
+		case 'pending-move':
+			return {
+				className: 'is-suggestion-pending-move',
+				// Matches the canvas wording: the block sits at the position it
+				// is proposed to move to, not the one it came from.
+				label: __( 'Suggested move destination.' ),
+			};
+		default:
+			return undefined;
+	}
+};
+
+/**
  * Returns true if the client ID occurs within the block selection or multi-selection,
  * or false otherwise.
  *

--- a/test/e2e/specs/editor/various/suggestion-mode-list-view.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-list-view.spec.js
@@ -1,0 +1,186 @@
+/**
+ * E2E coverage for how pending block-level suggestions surface in List View
+ * (#73411, finding F-24). The canvas carries the whole story of a structural
+ * suggestion - outline, strikethrough, move tab - and every one of those cues
+ * is colour and decoration. List View is the primary way to perceive
+ * structural change and the main non-visual navigation surface, so a row whose
+ * block is slated for removal has to say so both in its class and in its
+ * accessible description.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection.
+	await page.keyboard.press( 'Escape' );
+}
+
+/**
+ * Opens List View and returns its treegrid locator.
+ *
+ * @param {import('@playwright/test').Page} page      Page under test.
+ * @param {Object}                          pageUtils Playwright page utils.
+ * @return {Promise<import('@playwright/test').Locator>} The List View treegrid.
+ */
+async function openListView( page, pageUtils ) {
+	await pageUtils.pressKeys( 'access+o' );
+	const listView = page.getByRole( 'treegrid', {
+		name: 'Block navigation structure',
+	} );
+	await expect( listView ).toBeVisible();
+	return listView;
+}
+
+/**
+ * Finds the List View row belonging to a canvas block. Keys off the block's
+ * client id rather than its index, since every paragraph row shares the same
+ * accessible name.
+ *
+ * @param {import('@playwright/test').Locator} listView    List View treegrid.
+ * @param {import('@playwright/test').Locator} canvasBlock The block in the canvas.
+ * @return {Promise<import('@playwright/test').Locator>} The matching row.
+ */
+async function rowForBlock( listView, canvasBlock ) {
+	await expect( canvasBlock ).toHaveAttribute( 'data-block', /.+/ );
+	const clientId = await canvasBlock.getAttribute( 'data-block' );
+	return listView.locator( `[role="row"][data-block="${ clientId }"]` );
+}
+
+test.describe( 'Suggestion mode - List View', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'marks a pending removal in List View, and leaves untouched rows alone', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Keep me' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Remove me' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const doomed = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Remove me' } );
+		await doomed.click();
+		await editor.clickBlockOptionsMenuItem( 'Delete' );
+
+		// Anchor on the canvas treatment first: once the block carries the
+		// pending-remove class the marker is committed, so a later assertion
+		// about List View cannot land before the store has caught up.
+		await expect( doomed ).toHaveClass( /is-suggestion-pending-remove/ );
+
+		const listView = await openListView( page, pageUtils );
+		const doomedRow = await rowForBlock( listView, doomed );
+
+		await expect( doomedRow ).toHaveClass( /is-suggestion-pending-remove/ );
+		await expect(
+			doomedRow.getByRole( 'link' )
+		).toHaveAccessibleDescription( /Suggested removal\./ );
+
+		// The surviving paragraph is untouched - no class, nothing announced.
+		const keeper = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Keep me' } );
+		const keeperRow = await rowForBlock( listView, keeper );
+		await expect( keeperRow ).not.toHaveClass( /is-suggestion-pending/ );
+		await expect(
+			keeperRow.getByRole( 'link' )
+		).not.toHaveAccessibleDescription( /Suggested/ );
+	} );
+
+	test( 'marks a pending insertion in List View', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Existing paragraph' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Newly suggested paragraph' );
+
+		const added = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'Newly suggested paragraph' } );
+		await expect( added ).toHaveClass( /is-suggestion-pending-insert/ );
+
+		const listView = await openListView( page, pageUtils );
+		const addedRow = await rowForBlock( listView, added );
+
+		await expect( addedRow ).toHaveClass( /is-suggestion-pending-insert/ );
+		await expect(
+			addedRow.getByRole( 'link' )
+		).toHaveAccessibleDescription( /Suggested insertion\./ );
+	} );
+
+	test( 'marks a pending move in List View', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First paragraph' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second paragraph' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const mover = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.filter( { hasText: 'First paragraph' } );
+		// Select via the store: the freshly-inserted second block's floating
+		// toolbar hovers over the first paragraph and intercepts a raw click.
+		await editor.selectBlocks( mover );
+		await editor.clickBlockToolbarButton( 'Move down' );
+		await expect( mover ).toHaveClass( /is-suggestion-pending-move/ );
+
+		const listView = await openListView( page, pageUtils );
+		const moverRow = await rowForBlock( listView, mover );
+
+		await expect( moverRow ).toHaveClass( /is-suggestion-pending-move/ );
+		await expect(
+			moverRow.getByRole( 'link' )
+		).toHaveAccessibleDescription( /Suggested move destination\./ );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes finding F-24 from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work in #73411. Based on `suggest/inline-wiring` (#80433), same as the other fixes in this round.

## The problem

Suggest a block insertion, a block removal or a block move, then open List View. Every row reports the same thing it reported before the suggestion existed: no class, and an accessible description that mentions position and nothing else. The testing pass measured `suggestionClasses: "none"` on all rows with pending-insert blocks in the document.

The canvas does carry the story - an outline for an insertion, a strikethrough for a removal, a "Suggested move" tab - but all of it is colour and text-decoration, which is exactly the shape of the complaint in F-23 (fixed for inline markers in #81663). List View is the clearest place to take in *structural* change, which is the thing the canvas conveys least well, and it is the main way to navigate a post without seeing it. So the reviewers least served by tinted canvas markers were the ones getting nothing at all here.

The doc's proposed remedy - "a badge or a class on rows whose block carries `metadata.suggestion`" - held up on measurement. Nothing in List View reads `metadata.suggestion` at all, though the neighbouring `metadata.blockVisibility` is already read a few lines away.

## The fix

`ListViewBlock` already pulls `metadata.blockVisibility` out of the block's attributes to build the row's description. Read `metadata.suggestion` in the same `useSelect` and give the row both halves of the treatment:

- The row gets the same `is-suggestion-pending-insert` / `-remove` / `-move` class the canvas uses, so the two surfaces stay in step. In List View that drives a strikethrough for a proposed removal, an underline for a proposed insertion and a dashed underline for a proposed move, tinted only when the row is not the selected one (a selected row already paints its cells with the admin theme colour).
- A sentence joins the row's existing `aria-describedby` text: "Suggested removal.", "Suggested insertion.", "Suggested move destination." - the last matching the wording the canvas already uses for the move destination. Colour never carries this on its own.

The mapping lives in one small pure helper, `getBlockSuggestionTreatment`, next to the other List View description helpers, and returns nothing for a marker type it does not recognise rather than inventing a class name.

The three suggestion colours repeat the values in `block-list/content-suggestion.scss` rather than sharing with it, because that stylesheet is compiled into the canvas iframe and List View lives in the editor chrome. Noted in a comment where they are defined.

**Remaining gap:** the row is not tinted with the suggester's avatar colour the way canvas markers are. The per-author stylesheet is injected into the canvas through `useStyleOverride`, so reaching the chrome would mean a second injection path - out of scope here, and the who is already available from the note card.

This PR does not touch any of the files the other open fixes in this round are editing.

## Screenshots

List View with one paragraph suggested for insertion and one suggested for removal. The panel reads each row's live class and its resolved accessible description straight out of the editor, since half of this fix has no visual surface of its own.

Before - the canvas shows both suggestions, every List View row reports `none` and says nothing:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f24-list-view-before.png" alt="Before: List View rows carry no suggestion class and no suggestion description" width="700">

After - the insertion row is underlined and green, the removal row struck through and red, and each row's description names the pending change:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f24-list-view-after.png" alt="After: List View rows carry the suggestion class and announce the pending change" width="700">

## Testing instructions

1. Enable the `gutenberg-suggestion-mode` experiment.
2. Create a post with a heading and two paragraphs, then switch the Options menu to Suggesting.
3. Select the last paragraph and delete it. It stays on the canvas, struck through.
4. Click into the first paragraph, press End then Enter, and type a new paragraph.
5. Open List View (`Shift+Alt+O`).

Before: all four rows look identical, and a screen reader reads only "Block N of 4, Level 1." on each.

After: the inserted paragraph's row is underlined and green, the deleted paragraph's row is struck through and red, and their descriptions end with "Suggested insertion." and "Suggested removal." respectively. The untouched heading and paragraph are unchanged.

6. To check the move case, select a paragraph and use Move down in the block toolbar. Its List View row picks up a dashed underline and "Suggested move destination."

### Automated coverage

New e2e spec `test/e2e/specs/editor/various/suggestion-mode-list-view.spec.js`:

- `marks a pending removal in List View, and leaves untouched rows alone`
- `marks a pending insertion in List View`
- `marks a pending move in List View`

All three were verified red on an unmodified `suggest/inline-wiring` build (`Received string: "block-editor-list-view-leaf is-selected is-first-selected is-last-selected is-draggable"` - no suggestion class present) and green with the fix, including a `--repeat-each=3` run with no flakes.

New unit tests in `packages/block-editor/src/components/list-view/test/utils.js` cover `getBlockSuggestionTreatment` for all three marker types, for a block with no suggestion, and for an unrecognised marker type.

The neighbouring `list-view.spec.js` suite was run against the base build first for a baseline: 15 passed, 1 skipped, 1 pre-existing failure (`block settings dropdown menu`). Identical result with the fix applied. `suggestion-mode.spec.js` and `suggestion-mode-review.spec.js` were also run with the fix: 40 passed, with only the known F-17 failure (`a closed sidebar stays closed when a suggestion is created`, fixed separately in #81671).

## AI Use

Claude Code did the typing here, I did the asking - code, tests and description. I will review and test.
