### PR TITLE
UI: Share item popup typography variants

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Internal
 
+-   Reuse `Text` CSS variants for Menu, Select, Combobox, and Autocomplete popup typography. ([#81822](https://github.com/WordPress/gutenberg/pull/81822))
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 

--- a/packages/ui/src/menu/style.module.css
+++ b/packages/ui/src/menu/style.module.css
@@ -11,11 +11,17 @@
 			--wp-ui-menu-min-width: 160px;
 			--wp-ui-menu-max-width: var(--wpds-dimension-surface-width-md);
 			--wp-ui-menu-item-padding-inline: var(--wpds-dimension-padding-md);
-			--wp-ui-menu-group-head-padding-inline: var(--wpds-dimension-padding-md);
+			--wp-ui-menu-group-head-padding-inline: var(
+				--wpds-dimension-padding-md
+			);
 			--wp-ui-menu-selection-indicator-track-size: 0px;
-			--wp-ui-menu-selection-indicator-size: var(--wpds-dimension-size-sm);
+			--wp-ui-menu-selection-indicator-size: var(
+				--wpds-dimension-size-sm
+			);
 			--wp-ui-menu-selection-indicator-gap: 0px;
-			--_wp-ui-menu-elevation-md: 0px 2px 3px 0px #0000000d, 0px 4px 5px 0px #0000000a, 0px 12px 12px 0px #00000008, 0px 16px 16px 0px #00000005;
+			--_wp-ui-menu-elevation-md: 0px 2px 3px 0px #0000000d,
+				0px 4px 5px 0px #0000000a, 0px 12px 12px 0px #00000008,
+				0px 16px 16px 0px #00000005;
 
 			max-height: min(var(--available-height), 480px, 60dvh);
 			min-width: min(var(--available-width), var(--wp-ui-menu-min-width));
@@ -25,15 +31,24 @@
 			padding: var(--wp-ui-menu-popup-padding);
 			scroll-padding: var(--wp-ui-menu-popup-padding);
 			border-radius: var(--wpds-border-radius-md);
-			border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+			border: var(--wpds-border-width-xs) solid
+				var(--wpds-color-stroke-surface-neutral);
 			box-shadow: var(--_wp-ui-menu-elevation-md);
-			background-color: var(--wpds-color-background-surface-neutral-strong);
+			background-color: var(
+				--wpds-color-background-surface-neutral-strong
+			);
 			outline: none;
 
 			&:has(.item-selection-indicator) {
-				--wp-ui-menu-item-padding-inline: var(--wpds-dimension-padding-sm);
-				--wp-ui-menu-selection-indicator-track-size: var(--wpds-dimension-size-2xs);
-				--wp-ui-menu-selection-indicator-gap: var(--wpds-dimension-gap-sm);
+				--wp-ui-menu-item-padding-inline: var(
+					--wpds-dimension-padding-sm
+				);
+				--wp-ui-menu-selection-indicator-track-size: var(
+					--wpds-dimension-size-2xs
+				);
+				--wp-ui-menu-selection-indicator-gap: var(
+					--wpds-dimension-gap-sm
+				);
 			}
 		}
 
@@ -46,9 +61,8 @@
 		}
 
 		.list {
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-md);
-			line-height: var(--wpds-typography-line-height-sm);
+			composes: body-md from "../text/style.module.css";
+
 			color: var(--wpds-color-foreground-interactive-neutral);
 		}
 
@@ -65,7 +79,9 @@
 			display: grid;
 			grid-template-columns:
 				[item-padding-start] var(--wp-ui-menu-item-padding-inline)
-				[selection-start] var(--wp-ui-menu-selection-indicator-track-size)
+				[selection-start] var(
+					--wp-ui-menu-selection-indicator-track-size
+				)
 				[selection-end] var(--wp-ui-menu-selection-indicator-gap)
 				[prefix-start] max-content
 				[prefix-end] var(--wp-ui-menu-group-prefix-gap)
@@ -108,7 +124,7 @@
 			margin-inline: var(--wp-ui-menu-group-head-padding-inline);
 			background-color: var(--wpds-color-stroke-surface-neutral-weak);
 
-			@media ( forced-colors: active ) {
+			@media (forced-colors: active) {
 				background-color: CanvasText;
 			}
 		}
@@ -122,7 +138,9 @@
 			grid-column: 1 / -1;
 			grid-template-columns:
 				[item-padding-start] var(--wp-ui-menu-item-padding-inline)
-				[selection-start] var(--wp-ui-menu-selection-indicator-track-size)
+				[selection-start] var(
+					--wp-ui-menu-selection-indicator-track-size
+				)
 				[selection-end] var(--wp-ui-menu-selection-indicator-gap)
 				[prefix-start] max-content
 				[prefix-end] var(--wp-ui-menu-group-prefix-gap)
@@ -150,29 +168,34 @@
 				cursor: pointer;
 			}
 
