### PR TITLE
Core Data: Validate the parsed-blocks cache against registered block types

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#81809](https://github.com/WordPress/gutenberg/pull/81809)).
 
 ### Internal
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 ### Internal
 
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81514](https://github.com/WordPress/gutenberg/pull/81514))

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -4,7 +4,7 @@ import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import { STORE_NAME } from '../name';
 import useEntityId from './use-entity-id';
 import { updateFootnotesFromMeta } from '../footnotes';
-import { parsedBlocksCache, getCacheKey } from '../parsed-blocks-cache';
+import { getCachedBlocks, setCachedBlocks } from '../parsed-blocks-cache';
 
 const EMPTY_ARRAY = [];
 
@@ -60,17 +60,15 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			return EMPTY_ARRAY;
 		}
 
-		// Cache parsed blocks by entity identity. Store the content
-		// alongside the blocks so we can validate it hasn't changed.
-		const cacheKey = getCacheKey( kind, name, id );
-		const cached = parsedBlocksCache.get( cacheKey );
-		let _blocks;
+		// The cache validates the content and the registered block types, so
+		// an entry parsed from other content — or before the block types were
+		// registered, as happens when a record resolves while the editor's
+		// assets are still loading — is re-parsed instead of adopted.
+		let _blocks = getCachedBlocks( kind, name, id, content );
 
