### PR TITLE
Add `__unstable_wp_sync_storage` filter for pluggable storage backends

### DIFF
--- a/lib/experimental/collaboration/collaboration.php
+++ b/lib/experimental/collaboration/collaboration.php
@@ -80,6 +80,7 @@ if ( ! function_exists( 'gutenberg_register_collaboration_rest_routes' ) ) {
 		if ( ! $sync_storage instanceof WP_Sync_Storage ) {
 			$sync_storage = new WP_Sync_Post_Meta_Storage();
 		}
+
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();
 

--- a/lib/experimental/collaboration/collaboration.php
+++ b/lib/experimental/collaboration/collaboration.php
@@ -66,12 +66,20 @@ if ( ! function_exists( 'gutenberg_register_collaboration_rest_routes' ) ) {
 		 * which uses Presence API for awareness and a dedicated wp_collaboration
 		 * table for CRDT updates, eliminating cache side effects.
 		 *
+		 * This filter is unstable and may change as RTC explores fundamental changes
+		 * to how syncing works. The current interface assumes a pure naïve relay,
+		 * which could change.
+		 *
 		 * @since Gutenberg 21.x
 		 *
 		 * @param WP_Sync_Storage $sync_storage Storage implementation. Must implement
 		 *                                      the WP_Sync_Storage interface.
 		 */
-		$sync_storage = apply_filters( 'wp_sync_storage', new WP_Sync_Post_Meta_Storage() );
+		$sync_storage = apply_filters( '__unstable_wp_sync_storage', new WP_Sync_Post_Meta_Storage() );
+
+		if ( ! $sync_storage instanceof WP_Sync_Storage ) {
+			$sync_storage = new WP_Sync_Post_Meta_Storage();
+		}
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();
 

--- a/lib/experimental/collaboration/collaboration.php
+++ b/lib/experimental/collaboration/collaboration.php
@@ -81,7 +81,7 @@ if ( ! function_exists( 'gutenberg_register_collaboration_rest_routes' ) ) {
 			$sync_storage = new WP_Sync_Post_Meta_Storage();
 		}
 
-		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
+		$sync_server = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();
 
 		$sync_save_server = new WP_Sync_Save_Server();

--- a/lib/experimental/collaboration/collaboration.php
+++ b/lib/experimental/collaboration/collaboration.php
@@ -58,7 +58,20 @@ if ( ! function_exists( 'gutenberg_register_collaboration_rest_routes' ) ) {
 	 * Registers REST API routes for collaborative editing.
 	 */
 	function gutenberg_register_collaboration_rest_routes(): void {
-		$sync_storage = new WP_Sync_Post_Meta_Storage();
+		/**
+		 * Filters the sync storage implementation for collaborative editing.
+		 *
+		 * Allows plugins to replace the default post meta storage with alternative
+		 * backends. The primary use case is the realtime-collaboration plugin,
+		 * which uses Presence API for awareness and a dedicated wp_collaboration
+		 * table for CRDT updates, eliminating cache side effects.
+		 *
+		 * @since Gutenberg 21.x
+		 *
+		 * @param WP_Sync_Storage $sync_storage Storage implementation. Must implement
+		 *                                      the WP_Sync_Storage interface.
+		 */
+		$sync_storage = apply_filters( 'gutenberg_sync_storage', new WP_Sync_Post_Meta_Storage() );
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();
 

--- a/lib/experimental/collaboration/collaboration.php
+++ b/lib/experimental/collaboration/collaboration.php
@@ -71,7 +71,7 @@ if ( ! function_exists( 'gutenberg_register_collaboration_rest_routes' ) ) {
 		 * @param WP_Sync_Storage $sync_storage Storage implementation. Must implement
 		 *                                      the WP_Sync_Storage interface.
 		 */
-		$sync_storage = apply_filters( 'gutenberg_sync_storage', new WP_Sync_Post_Meta_Storage() );
+		$sync_storage = apply_filters( 'wp_sync_storage', new WP_Sync_Post_Meta_Storage() );
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();
 


### PR DESCRIPTION
## What

Adds `__unstable_wp_sync_storage` filter to allow custom storage backends for collaborative editing data.

## Why

Current RTC stores sync data in post meta, causing site-wide cache invalidation on every edit (Trac [#64696](https://core.trac.wordpress.org/ticket/64696)). Plugins can now provide alternative storage without forking Gutenberg.

Use case: [proposed realtime-collaboration](https://github.com/josephfusco/realtime-collaboration):
- Presence API for awareness (cursors, user metadata)
- Dedicated `wp_collaboration` table for CRDT updates
- Eliminates cache invalidation while maintaining Gutenberg's HTTP polling provider

## How

```php
/**
 * Filters the sync storage implementation for collaborative editing.
 *
 * Allows plugins to replace the default post meta storage with alternative
 * backends. The primary use case is the realtime-collaboration plugin,
 * which uses Presence API for awareness and a dedicated wp_collaboration
 * table for CRDT updates, eliminating cache side effects.
 *
 * @since Gutenberg 21.x
 *
 * @param WP_Sync_Storage $sync_storage Storage implementation. Must implement
 *                                      the WP_Sync_Storage interface.
 */
$sync_storage = apply_filters( '__unstable_wp_sync_storage', new WP_Sync_Post_Meta_Storage() );
```