### PR TITLE
Add targeted block attribute persistence

### DIFF
--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -43,6 +43,14 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		const MAX_DOC_LENGTH = 16 * MB_IN_BYTES;
 
 		/**
+		 * Whether a save is already running in this request.
+		 *
+		 * @since 7.1.0
+		 * @var bool
+		 */
+		private static $save_in_progress = false;
+
+		/**
 		 * Registers REST API routes.
 		 *
 		 * @since 7.1.0
@@ -64,10 +72,14 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 							'required' => true,
 							'type'     => 'string',
 						),
-						'doc'  => array(
+						'doc'          => array(
 							'maxLength' => self::MAX_DOC_LENGTH,
 							'required'  => true,
 							'type'      => 'string',
+						),
+						'expected_doc' => array(
+							'required' => true,
+							'type'     => 'string',
 						),
 					),
 				)
@@ -114,8 +126,16 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		 * @return WP_REST_Response|WP_Error Response object or error.
 		 */
 		public function handle_request( WP_REST_Request $request ) {
-			$room        = $request['room'];
-			$parsed_room = is_string( $room ) ? WP_Sync_Config::parse_room( $room ) : null;
+			global $wpdb;
+
+			if ( self::$save_in_progress ) {
+				return $this->get_save_conflict_error();
+			}
+
+			self::$save_in_progress = true;
+			$transaction_open       = false;
+			$room                   = $request['room'];
+			$parsed_room            = is_string( $room ) ? WP_Sync_Config::parse_room( $room ) : null;
 
 			$post_id = WP_Sync_Config::get_crdt_doc_persistence_post_id(
 				$parsed_room['entity_kind'],
@@ -123,10 +143,85 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 				$parsed_room['object_id']
 			);
 
-			$doc = $request['doc'];
+			try {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- All CRDT writers lock the same post row before updating metadata.
+				if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+					return $this->get_transaction_error( 'start' );
+				}
+				$transaction_open = true;
 
-			$updated = update_post_meta( $post_id, self::CRDT_DOC_META_KEY, $doc );
-			if ( false === $updated && get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true ) !== $doc ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Serializes CRDT writes even when the metadata row does not exist yet.
+				$locked_post_id = $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT ID FROM $wpdb->posts WHERE ID = %d FOR UPDATE",
+						$post_id
+					)
+				);
+				if ( (int) $locked_post_id !== (int) $post_id ) {
+					return new WP_Error(
+						'rest_sync_post_not_found',
+						__( 'The synchronized post could not be found.', 'gutenberg' ),
+						array( 'status' => 404 )
+					);
+				}
+
+				$updated = $this->update_crdt_doc(
+					$post_id,
+					$request['doc'],
+					$request['expected_doc']
+				);
+				if ( is_wp_error( $updated ) ) {
+					return $updated;
+				}
+
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Completes the transaction started above.
+				if ( false === $wpdb->query( 'COMMIT' ) ) {
+					return $this->get_transaction_error( 'commit' );
+				}
+				$transaction_open = false;
+
+				return array();
+			} finally {
+				if ( $transaction_open ) {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Prevents a failed CRDT save from persisting.
+					$wpdb->query( 'ROLLBACK' );
+				}
+				self::$save_in_progress = false;
+			}
+		}
+
+		/**
+		 * Updates a CRDT document only when its persisted base is unchanged.
+		 *
+		 * @param int    $post_id      Post ID.
+		 * @param string $doc          Replacement CRDT document.
+		 * @param string $expected_doc Expected persisted CRDT document.
+		 * @return true|WP_Error True on success, otherwise an error.
+		 */
+		private function update_crdt_doc( int $post_id, string $doc, string $expected_doc ) {
+			wp_cache_delete( $post_id, 'post_meta' );
+			$current_doc = get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true );
+			if ( $current_doc !== $expected_doc ) {
+				return new WP_Error(
+					'rest_sync_document_conflict',
+					__( 'The synchronized document changed before it could be saved.', 'gutenberg' ),
+					array( 'status' => 409 )
+				);
+			}
+
+			$updated = update_post_meta( $post_id, self::CRDT_DOC_META_KEY, $doc, $expected_doc );
+			if ( false === $updated ) {
+				wp_cache_delete( $post_id, 'post_meta' );
+				$current_doc = get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true );
+				if ( $current_doc !== $expected_doc && $current_doc !== $doc ) {
+					return new WP_Error(
+						'rest_sync_document_conflict',
+						__( 'The synchronized document changed before it could be saved.', 'gutenberg' ),
+						array( 'status' => 409 )
+					);
+				}
+			}
+			if ( false === $updated && $current_doc !== $doc ) {
 				return new WP_Error(
 					'rest_crdt_save_failed',
 					__( 'Failed to save CRDT document.', 'gutenberg' ),
@@ -134,7 +229,37 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 				);
 			}
 
