### PR TITLE
Make CRDT snapshot saves conflict-safe

### DIFF
--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -43,6 +43,14 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		const MAX_DOC_LENGTH = 16 * MB_IN_BYTES;
 
 		/**
+		 * Whether a save is already running in this request.
+		 *
+		 * @since 7.1.0
+		 * @var bool
+		 */
+		private static $save_in_progress = false;
+
+		/**
 		 * Registers REST API routes.
 		 *
 		 * @since 7.1.0
@@ -64,10 +72,14 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 							'required' => true,
 							'type'     => 'string',
 						),
-						'doc'  => array(
+						'doc'          => array(
 							'maxLength' => self::MAX_DOC_LENGTH,
 							'required'  => true,
 							'type'      => 'string',
+						),
+						'expected_doc' => array(
+							'required' => true,
+							'type'     => 'string',
 						),
 					),
 				)
@@ -114,8 +126,16 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		 * @return WP_REST_Response|WP_Error Response object or error.
 		 */
 		public function handle_request( WP_REST_Request $request ) {
-			$room        = $request['room'];
-			$parsed_room = is_string( $room ) ? WP_Sync_Config::parse_room( $room ) : null;
+			global $wpdb;
+
+			if ( self::$save_in_progress ) {
+				return $this->get_save_conflict_error();
+			}
+
+			self::$save_in_progress = true;
+			$transaction_open       = false;
+			$room                   = $request['room'];
+			$parsed_room            = is_string( $room ) ? WP_Sync_Config::parse_room( $room ) : null;
 
 			$post_id = WP_Sync_Config::get_crdt_doc_persistence_post_id(
 				$parsed_room['entity_kind'],
@@ -123,10 +143,85 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 				$parsed_room['object_id']
 			);
 
-			$doc = $request['doc'];
+			try {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- All CRDT writers lock the same post row before updating metadata.
+				if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+					return $this->get_transaction_error( 'start' );
+				}
+				$transaction_open = true;
 
-			$updated = update_post_meta( $post_id, self::CRDT_DOC_META_KEY, $doc );
-			if ( false === $updated && get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true ) !== $doc ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Serializes CRDT writes even when the metadata row does not exist yet.
+				$locked_post_id = $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT ID FROM $wpdb->posts WHERE ID = %d FOR UPDATE",
+						$post_id
+					)
+				);
+				if ( (int) $locked_post_id !== (int) $post_id ) {
+					return new WP_Error(
+						'rest_sync_post_not_found',
+						__( 'The synchronized post could not be found.', 'gutenberg' ),
+						array( 'status' => 404 )
+					);
+				}
+
+				$updated = $this->update_crdt_doc(
+					$post_id,
+					$request['doc'],
+					$request['expected_doc']
+				);
+				if ( is_wp_error( $updated ) ) {
+					return $updated;
+				}
+
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Completes the transaction started above.
+				if ( false === $wpdb->query( 'COMMIT' ) ) {
+					return $this->get_transaction_error( 'commit' );
+				}
+				$transaction_open = false;
+
+				return array();
+			} finally {
+				if ( $transaction_open ) {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Prevents a failed CRDT save from persisting.
+					$wpdb->query( 'ROLLBACK' );
+				}
+				self::$save_in_progress = false;
+			}
+		}
+
+		/**
+		 * Updates a CRDT document only when its persisted base is unchanged.
+		 *
+		 * @param int    $post_id      Post ID.
+		 * @param string $doc          Replacement CRDT document.
+		 * @param string $expected_doc Expected persisted CRDT document.
+		 * @return true|WP_Error True on success, otherwise an error.
+		 */
+		private function update_crdt_doc( int $post_id, string $doc, string $expected_doc ) {
+			wp_cache_delete( $post_id, 'post_meta' );
+			$current_doc = get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true );
+			if ( $current_doc !== $expected_doc ) {
+				return new WP_Error(
+					'rest_sync_document_conflict',
+					__( 'The synchronized document changed before it could be saved.', 'gutenberg' ),
+					array( 'status' => 409 )
+				);
+			}
+
+			$updated = update_post_meta( $post_id, self::CRDT_DOC_META_KEY, $doc, $expected_doc );
+			if ( false === $updated ) {
+				wp_cache_delete( $post_id, 'post_meta' );
+				$current_doc = get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true );
+				if ( $current_doc !== $expected_doc && $current_doc !== $doc ) {
+					return new WP_Error(
+						'rest_sync_document_conflict',
+						__( 'The synchronized document changed before it could be saved.', 'gutenberg' ),
+						array( 'status' => 409 )
+					);
+				}
+			}
+			if ( false === $updated && $current_doc !== $doc ) {
 				return new WP_Error(
 					'rest_crdt_save_failed',
 					__( 'Failed to save CRDT document.', 'gutenberg' ),
@@ -134,7 +229,37 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 				);
 			}
 
