### PR TITLE
Lazy Editor: Keep the theme's editor styles on the canvas

### DIFF
--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Bug Fixes
 
+-   Add the styles a host passes to the theme's and the user's instead of replacing them, so an editor canvas keeps the CSS a theme registers with `add_editor_style` ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
 -   Render the editor preferences modal, so the Preferences menu item and command open it ([#81630](https://github.com/WordPress/gutenberg/pull/81630)).
+
+### Performance
+
+-   Memoize the generated global stylesheet, which walks every registered block, instead of rebuilding it on each render ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
 
 ## 1.19.0 (2026-08-12)
 

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Bug Fixes
 
--   Add the styles a host passes to the theme's and the user's instead of replacing them, so an editor canvas keeps the CSS a theme registers with `add_editor_style` ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Add the styles a host passes to the theme's and the user's instead of replacing them, so an editor canvas keeps the CSS a theme registers with `add_editor_style` ([#81747](https://github.com/WordPress/gutenberg/pull/81747)).
 -   Render the editor preferences modal, so the Preferences menu item and command open it ([#81630](https://github.com/WordPress/gutenberg/pull/81630)).
 
 ### Performance
 
--   Memoize the generated global stylesheet, which walks every registered block, instead of rebuilding it on each render ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Memoize the generated global stylesheet, which walks every registered block, instead of rebuilding it on each render ([#81747](https://github.com/WordPress/gutenberg/pull/81747)).
 
 ## 1.19.0 (2026-08-12)
 

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -88,6 +88,16 @@ export function Editor( {
 		() => ( {
 			...editorSettings,
 			...settings,
+			/*
+			 * The theme's styles and the user's global styles, then whatever the
+			 * host adds for the surface it is rendering into. Spelled out after
+			 * the spread because `styles` is a list each source adds to: a host
+			 * contributing its own must not drop everyone else's.
+			 */
+			styles: [
+				...( editorSettings.styles ?? [] ),
+				...( settings?.styles ?? [] ),
+			],
 		} ),
 		[ editorSettings, settings ]
 	);

--- a/packages/lazy-editor/src/hooks/use-editor-settings.tsx
+++ b/packages/lazy-editor/src/hooks/use-editor-settings.tsx
@@ -1,5 +1,6 @@
 import { generateGlobalStyles } from '@wordpress/global-styles-engine';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { store as blocksStore } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { useUserGlobalStyles } from './use-global-styles';
@@ -13,17 +14,28 @@ import { unlock } from '../lock-unlock';
  * @return Editor settings.
  */
 export function useEditorSettings( { stylesId }: { stylesId: string } ) {
-	const { editorSettings } = useSelect(
+	const { editorSettings, blockTypes } = useSelect(
 		( select ) => ( {
 			editorSettings: unlock(
 				select( coreDataStore )
 			).getEditorSettings(),
+			blockTypes: select( blocksStore ).getBlockTypes(),
 		} ),
 		[]
 	);
 
 	const { user: globalStyles } = useUserGlobalStyles( stylesId );
-	const [ globalStylesCSS ] = generateGlobalStyles( globalStyles );
+	/*
+	 * Building the stylesheet walks every registered block, so it is memoized
+	 * rather than repeated on each render. The blocks are read from the store
+	 * and passed in rather than left to the fallback inside, so that the ones
+	 * registering after this first runs invalidate the result: nothing else
+	 * here changes when they arrive.
+	 */
+	const [ globalStylesCSS ] = useMemo(
+		() => generateGlobalStyles( globalStyles, blockTypes ),
+		[ globalStyles, blockTypes ]
+	);
 
 	const hasEditorSettings = !! editorSettings;
 	const styles = useMemo( () => {


### PR DESCRIPTION
## What?

Two changes to how `@wordpress/lazy-editor` assembles canvas styles:

1. **Bug fix.** The styles a host passes are added to the theme's and the user's rather than replacing them, so an editor canvas keeps the CSS a theme registers with `add_editor_style`.
2. **Performance.** The generated global stylesheet is memoized instead of rebuilt on every render.

## Why?

### The styles were being replaced

`useEditorSettings` builds the list correctly — REST settings (global styles + `get_block_editor_theme_styles()`, merged server-side at `lib/block-editor-settings.php`) plus the user's generated global styles. `Editor` then merged the host's settings over it:

```js
{ ...editorSettings, ...settings }
```

`styles` is an ordinary key, so a host passing its own **replaced** the whole list. Boot's canvas passes `styles: []` when editing and a single `min-height` rule when previewing, so the canvas rendered with that and nothing else.

Most of it was invisible, which is why this went unnoticed:

- **Global styles** are re-added by `GlobalStylesRenderer` once the editor mounts — it filters `isGlobalStyles` out of the settings and appends its own.
- **`__experimentalFeatures`** (content width, layout) is set by that same component, so blocks stayed correctly constrained.
- **Theme stylesheets present on the page** are copied into the iframe by `getCompatibilityStyles()`.

What nothing restores is `add_editor_style` CSS: it arrives in the REST settings payload and was never a page stylesheet, so the compatibility layer has nothing to copy. A block theme puts almost everything in `theme.json` and shows no symptom at all. A classic theme loses its entire editor stylesheet — Twenty Twenty-One drops 80KB, including the canvas background.

### The global stylesheet was rebuilt every render

`generateGlobalStyles()` walks every registered block, and was called unmemoized. Its result fed a `useMemo` that consequently never held, so the settings object changed identity on every render — and the editor provider pushes settings into the store whenever that happens.

## How?

`Editor` spells `styles` out after the spread, concatenating both sources with the host's last so it still wins where they overlap. Boot needs no change.

The stylesheet call is wrapped in `useMemo`. Worth noting for review: memoizing on the config alone would have been wrong. `generateGlobalStyles` falls back to `getBlockTypes()` internally, and this hook runs *before* the editor mounts, so the first call can land before blocks register — freezing a stylesheet with no per-block CSS. That is harmless on the editor path, where `GlobalStylesRenderer` supersedes it, but `routes/styles` calls this hook with no editor mounted, so the stale result would be final for the style book. Block types are therefore read from the store and passed in explicitly, which makes them a real dependency.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**.
2. Activate a classic theme: `wp theme activate twentytwentyone`.
3. Open a page in the canvas at `admin.php?page=site-editor-v2`.
4. Confirm the canvas has Twenty Twenty-One's pale green background and serif headings. On `trunk` it is unstyled white.
5. Check the count is no longer zero:
   ```js
   wp.data.select( 'core/block-editor' ).getSettings().styles.filter( s => ! s.isGlobalStyles ).length
   ```
6. Switch back to a block theme (`wp theme activate twentytwentyfive`) and confirm nothing regressed — global styles must not be duplicated or dropped.
7. Select a page in the list so it renders as a preview, and confirm a short page still fills the canvas (boot's `min-height` rule survives the merge).
8. Open **Styles** on both a classic and a block theme and confirm the style book still renders with theme colors and typography — this exercises the memoization path where no editor mounts.

## Screenshots or screencast

<!-- To be added. -->

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/lazy-editor --force` exits 0; `routes/styles` type-checks clean under a throwaway tsconfig, since `routes/*` sits outside the project graph and CI does not check it. The bug itself was reproduced in the browser against Twenty Twenty-One before the fix. Not verified by me post-fix: steps 4–8 above.
