### PR TITLE
MediaPlaceholder: identify canvas drags when checking drop eligibility

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   `MediaPlaceholder`: Identify blocks dragged from the canvas when deciding whether a drag may be dropped. Canvas drags carry only a client id reference, so the `wp-block:*` type names the check relied on are only ever present on drags started from the inserter. The check now falls back to the dragged blocks recorded in the store, and no longer treats a drag it cannot identify as eligible.
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -18,7 +18,7 @@ import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
 import { store as blockEditorStore } from '../../store';
 import { parseDropEvent } from '../use-on-block-drop';
-import { getComputedAcceptAttribute } from './utils';
+import { getComputedAcceptAttribute, isMediaDragEligible } from './utils';
 
 const noop = () => {};
 
@@ -147,6 +147,12 @@ export function MediaPlaceholder( {
 			allowedMimeTypes: settings.allowedMimeTypes,
 		};
 	}, [] );
+
+	// Canvas drags announce what they carry through the store rather than
+	// through the `dataTransfer`, so the drop zone needs selector access.
+	const { getDraggedBlockClientIds, getBlockNamesByClientId } =
+		useSelect( blockEditorStore );
+
 	const [ src, setSrc ] = useState( '' );
 
 	useEffect( () => {
@@ -363,6 +369,54 @@ export function MediaPlaceholder( {
 	};
 	const renderPlaceholder = placeholder ?? defaultRenderPlaceholder;
 
+	/**
+	 * Identifies what is being dragged, during dragover.
+	 *
+	 * Block drags reach the drop zone in two shapes, and each publishes what
+	 * it carries in a different place:
+	 *
+	 * - Inserter drags advertise their block names as `dataTransfer` type
+	 *   names, because the blocks do not exist in the store yet.
+	 * - Canvas drags carry only a client id reference, and announce the
+	 *   dragged blocks through the block editor store instead.
+	 *
+	 * File drags never get here; `DropZone` routes those to `onFilesDrop`
+	 * before `isEligible` is consulted.
+	 *
+	 * Note the two sources currently report different shapes: the inserter
+	 * prefix is still `wp-block:core/`, so its names come back bare
+	 * (`image`) and non-core blocks are ignored, while the store reports
+	 * fully qualified names (`core/image`). Reconciling those is a follow-up.
+	 *
+	 * @param {DataTransfer} dataTransfer The drag's data transfer.
+	 *
+	 * @return {{source: string, blockNames: string[]}} The drag's origin and
+	 * the names of the blocks it carries.
+	 */
+	const getDragInfo = ( dataTransfer ) => {
+		const prefix = 'wp-block:core/';
+		const namesFromTypes = [];
+		for ( const type of dataTransfer.types ) {
+			if ( type.startsWith( prefix ) ) {
+				namesFromTypes.push( type.slice( prefix.length ) );
+			}
+		}
+
+		if ( namesFromTypes.length ) {
+			return { source: 'inserter', blockNames: namesFromTypes };
+		}
+
+		const draggedClientIds = getDraggedBlockClientIds();
+		if ( draggedClientIds.length ) {
+			return {
+				source: 'canvas',
+				blockNames: getBlockNamesByClientId( draggedClientIds ),
+			};
+		}
+
+		return { source: 'unknown', blockNames: [] };
+	};
+
 	const renderDropZone = () => {
 		if ( disableDropZone ) {
 			return null;
@@ -373,18 +427,13 @@ export function MediaPlaceholder( {
 				onFilesDrop={ onFilesUpload }
 				onDrop={ handleBlocksDrop }
 				isEligible={ ( dataTransfer ) => {
-					const prefix = 'wp-block:core/';
-					const types = [];
-					for ( const type of dataTransfer.types ) {
-						if ( type.startsWith( prefix ) ) {
-							types.push( type.slice( prefix.length ) );
-						}
-					}
-					return (
-						types.every( ( type ) =>
-							allowedTypes.includes( type )
-						) && ( multiple ? true : types.length === 1 )
-					);
+					const { blockNames } = getDragInfo( dataTransfer );
+
+					return isMediaDragEligible( {
+						blockNames,
+						allowedTypes,
+						multiple,
+					} );
 				} }
 			/>
 		);

--- a/packages/block-editor/src/components/media-placeholder/test/is-media-drag-eligible.js
+++ b/packages/block-editor/src/components/media-placeholder/test/is-media-drag-eligible.js
@@ -1,0 +1,83 @@
+import { isMediaDragEligible } from '../utils';
+
+describe( 'isMediaDragEligible', () => {
+	it( 'accepts a single allowed block dragged from the canvas', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'core/image' ],
+				allowedTypes: [ 'image' ],
+				multiple: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'accepts bare names as reported by inserter drags', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'image' ],
+				allowedTypes: [ 'image' ],
+				multiple: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects a block whose type is not allowed', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'core/paragraph' ],
+				allowedTypes: [ 'image' ],
+				multiple: true,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects a drag whose contents could not be identified', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [],
+				allowedTypes: [ 'image' ],
+				multiple: true,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects several blocks when only one is accepted', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'core/image', 'core/image' ],
+				allowedTypes: [ 'image' ],
+				multiple: false,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'accepts several blocks when many are accepted', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'core/image', 'core/image' ],
+				allowedTypes: [ 'image' ],
+				multiple: true,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects a mixed drag when one block is not allowed', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'core/image', 'core/paragraph' ],
+				allowedTypes: [ 'image', 'video' ],
+				multiple: true,
+			} )
+		).toBe( false );
+	} );
+
+	it( 'rejects rather than throwing when no types are allowed', () => {
+		expect(
+			isMediaDragEligible( {
+				blockNames: [ 'core/image' ],
+				allowedTypes: undefined,
+				multiple: true,
+			} )
+		).toBe( false );
+	} );
+} );