-			return array();
+			return true;
+		}
+
+		/**
+		 * Returns the shared conflict error for reentrant sync saves.
+		 *
+		 * @return WP_Error Conflict error.
+		 */
+		private function get_save_conflict_error(): WP_Error {
+			return new WP_Error(
+				'rest_sync_document_conflict',
+				__( 'Another synchronized document save is already in progress.', 'gutenberg' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		/**
+		 * Returns a transaction error.
+		 *
+		 * @param string $operation Failed transaction operation.
+		 * @return WP_Error Transaction error.
+		 */
+		private function get_transaction_error( string $operation ): WP_Error {
+			$message = 'start' === $operation
+				? __( 'Failed to start synchronized content transaction.', 'gutenberg' )
+				: __( 'Failed to commit synchronized content transaction.', 'gutenberg' );
+			return new WP_Error(
+				'rest_sync_transaction_failed',
+				$message,
+				array( 'status' => 500 )
+			);
 		}
 
 		/**

--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -56,34 +56,162 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		 * @since 7.1.0
 		 */
 		public function register_routes(): void {
-			if ( isset( rest_get_server()->get_routes()[ '/' . self::REST_NAMESPACE . '/save' ] ) ) {
-				return;
+			$routes = rest_get_server()->get_routes();
+			if ( ! isset( $routes[ '/' . self::REST_NAMESPACE . '/save' ] ) ) {
+				register_rest_route(
+					self::REST_NAMESPACE,
+					'/save',
+					array(
+						'methods'             => array( WP_REST_Server::CREATABLE ),
+						'callback'            => array( $this, 'handle_request' ),
+						'permission_callback' => array( $this, 'check_permissions' ),
+						'args'                => array(
+							'room'         => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'doc'          => array(
+								'maxLength' => self::MAX_DOC_LENGTH,
+								'required'  => true,
+								'type'      => 'string',
+							),
+							'expected_doc' => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+						),
+					)
+				);
 			}
 
-			register_rest_route(
-				self::REST_NAMESPACE,
-				'/save',
-				array(
-					'methods'             => array( WP_REST_Server::CREATABLE ),
-					'callback'            => array( $this, 'handle_request' ),
-					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => array(
-						'room' => array(
-							'required' => true,
-							'type'     => 'string',
+			if ( ! isset( $routes[ '/' . self::REST_NAMESPACE . '/save-entity' ] ) ) {
+				register_rest_route(
+					self::REST_NAMESPACE,
+					'/save-entity',
+					array(
+						'methods'             => array( WP_REST_Server::CREATABLE ),
+						'callback'            => array( $this, 'handle_entity_request' ),
+						'permission_callback' => array( $this, 'check_permissions' ),
+						'args'                => array(
+							'room'             => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'doc'              => array(
+								'maxLength' => self::MAX_DOC_LENGTH,
+								'required'  => true,
+								'type'      => 'string',
+							),
+							'expected_doc'     => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'expected_content' => array(
+								'required' => true,
+								'type'     => 'string',
+							),
+							'content'          => array(
+								'required' => true,
+								'type'     => 'string',
+							),
 						),
-						'doc'          => array(
-							'maxLength' => self::MAX_DOC_LENGTH,
-							'required'  => true,
-							'type'      => 'string',
-						),
-						'expected_doc' => array(
-							'required' => true,
-							'type'     => 'string',
-						),
-					),
-				)
-			);
+					)
+				);
+			}
+		}
+
+		/**
+		 * Atomically persists entity content and its CRDT snapshot.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return array|WP_Error Empty response or a conflict/error.
+		 */
+		public function handle_entity_request( WP_REST_Request $request ) {
+			global $wpdb;
+
+			if ( self::$save_in_progress ) {
+				return $this->get_save_conflict_error();
+			}
+
+			self::$save_in_progress = true;
+			$transaction_open       = false;
+
+			try {
+				// A stale writer must not leave post content paired with another writer's CRDT snapshot.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- The two-table conditional save requires one transaction.
+				if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+					return $this->get_transaction_error( 'start' );
+				}
+				$transaction_open = true;
+
+				$parsed_room = WP_Sync_Config::parse_room( $request['room'] );
+				$post_id     = WP_Sync_Config::get_crdt_doc_persistence_post_id(
+					$parsed_room['entity_kind'],
+					$parsed_room['entity_name'],
+					$parsed_room['object_id']
+				);
+				$content     = $request['content'];
+				$expected    = $request['expected_content'];
+
+				$updated = $wpdb->query(
+					$wpdb->prepare(
+						"UPDATE $wpdb->posts SET post_content = %s WHERE ID = %d AND post_content = %s",
+						$content,
+						$post_id,
+						$expected
+					)
+				);
+
+				if ( false === $updated ) {
+					return new WP_Error(
+						'rest_sync_content_save_failed',
+						__( 'Failed to save synchronized content.', 'gutenberg' ),
+						array( 'status' => 500 )
+					);
+				}
+
+				if ( 0 === $updated ) {
+					$current = $wpdb->get_var(
+						$wpdb->prepare(
+							"SELECT post_content FROM $wpdb->posts WHERE ID = %d",
+							$post_id
+						)
+					);
+					if ( $current !== $expected ) {
+						return new WP_Error(
+							'rest_sync_content_conflict',
+							__( 'The synchronized content changed before it could be saved.', 'gutenberg' ),
+							array( 'status' => 409 )
+						);
+					}
+				}
+
+				$doc_updated = $this->update_crdt_doc(
+					$post_id,
+					$request['doc'],
+					$request['expected_doc']
+				);
+				if ( is_wp_error( $doc_updated ) ) {
+					return $doc_updated;
+				}
+
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Completes the transaction started above.
+				if ( false === $wpdb->query( 'COMMIT' ) ) {
+					return $this->get_transaction_error( 'commit' );
+				}
+				$transaction_open = false;
+
+				clean_post_cache( $post_id );
+				return array();
+			} finally {
+				if ( $transaction_open ) {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Prevents either half of a failed conditional save from persisting.
+					$wpdb->query( 'ROLLBACK' );
+				}
+				self::$save_in_progress = false;
+			}
 		}
 
 		/**

--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 					'callback'            => array( $this, 'handle_request' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
 					'args'                => array(
-						'room' => array(
+						'room'         => array(
 							'required' => true,
 							'type'     => 'string',
 						),

--- a/lib/experimental/collaboration/class-wp-sync-save-server.php
+++ b/lib/experimental/collaboration/class-wp-sync-save-server.php
@@ -78,8 +78,7 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 							'type'      => 'string',
 						),
 						'expected_doc' => array(
-							'required' => true,
-							'type'     => 'string',
+							'type' => 'string',
 						),
 					),
 				)
@@ -168,7 +167,7 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 				$updated = $this->update_crdt_doc(
 					$post_id,
 					$request['doc'],
-					$request['expected_doc']
+					$request->has_param( 'expected_doc' ) ? $request['expected_doc'] : null
 				);
 				if ( is_wp_error( $updated ) ) {
 					return $updated;
@@ -195,12 +194,25 @@ if ( ! class_exists( 'WP_Sync_Save_Server' ) ) {
 		 *
 		 * @param int    $post_id      Post ID.
 		 * @param string $doc          Replacement CRDT document.
-		 * @param string $expected_doc Expected persisted CRDT document.
+		 * @param string|null $expected_doc Expected persisted CRDT document, or null for an unconditional save.
 		 * @return true|WP_Error True on success, otherwise an error.
 		 */
-		private function update_crdt_doc( int $post_id, string $doc, string $expected_doc ) {
+		private function update_crdt_doc( int $post_id, string $doc, ?string $expected_doc ) {
 			wp_cache_delete( $post_id, 'post_meta' );
 			$current_doc = get_post_meta( $post_id, self::CRDT_DOC_META_KEY, true );
+			if ( null === $expected_doc ) {
+				$updated = update_post_meta( $post_id, self::CRDT_DOC_META_KEY, $doc );
+				if ( false === $updated && $current_doc !== $doc ) {
+					return new WP_Error(
+						'rest_crdt_save_failed',
+						__( 'Failed to save CRDT document.', 'gutenberg' ),
+						array( 'status' => 500 )
+					);
+				}
+
+				return true;
+			}
+
 			if ( $current_doc !== $expected_doc ) {
 				return new WP_Error(
 					'rest_sync_document_conflict',

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -181,6 +181,24 @@ export const setCollaborationSupported =
 	};
 
 /**
+ * Creates a persisted CRDT snapshot with isolated entity changes without
+ * applying those changes to the live collaborative document.
+ *
+ * @param {string}        kind     Entity kind.
+ * @param {string}        name     Entity name.
+ * @param {number|string} recordId Entity record ID.
+ * @param {Object}        changes  Changes to include in the snapshot.
+ * @return {Promise<string|null>} Serialized CRDT document, when loaded.
+ */
+export const createEntityCRDTPersistenceSnapshot =
+	( kind, name, recordId, changes ) => () =>
+		getSyncManager()?.createPersistedCRDTDoc(
+			`${ kind }/${ name }`,
+			recordId,
+			changes
+		);
+
+/**
  * Returns an action object used to receive view config.
  *
  * @param {string} kind   Entity kind.

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -5,6 +5,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { STORE_NAME } from './name';
 import { getSyncManager, hasSyncManager } from './sync';
+import { saveCRDTDoc } from './utils';
 
 /**
  * Returns an action object used in signalling that the registered post meta
@@ -178,6 +179,30 @@ export const setCollaborationSupported =
 				hasRedo: false,
 			} );
 		}
+	};
+
+/**
+ * Persists the current CRDT document for a sync-enabled entity.
+ *
+ * @param {string}        kind     Entity kind.
+ * @param {string}        name     Entity name.
+ * @param {number|string} recordId Entity record ID.
+ * @return {Promise<boolean>} Whether a CRDT document was persisted.
+ */
+export const persistEntityCRDTDoc =
+	( kind, name, recordId ) =>
+	async ( { select } ) => {
+		const entityConfig = select.getEntityConfig( kind, name );
+		if ( ! entityConfig?.syncConfig?.supportsPersistence ) {
+			return false;
+		}
+
+		const record = select.getRawEntityRecord?.( kind, name, recordId );
+		return saveCRDTDoc(
+			`${ kind }/${ name }`,
+			recordId,
+			record?.meta?._crdt_document || ''
+		);
 	};
 
 /**

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -1,11 +1,12 @@
 import apiFetch from '@wordpress/api-fetch';
+import { parse, serialize } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { STORE_NAME } from './name';
 import { getSyncManager, hasSyncManager } from './sync';
-import { saveCRDTDoc } from './utils';
+import { enqueueCRDTDocSave, saveCRDTDoc, setPersistedCRDTDoc } from './utils';
 
 /**
  * Returns an action object used in signalling that the registered post meta
@@ -203,6 +204,245 @@ export const persistEntityCRDTDoc =
 			recordId,
 			record?.meta?._crdt_document || ''
 		);
+	};
+
+function getRawContent( record ) {
+	const content = record?.content;
+	if ( typeof content === 'string' ) {
+		return content;
+	}
+	return typeof content?.raw === 'string' ? content.raw : '';
+}
+
+function findBlockPaths( blocks, isMatch ) {
+	const paths = [];
+	for ( let index = 0; index < blocks.length; index++ ) {
+		const block = blocks[ index ];
+		if ( isMatch( block ) ) {
+			paths.push( [ index ] );
+		}
+
+		paths.push(
+			...findBlockPaths( block.innerBlocks || [], isMatch ).map(
+				( childPath ) => [ index, ...childPath ]
+			)
+		);
+	}
+
+	return paths;
+}
+
+function countBlocks( blocks ) {
+	return blocks.reduce(
+		( count, block ) => count + 1 + countBlocks( block.innerBlocks || [] ),
+		0
+	);
+}
+
+function getBlockAtPath( blocks, path ) {
+	return path.reduce(
+		( currentBlock, index ) =>
+			Array.isArray( currentBlock )
+				? currentBlock[ index ]
+				: currentBlock?.innerBlocks?.[ index ],
+		blocks
+	);
+}
+
+function updateBlockAttributesAtPath( blocks, path, attributes ) {
+	const [ index, ...rest ] = path;
+	const block = blocks[ index ];
+	if ( ! block ) {
+		return null;
+	}
+
+	const nextBlocks = [ ...blocks ];
+	if ( rest.length ) {
+		const innerBlocks = updateBlockAttributesAtPath(
+			block.innerBlocks || [],
+			rest,
+			attributes
+		);
+		if ( ! innerBlocks ) {
+			return null;
+		}
+
+		nextBlocks[ index ] = {
+			...block,
+			innerBlocks,
+		};
+		return nextBlocks;
+	}
+
+	const attributeChanges =
+		typeof attributes === 'function'
+			? attributes( block.attributes || {} )
+			: attributes;
+	if ( ! attributeChanges ) {
+		return null;
+	}
+
+	nextBlocks[ index ] = {
+		...block,
+		attributes: {
+			...block.attributes,
+			...attributeChanges,
+		},
+	};
+	return nextBlocks;
+}
+
+/**
+ * Persists targeted block attribute changes against a sync-enabled entity's
+ * saved content and CRDT document without using unrelated dirty editor state.
+ *
+ * @param {string}          kind                     Entity kind.
+ * @param {string}          name                     Entity name.
+ * @param {number|string}   recordId                 Entity record ID.
+ * @param {Object}          options                  Options.
+ * @param {Object}          options.record           Saved entity record snapshot.
+ * @param {number[]}        options.blockPath        Path to the block in saved content.
+ * @param {Object|Function} options.attributes       Attribute changes or updater.
+ * @param {Function}        options.isMatch          Optional block matcher for path validation.
+ * @param {number}          options.matchIndex       Zero-based occurrence of the matched live block.
+ * @param {number}          options.matchCount       Number of matching blocks in the live tree.
+ * @param {Function}        options.isDirtyPathValid Validates the saved tree before using a dirty path.
+ * @param {number}          options.blockCount       Number of blocks in the live tree.
+ * @param {string}          options.blockName        Name of the live target block.
+ * @return {Promise<boolean>} Whether block attributes were persisted.
+ */
+export const persistEntityBlockAttributes =
+	(
+		kind,
+		name,
+		recordId,
+		{
+			record,
+			blockPath,
+			attributes,
+			isMatch,
+			matchIndex,
+			matchCount,
+			isDirtyPathValid,
+			blockCount,
+			blockName,
+		}
+	) =>
+	async ( { select } ) => {
+		const entityConfig = select.getEntityConfig( kind, name );
+		if (
+			! entityConfig?.baseURL ||
+			! entityConfig?.syncConfig?.supportsPersistence ||
+			! Array.isArray( blockPath )
+		) {
+			return false;
+		}
+
+		const objectType = `${ kind }/${ name }`;
+		const room = `${ objectType }:${ recordId }`;
+		return enqueueCRDTDocSave( objectType, recordId, async () => {
+			const initialRecord =
+				select.getRawEntityRecord?.( kind, name, recordId ) || record;
+			if ( ! getRawContent( initialRecord ) ) {
+				return false;
+			}
+
+			for ( let attempt = 0; attempt < 20; attempt++ ) {
+				const persistedRecord = await apiFetch( {
+					path: `${ entityConfig.baseURL }/${ recordId }?context=edit`,
+				} );
+				const content = getRawContent( persistedRecord || record );
+				if ( ! content ) {
+					return false;
+				}
+
+				const parsedBlocks = parse( content );
+				let targetPath = blockPath;
+				if ( isMatch ) {
+					const matchingPaths = findBlockPaths(
+						parsedBlocks,
+						isMatch
+					);
+					if (
+						! Number.isInteger( matchIndex ) ||
+						! Number.isInteger( matchCount )
+					) {
+						return false;
+					}
+
+					if ( matchingPaths.length === matchCount ) {
+						targetPath = matchingPaths[ matchIndex ];
+					} else {
+						const pathBlock = getBlockAtPath(
+							parsedBlocks,
+							blockPath
+						);
+						const canUseDirtyPath =
+							matchingPaths.length === 0 &&
+							matchCount === 1 &&
+							Number.isInteger( blockCount ) &&
+							countBlocks( parsedBlocks ) === blockCount &&
+							pathBlock?.name === blockName &&
+							typeof isDirtyPathValid === 'function' &&
+							isDirtyPathValid( parsedBlocks );
+						if ( ! canUseDirtyPath ) {
+							return false;
+						}
+					}
+				}
+
+				if ( ! targetPath ) {
+					return false;
+				}
+
+				const blocks = updateBlockAttributesAtPath(
+					parsedBlocks,
+					targetPath,
+					attributes
+				);
+				if ( ! blocks ) {
+					return false;
+				}
+
+				const serializedDoc =
+					await getSyncManager()?.createPersistedCRDTDoc(
+						objectType,
+						recordId,
+						{ blocks }
+					);
+				if ( ! serializedDoc ) {
+					return false;
+				}
+				const expectedDoc = persistedRecord?.meta?._crdt_document || '';
+
+				try {
+					await apiFetch( {
+						path: '/wp-sync/v1/save-entity',
+						method: 'POST',
+						data: {
+							room,
+							expected_content: content,
+							expected_doc: expectedDoc,
+							content: serialize( blocks ),
+							doc: serializedDoc,
+						},
+					} );
+				} catch ( error ) {
+					if (
+						error?.code === 'rest_sync_content_conflict' ||
+						error?.code === 'rest_sync_document_conflict'
+					) {
+						continue;
+					}
+					throw error;
+				}
+
+				setPersistedCRDTDoc( objectType, recordId, serializedDoc );
+				return true;
+			}
+
+			return false;
+		} );
 	};
 
 /**

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -268,7 +268,8 @@ export const getEntityRecord =
 
 									await saveCRDTDoc(
 										`${ kind }/${ name }`,
-										entityId
+										entityId,
+										meta._crdt_document || ''
 									);
 								} );
 						},

--- a/packages/core-data/src/test/private-actions.js
+++ b/packages/core-data/src/test/private-actions.js
@@ -3,14 +3,23 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createRegistry } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '..';
-import { editMediaEntity, setCollaborationSupported } from '../private-actions';
+import {
+	editMediaEntity,
+	persistEntityCRDTDoc,
+	setCollaborationSupported,
+} from '../private-actions';
 import { getSyncManager, hasSyncManager } from '../sync';
+import { saveCRDTDoc } from '../utils';
 import { unlock } from '../lock-unlock';
 
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../sync', () => ( {
 	getSyncManager: jest.fn(),
 	hasSyncManager: jest.fn(),
+} ) );
+jest.mock( '../utils', () => ( {
+	...jest.requireActual( '../utils' ),
+	saveCRDTDoc: jest.fn(),
 } ) );
 
 describe( 'editMediaEntity', () => {
@@ -212,6 +221,55 @@ describe( 'editMediaEntity', () => {
 
 		expect( dispatch.receiveEntityRecords ).not.toHaveBeenCalled();
 		expect( result ).toBeUndefined();
+	} );
+} );
+
+describe( 'persistEntityCRDTDoc', () => {
+	let entityConfig;
+	let select;
+
+	beforeEach( () => {
+		saveCRDTDoc.mockReset();
+		saveCRDTDoc.mockResolvedValue( true );
+		entityConfig = {
+			syncConfig: {
+				supportsPersistence: true,
+			},
+		};
+		select = {
+			getEntityConfig: jest.fn( () => entityConfig ),
+			getRawEntityRecord: jest.fn( () => ( {
+				meta: { _crdt_document: 'persisted-doc' },
+			} ) ),
+		};
+	} );
+
+	it( 'persists CRDT docs for sync-enabled entities', async () => {
+		const didPersist = await persistEntityCRDTDoc(
+			'postType',
+			'post',
+			123
+		)( { select } );
+
+		expect( saveCRDTDoc ).toHaveBeenCalledWith(
+			'postType/post',
+			123,
+			'persisted-doc'
+		);
+		expect( didPersist ).toBe( true );
+	} );
+
+	it( 'does not persist entities without persistence support', async () => {
+		select.getEntityConfig.mockReturnValue( { syncConfig: {} } );
+
+		const didPersist = await persistEntityCRDTDoc(
+			'taxonomy',
+			'category',
+			123
+		)( { select } );
+
+		expect( saveCRDTDoc ).not.toHaveBeenCalled();
+		expect( didPersist ).toBe( false );
 	} );
 } );
 

--- a/packages/core-data/src/test/private-actions.js
+++ b/packages/core-data/src/test/private-actions.js
@@ -1,10 +1,12 @@
 import apiFetch from '@wordpress/api-fetch';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { parse, serialize } from '@wordpress/blocks';
 import { createRegistry } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '..';
 import {
 	editMediaEntity,
+	persistEntityBlockAttributes,
 	persistEntityCRDTDoc,
 	setCollaborationSupported,
 } from '../private-actions';
@@ -13,7 +15,13 @@ import { saveCRDTDoc } from '../utils';
 import { unlock } from '../lock-unlock';
 
 jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@wordpress/blocks', () => ( {
+	...jest.requireActual( '@wordpress/blocks' ),
+	parse: jest.fn(),
+	serialize: jest.fn(),
+} ) );
 jest.mock( '../sync', () => ( {
+	...jest.requireActual( '../sync' ),
 	getSyncManager: jest.fn(),
 	hasSyncManager: jest.fn(),
 } ) );
@@ -270,6 +278,316 @@ describe( 'persistEntityCRDTDoc', () => {
 
 		expect( saveCRDTDoc ).not.toHaveBeenCalled();
 		expect( didPersist ).toBe( false );
+	} );
+} );
+
+describe( 'persistEntityBlockAttributes', () => {
+	let entityConfig;
+	let select;
+	let syncManager;
+
+	beforeEach( () => {
+		apiFetch.mockReset();
+		parse.mockReset();
+		serialize.mockReset();
+		syncManager = {
+			createPersistedCRDTDoc: jest
+				.fn()
+				.mockResolvedValue( 'serialized CRDT document' ),
+		};
+		getSyncManager.mockReturnValue( syncManager );
+		entityConfig = {
+			baseURL: '/wp/v2/posts',
+			syncConfig: { supportsPersistence: true },
+		};
+		select = {
+			getEntityConfig: jest.fn( () => entityConfig ),
+			getRawEntityRecord: jest.fn(),
+		};
+		apiFetch.mockResolvedValue( {
+			id: 123,
+			content: { raw: 'serialized repaired content' },
+			meta: { _crdt_document: 'serialized CRDT document' },
+		} );
+	} );
+
+	it( 'persists targeted block attributes with matching content and CRDT metadata', async () => {
+		parse.mockReturnValue( [
+			{
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			},
+		] );
+		serialize.mockReturnValue( 'serialized repaired block content' );
+
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: 'saved content' },
+				blockPath: [ 0 ],
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( syncManager.createPersistedCRDTDoc ).toHaveBeenCalledWith(
+			'postType/post',
+			123,
+			{
+				blocks: [
+					expect.objectContaining( {
+						attributes: { metadata: { noteId: [ 456 ] } },
+					} ),
+				],
+			}
+		);
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp-sync/v1/save-entity',
+			method: 'POST',
+			data: {
+				room: 'postType/post:123',
+				expected_content: 'serialized repaired content',
+				expected_doc: 'serialized CRDT document',
+				content: 'serialized repaired block content',
+				doc: 'serialized CRDT document',
+			},
+		} );
+		expect( didPersist ).toBe( true );
+	} );
+
+	it( 'does not persist when the block path cannot be found', async () => {
+		parse.mockReturnValue( [
+			{
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			},
+		] );
+
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: 'saved content' },
+				blockPath: [ 1 ],
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( apiFetch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { method: 'POST' } )
+		);
+		expect( didPersist ).toBe( false );
+	} );
+
+	it( 'resolves a moved block by its matching occurrence', async () => {
+		parse.mockReturnValue( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Target paragraph' },
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Sibling paragraph' },
+				innerBlocks: [],
+			},
+		] );
+		serialize.mockReturnValue( 'serialized repaired content' );
+
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: 'saved content' },
+				blockPath: [ 1 ],
+				isMatch: ( block ) =>
+					block?.attributes?.content === 'Target paragraph',
+				matchIndex: 0,
+				matchCount: 1,
+				blockCount: 2,
+				blockName: 'core/paragraph',
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( serialize ).toHaveBeenCalledWith( [
+			expect.objectContaining( {
+				attributes: {
+					content: 'Target paragraph',
+					metadata: { noteId: [ 456 ] },
+				},
+			} ),
+			expect.objectContaining( {
+				attributes: { content: 'Sibling paragraph' },
+			} ),
+		] );
+		expect( didPersist ).toBe( true );
+	} );
+
+	it( 'allows a validated dirty block at a stable path', async () => {
+		parse.mockReturnValue( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: 'Saved paragraph' },
+				innerBlocks: [],
+			},
+		] );
+		serialize.mockReturnValue( 'serialized repaired content' );
+
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: 'saved content' },
+				blockPath: [ 0 ],
+				isMatch: ( block ) =>
+					block?.attributes?.content === 'Dirty paragraph',
+				matchIndex: 0,
+				matchCount: 1,
+				isDirtyPathValid: () => true,
+				blockCount: 1,
+				blockName: 'core/paragraph',
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( didPersist ).toBe( true );
+	} );
+
+	it.each( [
+		[ 'the matching blocks were reordered', 2, () => false ],
+		[ 'the block count changed', 3, undefined ],
+	] )(
+		'refuses a dirty path when %s',
+		async ( _label, blockCount, validator ) => {
+			parse.mockReturnValue( [
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Saved target' },
+					innerBlocks: [],
+				},
+				{
+					name: 'core/paragraph',
+					attributes: { content: 'Saved sibling' },
+					innerBlocks: [],
+				},
+			] );
+
+			const didPersist = await persistEntityBlockAttributes(
+				'postType',
+				'post',
+				123,
+				{
+					record: { content: 'saved content' },
+					blockPath: [ 1 ],
+					isMatch: ( block ) =>
+						block?.attributes?.content === 'Dirty target',
+					matchIndex: 0,
+					matchCount: 1,
+					isDirtyPathValid: validator,
+					blockCount,
+					blockName: 'core/paragraph',
+					attributes: { metadata: { noteId: [ 456 ] } },
+				}
+			)( { select } );
+
+			expect( apiFetch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { method: 'POST' } )
+			);
+			expect( didPersist ).toBe( false );
+		}
+	);
+
+	it( 'persists the selected occurrence among identical saved blocks', async () => {
+		parse.mockReturnValue( [
+			{ name: 'core/separator', attributes: {}, innerBlocks: [] },
+			{ name: 'core/separator', attributes: {}, innerBlocks: [] },
+		] );
+		serialize.mockReturnValue( 'serialized repaired content' );
+
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: 'saved content' },
+				blockPath: [ 2 ],
+				isMatch: ( block ) => block?.name === 'core/separator',
+				matchIndex: 1,
+				matchCount: 2,
+				blockCount: 3,
+				blockName: 'core/separator',
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( serialize ).toHaveBeenCalledWith( [
+			expect.objectContaining( { attributes: {} } ),
+			expect.objectContaining( {
+				attributes: { metadata: { noteId: [ 456 ] } },
+			} ),
+		] );
+		expect( didPersist ).toBe( true );
+	} );
+
+	it( 'does not parse an empty raw-content object', async () => {
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: { raw: '', rendered: '<p>Rendered</p>' } },
+				blockPath: [ 0 ],
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( parse ).not.toHaveBeenCalled();
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( didPersist ).toBe( false );
+	} );
+
+	it( 'retries against fresh content after a cross-session conflict', async () => {
+		const firstRecord = { content: 'first saved content' };
+		const secondRecord = { content: 'second saved content' };
+		select.getRawEntityRecord.mockReturnValue( firstRecord );
+		parse.mockReturnValue( [
+			{
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			},
+		] );
+		serialize.mockReturnValue( 'repaired content' );
+		const conflict = Object.assign( new Error( 'Conflict' ), {
+			code: 'rest_sync_content_conflict',
+		} );
+		apiFetch
+			.mockResolvedValueOnce( firstRecord )
+			.mockRejectedValueOnce( conflict )
+			.mockResolvedValueOnce( secondRecord )
+			.mockResolvedValueOnce( {} );
+
+		const didPersist = await persistEntityBlockAttributes(
+			'postType',
+			'post',
+			123,
+			{
+				record: { content: 'stale content' },
+				blockPath: [ 0 ],
+				attributes: { metadata: { noteId: [ 456 ] } },
+			}
+		)( { select } );
+
+		expect( parse ).toHaveBeenNthCalledWith( 1, 'first saved content' );
+		expect( parse ).toHaveBeenNthCalledWith( 2, 'second saved content' );
+		expect( didPersist ).toBe( true );
 	} );
 } );
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -380,6 +380,7 @@ describe( 'getEntityRecord', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: SERIALIZED_DOC,
+				expected_doc: 'doc2',
 			},
 		} );
 		expect( syncManager.update ).not.toHaveBeenCalled();
@@ -440,6 +441,7 @@ describe( 'getEntityRecord', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: SERIALIZED_DOC,
+				expected_doc: '',
 			},
 		} );
 		expect( syncManager.update ).not.toHaveBeenCalled();

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -15,4 +15,8 @@ export {
 } from './user-permissions';
 export { RECEIVE_INTERMEDIATE_RESULTS } from './receive-intermediate-results';
 export { default as normalizeQueryForResolution } from './normalize-query-for-resolution';
-export { saveCRDTDoc } from './save-crdt-doc';
+export {
+	enqueueCRDTDocSave,
+	saveCRDTDoc,
+	setPersistedCRDTDoc,
+} from './save-crdt-doc';

--- a/packages/core-data/src/utils/save-crdt-doc.js
+++ b/packages/core-data/src/utils/save-crdt-doc.js
@@ -3,36 +3,50 @@ import { getSyncManager } from '../sync';
 
 const SYNC_SAVE_API_PATH = '/wp-sync/v1/save';
 const saveCRDTDocQueues = new Map();
+const persistedCRDTDocs = new Map();
 
-async function serializeAndSaveCRDTDoc( objectType, objectId, room ) {
+async function saveSerializedCRDTDoc( room, serializedDoc, expectedDoc ) {
+	try {
+		await apiFetch( {
+			path: SYNC_SAVE_API_PATH,
+			method: 'POST',
+			data: {
+				room,
+				doc: serializedDoc,
+				expected_doc:
+					persistedCRDTDocs.get( room ) ?? expectedDoc ?? '',
+			},
+		} );
+	} catch ( error ) {
+		if ( error?.code === 'rest_sync_document_conflict' ) {
+			persistedCRDTDocs.delete( room );
+		}
+		throw error;
+	}
+
+	persistedCRDTDocs.set( room, serializedDoc );
+	return true;
+}
+
+async function serializeAndSaveCRDTDoc(
+	objectType,
+	objectId,
+	room,
+	expectedDoc
+) {
 	const serializedDoc = await getSyncManager()?.createPersistedCRDTDoc(
 		objectType,
 		objectId
 	);
 
 	if ( ! serializedDoc ) {
-		return;
+		return false;
 	}
 
-	await apiFetch( {
-		path: SYNC_SAVE_API_PATH,
-		method: 'POST',
-		data: {
-			room,
-			doc: serializedDoc,
-		},
-	} );
+	return saveSerializedCRDTDoc( room, serializedDoc, expectedDoc );
 }
 
-/**
- * Persist the current CRDT document through the sync /save endpoint.
- *
- * @param {import('@wordpress/sync').ObjectType} objectType Object type.
- * @param {import('@wordpress/sync').ObjectID}   objectId   Object ID.
- */
-export async function saveCRDTDoc( objectType, objectId ) {
-	const room = `${ objectType }:${ objectId }`;
-
+async function enqueueRoomSave( room, save ) {
 	// Saves are chained per-room, which forms a queue.
 	// Without a queue, two /save calls might fire close together with a risk
 	// that the older serialized CRDT snapshot completes after the newer one and
@@ -43,15 +57,62 @@ export async function saveCRDTDoc( objectType, objectId ) {
 	const currentSave = previousSave
 		// A failed save should reject its caller, but not block later saves.
 		.catch( () => {} )
-		.then( () => serializeAndSaveCRDTDoc( objectType, objectId, room ) );
+		.then( save );
 
 	saveCRDTDocQueues.set( room, currentSave );
 
 	try {
-		await currentSave;
+		return await currentSave;
 	} finally {
 		if ( saveCRDTDocQueues.get( room ) === currentSave ) {
 			saveCRDTDocQueues.delete( room );
 		}
 	}
+}
+
+/**
+ * Serialize persistence operations for a sync room.
+ *
+ * @param {import('@wordpress/sync').ObjectType} objectType Object type.
+ * @param {import('@wordpress/sync').ObjectID}   objectId   Object ID.
+ * @param {Function}                             save       Persistence operation.
+ * @return {Promise<*>} Result of the persistence operation.
+ */
+export function enqueueCRDTDocSave( objectType, objectId, save ) {
+	const room = `${ objectType }:${ objectId }`;
+	return enqueueRoomSave( room, save );
+}
+
+/**
+ * Record the latest CRDT document persisted by another room-queued operation.
+ *
+ * @param {import('@wordpress/sync').ObjectType} objectType Object type.
+ * @param {import('@wordpress/sync').ObjectID}   objectId   Object ID.
+ * @param {string}                               doc        Persisted CRDT document.
+ */
+export function setPersistedCRDTDoc( objectType, objectId, doc ) {
+	const room = `${ objectType }:${ objectId }`;
+	if ( doc === undefined ) {
+		persistedCRDTDocs.delete( room );
+		return;
+	}
+	persistedCRDTDocs.set( room, doc );
+}
+
+/**
+ * Persist the current CRDT document through the sync /save endpoint.
+ *
+ * @param {import('@wordpress/sync').ObjectType} objectType    Object type.
+ * @param {import('@wordpress/sync').ObjectID}   objectId      Object ID.
+ * @param {string}                               [expectedDoc] Last persisted CRDT document.
+ * @return {Promise<boolean>} Whether a CRDT document was persisted.
+ */
+export async function saveCRDTDoc( objectType, objectId, expectedDoc ) {
+	const room = `${ objectType }:${ objectId }`;
+	if ( expectedDoc !== undefined ) {
+		persistedCRDTDocs.set( room, expectedDoc );
+	}
+	return enqueueCRDTDocSave( objectType, objectId, () =>
+		serializeAndSaveCRDTDoc( objectType, objectId, room, expectedDoc )
+	);
 }

--- a/packages/core-data/src/utils/test/save-crdt-doc.js
+++ b/packages/core-data/src/utils/test/save-crdt-doc.js
@@ -1,6 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import { getSyncManager } from '../../sync';
-import { saveCRDTDoc } from '../save-crdt-doc';
+import {
+	enqueueCRDTDocSave,
+	saveCRDTDoc,
+	setPersistedCRDTDoc,
+} from '../save-crdt-doc';
 
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../../sync', () => ( {
@@ -27,6 +31,8 @@ describe( 'saveCRDTDoc', () => {
 
 	beforeEach( () => {
 		apiFetch.mockReset();
+		setPersistedCRDTDoc( 'postType/post', 1, undefined );
+		setPersistedCRDTDoc( 'postType/post', 2, undefined );
 		syncManager = {
 			createPersistedCRDTDoc: jest.fn(),
 		};
@@ -43,7 +49,7 @@ describe( 'saveCRDTDoc', () => {
 		await flushPromises();
 
 		fetch.resolve( {} );
-		await save;
+		await expect( save ).resolves.toBe( true );
 
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/wp-sync/v1/save',
@@ -51,6 +57,7 @@ describe( 'saveCRDTDoc', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: 'doc',
+				expected_doc: '',
 			},
 		} );
 	} );
@@ -58,7 +65,9 @@ describe( 'saveCRDTDoc', () => {
 	it( 'does not call the sync endpoint when there is no serialized CRDT document', async () => {
 		syncManager.createPersistedCRDTDoc.mockResolvedValue( null );
 
-		await saveCRDTDoc( 'postType/post', 1 );
+		await expect( saveCRDTDoc( 'postType/post', 1 ) ).resolves.toBe(
+			false
+		);
 
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
@@ -85,6 +94,7 @@ describe( 'saveCRDTDoc', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: 'doc-1',
+				expected_doc: '',
 			},
 		} );
 
@@ -100,6 +110,7 @@ describe( 'saveCRDTDoc', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: 'doc-2',
+				expected_doc: 'doc-1',
 			},
 		} );
 
@@ -128,6 +139,7 @@ describe( 'saveCRDTDoc', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: 'doc-1',
+				expected_doc: '',
 			},
 		} );
 		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
@@ -136,6 +148,7 @@ describe( 'saveCRDTDoc', () => {
 			data: {
 				room: 'postType/post:2',
 				doc: 'doc-2',
+				expected_doc: '',
 			},
 		} );
 
@@ -170,9 +183,47 @@ describe( 'saveCRDTDoc', () => {
 			data: {
 				room: 'postType/post:1',
 				doc: 'doc-2',
+				expected_doc: '',
 			},
 		} );
 
 		await secondSave;
+	} );
+
+	it( 'serializes another persistence operation against a sync save for the same room', async () => {
+		const repairFetch = createDeferred();
+		syncManager.createPersistedCRDTDoc.mockResolvedValue( 'sync-doc' );
+		apiFetch
+			.mockImplementationOnce( () => repairFetch.promise )
+			.mockResolvedValueOnce( {} );
+
+		const repair = enqueueCRDTDocSave( 'postType/post', 1, () =>
+			apiFetch( {
+				path: '/wp/v2/posts/1',
+				method: 'POST',
+				data: { content: 'repaired content' },
+			} )
+		);
+		const syncSave = saveCRDTDoc( 'postType/post', 1 );
+
+		await flushPromises();
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( syncManager.createPersistedCRDTDoc ).not.toHaveBeenCalled();
+
+		repairFetch.resolve( {} );
+		await repair;
+		await flushPromises();
+
+		expect( syncManager.createPersistedCRDTDoc ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/wp-sync/v1/save',
+			method: 'POST',
+			data: {
+				room: 'postType/post:1',
+				doc: 'sync-doc',
+				expected_doc: '',
+			},
+		} );
+		await syncSave;
 	} );
 } );

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -830,10 +830,12 @@ export function createSyncManager( debug = false ): SyncManager {
 	 *
 	 * @param {ObjectType} objectType Object type.
 	 * @param {ObjectID}   objectId   Object ID.
+	 * @param {ObjectData} changes    Changes to include in the snapshot.
 	 */
 	async function createPersistedCRDTDoc(
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		changes?: Partial< ObjectData >
 	): Promise< string | null > {
 		const entityId = getEntityId( objectType, objectId );
 		const entityState = entityStates.get( entityId );
@@ -845,6 +847,25 @@ export function createSyncManager( debug = false ): SyncManager {
 		// Local updates may be deferred when editing alone. Apply them so
 		// they are included in the serialized document.
 		flushPendingCRDTDocUpdates();
+
+		if ( changes ) {
+			const snapshot = createYjsDoc( { objectType } );
+			Y.applyUpdateV2(
+				snapshot,
+				Y.encodeStateAsUpdateV2( entityState.ydoc )
+			);
+			try {
+				snapshot.transact( () => {
+					entityState.syncConfig.applyChangesToCRDTDoc(
+						snapshot,
+						changes
+					);
+				}, LOCAL_SYNC_MANAGER_ORIGIN );
+				return serializeCrdtDoc( snapshot );
+			} finally {
+				snapshot.destroy();
+			}
+		}
 
 		return serializeCrdtDoc( entityState.ydoc );
 	}

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -27,7 +27,7 @@ import type {
 	RecordHandlers,
 	SyncConfig,
 } from '../types';
-import { serializeCrdtDoc } from '../utils';
+import { deserializeCrdtDoc, serializeCrdtDoc } from '../utils';
 
 // Mock dependencies.
 jest.mock( '../providers', () => ( {
@@ -901,6 +901,50 @@ describe( 'SyncManager', () => {
 				now
 			);
 			expect( stateMap.get( SAVED_BY_KEY ) ).toBe( ydoc.clientID );
+		} );
+	} );
+
+	describe( 'createPersistedCRDTDoc', () => {
+		it( 'applies explicit changes to a cloned snapshot', async () => {
+			let liveDoc: Y.Doc | null = null;
+			mockProviderCreator.mockImplementation( async ( { ydoc } ) => {
+				liveDoc = ydoc;
+				return mockProviderResult;
+			} );
+			mockSyncConfig.applyChangesToCRDTDoc.mockImplementation(
+				( ydoc, changes ) => {
+					const recordMap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
+					Object.entries( changes ).forEach( ( [ key, value ] ) =>
+						recordMap.set( key, value )
+					);
+				}
+			);
+			const manager = createSyncManager();
+
+			await manager.load(
+				mockSyncConfig,
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			const serialized = await manager.createPersistedCRDTDoc(
+				'post',
+				'123',
+				{ title: 'Repaired title' }
+			);
+			const snapshot = deserializeCrdtDoc( serialized ?? '' );
+
+			expect(
+				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
+			).toBe( 'Repaired title' );
+			expect(
+				( liveDoc as unknown as Y.Doc )
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'title' )
+			).toBe( 'Test Post' );
+			snapshot?.destroy();
 		} );
 	} );
 

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -928,6 +928,12 @@ describe( 'SyncManager', () => {
 				mockRecord,
 				mockHandlers
 			);
+			manager.update(
+				'post',
+				'123',
+				{ meta: { pending: true } },
+				'local'
+			);
 
 			const serialized = await manager.createPersistedCRDTDoc(
 				'post',
@@ -939,11 +945,22 @@ describe( 'SyncManager', () => {
 			expect(
 				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'title' )
 			).toBe( 'Repaired title' );
+			expect( snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'id' ) ).toBe(
+				'123'
+			);
+			expect(
+				snapshot?.getMap( CRDT_RECORD_MAP_KEY ).get( 'meta' )
+			).toEqual( { pending: true } );
 			expect(
 				( liveDoc as unknown as Y.Doc )
 					.getMap( CRDT_RECORD_MAP_KEY )
 					.get( 'title' )
 			).toBe( 'Test Post' );
+			expect(
+				( liveDoc as unknown as Y.Doc )
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'meta' )
+			).toEqual( { pending: true } );
 			snapshot?.destroy();
 		} );
 	} );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -156,7 +156,8 @@ export interface SyncConfig {
 export interface SyncManager {
 	createPersistedCRDTDoc: (
 		objectType: ObjectType,
-		objectId: ObjectID
+		objectId: ObjectID,
+		changes?: Partial< ObjectData >
 	) => Promise< string | null >;
 	getAwareness: < State extends Awareness >(
 		objectType: ObjectType,

--- a/phpunit/tests/collaboration/wpSyncSaveServer.php
+++ b/phpunit/tests/collaboration/wpSyncSaveServer.php
@@ -38,21 +38,24 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 
 		// Enable option for tests.
 		update_option( 'wp_collaboration_enabled', 1 );
+		delete_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY );
 	}
 
 	/**
 	 * Dispatches a CRDT document save request.
 	 *
-	 * @param string $room Room identifier.
-	 * @param string $doc  Serialized CRDT document.
+	 * @param string $room         Room identifier.
+	 * @param string $doc          Serialized CRDT document.
+	 * @param string $expected_doc Expected persisted CRDT document.
 	 * @return WP_REST_Response Response object.
 	 */
-	private function dispatch_save( $room, $doc = 'serialized-crdt-doc' ) {
+	private function dispatch_save( $room, $doc = 'serialized-crdt-doc', $expected_doc = '' ) {
 		$request = new WP_REST_Request( 'POST', '/wp-sync/v1/save' );
 		$request->set_body_params(
 			array(
-				'room' => $room,
-				'doc'  => $doc,
+				'room'         => $room,
+				'doc'          => $doc,
+				'expected_doc' => $expected_doc,
 			)
 		);
 		return rest_get_server()->dispatch( $request );
@@ -180,10 +183,20 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 		wp_set_current_user( self::$editor_id );
 		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'serialized-crdt-doc' );
 
-		$response = $this->dispatch_save( $this->get_post_room(), 'serialized-crdt-doc' );
+		$response = $this->dispatch_save( $this->get_post_room(), 'serialized-crdt-doc', 'serialized-crdt-doc' );
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'serialized-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
+	}
+
+	public function test_save_rejects_stale_crdt_doc() {
+		wp_set_current_user( self::$editor_id );
+		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'current-crdt-doc' );
+
+		$response = $this->dispatch_save( $this->get_post_room(), 'stale-crdt-doc', 'older-crdt-doc' );
+
+		$this->assertErrorResponse( 'rest_sync_document_conflict', $response, 409 );
+		$this->assertSame( 'current-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
 	}
 
 	public function test_save_rejects_taxonomy_entity() {

--- a/phpunit/tests/collaboration/wpSyncSaveServer.php
+++ b/phpunit/tests/collaboration/wpSyncSaveServer.php
@@ -39,6 +39,12 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 		// Enable option for tests.
 		update_option( 'wp_collaboration_enabled', 1 );
 		delete_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY );
+		wp_update_post(
+			array(
+				'ID'           => self::$post_id,
+				'post_content' => '',
+			)
+		);
 	}
 
 	/**
@@ -62,6 +68,28 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 	}
 
 	/**
+	 * Dispatches a conditional entity save request.
+	 *
+	 * @param string $expected_content Expected persisted post content.
+	 * @param string $content          Replacement post content.
+	 * @param string $expected_doc     Expected persisted CRDT document.
+	 * @return WP_REST_Response Response object.
+	 */
+	private function dispatch_entity_save( $expected_content, $content, $expected_doc = '' ) {
+		$request = new WP_REST_Request( 'POST', '/wp-sync/v1/save-entity' );
+		$request->set_body_params(
+			array(
+				'room'             => $this->get_post_room(),
+				'doc'              => 'serialized-entity-crdt-doc',
+				'expected_content' => $expected_content,
+				'expected_doc'     => $expected_doc,
+				'content'          => $content,
+			)
+		);
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
 	 * Returns the default room identifier for the test post.
 	 *
 	 * @return string Room identifier.
@@ -73,6 +101,7 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( '/wp-sync/v1/save', $routes );
+		$this->assertArrayHasKey( '/wp-sync/v1/save-entity', $routes );
 	}
 
 	/**
@@ -177,6 +206,87 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'updated-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
 		$this->assertSame( $modified, get_post_field( 'post_modified', self::$post_id ) );
+	}
+
+	public function test_entity_save_rejects_stale_content_without_overwriting() {
+		wp_set_current_user( self::$editor_id );
+		wp_update_post(
+			array(
+				'ID'           => self::$post_id,
+				'post_content' => 'current content',
+			)
+		);
+
+		$response = $this->dispatch_entity_save( 'stale content', 'replacement content' );
+
+		$this->assertErrorResponse( 'rest_sync_content_conflict', $response, 409 );
+		$this->assertSame( 'current content', get_post_field( 'post_content', self::$post_id, 'raw' ) );
+	}
+
+	public function test_entity_save_atomically_updates_expected_content_and_crdt_doc() {
+		wp_set_current_user( self::$editor_id );
+		wp_update_post(
+			array(
+				'ID'           => self::$post_id,
+				'post_content' => 'expected content',
+			)
+		);
+
+		$response = $this->dispatch_entity_save( 'expected content', 'replacement content' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'replacement content', get_post_field( 'post_content', self::$post_id, 'raw' ) );
+		$this->assertSame( 'serialized-entity-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
+	}
+
+	public function test_entity_save_rejects_reentrant_writer_without_tearing_content_and_crdt_doc() {
+		wp_set_current_user( self::$editor_id );
+		wp_update_post(
+			array(
+				'ID'           => self::$post_id,
+				'post_content' => 'expected content',
+			)
+		);
+		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'initial-crdt-doc' );
+
+		$nested_response = null;
+		$interleave      = function ( $check, $object_id, $meta_key ) use ( &$nested_response ) {
+			if ( WP_Sync_Save_Server::CRDT_DOC_META_KEY === $meta_key ) {
+				$nested_response = $this->dispatch_entity_save( 'replacement content', 'nested content', 'initial-crdt-doc' );
+			}
+			return $check;
+		};
+		add_filter( 'update_post_metadata', $interleave, 10, 3 );
+
+		$response = $this->dispatch_entity_save( 'expected content', 'replacement content', 'initial-crdt-doc' );
+
+		remove_filter( 'update_post_metadata', $interleave, 10 );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertErrorResponse( 'rest_sync_document_conflict', $nested_response, 409 );
+		$this->assertSame( 'replacement content', get_post_field( 'post_content', self::$post_id, 'raw' ) );
+		$this->assertSame( 'serialized-entity-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
+	}
+
+	public function test_entity_save_rolls_back_content_when_crdt_doc_save_fails() {
+		wp_set_current_user( self::$editor_id );
+		wp_update_post(
+			array(
+				'ID'           => self::$post_id,
+				'post_content' => 'expected content',
+			)
+		);
+		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'initial-crdt-doc' );
+		$reject_meta = static function ( $check, $object_id, $meta_key ) {
+			return WP_Sync_Save_Server::CRDT_DOC_META_KEY === $meta_key ? false : $check;
+		};
+		add_filter( 'update_post_metadata', $reject_meta, 10, 3 );
+
+		$response = $this->dispatch_entity_save( 'expected content', 'replacement content', 'initial-crdt-doc' );
+
+		remove_filter( 'update_post_metadata', $reject_meta, 10 );
+		$this->assertErrorResponse( 'rest_crdt_save_failed', $response, 500 );
+		$this->assertSame( 'expected content', get_post_field( 'post_content', self::$post_id, 'raw' ) );
+		$this->assertSame( 'initial-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
 	}
 
 	public function test_save_allows_unchanged_crdt_doc_meta() {

--- a/phpunit/tests/collaboration/wpSyncSaveServer.php
+++ b/phpunit/tests/collaboration/wpSyncSaveServer.php
@@ -46,18 +46,19 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 	 *
 	 * @param string $room         Room identifier.
 	 * @param string $doc          Serialized CRDT document.
-	 * @param string $expected_doc Expected persisted CRDT document.
+	 * @param string|null $expected_doc Expected persisted CRDT document.
 	 * @return WP_REST_Response Response object.
 	 */
-	private function dispatch_save( $room, $doc = 'serialized-crdt-doc', $expected_doc = '' ) {
+	private function dispatch_save( $room, $doc = 'serialized-crdt-doc', $expected_doc = null ) {
 		$request = new WP_REST_Request( 'POST', '/wp-sync/v1/save' );
-		$request->set_body_params(
-			array(
-				'room'         => $room,
-				'doc'          => $doc,
-				'expected_doc' => $expected_doc,
-			)
+		$body    = array(
+			'room' => $room,
+			'doc'  => $doc,
 		);
+		if ( null !== $expected_doc ) {
+			$body['expected_doc'] = $expected_doc;
+		}
+		$request->set_body_params( $body );
 		return rest_get_server()->dispatch( $request );
 	}
 
@@ -187,6 +188,16 @@ class Tests_Collaboration_WpSyncSaveServer extends WP_Test_REST_Controller_Testc
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'serialized-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
+	}
+
+	public function test_save_without_expected_doc_preserves_existing_client_behavior() {
+		wp_set_current_user( self::$editor_id );
+		update_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, 'current-crdt-doc' );
+
+		$response = $this->dispatch_save( $this->get_post_room(), 'updated-crdt-doc' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'updated-crdt-doc', get_post_meta( self::$post_id, WP_Sync_Save_Server::CRDT_DOC_META_KEY, true ) );
 	}
 
 	public function test_save_rejects_stale_crdt_doc() {

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -15,6 +15,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -177,6 +177,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Atomic content base.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 
@@ -234,7 +235,13 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 						},
 					} );
 				} catch ( error ) {
-					conflictCode = error.code;
+					if (
+						error &&
+						typeof error === 'object' &&
+						'code' in error
+					) {
+						conflictCode = String( error.code );
+					}
 				}
 				const finalRecord = await window.wp.apiFetch( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -333,4 +333,54 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		expect( requests ).toHaveLength( 2 );
 		expect( requests[ 1 ].expected_doc ).toBe( requests[ 0 ].doc );
 	} );
