### PR TITLE
Suggest mode: explain why formatting is refused across a multi-block selection

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -51,6 +51,7 @@ import {
 	SuggestionDeletionKeyboard,
 	SuggestionAdditionKeyboard,
 	SuggestionFormatKeyboard,
+	SuggestionMultiBlockFormatNotice,
 	SuggestionContentReconciler,
 	registerSuggestionOverlayFilter,
 	isSuggestionModeEnabled,
@@ -501,6 +502,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 													<SuggestionDeletionKeyboard />
 													<SuggestionAdditionKeyboard />
 													<SuggestionFormatKeyboard />
+													<SuggestionMultiBlockFormatNotice />
 													<SuggestionContentReconciler />
 												</>
 											) }

--- a/packages/editor/src/components/suggestion-mode/index.js
+++ b/packages/editor/src/components/suggestion-mode/index.js
@@ -16,6 +16,7 @@ export { default as SuggestionNoteGC } from './suggestion-note-gc';
 export { default as SuggestionDeletionKeyboard } from './suggestion-deletion-keyboard';
 export { default as SuggestionAdditionKeyboard } from './suggestion-addition-keyboard';
 export { default as SuggestionFormatKeyboard } from './suggestion-format-keyboard';
+export { default as SuggestionMultiBlockFormatNotice } from './multi-block-format-notice';
 export { default as SuggestionContentReconciler } from './suggestion-content-reconciler';
 export {
 	default as SuggestionAnnotations,

--- a/packages/editor/src/components/suggestion-mode/multi-block-format-notice.js
+++ b/packages/editor/src/components/suggestion-mode/multi-block-format-notice.js
@@ -1,0 +1,123 @@
+import { useCallback, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { isKeyboardEvent } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
+import { unlock } from '../../lock-unlock';
+import { EDITOR_STORE_NAME, SUGGEST_INTENT } from './constants';
+import { getCandidateDocuments } from './keyboard-target';
+
+/*
+ * The inline-format shortcuts `@wordpress/format-library` registers through
+ * `RichTextShortcut`. Those registrations live inside a rich text's own format
+ * edits, which only render while a single block is selected — so with a
+ * multi-block selection there is nothing listening for any of them.
+ */
+const FORMAT_SHORTCUTS = [
+	[ 'primary', 'b' ],
+	[ 'primary', 'i' ],
+	[ 'primary', 'u' ],
+	[ 'primary', 'k' ],
+	[ 'primaryShift', 'k' ],
+	[ 'access', 'd' ],
+	[ 'access', 'x' ],
+];
+
+/*
+ * A stable id so holding a shortcut down replaces the snackbar instead of
+ * stacking a queue of identical ones.
+ */
+const NOTICE_ID = 'editor/suggestion-mode/multi-block-format';
+
+/*
+ * `useWritingFlow` stamps this on the wrapper it makes the editing host for a
+ * multi-block selection, so it identifies the one element whose keystrokes are
+ * the cross-block formatting attempt. Block selection survives focus moving to
+ * the notes sidebar, so `hasMultiSelection` alone would also fire this notice
+ * for a Cmd+B pressed inside a note reply.
+ */
+const MULTI_SELECTION_HOST_SELECTOR = '[data-has-multi-selection="true"]';
+
+/**
+ * Explains why an inline-formatting shortcut does nothing across a multi-block
+ * selection in Suggest mode.
+ *
+ * The refusal itself is correct and belongs to the block editor, not to this
+ * layer: with a multi-block selection the writing-flow wrapper is the editing
+ * host, and `useInput` cancels its `beforeinput`, so a browser-native bold
+ * never reaches the blocks. Nothing commits directly, which is what the flow
+ * asks for. What is missing is any sign that a decision was taken — no note,
+ * no marker, no snackbar, and no disabled control to point at, because the
+ * format toolbar does not render for a multi-block selection at all. Pressing
+ * bold and getting silence reads as a broken editor.
+ *
+ * So this listens for the inline-format shortcuts on the multi-selection
+ * editing host and answers with a snackbar naming the constraint. It is
+ * feedback only: the keystroke is left alone rather than cancelled, so nothing
+ * about the (already correct) refusal changes.
+ *
+ * @return {null} Renders nothing.
+ */
+export default function SuggestionMultiBlockFormatNotice() {
+	const isSuggestMode = useSelect(
+		( select ) =>
+			// `getEditorIntent` is private while Suggest mode is experimental.
+			unlock( select( EDITOR_STORE_NAME ) ).getEditorIntent() ===
+			SUGGEST_INTENT,
+		[]
+	);
+	const hasMultiSelection = useSelect(
+		( select ) => select( blockEditorStore ).hasMultiSelection(),
+		[]
+	);
+	const { createNotice } = useDispatch( noticesStore );
+
+	const onKeyDown = useCallback(
+		( event ) => {
+			if (
+				! FORMAT_SHORTCUTS.some( ( [ type, character ] ) =>
+					isKeyboardEvent[ type ]( event, character )
+				)
+			) {
+				return;
+			}
+			if ( ! event.target?.closest?.( MULTI_SELECTION_HOST_SELECTOR ) ) {
+				return;
+			}
+			createNotice(
+				'info',
+				__(
+					'Formatting suggestions apply to a selection within a single block.'
+				),
+				{
+					id: NOTICE_ID,
+					type: 'snackbar',
+					isDismissible: true,
+				}
+			);
+		},
+		[ createNotice ]
+	);
+
+	useEffect( () => {
+		// Only listen while there is a cross-block selection to explain. The
+		// canvas iframe has long since mounted by then, so the documents are
+		// resolved at that point rather than on every selection change.
+		if ( ! isSuggestMode || ! hasMultiSelection ) {
+			return undefined;
+		}
+		const docs = getCandidateDocuments();
+		const listener = ( event ) => onKeyDown( event );
+		for ( const doc of docs ) {
+			doc.addEventListener( 'keydown', listener, true );
+		}
+		return () => {
+			for ( const doc of docs ) {
+				doc.removeEventListener( 'keydown', listener, true );
+			}
+		};
+	}, [ isSuggestMode, hasMultiSelection, onKeyDown ] );
+
+	return null;
+}

--- a/packages/editor/src/components/suggestion-mode/test/multi-block-format-notice.js
+++ b/packages/editor/src/components/suggestion-mode/test/multi-block-format-notice.js
@@ -1,0 +1,162 @@
+import { render } from '@testing-library/react';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
+import SuggestionMultiBlockFormatNotice from '../multi-block-format-notice';
+import { store as editorStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
+
+const TEST_BLOCK_NAME = 'core/test-multi-block-format';
+
+beforeAll( () => {
+	registerBlockType( TEST_BLOCK_NAME, {
+		apiVersion: 3,
+		title: 'Test block',
+		category: 'text',
+		attributes: { content: { type: 'string' } },
+		save: () => null,
+	} );
+} );
+
+// Stands in for the writing-flow wrapper, which is the editing host (and the
+// event target) while a multi-block selection is live.
+function mountHost( hasMultiSelection = true ) {
+	const host = document.createElement( 'div' );
+	host.dataset.hasMultiSelection = String( hasMultiSelection );
+	document.body.appendChild( host );
+	return host;
+}
+
+function pressBold( target ) {
+	target.dispatchEvent(
+		new window.KeyboardEvent( 'keydown', {
+			key: 'b',
+			code: 'KeyB',
+			ctrlKey: true,
+			bubbles: true,
+			cancelable: true,
+		} )
+	);
+}
+
+function setup( { intent = 'suggest', multiSelect = true } = {} ) {
+	const registry = createRegistry();
+	registry.register( noticesStore );
+	registry.register( preferencesStore );
+	registry.register( blockEditorStore );
+	registry.register( editorStore );
+	unlock( registry.dispatch( editorStore ) ).setEditorIntent( intent );
+
+	const first = createBlock( TEST_BLOCK_NAME, { content: 'Alpha' } );
+	const second = createBlock( TEST_BLOCK_NAME, { content: 'Beta' } );
+	registry.dispatch( blockEditorStore ).resetBlocks( [ first, second ] );
+	if ( multiSelect ) {
+		registry
+			.dispatch( blockEditorStore )
+			.multiSelect( first.clientId, second.clientId );
+	} else {
+		registry.dispatch( blockEditorStore ).selectBlock( first.clientId );
+	}
+
+	render( <SuggestionMultiBlockFormatNotice />, {
+		wrapper: ( { children } ) => (
+			<RegistryProvider value={ registry }>{ children }</RegistryProvider>
+		),
+	} );
+
+	return {
+		registry,
+		// `setEditorIntent` announces the mode change with its own snackbar,
+		// so scope the assertions to this component's notice.
+		getNotices: () =>
+			registry
+				.select( noticesStore )
+				.getNotices()
+				.filter(
+					( notice ) =>
+						notice.id ===
+						'editor/suggestion-mode/multi-block-format'
+				),
+	};
+}
+
+describe( 'SuggestionMultiBlockFormatNotice', () => {
+	afterEach( () => {
+		document.body.replaceChildren();
+	} );
+
+	it( 'explains the refusal when a format shortcut is pressed across blocks', () => {
+		const { getNotices } = setup();
+		const host = mountHost();
+
+		expect( getNotices() ).toHaveLength( 0 );
+		pressBold( host );
+
+		const notices = getNotices();
+		expect( notices ).toHaveLength( 1 );
+		expect( notices[ 0 ].content ).toBe(
+			'Formatting suggestions apply to a selection within a single block.'
+		);
+		expect( notices[ 0 ].type ).toBe( 'snackbar' );
+	} );
+
+	it( 'replaces rather than stacks when the shortcut repeats', () => {
+		const { getNotices } = setup();
+		const host = mountHost();
+
+		pressBold( host );
+		pressBold( host );
+		pressBold( host );
+
+		expect( getNotices() ).toHaveLength( 1 );
+	} );
+
+	it( 'stays quiet for a single-block selection', () => {
+		const { getNotices } = setup( { multiSelect: false } );
+		const host = mountHost( false );
+
+		pressBold( host );
+
+		expect( getNotices() ).toHaveLength( 0 );
+	} );
+
+	it( 'stays quiet outside Suggest mode', () => {
+		const { getNotices } = setup( { intent: 'edit' } );
+		const host = mountHost();
+
+		pressBold( host );
+
+		expect( getNotices() ).toHaveLength( 0 );
+	} );
+
+	it( 'stays quiet when the shortcut is pressed outside the multi-selection host', () => {
+		const { getNotices } = setup();
+		// Block selection survives focus moving to the notes sidebar, so a
+		// Cmd+B typed into a note reply must not be answered with this.
+		const elsewhere = document.createElement( 'div' );
+		document.body.appendChild( elsewhere );
+
+		pressBold( elsewhere );
+
+		expect( getNotices() ).toHaveLength( 0 );
+	} );
+
+	it( 'ignores keys that are not inline-format shortcuts', () => {
+		const { getNotices } = setup();
+		const host = mountHost();
+
+		host.dispatchEvent(
+			new window.KeyboardEvent( 'keydown', {
+				key: 'a',
+				code: 'KeyA',
+				ctrlKey: true,
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+
+		expect( getNotices() ).toHaveLength( 0 );
+	} );
+} );

--- a/test/e2e/specs/editor/various/suggestion-mode-multi-block-format.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-multi-block-format.spec.js
@@ -1,0 +1,131 @@
+/**
+ * E2E coverage for finding F-30 of the Suggest mode guided testing pass
+ * (#73411): an inline-format shortcut pressed across a multi-block selection
+ * is refused, correctly, but used to be refused in complete silence.
+ *
+ * The refusal itself belongs to the block editor — the writing-flow wrapper is
+ * the editing host for a multi-block selection and cancels its `beforeinput`,
+ * so nothing commits. These tests pin the missing half: Suggest mode now says
+ * why nothing happened, and still writes nothing.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection.
+	await page.keyboard.press( 'Escape' );
+}
+
+// Select from inside the first paragraph down into the second, which is what
+// makes the block editor promote the selection to a multi-block one.
+async function selectAcrossTwoBlocks( editor, page, pageUtils ) {
+	// Click the last paragraph rather than the first: the selected block's
+	// toolbar floats over the block above it and would swallow the click.
+	await editor.canvas
+		.getByRole( 'document', { name: 'Block: Paragraph' } )
+		.last()
+		.click();
+	await page.keyboard.press( 'ArrowUp' );
+	await page.keyboard.press( 'Home' );
+	await pageUtils.pressKeys( 'shift+ArrowDown' );
+	await pageUtils.pressKeys( 'shift+End' );
+	// The wrapper carries the flag only while the selection genuinely spans
+	// blocks, so this is the positive signal that the fixture is real.
+	await expect(
+		editor.canvas.locator( '[data-has-multi-selection="true"]' )
+	).toBeVisible();
+}
+
+test.describe( 'Suggestion mode: formatting across blocks', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First paragraph' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second paragraph' },
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'explains why bold does nothing across a multi-block selection', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await switchIntent( page, 'Suggesting' );
+		await selectAcrossTwoBlocks( editor, page, pageUtils );
+
+		// Scope to the snackbar list: the notice is also announced in a live
+		// region, which would make a bare text match ambiguous.
+		const snackbarList = page.locator( '.components-snackbar-list' );
+		await pageUtils.pressKeys( 'primary+b' );
+		await expect(
+			snackbarList.getByText(
+				'Formatting suggestions apply to a selection within a single block.'
+			)
+		).toBeVisible();
+
+		// The refusal still holds: no marker anywhere, and the serialized
+		// content is exactly what it was before the keystroke.
+		await expect(
+			editor.canvas.locator( 'mark.wp-suggestion' )
+		).toHaveCount( 0 );
+		const serialized = await editor.getEditedPostContent();
+		expect( serialized ).not.toContain( 'wp-suggestion' );
+		expect( serialized ).not.toContain( '<strong>' );
+	} );
+
+	test( 'stays silent when the same shortcut lands inside one block', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await switchIntent( page, 'Suggesting' );
+
+		// The last paragraph, for the same toolbar-overlap reason as above.
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.last();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 9 } );
+		await pageUtils.pressKeys( 'primary+b' );
+
+		// Anchor on the suggestion actually being captured before asserting
+		// the notice is absent, so the absence is measured after the flow has
+		// had its turn rather than before it started.
+		await expect(
+			paragraph.locator(
+				'mark.wp-suggestion[data-suggestion-type="format"]'
+			)
+		).toContainText( 'paragraph' );
+		await expect(
+			page
+				.locator( '.components-snackbar-list' )
+				.getByText(
+					'Formatting suggestions apply to a selection within a single block.'
+				)
+		).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes finding **F-30** from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of the Suggest mode work tracked in https://github.com/WordPress/gutenberg/issues/73411. Stacked on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), same as the rest of this round.

## The problem

Flow FS-07 asks for "per-block format suggestions or a clean refusal, never a direct commit" when a selection spans a block boundary. The refusal is clean. With a real two-block keyboard selection in Suggesting mode, Cmd+B leaves both blocks byte-identical - no note, no marker, nothing written.

The trouble is that it is also completely silent. Nothing tells the user a decision was taken. Press bold, get nothing, and the editor reads as broken.

Two corrections to the write-up in the doc, both from measuring rather than assuming:

The refusal is not Suggest mode's doing. With a multi-block selection the writing-flow wrapper becomes the editing host, and `useInput` calls `preventDefault()` on its `beforeinput` - so the browser's native `formatBold` never reaches the blocks. That guard is core block-editor behavior and it holds in Editing mode too.

And the doc's first proposed remedy, disabling the formatting controls, has nothing to disable. `RichTextShortcut` and `RichTextToolbarButton` are both registered from inside a rich text's own format edits, which only render while a single block is selected. With a multi-block selection there is no bold button in the toolbar at all - visible in the before screenshot below, where the toolbar shows only block-level tools. So the remaining option is the doc's second one: say why.

## The fix

A small `SuggestionMultiBlockFormatNotice` component that listens for the inline-format shortcuts while a cross-block selection is live in Suggesting mode, and answers with a snackbar: **"Formatting suggestions apply to a selection within a single block."**

Details worth calling out:

- It covers the full set of shortcuts `@wordpress/format-library` registers - bold, italic, underline, link, unlink, strikethrough and code - not just Cmd+B, since all of them go equally quiet.
- The listener attaches only while `hasMultiSelection()` is true in Suggest mode, so there is no keydown handler on the canvas the rest of the time.
- The event target has to be inside the multi-selection editing host (`[data-has-multi-selection="true"]`, stamped by `useWritingFlow`). Block selection survives focus moving to the notes sidebar, so `hasMultiSelection` alone would have fired this notice for a Cmd+B typed into a note reply.
- The notice carries a fixed id, so holding a shortcut down replaces the snackbar rather than stacking a queue of identical ones.
- It is feedback only. The keystroke is not cancelled, so the refusal itself - which is core's, and correct - is untouched.

On the hot files: this touches `packages/editor/src/components/provider/index.js` and `suggestion-mode/index.js`, which https://github.com/WordPress/gutenberg/pull/81670 and https://github.com/WordPress/gutenberg/pull/81674 also edit. The hunks here are two one-line additions in each, in the same import/mount lists, so they should merge cleanly with both.

**Remaining gap:** this is the "clean refusal" half of FS-07. The other half the flow allows, actually capturing per-block format suggestions across a multi-block selection, is a feature rather than a fix and is not attempted here.

## Screenshots

Two paragraphs selected across the block boundary in Suggesting mode, immediately after pressing Cmd+B. Before, only the mode-change snackbar from earlier is on screen and the keystroke leaves no trace at all:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f30-before.png" alt="Before: bold pressed across two selected paragraphs produces no feedback of any kind" width="780">

After, the same keystroke explains itself, and still writes nothing:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f30-after.png" alt="After: a snackbar reads Formatting suggestions apply to a selection within a single block" width="780">

## Testing instructions

1. Enable the Suggestion mode experiment (Gutenberg > Experiments > Suggestion mode).
2. Create a new post with two paragraphs, eg. "First paragraph" and "Second paragraph".
3. Switch to Suggesting from the Options menu in the top bar.
4. Click into the second paragraph, press ArrowUp then Home, then Shift+ArrowDown and Shift+End. Both blocks should now be selected.
5. Press Cmd+B (Ctrl+B on Windows/Linux).
6. **Before:** nothing happens. No snackbar, no marker, no note, and no bold button in the toolbar to explain itself.
7. **After:** a snackbar reads "Formatting suggestions apply to a selection within a single block." The blocks are still untouched - check the code editor and confirm there is no `wp-suggestion` mark and no `<strong>`.
8. Now select a word inside a single paragraph and press Cmd+B. The format suggestion is captured as before and no snackbar appears.
9. Switch to Editing mode, re-select across the two blocks and press Cmd+B. No snackbar - the notice is Suggest mode only.

### Automated coverage

E2E, new file `test/e2e/specs/editor/various/suggestion-mode-multi-block-format.spec.js`:

- `Suggestion mode: formatting across blocks › explains why bold does nothing across a multi-block selection` - verified red on the unmodified base branch (`element(s) not found` waiting for the snackbar), green with the fix. It also asserts the refusal still holds: no `mark.wp-suggestion` in the canvas, and no `wp-suggestion` or `<strong>` in the serialized post.
- `Suggestion mode: formatting across blocks › stays silent when the same shortcut lands inside one block` - the control. Passes on the base branch and with the fix, so the notice is proven not to fire on the ordinary single-block path. It anchors on the format marker actually being written before asserting the snackbar's absence, so the absence is measured after the flow has had its turn.

Both were run with `--repeat-each=5`, 10/10 passing.

Unit, new file `packages/editor/src/components/suggestion-mode/test/multi-block-format-notice.js` - six cases covering the notice firing, repeats replacing rather than stacking, and the four ways it must stay quiet (single-block selection, Editing mode, an event outside the multi-selection host, and a non-format shortcut).

Neighbouring suites: `suggestion-mode.spec.js` runs 21 passed / 1 failed, the single failure being the known pre-existing "a closed sidebar stays closed when a suggestion is created" (F-17, fixed in https://github.com/WordPress/gutenberg/pull/81671, not on this base). Core's `multi-block-selection.spec.js` runs 123/124 across all three browsers, with one webkit case that passes on re-run.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