-			return array();
+			return true;
+		}
+
+		/**
+		 * Returns the shared conflict error for reentrant sync saves.
+		 *
+		 * @return WP_Error Conflict error.
+		 */
+		private function get_save_conflict_error(): WP_Error {
+			return new WP_Error(
+				'rest_sync_document_conflict',
+				__( 'Another synchronized document save is already in progress.', 'gutenberg' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		/**
+		 * Returns a transaction error.
+		 *
+		 * @param string $operation Failed transaction operation.
+		 * @return WP_Error Transaction error.
+		 */
+		private function get_transaction_error( string $operation ): WP_Error {
+			$message = 'start' === $operation
+				? __( 'Failed to start synchronized content transaction.', 'gutenberg' )
+				: __( 'Failed to commit synchronized content transaction.', 'gutenberg' );
+			return new WP_Error(
+				'rest_sync_transaction_failed',
+				$message,
+				array( 'status' => 500 )
+			);
 		}
 
 		/**

--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 					'callback'            => array( $this, 'handle_request' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
 					'args'                => array(
-						'room' => array(
+						'room'         => array(
 							'required' => true,
 							'type'     => 'string',
 						),

--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -78,8 +78,7 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 							'type'      => 'string',
 						),
 						'expected_doc' => array(
-							'required' => true,
-							'type'     => 'string',
+							'type' => 'string',
 						),
 					),
 				)
@@ -168,7 +167,7 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 				$updated = $this->update_crdt_doc(
 					$post_id,
 					$request['doc'],
-					$request['expected_doc']
+					$request->has_param( 'expected_doc' ) ? $request['expected_doc'] : null
 				);
 				if ( is_wp_error( $updated ) ) {
 					return $updated;
@@ -195,12 +194,25 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		 *
 		 * @param int    $post_id      Post ID.
 		 * @param string $doc          Replacement CRDT document.
-		 * @param string $expected_doc Expected persisted CRDT document.
+		 * @param string|null $expected_doc Expected persisted CRDT document, or null for an unconditional save.
 		 * @return true|WP_Error True on success, otherwise an error.
 		 */
-		private function update_crdt_doc( int $post_id, string $doc, string $expected_doc ) {
+		private function update_crdt_doc( int $post_id, string $doc, ?string $expected_doc ) {
 			wp_cache_delete( $post_id, 'post_meta' );
 			$current_doc = get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true );
+			if ( null === $expected_doc ) {
+				$updated = update_post_meta( $post_id, self::CRDT_DOC_META_KEY, $doc );
+				if ( false === $updated && $current_doc !== $doc ) {
+					return new WP_Error(
+						'rest_crdt_save_failed',
+						__( 'Failed to save CRDT document.', 'gutenberg' ),
+						array( 'status' => 500 )
+					);
+				}
+
+				return true;
+			}
+
 			if ( $current_doc !== $expected_doc ) {
 				return new WP_Error(
 					'rest_sync_document_conflict',

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -181,6 +181,24 @@ export const setCollaborationSupported =
 	};
 
 /**
+ * Creates a persisted CRDT snapshot with isolated entity changes without
+ * applying those changes to the live collaborative document.
+ *
+ * @param {string}        kind     Entity kind.
+ * @param {string}        name     Entity name.
+ * @param {number|string} recordId Entity record ID.
+ * @param {Object}        changes  Changes to include in the snapshot.
+ * @return {Promise<string|null>} Serialized CRDT document, when loaded.
+ */
+export const createEntityCRDTPersistenceSnapshot =
+	( kind, name, recordId, changes ) => () =>
+		getSyncManager()?.createPersistedCRDTDoc(
+			`${ kind }/${ name }`,
+			recordId,
+			changes
+		);
+
+/**
  * Returns an action object used to receive view config.
  *
  * @param {string} kind   Entity kind.

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -830,10 +830,12 @@ export function createSyncManager( debug = false ): SyncManager {
 	 *
 	 * @param {ObjectType} objectType Object type.
 	 * @param {ObjectID}   objectId   Object ID.
+	 * @param {ObjectData} changes    Changes to include in the snapshot.
 	 */
 	async function createPersistedCRDTDoc(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		changes?: Partial< ObjectData >
 	): Promise< string | null > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -845,6 +847,25 @@ export function createSyncManager( debug = false ): SyncManager {
 		// Local updates may be deferred when editing alone. Apply them so
 		// they are included in the serialized document.
 		flushPendingCRDTDocUpdates();
+
+		if ( changes ) {
+			const snapshot = createYjsDoc( { objectType } );
+			Y.applyUpdateV2(
+				snapshot,
+				Y.encodeStateAsUpdateV2( entityState.ydoc )
+			);
+			try {
+				snapshot.transact( () => {
+					entityState.syncConfig.applyChangesToCRDTDoc(
+						snapshot,
+						changes
+					);
+				}, LOCAL_SYNC_MANAGER_ORIGIN );
+				return serializeCrdtDoc( snapshot );
+			} finally {
+				snapshot.destroy();
+			}
+		}
 
 		return serializeCrdtDoc( entityState.ydoc );
 	}

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -27,7 +27,7 @@ import type {
 	RecordHandlers,
 	SyncConfig,
 } from '../types';
-import { serializeCrdtDoc } from '../utils';
+import { deserializeCrdtDoc, serializeCrdtDoc } from '../utils';
 
 // Mock dependencies.
 jest.mock( '../providers', () => ( {
@@ -901,6 +901,50 @@ describe( 'SyncManager', () => {
 				now
 			);
 			expect( stateMap.get( SAVED_BY_KEY ) ).toBe( ydoc.clientID );
+		} );
+	} );
+
+	describe( 'createPersistedCRDTDoc', () => {
+		it( 'applies explicit changes to a cloned snapshot', async () => {
+			let liveDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				liveDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc.mockImplementation(
+				( ydoc, changes ) => {
+					const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						recordMap.set( key, value )
+					);
+				}
+			);
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			const serialized = await manager.createPersistedCRDTDoc(
+				'post',
+				'123',
+				{ title: 'Repaired title' }
+			);
+			const snapshot = deserializeCrdtDoc( serialized ?? '' );
+
+			expect(
+				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
+			).toBe( 'Repaired title' );
+			expect(
+				( liveDoc as unknown as Y.Doc )
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'title' )
+			).toBe( 'Test Post' );
+			snapshot?.destroy();
 		} );
 	} );
 

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -928,6 +928,12 @@ describe( 'SyncManager', () => {
 				mockRecord,
 				mockHandlers
 			);
+			manager.update(
+				'post',
+				'123',
+				{ meta: { pending: true } },
+				'local'
+			);
 
 			const serialized = await manager.createPersistedCRDTDoc(
 				'post',
@@ -939,11 +945,22 @@ describe( 'SyncManager', () => {
 			expect(
 				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
 			).toBe( 'Repaired title' );
+			expect( snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'id' ) ).toBe(
+				'123'
+			);
+			expect(
+				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'meta' )
+			).toEqual( { pending: true } );
 			expect(
 				( liveDoc as unknown as Y.Doc )
 					.getMap( CRDT_RECORD_MAP_KEY )
 					.get( 'title' )
 			).toBe( 'Test Post' );
+			expect(
+				( liveDoc as unknown as Y.Doc )
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'meta' )
+			).toEqual( { pending: true } );
 			snapshot?.destroy();
 		} );
 	} );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -156,7 +156,8 @@ export interface SyncConfig {
 export interface SyncManager {
 	createPersistedCRDTDoc: (
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		changes?: Partial< ObjectData >
 	) => Promise< string | null >;
 	getAwareness: < State extends Awareness >(
 		objectType: ObjectType,

--- a/phpunit/tests/collaboration/wpSyncSaveServer.php
+++ b/phpunit/tests/collaboration/wpSyncSaveServer.php
@@ -38,21 +38,24 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 
 		// Enable option for tests.
 		update_option( 'wp_collaboration_enabled', 1 );
+		delete_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY );
 	}
 
 	/**
 	 * Dispatches a CRDT document save request.
 	 *
-	 * @param string $room Room identifier.
-	 * @param string $doc  Serialized CRDT document.
+	 * @param string $room         Room identifier.
+	 * @param string $doc          Serialized CRDT document.
+	 * @param string $expected_doc Expected persisted CRDT document.
 	 * @return WP_REST_Response Response object.
 	 */
-	private function dispatch_save( $room, $doc = 'serialized-crdt-doc' ) {
+	private function dispatch_save( $room, $doc = 'serialized-crdt-doc', $expected_doc = '' ) {
 		$request = new WP_REST_Request( 'POST', '/wp-sync/v1/save' );
 		$request->set_body_params(
 			array(
-				'room' => $room,
-				'doc'  => $doc,
+				'room'         => $room,
+				'doc'          => $doc,
+				'expected_doc' => $expected_doc,
 			)
 		);
 		return rest_get_server()->dispatch( $request );
@@ -180,10 +183,20 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( self::$editor_id );
 		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'serialized-crdt-doc' );
 
-		$response = $this->dispatch_save( $this->get_post_room(), 'serialized-crdt-doc' );
+		$response = $this->dispatch_save( $this->get_post_room(), 'serialized-crdt-doc', 'serialized-crdt-doc' );
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'serialized-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
+	}
+
+	public function test_save_rejects_stale_crdt_doc() {
+		wp_set_current_user( self::$editor_id );
+		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'current-crdt-doc' );
+
+		$response = $this->dispatch_save( $this->get_post_room(), 'stale-crdt-doc', 'older-crdt-doc' );
+
+		$this->assertErrorResponse( 'rest_sync_document_conflict', $response, 409 );
+		$this->assertSame( 'current-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
 	}
 
 	public function test_save_rejects_taxonomy_entity() {

--- a/phpunit/tests/collaboration/wpSyncSaveServer.php
+++ b/phpunit/tests/collaboration/wpSyncSaveServer.php
@@ -46,18 +46,19 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 	 *
 	 * @param string $room         Room identifier.
 	 * @param string $doc          Serialized CRDT document.
-	 * @param string $expected_doc Expected persisted CRDT document.
+	 * @param string|null $expected_doc Expected persisted CRDT document.
 	 * @return WP_REST_Response Response object.
 	 */
-	private function dispatch_save( $room, $doc = 'serialized-crdt-doc', $expected_doc = '' ) {
+	private function dispatch_save( $room, $doc = 'serialized-crdt-doc', $expected_doc = null ) {
 		$request = new WP_REST_Request( 'POST', '/wp-sync/v1/save' );
-		$request->set_body_params(
-			array(
-				'room'         => $room,
-				'doc'          => $doc,
-				'expected_doc' => $expected_doc,
-			)
+		$body    = array(
+			'room' => $room,
+			'doc'  => $doc,
 		);
+		if ( null !== $expected_doc ) {
+			$body['expected_doc'] = $expected_doc;
+		}
+		$request->set_body_params( $body );
 		return rest_get_server()->dispatch( $request );
 	}
 
@@ -187,6 +188,16 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'serialized-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
+	}
+
+	public function test_save_without_expected_doc_preserves_existing_client_behavior() {
+		wp_set_current_user( self::$editor_id );
+		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'current-crdt-doc' );
+
+		$response = $this->dispatch_save( $this->get_post_room(), 'updated-crdt-doc' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'updated-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
 	}
 
 	public function test_save_rejects_stale_crdt_doc() {

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -15,6 +15,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from './fixtures';
+
+const CORE_DATA_PRIVATE_APIS_CONSENT =
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
+
+test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
+	test( 'reloads isolated snapshot changes without mutating or duplicating the live document', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Targeted CRDT snapshot',
+			content:
+				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const liveContent = await page.evaluate(
+			async ( { consent, postId } ) => {
+				const { unlock } =
+					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				const coreDispatch = unlock(
+					window.wp.data.dispatch( 'core' )
+				);
+				const persistedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				const blocks = window.wp.blocks.parse(
+					persistedRecord.content.raw
+				);
+				blocks[ 0 ] = {
+					...blocks[ 0 ],
+					attributes: {
+						...blocks[ 0 ].attributes,
+						content: 'Targeted snapshot content.',
+					},
+				};
+				const doc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ blocks }
+					);
+				await window.wp.apiFetch( {
+					path: '/wp-sync/v1/save',
+					method: 'POST',
+					data: {
+						room: `postType/post:${ postId }`,
+						doc,
+						expected_doc:
+							persistedRecord.meta?._crdt_document || '',
+					},
+				} );
+
+				return window.wp.data
+					.select( 'core/block-editor' )
+					.getBlocks()[ 0 ]
+					.attributes.content.toString();
+			},
+			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
+		);
+
+		expect( liveContent ).toBe( 'Original persisted content.' );
+		await page.reload();
+		await collaborationUtils.waitForEntityReady( page );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].attributes.content ).toBe(
+			'Targeted snapshot content.'
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -89,6 +89,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Conflict base.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 
@@ -142,7 +143,13 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 						},
 					} );
 				} catch ( error ) {
-					conflictCode = error.code;
+					if (
+						error &&
+						typeof error === 'object' &&
+						'code' in error
+					) {
+						conflictCode = String( error.code );
+					}
 				}
 				const finalRecord = await window.wp.apiFetch( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -77,4 +77,85 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			'Targeted snapshot content.'
 		);
 	} );