+
+	test( 'repairs the selected occurrence among duplicate contentless blocks', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Targeted duplicate block repair',
+			content:
+				'<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->\n\n<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const didPersist = await page.evaluate( async ( consent ) => {
+			const { unlock } =
+				window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					consent,
+					'@wordpress/core-data'
+				);
+			const editorSelect = window.wp.data.select( 'core/editor' );
+			return unlock(
+				window.wp.data.dispatch( 'core' )
+			).persistEntityBlockAttributes(
+				'postType',
+				editorSelect.getCurrentPostType(),
+				editorSelect.getCurrentPostId(),
+				{
+					record: editorSelect.getCurrentPost(),
+					blockPath: [ 1 ],
+					isMatch: ( block ) => block.name === 'core/separator',
+					matchCount: 2,
+					matchIndex: 1,
+					blockCount: 2,
+					blockName: 'core/separator',
+					attributes: { metadata: { noteId: [ 123 ] } },
+				}
+			);
+		}, CORE_DATA_PRIVATE_APIS_CONSENT );
+
+		expect( didPersist ).toBe( true );
+		await page.reload();
+		await collaborationUtils.waitForEntityReady( page );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 2 );
+		expect( blocks[ 0 ].attributes.metadata?.noteId ).toBeUndefined();
+		expect( blocks[ 1 ].attributes.metadata?.noteId ).toEqual( [ 123 ] );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from './fixtures';
+
+const CORE_DATA_PRIVATE_APIS_CONSENT =
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
+
+test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
+	test( 'reloads isolated snapshot changes without mutating or duplicating the live document', async ( {
+		collaborationUtils,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Targeted CRDT snapshot',
+			content:
+				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const liveContent = await page.evaluate(
+			async ( { consent, postId } ) => {
+				const { unlock } =
+					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				const coreDispatch = unlock(
+					window.wp.data.dispatch( 'core' )
+				);
+				const persistedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				const blocks = window.wp.blocks.parse(
+					persistedRecord.content.raw
+				);
+				blocks[ 0 ] = {
+					...blocks[ 0 ],
+					attributes: {
+						...blocks[ 0 ].attributes,
+						content: 'Targeted snapshot content.',
+					},
+				};
+				const doc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ blocks }
+					);
+				await window.wp.apiFetch( {
+					path: '/wp-sync/v1/save',
+					method: 'POST',
+					data: {
+						room: `postType/post:${ postId }`,
+						doc,
+						expected_doc:
+							persistedRecord.meta?._crdt_document || '',
+					},
+				} );
+
+				return window.wp.data
+					.select( 'core/block-editor' )
+					.getBlocks()[ 0 ]
+					.attributes.content.toString();
+			},
+			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
+		);
+
+		expect( liveContent ).toBe( 'Original persisted content.' );
+		await page.reload();
+		await collaborationUtils.waitForEntityReady( page );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].attributes.content ).toBe(
+			'Targeted snapshot content.'
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -89,6 +89,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Conflict base.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 
@@ -142,7 +143,13 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 						},
 					} );
 				} catch ( error ) {
-					conflictCode = error.code;
+					if (
+						error &&
+						typeof error === 'object' &&
+						'code' in error
+					) {
+						conflictCode = String( error.code );
+					}
 				}
 				const finalRecord = await window.wp.apiFetch( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -158,4 +158,92 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		expect( result.conflictCode ).toBe( 'rest_sync_document_conflict' );
 		expect( result.persistedDoc ).toBe( result.firstDoc );
 	} );
