### PR TITLE
Fix: Accordion: Anchored hash inside the accordion throws the malformed URL console error

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 -   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
+-   Accordion: Update the frontend script for the Accordion block to use the `:target` pseudo-selector instead of location.hash, so that we never encounter malformed URL errors ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
 
 ## 10.4.0 (2026-08-12)
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -11,7 +11,7 @@
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 -   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
--   Accordion: Update the frontend script for the Accordion block to use the `:target` pseudo-selector instead of location.hash, so that we never encounter malformed URL errors ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
+-   Accordion: Resolve the URL fragment with the `:target` pseudo-class instead of decoding `window.location.hash`, so a hash containing malformed percent-encoding no longer throws a `URIError` when a panel is opened ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
 
 ## 10.4.0 (2026-08-12)
 

--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -41,16 +41,13 @@ const { actions } = store(
 				}
 			},
 			openPanelByHash: () => {
-				if ( hashHandled || ! window.location?.hash?.length ) {
+				if ( hashHandled ) {
 					return;
 				}
 
 				const context = getContext();
 				const { id, accordionItems, autoclose } = context;
-				const hash = decodeURIComponent(
-					window.location.hash.slice( 1 )
-				);
-				const targetElement = window.document.getElementById( hash );
+				const targetElement = document.querySelector( ':target' );
 
 				if ( ! targetElement ) {
 					return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/81779

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR fixes the console error and also resolves anchor hash in accordion when hash contains some malformed symbols like `%` which makes URL malformed and `decodeURIComponent` results in console error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Instead of using `window.location.hash`, PR uses `:target` pseudoselector to identify the hash via ID and use that for further inputs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open post/page.
2. Add the accordion block with 2 or more accordions.
3. Add the anchor heading block inside second accordion. Add the anchor as `50%off`.
4. Now save and open the URL in frontend.
5. Update the URL in the end with `#50%off`.
6. Notice there is no console error and also the anchor is correctly selected and scrolled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
- None.
