### PR TITLE
Fix the drop target when editing a post that is not the first in a Post Template

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -31,6 +31,7 @@
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 -   `BlockVariationPicker`: Set icon colors with `color` so stroke-based variation icons retain their intended unfilled appearance, while keeping a non-important `fill` fallback for third-party icons that do not use `currentColor`. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `BlockIcon`, List View: Remove the obsolete `fill: CanvasText` override for forced colors mode. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
+-   Read a block's position from the block refs registry when working out a drop target, rather than looking the element up by its `block-` id. Live block previews render the same blocks, and so the same ids, which made a drop inside a Post Template resolve against a preview of another post whenever the post being edited was not the first one in the loop ([#73239](https://github.com/WordPress/gutenberg/issues/73239)).
 
 ### Internal
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useContext, useState } from '@wordpress/element';
 import {
 	useThrottle,
 	__experimentalUseDropZone as useDropZone,
@@ -18,6 +18,7 @@ import {
 } from '../../utils/math';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { BlockRefs } from '../provider/block-refs-provider';
 
 const THRESHOLD_DISTANCE = 30;
 const MINIMUM_HEIGHT_FOR_THRESHOLD = 120;
@@ -311,6 +312,7 @@ export default function useBlockDropZone( {
 	isDisabled = false,
 } = {} ) {
 	const registry = useRegistry();
+	const { refsMap } = useContext( BlockRefs );
 	const [ dropTarget, setDropTarget ] = useState( {
 		index: null,
 		operation: 'insert',
@@ -351,7 +353,7 @@ export default function useBlockDropZone( {
 	);
 	const throttled = useThrottle(
 		useCallback(
-			( event, ownerDocument ) => {
+			( event ) => {
 				if ( ! isDragging() ) {
 					// When dragging from the desktop, no drag start event is fired.
 					// So, ensure that the drag state is set when the user drags over a drop zone.
@@ -435,9 +437,19 @@ export default function useBlockDropZone( {
 						isUnmodifiedDefaultBlock:
 							getIsUnmodifiedDefaultBlock( block ),
 						getBoundingClientRect: () => {
-							const blockElement = ownerDocument.getElementById(
-								`block-${ clientId }`
-							);
+							/*
+							 * The element is read from the block refs registry
+							 * rather than looked up by its `block-` id. Live
+							 * block previews render the same blocks, and so the
+							 * same ids, which makes an id lookup resolve to
+							 * whichever copy comes first in the document — for
+							 * example a Post Template preview above the post
+							 * being edited. Each preview has its own block
+							 * editor provider, so the registry only ever holds
+							 * the elements of the block list this drop zone
+							 * belongs to.
+							 */
+							const blockElement = refsMap.get( clientId );
 							return blockElement
 								? blockElement.getBoundingClientRect()
 								: null;
@@ -551,6 +563,7 @@ export default function useBlockDropZone( {
 				isZoomOut,
 				getBlocks,
 				getBlockListSettings,
+				refsMap,
 				dropZoneElement,
 				parentBlockClientId,
 				getBlockIndex,
@@ -571,10 +584,7 @@ export default function useBlockDropZone( {
 		isDisabled,
 		onDrop: onBlockDrop,
 		onDragOver( event ) {
-			// `currentTarget` is only available while the event is being
-			// handled, so get it now and pass it to the throttled function.
-			// https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget
-			throttled( event, event.currentTarget.ownerDocument );
+			throttled( event );
 		},
 		onDragLeave( event ) {
 			const { ownerDocument } = event.currentTarget;

--- a/test/e2e/specs/editor/blocks/post-template.spec.js
+++ b/test/e2e/specs/editor/blocks/post-template.spec.js
@@ -1,0 +1,159 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.use( {
+	// Make the viewport large enough so that a scrollbar isn't displayed.
+	// Otherwise, the page scrolling can interfere with the test runner's
+	// ability to drop a block in the right location.
+	viewport: {
+		width: 960,
+		height: 1024,
+	},
+} );
+
+async function dragTo( page, x, y ) {
+	// Call the move function twice to make sure the `dragOver` event is sent.
+	// @see https://github.com/microsoft/playwright/issues/17153
+	for ( let i = 0; i < 2; i += 1 ) {
+		await page.mouse.move( x, y );
+	}
+}
+
+test.describe( 'Post Template', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllPosts(),
+			requestUtils.deleteAllPages(),
+		] );
+		await requestUtils.createPost( {
+			title: 'First post',
+			content: 'Excerpt of the first post.',
+			status: 'publish',
+		} );
+		await requestUtils.createPost( {
+			title: 'Second post',
+			content: 'Excerpt of the second post.',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPages();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	// Every post in the loop other than the active one is rendered as a live
+	// block preview of the same blocks, so the canvas holds several elements
+	// per client ID. Dropping used to be resolved against whichever of those
+	// came first in the document, which is a preview whenever the post being
+	// edited is not the first one in the loop.
+	test( 'drops a block where it is dropped when the active post is not the first one', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost( { postType: 'page' } );
+
+		await editor.insertBlock( {
+			name: 'core/query',
+			attributes: {
+				query: {
+					perPage: 2,
+					offset: 0,
+					postType: 'post',
+					// Oldest first, so the loop lists the posts in the order
+					// they are created above.
+					order: 'asc',
+					orderBy: 'date',
+					inherit: false,
+				},
+			},
+			innerBlocks: [
+				{
+					name: 'core/post-template',
+					innerBlocks: [
+						{ name: 'core/post-title' },
+						{ name: 'core/post-excerpt' },
+						{ name: 'core/post-date' },
+					],
+				},
+			],
+		} );
+
+		const posts = editor.canvas.locator( 'li.wp-block-post' );
+		await expect( posts ).toHaveCount( 3 );
+
+		// Make the second post in the loop the editable one. The first post is
+		// left behind as a preview above it.
+		await posts.last().click();
+
+		const activePost = editor.canvas.locator(
+			'li.wp-block-post:not(.block-editor-block-preview__live-content)'
+		);
+		await expect( activePost ).toHaveText( /Second post/ );
+
+		const title = activePost.getByRole( 'document', {
+			name: 'Block: Title',
+		} );
+		const excerpt = activePost.getByRole( 'document', {
+			name: 'Block: Excerpt',
+		} );
+		const date = activePost.getByRole( 'document', {
+			name: 'Block: Date',
+		} );
+
+		await date.click();
+		await editor.showBlockToolbar();
+		await page
+			.locator(
+				'role=toolbar[name="Block tools"i] >> role=button[name="Drag"i][include-hidden]'
+			)
+			.hover();
+		await page.mouse.down();
+
+		// Hover over the top half of the excerpt, so the date is dropped
+		// between the title and the excerpt.
+		const excerptBox = await excerpt.boundingBox();
+		await dragTo(
+			page,
+			excerptBox.x + excerptBox.width / 2,
+			excerptBox.y + 1
+		);
+
+		const indicator = page.locator(
+			'data-testid=block-list-insertion-point-indicator'
+		);
+		await expect( indicator ).toBeVisible();
+
+		// The indicator sits between the title and the excerpt of the post
+		// being edited, rather than being pushed past the last block because
+		// the drop was resolved against the preview above.
+		const titleBox = await title.boundingBox();
+		await expect
+			.poll( () => indicator.boundingBox().then( ( { y } ) => y ) )
+			.toBeGreaterThan( titleBox.y );
+		await expect
+			.poll( () => indicator.boundingBox().then( ( { y } ) => y ) )
+			.toBeLessThan( excerptBox.y + excerptBox.height / 2 );
+
+		await page.mouse.up();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/query',
+				innerBlocks: [
+					{
+						name: 'core/post-template',
+						innerBlocks: [
+							{ name: 'core/post-title' },
+							{ name: 'core/post-date' },
+							{ name: 'core/post-excerpt' },
+						],
+					},
+				],
+			},
+		] );
+	} );
+} );


### PR DESCRIPTION
## What?

Closes #73239

Resolves a block's position from the block refs registry when working out a drop target, instead of looking the element up by its `block-` id.

## Why?

`Post Template` renders every post in the loop, but only the active one is an editable block list — the rest are live block previews of the same blocks, so they emit the same wrapper ids. `useBlockDropZone` read each sibling's geometry with `ownerDocument.getElementById( 'block-' + clientId )`, which returns the first match in document order.

When the post being edited is the first one in the loop, that first match happens to be the editable block and everything works. As soon as it is not — click any later post to edit it — the first match is a preview rendered above it, and the drop calculation runs against rectangles that belong to a different post.

Measured in the canvas with the second post active, comparing the element the lookup returns against the element actually being dragged over:

| Block | Rect used by the drop zone | Rect of the block on screen |
| --- | --- | --- |
| Featured Image | 150 – 350 | 539 – 877 |
| Title | 377 – 413 | 904 – 940 |
| Excerpt | 439 – 520 | 966 – 1078 |

Every rectangle sits 390–560px above the pointer, so the nearest edge is always the bottom of the last one. That is why dropping at the end of the post works while dropping between two blocks does not.

## How?

Each live preview mounts its own `ExperimentalBlockEditorProvider`, and `BlockRefsProvider` sits inside it, so a preview's blocks register in a separate refs map. Reading from the registry therefore only ever yields elements from the block list the drop zone belongs to, with no ambiguity to resolve.

It also puts the drop maths on the same source as the rest of block tools: `BlockPopover` (which positions the insertion-point indicator), `useBlockToolbarPopoverProps` and `BlockDraggable` already read positions from this registry. Before this change the indicator was drawn from one source and the drop index computed from another, which is how they could disagree.

The `ownerDocument` argument that was threaded into the throttled `dragover` handler is no longer used and has been dropped.

## Testing Instructions

1. Publish at least two posts.
2. Create a page, add a Query Loop, and pick a layout that shows Featured Image, Title and Excerpt.
3. Click a post in the loop that is **not** the first one, to make it the one being edited.
4. Select its Featured Image block and drag it by the toolbar handle to between Title and Excerpt.
5. The drop indicator appears between Title and Excerpt, and releasing drops the block there.

On trunk, steps 4 and 5 always drop the block at the end of the post instead.

Repeat with the first post in the loop active to confirm that case still behaves as before.

### Testing Instructions for Keyboard

Block movement by keyboard does not go through the drop zone. To confirm there is no regression, select a block inside a non-first post in the loop, <kbd>Tab</kbd> to the block toolbar and use the "Move up" and "Move down" buttons; the order changes as before.

## Screenshots or screencast

Not included — the change is not visual. The observable difference is where a dragged block lands, which the automated test below covers.

## Automated tests

`test/e2e/specs/editor/blocks/post-template.spec.js` is new. It builds a Query Loop over two posts, activates the second one, drags the Date block to between Title and Excerpt, and asserts both the position of the insertion indicator and the resulting block order. It fails on trunk (indicator at `y = 678`, expected `< 646`) and passes with this change, 3/3 repeats.

Also run locally against this branch: `draggable-blocks.spec.js`, `inserting-blocks.spec.js` and `query.spec.js` — 28 passed in total, and the drop-zone unit tests (20/20) are unaffected since `getDropTargetPosition` itself does not change.

## Notes

The duplicate ids are the underlying problem here, and the same `getElementById( 'block-…' )` lookup appears in `use-clipboard-handler.js`, `use-select-all.js` and `use-click-selection.js`. I have not tested whether those misbehave in the same situation, so they are deliberately left alone; happy to open a separate issue.

## Use of AI Tools

Authored with Claude Code under direction and review.
