### PR TITLE
ui/Card: Use the default neutral border

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))
 
+### Bug Fixes
+
+-   `Card`: Use the normal neutral surface stroke for the default border.
+
 ## 0.20.0 (2026-08-12)
 
 ### Breaking Changes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `Card`: Use the normal neutral surface stroke for the default border.
+-   `Card`: Use the normal neutral surface stroke for the default border. ([#81746](https://github.com/WordPress/gutenberg/pull/81746))
 
 ## 0.20.0 (2026-08-12)
 

--- a/packages/ui/src/card/style.module.css
+++ b/packages/ui/src/card/style.module.css
@@ -9,7 +9,7 @@
 
 			display: flex;
 			flex-direction: column;
-			border: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+			border: 1px solid var(--wpds-color-stroke-surface-neutral);
 			border-radius: var(--wpds-border-radius-lg);
 			overflow: clip;
 			background-color: var(--wpds-color-background-surface-neutral-strong);


### PR DESCRIPTION
## What

Use the default neutral surface stroke for the `Card` border.

## Why

`Card` uses the strong neutral surface background, and the design-token documentation defines the default neutral stroke for normal surface boundaries. The weak stroke is intended for weak-emphasis boundaries. This also aligns Card with sibling surface components such as Popover, Dialog, and Drawer.

## Testing Instructions

Review the `Design System/Components/Card` Storybook story and confirm the border uses the normal neutral stroke.

## Screenshots

| Before | After |
|---|---|
| <img width="1292" height="446" alt="Screenshot 2026-08-17 at 13 30 51" src="https://github.com/user-attachments/assets/cd25b49f-2af4-4f12-a35a-42c08135fb7f" />  | <img width="1296" height="442" alt="Screenshot 2026-08-17 at 13 29 56" src="https://github.com/user-attachments/assets/4461f5a8-c2d7-4ab1-8b55-10fd7e5f8e12" /> |
