### PR TITLE
Navigation: Close the mobile overlay when the preview viewport gets wider

### DIFF
--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -4,6 +4,8 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import OverlayMenuIcon from './overlay-menu-icon';
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
@@ -26,6 +28,32 @@ export default function ResponsiveWrapper( {
 		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
 		[]
 	);
+
+	// In state so the viewport match re-runs once the container has mounted.
+	const [ container, setContainer ] = useState();
+
+	// Match against the canvas window, which the device preview resizes.
+	const rawCanvasView = container?.ownerDocument?.defaultView;
+	const canvasView = rawCanvasView === null ? undefined : rawCanvasView;
+
+	// `small` mirrors the `$break-small` breakpoint used by the overlay styles.
+	const isAboveOverlayBreakpoint = useViewportMatch(
+		'small',
+		'>=',
+		canvasView
+	);
+
+	// CSS decides when the overlay applies, but JS opens it. Resizing the canvas
+	// skips the toggle, so close it here. An "always" overlay ignores the
+	// viewport, so leave that one to the user.
+	const shouldCloseOverlay =
+		isOpen && ! isHiddenByDefault && isAboveOverlayBreakpoint;
+
+	useEffect( () => {
+		if ( shouldCloseOverlay ) {
+			onToggle( false );
+		}
+	}, [ shouldCloseOverlay, onToggle ] );
 
 	if ( ! isResponsive ) {
 		return children;
@@ -115,6 +143,7 @@ export default function ResponsiveWrapper( {
 			) }
 
 			<div
+				ref={ setContainer }
 				className={ responsiveContainerClasses }
 				style={ styles }
 				id={ modalId }

--- a/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
@@ -1,7 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 import ResponsiveWrapper from '../responsive-wrapper';
+
+// jsdom has no layout, so the viewport match is stubbed.
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
 
 // Mock block-editor to avoid private API issues
 jest.mock( '@wordpress/block-editor', () => ( {
@@ -163,6 +170,90 @@ describe( 'ResponsiveWrapper', () => {
 				postId: 'custom-theme//my-overlay',
 				postType: 'wp_template_part',
 			} );
+		} );
+	} );
+
+	describe( 'Closing the overlay on viewport changes', () => {
+		// Stands in for a resize of the editor canvas.
+		function resizeTo( { isAboveBreakpoint }, rerender, props = {} ) {
+			useViewportMatch.mockReturnValue( isAboveBreakpoint );
+			rerender(
+				<ResponsiveWrapper { ...defaultProps } isOpen { ...props } />
+			);
+		}
+
+		it( 'should close an open overlay when the viewport widens past the breakpoint', () => {
+			useViewportMatch.mockReturnValue( false );
+
+			const { rerender } = render(
+				<ResponsiveWrapper { ...defaultProps } isOpen />
+			);
+
+			expect( mockOnToggle ).not.toHaveBeenCalled();
+
+			resizeTo( { isAboveBreakpoint: true }, rerender );
+
+			expect( mockOnToggle ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'should close an open overlay that is already rendered above the breakpoint', () => {
+			useViewportMatch.mockReturnValue( true );
+
+			render( <ResponsiveWrapper { ...defaultProps } isOpen /> );
+
+			expect( mockOnToggle ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'should keep an open overlay below the breakpoint', () => {
+			useViewportMatch.mockReturnValue( false );
+
+			render( <ResponsiveWrapper { ...defaultProps } isOpen /> );
+
+			expect( mockOnToggle ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not close an overlay that is set to show at every viewport size', () => {
+			useViewportMatch.mockReturnValue( false );
+
+			const { rerender } = render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					isOpen
+					isHiddenByDefault
+				/>
+			);
+
+			resizeTo( { isAboveBreakpoint: true }, rerender, {
+				isHiddenByDefault: true,
+			} );
+
+			expect( mockOnToggle ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not toggle a closed overlay when the viewport changes', () => {
+			useViewportMatch.mockReturnValue( false );
+
+			const { rerender } = render(
+				<ResponsiveWrapper { ...defaultProps } />
+			);
+
+			useViewportMatch.mockReturnValue( true );
+			rerender( <ResponsiveWrapper { ...defaultProps } /> );
+
+			expect( mockOnToggle ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should match the breakpoint against the window the navigation renders in', () => {
+			useViewportMatch.mockReturnValue( false );
+
+			render( <ResponsiveWrapper { ...defaultProps } isOpen /> );
+
+			// The canvas window is passed through, not the admin window.
+			expect( useViewportMatch ).toHaveBeenLastCalledWith(
+				'small',
+				'>=',
+				window
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Closes #81733

Closes the Navigation block's mobile overlay in the editor when you change the preview to a wider viewport.

## Why?

Open the mobile overlay in the editor, then switch the preview to Tablet or Desktop, and the overlay stays on the canvas. You have to close it by hand. That does not match what the page would really look like at that width.

## How?

The overlay is opened by JavaScript, but CSS decides the viewport it applies at. Changing the preview resizes the canvas without going through the toggle, so nothing tells the overlay to close.

`ResponsiveWrapper` now checks the same breakpoint the styles use and closes the overlay when the canvas is wide enough for the menu to show inline:

- `useViewportMatch( 'small', '>=', canvasView )`. The `small` breakpoint is the JS copy of `$break-small`, which is what the `break-small` mixin uses in the overlay styles.
- The breakpoint is matched against the canvas window, not the admin window, so it follows the preview size. This is the same approach as `useBlockVisibility` in the block editor.
- Overlays set to "always" are skipped, because they are not tied to the viewport. Only the user closes those.

Because the canvas window is used, this also covers simply making the browser window narrower or wider.

Worth noting for reviewers: #57520 tried moving the overlay breakpoints to JS and was reverted in #59149, because deciding *visibility* in JS caused a flash on slow connections (#58724). This change is not that. CSS still decides when the overlay applies, nothing on the front end changes, and the only new behaviour is closing an overlay that is already open in the editor.

## Testing Instructions

1. Edit a template or template part that has a Navigation block, for example the Header in Twenty Twenty-Five.
2. Set the Navigation block's Overlay Menu option to "Mobile" (the default).
3. Switch the preview to Mobile.
4. Open the overlay with the hamburger button.
5. Switch the preview to Tablet, then Desktop.
6. The overlay should close on its own, and the menu should show inline.
7. Go back to Mobile and check the overlay still opens as before.

Also check the "always" option is not affected:

1. Set Overlay Menu to "Always".
2. Open the overlay and switch the preview between Mobile, Tablet and Desktop.
3. The overlay should stay open, since it is meant to show at every size.

### Testing Instructions for Keyboard

1. Follow the steps above, but use `Tab` to reach the hamburger button and `Enter` or `Space` to open the overlay.
2. Change the preview from the View menu in the header using the keyboard.
3. Focus should stay in the canvas and the overlay should close, leaving the menu shown inline.

## Screenshots or screencast

Preview switched from Mobile to Desktop with the overlay open:

https://github.com/user-attachments/assets/3b4e7e67-1244-40da-bc25-df410e037cc2

## Use of AI Tools

Used Claude Code to help investigate the issue, write the fix and the unit tests, and check the behaviour in the editor. I have reviewed all of the changes.