### PR TITLE
Rename the media editor toolbar button to 'Edit image'

### DIFF
--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -113,7 +113,7 @@ export default function CoverBlockControls( {
 						<ToolbarButton
 							ref={ editMediaButtonRef }
 							icon={ crop }
-							label={ __( 'Crop background image' ) }
+							label={ __( 'Edit image' ) }
 							onClick={ onEditMedia }
 							aria-haspopup="dialog"
 							// Disable rather than hide while the edited image

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -918,7 +918,7 @@ export default function Image( {
 							onClick={ openImageMediaEditorModal }
 							aria-haspopup="dialog"
 							icon={ crop }
-							label={ __( 'Crop' ) }
+							label={ __( 'Edit image' ) }
 							// Disable rather than hide while the edited image
 							// loads, so the button keeps focus when the modal
 							// closes instead of dropping it to the canvas.

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -344,7 +344,7 @@ const SiteLogo = ( {
 							}
 							aria-haspopup="dialog"
 							icon={ crop }
-							label={ __( 'Crop' ) }
+							label={ __( 'Edit image' ) }
 						/>
 					</BlockControls>
 				) }

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -238,7 +238,7 @@ test.describe( 'Image', () => {
 		] = await editor.getBlocks();
 
 		// Open the media editor modal from the block toolbar.
-		await editor.clickBlockToolbarButton( 'Crop' );
+		await editor.clickBlockToolbarButton( 'Edit image' );
 		const modal = page.locator( 'role=dialog[name="Edit media"i]' );
 		await expect( modal ).toBeVisible();
 
@@ -268,11 +268,11 @@ test.describe( 'Image', () => {
 			imageBlock.locator( '.components-spinner' )
 		).toBeHidden();
 
-		// Closing the modal returns focus to the Crop toolbar button. The
-		// button is disabled (not hidden) while the edit loads, so it stays in
-		// the DOM to receive focus rather than dropping it to the canvas.
+		// Closing the modal returns focus to the "Edit image" toolbar button.
+		// The button is disabled (not hidden) while the edit loads, so it stays
+		// in the DOM to receive focus rather than dropping it to the canvas.
 		await expect(
-			page.locator( 'role=button[name="Crop"i]' )
+			page.locator( 'role=button[name="Edit image"i]' )
 		).toBeFocused();
 	} );
 


### PR DESCRIPTION
## What?

Closes #81704

Renames the block toolbar button that opens the media editor from `Crop` (Image, Site Logo) and `Crop background image` (Cover) to `Edit image`.

## Why?

The button opens the media editor modal, which does far more than cropping: rotate, flip, zoom, aspect ratio presets, and editing the image details (title, alt text, caption, description, attached to). Labelling it `Crop` suggests a single action and misrepresents what the button does. `Edit image` is an established label in WordPress. For the Cover block, mentioning "background" isn't necessary since the button lives in that block's own toolbar.

## How?

Updates the `label` prop of the `ToolbarButton` in the three blocks that expose the media editor:

- `packages/block-library/src/image/image.js`
- `packages/block-library/src/site-logo/edit.js`
- `packages/block-library/src/cover/edit/block-controls.js`

The e2e test that clicks the button by its accessible name is updated to match. The icon is unchanged.

## Testing Instructions

1. Add an Image block and upload/select an image.
2. Select the block and hover the media editor button in the toolbar — the tooltip and accessible name read `Edit image`.
3. Click it and confirm the media editor modal still opens as before.
4. Repeat with a Site Logo block and with a Cover block that has a background image (the Cover button previously read `Crop background image`).

### Testing Instructions for Keyboard

1. Select the block, press <kbd>Alt</kbd> + <kbd>F10</kbd> to move focus to the block toolbar.
2. Arrow to the media editor button — the screen reader announces `Edit image`.
3. Press <kbd>Enter</kbd> or <kbd>Space</kbd> to open the modal, then close it with <kbd>Esc</kbd> and confirm focus returns to the `Edit image` button.

## Screenshots or screencast

|Before|After|
|-|-|
|Toolbar button tooltip: `Crop` / `Crop background image`|Toolbar button tooltip: `Edit image`|

| Image | Cover | Site Logo |
| --- | --- | --- |
| <img width="999" height="412" alt="image" src="https://github.com/user-attachments/assets/62df1c81-b124-40e6-880a-9f6928800c4b" /> | <img width="1023" height="442" alt="image" src="https://github.com/user-attachments/assets/aea9eb1d-b56a-4597-8f46-5e722d5aec1a" /> | <img width="1070" height="419" alt="image" src="https://github.com/user-attachments/assets/b6620822-4efa-4857-863e-55c2fa92105f" /> |

## Use of AI Tools

Used Claude Code to locate the affected files and draft this change. The change and its testing instructions were reviewed by me.
