### PR TITLE
Suggest mode: strike a suggested split's removed text through in place

### DIFF
--- a/packages/editor/src/components/suggestion-mode/plan-store-content-edit.js
+++ b/packages/editor/src/components/suggestion-mode/plan-store-content-edit.js
@@ -1,0 +1,83 @@
+import { planEditMarkers } from '../inline-suggestions';
+
+/**
+ * True for plain strings and for objects that stringify to a meaningful HTML
+ * form (the rich-text package's `RichTextData` is the case we care about).
+ * Duck-typed against `toString` rather than `instanceof RichTextData` so this
+ * module doesn't take a hard dependency on the rich-text package's internal
+ * class. Mirrors the same check in `with-suggestion-overlay.js`, which can't be
+ * imported from here — that module already imports this directory's
+ * `store-interceptor`.
+ *
+ * @param {*} value Candidate attribute value.
+ * @return {boolean} True when `String( value )` will produce useful HTML.
+ */
+function isStringLike( value ) {
+	if ( typeof value === 'string' ) {
+		return true;
+	}
+	return (
+		value !== null &&
+		value !== undefined &&
+		typeof value.toString === 'function' &&
+		value.toString !== Object.prototype.toString
+	);
+}
+
+/**
+ * Decide whether a store-level attribute change is a plain removal of text from
+ * a block's `content` that can be re-expressed as an inline deletion marker.
+ *
+ * `withSuggestionOverlay` already asks a version of this question for edits that
+ * arrive through a block's `setAttributes` prop. The store interceptor sees the
+ * other half — changes dispatched straight at the block-editor store — and had
+ * no equivalent, so every one of them became a whole-attribute overlay. The
+ * splitting Enter is the case that matters (#73411, F-07):
+ * `__unstableSplitSelection` dispatches `replaceBlocks` with a truncated head
+ * and a new tail block, and the head's truncation reached the overlay. The
+ * overlay renders its clean snapshot *in place of* the block's value, so the
+ * text proposed for removal simply vanished from the canvas: the split read as
+ * already applied rather than as something to review.
+ *
+ * Removals are the asymmetric case, which is why this is limited to them. When
+ * an overlay swallows an insertion the reviewer still sees the proposed text —
+ * it is the new value being rendered. When it swallows a removal there is
+ * nothing left on screen to review, and the block reads as a completed edit.
+ * Insertions and type-overs reaching this seam (a multi-line paste, most
+ * notably) keep the overlay capture they have today; converting those is the
+ * "reach the fallback less often" work F-09 leaves open.
+ *
+ * Also narrow in the other axes: only a change whose sole user-visible key is
+ * `content` qualifies, and only a plan whose single action opens a fresh note —
+ * the bar `SuggestionContentReconciler` can actually execute. Anything else (a
+ * mixed attribute change, an edit that would grow or drop an existing marker, a
+ * diff the planner can't resolve) returns null and keeps today's behaviour.
+ *
+ * @param {Object}        previous   Block attributes before the change.
+ * @param {Object}        current    Block attributes after the change.
+ * @param {Object}        changed    Changed attributes, system metadata already stripped.
+ * @param {number|string} [authorId] Current author id, stamped on new markers.
+ * @return {?{ kind: string, actions: Array }} The marker plan, or null when the
+ * change should keep taking the overlay path.
+ */
+export function planStoreContentEdit( previous, current, changed, authorId ) {
+	const keys = Object.keys( changed ?? {} );
+	if ( keys.length !== 1 || keys[ 0 ] !== 'content' ) {
+		return null;
+	}
+	const prevContent = previous?.content;
+	const nextContent = current?.content;
+	if ( ! isStringLike( prevContent ) || ! isStringLike( nextContent ) ) {
+		return null;
+	}
+	const plan = planEditMarkers( prevContent, nextContent, { authorId } );
+	const actions = plan?.actions ?? [];
+	if ( actions.length !== 1 ) {
+		return null;
+	}
+	const [ action ] = actions;
+	if ( action.type !== 'wrap-del' || ! action.newNote ) {
+		return null;
+	}
+	return plan;
+}

--- a/packages/editor/src/components/suggestion-mode/store-interceptor.js
+++ b/packages/editor/src/components/suggestion-mode/store-interceptor.js
@@ -55,6 +55,7 @@ import { useSuggestionOverlay } from './overlay-context';
 import { EDITOR_STORE_NAME, SUGGEST_INTENT } from './constants';
 import { parseSuggestionPayload } from './provider';
 import { createRevertGuard } from '../attribute-suggestions/revert-guard';