+
+	test( 'rolls back content when the matching CRDT snapshot is stale', async ( {
+		collaborationUtils,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Atomic synchronized entity save',
+			content:
+				'<!-- wp:paragraph --><p>Atomic content base.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const result = await page.evaluate(
+			async ( { consent, postId } ) => {
+				const { unlock } =
+					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				const coreDispatch = unlock(
+					window.wp.data.dispatch( 'core' )
+				);
+				const persistedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				const originalContent = persistedRecord.content.raw;
+				const expectedDoc = persistedRecord.meta?._crdt_document || '';
+				const winningDoc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ title: 'Winning snapshot' }
+					);
+				const staleEntityDoc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ title: 'Stale entity snapshot' }
+					);
+				await window.wp.apiFetch( {
+					path: '/wp-sync/v1/save',
+					method: 'POST',
+					data: {
+						room: `postType/post:${ postId }`,
+						doc: winningDoc,
+						expected_doc: expectedDoc,
+					},
+				} );
+
+				let conflictCode = null;
+				try {
+					await window.wp.apiFetch( {
+						path: '/wp-sync/v1/save-entity',
+						method: 'POST',
+						data: {
+							room: `postType/post:${ postId }`,
+							expected_content: originalContent,
+							expected_doc: expectedDoc,
+							content:
+								'<!-- wp:paragraph --><p>Torn replacement.</p><!-- /wp:paragraph -->',
+							doc: staleEntityDoc,
+						},
+					} );
+				} catch ( error ) {
+					conflictCode = error.code;
+				}
+				const finalRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				return {
+					conflictCode,
+					originalContent,
+					winningDoc,
+					finalContent: finalRecord.content.raw,
+					finalDoc: finalRecord.meta?._crdt_document,
+				};
+			},
+			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
+		);
+
+		expect( result.conflictCode ).toBe( 'rest_sync_document_conflict' );
+		expect( result.finalContent ).toBe( result.originalContent );
+		expect( result.finalDoc ).toBe( result.winningDoc );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -77,4 +77,85 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			'Targeted snapshot content.'
 		);
 	} );
