### PR TITLE
RichText: Use the current record when handling Enter

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.
 -   `DimensionsTool`: Reflect aspect ratio and scale values that are updated from outside the component, such as by undo or `updateBlockAttributes`. The scale control no longer displays a stale value, and an aspect ratio that is written differently to its preset, e.g. `1/1` rather than `1`, is displayed as that preset instead of as "Original" ([#80747](https://github.com/WordPress/gutenberg/pull/80747)).
 -   `ListView`: Only move focus into the list when the new `focusOnMount` prop is set, so that a list mounted as a side effect of a selection no longer pulls focus out of the editor canvas ([#81659](https://github.com/WordPress/gutenberg/pull/81659)).
+-   `RichText`: Handle Enter using the current record, so pressing it right after moving the caret splits at the caret's new position instead of the previous one ([#81696](https://github.com/WordPress/gutenberg/pull/81696)).
 
 ## 16.2.0 (2026-08-12)
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/enter.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/enter.js
@@ -22,11 +22,15 @@ export default ( props ) => ( element ) => {
 			supportsSplitting,
 			disableLineBreaks,
 			onChange,
-			value,
+			getValue,
 			onSplitAtDoubleLineEnd,
 			registry,
 			onSplitAtEnd,
 		} = props.current;
+		// The rendered value can lag the record: the capture phase listener
+		// that syncs the selection runs on this event, and a re-render with
+		// the new selection has not happened yet.
+		const value = getValue();
 		const { text, start, end } = value;
 
 		if ( event.shiftKey ) {


### PR DESCRIPTION
## What?
But was caught by flaky Tabs block e2e test - https://github.com/WordPress/gutenberg/pull/81693#issuecomment-5301018075.

The Enter handler in `RichText` now reads the caret position from the live rich text record via `getValue()` instead of the value React last rendered.

In the Tabs block, clicking in the middle of a tab label, pressing End and pressing Enter would insert a line break in the label instead of adding a new tab.

## Why?

The browser delivers `selectionchange` asynchronously, so the rendered value can hold the caret position from before the last move. `@wordpress/rich-text` already compensates with a capture phase `keydown` listener that syncs the selection, but that sync can only refresh the record and the store synchronously. The rendered value needs a React render.

Only blocks passing `__unstableOnSplitAtEnd` were affected, since that is the one Enter branch whose behavior depends on the caret offset. Everything else defers to `__unstableSplitSelection`, which reads the store.

## Testing Instructions
It's hard to reproduce manually, but here are the steps anyway.

1. Open a post or page.
2. Insert a Tabs block. It starts with "Tab 1" and "Tab 2".
3. Click in the middle of the "Tab 2" label.
4. Press End, then Enter.
5. A third tab is added, activated and focused, showing the "Tab title" placeholder.

The bug is a race condition, so on trunk step 5 fails intermittently. Repeat steps 3 and 4 a few times.

Automated coverage:

- `adds and activates a new tab when pressing Enter at the end of a tab label`: 1 of 8 passing before, 8 of 8 after.
- Full `tabs.spec.js`, four repeats: 28 of 28.
- splitting-merging, writing-flow, list, quote, paragraph and heading: 368 of 368 across Chromium, Firefox and WebKit.

## Testing Instructions for Keyboard

Same as above, except step 3: from the "Tab 1" label, press End, then Right Arrow, which moves the caret into "Tab 2" and activates it.

## Use of AI Tools

Assisted by Claude.
