### PR TITLE
Dashboard Widgets: resolve widget types without a metadata module

### DIFF
--- a/docs/explanations/architecture/assets/dashboard-widgets-pipeline.svg
+++ b/docs/explanations/architecture/assets/dashboard-widgets-pipeline.svg
@@ -10,7 +10,7 @@
   <!-- Station 1: authoring -->
   <rect x="216" y="30" width="480" height="66" rx="9" fill="#e2ecfd" stroke="#2f54a5" stroke-width="1.5"/>
   <text x="240" y="57" font-family="ui-monospace, SFMono-Regular, monospace" font-size="13" font-weight="700" fill="#1e3a8a">widgets/&lt;name&gt;/</text>
-  <text x="240" y="78" font-family="-apple-system, system-ui, sans-serif" font-size="11.5" fill="#2f54a5" opacity="0.85">authoring · one folder per widget · widget.json + widget.ts + render.tsx</text>
+  <text x="240" y="78" font-family="-apple-system, system-ui, sans-serif" font-size="11.5" fill="#2f54a5" opacity="0.85">authoring · one folder per widget · widget.json + render.tsx + optional widget.ts</text>
 
   <line x1="456" y1="96" x2="456" y2="134" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
   <text x="472" y="120" font-family="ui-monospace, monospace" font-size="11" fill="#94a3b8">build time</text>