+
+	test( 'rejects a stale CRDT snapshot writer', async ( {
+		collaborationUtils,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'CRDT snapshot conflict',
+			content:
+				'<!-- wp:paragraph --><p>Conflict base.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		const result = await page.evaluate(
+			async ( { consent, postId } ) => {
+				const { unlock } =
+					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+						consent,
+						'@wordpress/core-data'
+					);
+				const coreDispatch = unlock(
+					window.wp.data.dispatch( 'core' )
+				);
+				const persistedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				const expectedDoc = persistedRecord.meta?._crdt_document || '';
+				const firstDoc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ title: 'First writer' }
+					);
+				const staleDoc =
+					await coreDispatch.createEntityCRDTPersistenceSnapshot(
+						'postType',
+						'post',
+						postId,
+						{ title: 'Stale writer' }
+					);
+				await window.wp.apiFetch( {
+					path: '/wp-sync/v1/save',
+					method: 'POST',
+					data: {
+						room: `postType/post:${ postId }`,
+						doc: firstDoc,
+						expected_doc: expectedDoc,
+					},
+				} );
+
+				let conflictCode = null;
+				try {
+					await window.wp.apiFetch( {
+						path: '/wp-sync/v1/save',
+						method: 'POST',
+						data: {
+							room: `postType/post:${ postId }`,
+							doc: staleDoc,
+							expected_doc: expectedDoc,
+						},
+					} );
+				} catch ( error ) {
+					conflictCode = error.code;
+				}
+				const finalRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
+				return {
+					conflictCode,
+					firstDoc,
+					persistedDoc: finalRecord.meta?._crdt_document,
+				};
+			},
+			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
+		);
+
+		expect( result.conflictCode ).toBe( 'rest_sync_document_conflict' );
+		expect( result.persistedDoc ).toBe( result.firstDoc );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -246,4 +246,91 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		expect( result.finalContent ).toBe( result.originalContent );
 		expect( result.finalDoc ).toBe( result.winningDoc );
 	} );
