### PR TITLE
Add Post Edit Link variation and binding

### DIFF
--- a/lib/compat/wordpress-7.1/block-bindings.php
+++ b/lib/compat/wordpress-7.1/block-bindings.php
@@ -99,3 +99,80 @@ function gutenberg_restore_list_item_inner_blocks_after_binding( $block_content,
 	return substr( $block_content, 0, $closer_position ) . $inner_blocks_html . substr( $block_content, $closer_position );
 }
 add_filter( 'render_block', 'gutenberg_restore_list_item_inner_blocks_after_binding', 10, 3 );
+
+/**
+ * Callback to retrieve the post edit URL for the block binding.
+ *
+ * @since 7.2.0
+ *
+ * @param array    $source_args    Array containing source arguments.
+ * @param WP_Block $block_instance The block instance.
+ * @return string|null The post edit URL, or null if the user cannot edit.
+ */
+function gutenberg_block_bindings_post_edit_url_callback( $source_args, $block_instance ) {
+	$post_id = $block_instance->context['postId'] ?? get_the_ID();
+
+	if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+		return null;
+	}
+
+	return get_edit_post_link( $post_id, 'raw' );
+}
+
+/**
+ * Registers the post edit URL block binding source.
+ *
+ * @since 7.2.0
+ */
+function gutenberg_register_block_bindings_post_edit_url() {
+	register_block_bindings_source(
+		'core/post-edit-url',
+		array(
+			'label'              => _x( 'Post Edit URL', 'block bindings source', 'gutenberg' ),
+			'uses_context'       => array( 'postId' ),
+			'get_value_callback' => 'gutenberg_block_bindings_post_edit_url_callback',
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_block_bindings_post_edit_url' );
+
+/**
+ * Conditionally hides blocks bound to the post edit url if the user lacks capabilities.
+ *
+ * The Block Bindings API falls back to static markup if the binding callback returns null.
+ * This filter is load bearing, it ensures unauthorized users don't see a dead link
+ * or an empty button shell on the frontend.
+ *
+ * @since 7.2.0
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The parsed block.
+ * @param WP_Block $instance      The block instance.
+ * @return string The block content, or empty string if unauthorized.
+ */
+function gutenberg_hide_post_edit_url_bound_blocks( $block_content, $block, $instance ) {
+	$post_id = $instance->context['postId'] ?? get_the_ID();
+
+	$bindings = $block['attrs']['metadata']['bindings'] ?? array();
+	if ( is_array( $bindings ) ) {
+		foreach ( $bindings as $binding ) {
+			if ( is_array( $binding ) && isset( $binding['source'] ) && 'core/post-edit-url' === $binding['source'] ) {
+				if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+					return '';
+				}
+			}
+		}
+	}
+
+	if ( 'core/buttons' === $block['blockName'] ) {
+		$classes = $block['attrs']['className'] ?? '';
+		if ( str_contains( $classes, 'wp-block-post-edit-link-wrapper' ) ) {
+			if ( ! preg_match( '/\bwp-block-button\b/', $block_content ) ) {
+				return '';
+			}
+		}
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_hide_post_edit_url_bound_blocks', 10, 3 );

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -13,6 +13,7 @@ import transforms from './transforms';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -39,6 +40,7 @@ export const settings = {
 		],
 	},
 	deprecated,
+	variations,
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/buttons/variations.js
+++ b/packages/block-library/src/buttons/variations.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'post-edit-link',
+		title: __( 'Post Edit Link' ),
+		description: __(
+			'Displays a link to edit the current post for users with permission.'
+		),
+		className: 'wp-block-post-edit-link-wrapper',
+		icon: pencil,
+		scope: [ 'inserter' ],
+		keywords: [ __( 'edit' ), __( 'edit post' ), __( 'edit link' ) ],
+		innerBlocks: [
+			[
+				'core/button',
+				{
+					text: __( 'Edit Post' ),
+					url: '#',
+					rel: 'nofollow',
+					metadata: {
+						bindings: {
+							url: {
+								source: 'core/post-edit-url',
+							},
+						},
+					},
+				},
+			],
+		],
+	},
+];
+
+export default variations;

--- a/phpunit/class-block-bindings-post-edit-url-test.php
+++ b/phpunit/class-block-bindings-post-edit-url-test.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Tests for the core/post-edit-url block binding source.
+ *
+ * @package Gutenberg
+ * @subpackage BlockBindings
+ */
+
+/**
+ * Test class for Block_Bindings_Post_Edit_Url.
+ */
+class Block_Bindings_Post_Edit_Url_Test extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Sets up the class environment before tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory The unit test factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$post_id       = $factory->post->create();
+	}
+
+	/**
+	 * Tears down the test environment after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper function to create a dummy WP_Block instance.
+	 *
+	 * @param array  $context    Block context.
+	 * @param string $block_name Block name.
+	 * @param array  $attrs      Block attributes.
+	 * @return WP_Block The dummy block instance.
+	 */
+	private function create_dummy_block_instance( $context = array(), $block_name = 'core/button', $attrs = array() ) {
+		$parsed_block            = array(
+			'blockName' => $block_name,
+			'attrs'     => $attrs,
+		);
+		$block_instance          = new WP_Block( $parsed_block );
+		$block_instance->context = $context;
+
+		return $block_instance;
+	}
+
+	/**
+	 * Tests that the binding returns a valid edit link for an authorized user.
+	 */
+	public function test_returns_link_for_authorized_user_with_context() {
+		wp_set_current_user( self::$admin_id );
+
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ) );
+		$result         = gutenberg_block_bindings_post_edit_url_callback( array(), $block_instance );
+		$expected       = get_edit_post_link( self::$post_id, 'raw' );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Tests that the binding returns null for an unauthorized user.
+	 */
+	public function test_returns_null_for_unauthorized_user_with_context() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ) );
+		$result         = gutenberg_block_bindings_post_edit_url_callback( array(), $block_instance );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests that the binding returns null for a logged out user.
+	 */
+	public function test_returns_null_for_logged_out_user() {
+		wp_set_current_user( 0 );
+
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ) );
+		$result         = gutenberg_block_bindings_post_edit_url_callback( array(), $block_instance );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests that the binding falls back to the global post ID when context is missing.
+	 */
+	public function test_returns_link_using_global_post_fallback() {
+		wp_set_current_user( self::$admin_id );
+
+		$this->go_to( get_permalink( self::$post_id ) );
+
+		$block_instance = $this->create_dummy_block_instance( array() );
+		$result         = gutenberg_block_bindings_post_edit_url_callback( array(), $block_instance );
+		$expected       = get_edit_post_link( self::$post_id, 'raw' );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Tests that the binding returns null when there is no post context available.
+	 */
+	public function test_returns_null_when_no_post_exists() {
+		wp_set_current_user( self::$admin_id );
+
+		// Navigate to a guaranteed 404 page so WP_Query correctly yields no global post,
+		// rather than home_url() which populates $post via the Latest Posts loop.
+		$this->go_to( '/?p=99999999' );
+
+		$block_instance = $this->create_dummy_block_instance( array() );
+		$result         = gutenberg_block_bindings_post_edit_url_callback( array(), $block_instance );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests that the render block filter allows the block for authorized users.
+	 */
+	public function test_render_block_keeps_authorized_bound_block() {
+		wp_set_current_user( self::$admin_id );
+
+		$attrs          = array(
+			'metadata' => array(
+				'bindings' => array(
+					'url' => array( 'source' => 'core/post-edit-url' ),
+				),
+			),
+		);
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ), 'core/button', $attrs );
+		$original_html  = '<div class="wp-block-button"><a href="...">Edit</a></div>';
+
+		$result = gutenberg_hide_post_edit_url_bound_blocks( $original_html, $block_instance->parsed_block, $block_instance );
+
+		$this->assertSame( $original_html, $result );
+	}
+
+	/**
+	 * Tests that the render block filter strips the block for unauthorized users.
+	 */
+	public function test_render_block_hides_unauthorized_bound_block() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$attrs          = array(
+			'metadata' => array(
+				'bindings' => array(
+					'url' => array( 'source' => 'core/post-edit-url' ),
+				),
+			),
+		);
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ), 'core/button', $attrs );
+		$original_html  = '<div class="wp-block-button"><a href="#">Edit</a></div>';
+
+		$result = gutenberg_hide_post_edit_url_bound_blocks( $original_html, $block_instance->parsed_block, $block_instance );
+
+		$this->assertSame( '', $result, 'Filter should return empty string for unauthorized user.' );
+	}
+
+	/**
+	 * Tests that the render block filter removes the wrapper if all buttons were stripped.
+	 */
+	public function test_render_block_removes_empty_buttons_wrapper() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$attrs          = array( 'className' => 'wp-block-post-edit-link-wrapper' );
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ), 'core/buttons', $attrs );
+
+		$empty_wrapper_html = '<div class="wp-block-buttons wp-block-post-edit-link-wrapper"></div>';
+
+		$result = gutenberg_hide_post_edit_url_bound_blocks( $empty_wrapper_html, $block_instance->parsed_block, $block_instance );
+
+		$this->assertSame( '', $result, 'Filter should strip the wrapper if it contains no buttons.' );
+	}
+
+	/**
+	 * Tests that the render block filter preserves the wrapper if it contains other buttons.
+	 */
+	public function test_render_block_keeps_buttons_wrapper_with_sibling() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$attrs          = array( 'className' => 'wp-block-post-edit-link-wrapper' );
+		$block_instance = $this->create_dummy_block_instance( array( 'postId' => self::$post_id ), 'core/buttons', $attrs );
+
+		$wrapper_with_sibling = '<div class="wp-block-buttons wp-block-post-edit-link-wrapper"><div class="wp-block-button"><a href="/about">Read More</a></div></div>';
+
+		$result = gutenberg_hide_post_edit_url_bound_blocks( $wrapper_with_sibling, $block_instance->parsed_block, $block_instance );
+
+		$this->assertSame( $wrapper_with_sibling, $result, 'Filter should preserve the wrapper if other buttons exist inside it.' );
+	}
+}

