### PR TITLE
Block Editor: Add translator context to pseudo-state labels

### DIFF
--- a/packages/block-editor/src/hooks/states.js
+++ b/packages/block-editor/src/hooks/states.js
@@ -1,6 +1,6 @@
 import { useMemo } from '@wordpress/element';
 import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-styles-engine';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import StateControl from '../components/global-styles/state-control';
 import StateControlBadges from '../components/global-styles/state-control-badges';
 import { useToolsPanelDropdownMenuProps } from '../components/global-styles/utils';
@@ -10,10 +10,13 @@ import { unlock } from '../lock-unlock';
 const { getViewportBreakpoints } = unlock( globalStylesEnginePrivateApis );
 
 export const PSEUDO_STATE_LABELS = {
-	':hover': __( 'Hover' ),
-	':focus': __( 'Focus' ),
-	':focus-visible': __( 'Focus-visible' ),
-	':active': __( 'Active' ),
+	':hover': _x( 'Hover', 'Name for the CSS pseudo-class selector' ),
+	':focus': _x( 'Focus', 'Name for the CSS pseudo-class selector' ),
+	':focus-visible': _x(
+		'Focus-visible',
+		'Name for the CSS pseudo-class selector'
+	),
+	':active': _x( 'Active', 'Name for the CSS pseudo-class selector' ),
 };
 
 export const RESPONSIVE_STATE_LABELS = {


### PR DESCRIPTION
Follow-up to #76491

## What?

Adds a translator context to the pseudo-state labels.

## Why?

These labels stand for CSS pseudo-classes, so a plain translation can end up obscuring their meaning in some locales. Without a context, they also share the translation of identical strings used elsewhere — `Active`, for example, already exists in other places — so the pseudo-state labels cannot be translated independently.

## Screenshot

The screenshot below shows that despite wanting to apply English CSS names in the Japanese locale, the existing Japanese translation is applied to 'Active' and 'Hover'.
<img width="388" height="311" alt="image" src="https://github.com/user-attachments/assets/1576b94a-b99a-4781-bfaa-78ebd73ddb7d" />

## Testing Instructions


No logic changes.

## Use of AI Tools

Claude Code was used to apply the `_x()` change and to draft this description. All changes were reviewed by the author.
