### PR TITLE
Support targeted CRDT persistence snapshots

### DIFF
--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -181,6 +181,24 @@ export const setCollaborationSupported =
 	};
 
 /**
+ * Creates a persisted CRDT snapshot with isolated entity changes without
+ * applying those changes to the live collaborative document.
+ *
+ * @param {string}        kind     Entity kind.
+ * @param {string}        name     Entity name.
+ * @param {number|string} recordId Entity record ID.
+ * @param {Object}        changes  Changes to include in the snapshot.
+ * @return {Promise<string|null>} Serialized CRDT document, when loaded.
+ */
+export const createEntityCRDTPersistenceSnapshot =
+	( kind, name, recordId, changes ) => () =>
+		getSyncManager()?.createPersistedCRDTDoc(
+			`${ kind }/${ name }`,
+			recordId,
+			changes
+		);
+
+/**
  * Returns an action object used to receive view config.
  *
  * @param {string} kind   Entity kind.

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -830,10 +830,12 @@ export function createSyncManager( debug = false ): SyncManager {
 	 *
 	 * @param {ObjectType} objectType Object type.
 	 * @param {ObjectID}   objectId   Object ID.
+	 * @param {ObjectData} changes    Changes to include in the snapshot.
 	 */
 	async function createPersistedCRDTDoc(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		changes?: Partial< ObjectData >
 	): Promise< string | null > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -845,6 +847,25 @@ export function createSyncManager( debug = false ): SyncManager {
 		// Local updates may be deferred when editing alone. Apply them so
 		// they are included in the serialized document.
 		flushPendingCRDTDocUpdates();
+
+		if ( changes ) {
+			const snapshot = createYjsDoc( { objectType } );
+			Y.applyUpdateV2(
+				snapshot,
+				Y.encodeStateAsUpdateV2( entityState.ydoc )
+			);
+			try {
+				snapshot.transact( () => {
+					entityState.syncConfig.applyChangesToCRDTDoc(
+						snapshot,
+						changes
+					);
+				}, LOCAL_SYNC_MANAGER_ORIGIN );
+				return serializeCrdtDoc( snapshot );
+			} finally {
+				snapshot.destroy();
+			}
+		}
 
 		return serializeCrdtDoc( entityState.ydoc );
 	}

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -27,7 +27,7 @@ import type {
 	RecordHandlers,
 	SyncConfig,
 } from '../types';
