### PR TITLE
TypeScript: Remove `emitDeclarationOnly` property from tsconfig dev config

### DIFF
--- a/tsconfig.dev.base.json
+++ b/tsconfig.dev.base.json
@@ -3,7 +3,6 @@
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
 		"noEmit": true,
-		"emitDeclarationOnly": false,
 		"checkJs": false,
 		"types": [ "jest" ]
 	},


### PR DESCRIPTION
## What?

Part of: https://github.com/WordPress/gutenberg/issues/81473
Related comment: https://github.com/WordPress/gutenberg/pull/81499#discussion_r3810636873

Removes the redundant `emitDeclarationOnly: false` override from `tsconfig.dev.base.json`.

## Why?

`noEmit: true` in the same `compilerOptions` block already suppresses all output, so the inherited `emitDeclarationOnly: true` from `tsconfig.base.json` can never take effect. The override is dead weight.

## Testing Instructions

1. `npm run typecheck` on this branch, then re-add the line and run it again (delete `packages/*/tsconfig.tsbuildinfo` between runs so nothing is cached).
2. Confirm the error output is identical and no `.d.ts` files appear in any package's `build-types` from the dev projects.

N/A. Verified by comparing `npm run typecheck` output, both runs from a wiped `tsbuildinfo` state:

| | Errors | Exit |
|-|-|-|
|With `emitDeclarationOnly: false`|0|0|
|Without it|0|0|


## Use of AI Tools

Claude Code 