+import { planStoreContentEdit } from './plan-store-content-edit';
 import { unlock } from '../../lock-unlock';
 
 const BLOCK_EDITOR_STORE_NAME = 'core/block-editor';
@@ -722,6 +723,7 @@ export default function SuggestionStoreInterceptor() {
 		isDeferredInsertion,
 		clearDeferredInsertions,
 		consumeUndoRedoAdoption,
+		requestContentSuggestion,
 	} = useSuggestionOverlay();
 	const registry = useRegistry();
 
@@ -752,6 +754,9 @@ export default function SuggestionStoreInterceptor() {
 
 	const consumeUndoRedoAdoptionRef = useRef( consumeUndoRedoAdoption );
 	consumeUndoRedoAdoptionRef.current = consumeUndoRedoAdoption;
+
+	const requestContentSuggestionRef = useRef( requestContentSuggestion );
+	requestContentSuggestionRef.current = requestContentSuggestion;
 
 	// The deferred-insertion callbacks are identity-stable (`useCallback`
 	// with no dependencies in the overlay provider), so unlike the values
@@ -1085,27 +1090,56 @@ export default function SuggestionStoreInterceptor() {
 					continue;
 				}
 
-				// Capture a baseline if one isn't already set. The HOC's
-				// own captureBaseline only fires for `setAttributes` calls;
-				// for store-level mutations we have to seed one here.
-				const overlayEntries = entriesRef.current;
-				if ( ! overlayEntries[ clientId ] ) {
-					const block = blockEditor.getBlock?.( clientId );
-					captureBaselineRef.current(
-						clientId,
-						block?.name ?? '',
-						previous
-					);
-				}
-
-				// Route the changes into the overlay so the user still sees
-				// their edit, then revert the underlying store back to the
-				// snapshot so the post itself isn't actually modified. System
-				// metadata is filtered out of the overlay payload — it isn't
-				// a user edit, and `delta.restore` already preserves it.
+				// System metadata is filtered out before the change is
+				// classified — it isn't a user edit, and `delta.restore`
+				// already preserves it.
 				const overlayChanged = stripSystemMetadata( delta.changed );
-				if ( Object.keys( overlayChanged ).length > 0 ) {
-					setOverlayAttributesRef.current( clientId, overlayChanged );
+
+				/*
+				 * A `content` change that is a plain removal goes to the
+				 * content reconciler as an inline deletion marker rather than
+				 * to the overlay. The splitting Enter is why (#73411, F-07):
+				 * it dispatches `replaceBlocks` with a truncated head, so the
+				 * removed tail reached the overlay, which draws its clean
+				 * snapshot in place of the block's value — the removal rendered
+				 * as already done instead of struck through where it still is.
+				 * The reconciler runs asynchronously and re-reads the block, so
+				 * the revert below has to land first; the overlay fallback is
+				 * unaffected by the reordering because it works off `delta`.
+				 */
+				const markerPlan = planStoreContentEdit(
+					previous,
+					current,
+					overlayChanged,
+					currentUserId
+				);
+				const block = blockEditor.getBlock?.( clientId );
+
+				// Capture a baseline if one isn't already set (the HOC's own
+				// captureBaseline only fires for `setAttributes` calls; for
+				// store-level mutations we have to seed one here), then route
+				// the changes into the overlay so the user still sees their
+				// edit. The revert below restores the store so the post itself
+				// isn't actually modified.
+				const routeToOverlay = () => {
+					const overlayEntries = entriesRef.current;
+					if ( ! overlayEntries[ clientId ] ) {
+						captureBaselineRef.current(
+							clientId,
+							block?.name ?? '',
+							previous
+						);
+					}
+					if ( Object.keys( overlayChanged ).length > 0 ) {
+						setOverlayAttributesRef.current(
+							clientId,
+							overlayChanged
+						);
+					}
+				};
+
+				if ( ! markerPlan ) {
+					routeToOverlay();
 				}
 
 				// Record what this revert will make true, so its echo can be
@@ -1140,6 +1174,26 @@ export default function SuggestionStoreInterceptor() {
 					clientId,
 					blockEditor.getBlockAttributes( clientId )
 				);
+
+				/*
+				 * Hand the marker plan over now that the block is back at the
+				 * value the plan was diffed from. The reconciler opens the
+				 * note(s) and writes the marked content through an interceptor
+				 * bypass. It returns a synchronous verdict, so a refusal (no
+				 * handler mounted, as in isolated unit tests) still lands in
+				 * the overlay exactly as it did before this branch existed.
+				 */
+				if ( markerPlan ) {
+					const handed = requestContentSuggestionRef.current?.( {
+						clientId,
+						blockName: block?.name ?? '',
+						prevContent: previous?.content,
+						plan: markerPlan,
+					} );
+					if ( ! handed ) {
+						routeToOverlay();
+					}
+				}
 
 				// The snapshot reflects the (now-restored) baseline for this
 				// block; do NOT update it to `current` here.

--- a/packages/editor/src/components/suggestion-mode/test/plan-store-content-edit.js
+++ b/packages/editor/src/components/suggestion-mode/test/plan-store-content-edit.js
@@ -1,0 +1,140 @@
+import {
+	RichTextData,
+	unregisterFormatType,
+	store as richTextStore,
+} from '@wordpress/rich-text';
+import { select } from '@wordpress/data';
+import { planStoreContentEdit } from '../plan-store-content-edit';
+import {
+	registerSuggestionFormat,
+	SUGGESTION_FORMAT_NAME,
+} from '../../inline-suggestions/format';
+
+beforeAll( () => {
+	registerSuggestionFormat();
+} );
+
+afterAll( () => {
+	if ( select( richTextStore ).getFormatType( SUGGESTION_FORMAT_NAME ) ) {
+		unregisterFormatType( SUGGESTION_FORMAT_NAME );
+	}
+} );
+
+const SENTENCE = 'The quick brown fox jumps over the lazy dog.';
+const HEAD = 'The quick brown fox ';
+
+describe( 'planStoreContentEdit', () => {
+	it( 'plans a deletion marker for the head half of a block split', () => {
+		// What `__unstableSplitSelection` dispatches: the head block keeps its
+		// client id and loses everything after the caret.
+		const plan = planStoreContentEdit(
+			{ content: SENTENCE },
+			{ content: HEAD },
+			{ content: HEAD },
+			1
+		);
+		expect( plan ).toEqual( {
+			kind: 'delete',
+			actions: [
+				{
+					type: 'wrap-del',
+					start: HEAD.length,
+					end: SENTENCE.length,
+					newNote: true,
+				},
+			],
+		} );
+	} );
+
+	it( 'accepts RichTextData values on either side', () => {
+		const plan = planStoreContentEdit(
+			{ content: RichTextData.fromHTMLString( SENTENCE ) },
+			{ content: RichTextData.fromHTMLString( HEAD ) },
+			{ content: RichTextData.fromHTMLString( HEAD ) },
+			1
+		);
+		expect( plan?.actions?.[ 0 ]?.type ).toBe( 'wrap-del' );
+	} );
+
+	it( 'declines a change that touches any attribute besides content', () => {
+		expect(
+			planStoreContentEdit(
+				{ content: SENTENCE, level: 2 },
+				{ content: HEAD, level: 3 },
+				{ content: HEAD, level: 3 },
+				1
+			)
+		).toBeNull();
+		expect(
+			planStoreContentEdit(
+				{ content: SENTENCE, level: 2 },
+				{ content: SENTENCE, level: 3 },
+				{ level: 3 },
+				1
+			)
+		).toBeNull();
+	} );
+
+	it( 'declines a non-string-like content value', () => {
+		expect(
+			planStoreContentEdit(
+				{ content: SENTENCE },
+				{ content: undefined },
+				{ content: undefined },
+				1
+			)
+		).toBeNull();
+	} );
+
+	it( 'declines when the planner has no action to propose', () => {
+		expect(
+			planStoreContentEdit(
+				{ content: SENTENCE },
+				{ content: SENTENCE },
+				{ content: SENTENCE },
+				1
+			)
+		).toBeNull();
+	} );
+
+	it( 'declines an insertion, which the overlay still renders for the reviewer', () => {
+		// A multi-line paste reaches this same seam. The overlay shows the
+		// pasted text (it is the new value), so there is nothing invisible to
+		// rescue and it keeps the capture it has today.
+		expect(
+			planStoreContentEdit(
+				{ content: 'Start' },
+				{ content: 'Start one two' },
+				{ content: 'Start one two' },
+				1
+			)
+		).toBeNull();
+	} );
+
+	it( 'declines a type-over, whose plan is a deletion plus an addition', () => {
+		expect(
+			planStoreContentEdit(
+				{ content: SENTENCE },
+				{ content: HEAD + 'sleeps.' },
+				{ content: HEAD + 'sleeps.' },
+				1
+			)
+		).toBeNull();
+	} );
+
+	it( 'declines a plan that would edit an existing marker instead of opening a note', () => {
+		// Growing the author's own open addition is a `grow-add`, which reuses
+		// an existing note id — the reconciler only executes plans whose every
+		// action opens a fresh note, so this keeps the overlay path.
+		const withAddition =
+			'Hello <mark data-suggestion-id="7" data-suggestion-type="add" data-author="1" class="wp-suggestion">NEW</mark>';
+		expect(
+			planStoreContentEdit(
+				{ content: withAddition },
+				{ content: withAddition.replace( 'NEW', 'NEWER' ) },
+				{ content: withAddition.replace( 'NEW', 'NEWER' ) },
+				1
+			)
+		).toBeNull();
+	} );
+} );

--- a/test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js
@@ -518,6 +518,64 @@ test.describe( 'Suggest mode: overlay-retirement safety net (Phase 0)', () => {
 	} );
 
 	/*
+	 * A splitting Enter reaches the store as `replaceBlocks` — a truncated head
+	 * plus a new tail block — so it never passes through the overlay HOC's
+	 * `setAttributes` seam and the head's truncation used to be captured as a
+	 * whole-attribute overlay. The overlay renders its clean snapshot in place
+	 * of the block's value, which drew the proposed removal as already done: a
+	 * short first paragraph followed by a pending-insert block, indistinguishable
+	 * from a split that had actually been applied (#73411, F-07).
+	 */
+	test( 'seam: a split strikes the removed tail through in place', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'The quick brown fox jumps over the lazy dog.',
+			},
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		// Caret between "fox " and "jumps": the tail is the last 24 characters.
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 24 } );
+		await page.keyboard.press( 'Enter' );
+
+		// Positive signal first: the deletion marker lands on the head block,
+		// with the removed run still readable inside it.
+		const delMarker = paragraph.locator(
+			`${ SUGGESTION_MARK }[data-suggestion-type="del"]`
+		);
+		await expect( delMarker ).toHaveAttribute( 'data-suggestion-id', /\d/ );
+		await expect( delMarker ).toHaveText( 'jumps over the lazy dog.' );
+		await deselect( page );
+
+		// The head block keeps its whole sentence rather than being repainted
+		// as the post-split "The quick brown fox ".
+		await expect( paragraph ).toHaveText(
+			'The quick brown fox jumps over the lazy dog.'
+		);
+		// And it carries no overlay, so the marker is the only representation
+		// of the pending change on that block.
+		await expect( paragraph ).not.toHaveClass( /is-suggestion-pending\b/ );
+
+		// The other half of the split is still proposed as an inserted block.
+		const tail = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.nth( 1 );
+		await expect( tail ).toHaveClass( /is-suggestion-pending-insert/ );
+		await expect( tail ).toHaveText( 'jumps over the lazy dog.' );
+	} );
+
+	/*
 	 * Remaining seam that needs lower-level input injection than Playwright's
 	 * event APIs expose end-to-end: drag-and-drop text. The `onChange`
 	 * diff->marker converter (`SuggestionContentReconciler`) is

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1374,7 +1374,7 @@
 	},
 	"packages/editor/src/components/suggestion-mode/store-interceptor.js": {
 		"react-hooks/refs": {
-			"count": 6
+			"count": 7
 		}
 	},
 	"packages/editor/src/components/suggestion-mode/suggestion-note-gc.js": {


### PR DESCRIPTION
## What

Fixes finding F-07 from the Suggest mode guided testing round: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), like the other fixes in this round.

## The problem

Pressing Enter mid-paragraph in Suggesting mode captures fine at the data layer: block 0 keeps its whole original `content`, a new block carries `metadata.suggestion: {type:"pending-insert"}` with the tail text, and two notes are created. What the canvas paints is the problem. Block 0 renders truncated to "The quick brown fox " and the tail shows up as a separate pending-insert block, so the split reads as something that already happened rather than something to review.

The doc's diagnosis holds up, and measurement on the base branch adds the mechanism. A splitting Enter goes through `__unstableSplitSelection`, which dispatches `replaceBlocks` with a truncated head plus a new tail block. That never passes through the overlay HOC's `setAttributes` seam, so the store interceptor is what sees it, and the interceptor had exactly one destination for a changed attribute: the whole-content overlay. The overlay renders its clean snapshot *in place of* the block's live value, which is the same root cause as F-09 (https://github.com/WordPress/gutenberg/pull/81655) - the text proposed for removal has nowhere to be shown, so it simply vanishes.

Base-branch state after the repro, for the record:

```
block 0  content: "The quick brown fox jumps over the lazy dog."   metadata.noteId: [3]
block 1  content: "jumps over the lazy dog."                       pending-insert
canvas   <p class="... is-suggestion-pending ...">The quick brown fox </p>
```

## The fix

Give that removal the inline treatment a Backspace already gets. The store interceptor now runs the marker planner (`planEditMarkers`) over a content-only change and, when the plan is a single fresh `wrap-del`, hands it to `SuggestionContentReconciler` instead of routing it to the overlay. The handoff happens after the revert lands, since the reconciler re-reads the block and validates it against the value the plan was diffed from. A refused handoff falls back to the overlay, so the path is unchanged wherever the reconciler is not mounted.

This is limited to removals on purpose. When an overlay swallows an *insertion* the reviewer still sees the proposed text - the new value is what renders. Only a removal leaves nothing on screen. Insertions and type-overs reaching this same seam (a multi-line paste is the notable one) keep the capture they have today, which is the "reach the fallback less often" work F-09 leaves open. Widening the branch to insertions was tried first and it did convert multi-line paste to markers, but that is a different flow with its own finding, so the branch was narrowed back to the case F-07 describes.

Two files carry it: a new `plan-store-content-edit.js` holds the pure decision, and the interceptor hunk is confined to the attribute-drift branch. `store-interceptor.js` is being edited by several other fixes in this round, so the hunk was kept as small as it could be - the existing overlay routing moved into a local closure so the refusal path can reuse it, and nothing else in the subscribe loop moved.

After the fix, same repro:

```
block 0  content: 'The quick brown fox <mark data-suggestion-id="4" data-suggestion-type="del" data-author="1" class="wp-suggestion">jumps over the lazy dog.</mark>'
block 1  content: "jumps over the lazy dog."   pending-insert
```

## Screenshots

Before, on the unmodified base branch - block 0 is repainted as the post-split "The quick brown fox " and the removal is invisible:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f07-before.png" alt="Suggested split before the fix: a truncated first paragraph reading The quick brown fox, then a red pending-insert block reading jumps over the lazy dog." width="700">

After - the sentence stays whole and the proposed removal is struck through where it sits, with the proposed new block below it:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f07-after.png" alt="Suggested split after the fix: the full sentence with jumps over the lazy dog struck through, then the red pending-insert block below" width="700">

## Testing instructions

1. Enable the Suggest mode experiment (Gutenberg > Experiments > "Suggestion mode").
2. Create a post with one paragraph: "The quick brown fox jumps over the lazy dog."
3. Switch the editor to Suggesting from the Options menu in the top bar.
4. Click into the paragraph, press End, then press Left arrow 24 times so the caret sits between "fox " and "jumps".
5. Press Enter.

Before: the first paragraph is repainted as "The quick brown fox " with the green attribute-pending bracket around it, and the removed tail appears only as the separate red pending-insert block below.

After: the first paragraph still reads "The quick brown fox jumps over the lazy dog." with "jumps over the lazy dog." struck through, no bracket, and the red pending-insert block sits below it. Accepting or rejecting from the sidebar behaves as it does for any other deletion marker.

### Automated coverage

New e2e in `test/e2e/specs/editor/various/suggestion-mode-overlay-retirement.spec.js`:

- `Suggest mode: overlay-retirement safety net (Phase 0) > seam: a split strikes the removed tail through in place`

Verified red on the unmodified base build - `element(s) not found` for `mark.wp-suggestion[data-suggestion-type="del"]` - and green after the fix, 5/5 with `--repeat-each=5`.

New unit tests in `packages/editor/src/components/suggestion-mode/test/plan-store-content-edit.js` cover the accept case and each decline: a mixed attribute change, a non-string-like value, a no-op, an insertion, a type-over, and a plan that would grow an existing marker rather than open a note.

The whole suggestion-mode e2e set was run against this build: 64 passed, 1 failed. The failure is the known pre-existing `a closed sidebar stays closed when a suggestion is created`, which is F-17 and is fixed separately in https://github.com/WordPress/gutenberg/pull/81671. Unit tests for `suggestion-mode` and `inline-suggestions` are 433 passing.

One note on lint: `store-interceptor.js` carries six suppressed `react-hooks/refs` errors from its existing ref-mirroring pattern, and the new ref makes seven, so `tools/eslint/suppressions.json` is bumped to match.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
