### PR TITLE
Global Styles: Expose Labels under Form controls

### DIFF
--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Group input and select typography and color controls in a dedicated Forms section in Global Styles.
+-   Add an Elements section to Global Styles for the elements already available in Typography and Colors.
 -   Expose typography and color controls for citations, inputs, and selects in Global Styles ([#80852](https://github.com/WordPress/gutenberg/pull/80852)).
 
 ## 1.20.0 (2026-08-12)

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Group input and select typography and color controls in a dedicated Forms section in Global Styles.
 -   Expose typography and color controls for citations, inputs, and selects in Global Styles ([#80852](https://github.com/WordPress/gutenberg/pull/80852)).
 
 ## 1.20.0 (2026-08-12)

--- a/packages/global-styles-ui/src/element-colors.tsx
+++ b/packages/global-styles-ui/src/element-colors.tsx
@@ -1,0 +1,58 @@
+// @ts-expect-error: Not typed yet.
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import type {
+	GlobalStylesSettings,
+	GlobalStylesStyles,
+} from '@wordpress/global-styles-engine';
+import { useSetting, useStyle } from './hooks';
+import { unlock } from './lock-unlock';
+
+const { useSettingsForBlockElement, ColorPanel: StylesColorPanel } = unlock(
+	blockEditorPrivateApis
+);
+
+interface ElementColorsProps {
+	additionalElements: { name: string; label: string }[];
+	defaultControls: Record< string, boolean >;
+	settingsTransform?: (
+		settings: GlobalStylesSettings
+	) => GlobalStylesSettings;
+	label?: string;
+}
+
+export function ElementColors( {
+	additionalElements,
+	defaultControls,
+	settingsTransform = ( settings ) => settings,
+	label,
+}: ElementColorsProps ) {
+	const [ style, setStyle ] = useStyle< GlobalStylesStyles >(
+		'',
+		undefined,
+		'user',
+		false
+	);
+	const [ inheritedStyle ] = useStyle< GlobalStylesStyles >(
+		'',
+		undefined,
+		'merged',
+		false
+	);
+	const [ rawSettings ] = useSetting< GlobalStylesSettings >( '' );
+	const settings = settingsTransform(
+		useSettingsForBlockElement( rawSettings )
+	);
+
+	return (
+		<StylesColorPanel
+			inheritedValue={ inheritedStyle }
+			value={ style }
+			onChange={ setStyle }
+			settings={ settings }
+			additionalElements={ additionalElements }
+			defaultControls={ defaultControls }
+			label={ label }
+			showInheritanceLabelIndicators={ false }
+		/>
+	);
+}

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -17,6 +17,7 @@ import ScreenBlock from './screen-block';
 import ScreenTypography from './screen-typography';
 import ScreenTypographyElement from './screen-typography-element';
 import ScreenColors from './screen-colors';
+import ScreenForms from './screen-forms';
 import ScreenColorPalette from './screen-color-palette';
 import ScreenBackground from './screen-background';
 import { ScreenShadows, ScreenShadowsEdit } from './screen-shadows';
@@ -204,6 +205,9 @@ export function GlobalStylesUI( {
 					<GlobalStylesNavigationScreen path="/typography">
 						<ScreenTypography />
 					</GlobalStylesNavigationScreen>
+					<GlobalStylesNavigationScreen path="/forms">
+						<ScreenForms />
+					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/typography/font-sizes">
 						<FontSizes />
 					</GlobalStylesNavigationScreen>
@@ -252,10 +256,10 @@ export function GlobalStylesUI( {
 					<GlobalStylesNavigationScreen path="/typography/button">
 						<ScreenTypographyElement element="button" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/textInput">
+					<GlobalStylesNavigationScreen path="/forms/typography/textInput">
 						<ScreenTypographyElement element="textInput" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/select">
+					<GlobalStylesNavigationScreen path="/forms/typography/select">
 						<ScreenTypographyElement element="select" />
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/blocks">

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -17,6 +17,7 @@ import ScreenBlock from './screen-block';
 import ScreenTypography from './screen-typography';
 import ScreenTypographyElement from './screen-typography-element';
 import ScreenColors from './screen-colors';
+import ScreenElements from './screen-elements';
 import ScreenForms from './screen-forms';
 import ScreenColorPalette from './screen-color-palette';
 import ScreenBackground from './screen-background';
@@ -205,7 +206,10 @@ export function GlobalStylesUI( {
 					<GlobalStylesNavigationScreen path="/typography">
 						<ScreenTypography />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/forms">
+					<GlobalStylesNavigationScreen path="/elements">
+						<ScreenElements />
+					</GlobalStylesNavigationScreen>
+					<GlobalStylesNavigationScreen path="/elements/form-controls">
 						<ScreenForms />
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/typography/font-sizes">
@@ -238,29 +242,35 @@ export function GlobalStylesUI( {
 					<GlobalStylesNavigationScreen path="/background">
 						<ScreenBackground />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/text">
+					<GlobalStylesNavigationScreen path="/elements/text">
 						<ScreenTypographyElement element="text" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/link">
+					<GlobalStylesNavigationScreen path="/elements/link">
 						<ScreenTypographyElement element="link" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/heading">
+					<GlobalStylesNavigationScreen path="/elements/heading">
 						<ScreenTypographyElement element="heading" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/caption">
+					<GlobalStylesNavigationScreen path="/elements/caption">
 						<ScreenTypographyElement element="caption" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/cite">
+					<GlobalStylesNavigationScreen path="/elements/cite">
 						<ScreenTypographyElement element="cite" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/typography/button">
+					<GlobalStylesNavigationScreen path="/elements/button">
 						<ScreenTypographyElement element="button" />
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/forms/typography/textInput">
-						<ScreenTypographyElement element="textInput" />
+					<GlobalStylesNavigationScreen path="/elements/form-controls/typography/textInput">
+						<ScreenTypographyElement
+							element="textInput"
+							showColorControls={ false }
+						/>
 					</GlobalStylesNavigationScreen>
-					<GlobalStylesNavigationScreen path="/forms/typography/select">
-						<ScreenTypographyElement element="select" />
+					<GlobalStylesNavigationScreen path="/elements/form-controls/typography/select">
+						<ScreenTypographyElement
+							element="select"
+							showColorControls={ false }
+						/>
 					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/blocks">
 						<ScreenBlockList />

--- a/packages/global-styles-ui/src/global-styles-ui.tsx
+++ b/packages/global-styles-ui/src/global-styles-ui.tsx
@@ -260,6 +260,12 @@ export function GlobalStylesUI( {
 					<GlobalStylesNavigationScreen path="/elements/button">
 						<ScreenTypographyElement element="button" />
 					</GlobalStylesNavigationScreen>
+					<GlobalStylesNavigationScreen path="/elements/form-controls/typography/label">
+						<ScreenTypographyElement
+							element="label"
+							showColorControls={ false }
+						/>
+					</GlobalStylesNavigationScreen>
 					<GlobalStylesNavigationScreen path="/elements/form-controls/typography/textInput">
 						<ScreenTypographyElement
 							element="textInput"

--- a/packages/global-styles-ui/src/root-menu.tsx
+++ b/packages/global-styles-ui/src/root-menu.tsx
@@ -4,6 +4,7 @@ import {
 	typography,
 	color,
 	layout,
+	postCommentsForm,
 	shadow as shadowIcon,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -36,6 +37,7 @@ function RootMenu() {
 	const hasShadowPanel = true; // Same as Gutenberg
 	const hasDimensionsPanel = useHasDimensionsPanel( settings );
 	const hasLayoutPanel = hasDimensionsPanel;
+	const hasFormsPanel = hasTypographyPanel || hasColorPanel;
 
 	return (
 		<>
@@ -51,6 +53,14 @@ function RootMenu() {
 				{ hasColorPanel && (
 					<NavigationButtonAsItem icon={ color } path="/colors">
 						{ __( 'Colors' ) }
+					</NavigationButtonAsItem>
+				) }
+				{ hasFormsPanel && (
+					<NavigationButtonAsItem
+						icon={ postCommentsForm }
+						path="/forms"
+					>
+						{ __( 'Forms' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasBackgroundPanel && (

--- a/packages/global-styles-ui/src/root-menu.tsx
+++ b/packages/global-styles-ui/src/root-menu.tsx
@@ -4,7 +4,6 @@ import {
 	typography,
 	color,
 	layout,
-	postCommentsForm,
 	shadow as shadowIcon,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -37,7 +36,6 @@ function RootMenu() {
 	const hasShadowPanel = true; // Same as Gutenberg
 	const hasDimensionsPanel = useHasDimensionsPanel( settings );
 	const hasLayoutPanel = hasDimensionsPanel;
-	const hasFormsPanel = hasTypographyPanel || hasColorPanel;
 
 	return (
 		<>
@@ -53,14 +51,6 @@ function RootMenu() {
 				{ hasColorPanel && (
 					<NavigationButtonAsItem icon={ color } path="/colors">
 						{ __( 'Colors' ) }
-					</NavigationButtonAsItem>
-				) }
-				{ hasFormsPanel && (
-					<NavigationButtonAsItem
-						icon={ postCommentsForm }
-						path="/forms"
-					>
-						{ __( 'Forms' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasBackgroundPanel && (

--- a/packages/global-styles-ui/src/screen-colors.tsx
+++ b/packages/global-styles-ui/src/screen-colors.tsx
@@ -16,11 +16,7 @@ const { useSettingsForBlockElement, ColorPanel: StylesColorPanel } = unlock(
 	blockEditorPrivateApis
 );
 
-const ADDITIONAL_ELEMENTS = [
-	{ name: 'cite', label: __( 'Citations' ) },
-	{ name: 'textInput', label: __( 'Inputs' ) },
-	{ name: 'select', label: __( 'Selects' ) },
-];
+const ADDITIONAL_ELEMENTS = [ { name: 'cite', label: __( 'Citations' ) } ];
 
 const DEFAULT_CONTROLS = {
 	link: true,
@@ -28,11 +24,23 @@ const DEFAULT_CONTROLS = {
 	button: true,
 	caption: true,
 	cite: true,
-	textInput: true,
-	select: true,
 };
 
-function ScreenColors() {
+interface ElementColorsProps {
+	additionalElements: { name: string; label: string }[];
+	defaultControls: Record< string, boolean >;
+	settingsTransform?: (
+		settings: GlobalStylesSettings
+	) => GlobalStylesSettings;
+	label?: string;
+}
+
+export function ElementColors( {
+	additionalElements,
+	defaultControls,
+	settingsTransform = ( settings ) => settings,
+	label,
+}: ElementColorsProps ) {
 	// Get user styles for editing
 	const [ style, setStyle ] = useStyle< GlobalStylesStyles >(
 		'',
@@ -49,8 +57,25 @@ function ScreenColors() {
 	);
 	// Get settings for the color panel
 	const [ rawSettings ] = useSetting< GlobalStylesSettings >( '' );
-	const settings = useSettingsForBlockElement( rawSettings );
+	const settings = settingsTransform(
+		useSettingsForBlockElement( rawSettings )
+	);
 
+	return (
+		<StylesColorPanel
+			inheritedValue={ inheritedStyle }
+			value={ style }
+			onChange={ setStyle }
+			settings={ settings }
+			additionalElements={ additionalElements }
+			defaultControls={ defaultControls }
+			label={ label }
+			showInheritanceLabelIndicators={ false }
+		/>
+	);
+}
+
+function ScreenColors() {
 	return (
 		<>
 			<ScreenHeader
@@ -64,14 +89,9 @@ function ScreenColors() {
 					<Palette />
 				</VStack>
 			</ScreenBody>
-			<StylesColorPanel
-				inheritedValue={ inheritedStyle }
-				value={ style }
-				onChange={ setStyle }
-				settings={ settings }
+			<ElementColors
 				additionalElements={ ADDITIONAL_ELEMENTS }
 				defaultControls={ DEFAULT_CONTROLS }
-				showInheritanceLabelIndicators={ false }
 			/>
 		</>
 	);

--- a/packages/global-styles-ui/src/screen-colors.tsx
+++ b/packages/global-styles-ui/src/screen-colors.tsx
@@ -1,79 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-// @ts-expect-error: Not typed yet.
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import type {
-	GlobalStylesStyles,
-	GlobalStylesSettings,
-} from '@wordpress/global-styles-engine';
 import { ScreenHeader } from './screen-header';
 import { ScreenBody } from './screen-body';
 import Palette from './palette';
-import { useStyle, useSetting } from './hooks';
-import { unlock } from './lock-unlock';
-
-const { useSettingsForBlockElement, ColorPanel: StylesColorPanel } = unlock(
-	blockEditorPrivateApis
-);
-
-const ADDITIONAL_ELEMENTS = [ { name: 'cite', label: __( 'Citations' ) } ];
-
-const DEFAULT_CONTROLS = {
-	link: true,
-	heading: true,
-	button: true,
-	caption: true,
-	cite: true,
-};
-
-interface ElementColorsProps {
-	additionalElements: { name: string; label: string }[];
-	defaultControls: Record< string, boolean >;
-	settingsTransform?: (
-		settings: GlobalStylesSettings
-	) => GlobalStylesSettings;
-	label?: string;
-}
-
-export function ElementColors( {
-	additionalElements,
-	defaultControls,
-	settingsTransform = ( settings ) => settings,
-	label,
-}: ElementColorsProps ) {
-	// Get user styles for editing
-	const [ style, setStyle ] = useStyle< GlobalStylesStyles >(
-		'',
-		undefined,
-		'user',
-		false
-	);
-	// Get inherited styles for display
-	const [ inheritedStyle ] = useStyle< GlobalStylesStyles >(
-		'',
-		undefined,
-		'merged',
-		false
-	);
-	// Get settings for the color panel
-	const [ rawSettings ] = useSetting< GlobalStylesSettings >( '' );
-	const settings = settingsTransform(
-		useSettingsForBlockElement( rawSettings )
-	);
-
-	return (
-		<StylesColorPanel
-			inheritedValue={ inheritedStyle }
-			value={ style }
-			onChange={ setStyle }
-			settings={ settings }
-			additionalElements={ additionalElements }
-			defaultControls={ defaultControls }
-			label={ label }
-			showInheritanceLabelIndicators={ false }
-		/>
-	);
-}
 
 function ScreenColors() {
 	return (
@@ -81,7 +10,7 @@ function ScreenColors() {
 			<ScreenHeader
 				title={ __( 'Colors' ) }
 				description={ __(
-					'Palette colors and the application of those colors on site elements.'
+					'Manage the color palettes used on the site.'
 				) }
 			/>
 			<ScreenBody>
@@ -89,10 +18,6 @@ function ScreenColors() {
 					<Palette />
 				</VStack>
 			</ScreenBody>
-			<ElementColors
-				additionalElements={ ADDITIONAL_ELEMENTS }
-				defaultControls={ DEFAULT_CONTROLS }
-			/>
 		</>
 	);
 }

--- a/packages/global-styles-ui/src/screen-elements.tsx
+++ b/packages/global-styles-ui/src/screen-elements.tsx
@@ -1,0 +1,56 @@
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import {
+	button,
+	caption,
+	heading,
+	link,
+	quote,
+	settings,
+	typography,
+} from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { NavigationButtonAsItem } from './navigation-button';
+import { ScreenBody } from './screen-body';
+import { ScreenHeader } from './screen-header';
+
+const ELEMENTS = [
+	{ icon: button, label: __( 'Buttons' ), path: '/elements/button' },
+	{ icon: link, label: __( 'Links' ), path: '/elements/link' },
+	{
+		icon: settings,
+		label: __( 'Form controls' ),
+		path: '/elements/form-controls',
+	},
+	{ icon: typography, label: __( 'Text' ), path: '/elements/text' },
+	{ icon: heading, label: __( 'Headings' ), path: '/elements/heading' },
+	{ icon: caption, label: __( 'Captions' ), path: '/elements/caption' },
+	{ icon: quote, label: __( 'Citations' ), path: '/elements/cite' },
+];
+
+function ScreenElements() {
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Elements' ) }
+				description={ __(
+					'Customize the appearance of text, buttons, links, and form controls for the whole site.'
+				) }
+			/>
+			<ScreenBody>
+				<ItemGroup>
+					{ ELEMENTS.map( ( { icon, label, path } ) => (
+						<NavigationButtonAsItem
+							key={ path }
+							icon={ icon }
+							path={ path }
+						>
+							{ label }
+						</NavigationButtonAsItem>
+					) ) }
+				</ItemGroup>
+			</ScreenBody>
+		</>
+	);
+}
+
+export default ScreenElements;

--- a/packages/global-styles-ui/src/screen-forms.tsx
+++ b/packages/global-styles-ui/src/screen-forms.tsx
@@ -3,7 +3,7 @@ import type { GlobalStylesSettings } from '@wordpress/global-styles-engine';
 import { ScreenHeader } from './screen-header';
 import { ScreenBody } from './screen-body';
 import TypographyElements from './typography-elements';
-import { ElementColors } from './screen-colors';
+import { ElementColors } from './element-colors';
 
 const FORM_ELEMENTS = [
 	{ element: 'textInput', label: __( 'Inputs' ) },
@@ -41,7 +41,7 @@ function ScreenForms() {
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'Forms' ) }
+				title={ __( 'Form controls' ) }
 				description={ __(
 					'Customize the typography and colors of inputs and selects.'
 				) }
@@ -49,7 +49,7 @@ function ScreenForms() {
 			<ScreenBody>
 				<TypographyElements
 					elements={ FORM_ELEMENTS }
-					parentMenu="/forms"
+					parentMenu="/elements/form-controls"
 					title={ __( 'Typography' ) }
 				/>
 			</ScreenBody>

--- a/packages/global-styles-ui/src/screen-forms.tsx
+++ b/packages/global-styles-ui/src/screen-forms.tsx
@@ -1,0 +1,66 @@
+import { __ } from '@wordpress/i18n';
+import type { GlobalStylesSettings } from '@wordpress/global-styles-engine';
+import { ScreenHeader } from './screen-header';
+import { ScreenBody } from './screen-body';
+import TypographyElements from './typography-elements';
+import { ElementColors } from './screen-colors';
+
+const FORM_ELEMENTS = [
+	{ element: 'textInput', label: __( 'Inputs' ) },
+	{ element: 'select', label: __( 'Selects' ) },
+];
+
+const COLOR_ELEMENTS = [
+	{ name: 'textInput', label: __( 'Inputs' ) },
+	{ name: 'select', label: __( 'Selects' ) },
+];
+
+const DEFAULT_COLOR_CONTROLS = {
+	link: false,
+	heading: false,
+	button: false,
+	caption: false,
+	textInput: true,
+	select: true,
+};
+
+function getFormColorSettings( settings: GlobalStylesSettings ) {
+	return {
+		...settings,
+		color: {
+			...settings.color,
+			link: false,
+			heading: false,
+			button: false,
+			caption: false,
+		},
+	};
+}
+
+function ScreenForms() {
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Forms' ) }
+				description={ __(
+					'Customize the typography and colors of inputs and selects.'
+				) }
+			/>
+			<ScreenBody>
+				<TypographyElements
+					elements={ FORM_ELEMENTS }
+					parentMenu="/forms"
+					title={ __( 'Typography' ) }
+				/>
+			</ScreenBody>
+			<ElementColors
+				additionalElements={ COLOR_ELEMENTS }
+				defaultControls={ DEFAULT_COLOR_CONTROLS }
+				settingsTransform={ getFormColorSettings }
+				label={ __( 'Colors' ) }
+			/>
+		</>
+	);
+}
+
+export default ScreenForms;

--- a/packages/global-styles-ui/src/screen-forms.tsx
+++ b/packages/global-styles-ui/src/screen-forms.tsx
@@ -6,11 +6,13 @@ import TypographyElements from './typography-elements';
 import { ElementColors } from './element-colors';
 
 const FORM_ELEMENTS = [
+	{ element: 'label', label: __( 'Labels' ) },
 	{ element: 'textInput', label: __( 'Inputs' ) },
 	{ element: 'select', label: __( 'Selects' ) },
 ];
 
 const COLOR_ELEMENTS = [
+	{ name: 'label', label: __( 'Labels' ) },
 	{ name: 'textInput', label: __( 'Inputs' ) },
 	{ name: 'select', label: __( 'Selects' ) },
 ];
@@ -20,6 +22,7 @@ const DEFAULT_COLOR_CONTROLS = {
 	heading: false,
 	button: false,
 	caption: false,
+	label: true,
 	textInput: true,
 	select: true,
 };
@@ -43,7 +46,7 @@ function ScreenForms() {
 			<ScreenHeader
 				title={ __( 'Form controls' ) }
 				description={ __(
-					'Customize the typography and colors of inputs and selects.'
+					'Customize the typography and colors of labels, inputs, and selects.'
 				) }
 			/>
 			<ScreenBody>

--- a/packages/global-styles-ui/src/screen-root.tsx
+++ b/packages/global-styles-ui/src/screen-root.tsx
@@ -69,6 +69,31 @@ function ScreenRoot() {
 					marginBottom={ 4 }
 				>
 					{ __(
+						'Customize the appearance of text, buttons, links, and form controls for the whole site.'
+					) }
+				</Spacer>
+				<ItemGroup>
+					<NavigationButtonAsItem path="/elements">
+						<HStack justify="space-between">
+							<FlexItem>{ __( 'Elements' ) }</FlexItem>
+							<IconWithCurrentColor
+								icon={ isRTL() ? chevronLeft : chevronRight }
+							/>
+						</HStack>
+					</NavigationButtonAsItem>
+				</ItemGroup>
+			</CardBody>
+
+			<CardDivider />
+
+			<CardBody>
+				<Spacer
+					as="p"
+					paddingTop={ 2 }
+					paddingX="13px"
+					marginBottom={ 4 }
+				>
+					{ __(
 						'Customize the appearance of specific blocks for the whole site.'
 					) }
 				</Spacer>

--- a/packages/global-styles-ui/src/screen-typography-element.tsx
+++ b/packages/global-styles-ui/src/screen-typography-element.tsx
@@ -5,6 +5,8 @@ import {
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import type { GlobalStylesSettings } from '@wordpress/global-styles-engine';
+import { ElementColors } from './element-colors';
 import TypographyPanel from './typography-panel';
 import { ScreenHeader } from './screen-header';
 import TypographyPreview from './typography-preview';
@@ -46,10 +48,51 @@ const elements = {
 
 interface ScreenTypographyElementProps {
 	element: keyof typeof elements;
+	showColorControls?: boolean;
 }
 
-function ScreenTypographyElement( { element }: ScreenTypographyElementProps ) {
+const ADDITIONAL_COLOR_ELEMENTS = [ 'cite', 'textInput', 'select' ];
+
+function getColorSettingsForElement(
+	settings: GlobalStylesSettings,
+	element: keyof typeof elements
+) {
+	const colorSettings = settings.color as typeof settings.color & {
+		heading?: boolean;
+		button?: boolean;
+		caption?: boolean;
+	};
+
+	return {
+		...settings,
+		color: {
+			...colorSettings,
+			link: element === 'link' && colorSettings?.link,
+			heading: element === 'heading' && colorSettings?.heading,
+			button: element === 'button' && colorSettings?.button,
+			caption: element === 'caption' && colorSettings?.caption,
+		},
+	};
+}
+
+function ScreenTypographyElement( {
+	element,
+	showColorControls = true,
+}: ScreenTypographyElementProps ) {
 	const [ headingLevel, setHeadingLevel ] = useState( 'heading' );
+	const hasColorPanel = showColorControls && element !== 'text';
+	const additionalElements = ADDITIONAL_COLOR_ELEMENTS.includes( element )
+		? [ { name: element, label: elements[ element ].title } ]
+		: [];
+	const defaultColorControls = {
+		link: element === 'link',
+		heading: element === 'heading',
+		button: element === 'button',
+		caption: element === 'caption',
+		cite: element === 'cite',
+		textInput: element === 'textInput',
+		select: element === 'select',
+	};
 
 	return (
 		<>
@@ -122,7 +165,18 @@ function ScreenTypographyElement( { element }: ScreenTypographyElementProps ) {
 			<TypographyPanel
 				element={ element }
 				headingLevel={ headingLevel }
+				showTextColor={ element === 'text' || ! hasColorPanel }
 			/>
+			{ hasColorPanel && (
+				<ElementColors
+					additionalElements={ additionalElements }
+					defaultControls={ defaultColorControls }
+					settingsTransform={ ( settings ) =>
+						getColorSettingsForElement( settings, element )
+					}
+					label={ __( 'Colors' ) }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/global-styles-ui/src/screen-typography-element.tsx
+++ b/packages/global-styles-ui/src/screen-typography-element.tsx
@@ -36,6 +36,10 @@ const elements = {
 		description: __( 'Manage the fonts and typography used on buttons.' ),
 		title: __( 'Buttons' ),
 	},
+	label: {
+		description: __( 'Manage the fonts and typography used on labels.' ),
+		title: __( 'Labels' ),
+	},
 	textInput: {
 		description: __( 'Manage the fonts and typography used on inputs.' ),
 		title: __( 'Inputs' ),
@@ -51,7 +55,7 @@ interface ScreenTypographyElementProps {
 	showColorControls?: boolean;
 }
 
-const ADDITIONAL_COLOR_ELEMENTS = [ 'cite', 'textInput', 'select' ];
+const ADDITIONAL_COLOR_ELEMENTS = [ 'cite', 'label', 'textInput', 'select' ];
 
 function getColorSettingsForElement(
 	settings: GlobalStylesSettings,

--- a/packages/global-styles-ui/src/screen-typography.tsx
+++ b/packages/global-styles-ui/src/screen-typography.tsx
@@ -3,7 +3,6 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 import { ScreenHeader } from './screen-header';
 import { ScreenBody } from './screen-body';
-import TypographyElements from './typography-elements';
 import TypographyVariations from './variations/variations-typography';
 import FontFamilies from './font-families';
 import FontSizesCount from './font-sizes/font-sizes-count';
@@ -17,14 +16,13 @@ function ScreenTypography() {
 			<ScreenHeader
 				title={ __( 'Typography' ) }
 				description={ __(
-					'Available fonts, typographic styles, and the application of those styles.'
+					'Manage the fonts and typographic styles available across the site.'
 				) }
 			/>
 			<ScreenBody>
 				<VStack spacing={ 7 }>
 					<TypographyVariations title={ __( 'Typesets' ) } />
 					{ fontLibraryEnabled && <FontFamilies /> }
-					<TypographyElements />
 					<FontSizesCount />
 				</VStack>
 			</ScreenBody>

--- a/packages/global-styles-ui/src/typography-elements.tsx
+++ b/packages/global-styles-ui/src/typography-elements.tsx
@@ -16,8 +16,8 @@ interface ElementItemProps {
 }
 
 interface TypographyElementsProps {
-	elements?: Omit< ElementItemProps, 'parentMenu' >[];
-	parentMenu?: string;
+	elements: Omit< ElementItemProps, 'parentMenu' >[];
+	parentMenu: string;
 	title?: string;
 }
 
@@ -74,23 +74,14 @@ function ElementItem( { parentMenu, element, label }: ElementItemProps ) {
 
 function TypographyElements( {
 	elements,
-	parentMenu = '',
-	title = __( 'Elements' ),
+	parentMenu,
+	title,
 }: TypographyElementsProps ) {
-	const displayedElements = elements ?? [
-		{ element: 'text', label: __( 'Text' ) },
-		{ element: 'link', label: __( 'Links' ) },
-		{ element: 'heading', label: __( 'Headings' ) },
-		{ element: 'caption', label: __( 'Captions' ) },
-		{ element: 'cite', label: __( 'Citations' ) },
-		{ element: 'button', label: __( 'Buttons' ) },
-	];
-
 	return (
 		<VStack spacing={ 3 }>
-			<Subtitle level={ 3 }>{ title }</Subtitle>
+			{ title && <Subtitle level={ 3 }>{ title }</Subtitle> }
 			<ItemGroup isBordered isSeparated>
-				{ displayedElements.map( ( { element, label } ) => (
+				{ elements.map( ( { element, label } ) => (
 					<ElementItem
 						key={ element }
 						parentMenu={ parentMenu }

--- a/packages/global-styles-ui/src/typography-elements.tsx
+++ b/packages/global-styles-ui/src/typography-elements.tsx
@@ -15,6 +15,12 @@ interface ElementItemProps {
 	label: string;
 }
 
+interface TypographyElementsProps {
+	elements?: Omit< ElementItemProps, 'parentMenu' >[];
+	parentMenu?: string;
+	title?: string;
+}
+
 function ElementItem( { parentMenu, element, label }: ElementItemProps ) {
 	const prefix =
 		element === 'text' || ! element ? '' : `elements.${ element }.`;
@@ -66,53 +72,32 @@ function ElementItem( { parentMenu, element, label }: ElementItemProps ) {
 	);
 }
 
-function TypographyElements() {
-	const parentMenu = '';
+function TypographyElements( {
+	elements,
+	parentMenu = '',
+	title = __( 'Elements' ),
+}: TypographyElementsProps ) {
+	const displayedElements = elements ?? [
+		{ element: 'text', label: __( 'Text' ) },
+		{ element: 'link', label: __( 'Links' ) },
+		{ element: 'heading', label: __( 'Headings' ) },
+		{ element: 'caption', label: __( 'Captions' ) },
+		{ element: 'cite', label: __( 'Citations' ) },
+		{ element: 'button', label: __( 'Buttons' ) },
+	];
 
 	return (
 		<VStack spacing={ 3 }>
-			<Subtitle level={ 3 }>{ __( 'Elements' ) }</Subtitle>
+			<Subtitle level={ 3 }>{ title }</Subtitle>
 			<ItemGroup isBordered isSeparated>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="text"
-					label={ __( 'Text' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="link"
-					label={ __( 'Links' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="heading"
-					label={ __( 'Headings' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="caption"
-					label={ __( 'Captions' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="cite"
-					label={ __( 'Citations' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="button"
-					label={ __( 'Buttons' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="textInput"
-					label={ __( 'Inputs' ) }
-				/>
-				<ElementItem
-					parentMenu={ parentMenu }
-					element="select"
-					label={ __( 'Selects' ) }
-				/>
+				{ displayedElements.map( ( { element, label } ) => (
+					<ElementItem
+						key={ element }
+						parentMenu={ parentMenu }
+						element={ element }
+						label={ label }
+					/>
+				) ) }
 			</ItemGroup>
 		</VStack>
 	);

--- a/packages/global-styles-ui/src/typography-panel.tsx
+++ b/packages/global-styles-ui/src/typography-panel.tsx
@@ -9,11 +9,13 @@ const { useSettingsForBlockElement, TypographyPanel: StylesTypographyPanel } =
 interface TypographyPanelProps {
 	element: string;
 	headingLevel: string;
+	showTextColor?: boolean;
 }
 
 export default function TypographyPanel( {
 	element,
 	headingLevel,
+	showTextColor = true,
 }: TypographyPanelProps ) {
 	let prefixParts: string[] = [];
 	if ( element === 'heading' ) {
@@ -32,11 +34,20 @@ export default function TypographyPanel( {
 	);
 	const [ rawSettings ] = useSetting( '' );
 	const usedElement = element === 'heading' ? headingLevel : element;
-	const settings = useSettingsForBlockElement(
+	const elementSettings = useSettingsForBlockElement(
 		rawSettings,
 		undefined,
 		usedElement
 	);
+	const settings = showTextColor
+		? elementSettings
+		: {
+				...elementSettings,
+				color: {
+					...elementSettings.color,
+					text: false,
+				},
+		  };
 
 	return (
 		<StylesTypographyPanel


### PR DESCRIPTION
## What?
Adds the `label` element to the Form controls screen in Global Styles.

Part of #34198. Fixes #81650.

Stacked on #81645 — this PR targets that branch and should merge after it.

## Why?
Labels can be styled in `theme.json` since #81160, but there was no UI for it. This exposes them alongside Inputs and Selects.

## How?
Adds Labels to the typography and color element lists on the Form controls screen, a description entry, and the `/elements/form-controls/typography/label` route.

## Testing Instructions
Note: #81645's base predates #81160, so on this branch as-is the control renders but does not apply. To test, merge `trunk` in first — that is the state verified below, and the state that will exist once #81645 is rebased.

1. Activate a block theme and open Appearance > Editor > Styles.
2. Open Elements > Form controls.
3. Confirm Typography and Colors both list Labels, Inputs, Selects.
4. Open Labels under Typography and change the font.
5. Under Colors, set a Labels text colour, save, and confirm it applies to a `<label>` on the front end.

Verified locally: selecting a colour writes `styles.elements.label.color.text` and emits `label { color: var(--wp--preset--color--accent-1); }`.

## Use of AI Tools
An AI coding assistant was used.
