### PR TITLE
Docs: Fix broken link to the getEntityRecords selector reference.

### DIFF
--- a/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
+++ b/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
@@ -45,7 +45,7 @@ If it doesn’t, go ahead and create a few pages – you can use the same titles
 
 Now that we have the data to work with, let’s dive into the code. We will take advantage of the [`@wordpress/core-data`](https://github.com/WordPress/gutenberg/tree/trunk/packages/core-data) package which provides resolvers, selectors, and actions to work with the WordPress core API. `@wordpress/core-data` builds on top of the [`@wordpress/data`](https://github.com/WordPress/gutenberg/tree/trunk/packages/data) package.
 
-To fetch the list of pages, we will use the [`getEntityRecords`](/docs/reference-guides/data/data-core/#getentityrecords) selector. In broad strokes, it will issue the correct API request, cache the results, and return the list of the records we need. Here’s how to use it:
+To fetch the list of pages, we will use the [`getEntityRecords`](/docs/reference-guides/data/data-core.md#getentityrecords) selector. In broad strokes, it will issue the correct API request, cache the results, and return the list of the records we need. Here’s how to use it:
 
 ```js
 wp.data.select( 'core' ).getEntityRecords( 'postType', 'page' )


### PR DESCRIPTION
The second chapter of the data basics tutorial links the `getEntityRecords` selector to `/docs/reference-guides/data/data-core/#getentityrecords`, which is missing the `.md` extension, so the link returns a 404. This PR adds the missing extension so the link resolves to the `getEntityRecords` section of the core data reference, matching how the other chapters of the tutorial already link that page.

## Testing Instructions

Verify the link updated on this PR loads the `getEntityRecords` section of the core data reference, while the previous link returns a 404.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
