### PR TITLE
Show the block outline where the grab cursor shows

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -89,6 +89,7 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-highlighted ~ .is-multi-selected,
 	.block-editor-block-list__block.is-hovered-draggable[draggable="true"]:not(.is-multi-selected),
+	.block-editor-block-list__block.is-hovered-draggable[data-draggable="true"]:not(.is-multi-selected),
 	.block-editor-block-list__block:not([contenteditable="true"]):focus {
 		outline: none;
 

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -80,13 +80,15 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		}
 	}
 
-	// Block highlight, and navigation mode, and focus.
+	// Block highlight, and navigation mode, and focus, and hover where the
+	// grab cursor shows what a drag would take.
 	// This piece of code has gone back and forth between using a pseudo element
 	// vs. styling the block directly. Ultimately we likely need a pseudo element
 	// (unless styles like focus and selection overlay can be rendered as separate elements),
 	// since things like border-radius need to be able to be set on the block itself.
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-highlighted ~ .is-multi-selected,
+	.block-editor-block-list__block.is-hovered:is([draggable="true"], [data-draggable="true"]):not([contenteditable="true"]):not(.is-multi-selected):not(:has([contenteditable="true"]:hover)),
 	.block-editor-block-list__block:not([contenteditable="true"]):focus {
 		outline: none;
 

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -88,7 +88,7 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	// since things like border-radius need to be able to be set on the block itself.
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-highlighted ~ .is-multi-selected,
-	.block-editor-block-list__block.is-hovered:is([draggable="true"], [data-draggable="true"]):not([contenteditable="true"]):not(.is-multi-selected):not(:has([contenteditable="true"]:hover)),
+	.block-editor-block-list__block.is-hovered-draggable[draggable="true"]:not(.is-multi-selected),
 	.block-editor-block-list__block:not([contenteditable="true"]):focus {
 		outline: none;
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -31,22 +31,23 @@ export function useIsHovered( { isEnabled = true } = {} ) {
 				event.preventDefault();
 				const isHovered = event.type === 'mouseover';
 				node.classList.toggle( 'is-hovered', isHovered );
+				clearTimeout( timeoutId );
+				if ( ! isHovered ) {
+					node.classList.remove( 'is-hovered-draggable' );
+					return;
+				}
 				// Over editable content the cursor is a text cursor, not
 				// the grab cursor, so no drag would start there. The
-				// delay keeps the outline from flashing on every block
-				// the pointer merely passes over.
-				if (
-					isHovered &&
-					! event.target.closest( '[contenteditable="true"]' )
-				) {
-					timeoutId ??= setTimeout( () => {
-						node.classList.add( 'is-hovered-draggable' );
-					}, 100 );
-				} else {
-					clearTimeout( timeoutId );
-					timeoutId = undefined;
-					node.classList.remove( 'is-hovered-draggable' );
-				}
+				// editability check can force a style recalculation, so it
+				// runs once the pointer rests, which also keeps the
+				// outline from flashing on blocks it merely passes over.
+				const { target } = event;
+				timeoutId = setTimeout( () => {
+					node.classList.toggle(
+						'is-hovered-draggable',
+						! target.isContentEditable
+					);
+				}, 100 );
 			}
 
 			const unsubscribeOut = subscribeDelegatedListener(

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -22,15 +22,31 @@ export function useIsHovered( { isEnabled = true } = {} ) {
 				return;
 			}
 
+			let timeoutId;
+
 			function listener( event ) {
 				if ( event.defaultPrevented ) {
 					return;
 				}
 				event.preventDefault();
-				node.classList.toggle(
-					'is-hovered',
-					event.type === 'mouseover'
-				);
+				const isHovered = event.type === 'mouseover';
+				node.classList.toggle( 'is-hovered', isHovered );
+				// Over editable content the cursor is a text cursor, not
+				// the grab cursor, so no drag would start there. The
+				// delay keeps the outline from flashing on every block
+				// the pointer merely passes over.
+				if (
+					isHovered &&
+					! event.target.closest( '[contenteditable="true"]' )
+				) {
+					timeoutId ??= setTimeout( () => {
+						node.classList.add( 'is-hovered-draggable' );
+					}, 100 );
+				} else {
+					clearTimeout( timeoutId );
+					timeoutId = undefined;
+					node.classList.remove( 'is-hovered-draggable' );
+				}
 			}
 
 			const unsubscribeOut = subscribeDelegatedListener(
@@ -48,8 +64,10 @@ export function useIsHovered( { isEnabled = true } = {} ) {
 				unsubscribeOut();
 				unsubscribeOver();
 
-				// Remove class in case it lingers.
+				// Remove classes in case they linger.
+				clearTimeout( timeoutId );
 				node.classList.remove( 'is-hovered' );
+				node.classList.remove( 'is-hovered-draggable' );
 			};
 		},
 		[ isEnabled ]


### PR DESCRIPTION

<img width="792" height="375" alt="image" src="https://github.com/user-attachments/assets/f065d82c-647e-4ad2-9478-a3d4f857f931" />


## What?

Show the block outline whenever we also show the grab cursor.

## Why?

The grab cursor shows that an item can be dragged but:

* It's not clear to how far the drag target extends. For example, will I drag the list item or the whole list?
* It's easier to miss the drag cursor.

## How?

The hover hook now also toggles an `is-hovered-draggable` class, set only when the pointer is outside editable content (where no drag would start) and after a short delay so the outline does not flash on blocks the pointer merely passes over.

## Testing Instructions

1. Open a post with an image, a separator, and a group with text.
2. Hover the image or separator: grab cursor and outline together.
3. Hover the group's padding: same. Hover text: neither.

### Testing Instructions for Keyboard

Pointer-only change; keyboard behavior is untouched.

## Screenshots or screencast

## Use of AI Tools

Written with Claude Code, reviewed and tested by me.