+
+	test( 'rejects a stale CRDT snapshot writer', async ( {
+		collaborationUtils,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'CRDT snapshot conflict',
+			content:
+				'<!-- wp:paragraph --><p>Conflict base.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const result = await page.evaluate(
+			async ( { consent, postId } ) => {
+				const { unlock } =
+					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				const coreDispatch = unlock(
+					window.wp.data.dispatch( 'core' )
+				);
+				const persistedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				const expectedDoc = persistedRecord.meta?._crdt_document || '';
+				const firstDoc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ title: 'First writer' }
+					);
+				const staleDoc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ title: 'Stale writer' }
+					);
+				await window.wp.apiFetch( {
+					path: '/wp-sync/v1/save',
+					method: 'POST',
+					data: {
+						room: `postType/post:${ postId }`,
+						doc: firstDoc,
+						expected_doc: expectedDoc,
+					},
+				} );
+
+				let conflictCode = null;
+				try {
+					await window.wp.apiFetch( {
+						path: '/wp-sync/v1/save',
+						method: 'POST',
+						data: {
+							room: `postType/post:${ postId }`,
+							doc: staleDoc,
+							expected_doc: expectedDoc,
+						},
+					} );
+				} catch ( error ) {
+					conflictCode = error.code;
+				}
+				const finalRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				return {
+					conflictCode,
+					firstDoc,
+					persistedDoc: finalRecord.meta?._crdt_document,
+				};
+			},
+			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
+		);
+
+		expect( result.conflictCode ).toBe( 'rest_sync_document_conflict' );
+		expect( result.persistedDoc ).toBe( result.firstDoc );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '../fixtures';
 
 const CORE_DATA_PRIVATE_APIS_CONSENT =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -4,7 +4,7 @@ const CORE_DATA_PRIVATE_APIS_CONSENT =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