-			@supports ( grid-template-columns: subgrid ) {
+			@supports (grid-template-columns: subgrid) {
 				grid-template-columns: subgrid;
 			}
 
 			&[data-highlighted]:not([aria-disabled="true"]) {
-				background-color: var(--wpds-color-background-interactive-brand-weak-active);
+				background-color: var(
+					--wpds-color-background-interactive-brand-weak-active
+				);
 				color: var(--wpds-color-foreground-interactive-neutral);
 				outline: none;
 
-				@media ( forced-colors: active ) {
+				@media (forced-colors: active) {
 					outline: var(--wpds-border-width-xs) solid Highlight;
 				}
 			}
 
 			&[aria-disabled="true"] {
-				background-color: var(--wpds-color-background-interactive-brand-weak-disabled);
-				color: var(--wpds-color-foreground-interactive-neutral-disabled);
+				background-color: var(
+					--wpds-color-background-interactive-brand-weak-disabled
+				);
+				color: var(
+					--wpds-color-foreground-interactive-neutral-disabled
+				);
 
-				@media ( forced-colors: active ) {
+				@media (forced-colors: active) {
 					color: GrayText;
 				}
 			}
-
 		}
 
 		/*
@@ -244,20 +267,16 @@
 		}
 
 		.item-label {
+			composes: body-md from "../text/style.module.css";
+
 			min-width: 0;
 			overflow-wrap: anywhere;
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-md);
-			line-height: var(--wpds-typography-line-height-sm);
-			font-weight: var(--wpds-typography-font-weight-default);
 			color: inherit;
 		}
 
 		.item-description {
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-sm);
-			line-height: var(--wpds-typography-line-height-xs);
-			font-weight: var(--wpds-typography-font-weight-default);
+			composes: body-sm from "../text/style.module.css";
+
 			color: var(--wpds-color-foreground-content-neutral-weak);
 			overflow-wrap: anywhere;
 			/* For better optical alignment and spacing */
@@ -324,7 +343,8 @@
 		.item[data-highlighted]:not([aria-disabled="true"]) .item-suffix,
 		.item[data-highlighted]:not([aria-disabled="true"]) .item-shortcut,
 		.item[data-highlighted]:not([aria-disabled="true"]) .item-trailing,
-		.item[data-highlighted]:not([aria-disabled="true"]) .item-selection-indicator,
+		.item[data-highlighted]:not([aria-disabled="true"])
+			.item-selection-indicator,
 		.item[aria-disabled="true"] .item-prefix,
 		.item[aria-disabled="true"] .item-description,
 		.item[aria-disabled="true"] .item-suffix,

--- a/packages/ui/src/utils/css/item-popup.module.css
+++ b/packages/ui/src/utils/css/item-popup.module.css
@@ -6,10 +6,8 @@
 			composes: dropdown-motion from "./dropdown-motion.module.css";
 
 			--wp-ui-popup-padding: var(--wpds-dimension-padding-xs);
-			--_wp-ui-elevation-md:
-				0 2px 3px rgba(0, 0, 0, 0.05),
-				0 4px 5px rgba(0, 0, 0, 0.04),
-				0 12px 12px rgba(0, 0, 0, 0.03),
+			--_wp-ui-elevation-md: 0 2px 3px rgba(0, 0, 0, 0.05),
+				0 4px 5px rgba(0, 0, 0, 0.04), 0 12px 12px rgba(0, 0, 0, 0.03),
 				0 16px 16px rgba(0, 0, 0, 0.02);
 
 			display: grid;
@@ -19,19 +17,21 @@
 			min-width: var(--anchor-width);
 			max-width: var(--available-width);
 			border-radius: var(--wpds-border-radius-md);
-			border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+			border: var(--wpds-border-width-xs) solid
+				var(--wpds-color-stroke-surface-neutral);
 			box-shadow: var(--_wp-ui-elevation-md);
-			background-color: var(--wpds-color-background-surface-neutral-strong);
+			background-color: var(
+				--wpds-color-background-surface-neutral-strong
+			);
 		}
 
 		.list {
+			composes: body-md from "../../text/style.module.css";
+
 			display: grid;
 			grid-area: main;
 			grid-template-rows: minmax(0, 1fr) auto;
 			grid-template-areas: "scrollable" "footer";
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-md);
-			line-height: var(--wpds-typography-line-height-sm);
 			color: var(--wpds-color-foreground-interactive-neutral);
 		}
 
@@ -51,7 +51,8 @@
 			padding-block: var(--wp-ui-popup-padding);
 
 			.list-scrollable-container:not(:empty) + & {
-				border-block-start: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+				border-block-start: var(--wpds-border-width-xs) solid
+					var(--wpds-color-stroke-surface-neutral);
 			}
 		}
 
@@ -83,7 +84,10 @@
 			padding-block: var(--wp-ui-popup-item-padding-block);
 
 			/* Optically adjust the prefix icon to a more balanced position. */
