### PR TITLE
List View: Fix flaky global shortcut test and re-enable it

### DIFF
--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -331,7 +331,7 @@ test.describe( 'List View', () => {
 	// If list view sidebar is open and focus is not inside the sidebar, move
 	// focus to the sidebar when using the shortcut. If focus is inside the
 	// sidebar, shortcut should close the sidebar.
-	test.skip( 'ensures List View global shortcut works properly', async ( {
+	test( 'ensures List View global shortcut works properly', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -353,7 +353,7 @@ test.describe( 'List View', () => {
 			name: 'Block navigation structure',
 		} );
 
-		// The paragraph item should be selected.
+		// The paragraph item should be selected and focused.
 		await expect(
 			listView.getByRole( 'gridcell', {
 				name: 'Paragraph',
@@ -361,6 +361,9 @@ test.describe( 'List View', () => {
 				selected: true,
 			} )
 		).toBeVisible();
+		await expect(
+			listView.getByRole( 'link', { name: 'Paragraph' } )
+		).toBeFocused();
 
 		// Navigate to the image block item.
 		await page.keyboard.press( 'ArrowUp' );
@@ -400,6 +403,7 @@ test.describe( 'List View', () => {
 
 		// Open List View.
 		await pageUtils.pressKeys( 'access+o' );
+		await expect( imageItem ).toBeFocused();
 
 		// Focus the list view close button and make sure the shortcut will
 		// close the list view. This is to catch a bug where elements could be
@@ -421,6 +425,7 @@ test.describe( 'List View', () => {
 
 		// Open List View.
 		await pageUtils.pressKeys( 'access+o' );
+		await expect( imageItem ).toBeFocused();
 
 		// Focus the outline tab and select it. This test ensures the outline
 		// tab receives similar focus events based on the shortcut.

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -1353,6 +1353,11 @@ test.describe( 'List View', () => {
 		const optionsForFileMenu = page.getByRole( 'menu', {
 			name: 'Options',
 		} );
+		// The menu moves focus to its first item on mount. Keys sent before
+		// that lands are handled by the toggle button instead of the menu.
+		const firstMenuItem = optionsForFileMenu
+			.getByRole( 'menuitem' )
+			.first();
 		await expect(
 			optionsForFileToggle,
 			'Pressing arrow right should move focus to the menu dropdown toggle button'
@@ -1363,6 +1368,7 @@ test.describe( 'List View', () => {
 			optionsForFileMenu,
 			'Pressing Enter should open the menu dropdown'
 		).toBeVisible();
+		await expect( firstMenuItem ).toBeFocused();
 
 		await page.keyboard.press( 'Escape' );
 		await expect(
@@ -1379,6 +1385,7 @@ test.describe( 'List View', () => {
 			optionsForFileMenu,
 			'Pressing Space should also open the menu dropdown'
 		).toBeVisible();
+		await expect( firstMenuItem ).toBeFocused();
 
 		await pageUtils.pressKeys( 'primaryAlt+t' ); // Keyboard shortcut for Insert before.
 		await expect
@@ -1400,6 +1407,7 @@ test.describe( 'List View', () => {
 			optionsForFileMenu,
 			'Pressing Space should also open the menu dropdown'
 		).toBeVisible();
+		await expect( firstMenuItem ).toBeFocused();
 		await pageUtils.pressKeys( 'access+z' ); // Keyboard shortcut for Delete.
 		await expect
 			.poll(
@@ -1420,6 +1428,7 @@ test.describe( 'List View', () => {
 			optionsForFileMenu.getByRole( 'menuitem', { name: 'Delete' } ),
 			'The delete menu item should be hidden for locked blocks'
 		).toBeHidden();
+		await expect( firstMenuItem ).toBeFocused();
 		await pageUtils.pressKeys( 'access+z' );
 		await expect
 			.poll(


### PR DESCRIPTION
## What?
Closes #73301
Requires #81659.

PR fixes and re-enabled the skipped flaky `ensures List View global shortcut works properly` e2e test. Wait for focus shifts before triggering shortcuts, so it doesn't compete with `focusOnMount` which is async.

I've also fixed a flaky (at least locally for me) `block settings dropdown menu` test.

## Testing Instructions

```
npm run test:e2e -- test/e2e/specs/editor/various/list-view.spec.js --repeat-each=5
```