+
+	test( 'serializes overlapping CRDT saves for the same room', async ( {
+		collaborationUtils,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Queued CRDT persistence',
+			content:
+				'<!-- wp:paragraph --><p>Queued persistence base.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+		} );
+		await collaborationUtils.openPost( post.id );
+
+		let releaseFirstSave;
+		const firstSaveReleased = new Promise< void >( ( resolve ) => {
+			releaseFirstSave = resolve;
+		} );
+		let markFirstSaveStarted;
+		const firstSaveStarted = new Promise< void >( ( resolve ) => {
+			markFirstSaveStarted = resolve;
+		} );
+		const requests = [];
+		await page.route( '**/*', async ( route ) => {
+			const request = route.request();
+			const url = new URL( request.url() );
+			const restPath =
+				url.searchParams.get( 'rest_route' ) ||
+				url.pathname.replace( /^\/wp-json/, '' );
+			if (
+				request.method() !== 'POST' ||
+				restPath !== '/wp-sync/v1/save'
+			) {
+				await route.continue();
+				return;
+			}
+
+			requests.push( request.postDataJSON() );
+			if ( requests.length === 1 ) {
+				markFirstSaveStarted();
+				await firstSaveReleased;
+			}
+			await route.continue();
+		} );
+
+		await page.evaluate( ( consent ) => {
+			const { unlock } =
+				window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					consent,
+					'@wordpress/core-data'
+				);
+			const editorSelect = window.wp.data.select( 'core/editor' );
+			const dispatch = unlock( window.wp.data.dispatch( 'core' ) );
+			window.__firstQueuedSave = dispatch.persistEntityCRDTDoc(
+				'postType',
+				editorSelect.getCurrentPostType(),
+				editorSelect.getCurrentPostId()
+			);
+		}, CORE_DATA_PRIVATE_APIS_CONSENT );
+		await firstSaveStarted;
+		await page.evaluate( ( consent ) => {
+			const { unlock } =
+				window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					consent,
+					'@wordpress/core-data'
+				);
+			const editorSelect = window.wp.data.select( 'core/editor' );
+			const dispatch = unlock( window.wp.data.dispatch( 'core' ) );
+			window.__secondQueuedSave = dispatch.persistEntityCRDTDoc(
+				'postType',
+				editorSelect.getCurrentPostType(),
+				editorSelect.getCurrentPostId()
+			);
+		}, CORE_DATA_PRIVATE_APIS_CONSENT );
+
+		expect( requests ).toHaveLength( 1 );
+		releaseFirstSave();
+		await page.evaluate( () =>
+			Promise.all( [
+				window.__firstQueuedSave,
+				window.__secondQueuedSave,
+			] )
+		);
+
+		expect( requests ).toHaveLength( 2 );
+		expect( requests[ 1 ].expected_doc ).toBe( requests[ 0 ].doc );
+	} );
 } );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -272,18 +272,19 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:paragraph --><p>Queued persistence base.</p><!-- /wp:paragraph -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 
