### PR TITLE
RTC: Align collaboration migration version markers with the 23.8.0 release

### DIFF
--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -7,7 +7,7 @@
 
 if ( ! defined( '_GUTENBERG_VERSION_MIGRATION' ) ) {
 	// It's necessary to update this version every time a new migration is needed.
-	define( '_GUTENBERG_VERSION_MIGRATION', '23.7.0' );
+	define( '_GUTENBERG_VERSION_MIGRATION', '23.8.0' );
 }
 
 /**
@@ -25,7 +25,7 @@ function _gutenberg_migrate_database() {
 			_gutenberg_migrate_remove_fse_drafts();
 		}
 
-		if ( version_compare( $gutenberg_installed_version, '23.7.0', '<' ) ) {
+		if ( version_compare( $gutenberg_installed_version, '23.8.0', '<' ) ) {
 			_gutenberg_migrate_remove_legacy_collaboration_options();
 		}
 
@@ -70,7 +70,7 @@ function _gutenberg_migrate_remove_fse_drafts() {
  * collaboration is now opt-in, so existing sites must explicitly enable the
  * experiment instead of being opted in by a legacy setting.
  *
- * @since 23.7.0
+ * @since 23.8.0
  */
 function _gutenberg_migrate_remove_legacy_collaboration_options() {
 	delete_option( 'enable_real_time_collaboration' );

--- a/phpunit/tests/collaboration/collaborationUpgrade.php
+++ b/phpunit/tests/collaboration/collaborationUpgrade.php
@@ -48,7 +48,9 @@ class Tests_Collaboration_Upgrade extends WP_UnitTestCase {
 	}
 
 	public function test_removes_legacy_collaboration_options_without_enabling_the_experiment() {
-		update_option( 'gutenberg_version_migration', '22.8.0' );
+		// 23.7.2 shipped without this migration, so sites upgrading from any
+		// 23.7.x release must still run it.
+		update_option( 'gutenberg_version_migration', '23.7.2' );
 		update_option( 'enable_real_time_collaboration', '1' );
 		update_option( 'wp_enable_real_time_collaboration', '1' );
 		update_option( 'wp_collaboration_enabled', '1' );


### PR DESCRIPTION
## What?

Follow-up to #80658. Updates the version markers on the collaboration legacy-option cleanup migration from `23.7.0` to `23.8.0`:

## Why?
The migration merged in #80658 was marked `23.7.0`, but `23.7.2` has already shipped without it and `23.8` is in RC. The migration actually ships in `23.8.0`.

## How?
Version string changes only; no behavioral changes to the migration itself.

## Testing Instructions

1. Run the migration test: `npm run test:unit:php:base -- -- --filter Tests_Collaboration_Upgrade`.
2. Optionally, on a test site: set `gutenberg_version_migration` to `23.7.2` and `wp_collaboration_enabled` to 1, load any page, and confirm the marker becomes `23.8.0` and the legacy option is deleted.

## Use of AI tools

Claude Code was directed to make edits and commits on my behalf.