### PR TITLE
Media Editor: Prevent shortcuts modal Escape from opening discard dialog

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Keep the Details sidebar from clipping focus outlines, with balanced horizontal padding ([#81703](https://github.com/WordPress/gutenberg/pull/81703)).
 -   Keep initial focus on the modal dialog frame instead of moving it to the crop area once the image loads ([#81541](https://github.com/WordPress/gutenberg/pull/81541)).
+-   Prevent Escape in nested dialogs from prompting to discard Media Editor changes ([#81775](https://github.com/WordPress/gutenberg/pull/81775)).
 
 ### Internal
 

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -544,6 +544,12 @@ function MediaEditorContent( {
 	};
 
 	const handleKeyDown = ( event: ReactKeyboardEvent< HTMLElement > ) => {
+		// Ignore events from nested components rendered outside this modal's DOM,
+		// such as portaled dialogs.
+		if ( ! event.currentTarget.contains( event.target as Node ) ) {
+			return;
+		}
+
 		const isUndoShortcut = isKeyboardEvent.primary( event, 'z' );
 		const isRedoShortcut =
 			isKeyboardEvent.primaryShift( event, 'z' ) ||


### PR DESCRIPTION
## What, Why, and How?

Closes https://github.com/WordPress/gutenberg/issues/81774

Key events from portaled Media Editor dialogs could also reach the editor behind them. This caused Escape in Keyboard shortcuts to open the discard dialog. The editor's key handler now scopes key events whose targets are within its DOM subtree.

## Testing Instructions

1. Create a new post.
2. Insert an Image block and select an image from the Media Library.
3. Select the image and click `Crop` in the block toolbar.
4. Edit the image to create unsaved changes.
5. Open Keyboard shortcuts from the Media Editor header.
6. Press Escape.
7. Verify that only the Keyboard shortcuts dialog closes and the discard confirmation does not appear.

## Screencast

https://github.com/user-attachments/assets/c033ec45-43b7-4900-b686-f46e2a44bbfc

## Use of AI Tools

AI Usage: Yes
Model: GPT-5.6 Sol with Codex
Role: Used for scoping the issue and internal code review.