-		let releaseFirstSave;
+		let releaseFirstSave!: () => void;
 		const firstSaveReleased = new Promise< void >( ( resolve ) => {
 			releaseFirstSave = resolve;
 		} );
-		let markFirstSaveStarted;
+		let markFirstSaveStarted!: () => void;
 		const firstSaveStarted = new Promise< void >( ( resolve ) => {
 			markFirstSaveStarted = resolve;
 		} );
-		const requests = [];
+		const requests: Array< { doc: string; expected_doc: string } > = [];
 		await page.route( '**/*', async ( route ) => {
 			const request = route.request();
 			const url = new URL( request.url() );
@@ -314,7 +315,10 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				);
 			const editorSelect = window.wp.data.select( 'core/editor' );
 			const dispatch = unlock( window.wp.data.dispatch( 'core' ) );
-			window.__firstQueuedSave = dispatch.persistEntityCRDTDoc(
+			const queuedWindow = window as typeof window & {
+				__firstQueuedSave: Promise< boolean >;
+			};
+			queuedWindow.__firstQueuedSave = dispatch.persistEntityCRDTDoc(
 				'postType',
 				editorSelect.getCurrentPostType(),
 				editorSelect.getCurrentPostId()
@@ -329,7 +333,10 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				);
 			const editorSelect = window.wp.data.select( 'core/editor' );
 			const dispatch = unlock( window.wp.data.dispatch( 'core' ) );
-			window.__secondQueuedSave = dispatch.persistEntityCRDTDoc(
+			const queuedWindow = window as typeof window & {
+				__secondQueuedSave: Promise< boolean >;
+			};
+			queuedWindow.__secondQueuedSave = dispatch.persistEntityCRDTDoc(
 				'postType',
 				editorSelect.getCurrentPostType(),
 				editorSelect.getCurrentPostId()
@@ -338,12 +345,16 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 
 		expect( requests ).toHaveLength( 1 );
 		releaseFirstSave();
-		await page.evaluate( () =>
-			Promise.all( [
-				window.__firstQueuedSave,
-				window.__secondQueuedSave,
-			] )
-		);
+		await page.evaluate( () => {
+			const queuedWindow = window as typeof window & {
+				__firstQueuedSave: Promise< boolean >;
+				__secondQueuedSave: Promise< boolean >;
+			};
+			return Promise.all( [
+				queuedWindow.__firstQueuedSave,
+				queuedWindow.__secondQueuedSave,
+			] );
+		} );
 
 		expect( requests ).toHaveLength( 2 );
 		expect( requests[ 1 ].expected_doc ).toBe( requests[ 0 ].doc );

--- a/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/collaboration-targeted-crdt-snapshot.spec.ts
@@ -371,6 +371,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 			content:
 				'<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->\n\n<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->',
 			status: 'draft',
+			date_gmt: new Date().toISOString(),
 		} );
 		await collaborationUtils.openPost( post.id );
 
@@ -390,7 +391,8 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				{
 					record: editorSelect.getCurrentPost(),
 					blockPath: [ 1 ],
-					isMatch: ( block ) => block.name === 'core/separator',
+					isMatch: ( block: { name: string } ) =>
+						block.name === 'core/separator',
 					matchCount: 2,
 					matchIndex: 1,
 					blockCount: 2,
@@ -406,7 +408,11 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 
 		const blocks = await editor.getBlocks();
 		expect( blocks ).toHaveLength( 2 );
-		expect( blocks[ 0 ].attributes.metadata?.noteId ).toBeUndefined();
-		expect( blocks[ 1 ].attributes.metadata?.noteId ).toEqual( [ 123 ] );
+		const metadata = blocks.map(
+			( block ) =>
+				block.attributes.metadata as { noteId?: number[] } | undefined
+		);
+		expect( metadata[ 0 ]?.noteId ).toBeUndefined();
+		expect( metadata[ 1 ]?.noteId ).toEqual( [ 123 ] );
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect } from '../fixtures';
 
 const CORE_DATA_PRIVATE_APIS_CONSENT =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -4,7 +4,7 @@ const CORE_DATA_PRIVATE_APIS_CONSENT =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
-	test( 'reloads isolated snapshot changes without mutating or duplicating the live document', async ( {
+	test( 'persists an isolated snapshot without mutating or duplicating block content', async ( {
 		collaborationUtils,
 		editor,
 		page,
@@ -19,7 +19,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		} );
 		await collaborationUtils.openPost( post.id );
 
-		const liveContent = await page.evaluate(
+		const result = await page.evaluate(
 			async ( { consent, postId } ) => {
 				const { unlock } =
 					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
@@ -59,23 +59,31 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 							persistedRecord.meta?._crdt_document || '',
 					},
 				} );
+				const savedRecord = await window.wp.apiFetch( {
+					path: `/wp/v2/posts/${ postId }?context=edit`,
+				} );
 
-				return window.wp.data
-					.select( 'core/block-editor' )
-					.getBlocks()[ 0 ]
-					.attributes.content.toString();
+				return {
+					doc,
+					persistedDoc: savedRecord.meta?._crdt_document,
+					liveContent: window.wp.data
+						.select( 'core/block-editor' )
+						.getBlocks()[ 0 ]
+						.attributes.content.toString(),
+				};
 			},
 			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
 		);
 
-		expect( liveContent ).toBe( 'Original persisted content.' );
+		expect( result.persistedDoc ).toBe( result.doc );
+		expect( result.liveContent ).toBe( 'Original persisted content.' );
 		await page.reload();
 		await collaborationUtils.waitForEntityReady( page );
 
 		const blocks = await editor.getBlocks();
 		expect( blocks ).toHaveLength( 1 );
 		expect( blocks[ 0 ].attributes.content ).toBe(
-			'Targeted snapshot content.'
+			'Original persisted content.'
 		);
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -13,7 +13,7 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 		const post = await requestUtils.createPost( {
 			title: 'Targeted CRDT snapshot',
 			content:
-				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->',
+				'<!-- wp:paragraph --><p>Original persisted content.</p><!-- /wp:paragraph -->\n\n<!-- wp:paragraph --><p>Preserved sibling content.</p><!-- /wp:paragraph -->',
 			status: 'draft',
 			date_gmt: new Date().toISOString(),
 		} );
@@ -21,8 +21,9 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 
 		const result = await page.evaluate(
 			async ( { consent, postId } ) => {
+				const privateApis = ( window as any ).wp.privateApis;
 				const { unlock } =
-					window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+					privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 						consent,
 						'@wordpress/core-data'
 					);
@@ -62,28 +63,63 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				const savedRecord = await window.wp.apiFetch( {
 					path: `/wp/v2/posts/${ postId }?context=edit`,
 				} );
+				const { CRDT_RECORD_MAP_KEY } = unlock(
+					( window as any ).wp.sync.privateApis
+				);
+				const snapshot = new ( window as any ).wp.sync.Y.Doc();
+				const encodedDocument = JSON.parse( doc ).document;
+				const update = Uint8Array.from(
+					window.atob( encodedDocument ),
+					( character ) => character.charCodeAt( 0 )
+				);
+				( window as any ).wp.sync.Y.applyUpdateV2( snapshot, update );
+				const snapshotBlocks = snapshot
+					.getMap( CRDT_RECORD_MAP_KEY )
+					.get( 'blocks' )
+					.toJSON();
+				snapshot.destroy();
 
 				return {
 					doc,
 					persistedDoc: savedRecord.meta?._crdt_document,
+					snapshotContent: snapshotBlocks.map(
+						( block: { attributes: { content: string } } ) =>
+							block.attributes.content
+					),
 					liveContent: window.wp.data
 						.select( 'core/block-editor' )
-						.getBlocks()[ 0 ]
-						.attributes.content.toString(),
+						.getBlocks()
+						.map(
+							( block: {
+								attributes: {
+									content: { toString: () => string };
+								};
+							} ) => block.attributes.content.toString()
+						),
 				};
 			},
 			{ consent: CORE_DATA_PRIVATE_APIS_CONSENT, postId: post.id }
 		);
 
 		expect( result.persistedDoc ).toBe( result.doc );
-		expect( result.liveContent ).toBe( 'Original persisted content.' );
+		expect( result.snapshotContent ).toEqual( [
+			'Targeted snapshot content.',
+			'Preserved sibling content.',
+		] );
+		expect( result.liveContent ).toEqual( [
+			'Original persisted content.',
+			'Preserved sibling content.',
+		] );
 		await page.reload();
 		await collaborationUtils.waitForEntityReady( page );
 
 		const blocks = await editor.getBlocks();
-		expect( blocks ).toHaveLength( 1 );
+		expect( blocks ).toHaveLength( 2 );
 		expect( blocks[ 0 ].attributes.content ).toBe(
 			'Original persisted content.'
+		);
+		expect( blocks[ 1 ].attributes.content ).toBe(
+			'Preserved sibling content.'
 		);
 	} );
 } );

