### PR TITLE
Make Back button grid column flexible.

### DIFF
--- a/packages/edit-post/src/components/back-button/index.js
+++ b/packages/edit-post/src/components/back-button/index.js
@@ -1,5 +1,7 @@
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __unstableMotion as motion } from '@wordpress/components';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 import FullscreenModeClose from './fullscreen-mode-close';
 import { unlock } from '../../lock-unlock';
 
@@ -12,6 +14,10 @@ const slideX = {
 };
 
 function BackButton( { initialPost } ) {
+	const showIconLabels = useSelect( ( select ) => {
+		return select( preferencesStore ).get( 'core', 'showIconLabels' );
+	}, [] );
+
 	return (
 		<BackButtonFill>
 			{ ( { length } ) =>
@@ -21,7 +27,7 @@ function BackButton( { initialPost } ) {
 						transition={ { type: 'tween', delay: 0.8 } }
 					>
 						<FullscreenModeClose
-							showTooltip
+							showTooltip={ ! showIconLabels }
 							initialPost={ initialPost }
 						/>
 					</motion.div>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -14,6 +14,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
+import { store as preferencesStore } from '@wordpress/preferences';
 import WelcomeGuide from '../welcome-guide';
 import CanvasLoader from '../canvas-loader';
 import { unlock } from '../../lock-unlock';
@@ -85,6 +86,11 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	const { postType, postId, context } = entity;
 	const isBlockBasedTheme = useSelect(
 		( select ) => select( coreDataStore ).getCurrentTheme()?.is_block_theme,
+		[]
+	);
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showIconLabels' ),
 		[]
 	);
 	const postWithTemplate = !! context?.postId;
@@ -197,7 +203,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 									<Button
 										size="compact"
 										label={ __( 'Open Navigation' ) }
-										showTooltip
+										showTooltip={ ! showIconLabels }
 										tooltipPosition="middle right"
 										onClick={ () => {
 											resetZoomLevel();

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Register the editor and block editor keyboard shortcuts from the editor provider, so shortcuts work for consumers that mount the editor without rendering `EditorKeyboardShortcutsRegister` themselves ([#81580](https://github.com/WordPress/gutenberg/pull/81580)).
+-   Header: Allow the Back button column to grow when "Show button text labels" is enabled so the label is not obscured by the following controls ([#81701](https://github.com/WordPress/gutenberg/pull/81701)).
 
 ## 14.53.0 (2026-08-12)
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -10,11 +10,11 @@
 	background: $white;
 	display: grid;
 	grid-auto-flow: row;
-	grid-template: auto / $button-size-compact minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	grid-template: auto / auto minmax(0, max-content) minmax(min-content, 1fr) $header-height;
 	&:has(> .editor-header__center) {
-		grid-template: auto / $button-size-compact min-content 1fr min-content $header-height;
+		grid-template: auto / auto min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / $button-size-compact minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
+			grid-template: auto / auto minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {
@@ -32,7 +32,11 @@
 }
 
 .editor-header__back-button {
-	padding-left: $grid-unit;
+	margin: 0 (-$grid-unit) 0 $grid-unit;
+
+	.show-icon-labels & {
+		margin-right: 0;
+	}
 }
 
 .editor-header__toolbar {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See #81680

Alternative approach to fix the Back button grid column when the 'Show button text labels' preference is enabled.

Additionally, tooltips should not be used when a control already shows a visible text label. The only exception is when a tooltip shows also a keyboard shortcut, which is not the case for the Back buttons.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
- Makes the first grid column flexible by usint `auto`.
- Makes the tooltips conditional based on the showIconLabels preference.

## Testing Instructions

- Repeat the steps described in the issue at https://github.com/WordPress/gutenberg/issues/81680
- Observe the buttons text in both the Post and Site editors is not obscured.
- Test also with 'Distraction free' mode enabled and double check the animations work as expected.
- Test the responsive viee.

Additionally:
- With the 'Show button text labels' preference is enabled, hover or focus the back buttons.
- Observe the buttons tooltip is not shown.
- Disable the preference.
- Observe the buttons tooltip does show.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

In the screenshots, I'm using a red outline to illustrate the size and spacing of the various controls after the fix.

Post editor:

<img width="741" height="137" alt="01 post editor" src="https://github.com/user-attachments/assets/9c3b8dc5-dc11-4f8a-ab83-278321bdf3c3" />

Site editor:

<img width="799" height="113" alt="02 site editor" src="https://github.com/user-attachments/assets/78edfebf-9ec0-468c-a9e9-e1d32c3956eb" />



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