-import { serializeCrdtDoc } from '../utils';
+import { deserializeCrdtDoc, serializeCrdtDoc } from '../utils';
 
 // Mock dependencies.
 jest.mock( '../providers', () => ( {
@@ -901,6 +901,50 @@ describe( 'SyncManager', () => {
 				now
 			);
 			expect( stateMap.get( SAVED_BY_KEY ) ).toBe( ydoc.clientID );
+		} );
+	} );
+
+	describe( 'createPersistedCRDTDoc', () => {
+		it( 'applies explicit changes to a cloned snapshot', async () => {
+			let liveDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				liveDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc.mockImplementation(
+				( ydoc, changes ) => {
+					const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						recordMap.set( key, value )
+					);
+				}
+			);
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			const serialized = await manager.createPersistedCRDTDoc(
+				'post',
+				'123',
+				{ title: 'Repaired title' }
+			);
+			const snapshot = deserializeCrdtDoc( serialized ?? '' );
+
+			expect(
+				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
+			).toBe( 'Repaired title' );
+			expect(
+				( liveDoc as unknown as Y.Doc )
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'title' )
+			).toBe( 'Test Post' );
+			snapshot?.destroy();
 		} );
 	} );
 

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -928,6 +928,12 @@ describe( 'SyncManager', () => {
 				mockRecord,
 				mockHandlers
 			);
+			manager.update(
+				'post',
+				'123',
+				{ meta: { pending: true } },
+				'local'
+			);
 
 			const serialized = await manager.createPersistedCRDTDoc(
 				'post',
@@ -939,11 +945,22 @@ describe( 'SyncManager', () => {
 			expect(
 				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
 			).toBe( 'Repaired title' );
+			expect( snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'id' ) ).toBe(
+				'123'
+			);
+			expect(
+				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'meta' )
+			).toEqual( { pending: true } );
 			expect(
 				( liveDoc as unknown as Y.Doc )
 					.getMap( CRDT_RECORD_MAP_KEY )
 					.get( 'title' )
 			).toBe( 'Test Post' );
+			expect(
+				( liveDoc as unknown as Y.Doc )
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'meta' )
+			).toEqual( { pending: true } );
 			snapshot?.destroy();
 		} );
 	} );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -156,7 +156,8 @@ export interface SyncConfig {
 export interface SyncManager {
 	createPersistedCRDTDoc: (
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		changes?: Partial< ObjectData >
 	) => Promise< string | null >;
 	getAwareness: < State extends Awareness >(
 		objectType: ObjectType,

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -15,6 +15,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from './fixtures';
+
+const CORE_DATA_PRIVATE_APIS_CONSENT =
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
+
+test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
+	test( 'reloads isolated snapshot changes without mutating or duplicating the live document', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Targeted CRDT snapshot',
+			content:
+				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const liveContent = await page.evaluate(
+			async ( { consent, postId } ) => {
+				const { unlock } =
+					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				const coreDispatch = unlock(
+					window.wp.data.dispatch( 'core' )
+				);
+				const persistedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				const blocks = window.wp.blocks.parse(
+					persistedRecord.content.raw
+				);
+				blocks[ 0 ] = {
+					...blocks[ 0 ],
+					attributes: {
+						...blocks[ 0 ].attributes,
+						content: 'Targeted snapshot content.',
+					},
+				};
+				const doc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ blocks }
+					);
+				await window.wp.apiFetch( {
+					path: '/wp-sync/v1/save',
+					method: 'POST',
+					data: {
+						room: `postType/post:${ postId }`,
+						doc,
+						expected_doc:
+							persistedRecord.meta?._crdt_document || '',
+					},
+				} );
+
+				return window.wp.data
+					.select( 'core/block-editor' )
+					.getBlocks()[ 0 ]
+					.attributes.content.toString();
+			},
+			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
+		);
+
+		expect( liveContent ).toBe( 'Original persisted content.' );
+		await page.reload();
+		await collaborationUtils.waitForEntityReady( page );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].attributes.content ).toBe(
+			'Targeted snapshot content.'
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '../fixtures';
 
 const CORE_DATA_PRIVATE_APIS_CONSENT =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -4,7 +4,7 @@ const CORE_DATA_PRIVATE_APIS_CONSENT =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
-	test( 'reloads isolated snapshot changes without mutating or duplicating the live document', async ( {
+	test( 'persists an isolated snapshot without mutating or duplicating block content', async ( {
 		collaborationUtils,
 		editor,
 		page,
@@ -19,7 +19,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		} );
 		await collaborationUtils.openPost( post.id );
 
-		const liveContent = await page.evaluate(
+		const result = await page.evaluate(
 			async ( { consent, postId } ) => {
 				const { unlock } =
 					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -59,23 +59,31 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 							persistedRecord.meta?._crdt_document || '',
 					},
 				} );
+				const savedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
 
-				return window.wp.data
-					.select( 'core/block-editor' )
-					.getBlocks()[ 0 ]
-					.attributes.content.toString();
+				return {
+					doc,
+					persistedDoc: savedRecord.meta?._crdt_document,
+					liveContent: window.wp.data
+						.select( 'core/block-editor' )
+						.getBlocks()[ 0 ]
+						.attributes.content.toString(),
+				};
 			},
 			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
 		);
 
-		expect( liveContent ).toBe( 'Original persisted content.' );
+		expect( result.persistedDoc ).toBe( result.doc );
+		expect( result.liveContent ).toBe( 'Original persisted content.' );
 		await page.reload();
 		await collaborationUtils.waitForEntityReady( page );
 
 		const blocks = await editor.getBlocks();
 		expect( blocks ).toHaveLength( 1 );
 		expect( blocks[ 0 ].attributes.content ).toBe(
-			'Targeted snapshot content.'
+			'Original persisted content.'
 		);
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -13,7 +13,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Targeted CRDT snapshot',
 			content:
-				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
+				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->\n\n<!-- wp:paragraph --><p>Preserved sibling content.</p><!-- /wp:paragraph -->',
 			status: 'draft',
 			date_gmt: new Date().toISOString(),
 		} );
@@ -21,8 +21,9 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 
 		const result = await page.evaluate(
 			async ( { consent, postId } ) => {
+				const privateApis = ( window as any ).wp.privateApis;
 				const { unlock } =
-					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 						consent,
 						'@wordpress/core-data'
 					);
@@ -62,28 +63,63 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				const savedRecord = await window.wp.apiFetch( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,
 				} );
+				const { CRDT_RECORD_MAP_KEY } = unlock(
+					( window as any ).wp.sync.privateApis
+				);
+				const snapshot = new ( window as any ).wp.sync.Y.Doc();
+				const encodedDocument = JSON.parse( doc ).document;
+				const update = Uint8Array.from(
+					window.atob( encodedDocument ),
+					( character ) => character.charCodeAt( 0 )
+				);
+				( window as any ).wp.sync.Y.applyUpdateV2( snapshot, update );
+				const snapshotBlocks = snapshot
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'blocks' )
+					.toJSON();
+				snapshot.destroy();
 
 				return {
 					doc,
 					persistedDoc: savedRecord.meta?._crdt_document,
+					snapshotContent: snapshotBlocks.map(
+						( block: { attributes: { content: string } } ) =>
+							block.attributes.content
+					),
 					liveContent: window.wp.data
 						.select( 'core/block-editor' )
-						.getBlocks()[ 0 ]
-						.attributes.content.toString(),
+						.getBlocks()
+						.map(
+							( block: {
+								attributes: {
+									content: { toString: () => string };
+								};
+							} ) => block.attributes.content.toString()
+						),
 				};
 			},
 			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
 		);
 
 		expect( result.persistedDoc ).toBe( result.doc );
