### PR TITLE
Boot: Preview the site where the canvas has nothing to open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51594,6 +51594,7 @@
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",
+				"@wordpress/dom": "file:../dom",
 				"@wordpress/editor": "file:../editor",
 				"@wordpress/element": "file:../element",
 				"@wordpress/html-entities": "file:../html-entities",
@@ -55574,11 +55575,7 @@
 			"name": "@wordpress/home-route",
 			"version": "1.0.0",
 			"dependencies": {
-				"@wordpress/core-data": "file:../../packages/core-data",
-				"@wordpress/data": "file:../../packages/data",
-				"@wordpress/dom": "file:../../packages/dom",
-				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/url": "file:../../packages/url"
+				"@wordpress/i18n": "file:../../packages/i18n"
 			}
 		},
 		"routes/identity": {

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Canvas: Show the site's front end where a route names no entity and the theme has no block templates to resolve one from, instead of an editor with nothing open. Was previously handled by the home route alone, leaving `/identity` broken on a classic theme ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
 -   Canvas: Do not offer to edit a trashed entity from its preview ([#81632](https://github.com/WordPress/gutenberg/pull/81632)).
 -   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#81620](https://github.com/WordPress/gutenberg/pull/81620)).
 

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Canvas: Show the site's front end where a route names no entity and the theme has no block templates to resolve one from, instead of an editor with nothing open. Was previously handled by the home route alone, leaving `/identity` broken on a classic theme ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Canvas: Show the site's front end where a route names no entity and the theme has no block templates to resolve one from, instead of an editor with nothing open. Was previously handled by the home route alone, leaving `/identity` broken on a classic theme ([#81749](https://github.com/WordPress/gutenberg/pull/81749)).
 -   Canvas: Do not offer to edit a trashed entity from its preview ([#81632](https://github.com/WordPress/gutenberg/pull/81632)).
 -   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#81620](https://github.com/WordPress/gutenberg/pull/81620)).
 

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -48,6 +48,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/dom": "file:../dom",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/html-entities": "file:../html-entities",

--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -7,6 +7,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as bootStore } from '../../store';
 import type { CanvasData } from '../../store/types';
 import BootBackButton from './back-button';
+import SitePreview from './site-preview';
 import useNavigateToEntityRecord, {
 	useActionPerformed,
 } from './use-navigate-to-entity-record';
@@ -41,6 +42,22 @@ export default function Canvas( { canvas }: CanvasProps ) {
 	 * The record is the one the editor loads for this canvas, so reading it
 	 * here costs no request of its own.
 	 */
+	/*
+	 * A route that names no entity leaves the editor to resolve one, which it
+	 * does from the block templates only a block theme has. `undefined` while
+	 * the theme is still being read.
+	 */
+	const hasEntity = !! ( canvas.postType && canvas.postId );
+	const isBlockTheme = useSelect(
+		( select ) =>
+			(
+				select( coreStore ).getCurrentTheme() as
+					| { is_block_theme?: boolean }
+					| undefined
+			 )?.is_block_theme,
+		[]
+	);
+
 	const { editLink, isTrashed } = useSelect(
 		( select ) => {
 			if ( ! canvas.postType || ! canvas.postId ) {
@@ -97,8 +114,14 @@ export default function Canvas( { canvas }: CanvasProps ) {
 			} );
 	}, [] );
 
-	// Show spinner while loading the editor module
-	if ( ! Editor ) {
+	// Nothing for the editor to open, so show the site the route configures.
+	if ( ! hasEntity && isBlockTheme === false ) {
+		return <SitePreview />;
+	}
+
+	// Show spinner while loading the editor module, and until it is known which
+	// of the two this canvas is, so the wrong one is never shown first.
+	if ( ! Editor || ( ! hasEntity && isBlockTheme === undefined ) ) {
 		return (
 			<div
 				style={ {

--- a/packages/boot/src/components/canvas/site-preview.tsx
+++ b/packages/boot/src/components/canvas/site-preview.tsx
@@ -7,10 +7,12 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Renders the site's front end in an iframe.
  *
- * Used for themes that have no block templates for the canvas to edit, so that
- * the home route still shows what the site looks like.
+ * Shown where the canvas has no entity to edit, so that a route still says
+ * something about the site it is configuring.
+ *
+ * @return The preview, or nothing until the site's address is known.
  */
-function SitePreview() {
+export default function SitePreview() {
 	const siteUrl = useSelect( ( select ) => {
 		const siteData = select( coreStore ).getEntityRecord(
 			'root',
@@ -60,5 +62,3 @@ function SitePreview() {
 		/>
 	);
 }
-
-export const canvas = SitePreview;

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -12,6 +12,7 @@
 		{ "path": "../compose" },
 		{ "path": "../core-data" },
 		{ "path": "../data" },
+		{ "path": "../dom" },
 		{ "path": "../editor" },
 		{ "path": "../element" },
 		{ "path": "../html-entities" },

--- a/routes/home/package.json
+++ b/routes/home/package.json
@@ -7,10 +7,6 @@
 		"page": "site-editor-v2"
 	},
 	"dependencies": {
-		"@wordpress/core-data": "file:../../packages/core-data",
-		"@wordpress/data": "file:../../packages/data",
-		"@wordpress/dom": "file:../../packages/dom",
-		"@wordpress/i18n": "file:../../packages/i18n",
-		"@wordpress/url": "file:../../packages/url"
+		"@wordpress/i18n": "file:../../packages/i18n"
 	}
 }

--- a/routes/home/route.ts
+++ b/routes/home/route.ts
@@ -1,19 +1,8 @@
-import { resolveSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 export const route = {
 	title: () => __( 'Home' ),
 	async canvas() {
-		const currentTheme = await resolveSelect( coreStore ).getCurrentTheme();
-
-		// Classic themes have no block templates for the editor canvas to
-		// resolve, so fall back to the custom canvas, which previews the site's
-		// front end in an iframe.
-		if ( ! currentTheme?.is_block_theme ) {
-			return null;
-		}
-
 		return {
 			isPreview: true,
 		};


### PR DESCRIPTION
## What?

Moves the classic-theme site preview from the home route into the canvas, so every route gets it. Fixes `/identity`, which was broken on classic themes.

## Why?

A route can name the entity its canvas edits, or leave it out. When it leaves it out, the editor resolves one itself via `getHomePage()` — and that resolves through block templates, which a classic theme does not have. The editor then mounted with no `postType` or `postId` and the canvas broke.

The home route worked around this by opting out of the default canvas entirely: its `canvas()` resolved the theme, returned `null` for classic themes, and the route shipped its own iframe component. `/identity` names no entity either, but had no such workaround, so it broke.

The workaround was in the wrong place. Nothing about it is specific to home — it is a property of a canvas with nothing to open, and the next route to omit an entity would have hit the same wall.

## How?

The canvas decides, on the condition that actually applies:

| Canvas | Renders |
| --- | --- |
| Names an entity | Editor — classic themes included |
| No entity, block theme | Editor, resolving via `getHomePage()` |
| No entity, classic theme | The site's front end in an iframe |

`SitePreview` moves from `routes/home/canvas.tsx` into `packages/boot`. The home route drops its theme check and its custom canvas and becomes the same few lines as identity. `routes/identity` is not touched and is fixed by the move.

Editing a page from the list is unaffected — that names an entity, so it opens the editor on a classic theme exactly as it does now.

Keying on `is_block_theme` rather than on whether an entity is resolvable also keeps the guard simple. `getHomePage()` returns `null` both while resolving and — via a separate empty-object sentinel — when resolution finished with nothing found, so a resolvability check has to tell those apart or it flashes the wrong surface. `is_block_theme` has a single unknown state, so the canvas holds its spinner until the theme is read and shows the wrong surface at no point.

### Dependencies

`@wordpress/boot` gains `@wordpress/dom` for `focus.focusable`. `@wordpress/home-route` sheds the four it no longer uses.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**.
2. Activate a classic theme: `wp theme activate twentytwentyone`.
3. Open `admin.php?page=site-editor-v2` and go to **Identity**. Confirm the canvas shows the site's front end. On `trunk` it is broken.
4. Go to **Home** and confirm it still shows the site preview, as before.
5. Open a page from **Pages** and confirm it opens in the real editor, not the iframe — naming an entity still wins.
6. Switch back to a block theme (`wp theme activate twentytwentyfive`) and confirm Home and Identity both open the editor, with no flash of an iframe while the page loads.
7. Set a static front page on the classic theme (**Settings → Reading**) and confirm Home still shows the preview rather than opening that page. This is deliberate: only an explicitly named entity opens the editor.

### Testing Instructions for Keyboard

On a classic theme, tab through the Identity route and confirm the preview iframe traps nothing — its contents are made unfocusable on load.

## Use of AI Tools

Authored with Claude Code (Claude Opus 5), including this description; reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0; `routes/home` type-checks clean under a throwaway tsconfig, since `routes/*` sits outside the project graph and CI does not check it. Not verified: no browser pass — the steps above are unrun.

Noticed while working here and deliberately left out: `routes/identity/stage.tsx` line 85 passes `undefined` as the record key to `editEntityRecord` for the site singleton, which is a type error. It is intentional at runtime and the read side eight lines above already carries the cast for it. Pre-existing and unrelated, so it belongs in its own change.
