### PR TITLE
Boot: Mount the registered plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51625,6 +51625,7 @@
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/lazy-editor": "file:../lazy-editor",
 				"@wordpress/notices": "file:../notices",
+				"@wordpress/plugins": "file:../plugins",
 				"@wordpress/primitives": "file:../primitives",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/route": "file:../route",

--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Mount the plugins registered with `registerPlugin`, so the sidebars, panels and menu items they fill render ([#81754](https://github.com/WordPress/gutenberg/pull/81754)).
 -   Canvas: Show the site's front end where a route names no entity and the theme has no block templates to resolve one from, instead of an editor with nothing open. Was previously handled by the home route alone, leaving `/identity` broken on a classic theme ([#81749](https://github.com/WordPress/gutenberg/pull/81749)).
 -   Canvas: Do not offer to edit a trashed entity from its preview ([#81632](https://github.com/WordPress/gutenberg/pull/81632)).
 -   Translate the click-to-edit label on a previewed canvas, and name the action rather than the gesture ([#81620](https://github.com/WordPress/gutenberg/pull/81620)).

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -58,6 +58,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/lazy-editor": "file:../lazy-editor",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/route": "file:../route",

--- a/packages/boot/src/components/plugin-area/index.tsx
+++ b/packages/boot/src/components/plugin-area/index.tsx
@@ -1,0 +1,34 @@
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { PluginArea as WPPluginArea } from '@wordpress/plugins';
+
+/**
+ * Mounts every plugin registered with `registerPlugin`, so the fills they
+ * render reach their slots.
+ *
+ * Sits at the root rather than with the editor: a plugin's fills mostly target
+ * editor slots, but the component holding them is also where it registers
+ * commands and extends a list, which the routes without a canvas need too.
+ *
+ * @return The mount point. Renders whatever the plugins do, and nothing itself.
+ */
+export default function PluginArea() {
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	return (
+		<WPPluginArea
+			onError={ ( name ) => {
+				createErrorNotice(
+					sprintf(
+						/* translators: %s: plugin name */
+						__(
+							'The "%s" plugin has encountered an error and cannot be rendered.'
+						),
+						name
+					)
+				);
+			} }
+		/>
+	);
+}

--- a/packages/boot/src/components/root/index.tsx
+++ b/packages/boot/src/components/root/index.tsx
@@ -19,6 +19,7 @@ import Sidebar from '../sidebar';
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
 import ErrorBoundary from '../error-boundary';
+import PluginArea from '../plugin-area';
 import useRouteTitle from '../app/use-route-title';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
@@ -57,6 +58,7 @@ export default function Root() {
 	return (
 		<SlotFillProvider>
 			<Tooltip.Provider>
+				<PluginArea />
 				<ThemeProvider
 					isRoot
 					color={ { ...themeColors, background: '#f8f8f8' } }

--- a/packages/boot/src/components/root/single-page.tsx
+++ b/packages/boot/src/components/root/single-page.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@wordpress/theme';
 import { UnsavedChangesWarning } from '@wordpress/editor';
 import SavePanel from '../save-panel';
 import CanvasRenderer from '../canvas-renderer';
+import PluginArea from '../plugin-area';
 import { unlock } from '../../lock-unlock';
 import type { CanvasData } from '../../store/types';
 import useSyncBodyBackground from './use-sync-body-background';
@@ -39,6 +40,7 @@ export default function RootSinglePage() {
 
 	return (
 		<SlotFillProvider>
+			<PluginArea />
 			<ThemeProvider
 				isRoot
 				color={ { ...themeColors, background: '#f8f8f8' } }

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -22,6 +22,7 @@
 		{ "path": "../keycodes/tsconfig.build.json" },
 		{ "path": "../lazy-editor" },
 		{ "path": "../notices/tsconfig.build.json" },
+		{ "path": "../plugins" },
 		{ "path": "../primitives" },
 		{ "path": "../private-apis" },
 		{ "path": "../route" },


### PR DESCRIPTION
## What?

Mounts a `PluginArea` in the extensible site editor's shell, so plugins registered with `registerPlugin` render.

Extracted from #79222 by @scruffian — this is that PR's plugin-mount change on its own, unchanged in substance.

## Why?

`PluginArea` is what instantiates every registered plugin so the fills it renders reach their slots. Only the three v1 hosts render one — `edit-post`, `edit-site` and `edit-widgets`, all unscoped. Nothing in the v2 shell did, so **every `registerPlugin` component was inert**: `PluginSidebar`, `PluginDocumentSettingPanel`, `PluginPostStatusInfo`, `PluginMoreMenuItem` and the rest never mounted, anywhere.

## How?

A boot-local wrapper supplies the error notice, matching `edit-site`'s behavior, and both roots mount it inside the `SlotFillProvider` the fills need.

### Why the root rather than the editor

All eight `Plugin*` slot components now live in `@wordpress/editor`, so there's a reasonable argument that the editor should mount its own plugin area — the same reasoning that put the preferences modal in `lazy-editor` in #81630.

It doesn't hold here. Mounting from the editor would mean plugins exist only while an editor is mounted, and the component a plugin registers is also where it registers commands and extends a list — so on every route without a canvas (pages, patterns, templates) that code would never run. `edit-site` mounts at the layout level for the same reason. Editor-owned would be a partial fix that looks complete.

### What this does not cover

A plugin that gates its `admin_enqueue_scripts` on the site editor still has no assets loaded here, because the v2 asset request presents as the post editor. #79222 addresses that too, by adding a `context=site-editor` parameter to the block editor REST endpoints. That part is deliberately left there: it changes a shared experimental endpoint and overrides `$pagenow` and `$hook_suffix` to make plugins believe they are on `site-editor.php`, which deserves review on its own merits rather than riding along with a UI mount.

So this fixes plugins that enqueue unconditionally via `enqueue_block_editor_assets`. Plugins that gate on the site editor need that follow-up as well.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**.
2. Activate a plugin that registers editor UI and enqueues unconditionally. A minimal one:
   ```js
   wp.plugins.registerPlugin( 'test-plugin', {
       render: () => wp.element.createElement(
           wp.editor.PluginDocumentSettingPanel,
           { name: 'test', title: 'Test Panel' },
           'It renders.'
       ),
   } );
   ```
3. Open a page in the editor canvas and confirm the panel appears in the document sidebar. On `trunk` it never renders.
4. Navigate to **Pages** — a route with no canvas — and confirm the plugin's component is still mounted, for example by having it register a command and finding that command in the palette.
5. Make the plugin's `render` throw and confirm an error notice names it, and the rest of the screen keeps working.

### Testing Instructions for Keyboard

Tab to any control the plugin renders and confirm it can be focused and operated.

## Use of AI Tools

The plugin-mount change is @scruffian's from #79222, extracted with Claude Code (Claude Opus 5), which also wrote this description. Reviewed by the PR author.

Verified: lint clean; `tsc --build packages/boot --force` exits 0; `npm run lint:tsconfig` exits 0 (the new dependency needs a matching project reference). Not verified: no browser pass — the steps above are unrun, so I have not seen a plugin render.

One thing worth a reviewer's eye: `PluginArea` sits at the root, outside the per-surface error boundaries added in #81622. It has its own `onError`, so a plugin that throws is caught and noticed rather than taking the screen down, but the interaction between the two is untested.