-		expect( result.liveContent ).toBe( 'Original persisted content.' );
+		expect( result.snapshotContent ).toEqual( [
+			'Targeted snapshot content.',
+			'Preserved sibling content.',
+		] );
+		expect( result.liveContent ).toEqual( [
+			'Original persisted content.',
+			'Preserved sibling content.',
+		] );
 		await page.reload();
 		await collaborationUtils.waitForEntityReady( page );
 
 		const blocks = await editor.getBlocks();
-		expect( blocks ).toHaveLength( 1 );
+		expect( blocks ).toHaveLength( 2 );
 		expect( blocks[ 0 ].attributes.content ).toBe(
 			'Original persisted content.'
+		);
+		expect( blocks[ 1 ].attributes.content ).toBe(
+			'Preserved sibling content.'
 		);
 	} );
 } );


### PR DESCRIPTION
## What?

Add an isolated sync-manager snapshot primitive for targeted CRDT persistence.

## Review invariant

`createPersistedCRDTDoc( record, changes )` applies targeted changes to a temporary document initialized from the loaded room state. It must not mutate the live collaborative document or duplicate content when the snapshot reloads.

This is layer 1 of the replacement stack for #79020 and part of the fix for #72717.

## Testing

- Sync manager unit suite: 39 tests passed locally. The targeted snapshot test verifies that explicit changes are encoded in the cloned snapshot while the live document remains unchanged.
- Native Playwright regression: `persists an isolated snapshot without mutating or duplicating block content` decodes the persisted Yjs document and verifies the targeted block mutation plus an untouched sibling, while the live editor and reloaded post retain their original non-duplicated content.
- [End-to-End Tests run](https://github.com/WordPress/gutenberg/actions/runs/32055098475): all Playwright shards and RTC passed.
- All 42 required and informational checks passed on `790c0bfa82`.

## Stack

- 1/6: this PR
- 2/6: conflict-safe CRDT snapshot saves
- 3/6: atomic synchronized entity saves
- 4/6: queued revision-aware CRDT persistence
- 5/6: targeted block-attribute repair
- 6/6: Block Notes attachment integration

Later drafts target `trunk` because fork branches cannot be used as upstream base refs. Their cumulative diffs shrink as preceding layers merge.

Ordered drafts: [1/6 #81715](https://github.com/WordPress/gutenberg/pull/81715), [2/6 #81714](https://github.com/WordPress/gutenberg/pull/81714), [3/6 #81716](https://github.com/WordPress/gutenberg/pull/81716), [4/6 #81717](https://github.com/WordPress/gutenberg/pull/81717), [5/6 #81719](https://github.com/WordPress/gutenberg/pull/81719), [6/6 #81718](https://github.com/WordPress/gutenberg/pull/81718).

## AI assistance

GPT-5.6 Sol via OpenCode assisted with implementation, regression coverage, verification, and preparation of this PR description. Chris reviewed and is responsible for the submitted changes.