-	test( 'reloads isolated snapshot changes without mutating or duplicating the live document', async ( {
+	test( 'persists an isolated snapshot without mutating or duplicating block content', async ( {
 		collaborationUtils,
 		editor,
 		page,
@@ -19,7 +19,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		} );
 		await collaborationUtils.openPost( post.id );
 
-		const liveContent = await page.evaluate(
+		const result = await page.evaluate(
 			async ( { consent, postId } ) => {
 				const { unlock } =
 					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -59,23 +59,31 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 							persistedRecord.meta?._crdt_document || '',
 					},
 				} );
+				const savedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
 
-				return window.wp.data
-					.select( 'core/block-editor' )
-					.getBlocks()[ 0 ]
-					.attributes.content.toString();
+				return {
+					doc,
+					persistedDoc: savedRecord.meta?._crdt_document,
+					liveContent: window.wp.data
+						.select( 'core/block-editor' )
+						.getBlocks()[ 0 ]
+						.attributes.content.toString(),
+				};
 			},
 			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
 		);
 
-		expect( liveContent ).toBe( 'Original persisted content.' );
+		expect( result.persistedDoc ).toBe( result.doc );
+		expect( result.liveContent ).toBe( 'Original persisted content.' );
 		await page.reload();
 		await collaborationUtils.waitForEntityReady( page );
 
 		const blocks = await editor.getBlocks();
 		expect( blocks ).toHaveLength( 1 );
 		expect( blocks[ 0 ].attributes.content ).toBe(
-			'Targeted snapshot content.'
+			'Original persisted content.'
 		);
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -13,7 +13,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Targeted CRDT snapshot',
 			content:
-				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
+				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->\n\n<!-- wp:paragraph --><p>Preserved sibling content.</p><!-- /wp:paragraph -->',
 			status: 'draft',
 			date_gmt: new Date().toISOString(),
 		} );
