### PR TITLE
Suggest mode: register the intent shortcuts only where they can be used

### DIFF
--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -1,10 +1,22 @@
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { isAppleOS } from '@wordpress/keycodes';
-import { isSuggestionModeEnabled } from '../suggestion-mode/gate';
+import { useCanSuggest } from '../suggestion-mode/gate';
+
+/**
+ * The intent shortcuts, kept together so they are registered and removed as
+ * one set. Names only: the descriptions are translated at registration time.
+ *
+ * @type {string[]}
+ */
+const INTENT_SHORTCUT_NAMES = [
+	'core/editor/intent-edit',
+	'core/editor/intent-suggest',
+	'core/editor/intent-view',
+];
 
 /**
  * Component for registering editor keyboard shortcuts.
@@ -13,7 +25,9 @@ import { isSuggestionModeEnabled } from '../suggestion-mode/gate';
  */
 function EditorKeyboardShortcutsRegister() {
 	// Registering the shortcuts.
-	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
+	const { registerShortcut, unregisterShortcut } = useDispatch(
+		keyboardShortcutsStore
+	);
 	useEffect( () => {
 		registerShortcut( {
 			name: 'core/editor/toggle-mode',
@@ -117,44 +131,6 @@ function EditorKeyboardShortcutsRegister() {
 			},
 		} );
 
-		/*
-		 * Only register the intent shortcuts when the Suggestion Mode
-		 * experiment is on — registration alone lists them in the Keyboard
-		 * Shortcuts help modal, which would advertise a feature the
-		 * handlers refuse to run.
-		 */
-		if ( isSuggestionModeEnabled() ) {
-			registerShortcut( {
-				name: 'core/editor/intent-edit',
-				category: 'global',
-				description: __( 'Switch to Edit mode.' ),
-				keyCombination: {
-					modifier: 'secondary',
-					character: 'z',
-				},
-			} );
-
-			registerShortcut( {
-				name: 'core/editor/intent-suggest',
-				category: 'global',
-				description: __( 'Switch to Suggest mode.' ),
-				keyCombination: {
-					modifier: 'secondary',
-					character: 'x',
-				},
-			} );
-
-			registerShortcut( {
-				name: 'core/editor/intent-view',
-				category: 'global',
-				description: __( 'Switch to View mode.' ),
-				keyCombination: {
-					modifier: 'secondary',
-					character: 'c',
-				},
-			} );
-		}
-
 		registerShortcut( {
 			name: 'core/editor/next-region',
 			category: 'global',
@@ -191,6 +167,66 @@ function EditorKeyboardShortcutsRegister() {
 			],
 		} );
 	}, [ registerShortcut ] );
+
+	/*
+	 * The intent shortcuts follow the same runtime gate as the Mode menu and
+	 * the shortcut handlers: the Suggestion Mode experiment AND `editor.notes`
+	 * support on the current post type. Registration is what lists a shortcut
+	 * in the Keyboard Shortcuts help modal, so gating registration on the
+	 * experiment flag alone advertised "Switch to Suggest mode." on screens
+	 * that can never act on it. The Site Editor listed it for `wp_template`,
+	 * which has no notes support, renders no Mode menu, and does nothing when
+	 * the combination is pressed.
+	 *
+	 * `editor.notes` support arrives with the post type record, so the
+	 * predicate starts false and flips once it resolves. The set is removed
+	 * again if it flips back, which is why the effect is keyed on it.
+	 */
+	const canSuggest = useCanSuggest();
+	const intentShortcutsRegisteredRef = useRef( false );
+	useEffect( () => {
+		if ( canSuggest ) {
+			registerShortcut( {
+				name: 'core/editor/intent-edit',
+				category: 'global',
+				description: __( 'Switch to Edit mode.' ),
+				keyCombination: {
+					modifier: 'secondary',
+					character: 'z',
+				},
+			} );
+
+			registerShortcut( {
+				name: 'core/editor/intent-suggest',
+				category: 'global',
+				description: __( 'Switch to Suggest mode.' ),
+				keyCombination: {
+					modifier: 'secondary',
+					character: 'x',
+				},
+			} );
+
+			registerShortcut( {
+				name: 'core/editor/intent-view',
+				category: 'global',
+				description: __( 'Switch to View mode.' ),
+				keyCombination: {
+					modifier: 'secondary',
+					character: 'c',
+				},
+			} );
+
+			intentShortcutsRegisteredRef.current = true;
+			return;
+		}
+
+		if ( intentShortcutsRegisteredRef.current ) {
+			INTENT_SHORTCUT_NAMES.forEach( ( name ) =>
+				unregisterShortcut( name )
+			);
+			intentShortcutsRegisteredRef.current = false;
+		}
+	}, [ canSuggest, registerShortcut, unregisterShortcut ] );
 
 	return <BlockEditorKeyboardShortcuts.Register />;
 }

