### PR TITLE
DataViews: use `Menu` from `@wordpress/ui`

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Internal
 
 -   Update `@ariakit/react` to 0.4.37 ([#81080](https://github.com/WordPress/gutenberg/pull/81080)).
+-   DataViews: Replace the private `Menu` from `@wordpress/components` with the `Menu` from `@wordpress/ui` in the item actions, list layout, column header, add-filter, and layout switcher menus. ([#81783](https://github.com/WordPress/gutenberg/pull/81783))
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516))
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 -   DataForm: Narrow the combobox control's `onChange` handler parameter back to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. [#81568](https://github.com/WordPress/gutenberg/pull/81568)

--- a/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
@@ -1,14 +1,10 @@
 import type { Ref } from 'react';
-import {
-	privateApis as componentsPrivateApis,
-	Button,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
-import { unlock } from '../../lock-unlock';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Intentional early adoption of the new Menu, pending WordPress/gutenberg#76135.
+import { Menu } from '@wordpress/ui';
 import type { NormalizedFilter, View } from '../../types';
-
-const { Menu } = unlock( componentsPrivateApis );
 
 interface AddFilterProps {
 	filters: NormalizedFilter[];
@@ -24,13 +20,16 @@ export function AddFilterMenu( {
 	setOpenedFilter,
 	triggerProps,
 }: AddFilterProps & {
-	triggerProps: React.ComponentProps< typeof Menu.TriggerButton >;
+	triggerProps: React.ComponentProps< typeof Menu.Trigger >;
 } ) {
 	const inactiveFilters = filters.filter( ( filter ) => ! filter.isVisible );
 	return (
-		<Menu>
-			<Menu.TriggerButton { ...triggerProps } />
-			<Menu.Popover>
+		// The `disabled` prop on `Menu.Root` (rather than on the trigger)
+		// keeps the menu from opening while letting the trigger button stay
+		// focusable via its own `accessibleWhenDisabled`.
+		<Menu.Root disabled={ ! inactiveFilters.length }>
+			<Menu.Trigger { ...triggerProps } />
+			<Menu.Popup>
 				{ inactiveFilters.map( ( filter ) => {
 					return (
 						<Menu.Item
@@ -55,8 +54,8 @@ export function AddFilterMenu( {
 						</Menu.Item>
 					);
 				} ) }
-			</Menu.Popover>
-		</Menu>
+			</Menu.Popup>
+		</Menu.Root>
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -1,20 +1,14 @@
 import type { MouseEventHandler } from 'react';
-import {
-	Button,
-	Modal,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
-import { Stack } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Intentional early adoption of the new Menu, pending WordPress/gutenberg#76135.
+import { Menu, Stack } from '@wordpress/ui';
 import { kebabCase } from '@wordpress/kebab-case';
-import { unlock } from '../../lock-unlock';
 import type { Action, ActionModal as ActionModalType } from '../../types';
-
-const { Menu } = unlock( componentsPrivateApis );
 
 export interface ActionTriggerProps< Item > {
 	action: Action< Item >;
@@ -240,8 +234,11 @@ function CompactItemActions< Item >( {
 	);
 	return (
 		<>
-			<Menu placement="bottom-end">
-				<Menu.TriggerButton
+			{ /* The `disabled` prop on `Menu.Root` (rather than on the trigger)
+			     keeps the menu from opening while letting the trigger button
+			     stay focusable via its own `accessibleWhenDisabled`. */ }
+			<Menu.Root disabled={ ! actions.length }>
+				<Menu.Trigger
 					render={
 						<Button
 							size={ isSmall ? 'small' : 'compact' }
@@ -253,15 +250,15 @@ function CompactItemActions< Item >( {
 						/>
 					}
 				/>
-				<Menu.Popover>
+				<Menu.Popup positioner={ <Menu.Positioner align="end" /> }>
 					<ActionsMenuGroup
 						actions={ actions }
 						item={ item }
 						registry={ registry }
 						setActiveModalAction={ setActiveModalAction }
 					/>
-				</Menu.Popover>
-			</Menu>
+				</Menu.Popup>
+			</Menu.Root>
 			{ !! activeModalAction && (
 				<ActionModal
 					action={ activeModalAction }

--- a/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/list/index.tsx
@@ -1,11 +1,6 @@
 import clsx from 'clsx';
 import { useInstanceId, usePrevious } from '@wordpress/compose';
-import {
-	Button,
-	privateApis as componentsPrivateApis,
-	Spinner,
-	Composite,
-} from '@wordpress/components';
+import { Button, Spinner, Composite } from '@wordpress/components';
 import {
 	useCallback,
 	useEffect,
@@ -17,8 +12,8 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
-import { Stack, VisuallyHidden } from '@wordpress/ui';
-import { unlock } from '../../../lock-unlock';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Intentional early adoption of the new Menu, pending WordPress/gutenberg#76135.
+import { Menu, Stack, VisuallyHidden } from '@wordpress/ui';
 import { ActionsMenuGroup, ActionModal } from '../../dataviews-item-actions';
 import DataViewsContext from '../../dataviews-context';
 import { useDelayedLoading } from '../../../hooks/use-delayed-loading';
@@ -47,8 +42,6 @@ interface ListViewItemProps< Item > {
 	onDropdownTriggerKeyDown: React.KeyboardEventHandler< HTMLButtonElement >;
 	posinset?: number;
 }
-
-const { Menu } = unlock( componentsPrivateApis );
 
 function generateItemWrapperCompositeId( idPrefix: string ) {
 	return `${ idPrefix }-item-wrapper`;
@@ -226,13 +219,18 @@ function ListItem< Item >( {
 			) }
 			{ ! hasOnlyOnePrimaryAction && (
 				<div role="gridcell">
-					<Menu placement="bottom-end">
-						<Menu.TriggerButton
+					{ /* The `disabled` prop on `Menu.Root` (rather than on
+					     the trigger) keeps the menu from opening while
+					     letting the trigger button stay focusable via its
+					     own `accessibleWhenDisabled`. */ }
+					<Menu.Root disabled={ ! actions.length }>
+						<Menu.Trigger
 							render={
 								<Composite.Item
 									id={ generateDropdownTriggerCompositeId(
 										idPrefix
 									) }
+									accessibleWhenDisabled
 									render={
 										<Button
 											size="small"
@@ -240,7 +238,7 @@ function ListItem< Item >( {
 											label={ __( 'Actions' ) }
 											accessibleWhenDisabled
 											disabled={ ! actions.length }
-											onKeyDown={
+											onKeyDownCapture={
 												onDropdownTriggerKeyDown
 											}
 										/>
@@ -248,15 +246,17 @@ function ListItem< Item >( {
 								/>
 							}
 						/>
-						<Menu.Popover>
+						<Menu.Popup
+							positioner={ <Menu.Positioner align="end" /> }
+						>
 							<ActionsMenuGroup
 								actions={ eligibleActions }
 								item={ item }
 								registry={ registry }
 								setActiveModalAction={ setActiveModalAction }
 							/>
-						</Menu.Popover>
-					</Menu>
+						</Menu.Popup>
+					</Menu.Root>
 					{ !! activeModalAction && (
 						<ActionModal
 							action={ activeModalAction }
@@ -503,13 +503,15 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	}, [ isActiveIdInList, selectCompositeItem, previousActiveItemIndex ] );
 
 	// Prevent the default behavior (open dropdown menu) and instead select the
-	// dropdown menu trigger on the previous/next row.
-	// https://github.com/ariakit/ariakit/issues/3768
+	// dropdown menu trigger on the previous/next row. Runs in the capture
+	// phase and stops propagation because the menu's open-on-arrow-key
+	// behavior doesn't check whether the event's default was prevented.
 	const onDropdownTriggerKeyDown = useCallback(
 		( event: React.KeyboardEvent< HTMLButtonElement > ) => {
 			if ( event.key === 'ArrowDown' ) {
 				// Select the dropdown menu trigger item in the next row.
 				event.preventDefault();
+				event.stopPropagation();
 				selectCompositeItem(
 					activeItemIndex + 1,
 					generateDropdownTriggerCompositeId
@@ -518,6 +520,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 			if ( event.key === 'ArrowUp' ) {
 				// Select the dropdown menu trigger item in the previous row.
 				event.preventDefault();
+				event.stopPropagation();
 				selectCompositeItem(
 					activeItemIndex - 1,
 					generateDropdownTriggerCompositeId

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
@@ -1,13 +1,10 @@
 import type { ReactNode, Ref, PropsWithoutRef, RefAttributes } from 'react';
 import { __, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight, unseen, funnel } from '@wordpress/icons';
-import {
-	Button,
-	Icon as WCIcon,
-	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { forwardRef, Children, Fragment, useContext } from '@wordpress/element';
-import { unlock } from '../../../lock-unlock';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Intentional early adoption of the new Menu, pending WordPress/gutenberg#76135.
+import { Icon, Menu } from '@wordpress/ui';
 import { SORTING_DIRECTIONS, sortArrows, sortLabels } from '../../../constants';
 import type {
 	NormalizedField,
@@ -18,8 +15,6 @@ import type {
 } from '../../../types';
 import DataViewsContext from '../../dataviews-context';
 import getHideableFields from '../../../utils/get-hideable-fields';
-
-const { Menu } = unlock( componentsPrivateApis );
 
 interface HeaderMenuProps< Item > {
 	fieldId: string;
@@ -105,8 +100,8 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	const isRtl = isRTL();
 
 	return (
-		<Menu>
-			<Menu.TriggerButton
+		<Menu.Root>
+			<Menu.Trigger
 				render={
 					<Button
 						size="compact"
@@ -122,55 +117,47 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						{ sortArrows[ view.sort.direction ] }
 					</span>
 				) }
-			</Menu.TriggerButton>
-			<Menu.Popover style={ { minWidth: '240px' } }>
+			</Menu.Trigger>
+			<Menu.Popup style={ { minWidth: '240px' } }>
 				<WithMenuSeparators>
 					{ isSortable && (
-						<Menu.Group>
-							{ SORTING_DIRECTIONS.map(
-								( direction: SortDirection ) => {
-									const isChecked =
-										view.sort &&
-										isSorted &&
-										view.sort.direction === direction;
-
-									const value = `${ fieldId }-${ direction }`;
-
-									return (
+						<Menu.RadioGroup
+							value={
+								isSorted && view.sort
+									? view.sort.direction
+									: null
+							}
+							onValueChange={ ( direction: SortDirection ) => {
+								onChangeView( {
+									...view,
+									sort: {
+										field: fieldId,
+										direction,
+									},
+									showLevels: false,
+								} );
+							} }
+						>
+							<Menu.Group>
+								{ SORTING_DIRECTIONS.map(
+									( direction: SortDirection ) => (
 										<Menu.RadioItem
-											key={ value }
-											// All sorting radio items share the same name, so that
-											// selecting a sorting option automatically deselects the
-											// previously selected one, even if it is displayed in
-											// another submenu. The field and direction are passed via
-											// the `value` prop.
-											name="view-table-sorting"
-											value={ value }
-											checked={ isChecked }
-											onChange={ () => {
-												onChangeView( {
-													...view,
-													sort: {
-														field: fieldId,
-														direction,
-													},
-													showLevels: false,
-												} );
-											} }
+											key={ direction }
+											value={ direction }
 										>
 											<Menu.ItemLabel>
 												{ sortLabels[ direction ] }
 											</Menu.ItemLabel>
 										</Menu.RadioItem>
-									);
-								}
-							) }
-						</Menu.Group>
+									)
+								) }
+							</Menu.Group>
+						</Menu.RadioGroup>
 					) }
 					{ canAddFilter && (
 						<Menu.Group>
 							<Menu.Item
-								prefix={ <WCIcon icon={ funnel } /> }
+								prefix={ <Icon icon={ funnel } /> }
 								onClick={ () => {
 									setOpenedFilter( fieldId );
 									setIsShowingFilter( true );
@@ -198,7 +185,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						<Menu.Group>
 							{ canMove && (
 								<Menu.Item
-									prefix={ <WCIcon icon={ arrowLeft } /> }
+									prefix={ <Icon icon={ arrowLeft } /> }
 									disabled={
 										isRtl
 											? index >=
@@ -232,7 +219,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							) }
 							{ canMove && (
 								<Menu.Item
-									prefix={ <WCIcon icon={ arrowRight } /> }
+									prefix={ <Icon icon={ arrowRight } /> }
 									disabled={
 										isRtl
 											? index < 1
@@ -265,13 +252,13 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								</Menu.Item>
 							) }
 							{ canInsertLeft && !! hiddenFields.length && (
-								<Menu>
-									<Menu.SubmenuTriggerItem>
+								<Menu.SubmenuRoot>
+									<Menu.SubmenuTrigger>
 										<Menu.ItemLabel>
 											{ __( 'Insert left' ) }
 										</Menu.ItemLabel>
-									</Menu.SubmenuTriggerItem>
-									<Menu.Popover>
+									</Menu.SubmenuTrigger>
+									<Menu.Popup>
 										{ hiddenFields.map( ( hiddenField ) => {
 											const insertIndex = isRtl
 												? index + 1
@@ -301,17 +288,17 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 												</Menu.Item>
 											);
 										} ) }
-									</Menu.Popover>
-								</Menu>
+									</Menu.Popup>
+								</Menu.SubmenuRoot>
 							) }
 							{ canInsertRight && !! hiddenFields.length && (
-								<Menu>
-									<Menu.SubmenuTriggerItem>
+								<Menu.SubmenuRoot>
+									<Menu.SubmenuTrigger>
 										<Menu.ItemLabel>
 											{ __( 'Insert right' ) }
 										</Menu.ItemLabel>
-									</Menu.SubmenuTriggerItem>
-									<Menu.Popover>
+									</Menu.SubmenuTrigger>
+									<Menu.Popup>
 										{ hiddenFields.map( ( hiddenField ) => {
 											const insertIndex = isRtl
 												? index
@@ -341,12 +328,12 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 												</Menu.Item>
 											);
 										} ) }
-									</Menu.Popover>
-								</Menu>
+									</Menu.Popup>
+								</Menu.SubmenuRoot>
 							) }
 							{ isHidable && field && (
 								<Menu.Item
-									prefix={ <WCIcon icon={ unseen } /> }
+									prefix={ <Icon icon={ unseen } /> }
 									onClick={ () => {
 										onHide( field );
 										onChangeView( {
@@ -365,8 +352,8 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						</Menu.Group>
 					) }
 				</WithMenuSeparators>
-			</Menu.Popover>
-		</Menu>
+			</Menu.Popup>
+		</Menu.Root>
 	);
 } );
 

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
@@ -138,20 +138,18 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								} );
 							} }
 						>
-							<Menu.Group>
-								{ SORTING_DIRECTIONS.map(
-									( direction: SortDirection ) => (
-										<Menu.RadioItem
-											key={ direction }
-											value={ direction }
-										>
-											<Menu.ItemLabel>
-												{ sortLabels[ direction ] }
-											</Menu.ItemLabel>
-										</Menu.RadioItem>
-									)
-								) }
-							</Menu.Group>
+							{ SORTING_DIRECTIONS.map(
+								( direction: SortDirection ) => (
+									<Menu.RadioItem
+										key={ direction }
+										value={ direction }
+									>
+										<Menu.ItemLabel>
+											{ sortLabels[ direction ] }
+										</Menu.ItemLabel>
+									</Menu.RadioItem>
+								)
+							) }
 						</Menu.RadioGroup>
 					) }
 					{ canAddFilter && (

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -1,4 +1,3 @@
-import type { ChangeEvent } from 'react';
 import {
 	Button,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
@@ -8,22 +7,19 @@ import {
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	SelectControl,
 	__experimentalHeading as Heading,
-	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
 import { cog } from '@wordpress/icons';
 import warning from '@wordpress/warning';
 import { useInstanceId } from '@wordpress/compose';
-import { Stack } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Intentional early adoption of the new Menu, pending WordPress/gutenberg#76135.
+import { Menu, Stack } from '@wordpress/ui';
 import { SORTING_DIRECTIONS, sortIcons, sortLabels } from '../../constants';
 import { VIEW_LAYOUTS } from '../dataviews-layouts';
 import type { View } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import { PropertiesSection } from './properties-section';
-import { unlock } from '../../lock-unlock';
-
-const { Menu } = unlock( componentsPrivateApis );
 
 const DATAVIEWS_CONFIG_POPOVER_PROPS = {
 	className: 'dataviews-config__popover',
@@ -40,8 +36,8 @@ export function ViewTypeMenu() {
 	}
 	const activeView = VIEW_LAYOUTS.find( ( v ) => view.type === v.type );
 	return (
-		<Menu>
-			<Menu.TriggerButton
+		<Menu.Root>
+			<Menu.Trigger
 				render={
 					<Button
 						size="compact"
@@ -50,51 +46,53 @@ export function ViewTypeMenu() {
 					/>
 				}
 			/>
-			<Menu.Popover>
-				{ availableLayouts.map( ( layout ) => {
-					const config = VIEW_LAYOUTS.find(
-						( v ) => v.type === layout
-					);
-					if ( ! config ) {
-						return null;
-					}
-					return (
-						<Menu.RadioItem
-							key={ layout }
-							value={ layout }
-							name="view-actions-available-view"
-							checked={ layout === view.type }
-							hideOnClick
-							onChange={ (
-								e: ChangeEvent< HTMLInputElement >
-							) => {
-								switch ( e.target.value ) {
-									case 'list':
-									case 'grid':
-									case 'table':
-									case 'pickerGrid':
-									case 'pickerTable':
-									case 'pickerActivity':
-									case 'activity':
-										const viewWithoutLayout = { ...view };
-										if ( 'layout' in viewWithoutLayout ) {
-											delete viewWithoutLayout.layout;
-										}
-										return onChangeView( {
-											...viewWithoutLayout,
-											type: e.target.value,
-											...defaultLayouts[ e.target.value ],
-										} as View );
+			<Menu.Popup>
+				<Menu.RadioGroup
+					value={ view.type }
+					onValueChange={ ( value: string ) => {
+						switch ( value ) {
+							case 'list':
+							case 'grid':
+							case 'table':
+							case 'pickerGrid':
+							case 'pickerTable':
+							case 'pickerActivity':
+							case 'activity':
+								const viewWithoutLayout = { ...view };
+								if ( 'layout' in viewWithoutLayout ) {
+									delete viewWithoutLayout.layout;
 								}
-								warning( 'Invalid dataview' );
-							} }
-						>
-							<Menu.ItemLabel>{ config.label }</Menu.ItemLabel>
-						</Menu.RadioItem>
-					);
-				} ) }
-			</Menu.Popover>
-		</Menu>
+								return onChangeView( {
+									...viewWithoutLayout,
+									type: value,
+									...defaultLayouts[ value ],
+								} as View );
+						}
+						warning( 'Invalid dataview' );
+					} }
+				>
+					{ availableLayouts.map( ( layout ) => {
+						const config = VIEW_LAYOUTS.find(
+							( v ) => v.type === layout
+						);
+						if ( ! config ) {
+							return null;
+						}
+						return (
+							<Menu.RadioItem
+								key={ layout }
+								value={ layout }
+								closeOnClick
+							>
+								<Menu.ItemLabel>
+									{ config.label }
+								</Menu.ItemLabel>
+							</Menu.RadioItem>
+						);
+					} ) }
+				</Menu.RadioGroup>
+			</Menu.Popup>
+		</Menu.Root>
 	);
 }
 

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.tsx
@@ -664,7 +664,7 @@ describe( 'DataViews Picker', () => {
 
 			// Both "Grid" and "Table" picker layout options must appear in the menu.
 			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Grid' } )
+				await screen.findByRole( 'menuitemradio', { name: 'Grid' } )
 			).toBeInTheDocument();
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Table' } )

--- a/packages/dataviews/src/dataviews/test/dataviews.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.tsx
@@ -1130,7 +1130,7 @@ describe( 'DataViews component', () => {
 
 			// Table, Grid, and List options must all appear.
 			expect(
-				screen.getByRole( 'menuitemradio', { name: 'Table' } )
+				await screen.findByRole( 'menuitemradio', { name: 'Table' } )
 			).toBeInTheDocument();
 			expect(
 				screen.getByRole( 'menuitemradio', { name: 'Grid' } )


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/81230

> [!NOTE]
> Built on top of https://github.com/WordPress/gutenberg/pull/79560 (`Menu`), which should land first.

## What?

Migrates all menus in the `@wordpress/dataviews` package from the private `Menu` component in `@wordpress/components` to the new `Menu` component in `@wordpress/ui`:

-   Item actions dropdown (table, grid, and list layouts).
-   List layout actions dropdown (shares `ActionsMenuGroup` with the above).
-   Table / picker-table column header menu (sorting, add filter, move, insert left/right submenus, hide).
-   Filters "Add filter" menu.
-   View config layout switcher (`ViewTypeMenu`).

No usages of the old component remain in the package. The popover-style dropdowns (the "View options" panel, filter chips, modals) never used `Menu` and are untouched.

## Why?

See https://github.com/WordPress/gutenberg/issues/81230

Dogfoods the new design-system `Menu` (#79560) in a real product surface, and removes five more consumers of the `@wordpress/components` private APIs from a bundled package.

## How?

Mechanical API mapping, preserving the existing interaction behaviour.

## Testing Instructions

1. Open the Site Editor → Pages (or any DataViews screen).
2. Item actions: click the ⋮ "Actions" button on a row/card. Verify actions run, modals open, and focus returns to the trigger when the menu closes.
3. Column header menu (table layout): click a column header. Verify sorting radio options reflect and update the current sort, "Add filter" opens the filter, "Move left/right" work (including disabled states at the edges), "Insert left/right" submenus list hidden fields, and "Hide column" works.
4. Filters: with hidden filters available, click "Add filter" and add one. When all filters are visible, verify the button is disabled but still focusable, and the menu doesn't open.
5. Layout switcher: with multiple layouts configured, use the "Layout" button and switch between Table/Grid/List. The menu should close on selection.
6. Check RTL (e.g. `?wp_lang=ar`... or set the site language) for submenu direction and move left/right behavior.

### Testing Instructions for Keyboard

1. Tab to any of the menu triggers above and open with Enter, Space, or ArrowDown.
2. Verify arrow keys move through items, typeahead works, Esc closes and returns focus to the trigger.
3. In submenus ("Insert left/right"), ArrowRight opens and ArrowLeft closes (inverted in RTL).
4. In the list layout, focus the ⋮ actions button of a row: ArrowDown/ArrowUp must move to the next/previous row's actions button (not open the menu); Enter/Space opens it.
5. With a disabled "Add filter" or "Actions" button, verify it is still reachable with Tab, and no key opens a menu.

## Use of AI Tools

This PR was authored with Claude Code (Claude Fable 5); the migration, commit structure, and this description were AI-generated under human direction, then reviewed by the PR author.