--- a/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
+++ b/test/e2e/specs/editor/collaboration/http-only/collaboration-targeted-crdt-snapshot.spec.ts
@@ -312,7 +312,11 @@ test.describe( 'Collaboration - targeted CRDT persistence snapshot', () => {
 				markFirstSaveStarted();
 				await firstSaveReleased;
 			}
-			await route.continue();
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: '{}',
+			} );
 		} );
 
 		await page.evaluate( ( consent ) => {


### PR DESCRIPTION
## What?

Add a generic core-data action for persisting targeted block-attribute repairs without saving unrelated editor changes.

## Review invariant

The action identifies the exact saved block occurrence, validates the loaded tree, updates only requested attributes, and persists matching content/CRDT state. Divergent or ambiguous targets fail closed rather than writing to a fallback path.

This is layer 5 of the replacement stack for #79020 and depends on layers 1-4. It is part of the fix for #72717.

## Testing

- Targeted core-data unit suite passed locally.
- Native Playwright regression: `repairs the selected occurrence among duplicate contentless blocks`.
- Playwright execution is pending CI because the local runtime does not have Docker.

## Stack

- 1/6: targeted CRDT persistence snapshots
- 2/6: conflict-safe CRDT snapshot saves
- 3/6: atomic synchronized entity saves
- 4/6: queued revision-aware CRDT persistence
- 5/6: this PR
- 6/6: Block Notes attachment integration

This draft targets `trunk` because fork branches cannot be used as upstream base refs. Review should begin after layer 4 lands, when GitHub reduces this PR to its own layer.

Ordered drafts: [1/6 #81715](https://github.com/WordPress/gutenberg/pull/81715), [2/6 #81714](https://github.com/WordPress/gutenberg/pull/81714), [3/6 #81716](https://github.com/WordPress/gutenberg/pull/81716), [4/6 #81717](https://github.com/WordPress/gutenberg/pull/81717), [5/6 #81719](https://github.com/WordPress/gutenberg/pull/81719), [6/6 #81718](https://github.com/WordPress/gutenberg/pull/81718).

## AI assistance

GPT-5.6 Sol via OpenCode assisted with implementation, regression coverage, and verification. Chris reviewed and is responsible for the submitted changes.
