### PR TITLE
Docs: Fix broken link to the Document-Isolation-Policy explainer.

### DIFF
--- a/docs/how-to-guides/client-side-media.md
+++ b/docs/how-to-guides/client-side-media.md
@@ -288,7 +288,7 @@ WordPress calls this endpoint automatically as part of the client-side upload pi
 
 ## Cross-origin isolation considerations
 
-Client-side media processing requires `SharedArrayBuffer` for WASM threading. WordPress enables this automatically on block editor screens using [`Document-Isolation-Policy`](https://github.com/nicolo-ribaudo/tc39-proposal-structs/blob/main/test262-filtering/isolation-explainer.md) (DIP), which provides per-document cross-origin isolation without affecting other iframes on the page.
+Client-side media processing requires `SharedArrayBuffer` for WASM threading. WordPress enables this automatically on block editor screens using [`Document-Isolation-Policy`](https://github.com/WICG/document-isolation-policy) (DIP), which provides per-document cross-origin isolation without affecting other iframes on the page.
 
 ### Impact on plugins
 

--- a/lib/media/docs/client-side-media-docs.md
+++ b/lib/media/docs/client-side-media-docs.md
@@ -34,7 +34,7 @@ The fallback occurs when any of the following conditions are detected:
 
 WASM-based image optimization requires `SharedArrayBuffer` support, which in turn requires [cross-origin isolation](https://web.dev/articles/cross-origin-isolation-guide).
 
-This is achieved using the [`Document-Isolation-Policy`](https://github.com/nicolo-ribaudo/tc39-proposal-structs/blob/main/test262-filtering/isolation-explainer.md) header, which provides per-document cross-origin isolation without affecting other iframes on the page. This avoids the breakage that the older `Cross-Origin-Embedder-Policy` / `Cross-Origin-Opener-Policy` headers caused for third-party plugins and embeds.
+This is achieved using the [`Document-Isolation-Policy`](https://github.com/WICG/document-isolation-policy) header, which provides per-document cross-origin isolation without affecting other iframes on the page. This avoids the breakage that the older `Cross-Origin-Embedder-Policy` / `Cross-Origin-Opener-Policy` headers caused for third-party plugins and embeds.
 
 Once the page is served with this header, `SharedArrayBuffer` will be available in the browser, and WASM-based image optimization will work as expected. All embedded resources (e.g., images, scripts) are served with `crossorigin="anonymous"` to ensure cross-origin isolation is maintained.
 


### PR DESCRIPTION
The client-side media processing docs link the `Document-Isolation-Policy` header to a `github.com/nicolo-ribaudo/tc39-proposal-structs/...` URL that returns a 404, as that repository no longer exists. This PR points both occurrences of the link, on the how-to guide and on the `lib/media` docs, to the WICG Document-Isolation-Policy repository (https://github.com/WICG/document-isolation-policy), whose README is the explainer for the header. These were the only two references to the deleted repository in the codebase.

## Testing Instructions

Verify the two links updated on this PR load the WICG Document-Isolation-Policy explainer, while the previous link returns a 404.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