@@ -21,8 +21,9 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 
 		const result = await page.evaluate(
 			async ( { consent, postId } ) => {
+				const privateApis = ( window as any ).wp.privateApis;
 				const { unlock } =
-					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 						consent,
 						'@wordpress/core-data'
 					);
@@ -62,28 +63,63 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				const savedRecord = await window.wp.apiFetch( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,
 				} );
+				const { CRDT_RECORD_MAP_KEY } = unlock(
+					( window as any ).wp.sync.privateApis
+				);
+				const snapshot = new ( window as any ).wp.sync.Y.Doc();
+				const encodedDocument = JSON.parse( doc ).document;
+				const update = Uint8Array.from(
+					window.atob( encodedDocument ),
+					( character ) => character.charCodeAt( 0 )
+				);
+				( window as any ).wp.sync.Y.applyUpdateV2( snapshot, update );
+				const snapshotBlocks = snapshot
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'blocks' )
+					.toJSON();
+				snapshot.destroy();
 
 				return {
 					doc,
 					persistedDoc: savedRecord.meta?._crdt_document,
+					snapshotContent: snapshotBlocks.map(
+						( block: { attributes: { content: string } } ) =>
+							block.attributes.content
+					),
 					liveContent: window.wp.data
 						.select( 'core/block-editor' )
-						.getBlocks()[ 0 ]
-						.attributes.content.toString(),
+						.getBlocks()
+						.map(
+							( block: {
+								attributes: {
+									content: { toString: () => string };
+								};
+							} ) => block.attributes.content.toString()
+						),
 				};
 			},
 			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
 		);
 
 		expect( result.persistedDoc ).toBe( result.doc );
