### PR TITLE
Build Package: Use Core's boot module when a plugin has none

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Register the content module for routes that only export a `canvas`, so a route without a stage or inspector can render a custom canvas ([#81578](https://github.com/WordPress/gutenberg/pull/81578)).
+-   Pages: use the boot module that ships with Core when the plugin has no local one, so plugin pages are no longer empty ([#81761](https://github.com/WordPress/gutenberg/pull/81761)).
 
 ### Documentation
 

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -302,6 +302,12 @@ This generates two page modes:
 
 Each mode provides route/menu registration functions and a render callback. Routes are automatically registered for both modes.
 
+**Boot module:**
+
+Pages boot through the `@wordpress/boot` script module, which ships with WordPress Core 7.0+ and the Gutenberg plugin. Plugins do not need their own `packages/boot`.
+
+The generated page files use a plugin-local `build/modules/boot/index.min.asset.php` if it exists, and Core's copy in `wp-includes/js/dist/script-modules/boot/` otherwise. If neither is available, the page enqueues nothing and shows only the "This screen requires JavaScript" notice.
+
 **Registering a menu item for WP-Admin mode:**
 
 WP-Admin mode integrates within the standard WordPress admin interface (keeping the sidebar and header). Menu items should be registered with a simple slug and callback:

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -146,8 +146,12 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
 	// Get all registered routes
 	$routes = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_routes();
 
-	// Get boot module asset file for dependencies
+	// Get boot module asset file for dependencies. Plugins that build their own
+	// boot module use it; everyone else falls back to the copy bundled with Core.
 	$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
+	if ( ! file_exists( $asset_file ) ) {
+		$asset_file = ABSPATH . WPINC . '/js/dist/script-modules/boot/index.min.asset.php';
+	}
 	if ( file_exists( $asset_file ) ) {
 		$asset = require $asset_file;
 

--- a/packages/wp-build/templates/page.php.template
+++ b/packages/wp-build/templates/page.php.template
@@ -152,8 +152,12 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_render_page() {
 	$menu_items = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_menu_items();
 	$routes = {{PREFIX}}_get_{{PAGE_SLUG_UNDERSCORE}}_routes();
 
-	// Get boot module asset file for dependencies
+	// Get boot module asset file for dependencies. Plugins that build their own
+	// boot module use it; everyone else falls back to the copy bundled with Core.
 	$asset_file = __DIR__ . '/../../modules/boot/index.min.asset.php';
+	if ( ! file_exists( $asset_file ) ) {
+		$asset_file = ABSPATH . WPINC . '/js/dist/script-modules/boot/index.min.asset.php';
+	}
 	if ( file_exists( $asset_file ) ) {
 		$asset = require $asset_file;
 


### PR DESCRIPTION
## What?
Related #75987.
Closes #77516.
Closes #77883.

The generated admin page templates now use the boot script module that ships with WordPress Core when the plugin does not build its own.

A plugin that set `wpPlugin.pages` without shipping `packages/boot` got a page that enqueued nothing. Opening it showed only the "This screen requires JavaScript" notice, with no PHP error.

## Why?
`@wordpress/build` stopped bundling `@wordpress/boot` in 0.20.0, but the templates were never updated. They looked for the boot asset file only at `build/modules/boot/index.min.asset.php`, which exists only for builds that compile their own boot package, such as Gutenberg. Every script, module, and style enqueue sits inside `if ( file_exists( $asset_file ) )` with no else branch, so the miss was silent.

Only plugins without a local boot package were affected. Gutenberg and Core builds still resolve the local path, which is checked first.

## How?
The lookup keeps the plugin-local path first, then falls back to `ABSPATH . WPINC . '/js/dist/script-modules/boot/index.min.asset.php'`. Core already [edited that same path](https://github.com/WordPress/WordPress/blob/0e1f567118d6521c7f91a2c8db04f840ba7eb90d/wp-includes/build/pages/options-connectors/page-wp-admin.php#L149-L150) into its generated copies in `wp-includes/build/pages/*/page*.php` for 7.0.x, so the template now emits what Core ships.

## Testing Instructions
Honestly, I'm not 100% sure what the best option is for folks to test this. 

## Use of AI Tools

Assisted by Claude.