--- a/packages/editor/src/components/global-keyboard-shortcuts/test/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/test/register-shortcuts.js
@@ -1,0 +1,146 @@
+import { act, render } from '@testing-library/react';
+import {
+	createRegistry,
+	createReduxStore,
+	RegistryProvider,
+} from '@wordpress/data';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import EditorKeyboardShortcutsRegister from '../register-shortcuts';
+
+/*
+ * The block-editor half of the registration reads block editor settings,
+ * which would drag the whole block editor store into a test about the
+ * editor-level shortcut list.
+ */
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	BlockEditorKeyboardShortcuts: { Register: () => null },
+} ) );
+
+const INTENT_SHORTCUTS = [
+	'core/editor/intent-edit',
+	'core/editor/intent-suggest',
+	'core/editor/intent-view',
+];
+
+/*
+ * Stub the two stores the Suggest mode gate reads and register the real
+ * keyboard shortcuts store, so the assertions run against the same state
+ * the Keyboard Shortcuts help modal renders from. The post type supports
+ * live in the stub's state so a test can change them and watch the
+ * registration follow.
+ */
+function createStubRegistry( postTypeSupports ) {
+	const registry = createRegistry();
+	registry.register(
+		createReduxStore( 'core/editor', {
+			reducer: ( state = {} ) => state,
+			selectors: {
+				getEditedPostAttribute: () => 'post',
+			},
+		} )
+	);
+	registry.register(
+		createReduxStore( 'core', {
+			reducer: ( state = { supports: postTypeSupports }, action ) =>
+				action.type === 'SET_SUPPORTS'
+					? { supports: action.supports }
+					: state,
+			actions: {
+				setPostTypeSupports: ( supports ) => ( {
+					type: 'SET_SUPPORTS',
+					supports,
+				} ),
+			},
+			selectors: {
+				getPostType: ( state ) =>
+					state.supports === undefined
+						? null
+						: { supports: state.supports },
+			},
+		} )
+	);
+	registry.register( keyboardShortcutsStore );
+	return registry;
+}
+
+function registeredIntentShortcuts( registry ) {
+	return INTENT_SHORTCUTS.filter( ( name ) =>
+		registry
+			.select( keyboardShortcutsStore )
+			.getShortcutKeyCombination( name )
+	);
+}
+
+function renderRegister( registry ) {
+	return render(
+		<RegistryProvider value={ registry }>
+			<EditorKeyboardShortcutsRegister />
+		</RegistryProvider>
+	);
+}
+
+describe( 'EditorKeyboardShortcutsRegister', () => {
+	afterEach( () => {
+		delete window.__experimentalSuggestionMode;
+	} );
+
+	it( 'registers the intent shortcuts when the post type can host suggestions', () => {
+		window.__experimentalSuggestionMode = true;
+		const registry = createStubRegistry( { 'editor.notes': true } );
+
+		renderRegister( registry );
+
+		expect( registeredIntentShortcuts( registry ) ).toEqual(
+			INTENT_SHORTCUTS
+		);
+		expect(
+			registry
+				.select( keyboardShortcutsStore )
+				.getShortcutDescription( 'core/editor/intent-suggest' )
+		).toBe( 'Switch to Suggest mode.' );
+	} );
+
+	it( 'leaves the intent shortcuts unregistered when the post type has no notes support', () => {
+		window.__experimentalSuggestionMode = true;
+		const registry = createStubRegistry( { editor: true } );
+
+		renderRegister( registry );
+
+		/*
+		 * The rest of the editor shortcuts still register, so an empty
+		 * intent list means the component ran and skipped them rather
+		 * than never having registered anything at all.
+		 */
+		expect(
+			registry
+				.select( keyboardShortcutsStore )
+				.getShortcutKeyCombination( 'core/editor/keyboard-shortcuts' )
+		).toEqual( { modifier: 'access', character: 'h' } );
+		expect( registeredIntentShortcuts( registry ) ).toEqual( [] );
+	} );
+
+	it( 'leaves the intent shortcuts unregistered when the experiment is off', () => {
+		const registry = createStubRegistry( { 'editor.notes': true } );
+
+		renderRegister( registry );
+
+		expect( registeredIntentShortcuts( registry ) ).toEqual( [] );
+	} );
+
+	it( 'removes the intent shortcuts when notes support goes away', () => {
+		window.__experimentalSuggestionMode = true;
+		const registry = createStubRegistry( { 'editor.notes': true } );
+
+		renderRegister( registry );
+		expect( registeredIntentShortcuts( registry ) ).toEqual(
+			INTENT_SHORTCUTS
+		);
+
+		act( () => {
+			registry.dispatch( 'core' ).setPostTypeSupports( { editor: true } );
+		} );
+
+		expect( registeredIntentShortcuts( registry ) ).toEqual( [] );
+	} );
+} );

