### PR TITLE
Media: Add an experiment for smart cropping of image sizes

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -39,6 +39,9 @@ function gutenberg_enable_experiments() {
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-dashboard-widgets' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalDashboardWidgets = true', 'before' );
 	}
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-media-smart-crop' ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaSmartCrop = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -55,6 +55,11 @@ function gutenberg_initialize_experiments_settings() {
 					'label'       => __( 'Media Upload Modal', 'gutenberg' ),
 					'description' => __( 'Replaces the existing WordPress media modal with a new modal powered by Data Views, supporting browsing, selecting, and uploading media.', 'gutenberg' ),
 				),
+				array(
+					'id'          => 'gutenberg-media-smart-crop',
+					'label'       => __( 'Smart cropping of image sizes', 'gutenberg' ),
+					'description' => __( 'Positions hard-cropped image sizes around the most visually interesting part of the image instead of the center, during client-side media processing. Applies to newly uploaded images only.', 'gutenberg' ),
+				),
 			),
 		),
 		array(

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+-   Forward a `smartCrop` media upload setting, derived from the `gutenberg-media-smart-crop` experiment, so hard-cropped image sizes can be positioned around the most visually interesting part of the image during client-side processing ([#81706](https://github.com/WordPress/gutenberg/issues/81706)).
 -   Register and handle the keyboard shortcuts that blocks declare on their variations and transforms, so that any block can contribute a shortcut without the editor knowing about it. Shortcuts apply to the selected block, and are listed under "Block shortcuts" in the keyboard shortcuts help modal ([#81588](https://github.com/WordPress/gutenberg/pull/81588)).
 
 ### Bug Fixes

--- a/packages/block-editor/src/components/provider/use-media-upload-settings.js
+++ b/packages/block-editor/src/components/provider/use-media-upload-settings.js
@@ -20,6 +20,9 @@ function useMediaUploadSettings( settings = {} ) {
 			bigImageSizeThreshold: settings.bigImageSizeThreshold,
 			imageStripMeta: settings.imageStripMeta,
 			imageMaxBitDepth: settings.imageMaxBitDepth,
+			// Gated by the `gutenberg-media-smart-crop` experiment rather than an
+			// editor setting, so it is read from the global set in PHP.
+			smartCrop: Boolean( window.__experimentalMediaSmartCrop ),
 		} ),
 		[ settings ]
 	);

--- a/packages/upload-media/CHANGELOG.md
+++ b/packages/upload-media/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add a `smartCrop` setting that positions hard-cropped image sizes using libvips' saliency-aware `attention` strategy instead of cropping from the center. Only sizes registered with `crop => true` are affected; positional crops and soft resizes are unchanged. Off by default, and gated in the Gutenberg plugin by the "Smart cropping of image sizes" experiment ([#81706](https://github.com/WordPress/gutenberg/issues/81706)).
+
 ## 0.38.0 (2026-08-12)
 
 ### Enhancements

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1137,7 +1137,10 @@ export function resizeCropItem( id: QueueItemId, args?: ResizeCropItemArgs ) {
 
 		// Metadata stripping and bit depth cap from the `image_strip_meta`
 		// and `image_max_bit_depth` filters, carried in the editor settings.
-		const { imageStripMeta, imageMaxBitDepth } = select.getSettings();
+		// `smartCrop` is gated by the `gutenberg-media-smart-crop` experiment and
+		// only takes effect for sizes registered with `crop => true`.
+		const { imageStripMeta, imageMaxBitDepth, smartCrop } =
+			select.getSettings();
 
 		try {
 			const file = await vipsResizeImage(
@@ -1145,7 +1148,7 @@ export function resizeCropItem( id: QueueItemId, args?: ResizeCropItemArgs ) {
 				item.file,
 				args.resize,
 				{
-					smartCrop: false,
+					smartCrop: smartCrop ?? false,
 					addSuffix,
 					signal: item.abortController?.signal,
 					scaledSuffix,

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -1687,6 +1687,60 @@ describe( 'actions', () => {
 			expect( vipsResizeImage ).toHaveBeenCalled();
 		} );
 
+		it( 'enables smart crop when the setting is on', async () => {
+			unlock( registry.dispatch( uploadStore ) ).updateSettings( {
+				smartCrop: true,
+			} );
+
+			unlock( registry.dispatch( uploadStore ) ).addItem( {
+				file: jpegFile,
+			} );
+
+			const item = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			const { vipsResizeImage } = require( '../utils' );
+			( vipsResizeImage as jest.Mock ).mockClear();
+
+			await unlock( registry.dispatch( uploadStore ) ).resizeCropItem(
+				item.id,
+				{ resize: { width: 100, height: 100, crop: true } }
+			);
+
+			expect( vipsResizeImage ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				expect.anything(),
+				expect.objectContaining( { smartCrop: true } )
+			);
+		} );
+
+		it( 'defaults smart crop to false when the setting is unset', async () => {
+			unlock( registry.dispatch( uploadStore ) ).addItem( {
+				file: jpegFile,
+			} );
+
+			const item = unlock(
+				registry.select( uploadStore )
+			).getAllItems()[ 0 ];
+
+			const { vipsResizeImage } = require( '../utils' );
+			( vipsResizeImage as jest.Mock ).mockClear();
+
+			await unlock( registry.dispatch( uploadStore ) ).resizeCropItem(
+				item.id,
+				{ resize: { width: 100, height: 100, crop: true } }
+			);
+
+			expect( vipsResizeImage ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				expect.anything(),
+				expect.objectContaining( { smartCrop: false } )
+			);
+		} );
+
 		it( 'skips resize when no resize args are provided', async () => {
 			unlock( registry.dispatch( uploadStore ) ).addItem( {
 				file: jpegFile,

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -228,6 +228,11 @@ export interface Settings {
 	// Maximum output bit depth for generated images, from the
 	// `image_max_bit_depth` filter. Default is 16 (no cap).
 	imageMaxBitDepth?: number;
+	// Whether to position hard-cropped image sizes using libvips' saliency-aware
+	// `attention` strategy instead of cropping from the center. Only affects sizes
+	// registered with `crop => true`; positional crops and soft resizes ignore it.
+	// Default is false.
+	smartCrop?: boolean;
 	// Function for finalizing an upload after all client-side processing is complete.
 	// May return the up-to-date attachment so the queue and block markup can pick
 	// up the post-finalize URL (the scaled file), which is required for `srcset`.


### PR DESCRIPTION
_Claude wrote this one up after doing the code archaeology:_

## What?

See https://github.com/WordPress/gutenberg/issues/81706

Adds a `gutenberg-media-smart-crop` experiment that lets client-side media processing position hard-cropped image sizes using libvips' saliency-aware `attention` strategy instead of cropping from the geometric center.

This is the flag-only first step from that issue. Storing a focal point in attachment meta is not part of it.

## Why?

Hard-cropped sizes currently crop from the middle of the frame, so a subject sitting away from center gets cut off. `thumbnail` at 150x150 is the usual place this shows up.

Most of the work for this was already done and just unreachable. `applyResizeAndCrop()` in `packages/vips/src/index.ts` already picks between the `attention` and `centre` strategies based on a `smartCrop` flag, and `ResizeImageOptions.smartCrop` already exists. The flag was hardcoded to `false` at the single call site in `packages/upload-media/src/store/private-actions.ts`, so none of it could be turned on.

Putting it behind an experiment means the strategy can actually be tried on real images before deciding whether it should ever be a default.

## How?

The experiment sets `window.__experimentalMediaSmartCrop`, which `use-media-upload-settings.js` forwards into the upload-media store as a `smartCrop` setting. `resizeCropItem()` already reads store settings for `imageStripMeta` and `imageMaxBitDepth`, so it just reads one more key - no changes to operation args or to the sub-size queueing.

The Experiments screen builds its toggles from the REST settings schema, so registering the experiment in `lib/experimental/experiments/load.php` is enough to surface it. No admin screen JS.

Worth noting what stays untouched, since the vips layer scopes this narrowly on its own:

- Only sizes registered with `crop => true` consult the flag. Registered positional crops like `array( 'center', 'top' )` take a different branch and ignore it.
- Soft resizes never crop, so they are unaffected.
- The big-image-threshold `-scaled` resize queues no `crop`, so it can't smart crop by construction.
- Server-side PHP generation is unaffected, and existing attachments are never re-cropped. New uploads only, and only while the experiment is on.

## Testing Instructions

1. Enable "Smart cropping of image sizes" under Settings > Experiments.
2. Upload a portrait photo with the subject well up in the top third of the frame.
3. Check the generated `thumbnail` (150x150). The subject should be kept in frame.
4. Turn the experiment off, upload the same photo again, and compare - that one should crop from the center.
5. Confirm soft-cropped sizes and any sizes registered with a positional crop are unchanged either way.

`npm run test:unit -- packages/upload-media` covers the wiring: 381 tests pass, including two new ones asserting `vipsResizeImage` receives `smartCrop: true` when the setting is on and `false` when it is unset.

Separately, the two strategies were compared directly at the vips layer, calling `thumbnail` with exactly the options `applyResizeAndCrop()` builds for a `crop => true` size (`{ size: 'down', height, crop }`), on a 1200x2400 test image with a single high-saliency subject in the upper third.

For a 150x150 `thumbnail`, the source scales to 150x225 and a 150x150 window is chosen inside it:

- `centre` picks y offset 75 of a possible 150, the geometric middle. In source coordinates that window is y 600-1800, and the subject sits at roughly y 190-610, so it lands almost entirely outside the crop.
- `attention` picks y offset 0, a window of y 0-1200 in source coordinates, which contains the subject.

Note that a full upload through the browser has not been run yet, so the wiring from the experiment toggle down to `resizeCropItem` is currently covered by the unit tests rather than by an end to end test. That is worth someone confirming.

## Screenshots or screencast

The resulting `thumbnail`, shown at its real 150x150:

|Before (experiment off, `centre`)|After (experiment on, `attention`)|
|-|-|
|![Centre crop, subject cropped out](https://raw.githubusercontent.com/adamsilverstein/gutenberg/assets/gb-81706-smart-crop/images/before-centre-crop.png)|![Attention crop, subject kept in frame](https://raw.githubusercontent.com/adamsilverstein/gutenberg/assets/gb-81706-smart-crop/images/after-attention-crop.png)|

The window each strategy selected, drawn on the source. Green is `attention`, red is `centre`:

![Crop windows drawn on the source image](https://raw.githubusercontent.com/adamsilverstein/gutenberg/assets/gb-81706-smart-crop/images/crop-windows-explained.png)

The source is a generated 1200x2400 test image rather than a photograph, so it can be regenerated and carries no licensing question. The background is a low saturation gradient with almost no edge energy, and the subject is saturated and high frequency, which is what the attention heuristic keys on:

![Source test image](https://raw.githubusercontent.com/adamsilverstein/gutenberg/assets/gb-81706-smart-crop/images/source-test-image.jpg)

These are hosted on a branch of a fork rather than committed here, so they stay out of the diff.

## Open questions

Whether libvips `attention` is the right detector at all is worth settling before this goes any further than an experiment. Per https://github.com/libvips/libvips/discussions/3767 it is a heuristic over edges, saturation and skin tone, not face detection, so it can miss a face that a person would consider the obvious subject. There is a comparison of alternatives in the issue thread.

That question doesn't really block this PR - the flag is what makes it possible to judge `attention` on real images, and in most of the alternative designs vips `attention` still has a place as the zero-cost fallback when a detector finds nothing. But it does mean this shouldn't be read as settling on `attention`.

One more gap, pre-existing and not addressed here: `resizeHighBitDepth()` in `packages/vips/src/index.ts` resizes without cropping at all, so high bit depth AVIF sources bypass smart crop regardless of this setting.

## Use of AI Tools

Code and description both written with 🤖 Claude Code. I will review and test.
