### PR TITLE
Media: Attach unattached media to the current post on selection

### DIFF
--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Prevent editor block removal by stopping undo/redo event propagation when the Media Library modal is open ([#79898](https://github.com/WordPress/gutenberg/pull/79898)).
+-   Media selected from a picker is now attached to the post it is added to, when it is not already attached to another post — matching what uploading into that post has always done ([#81804](https://github.com/WordPress/gutenberg/pull/81804)).
 
 ### Internal
 

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -12,7 +12,7 @@ import {
 	privateApis as coreDataPrivateApis,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { resolveSelect, useDispatch } from '@wordpress/data';
+import { resolveSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
@@ -41,6 +41,7 @@ import {
 import { store as noticesStore, SnackbarNotices } from '@wordpress/notices';
 import type { Attachment, RestAttachment } from '../../utils/types';
 import { transformAttachment } from '../../utils/transform-attachment';
+import { attachMediaToCurrentPost } from '../../utils/attach-media-to-current-post';
 import { uploadMedia } from '../../utils/upload-media';
 import { unlock } from '../../lock-unlock';
 import { UploadStatusPopover } from './upload-status-popover';
@@ -235,6 +236,7 @@ export function MediaUploadModal( {
 		useDispatch( noticesStore );
 	const invalidateAttachmentResolutions =
 		useInvalidateAttachmentResolutions();
+	const registry = useRegistry();
 	const [ queryParams, setQueryParams ] = useState< ViewQueryParams >(
 		() => defaultQueryParams
 	);
@@ -455,10 +457,16 @@ export function MediaUploadModal( {
 
 					removeAllNotices( 'snackbar', NOTICES_CONTEXT );
 					onSelect( selectedItems );
+
+					// Attach exactly what landed in the block, and never
+					// awaited — see `attachMediaToCurrentPost`. Called after
+					// `onSelect` so a background write can't delay the
+					// selection reaching the editor.
+					attachMediaToCurrentPost( selectedItems, registry );
 				},
 			},
 		],
-		[ multiple, onSelect, selection, removeAllNotices ]
+		[ multiple, onSelect, selection, removeAllNotices, registry ]
 	);
 
 	const handleModalClose = useCallback( () => {

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -2,6 +2,7 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { select, dispatch } from '@wordpress/data';
 import { invalidateAttachmentResolutions } from '../../utils/invalidate-attachment-resolutions';
+import { attachMediaToCurrentPost } from '../../utils/attach-media-to-current-post';
 
 const DEFAULT_EMPTY_GALLERY = [];
 
@@ -240,6 +241,11 @@ const slimImageObject = ( img ) => {
 		'alt',
 		'link',
 		'caption',
+		// The attachment's parent post. Consumers use this to tell an
+		// unattached item from one that already belongs to another post; without
+		// it, selections coming through `onUpdate` (the gallery edit and replace
+		// flows) are indistinguishable from items whose parent is unknown.
+		'uploadedTo',
 	];
 	return attrSet.reduce( ( result, key ) => {
 		if ( img?.hasOwnProperty( key ) ) {
@@ -451,22 +457,28 @@ class MediaUpload extends Component {
 			return;
 		}
 
-		if ( multiple ) {
-			onSelect(
-				selectedImages.models.map( ( model ) =>
-					slimImageObject( model.toJSON() )
-				)
-			);
-		} else {
-			onSelect( slimImageObject( selectedImages.models[ 0 ].toJSON() ) );
-		}
+		const selection = selectedImages.models.map( ( model ) =>
+			slimImageObject( model.toJSON() )
+		);
+
+		const selected = multiple ? selection : selection[ 0 ];
+		onSelect( selected );
+
+		// Attach exactly what landed in the block, and never awaited — see
+		// `attachMediaToCurrentPost`. Called after `onSelect` so a background
+		// write can't delay the selection reaching the editor.
+		attachMediaToCurrentPost( selected, { select, dispatch } );
 	}
 
 	onSelect() {
 		const { onSelect, multiple = false } = this.props;
 		// Get media attachment details from the frame state.
 		const attachment = this.frame.state().get( 'selection' ).toJSON();
-		onSelect( multiple ? attachment : attachment[ 0 ] );
+		const selected = multiple ? attachment : attachment[ 0 ];
+		onSelect( selected );
+
+		// Not awaited — see `attachMediaToCurrentPost`.
+		attachMediaToCurrentPost( selected, { select, dispatch } );
 	}
 
 	onOpen() {

--- a/packages/media-utils/src/utils/attach-media-to-current-post.ts
+++ b/packages/media-utils/src/utils/attach-media-to-current-post.ts
@@ -1,0 +1,179 @@
+import type { DataRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { invalidateAttachmentResolutions } from './invalidate-attachment-resolutions';
+
+/**
+ * The shape a media item can arrive in. The classic Backbone modal hands over
+ * `toJSON()` output, the DataViews modal hands over transformed REST records,
+ * and both are looser than the `Attachment` type.
+ */
+type MediaItem = Record< string, unknown > | null | undefined;
+
+/**
+ * Normalizes a value to a positive integer post ID, or `undefined`.
+ *
+ * @param postId Value to normalize.
+ */
+function normalizePostId( postId: unknown ): number | undefined {
+	const parsedPostId = typeof postId === 'number' ? postId : Number( postId );
+
+	return Number.isInteger( parsedPostId ) && parsedPostId > 0
+		? parsedPostId
+		: undefined;
+}
+
+/**
+ * Returns the post currently being edited, if media can be attached to it.
+ *
+ * `wp_enqueue_media()` is what populates this: `edit-form-blocks.php` calls it
+ * as `wp_enqueue_media( array( 'post' => $post->ID ) )`, which is also where the
+ * classic modal's uploader reads the post to attach uploads to
+ * (`uploader.params.post_id`). Everywhere else — the site editor included — it
+ * is left at its `0` default, so this returns `undefined` and attaching is
+ * skipped.
+ *
+ * That makes this narrower than the editor's upload path, which resolves the
+ * post itself (`mediaUpload` in `@wordpress/editor` reads `getCurrentPost()` and
+ * falls back to a template's `wp_id`), and so parents uploads to templates too.
+ * Selecting existing media deliberately stops at the post editor: reparenting an
+ * attachment that already exists is a heavier, more surprising change than
+ * parenting a file the user just uploaded, and a template is a poor owner for
+ * media that may be shown across the whole site.
+ */
+function getCurrentPostId(): number | undefined {
+	const { wp } = window as Window &
+		typeof globalThis & {
+			wp?: {
+				media?: { view?: { settings?: { post?: { id?: unknown } } } };
+			};
+		};
+
+	return normalizePostId( wp?.media?.view?.settings?.post?.id );
+}
+
+/**
+ * Resolves the post an attachment is currently attached to, reading only what
+ * the picker already handed us.
+ *
+ * The two payload shapes name the parent differently, and each has its own "no
+ * parent" value:
+ *
+ * - REST records (the DataViews modal) expose `post`, which is `null` — not
+ *   `0` — when the attachment is unattached.
+ * - The classic Backbone modal's `toJSON()` shape exposes `uploadedTo`, which
+ *   is `0` when unattached.
+ *
+ * A *missing* key is not the same as an unattached item: it means the payload
+ * never carried the parent, so we cannot tell. That distinction is what keeps
+ * this from stealing attachments, so it is preserved rather than collapsed.
+ *
+ * There is deliberately no core-data fallback here. `getEntityRecord()` triggers
+ * the resolver rather than passively reading cache, so it would issue one REST
+ * request per selected item. Pickers that drop the parent are fixed at the
+ * source instead (see `slimImageObject` in the classic `MediaUpload`).
+ *
+ * @param mediaItem A media item from a picker's selection payload.
+ *
+ * @return The parent post ID (`0` when unattached), or `undefined` when the
+ *         payload doesn't say.
+ */
+function getAttachmentParent( mediaItem: MediaItem ): number | undefined {
+	if ( ! mediaItem || typeof mediaItem !== 'object' ) {
+		return undefined;
+	}
+
+	if ( Object.hasOwn( mediaItem, 'post' ) ) {
+		return normalizePostId( mediaItem.post ) ?? 0;
+	}
+
+	if ( Object.hasOwn( mediaItem, 'uploadedTo' ) ) {
+		return normalizePostId( mediaItem.uploadedTo ) ?? 0;
+	}
+
+	return undefined;
+}
+
+/**
+ * Attaches any unattached media in a picker selection to the post being edited,
+ * mirroring what uploading into that post has always done.
+ *
+ * Fire-and-forget by contract: callers must not await this, so a slow or failed
+ * write can never block the selection from landing in the editor. Items already
+ * attached to another post are skipped, as are items whose parent the payload
+ * didn't report — an attachment owned by another post must never be silently
+ * reparented.
+ *
+ * @param mediaItems The picker's selection payload.
+ * @param registry   A `@wordpress/data` registry (`useRegistry()`), or the
+ *                   default-registry `{ select, dispatch }` exports.
+ */
+export function attachMediaToCurrentPost(
+	mediaItems: MediaItem | MediaItem[],
+	registry: Pick< DataRegistry, 'select' | 'dispatch' >
+) {
+	const postId = getCurrentPostId();
+	if ( ! postId ) {
+		return;
+	}
+
+	const items = Array.isArray( mediaItems ) ? mediaItems : [ mediaItems ];
+
+	// Only ever fill an empty parent. Never steal one, and never guess.
+	const attachmentIds = [
+		...new Set(
+			items
+				.filter( ( item ) => getAttachmentParent( item ) === 0 )
+				.map( ( item ) => normalizePostId( item?.id ) )
+				.filter( Boolean )
+		),
+	] as number[];
+
+	if ( ! attachmentIds.length ) {
+		return;
+	}
+
+	const { saveEntityRecord, __experimentalBatch } =
+		registry.dispatch( coreStore );
+
+	const write =
+		attachmentIds.length === 1
+			? // A single write skips the OPTIONS preflight the batch endpoint
+			  // needs, which is the common case by a wide margin.
+			  saveEntityRecord(
+					'postType',
+					'attachment',
+					{ id: attachmentIds[ 0 ], post: postId },
+					{ throwOnError: true }
+			  )
+			: __experimentalBatch(
+					attachmentIds.map(
+						( attachmentId ) =>
+							( {
+								saveEntityRecord: save,
+							}: {
+								saveEntityRecord: typeof saveEntityRecord;
+							} ) =>
+								save( 'postType', 'attachment', {
+									id: attachmentId,
+									post: postId,
+								} )
+					)
+			  );
+
+	Promise.resolve( write )
+		.then( () => {
+			// Both modals invalidate the attachment cache when they close, but
+			// this write is deliberately not awaited, so it can land after that
+			// invalidation. Invalidate again so surfaces listing media by parent
+			// — the Gallery block's dynamic mode, the "Attached images" inserter
+			// tab — pick the new parent up.
+			invalidateAttachmentResolutions( registry );
+		} )
+		.catch( ( error ) => {
+			// Attaching is a silent convenience: a failure leaves the media
+			// unattached, which is exactly the state it was already in. Never
+			// interpolate the error — a rejected `apiFetch` is not reliably an
+			// `Error`, so `${ error }` can yield "[object Object]".
+			window.console.warn( 'Could not attach media to the post.', error );
+		} );
+}

--- a/packages/media-utils/src/utils/test/attach-media-to-current-post.ts
+++ b/packages/media-utils/src/utils/test/attach-media-to-current-post.ts
@@ -1,0 +1,156 @@
+import { attachMediaToCurrentPost } from '../attach-media-to-current-post';
+
+type Registry = Parameters< typeof attachMediaToCurrentPost >[ 1 ];
+
+/**
+ * Builds a minimal registry stub capturing the writes the util makes.
+ */
+function createRegistryStub() {
+	const saveEntityRecord = jest.fn().mockResolvedValue( {} );
+	const batch = jest.fn().mockResolvedValue( [] );
+	const invalidateResolution = jest.fn();
+
+	const registry = {
+		select: () => ( {
+			getCachedResolvers: () => ( {} ),
+		} ),
+		dispatch: () => ( {
+			saveEntityRecord,
+			__experimentalBatch: batch,
+			invalidateResolution,
+		} ),
+	} as unknown as Registry;
+
+	return { registry, saveEntityRecord, batch };
+}
+
+/**
+ * Sets (or clears) the post ID that `wp_enqueue_media()` exposes.
+ *
+ * @param postId Post ID, or `undefined` to remove the global entirely.
+ */
+function setCurrentPostId( postId: number | undefined ) {
+	if ( postId === undefined ) {
+		delete ( window as unknown as Record< string, unknown > ).wp;
+		return;
+	}
+
+	( window as unknown as Record< string, unknown > ).wp = {
+		media: { view: { settings: { post: { id: postId } } } },
+	};
+}
+
+describe( 'attachMediaToCurrentPost', () => {
+	afterEach( () => {
+		setCurrentPostId( undefined );
+	} );
+
+	it( 'attaches an unattached REST item to the current post', () => {
+		setCurrentPostId( 7 );
+		const { registry, saveEntityRecord } = createRegistryStub();
+
+		attachMediaToCurrentPost( { id: 12, post: null }, registry );
+
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			{ id: 12, post: 7 },
+			{ throwOnError: true }
+		);
+	} );
+
+	it( 'attaches an unattached classic-modal item, which reports uploadedTo: 0', () => {
+		setCurrentPostId( 7 );
+		const { registry, saveEntityRecord } = createRegistryStub();
+
+		attachMediaToCurrentPost( { id: 12, uploadedTo: 0 }, registry );
+
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			{ id: 12, post: 7 },
+			{ throwOnError: true }
+		);
+	} );
+
+	it( 'never steals media already attached to another post', () => {
+		setCurrentPostId( 7 );
+		const { registry, saveEntityRecord, batch } = createRegistryStub();
+
+		attachMediaToCurrentPost(
+			[
+				{ id: 12, post: 99 },
+				{ id: 13, uploadedTo: 99 },
+			],
+			registry
+		);
+
+		expect( saveEntityRecord ).not.toHaveBeenCalled();
+		expect( batch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'never guesses when the payload does not report a parent', () => {
+		setCurrentPostId( 7 );
+		const { registry, saveEntityRecord } = createRegistryStub();
+
+		attachMediaToCurrentPost(
+			{ id: 12, url: 'https://e.g/a.jpg' },
+			registry
+		);
+
+		expect( saveEntityRecord ).not.toHaveBeenCalled();
+	} );
+
+	it( 'batches a multi-item selection, deduplicated', () => {
+		setCurrentPostId( 7 );
+		const { registry, saveEntityRecord, batch } = createRegistryStub();
+
+		attachMediaToCurrentPost(
+			[
+				{ id: 12, post: null },
+				{ id: 13, post: null },
+				{ id: 13, post: null },
+				{ id: 14, post: 99 },
+			],
+			registry
+		);
+
+		expect( saveEntityRecord ).not.toHaveBeenCalled();
+		expect( batch ).toHaveBeenCalledTimes( 1 );
+
+		// The batch is described as a list of thunks; run them against a stub to
+		// assert on what would be written.
+		const save = jest.fn();
+		batch.mock.calls[ 0 ][ 0 ].forEach(
+			( thunk: ( arg: unknown ) => void ) =>
+				thunk( { saveEntityRecord: save } )
+		);
+
+		expect( save ).toHaveBeenCalledTimes( 2 );
+		expect( save ).toHaveBeenCalledWith( 'postType', 'attachment', {
+			id: 12,
+			post: 7,
+		} );
+		expect( save ).toHaveBeenCalledWith( 'postType', 'attachment', {
+			id: 13,
+			post: 7,
+		} );
+	} );
+
+	it( 'does nothing outside a post editing screen, where the post ID is 0', () => {
+		setCurrentPostId( 0 );
+		const { registry, saveEntityRecord } = createRegistryStub();
+
+		attachMediaToCurrentPost( { id: 12, post: null }, registry );
+
+		expect( saveEntityRecord ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when wp_enqueue_media() has not run at all', () => {
+		const { registry, saveEntityRecord } = createRegistryStub();
+
+		attachMediaToCurrentPost( { id: 12, post: null }, registry );
+
+		expect( saveEntityRecord ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
<!-- Claude generated summary
Uploading a file into a post has always parented that attachment to the post. Selecting an existing, unattached file from a picker did not, so the same image could end up attached or unattached depending on how it reached the block. This makes selection match upload.

The attach fires from the two imperative select callbacks that already invalidate the attachment cache -- `MediaUpload`'s `onSelect`/`onUpdate` for the classic Backbone modal, and the DataViews modal's select action. Nothing filters or wraps `editor.MediaUpload`: that filter returns a component plugins subclass, so wrapping it would change what they extend.

Only an empty parent is ever filled. Media already attached to another post is left alone, as is media whose payload doesn't report a parent at all -- a missing key means "unknown", not "unattached", and collapsing the two would silently reparent another post's attachments.

The post ID comes from `wp.media.view.settings.post.id`, which `wp_enqueue_media()` populates from `edit-form-blocks.php` and which is also what the classic modal's uploader parents uploads to. It is left at its `0` default everywhere else, so this is inert in the site editor.

That global is the only post context `@wordpress/media-utils` can reach -- it depends on neither `editor` nor `block-editor`. So this cannot see post status, capabilities, or post type, and correspondingly has no publish-only gate, no permission gate, and no media-type gate. Restoring any of those would mean inverting control so the editor registers the attach handler through media-utils' private APIs, as it already does for `MediaUploadModal`. -->

## What?

One potential way to fix:

* #66663 and
* #81491

When selecting an existing image via the media library modal (either the existing one or the new experimental modal) _attach_ the image to the current post if it is not already attached to another post.

This brings parity to the block editor as this behaviour already existed for the classic editor.

## Why?

As described in #66663 and raised during testing of the dynamic gallery block (#81491) it can be confusing to a user if they add an image to a post or page from the media library and it then doesn't appear to be attached to the post or page they're working with.

The approach in this PR is just one way to achieve it — the idea is to attach the media item _when the user selects it_ and to attach silently, that is without it being covered by undo/redo.

In #66663 we discussed ideas of whether this should happen on the server at publish/save time or client-side at the selection stage. The implementation in this PR follows what the classic editor does as described in https://github.com/WordPress/gutenberg/issues/66663#issuecomment-3153710155.

## How?

* Add an `attachMediaToCurrentPost` utility function to media-utils
* Call this from both media library modals when they perform selection/update actions

## Testing Instructions

* Open up the media library directly in wp-admin
* Upload some media here so that the media is uploaded and is not attached to anything
* If you want to double-check, you can use the list view of the media library to see the Uploaded to column is empty (Unattached) for these items
* Then, open a post or page (or create a new one)
* Add an Image block
* Select the image you uploaded
* Add a Gallery block and select the "Use attached images" option to dynamically show images attached to the current post
* You should see that the block displays the image you selected for the post

If you'd like, you can also verify that if you selected an image that's already attached to another post/page it does _not_ get reparented.

## Screenshots or screencast <!-- if applicable -->

This video demonstrates the "happy path" of uploading images to the media library and then selecting them within a post, and for them to then be displayed by the dynamic mode of the Gallery block.

https://github.com/user-attachments/assets/bcdd727d-73f0-4f13-bd53-998aa2fb65ab

## Use of AI Tools

Claude Code (Opus 5)