### PR TITLE
Patterns explorer: Refactor the category sidebar to use Tabs

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Patterns explorer: Refactor the category sidebar to use `Tabs`.
 -   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
 
 ### Bug Fixes

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Patterns explorer: Refactor the category sidebar to use `Tabs`.
+-   Patterns explorer: Refactor the category sidebar to use `Tabs` ([#81807](https://github.com/WordPress/gutenberg/pull/81807)).
 -   Show separate horizontal and vertical block spacing controls in the block inspector only for Flex and Grid layouts, while retaining axial gap support in Global Styles. Responsive Grid column calculations use the horizontal gap, while Flow and Constrained layouts use the vertical gap when receiving an axial value ([#81476](https://github.com/WordPress/gutenberg/pull/81476)).
 
 ### Bug Fixes

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
@@ -1,4 +1,5 @@
 import { Modal } from '@wordpress/components';
+import { Tabs } from '@wordpress/ui';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PatternExplorerSidebar from './pattern-explorer-sidebar';
@@ -14,22 +15,34 @@ function PatternsExplorer( { initialCategory, rootClientId, onModalClose } ) {
 	const patternCategories = usePatternCategories( rootClientId );
 
 	return (
-		<div className="block-editor-block-patterns-explorer">
+		<Tabs.Root
+			className="block-editor-block-patterns-explorer"
+			orientation="vertical"
+			value={ selectedCategory }
+			onValueChange={ setSelectedCategory }
+		>
 			<PatternExplorerSidebar
-				selectedCategory={ selectedCategory }
 				patternCategories={ patternCategories }
-				onClickCategory={ setSelectedCategory }
 				searchValue={ searchValue }
 				setSearchValue={ setSearchValue }
 			/>
-			<PatternList
-				searchValue={ searchValue }
-				selectedCategory={ selectedCategory }
-				patternCategories={ patternCategories }
-				rootClientId={ rootClientId }
-				onModalClose={ onModalClose }
-			/>
-		</div>
+			{ patternCategories.map( ( { name } ) => (
+				<Tabs.Panel
+					key={ name }
+					value={ name }
+					tabIndex={ -1 }
+					className="block-editor-block-patterns-explorer__panel"
+				>
+					<PatternList
+						searchValue={ searchValue }
+						selectedCategory={ name }
+						patternCategories={ patternCategories }
+						rootClientId={ rootClientId }
+						onModalClose={ onModalClose }
+					/>
+				</Tabs.Panel>
+			) ) }
+		</Tabs.Root>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-explorer-sidebar.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-explorer-sidebar.js
@@ -1,70 +1,32 @@
-import { Button, SearchControl } from '@wordpress/components';
+import { SearchControl } from '@wordpress/components';
+import { Stack, Tabs } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 
-function PatternCategoriesList( {
-	selectedCategory,
+function PatternExplorerSidebar( {
 	patternCategories,
-	onClickCategory,
+	searchValue,
+	setSearchValue,
 } ) {
-	const baseClassName = 'block-editor-block-patterns-explorer__sidebar';
 	return (
-		<div className={ `${ baseClassName }__categories-list` }>
-			{ patternCategories.map( ( { name, label } ) => {
-				return (
-					<Button
-						__next40pxDefaultSize
-						key={ name }
-						label={ label }
-						className={ `${ baseClassName }__categories-list__item` }
-						isPressed={ selectedCategory === name }
-						onClick={ () => {
-							onClickCategory( name );
-						} }
-					>
-						{ label }
-					</Button>
-				);
-			} ) }
-		</div>
-	);
-}
-
-function PatternsExplorerSearch( { searchValue, setSearchValue } ) {
-	const baseClassName = 'block-editor-block-patterns-explorer__search';
-	return (
-		<div className={ baseClassName }>
+		<Stack
+			direction="column"
+			gap="lg"
+			className="block-editor-block-patterns-explorer__sidebar"
+		>
 			<SearchControl
 				onChange={ setSearchValue }
 				value={ searchValue }
 				label={ __( 'Search' ) }
 				placeholder={ __( 'Search' ) }
 			/>
-		</div>
-	);
-}
-
-function PatternExplorerSidebar( {
-	selectedCategory,
-	patternCategories,
-	onClickCategory,
-	searchValue,
-	setSearchValue,
-} ) {
-	const baseClassName = 'block-editor-block-patterns-explorer__sidebar';
-	return (
-		<div className={ baseClassName }>
-			<PatternsExplorerSearch
-				searchValue={ searchValue }
-				setSearchValue={ setSearchValue }
-			/>
-			{ ! searchValue && (
-				<PatternCategoriesList
-					selectedCategory={ selectedCategory }
-					patternCategories={ patternCategories }
-					onClickCategory={ onClickCategory }
-				/>
-			) }
-		</div>
+			<Tabs.List>
+				{ patternCategories.map( ( { name, label } ) => (
+					<Tabs.Tab key={ name } value={ name }>
+						{ label }
+					</Tabs.Tab>
+				) ) }
+			</Tabs.List>
+		</Stack>
 	);
 }
 

--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
@@ -1,12 +1,11 @@
 import { useMemo, useEffect, useRef, useState } from '@wordpress/element';
-import { _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDebounce } from '@wordpress/compose';
-import { __experimentalHeading as Heading } from '@wordpress/components';
+import { Text } from '@wordpress/ui';
 import { speak } from '@wordpress/a11y';
 import BlockPatternsList from '../../block-patterns-list';
 import useInsertionPoint from '../hooks/use-insertion-point';
 import usePatternsState from '../hooks/use-patterns-state';
-import InserterListbox from '../../inserter-listbox';
 import { searchItems } from '../search-items';
 import BlockPatternsPaging from '../../block-patterns-paging';
 import usePatternsPaging from '../hooks/use-patterns-paging';
@@ -16,30 +15,6 @@ import {
 	myPatternsCategory,
 	starterPatternsCategory,
 } from '../block-patterns-tab/utils';
-
-function PatternsListHeader( { filterValue, filteredBlockPatternsLength } ) {
-	if ( ! filterValue ) {
-		return null;
-	}
-
-	return (
-		<Heading
-			level={ 2 }
-			lineHeight="48px"
-			className="block-editor-block-patterns-explorer__search-results-count"
-		>
-			{ sprintf(
-				/* translators: %d: number of patterns. */
-				_n(
-					'%d pattern found',
-					'%d patterns found',
-					filteredBlockPatternsLength
-				),
-				filteredBlockPatternsLength
-			) }
-		</Heading>
-	);
-}
 
 function PatternList( {
 	searchValue,
@@ -143,26 +118,26 @@ function PatternList( {
 			className="block-editor-block-patterns-explorer__list"
 			ref={ container }
 		>
-			<PatternsListHeader
-				filterValue={ searchValue }
-				filteredBlockPatternsLength={ filteredBlockPatterns.length }
-			/>
-
-			<InserterListbox>
-				{ hasItems && (
-					<>
-						<BlockPatternsList
-							blockPatterns={ pagingProps.categoryPatterns }
-							onClickPattern={ ( pattern, blocks ) => {
-								onClickPattern( pattern, blocks );
-								onModalClose();
-							} }
-							isDraggable={ false }
-						/>
-						<BlockPatternsPaging { ...pagingProps } />
-					</>
-				) }
-			</InserterListbox>
+			{ hasItems ? (
+				<>
+					<BlockPatternsList
+						blockPatterns={ pagingProps.categoryPatterns }
+						onClickPattern={ ( pattern, blocks ) => {
+							onClickPattern( pattern, blocks );
+							onModalClose();
+						} }
+						isDraggable={ false }
+					/>
+					<BlockPatternsPaging { ...pagingProps } />
+				</>
+			) : (
+				<Text
+					render={ <p /> }
+					className="block-editor-block-patterns-explorer__no-results"
+				>
+					{ __( 'No results found.' ) }
+				</Text>
+			) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -392,66 +392,62 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-block-patterns-explorer {
-	&__sidebar {
+.block-editor-block-patterns-explorer__sidebar {
+	padding-bottom: $grid-unit-30;
+
+	@include break-medium() {
 		position: absolute;
 		top: $header-height + $grid-unit-10;
 		left: 0;
 		bottom: 0;
 		width: $sidebar-width;
-		padding: $grid-unit-30 $grid-unit-30 $grid-unit-30;
+		padding: $grid-unit-30;
 		overflow-x: visible;
 		overflow-y: auto;
+	}
+}
 
-		&__categories-list__item {
-			display: block;
-			width: 100%;
-			height: 48px;
-			text-align: left;
-		}
+.block-editor-block-patterns-explorer__panel {
+	@include break-medium() {
+		margin-inline-start: $sidebar-width;
+	}
+}
+
+.block-editor-block-patterns-explorer__no-results {
+	padding: $grid-unit-40;
+	text-align: center;
+}
+
+.block-editor-block-patterns-explorer__list {
+	padding: $grid-unit-30 0 $grid-unit-40;
+
+	.block-editor-patterns__sync-status-filter .components-input-control__container {
+		width: 380px;
+	}
+}
+
+.block-editor-block-patterns-explorer .block-editor-block-patterns-list {
+	display: grid;
+	grid-gap: $grid-unit-40;
+	grid-template-columns: repeat(1, 1fr);
+	margin-bottom: $grid-unit-20;
+
+	@include break-xlarge() {
+		grid-template-columns: repeat(2, 1fr);
 	}
 
-	&__search {
-		margin-bottom: $grid-unit-40;
+	@include break-huge() {
+		grid-template-columns: repeat(3, 1fr);
 	}
 
-	&__search-results-count {
-		padding-bottom: $grid-unit-40;
+	.block-editor-block-patterns-list__list-item {
+		min-height: 240px;
 	}
 
-	&__list {
-		margin-left: $sidebar-width;
-		padding: $grid-unit-30 0 $grid-unit-40;
-		.block-editor-patterns__sync-status-filter {
-			.components-input-control__container {
-				width: 380px;
-			}
-		}
-	}
-
-	.block-editor-block-patterns-list {
-		display: grid;
-		grid-gap: $grid-unit-40;
-		grid-template-columns: repeat(1, 1fr);
-		margin-bottom: $grid-unit-20;
-
-		@include break-xlarge() {
-			grid-template-columns: repeat(2, 1fr);
-		}
-
-		@include break-huge() {
-			grid-template-columns: repeat(3, 1fr);
-		}
-
-		.block-editor-block-patterns-list__list-item {
-			min-height: 240px;
-		}
-
-		.block-editor-inserter__media-list__list-item {
-			height: inherit;
-			min-height: 100px;
-			max-height: 800px;
-		}
+	.block-editor-inserter__media-list__list-item {
+		height: inherit;
+		min-height: 100px;
+		max-height: 800px;
 	}
 }
 

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -190,11 +190,6 @@
 			"count": 2
 		}
 	},
-	"packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 5


### PR DESCRIPTION
## What?

Refactors the patterns explorer modal to build its category sidebar with `ui/Tabs`.

## Why?

- We should avoid custom implementations and build UI from the design system's existing components wherever possible.
- The same layout is already implemented with `Tabs` in the icon picker modal and the Preferences modal.

## How?

A straightforward `Tabs` refactor, with two notable points. Both match what the icon picker modal already does.

- The visual `'%d patterns found'` message is removed.
- Keyword filtering now works within each category. Previously the category list was hidden while searching, so the search was silently scoped to whichever category happened to be selected.

## Testing Instructions

1. Open the inserter, go to the Patterns tab, and click "Explore all patterns".
2. Switch between categories in the sidebar and confirm the pattern list updates.
3. Type a keyword and confirm the sidebar stays visible and results are filtered within the selected category.
4. Switch categories while the search field has a value, and confirm the search applies to the newly selected category.

### Testing Instructions for Keyboard

The category buttons are now a single tab stop, and the Up/Down arrow keys move between them.

## Screenshots or screencast

| Before | After |
|--------|--------|
| <img width="1239" height="867" alt="image" src="https://github.com/user-attachments/assets/6c82e97d-c195-48e4-ac0f-caa5cd5eb81b" /> | <img width="1231" height="859" alt="image" src="https://github.com/user-attachments/assets/ee3b9d16-ecd3-4d07-982f-f99f6930f25b" />

The text indicating the number of patterns found has been removed, and searching by category is now possible.

| Before | After |
|--------|--------|
| <img width="1228" height="874" alt="image" src="https://github.com/user-attachments/assets/33b29a27-ec88-4ba8-917c-1e09da20c016" /> | <img width="1232" height="859" alt="image" src="https://github.com/user-attachments/assets/eaf26171-89ac-477c-a2c4-ab12dec5a2f7" /> |

When no pattern is found:

| Before | After |
|--------|--------|
| <img width="1236" height="864" alt="image" src="https://github.com/user-attachments/assets/09d7119a-5819-4e9d-9402-ac6abd6efaa8" /> | <img width="1237" height="863" alt="image" src="https://github.com/user-attachments/assets/fd93d29a-22a1-43f6-bccb-1aa2c45b7d70" /> |

## Use of AI Tools

Claude Code was used to draft this pull request description and the commit message.

