### PR TITLE
Fields: migrate last remaining JS file to TS

### DIFF
--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81515](https://github.com/WordPress/gutenberg/pull/81515))
 -   `parent`: Narrow the combobox `onChange` handler parameter to `string | null`, following the upstream `ComboboxControl` type fix that removed the accidental `undefined` from the callback type. ([#81568](https://github.com/WordPress/gutenberg/pull/81568))
+-   `CreateTemplatePartModal`: Migrate the `utils` helpers to TypeScript. ([#81808](https://github.com/WordPress/gutenberg/pull/81808))
 
 ## 0.45.0 (2026-08-12)
 

--- a/packages/fields/src/components/create-template-part-modal/utils.ts
+++ b/packages/fields/src/components/create-template-part-modal/utils.ts
@@ -1,31 +1,34 @@
 import { paramCase as kebabCase } from 'change-case';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-export const useExistingTemplateParts = () => {
-	return (
-		useSelect(
-			( select ) =>
-				select( coreStore ).getEntityRecords(
-					'postType',
-					'wp_template_part',
-					{
-						per_page: -1,
-					}
-				),
-			[]
-		) ?? []
+import type { WpTemplatePart } from '@wordpress/core-data';
+
+const EMPTY_ARRAY: WpTemplatePart[] = [];
+
+export function useExistingTemplateParts(): WpTemplatePart[] {
+	return useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecords< WpTemplatePart >(
+				'postType',
+				'wp_template_part',
+				{ per_page: -1 }
+			) ?? EMPTY_ARRAY,
+		[]
 	);
-};
+}
 
 /**
  * Return a unique template part title based on
  * the given title and existing template parts.
  *
- * @param {string} title         The original template part title.
- * @param {Object} templateParts The array of template part entities.
- * @return {string} A unique template part title.
+ * @param title         The original template part title.
+ * @param templateParts The array of template part entities.
+ * @return A unique template part title.
  */
-export const getUniqueTemplatePartTitle = ( title, templateParts ) => {
+export function getUniqueTemplatePartTitle(
+	title: string,
+	templateParts: WpTemplatePart[]
+): string {
 	const lowercaseTitle = title.toLowerCase();
 	const existingTitles = templateParts.map( ( templatePart ) =>
 		templatePart.title.rendered.toLowerCase()
@@ -41,16 +44,16 @@ export const getUniqueTemplatePartTitle = ( title, templateParts ) => {
 	}
 
 	return `${ title } ${ suffix }`;
-};
+}
 
 /**
  * Get a valid slug for a template part.
  * Currently template parts only allow latin chars.
  * The fallback slug will receive suffix by default.
  *
- * @param {string} title The template part title.
- * @return {string} A valid template part slug.
+ * @param title The template part title.
+ * @return A valid template part slug.
  */
-export const getCleanTemplatePartSlug = ( title ) => {
+export function getCleanTemplatePartSlug( title: string ): string {
 	return kebabCase( title ).replace( /[^\w-]+/g, '' ) || 'wp-custom-part';
-};
+}


### PR DESCRIPTION
The Fields packages has only one file that is JavaScript, everything else is TypeScript. This PR migrates that only file. It's quite straightforward.

The recent discussions about recommending TypeScript by default inspired me to take a look at the JS/TS ratio in various packages and this one stood out.
