### PR TITLE
Make Back button grid column flexible (#81701)

### DIFF
--- a/packages/edit-post/src/components/back-button/index.js
+++ b/packages/edit-post/src/components/back-button/index.js
@@ -3,6 +3,8 @@
  */
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __unstableMotion as motion } from '@wordpress/components';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,6 +21,10 @@ const slideX = {
 };
 
 function BackButton( { initialPost } ) {
+	const showIconLabels = useSelect( ( select ) => {
+		return select( preferencesStore ).get( 'core', 'showIconLabels' );
+	}, [] );
+
 	return (
 		<BackButtonFill>
 			{ ( { length } ) =>
@@ -28,7 +34,7 @@ function BackButton( { initialPost } ) {
 						transition={ { type: 'tween', delay: 0.8 } }
 					>
 						<FullscreenModeClose
-							showTooltip
+							showTooltip={ ! showIconLabels }
 							initialPost={ initialPost }
 						/>
 					</motion.div>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -19,6 +19,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -95,6 +96,11 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	const { postType, postId, context } = entity;
 	const isBlockBasedTheme = useSelect(
 		( select ) => select( coreDataStore ).getCurrentTheme()?.is_block_theme,
+		[]
+	);
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showIconLabels' ),
 		[]
 	);
 	const postWithTemplate = !! context?.postId;
@@ -209,7 +215,7 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 									<Button
 										size="compact"
 										label={ __( 'Open Navigation' ) }
-										showTooltip
+										showTooltip={ ! showIconLabels }
 										tooltipPosition="middle right"
 										onClick={ () => {
 											resetZoomLevel();

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   Document tools: Fix icon button focus styles to use the design system `outset-ring__focus` mixin ([#81115](https://github.com/WordPress/gutenberg/pull/81115)).
 -   `mediaUpload`: Add an `isTransportOnly` parameter, set by the `@wordpress/upload-media` queue, which owns progress tracking and save locking for its own items and uses this function only as its server transport. Fixes the progress snackbar showing "1 of 2" for a single HEIC upload in Safari ([#80369](https://github.com/WordPress/gutenberg/issues/80369)).
 -   Improve error reporting in private action `saveDirtyEntities` ([#81151](https://github.com/WordPress/gutenberg/pull/81151)).
+-   Header: Allow the Back button column to grow when "Show button text labels" is enabled so the label is not obscured by the following controls ([#81701](https://github.com/WordPress/gutenberg/pull/81701)).
 
 ## 14.51.0 (2026-07-14)
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -10,11 +10,11 @@
 	background: $white;
 	display: grid;
 	grid-auto-flow: row;
-	grid-template: auto / $button-size-compact minmax(0, max-content) minmax(min-content, 1fr) $header-height;
+	grid-template: auto / auto minmax(0, max-content) minmax(min-content, 1fr) $header-height;
 	&:has(> .editor-header__center) {
-		grid-template: auto / $button-size-compact min-content 1fr min-content $header-height;
+		grid-template: auto / auto min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / $button-size-compact minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
+			grid-template: auto / auto minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {
@@ -32,7 +32,11 @@
 }
 
 .editor-header__back-button {
-	padding-left: $grid-unit;
+	margin: 0 (-$grid-unit) 0 $grid-unit;
+
+	.show-icon-labels & {
+		margin-right: 0;
+	}
 }
 
 .editor-header__toolbar {


### PR DESCRIPTION
## What?

Backport of #81701 to the `wp/7.1` branch.

## Why?

The cherry-pick of #81701 did not apply cleanly:

-   `packages/editor/CHANGELOG.md`: the contents of the `## Unreleased` section differ between `trunk` and `wp/7.1`.
-   The dependency group comments (`/** WordPress dependencies */`, `/** Internal dependencies */`) were removed on `trunk`, but still exist on `wp/7.1`.

## How?

Resolved the conflicts manually. There are no logic or CSS changes compared to #81701.

## Testing Instructions

See #81701.

## Use of AI Tools

Claude Code was used to resolve the cherry-pick conflicts and to draft this description. The result was reviewed manually.