--- a/docs/explanations/architecture/dashboard-widgets.md
+++ b/docs/explanations/architecture/dashboard-widgets.md
@@ -23,7 +23,7 @@ A widget is a directory under `widgets/`, discovered by convention; there is no 
 ```
 widgets/hello-world/
 ├── widget.json        static metadata (name, title, description, help, icon, actions, keywords, category, presentation, textdomain)
-├── widget.ts          metadata module: default-exports attributes, example
+├── widget.ts          optional metadata module: default-exports attributes, example
 ├── render.tsx         render module: default-exports the React component
 ├── style.module.css   optional, injected at runtime by the build
 └── report.csv         optional static asset; action `href`s resolve it only where `widgets/` ships
@@ -37,7 +37,7 @@ Unlike the other translatable strings, `help` is an object: `content` plus optio
 
 `icon`: a registered icon name (`collection/icon-name`), resolved client-side through the site's Icons API. Malformed names are dropped at registration.
 
-`widget.ts` is the live half of the metadata: values that only exist in JavaScript, such as the `attributes` field schema (including optional `relevance` hints) that hosts feed into `DataForm`.
+`widget.ts` is the live half of the metadata: values that only exist in JavaScript, such as the `attributes` field schema (including optional `relevance` hints) that hosts feed into `DataForm`. It is optional: a widget declared entirely by its manifest ships none, and resolves from its record alone.
 
 Its render component receives the widget's `attributes` and, optionally, `setAttributes`:
 
@@ -73,7 +73,7 @@ The registry exists as a class, rather than having REST read the manifest direct
 
 Everything after the REST record is the job of [`@wordpress/widget-primitives`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/widget-primitives), the contract both widget authors and hosts share. Its full surface (the contract types, the discovery hook, and the render component) is covered in the _Widget Primitives / Introduction_ story. In the pipeline it does two things.
 
-`useWidgetTypes( records )` takes the host-supplied records, imports each record's `widget_module` for the live metadata, and merges it with the record into `WidgetType[]`. The record's `presentation`, `category`, `title`, `description`, `help`, `actions`, and `keywords`, all sourced from `widget.json` (with `title`, `description`, `help`, `actions`, and `keywords` localized server-side), win over the module's value. The record's `icon` is a registered icon name: the hook resolves it through the application-registered resolver (`registerIconResolver`), and the resolved element wins over a module's element. The hook reaches for no store or endpoint; a host such as the dashboard reads its own `widgetModule` core-data entity (backed by `/wp/v2/widget-modules`) and passes the records in.
+`useWidgetTypes( records )` takes the host-supplied records, imports each record's `widget_module` for the live metadata, and merges it with the record into `WidgetType[]`. A record without a metadata module resolves from its own fields, as long as it carries a `render_module`. The record's `presentation`, `category`, `title`, `description`, `help`, `actions`, and `keywords`, all sourced from `widget.json` (with `title`, `description`, `help`, `actions`, and `keywords` localized server-side), win over the module's value. The record's `icon` is a registered icon name: the hook resolves it through the application-registered resolver (`registerIconResolver`), and the resolved element wins over a module's element. The hook reaches for no store or endpoint; a host such as the dashboard reads its own `widgetModule` core-data entity (backed by `/wp/v2/widget-modules`) and passes the records in.
 
 A module's `attributes` may also reference field types by name (`type: 'location'`). The application registers those definitions up front through `registerFieldType()` (the dashboard route registers its own on boot), and `useWidgetTypes` resolves every named reference through that registry while building each `WidgetType`: the registered definition supplies the field's behavior on top of its DataViews `baseType`, and hosts receive plain DataViews fields. The widget declaration stays serializable; resolution happens once, at this boundary.
 

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 -   `useWidgetTypes` resolves a record without a metadata module from its
     own fields, so a widget declared entirely by its manifest needs no
-    module stub ([#81738](https://github.com/WordPress/gutenberg/pull/81738)).
+    module stub; `apiVersion` defaults to `1` on both resolution paths
+    ([#81738](https://github.com/WordPress/gutenberg/pull/81738)).
 -   `useWidgetTypes` holds the icon slot with the stand-in while an action's
     icon reference resolves; an unresolvable reference clears it
     ([#81556](https://github.com/WordPress/gutenberg/pull/81556)).

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 -   `useWidgetTypes` resolves a record without a metadata module from its
     own fields, so a widget declared entirely by its manifest needs no
-    module stub.
+    module stub ([#81738](https://github.com/WordPress/gutenberg/pull/81738)).
 -   `useWidgetTypes` holds the icon slot with the stand-in while an action's
     icon reference resolves; an unresolvable reference clears it
     ([#81556](https://github.com/WordPress/gutenberg/pull/81556)).

--- a/packages/widget-primitives/CHANGELOG.md
+++ b/packages/widget-primitives/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Enhancements
 
+-   `useWidgetTypes` resolves a record without a metadata module from its
+    own fields, so a widget declared entirely by its manifest needs no
+    module stub.
 -   `useWidgetTypes` holds the icon slot with the stand-in while an action's
     icon reference resolves; an unresolvable reference clears it
     ([#81556](https://github.com/WordPress/gutenberg/pull/81556)).

--- a/packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
+++ b/packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
@@ -75,6 +75,29 @@ const iconReferenceRecords: WidgetModuleRecord[] = [
 	{ ...records[ 0 ], icon: 'core/calendar' },
 ];
 
+const emptyRecords: WidgetModuleRecord[] = [
+	{ name: 'test/empty', widget_module: null },
+];
+
+const moduleLessRecords: WidgetModuleRecord[] = [
+	{
+		name: 'test/manifest-only',
+		widget_module: null,
+		render_module: 'test-widget/render-module',
+		title: 'Manifest only',
+		description: 'Declared entirely by widget.json.',
+		icon: 'core/calendar',
+		actions: [
+			{
+				id: 'details',
+				label: 'Details',
+				href: 'admin.php?page=test&p=/details',
+				relevance: 'high',
+			},
+		],
+	},
+];
+
 const stringIconRecords: WidgetModuleRecord[] = [
 	{
 		name: 'test/string-icon',
@@ -132,6 +155,39 @@ describe( 'useWidgetTypes', () => {
 		} );
 		// …while plain DataViews fields pass through unchanged.
 		expect( label ).toMatchObject( { id: 'label', type: 'text' } );
+	} );
+
+	it( 'resolves a record without a metadata module from its fields', async () => {
+		const resolvedIcon = createElement( 'svg', {
+			viewBox: '0 0 20 20',
+		} ) as WidgetIcon;
+		registerIconResolver( async () => resolvedIcon );
+
+		const { result } = renderHook( () =>
+			useWidgetTypes( moduleLessRecords )
+		);
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+
+		expect( result.current[ 0 ][ 0 ] ).toMatchObject( {
+			name: 'test/manifest-only',
+			apiVersion: 1,
+			renderModule: 'test-widget/render-module',
+			title: 'Manifest only',
+			description: 'Declared entirely by widget.json.',
+		} );
+		expect( result.current[ 0 ][ 0 ].actions ).toHaveLength( 1 );
+
+		await waitFor( () =>
+			expect( result.current[ 0 ][ 0 ].icon ).toBe( resolvedIcon )
+		);
+	} );
+
+	it( 'drops a record with neither metadata nor render module', async () => {
+		const { result } = renderHook( () => useWidgetTypes( emptyRecords ) );
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+		expect( result.current[ 0 ] ).toHaveLength( 0 );
 	} );
 
 	it( 'prefers the resolved record icon over the module element', async () => {

--- a/packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
+++ b/packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
@@ -157,6 +157,15 @@ describe( 'useWidgetTypes', () => {
 		expect( label ).toMatchObject( { id: 'label', type: 'text' } );
 	} );
 
+	it( 'defaults apiVersion when the module omits it', async () => {
+		const { result } = renderHook( () =>
+			useWidgetTypes( stringIconRecords )
+		);
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+		expect( result.current[ 0 ][ 0 ].apiVersion ).toBe( 1 );
+	} );
+
 	it( 'resolves a record without a metadata module from its fields', async () => {
 		const resolvedIcon = createElement( 'svg', {
 			viewBox: '0 0 20 20',

--- a/packages/widget-primitives/src/hooks/use-widget-types.ts
+++ b/packages/widget-primitives/src/hooks/use-widget-types.ts
@@ -53,11 +53,19 @@ function withRenderableIcons(
    must not treat a widget instance as missing until it is `false`. */
 type UseWidgetTypesResult = readonly [ WidgetType[], boolean ];
 
+/*
+ * Applied to records without a metadata module, which have no place to
+ * declare one. Modules keep declaring their own.
+ */
+const DEFAULT_API_VERSION = 1;
+
 /**
  * Resolves widget types from host-supplied records.
  *
  * For each record it dynamically imports `widget_module` and merges the
  * module's default export with the runtime fields (`name`, `renderModule`).
+ * A record without a metadata module resolves from its own fields alone,
+ * so a widget declared entirely by its manifest needs no module stub.
  * Attribute schemas pass through `resolveFields`, so attributes referencing
  * registered field types reach hosts as plain DataViews fields. Icon
  * references resolve through the registered icon resolver, off the loading
@@ -92,7 +100,45 @@ export function useWidgetTypes(
 		Promise.all(
 			records.map( async ( record ) => {
 				if ( ! record.widget_module ) {
-					return null;
+					/*
+					 * No metadata module: the widget is declared entirely
+					 * by its manifest, so the record carries the metadata
+					 * and the render module carries the body. Without a
+					 * render module there is nothing to mount, and the
+					 * record drops.
+					 */
+					if ( ! record.render_module ) {
+						return null;
+					}
+
+					return {
+						apiVersion: DEFAULT_API_VERSION,
+						name: record.name as WidgetName,
+						renderModule: record.render_module,
+						title: record.title ?? record.name,
+						...( record.icon ? { icon: pendingIcon } : {} ),
+						...( record.presentation
+							? { presentation: record.presentation }
+							: {} ),
+						...( record.category
+							? { category: record.category }
+							: {} ),
+						...( record.description
+							? { description: record.description }
+							: {} ),
+						...( record.help ? { help: record.help } : {} ),
+						...( record.keywords
+							? { keywords: record.keywords }
+							: {} ),
+						...( record.actions
+							? {
+									actions: withRenderableIcons(
+										record.actions,
+										true
+									),
+							  }
+							: {} ),
+					} as WidgetType;
 				}
 
 				try {

--- a/packages/widget-primitives/src/hooks/use-widget-types.ts
+++ b/packages/widget-primitives/src/hooks/use-widget-types.ts
@@ -54,10 +54,25 @@ function withRenderableIcons(
 type UseWidgetTypesResult = readonly [ WidgetType[], boolean ];
 
 /*
- * Applied to records without a metadata module, which have no place to
- * declare one. Modules keep declaring their own.
+ * Applied when neither the record nor its metadata module declares one.
  */
 const DEFAULT_API_VERSION = 1;
+
+/*
+ * The record fields that overlay a module's metadata, shared by both
+ * resolution paths so they cannot drift.
+ */
+function recordOverlay( record: WidgetModuleRecord ) {
+	return {
+		name: record.name as WidgetName,
+		renderModule: record.render_module ?? '',
+		...( record.presentation ? { presentation: record.presentation } : {} ),
+		...( record.category ? { category: record.category } : {} ),
+		...( record.description ? { description: record.description } : {} ),
+		...( record.help ? { help: record.help } : {} ),
+		...( record.keywords ? { keywords: record.keywords } : {} ),
+	};
+}
 
 /**
  * Resolves widget types from host-supplied records.
@@ -113,23 +128,8 @@ export function useWidgetTypes(
 
 					return {
 						apiVersion: DEFAULT_API_VERSION,
-						name: record.name as WidgetName,
-						renderModule: record.render_module,
 						title: record.title ?? record.name,
 						...( record.icon ? { icon: pendingIcon } : {} ),
-						...( record.presentation
-							? { presentation: record.presentation }
-							: {} ),
-						...( record.category
-							? { category: record.category }
-							: {} ),
-						...( record.description
-							? { description: record.description }
-							: {} ),
-						...( record.help ? { help: record.help } : {} ),
-						...( record.keywords
-							? { keywords: record.keywords }
-							: {} ),
 						...( record.actions
 							? {
 									actions: withRenderableIcons(
@@ -138,6 +138,7 @@ export function useWidgetTypes(
 									),
 							  }
 							: {} ),
+						...recordOverlay( record ),
 					} as WidgetType;
 				}
 
@@ -166,6 +167,7 @@ export function useWidgetTypes(
 					const actions = record.actions ?? metadata.actions;
 
 					return {
+						apiVersion: DEFAULT_API_VERSION,
 						...metadata,
 						...( metadata.attributes
 							? {
@@ -174,8 +176,6 @@ export function useWidgetTypes(
 									),
 							  }
 							: {} ),
-						name: record.name as WidgetName,
-						renderModule: record.render_module ?? '',
 						icon,
 						/*
 						 * `title` is required:
@@ -184,19 +184,6 @@ export function useWidgetTypes(
 						 * - Then the record's name as fallback
 						 */
 						title: record.title ?? metadata.title ?? record.name,
-						...( record.presentation
-							? { presentation: record.presentation }
-							: {} ),
-						...( record.category
-							? { category: record.category }
-							: {} ),
-						...( record.description
-							? { description: record.description }
-							: {} ),
-						...( record.help ? { help: record.help } : {} ),
-						...( record.keywords
-							? { keywords: record.keywords }
-							: {} ),
 						...( actions
 							? {
 									actions: withRenderableIcons(
@@ -205,6 +192,7 @@ export function useWidgetTypes(
 									),
 							  }
 							: {} ),
+						...recordOverlay( record ),
 					} as WidgetType;
 				} catch {
 					return null;

--- a/widgets/hello-dolly/widget.ts
+++ b/widgets/hello-dolly/widget.ts
@@ -1,6 +1,0 @@
-/*
- * Widget type definition
- */
-export default {
-	name: 'core/hello-dolly',
-};

--- a/widgets/news/widget.json
+++ b/widgets/news/widget.json
@@ -4,5 +4,15 @@
 	"description": "Displays the latest news from WordPress.org and Planet WordPress.",
 	"category": "dashboard",
 	"presentation": "content-bleed",
-	"textdomain": "default"
+	"textdomain": "default",
+	"actions": [
+		{
+			"id": "news-visit",
+			"label": "Visit WordPress News",
+			"icon": "core/external",
+			"relevance": "high",
+			"href": "https://wordpress.org/news/",
+			"openInNewTab": true
+		}
+	]
 }

--- a/widgets/news/widget.ts
+++ b/widgets/news/widget.ts
@@ -1,3 +1,0 @@
-export default {
-	name: 'core/news',
-};

--- a/widgets/quick-draft/widget.ts
+++ b/widgets/quick-draft/widget.ts
@@ -1,6 +1,0 @@
-/*
- * Widget type definition
- */
-export default {
-	name: 'core/quick-draft',
-};

--- a/widgets/site-health/widget.ts
+++ b/widgets/site-health/widget.ts
@@ -1,3 +1,0 @@
-export default {
-	name: 'core/site-health',
-};

--- a/widgets/site-preview/widget.ts
+++ b/widgets/site-preview/widget.ts
@@ -1,3 +1,0 @@
-export default {
-	name: 'core/site-preview',
-};

--- a/widgets/welcome/widget.ts
+++ b/widgets/welcome/widget.ts
@@ -1,3 +1,0 @@
-export default {
-	name: 'core/welcome',
-};


### PR DESCRIPTION
## What

`useWidgetTypes` now resolves a record that carries no `widget_module` from the record's own fields, and the name-only `widget.ts` stubs drop from the bundled widgets.

Part of the [Dashboard Overview](https://github.com/WordPress/gutenberg/issues/77616). Tracked in #79231, on the `widget.json` metadata schema thread (#77629).

## Why

Six bundled widgets shipped a `widget.ts` file that exports only the name, which `widget.json` already declares.

The rest of the pipeline was ready for their absence: the build flags `has_widget` per widget, and the PHP registry and boot dependencies are null-safe.

Only the client dropped records without a metadata module.

## How

### The hook

A record without a metadata module resolves from its own fields: `title`, `description`, `icon`, `actions`, `presentation`, `category`, `help`, and `keywords`, with `apiVersion` defaulting to `1`.

Icon references and wire action icons resolve through the same paths as module-backed records.

A record with no render module either has nothing to mount or drops as before.

### The stubs

`site-preview`, `welcome`, `news`, `quick-draft`, `hello-dolly`, and `site-health` lose their `widget.ts`.

`activity`, `events`, and `hello-world` keep theirs: `attributes` (Edit components, translated labels, field-type references) and `example` are code that the manifest cannot carry yet.

## Testing

1. Rebuild so the widget manifest regenerates:

```bash
npm run build
```

2. On Dashboard (Beta), the six widgets still appear in the inserter with their title, icon, and description, and still render.
3. The site-health and hello-dolly actions still materialize in the chrome (footer and More menu).
4. Unit coverage for the new resolution path:

```bash
npx jest --config test/unit/jest.config.js packages/widget-primitives/src/hooks/test/use-widget-types.test.tsx
```