--- a/test/e2e/specs/editor/blocks/post-edit-link.spec.js
+++ b/test/e2e/specs/editor/blocks/post-edit-link.spec.js
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Post Edit Link variation', () => {
+	let subscriberUser;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		const uniqueSuffix = Date.now();
+		subscriberUser = await requestUtils.createUser( {
+			username: `sub_${ uniqueSuffix }`,
+			password: 'password123',
+			email: `sub_${ uniqueSuffix }@example.com`,
+			role: 'subscriber',
+		} );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should be discoverable in the slash inserter', async ( {
+		page,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.type( '/post edit link' );
+
+		await expect(
+			page.getByRole( 'option', { name: 'Post Edit Link' } )
+		).toBeVisible();
+	} );
+
+	test( 'should render for admins and disappear for logged out and unauthorized users', async ( {
+		editor,
+		page,
+		browser,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/buttons',
+			attributes: { className: 'wp-block-post-edit-link-wrapper' },
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						text: 'Edit Post',
+						url: '#',
+						rel: 'nofollow',
+						metadata: {
+							bindings: {
+								url: {
+									source: 'core/post-edit-url',
+								},
+							},
+						},
+					},
+				},
+			],
+		} );
+
+		await expect( editor.canvas.getByText( 'Edit Post' ) ).toBeVisible();
+
+		await editor.publishPost();
+		const postUrl = await page.evaluate( () => {
+			const postId = window.wp.data
+				.select( 'core/editor' )
+				.getCurrentPostId();
+			return `${ window.location.origin }/?p=${ postId }`;
+		} );
+
+		await page.goto( postUrl );
+		const adminButton = page.locator( '.wp-block-button__link', {
+			hasText: 'Edit Post',
+		} );
+		await expect( adminButton ).toBeVisible();
+		await expect( adminButton ).toHaveAttribute( 'href', /action=edit/ );
+
+		const loggedOutContext = await browser.newContext();
+		await loggedOutContext.clearCookies();
+		const loggedOutPage = await loggedOutContext.newPage();
+		await loggedOutPage.goto( postUrl );
+
+		await expect(
+			loggedOutPage.locator( '.wp-block-button__link', {
+				hasText: 'Edit Post',
+			} )
+		).toHaveCount( 0 );
+		await expect(
+			loggedOutPage.locator( '.wp-block-post-edit-link-wrapper' )
+		).toHaveCount( 0 );
+		await loggedOutContext.close();
+
+		const subscriberContext = await browser.newContext();
+		await subscriberContext.clearCookies();
+		const subscriberPage = await subscriberContext.newPage();
+
+		await subscriberPage.goto( '/wp-login.php' );
+		await subscriberPage
+			.locator( '#user_login' )
+			.fill( subscriberUser.username );
+		await subscriberPage.locator( '#user_pass' ).fill( 'password123' );
+		await subscriberPage.locator( '#wp-submit' ).click();
+
+		await subscriberPage.goto( postUrl );
+
+		await expect(
+			subscriberPage.locator( '.wp-block-button__link', {
+				hasText: 'Edit Post',
+			} )
+		).toHaveCount( 0 );
+		await expect(
+			subscriberPage.locator( '.wp-block-post-edit-link-wrapper' )
+		).toHaveCount( 0 );
+		await subscriberContext.close();
+	} );
+} );