--- a/test/e2e/specs/site-editor/suggestion-mode-intent-shortcuts.spec.js
+++ b/test/e2e/specs/site-editor/suggestion-mode-intent-shortcuts.spec.js
@@ -1,0 +1,83 @@
+/**
+ * The intent shortcuts (Edit / Suggest / View) are only usable where the
+ * Mode menu is offered: the Suggestion Mode experiment on AND the current
+ * post type supporting `editor.notes`. Registering them lists them in the
+ * Keyboard Shortcuts help modal, so registration has to follow the same
+ * gate. `wp_template` has no notes support, so the Site Editor is the
+ * screen where advertising them is wrong.
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SUGGEST_SHORTCUT = 'Switch to Suggest mode.';
+
+async function openShortcutHelp( page, pageUtils ) {
+	await pageUtils.pressKeys( 'access+h' );
+	const dialog = page.getByRole( 'dialog', { name: 'Keyboard shortcuts' } );
+	await expect( dialog ).toBeVisible();
+	return dialog;
+}
+
+test.describe( 'Suggest mode intent shortcuts', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyfour' );
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-suggestion-mode',
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'are listed in the post editor, where the Mode menu is offered', async ( {
+		admin,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.createNewPost();
+
+		const dialog = await openShortcutHelp( page, pageUtils );
+		// Anchor on a shortcut that is always registered before asserting
+		// on the one under test, so the list is known to have rendered.
+		await expect(
+			dialog.getByText( 'Show or hide the List View.' )
+		).toBeVisible();
+		await expect( dialog.getByText( SUGGEST_SHORTCUT ) ).toBeVisible();
+	} );
+
+	test( 'still switch the intent in the post editor', async ( {
+		admin,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.createNewPost();
+
+		// The mode change also fires an a11y live-region announcement
+		// carrying the same text, so scope to the snackbar list.
+		const snackbarList = page.locator( '.components-snackbar-list' );
+		await pageUtils.pressKeys( 'secondary+x' );
+		await expect(
+			snackbarList.getByText( "You're suggesting" )
+		).toBeVisible();
+	} );
+
+	test( 'are not listed in the Site Editor, where no post type supports notes', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await admin.visitAdminPage( 'site-editor.php?canvas=edit' );
+		await editor.setPreferences( 'core/edit-site', {
+			welcomeGuide: false,
+		} );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Template' );
+
+		const dialog = await openShortcutHelp( page, pageUtils );
+		await expect(
+			dialog.getByText( 'Show or hide the List View.' )
+		).toBeVisible();
+		await expect( dialog.getByText( SUGGEST_SHORTCUT ) ).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
## What

Fixes finding F-03 from the Suggest mode guided testing pass: https://github.com/adamsilverstein/gutenberg/blob/docs/suggest-mode-testing-2026-08-14/suggest-mode-testing/README.md

Part of #73411. Stacked on top of #80433 (`suggest/inline-wiring`), which is the base branch here.

## The problem

The three intent shortcuts (`core/editor/intent-edit`, `-suggest`, `-view`) were registered whenever the Suggestion Mode experiment flag was on. Registration is what puts a shortcut in the Keyboard Shortcuts help modal, so the Site Editor listed "Switch to Edit mode.", "Switch to Suggest mode." and "Switch to View mode." under Global shortcuts.

None of them do anything there. `wp_template` has no `editor.notes` support, so no Mode menu renders and the handlers in `global-keyboard-shortcuts/index.js` return early. Pressing the combination gives no snackbar and no mode change.

The doc's diagnosis held up exactly on measurement: three gates for one feature, and the registration gate was the loose one. `register-shortcuts.js` checked `isSuggestionModeEnabled()` (the flag), while the Mode menu (`PostTypeSupportCheck supportKeys="editor.notes"`) and the shortcut handlers (`useCanSuggest()`) both check the flag AND notes support.

## The fix

Move the intent registrations into their own effect keyed on `useCanSuggest()`, the same runtime predicate the menu and the handlers use. `editor.notes` support arrives with the post type record, so the predicate starts false and flips once that resolves - hence a separate effect rather than a condition inside the existing one-shot registration. If it flips back the set is unregistered again, which is the pattern `BlockEditorKeyboardShortcutsRegister` already uses for its `blockVisibility` shortcuts.

One narrow file, `packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js`, which no other open PR in this round touches.

Visible side effect worth calling out: in the post editor the three entries now sit at the end of the Global shortcuts list rather than in the middle of it, because they register on a later pass. Same shortcuts, same key combinations, same behavior.

## Screenshots

Site Editor, Keyboard Shortcuts modal, Global shortcuts section. Before, the three intent shortcuts are advertised on a screen that cannot honor them:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f03-before-site-editor-shortcuts.png" alt="Before: the Site Editor lists Switch to Edit mode, Switch to Suggest mode and Switch to View mode" width="480">

After, they are gone and nothing else moved:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f03-after-site-editor-shortcuts.png" alt="After: the Site Editor global shortcuts list no longer includes the three intent shortcuts" width="480">

The post editor keeps all three. Before:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f03-before-post-editor-shortcuts.png" alt="Before: the post editor lists the three intent shortcuts mid-list" width="480">

After, still listed, now at the end of the section:

<img src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/f03-after-post-editor-shortcuts.png" alt="After: the post editor still lists the three intent shortcuts, at the end of the global section" width="480">

## Testing instructions

Enable the Suggestion Mode experiment (Gutenberg > Experiments) and use a block theme.

Before (on `suggest/inline-wiring`):

1. Open the Site Editor and edit any template.
2. Press `Shift+Alt+Cmd+H` (Mac) or `Shift+Alt+H` to open Keyboard shortcuts.
3. Under Global shortcuts, note "Switch to Edit mode.", "Switch to Suggest mode." and "Switch to View mode.".
4. Close the modal and press `Shift+Alt+Cmd+X`. Nothing happens: no snackbar, no mode change, and there is no Mode section in the Options menu.

After (this branch):

5. Repeat steps 1-3. The three entries are no longer listed.
6. Open a new post, open Keyboard shortcuts, and confirm the three entries are still listed there.
7. Close the modal and press `Shift+Alt+Cmd+X`. The "You're suggesting" snackbar appears and the Options menu shows Suggesting selected.

### Automated coverage

Unit, `packages/editor/src/components/global-keyboard-shortcuts/test/register-shortcuts.js`:

- "registers the intent shortcuts when the post type can host suggestions"
- "leaves the intent shortcuts unregistered when the post type has no notes support"
- "leaves the intent shortcuts unregistered when the experiment is off"
- "removes the intent shortcuts when notes support goes away"

Verified red on the unmodified base first: the second and fourth fail there with all three names still registered, while the first and third (the controls) pass on base and after. All four pass with the fix.

E2E, `test/e2e/specs/site-editor/suggestion-mode-intent-shortcuts.spec.js`:

- "are listed in the post editor, where the Mode menu is offered"
- "still switch the intent in the post editor"
- "are not listed in the Site Editor, where no post type supports notes"

Same story: on a base build the two post editor controls pass and the Site Editor one fails on "Switch to Suggest mode." still being visible; with the fix all three pass, run with `--repeat-each=5` for 15/15. The neighbouring suites were run against the fixed build too - `shortcut-help.spec.js` and `suggestion-mode.spec.js` give 23 passed with the one known pre-existing failure, "a closed sidebar stays closed when a suggestion is created", which is F-03's neighbour F-17 and is fixed separately in #81671.

## AI Use

Claude Code did the typing here, I did the asking. Description too. I will review and test.