-		expect( result.liveContent ).toBe( 'Original persisted content.' );
+		expect( result.snapshotContent ).toEqual( [
+			'Targeted snapshot content.',
+			'Preserved sibling content.',
+		] );
+		expect( result.liveContent ).toEqual( [
+			'Original persisted content.',
+			'Preserved sibling content.',
+		] );
 		await page.reload();
 		await collaborationUtils.waitForEntityReady( page );
 
 		const blocks = await editor.getBlocks();
-		expect( blocks ).toHaveLength( 1 );
+		expect( blocks ).toHaveLength( 2 );
 		expect( blocks[ 0 ].attributes.content ).toBe(
 			'Original persisted content.'
+		);
+		expect( blocks[ 1 ].attributes.content ).toBe(
+			'Preserved sibling content.'
 		);
 	} );
 } );


### PR DESCRIPTION
## What?

Make `/wp-sync/v1/save` reject stale CRDT snapshot writers.

## Review invariant

The endpoint locks the entity, compares `expected_doc` with the persisted `_crdt_document`, and conditionally writes the next snapshot in one transaction. A stale writer receives a conflict instead of overwriting newer collaborative state.

This is layer 2 of the replacement stack for #79020 and depends on layer 1. It is part of the fix for #72717.

## Testing

- Collaboration PHP fixture syntax passed locally.
- Native Playwright regression: `rejects a stale CRDT snapshot writer`.
- Playwright and PHPUnit runtime execution are pending CI because the local runtime does not have Docker.

## Stack

- 1/6: targeted CRDT persistence snapshots
- 2/6: this PR
- 3/6: atomic synchronized entity saves
- 4/6: queued revision-aware CRDT persistence
- 5/6: targeted block-attribute repair
- 6/6: Block Notes attachment integration

This draft targets `trunk` because fork branches cannot be used as upstream base refs. Review should begin after layer 1 lands, when GitHub reduces this PR to its own layer.

Ordered drafts: [1/6 #81715](https://github.com/WordPress/gutenberg/pull/81715), [2/6 #81714](https://github.com/WordPress/gutenberg/pull/81714), [3/6 #81716](https://github.com/WordPress/gutenberg/pull/81716), [4/6 #81717](https://github.com/WordPress/gutenberg/pull/81717), [5/6 #81719](https://github.com/WordPress/gutenberg/pull/81719), [6/6 #81718](https://github.com/WordPress/gutenberg/pull/81718).

## AI assistance

GPT-5.6 Sol via OpenCode assisted with implementation, regression coverage, and verification. Chris reviewed and is responsible for the submitted changes.