### PR DESCRIPTION
# PROOF OF CONCEPT

## What?
Closes #71328

This PR implements the "Post Edit Link" feature without adding a new standalone block to the core library. It utilizes the Block Bindings API paired with the Block Variations API to deliver the functionality dynamically through the native Button block.

## Why?
As suggested in the issue thread, combining Block Bindings with Block Variations serves as the perfect compromise. Theme authors get 100% design control (using standard Button block styling), users can easily discover it via the inserter, and the core block registry remains slim. This POC demonstrates how resilient and clean this pattern can be.

## How?

-  Registers a new `core/post-edit-url` binding source in lib/compat/wordpress-7.1/block-bindings.php that dynamically fetches `get_edit_post_link( $post_id, 'raw' )`.
- Registers a `post-edit-link` variation on the `core/buttons` block.
- Includes full PHPUnit coverage for the binding contexts and the multi button wrapper cleanup logic, alongside a decoupled Playwright E2E suite that asserts the frontend auth matrix across Admin, Logged out, and Subscriber states.

## Testing Instructions

1. Log in as an Administrator and create a new Post.
2. Open the block inserter (or use the / slash command) and search for "Post Edit Link".
3. Insert the block. It will render as a standard Button block. You can change its colors, radius, and typography.
4. Publish the post and view it on the frontend. Click the button to verify it successfully redirects you back to the Gutenberg editor for that post.
5. Create a Query Loop block, insert the "Post Edit Link" inside the post template, and verify on the frontend that the URLs dynamically adapt to each respective post in the loop.
6. Open an incognito window (logged-out user) and view the frontend. Inspect the DOM to verify the button and its parent wrapper have been completely removed.
7. Log in as a Subscriber (lacking edit_post capabilities) and view the frontend. Verify the block is completely removed from the DOM.

## Screenshots or screencast <!-- if applicable -->

### Variation without context
https://github.com/user-attachments/assets/590c7b47-2240-4589-af63-acd7fdbe2be3

### Inside query loop context
https://github.com/user-attachments/assets/79ec1b9b-4815-470a-bbfa-7f17ba69ae14

### Logged out user
<img width="2934" height="1668" alt="image" src="https://github.com/user-attachments/assets/642842ac-7015-4545-be85-b25cc6c22d6b" />

## Use of AI Tools

Utilized AI tools to assist in scaffolding the Playwright E2E and the PHPUnit tests.