--- a/packages/block-editor/src/components/media-placeholder/utils.js
+++ b/packages/block-editor/src/components/media-placeholder/utils.js
@@ -63,3 +63,34 @@ export function getComputedAcceptAttribute(
 
 	return allowedTypes.map( ( type ) => `${ type }/*` ).join( ',' );
 }
+
+/**
+ * Decides whether a block drag may be dropped on a media placeholder.
+ *
+ * Block names are accepted either fully qualified (`core/image`, as reported
+ * by the block editor store for canvas drags) or bare (`image`, as advertised
+ * in the `dataTransfer` type names of inserter drags).
+ *
+ * @param {Object}   options
+ * @param {string[]} options.blockNames   Names of the blocks being dragged.
+ * @param {string[]} options.allowedTypes Media types the placeholder accepts.
+ * @param {boolean}  options.multiple     Whether more than one item is
+ *                                        accepted.
+ *
+ * @return {boolean} Whether the drag is eligible.
+ */
+export function isMediaDragEligible( { blockNames, allowedTypes, multiple } ) {
+	// An unidentified drag is never eligible. Without this, `every` below
+	// would vacuously accept a drag whose contents are unknown.
+	if ( ! blockNames?.length || ! allowedTypes?.length ) {
+		return false;
+	}
+
+	if ( ! multiple && blockNames.length > 1 ) {
+		return false;
+	}
+
+	return blockNames.every( ( name ) =>
+		allowedTypes.includes( name.split( '/' ).pop() )
+	);
+}

--- a/test/e2e/specs/editor/various/media-placeholder-drop-zone.spec.js
+++ b/test/e2e/specs/editor/various/media-placeholder-drop-zone.spec.js
@@ -1,0 +1,137 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.use( {
+	// Large enough that the canvas does not scroll while dragging, which would
+	// move the drop target out from under the cursor.
+	viewport: {
+		width: 960,
+		height: 1024,
+	},
+} );
+
+/**
+ * Moves the mouse to the given coordinates.
+ *
+ * The move is repeated because a single move does not reliably emit a
+ * `dragOver` event.
+ *
+ * @see https://github.com/microsoft/playwright/issues/17153
+ *
+ * @param {Object} page Playwright page.
+ * @param {number} x    Horizontal coordinate.
+ * @param {number} y    Vertical coordinate.
+ */
+async function dragTo( page, x, y ) {
+	for ( let i = 0; i < 2; i += 1 ) {
+		await page.mouse.move( x, y );
+	}
+}
+
+/**
+ * Drags a block over an empty Gallery block's media placeholder and reports
+ * how many drop zones are active while the drag is held over it.
+ *
+ * @param {Object} options
+ * @param {Object} options.editor Editor utils.
+ * @param {Object} options.page   Playwright page.
+ * @param {Object} options.block  The block to insert and drag.
+ *
+ * @return {Promise<number>} The number of active drop zones.
+ */
+async function countActiveDropZonesWhileDragging( { editor, page, block } ) {
+	await editor.insertBlock( block );
+	await editor.insertBlock( { name: 'core/gallery' } );
+
+	const placeholder = editor.canvas
+		.locator( '.block-editor-media-placeholder' )
+		.first();
+	await expect( placeholder ).toBeVisible();
+	const placeholderBox = await placeholder.boundingBox();
+
+	await editor.selectBlocks(
+		editor.canvas.locator( `[data-type="${ block.name }"]` ).first()
+	);
+	await editor.showBlockToolbar();
+
+	await page
+		.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Drag"i][include-hidden]'
+		)
+		.hover();
+	await page.mouse.down();
+	await dragTo(
+		page,
+		placeholderBox.x + placeholderBox.width / 2,
+		placeholderBox.y + placeholderBox.height / 2
+	);
+
+	const activeDropZones = await editor.canvas
+		.locator( '.components-drop-zone.is-active' )
+		.count();
+
+	await page.mouse.up();
+
+	return activeDropZones;
+}
+
+test.describe( 'MediaPlaceholder drop zone', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'does not activate for a paragraph dragged from the canvas', async ( {
+		editor,
+		page,
+	} ) => {
+		const activeDropZones = await countActiveDropZonesWhileDragging( {
+			editor,
+			page,
+			block: {
+				name: 'core/paragraph',
+				attributes: { content: 'drag me' },
+			},
+		} );
+
+		expect( activeDropZones ).toBe( 0 );
+	} );
+
+	test( 'does not activate for a media block of an unaccepted type', async ( {
+		editor,
+		page,
+	} ) => {
+		const activeDropZones = await countActiveDropZonesWhileDragging( {
+			editor,
+			page,
+			block: {
+				name: 'core/audio',
+				attributes: {
+					src: 'https://example.com/sound.mp3',
+					id: 33,
+				},
+			},
+		} );
+
+		expect( activeDropZones ).toBe( 0 );
+	} );
+
+	// Guards the tests above: without this, they would also pass if the drop
+	// zone never activated for anything.
+	test( 'activates for an image dragged from the canvas', async ( {
+		editor,
+		page,
+	} ) => {
+		const activeDropZones = await countActiveDropZonesWhileDragging( {
+			editor,
+			page,
+			block: {
+				name: 'core/image',
+				attributes: {
+					url: 'https://example.com/photo.jpg',
+					id: 22,
+				},
+			},
+		} );
+
+		expect( activeDropZones ).toBeGreaterThan( 0 );
+	} );
+} );


### PR DESCRIPTION
Attempt at identifying blocks dragged when originating from the canvas so we can appropriately decide if it's eligible to be dropped in a location.

Alt to https://github.com/WordPress/gutenberg/pull/81431