-		if ( cached && cached.content === content ) {
-			_blocks = cached.blocks;
-		} else {
+		if ( ! _blocks ) {
 			_blocks = parse( content );
-			parsedBlocksCache.set( cacheKey, { content, blocks: _blocks } );
+			setCachedBlocks( kind, name, id, content, _blocks );
 		}
 
 		return _blocks;

--- a/packages/core-data/src/parsed-blocks-cache.js
+++ b/packages/core-data/src/parsed-blocks-cache.js
@@ -1,12 +1,79 @@
+import { select } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
+
 /**
  * Shared cache of blocks parsed from an entity's `content` string, keyed by
  * `kind:name:id`. Populated both eagerly by the `getEntityRecord` resolver
  * (when the sync manager parses content for transient edits) and lazily by
- * `useEntityBlockEditor`. The stored `content` string acts as a validator so
- * stale entries are discarded when the underlying record changes.
+ * `useEntityBlockEditor`.
+ *
+ * A parse result is a function of the content and of the block types
+ * registered at the time: a block whose type is not registered yet is
+ * dropped or replaced, not kept. Both are therefore stored with the entry,
+ * and a lookup only hits while both still match — the content string, and,
+ * by identity, the list of registered block types, which the blocks store
+ * memoizes until a type is added or removed. A record resolved before the
+ * editor's assets have registered the block types — a resolver can run that
+ * early — caches whatever parsing without them produced, and the editor
+ * must re-parse rather than adopt it.
  */
-export const parsedBlocksCache = new Map();
+const parsedBlocksCache = new Map();
 
-export function getCacheKey( kind, name, id ) {
+function getCacheKey( kind, name, id ) {
 	return `${ kind }:${ name }:${ id }`;
+}
+
+/**
+ * Returns the registered block types, from the registry `parse` reads.
+ *
+ * Block types are registered on the default registry, so the validator is
+ * read from there rather than from the registry hosting the entities.
+ *
+ * @return {Array} Registered block types.
+ */
+function getBlockTypesValidator() {
+	return select( blocksStore ).getBlockTypes();
+}
+
+/**
+ * Returns the blocks cached for an entity, if they were parsed from the
+ * given content with the block types registered right now.
+ *
+ * @param {string}        kind    Entity kind.
+ * @param {string}        name    Entity name.
+ * @param {string|number} id      Record ID.
+ * @param {string}        content The record's current `content` string.
+ *
+ * @return {Array|undefined} The cached blocks, or undefined without a valid
+ *                           entry.
+ */
+export function getCachedBlocks( kind, name, id, content ) {
+	const cached = parsedBlocksCache.get( getCacheKey( kind, name, id ) );
+
+	if (
+		cached &&
+		cached.content === content &&
+		cached.blockTypes === getBlockTypesValidator()
+	) {
+		return cached.blocks;
+	}
+}
+
+/**
+ * Caches the blocks parsed for an entity, remembering the content and the
+ * registered block types they were parsed with.
+ *
+ * @param {string}        kind    Entity kind.
+ * @param {string}        name    Entity name.
+ * @param {string|number} id      Record ID.
+ * @param {string}        content The `content` string the blocks were parsed
+ *                                from.
+ * @param {Array}         blocks  The parsed blocks.
+ */
+export function setCachedBlocks( kind, name, id, content, blocks ) {
+	parsedBlocksCache.set( getCacheKey( kind, name, id ), {
+		content,
+		blocks,
+		blockTypes: getBlockTypesValidator(),
+	} );
 }

--- a/packages/core-data/src/parsed-blocks-cache.js
+++ b/packages/core-data/src/parsed-blocks-cache.js
@@ -2,22 +2,25 @@ import { select } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 
 /**
- * Shared cache of blocks parsed from an entity's `content` string, keyed by
- * `kind:name:id`. Populated both eagerly by the `getEntityRecord` resolver
- * (when the sync manager parses content for transient edits) and lazily by
- * `useEntityBlockEditor`.
+ * Shared cache of blocks parsed from an entity's `content` string. Populated
+ * both eagerly by the `getEntityRecord` resolver (when the sync manager
+ * parses content for transient edits) and lazily by `useEntityBlockEditor`.
  *
  * A parse result is a function of the content and of the block types
  * registered at the time: a block whose type is not registered yet is
- * dropped or replaced, not kept. Both are therefore stored with the entry,
- * and a lookup only hits while both still match — the content string, and,
- * by identity, the list of registered block types, which the blocks store
- * memoizes until a type is added or removed. A record resolved before the
- * editor's assets have registered the block types — a resolver can run that
- * early — caches whatever parsing without them produced, and the editor
- * must re-parse rather than adopt it.
+ * dropped or replaced, not kept. The cache is therefore two levels — the
+ * outer one keyed by the registered block types list, the inner one by
+ * `kind:name:id`, holding the blocks with the `content` string they were
+ * parsed from as the remaining validator. A record resolved before the
+ * editor's assets have registered the block types — a resolver can run
+ * that early — lands under a list that registration then replaces.
+ *
+ * The outer level is a WeakMap keyed by the list itself: the blocks store
+ * memoizes it until a type is added or removed, then produces a new one and
+ * drops the old, taking every entry parsed against it with it. Nothing is
+ * invalidated by hand and nothing stale is retained.
  */
-const parsedBlocksCache = new Map();
+const caches = new WeakMap();
 
 function getCacheKey( kind, name, id ) {
 	return `${ kind }:${ name }:${ id }`;
@@ -26,12 +29,13 @@ function getCacheKey( kind, name, id ) {
 /**
  * Returns the registered block types, from the registry `parse` reads.
  *
- * Block types are registered on the default registry, so the validator is
- * read from there rather than from the registry hosting the entities.
+ * Block types are registered on the default registry, so the cache is
+ * partitioned by that registry's list rather than one from the registry
+ * hosting the entities.
  *
  * @return {Array} Registered block types.
  */
-function getBlockTypesValidator() {
+function getBlockTypes() {
 	return select( blocksStore ).getBlockTypes();
 }
 
@@ -48,20 +52,18 @@ function getBlockTypesValidator() {
  *                           entry.
  */
 export function getCachedBlocks( kind, name, id, content ) {
-	const cached = parsedBlocksCache.get( getCacheKey( kind, name, id ) );
+	const cached = caches
+		.get( getBlockTypes() )
+		?.get( getCacheKey( kind, name, id ) );
 
-	if (
-		cached &&
-		cached.content === content &&
-		cached.blockTypes === getBlockTypesValidator()
-	) {
+	if ( cached && cached.content === content ) {
 		return cached.blocks;
 	}
 }
 
 /**
- * Caches the blocks parsed for an entity, remembering the content and the
- * registered block types they were parsed with.
+ * Caches the blocks parsed for an entity, under the block types they were
+ * parsed with.
  *
  * @param {string}        kind    Entity kind.
  * @param {string}        name    Entity name.
@@ -71,9 +73,13 @@ export function getCachedBlocks( kind, name, id, content ) {
  * @param {Array}         blocks  The parsed blocks.
  */
 export function setCachedBlocks( kind, name, id, content, blocks ) {
-	parsedBlocksCache.set( getCacheKey( kind, name, id ), {
-		content,
-		blocks,
-		blockTypes: getBlockTypesValidator(),
-	} );
+	const blockTypes = getBlockTypes();
+	let cache = caches.get( blockTypes );
+
+	if ( ! cache ) {
+		cache = new Map();
+		caches.set( blockTypes, cache );
+	}
+
+	cache.set( getCacheKey( kind, name, id ), { content, blocks } );
 }

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -18,7 +18,7 @@ import {
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
-import { parsedBlocksCache, getCacheKey } from './parsed-blocks-cache';
+import { setCachedBlocks } from './parsed-blocks-cache';
 
 /**
  * Requests authors from the REST API.
@@ -172,15 +172,20 @@ export const getEntityRecord =
 					} );
 
 				// Share the parsed blocks with `useEntityBlockEditor` so the
-				// editor doesn't re-parse the same `content` string.
+				// editor doesn't re-parse the same `content` string. The cache
+				// remembers which block types the parse ran against, so an
+				// entry computed before they register is discarded, not served.
 				if (
 					recordWithTransients.blocks &&
 					typeof recordWithTransients.content?.raw === 'string'
 				) {
-					parsedBlocksCache.set( getCacheKey( kind, name, key ), {
-						content: recordWithTransients.content.raw,
-						blocks: recordWithTransients.blocks,
-					} );
+					setCachedBlocks(
+						kind,
+						name,
+						key,
+						recordWithTransients.content.raw,
+						recordWithTransients.blocks
+					);
 				}
 
 				const syncManager =
@@ -189,6 +194,11 @@ export const getEntityRecord =
 						: getSyncManager();
 
 				// Load the entity record for syncing. Do not await promise.
+				// NOTE: when this resolver runs before block types register,
+				// `recordWithTransients.blocks` was parsed as empty. The cache
+				// above discards such an entry; the sync manager receives it
+				// as-is, and seeding a collaborative document from it is an
+				// open problem of the collaboration path.
 				void syncManager?.load(
 					entityConfig.syncConfig,
 					objectType,

--- a/packages/core-data/src/test/parsed-blocks-cache.js
+++ b/packages/core-data/src/test/parsed-blocks-cache.js
@@ -1,0 +1,43 @@
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { getCachedBlocks, setCachedBlocks } from '../parsed-blocks-cache';
+
+describe( 'parsed blocks cache', () => {
+	const content = '<!-- wp:test/block /-->';
+	const blocks = [];
+
+	it( 'returns an entry parsed from the same content with the same block types', () => {
+		setCachedBlocks( 'postType', 'page', 1, content, blocks );
+
+		expect( getCachedBlocks( 'postType', 'page', 1, content ) ).toBe(
+			blocks
+		);
+	} );
+
+	it( 'discards an entry when the content changed', () => {
+		setCachedBlocks( 'postType', 'page', 2, content, blocks );
+
+		expect(
+			getCachedBlocks( 'postType', 'page', 2, '<!-- wp:test/other /-->' )
+		).toBeUndefined();
+	} );
+
+	it( 'discards an entry once block types register, so blocks parsed too early are not served', () => {
+		// Parsed and cached while `test/block` was not registered — as happens
+		// when a record resolves before the editor's assets have loaded.
+		setCachedBlocks( 'postType', 'page', 3, content, blocks );
+
+		registerBlockType( 'test/block', {
+			apiVersion: 3,
+			title: 'Test Block',
+			category: 'text',
+		} );
+
+		try {
+			expect(
+				getCachedBlocks( 'postType', 'page', 3, content )
+			).toBeUndefined();
+		} finally {
+			unregisterBlockType( 'test/block' );
+		}
+	} );
+} );


### PR DESCRIPTION
## What?

Makes the shared parsed-blocks cache validate the registered block types as well as the content, so a record resolved before block types register is re-parsed instead of served as an empty block list.

Fixes the extensible site editor rendering a saved page as an empty canvas after a refresh — a state whose first save erases the post's content.

## Why?

Three pieces, each reasonable alone:

1. **Parsing without registered block types silently drops blocks.** In `parseRawBlock`, a block with no registered type and no `core/missing` fallback (the fallback itself is registered by the block library) is omitted — `parse( content )` on a full page returns `[]`.
2. **The `getEntityRecord` resolver parses at resolution time** (#72145, for the sync manager's `blocks` transient), and **shares the result with `useEntityBlockEditor` through a cache validated by content string only** (#78026, so the editor doesn't re-parse the same string).
3. **The extensible site editor registers block types lazily** — they arrive with the editor's assets — while its post-edit route prefetches the record in `beforeLoad`, as early as possible, deliberately.

The prefetch wins the race, the resolver parses `[]` against an empty registry, and the cache serves it to the editor forever after — the content string still matches, and registration never invalidated it. The classic editors never lose this race because block types register in classic scripts before any application code runs, which is why the combination stayed invisible until now.

The severity is what makes this worth fixing at the cache rather than by re-ordering v2's loading: the editor persists via `content: ( { blocks } ) => __unstableSerializeAndClean( blocks )`, so the empty canvas is one edit-and-save away from writing `''` to the database. Any early resolution — a route loader, a list prefetch, a selector on the canvas — can poison the cache, so the cache has to tolerate early resolution rather than every call site having to avoid it.

## How?

A parse result is a function of the content **and** of the block types registered at the time. The cache now stores both and requires both to match on lookup. The block types are compared by identity: the blocks store memoizes `getBlockTypes()` until a type is added or removed, so the check is a pointer comparison that invalidates exactly when registration changes. They're read from the default registry deliberately — that is the registry `parse()` itself consults.

The Map moves behind `getCachedBlocks`/`setCachedBlocks` helpers so the validation logic exists once, and both writers — the resolver and the hook — go through them.

Scope notes, honestly:

- A **mounted** canvas still doesn't live-re-parse when a third-party block registers late; nothing re-runs the parse without a remount or content change. Unchanged from today — this fix targets parses that happen before the editor mounts.
- When collaboration is on, the sync manager still receives the too-early parse as its document seed. The cache discards that entry, but seeding a CRDT from it is an open problem of the collaboration path — now marked with a NOTE at the `syncManager.load()` call.
- The wasted empty-registry parse still runs; the fix makes it harmless rather than removing it. Skipping the transient computation when collaboration is off would be a reasonable follow-up.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor**.
2. Open a page at **Appearance → Design → Pages**, edit it in the canvas, save.
3. Hard-refresh the editor URL. The content should render. On `trunk`, the canvas renders empty — and an edit plus save from that state erases the page's content.
4. Confirm the store agrees:
   ```js
   const r = wp.data.select( 'core' ).getEditedEntityRecord( 'postType', 'page', ID );
   [ r.blocks.length, wp.blocks.parse( r.content ).length ]
   ```
   Both nonzero and equal. On `trunk` the first is `0`.
5. Confirm the classic post editor (`post.php`) is unaffected.
6. Unit tests:
   ```bash
   npm run test:unit -- packages/core-data/src/test/parsed-blocks-cache.js
   ```

## Use of AI Tools

Authored with Claude Code (Claude Fable 5), including this description; reviewed by the PR author.

Verified: the three unit tests pass (including one reproducing the exact failure: cache an entry, register a block type, entry refused); lint clean; `tsc --build packages/core-data --force` exits 0; the adjacent `entity-provider` and `resolvers` suites pass. The bug itself was reproduced in the browser before the fix. Not verified by me: the browser steps above against the fixed build.
