### PR TITLE
Explain suggestion markers when Suggest mode is off

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -22,6 +22,7 @@ import { createBlock } from '@wordpress/blocks';
 import withRegistryProvider from './with-registry-provider';
 import { store as editorStore } from '../../store';
 import useAutosaveNotice from './use-autosave-notice';
+import useSuggestionReviewNotice from './use-suggestion-review-notice';
 import useBlockEditorSettings from './use-block-editor-settings';
 import { unlock } from '../../lock-unlock';
 import DisableNonPageContentBlocks from './disable-non-page-content-blocks';
@@ -400,6 +401,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// effect above so that its own mount effect runs once `setupEditor`
 		// has populated the current post.
 		useAutosaveNotice( { post, recovery, settings } );
+
+		// Explains suggestion markers to a user who does not have Suggest
+		// mode. Same ordering requirement as the autosave notice: it reads
+		// the current post, which `setupEditor` populates above.
+		useSuggestionReviewNotice();
 
 		// Synchronizes the active post with the state
 		useEffect( () => {

--- a/packages/editor/src/components/provider/test/use-suggestion-review-notice.js
+++ b/packages/editor/src/components/provider/test/use-suggestion-review-notice.js
@@ -1,0 +1,54 @@
+/**
+ * The detector behind the "this post has suggested edits" notice. It runs as a
+ * substring test on saved post content rather than a block-tree walk, so these
+ * cases pin the exact serialized shapes it has to recognise — and the ones it
+ * must not claim.
+ */
+import { hasSuggestionMarkers } from '../use-suggestion-review-notice';
+
+describe( 'hasSuggestionMarkers', () => {
+	it( 'ignores empty and non-string content', () => {
+		expect( hasSuggestionMarkers( undefined ) ).toBe( false );
+		expect( hasSuggestionMarkers( null ) ).toBe( false );
+		expect( hasSuggestionMarkers( '' ) ).toBe( false );
+		expect( hasSuggestionMarkers( {} ) ).toBe( false );
+	} );
+
+	it( 'ignores content with no suggestion state', () => {
+		expect(
+			hasSuggestionMarkers(
+				'<!-- wp:paragraph -->\n<p>The quick <strong>brown</strong> fox</p>\n<!-- /wp:paragraph -->'
+			)
+		).toBe( false );
+	} );
+
+	it( 'does not mistake a note marker for a suggestion', () => {
+		expect(
+			hasSuggestionMarkers(
+				'<!-- wp:paragraph -->\n<p>A <mark class="wp-note" data-note-id="7">noted</mark> phrase</p>\n<!-- /wp:paragraph -->'
+			)
+		).toBe( false );
+	} );
+
+	it.each( [ 'del', 'add', 'format' ] )(
+		'detects an inline %s marker',
+		( type ) => {
+			expect(
+				hasSuggestionMarkers(
+					`<!-- wp:paragraph -->\n<p>Hello <mark class="wp-suggestion" data-suggestion-id="12" data-suggestion-type="${ type }">world</mark></p>\n<!-- /wp:paragraph -->`
+				)
+			).toBe( true );
+		}
+	);
+
+	it.each( [ 'pending-remove', 'pending-insert', 'pending-move' ] )(
+		'detects a structural %s marker',
+		( type ) => {
+			expect(
+				hasSuggestionMarkers(
+					`<!-- wp:paragraph {"metadata":{"noteId":[12],"suggestion":{"type":"${ type }","noteId":12}}} -->\n<p>Hello</p>\n<!-- /wp:paragraph -->`
+				)
+			).toBe( true );
+		}
+	);
+} );

--- a/packages/editor/src/components/provider/use-suggestion-review-notice.js
+++ b/packages/editor/src/components/provider/use-suggestion-review-notice.js
@@ -1,0 +1,127 @@
+import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as interfaceStore } from '@wordpress/interface';
+import { store as editorStore } from '../../store';
+import { checkSupport } from '../post-type-support-check';
+import { isSuggestionModeEnabled } from '../suggestion-mode/gate';
+import { ALL_NOTES_SIDEBAR } from '../collab-sidebar/constants';
+
+/**
+ * Notice id. Stable so repeated creation replaces rather than stacks.
+ */
+const NOTICE_ID = 'editor/pending-suggestions';
+
+/**
+ * Marker class the `core/suggestion` format serializes to in post content.
+ */
+const INLINE_MARKER_CLASS = 'wp-suggestion';
+
+/**
+ * The `metadata.suggestion.type` values a structural suggestion serializes
+ * into a block comment delimiter. Matched as raw JSON fragments so the probe
+ * stays a substring test on the saved content instead of a block-tree walk.
+ */
+const STRUCTURAL_MARKER_VALUES = [
+	'"pending-remove"',
+	'"pending-insert"',
+	'"pending-move"',
+];
+
+/**
+ * Whether saved post content carries suggestion state of any kind.
+ *
+ * @param {string|undefined} content Raw post content.
+ * @return {boolean} True when an inline marker or a structural marker is present.
+ */
+export function hasSuggestionMarkers( content ) {
+	if ( typeof content !== 'string' || ! content ) {
+		return false;
+	}
+	return (
+		content.includes( INLINE_MARKER_CLASS ) ||
+		STRUCTURAL_MARKER_VALUES.some( ( value ) => content.includes( value ) )
+	);
+}
+
+/**
+ * Explains suggestion markers to a user who does not have Suggest mode.
+ *
+ * Suggestion state outlives the experiment flag by design: the
+ * `core/suggestion` format is registered unconditionally so a `<mark
+ * class="wp-suggestion">` survives a load-and-save byte for byte, which is
+ * what keeps content safe when the experiment is toggled off on a site that
+ * has been using it. The cost is comprehension. With the experiment off the
+ * intent switcher, the marker tooltips and the per-author tinting are all
+ * absent, so a proposed insertion reads as ordinary green underlined text
+ * with nothing to say what it is or where to act on it.
+ *
+ * The controls are not actually missing — a suggestion is a note comment, the
+ * notes sidebar ships in core, and its Accept/Reject buttons render whether or
+ * not the experiment is on. What is missing is any sign that they exist. This
+ * notice supplies it, and its action opens the sidebar.
+ *
+ * Stripping the markers instead would be the destructive answer: a pending
+ * addition's text is not public content until it is accepted, so dropping the
+ * wrapper on load and saving would silently promote every proposal and orphan
+ * its note.
+ */
+export default function useSuggestionReviewNotice() {
+	const { createInfoNotice } = useDispatch( noticesStore );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+
+	const hasPendingSuggestions = useSelect( ( select ) => {
+		/*
+		 * With the experiment on, the intent switcher and the suggestion UI
+		 * explain themselves; the notice would be noise.
+		 */
+		if ( isSuggestionModeEnabled() ) {
+			return false;
+		}
+		const { getCurrentPostAttribute, getCurrentPostType } =
+			select( editorStore );
+		if ( ! hasSuggestionMarkers( getCurrentPostAttribute( 'content' ) ) ) {
+			return false;
+		}
+		/*
+		 * Suggestions persist as note comments, so the sidebar the notice
+		 * points at only exists on a post type that supports notes.
+		 */
+		const postTypeSlug = getCurrentPostType();
+		const postType = postTypeSlug
+			? select( coreStore ).getPostType( postTypeSlug )
+			: null;
+		return !! postType && checkSupport( postType.supports, 'editor.notes' );
+	}, [] );
+
+	useEffect( () => {
+		if ( ! hasPendingSuggestions ) {
+			return;
+		}
+		createInfoNotice(
+			__(
+				'This post has suggested edits, shown as highlighted text in the content. Open the notes to accept or reject them.'
+			),
+			{
+				id: NOTICE_ID,
+				actions: [
+					{
+						label: __( 'Show notes' ),
+						onClick: () =>
+							enableComplementaryArea(
+								'core',
+								ALL_NOTES_SIDEBAR
+							),
+					},
+				],
+			}
+		);
+		/*
+		 * Created once per editor mount. `hasPendingSuggestions` is derived
+		 * from the saved post, so it flips false -> true at most once and a
+		 * dismissed notice is not resurrected by the next save.
+		 */
+	}, [ hasPendingSuggestions, createInfoNotice, enableComplementaryArea ] );
+}

--- a/test/e2e/specs/editor/various/suggestion-mode-experiment-off.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-experiment-off.spec.js
@@ -1,0 +1,176 @@
+/**
+ * E2E coverage for what a post carrying suggestion data looks like when the
+ * Suggest mode experiment is OFF (F-22 in the guided testing pass for #73411).
+ *
+ * Suggestion state deliberately outlives the experiment flag: the
+ * `core/suggestion` format is registered unconditionally so a `<mark
+ * class="wp-suggestion">` survives a load-and-save byte for byte. That keeps
+ * content safe when the experiment is toggled off on a site that has been
+ * using it, at the cost of comprehension — the markers render with no intent
+ * switcher, no tooltip and no per-author tinting to explain them.
+ *
+ * These tests pin the explanation that closes the gap, and the two cases it
+ * must stay out of:
+ *
+ *   - Experiment off + suggestion markers in the post: an explanatory notice
+ *     appears, and its action opens the notes sidebar where the Accept and
+ *     Reject controls already live.
+ *   - Experiment off + no suggestion markers: no notice.
+ *   - Experiment on: no notice, because the suggestion UI explains itself.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const NOTICE_TEXT = 'This post has suggested edits';
+
+async function switchIntent( page, intentLabel ) {
+	await page
+		.getByRole( 'region', { name: 'Editor top bar' } )
+		.getByRole( 'button', { name: 'Options' } )
+		.click();
+	const menuItem = page.getByRole( 'menuitemradio', {
+		name: new RegExp( `^${ intentLabel }` ),
+	} );
+	await menuItem.waitFor( { state: 'visible', timeout: 10000 } );
+	await menuItem.click();
+	// `MenuItemsChoice` doesn't auto-close its dropdown on selection.
+	await page.keyboard.press( 'Escape' );
+}
+
+/**
+ * Creates a post carrying one pending inline addition, with the experiment on,
+ * and returns its id.
+ *
+ * @param {Object} args        Fixtures.
+ * @param {Object} args.admin  Admin utils.
+ * @param {Object} args.editor Editor utils.
+ * @param {Object} args.page   Playwright page.
+ * @return {Promise<string>} The post id.
+ */
+async function createPostWithSuggestion( { admin, editor, page } ) {
+	await admin.createNewPost( { title: 'Suggestion carried past the flag' } );
+	await editor.insertBlock( {
+		name: 'core/paragraph',
+		attributes: { content: 'The quick brown fox' },
+	} );
+
+	await switchIntent( page, 'Suggesting' );
+
+	const paragraph = editor.canvas
+		.getByRole( 'document', { name: 'Block: Paragraph' } )
+		.first();
+	await paragraph.click();
+	await page.keyboard.press( 'End' );
+	await page.keyboard.type( ' jumps' );
+
+	// A populated id proves the backing note comment saved.
+	await expect(
+		paragraph.locator( 'mark.wp-suggestion[data-suggestion-type="add"]' )
+	).toHaveAttribute( 'data-suggestion-id', /\d/ );
+
+	await editor.saveDraft();
+	return new URL( page.url() ).searchParams.get( 'post' );
+}
+
+test.describe( 'Suggestion data with the experiment off', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllComments( 'note' );
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'a post carrying suggestion markers explains them and points at the notes sidebar', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+		const postId = await createPostWithSuggestion( {
+			admin,
+			editor,
+			page,
+		} );
+
+		// Turn the experiment off and reopen the post, the way a site that
+		// stops using the feature would.
+		await requestUtils.setGutenbergExperiments( [] );
+		await admin.editPost( postId );
+
+		// The marker is still there — content safety is the invariant this
+		// notice exists to explain, not to change.
+		await expect(
+			editor.canvas.locator(
+				'mark.wp-suggestion[data-suggestion-type="add"]'
+			)
+		).toBeVisible();
+
+		const notice = page.locator( '.components-notice', {
+			hasText: NOTICE_TEXT,
+		} );
+		await expect( notice ).toBeVisible();
+
+		// The action opens the sidebar where Accept/Reject already live.
+		await notice.getByRole( 'button', { name: 'Show notes' } ).click();
+		const sidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await expect(
+			sidebar.getByRole( 'button', { name: 'Accept suggestion' } )
+		).toBeVisible();
+	} );
+
+	test( 'a post with no suggestion markers gets no notice', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+		await admin.createNewPost( { title: 'No suggestions here' } );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'The quick brown fox' },
+		} );
+		await editor.saveDraft();
+		const postId = new URL( page.url() ).searchParams.get( 'post' );
+		await admin.editPost( postId );
+
+		// Anchor on a positive signal before asserting an absence, so the
+		// check cannot land before the editor has finished booting.
+		await expect(
+			editor.canvas
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.first()
+		).toBeVisible();
+		await expect(
+			page.locator( '.components-notice', { hasText: NOTICE_TEXT } )
+		).toHaveCount( 0 );
+	} );
+
+	test( 'the notice stays away while the experiment is on', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+		const postId = await createPostWithSuggestion( {
+			admin,
+			editor,
+			page,
+		} );
+		await admin.editPost( postId );
+
+		await expect(
+			editor.canvas.locator(
+				'mark.wp-suggestion[data-suggestion-type="add"]'
+			)
+		).toBeVisible();
+		await expect(
+			page.locator( '.components-notice', { hasText: NOTICE_TEXT } )
+		).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
## What

Fixes **F-22** from the [Suggest mode guided testing pass](https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md) for #73411. Stacked on the top of the Suggest mode stack, #80433 (`suggest/inline-wiring`), and targets that branch.

## The problem

Turn the `gutenberg-suggestion-mode` experiment off on a site that has been using it, reload a post that carries suggestions, and the markers are still there. That part is deliberate and good: the `core/suggestion` format is registered unconditionally, which is exactly why PM-07 in the testing pass found content survives a load-and-save byte for byte.

What is missing is any explanation. There is no intent switcher, no per-author tint, no tooltip. A proposed insertion just reads as green underlined text with nothing to say what it is.

**The doc's cheapest proposed fix - strip `wp-suggestion` marks at parse time when the experiment is off - turns out to be the destructive one.** A pending addition's text is not public content until it is accepted, so unwrapping the marker on load and letting the next save persist that would silently promote every proposal to permanent content and orphan its note. It would also undo the exact property that makes PM-07 safe today.

The doc also says the user "can neither interpret nor remove" the markers. Measuring it, the second half is wrong. A suggestion is a note comment, the notes sidebar ships in core, and its Accept and Reject buttons render whether or not the experiment is on. Probing the editor with the experiment off returned one "Accept suggestion" button and the sidebar summary "Add: ' PREEXISTING'". The controls are there. Nothing tells the user they exist.

## The fix

A new `useSuggestionReviewNotice` hook in the editor provider, called next to `useAutosaveNotice`. When the experiment is off and the saved post content carries a suggestion marker, it creates an info notice:

> This post has suggested edits, shown as highlighted text in the content. Open the notes to accept or reject them.

The notice carries a **Show notes** action that opens the All notes sidebar, where the decision already lives. It stays quiet in two cases: when the experiment is on (the suggestion UI explains itself), and on a post type without `editor.notes` support (there would be no sidebar to point at).

Detection is a substring test over the saved raw content rather than a block-tree walk, covering both inline markers (`wp-suggestion`) and structural ones (`"pending-remove"`, `"pending-insert"`, `"pending-move"`).

Note on the hot files: `packages/editor/src/components/provider/index.js` is edited by several other open fix PRs. The hunks here are two lines, both up by `useAutosaveNotice`, away from the suggestion mount list the others touch.

## Screenshots

Before, on the unmodified base branch. The experiment is off and the post carries a pending addition; the green underlined run is the only sign anything is happening, and nothing names it:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f22-experiment-off-before.png" alt="Before: a green underlined run with no explanation" width="900">

After, with this change. The notice names the highlighted text and offers a way to act on it:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f22-experiment-off-after.png" alt="After: an info notice explaining the suggested edits, with a Show notes action" width="900">

And where **Show notes** lands - the Accept and Reject controls that were already rendering, just unadvertised:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f22-experiment-off-after-sidebar.png" alt="The All notes sidebar open, showing the suggestion with accept and reject buttons" width="900">

## Testing instructions

1. Enable the Suggest mode experiment at Gutenberg > Experiments.
2. Create a post with a paragraph, switch to Suggesting from the Options menu, and type some text at the end of it. Wait for the marker to pick up a `data-suggestion-id`.
3. Save the draft and note the post id.
4. Turn the Suggest mode experiment back off.
5. Reopen the post.
   - **Before:** the marked run is still highlighted, with nothing to explain it and no route to a decision.
   - **After:** a notice reads "This post has suggested edits, shown as highlighted text in the content. Open the notes to accept or reject them." Clicking **Show notes** opens the All notes sidebar with the suggestion and its Accept/Reject buttons.
6. Open a post with no suggestions, experiment still off. No notice appears.
7. Turn the experiment back on and reopen the post from step 3. No notice appears; the normal Suggest mode UI is back.

### Automated coverage

New e2e spec `test/e2e/specs/editor/various/suggestion-mode-experiment-off.spec.js` - a new file rather than a fifth editor of `suggestion-mode.spec.js`:

- `a post carrying suggestion markers explains them and points at the notes sidebar` - the repro. Verified **red** on the unmodified base build (`Error: element(s) not found` waiting for the notice) and **green** after the fix.
- `a post with no suggestion markers gets no notice` - control. Passes on base and after.
- `the notice stays away while the experiment is on` - control. Passes on base and after.

Both controls passed on the base build in the same run that failed the repro, so they are not vacuous. The whole spec was run with `--repeat-each=5` (15/15 passed) after the fix.

New unit spec `packages/editor/src/components/provider/test/use-suggestion-review-notice.js` pins the detector against the serialized shapes it has to recognise - all three inline marker types, all three structural ones - and against a `wp-note` marker it must not claim. 9/9 passing.

Neighbouring suites `suggestion-mode-review.spec.js` and `suggestion-mode-persistence.spec.js` were run against the fixed build: 25/25 passing.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