-			padding-inline-start: calc(var(--wp-ui-popup-item-padding-inline) - var(--wpds-dimension-padding-xs));
+			padding-inline-start: calc(
+				var(--wp-ui-popup-item-padding-inline) -
+					var(--wpds-dimension-padding-xs)
+			);
 			padding-inline-end: var(--wp-ui-popup-item-padding-inline);
 
 			&:not([data-disabled]) {
@@ -92,7 +96,9 @@
 
 			&.is-size-small {
 				--wp-ui-popup-item-height: var(--wpds-dimension-size-sm);
-				--wp-ui-popup-item-padding-inline: var(--wpds-dimension-padding-sm);
+				--wp-ui-popup-item-padding-inline: var(
+					--wpds-dimension-padding-sm
+				);
 				--wp-ui-popup-item-padding-block: 2px;
 			}
 
@@ -103,11 +109,13 @@
 			}
 
 			&[data-highlighted]:not([aria-disabled="true"]) {
-				background-color: var(--wpds-color-background-interactive-brand-weak-active);
+				background-color: var(
+					--wpds-color-background-interactive-brand-weak-active
+				);
 				color: var(--wpds-color-foreground-interactive-neutral);
 				outline: none; /* Disable user agent focus ring */
 
-				@media ( forced-colors: active ) {
+				@media (forced-colors: active) {
 					outline: 1px solid Highlight;
 				}
 			}
@@ -117,10 +125,14 @@
 				   foreground text stays neutral in every state. The disabled
 				   background currently resolves to transparent, but referencing the
 				   token keeps it in sync if its value ever changes. */
-				background-color: var(--wpds-color-background-interactive-brand-weak-disabled);
-				color: var(--wpds-color-foreground-interactive-neutral-disabled);
+				background-color: var(
+					--wpds-color-background-interactive-brand-weak-disabled
+				);
+				color: var(
+					--wpds-color-foreground-interactive-neutral-disabled
+				);
 
-				@media ( forced-colors: active ) {
+				@media (forced-colors: active) {
 					color: GrayText;
 				}
 			}
@@ -133,19 +145,19 @@
 		/* Only style when there is content, because otherwise the element would block clicks
 		on the .list beneath it (both share grid-area: main and overlap). */
 		.empty:not(:empty) {
+			composes: body-md from "../../text/style.module.css";
+
 			--wp-ui-popup-empty-min-height: var(--wpds-dimension-size-md);
-			--wp-ui-popup-empty-padding-inline: var(--wpds-dimension-padding-md);
+			--wp-ui-popup-empty-padding-inline: var(
+				--wpds-dimension-padding-md
+			);
 
 			grid-area: main;
 			display: flex;
 			align-items: center;
 			min-height: var(--wp-ui-popup-empty-min-height);
 			padding-inline: var(--wp-ui-popup-empty-padding-inline);
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-md);
-			line-height: var(--wpds-typography-line-height-sm);
 			color: var(--wpds-color-foreground-content-neutral-weak);
 		}
-
 	}
 }

--- a/tools/stylelint/stylelint-suppressions.json
+++ b/tools/stylelint/stylelint-suppressions.json
@@ -103,5 +103,33 @@
 		"selector-class-pattern": {
 			"count": 5
 		}
+	},
+	"packages/ui/src/menu/style.module.css": {
+		"@stylistic/declaration-colon-newline-after": {
+			"count": 11
+		},
+		"@stylistic/function-parentheses-space-inside": {
+			"count": 22
+		},
+		"@stylistic/indentation": {
+			"count": 1
+		},
+		"@stylistic/value-list-comma-newline-after": {
+			"count": 1
+		}
+	},
+	"packages/ui/src/utils/css/item-popup.module.css": {
+		"@stylistic/declaration-colon-newline-after": {
+			"count": 10
+		},
+		"@stylistic/function-parentheses-space-inside": {
+			"count": 14
+		},
+		"@stylistic/indentation": {
+			"count": 1
+		},
+		"@stylistic/value-list-comma-newline-after": {
+			"count": 1
+		}
 	}
 }


### PR DESCRIPTION
Follow up to #79560.

## What?

Makes Menu and the shared Select/Combobox/Autocomplete popup styles compose the established `Text` CSS variants for body typography.

## Why?

These popups duplicated the same WPDS font family, size, line-height, and weight combinations. Keeping those declarations separate allows the combinations to drift.

Menu’s grid is intentionally not moved into the shared item-popup stylesheet. Menu needs menu-wide selection tracks and group-local prefix tracks, while value-selection popups use a simpler flex layout and separate scrolling regions.

## How?

- Composes `body-md` for popup lists, Menu labels, and empty states.
- Composes `body-sm` for Menu descriptions.
- Keeps component-specific layout, spacing, interaction, and scrolling styles in their existing stylesheets.

The touched CSS files also receive their current formatter output and corresponding stylelint suppression metadata.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Compare Menu, Select, Combobox, and Autocomplete stories before and after this change.
3. Confirm labels, descriptions, suffixes, shortcuts, empty states, and popup layout are visually unchanged.

### Testing Instructions for Keyboard

1. Open each popup with the keyboard.
2. Navigate its items and confirm highlighting, selection, and dismissal are unchanged.

## Use of AI Tools

This PR was implemented with AI assistance in Codex and reviewed locally.
