### PR TITLE
Menu: Support multiple item descriptions

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Enhancements
 
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `width` on Popups and `popupWidth` on composites, with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087), [#82193](https://github.com/WordPress/gutenberg/pull/82193)).
+-   `Menu`: Support multiple item descriptions. ([#81825](https://github.com/WordPress/gutenberg/pull/81825))
 -   `Menu`: Use `Text` for item labels and descriptions to share typography and apply `text-wrap: pretty`. ([#82237](https://github.com/WordPress/gutenberg/pull/82237))
 -   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
 

--- a/packages/ui/src/menu/checkbox-item.tsx
+++ b/packages/ui/src/menu/checkbox-item.tsx
@@ -28,14 +28,18 @@ const CheckboxItem = forwardRef< HTMLDivElement, CheckboxItemProps >(
 		},
 		ref
 	) {
-		const { contentContextValue, itemAriaProps, shortcutDescriptionId } =
-			useItemContent( children, {
-				'aria-describedby': ariaDescribedBy,
-				'aria-keyshortcuts': ariaKeyShortcuts,
-				'aria-label': ariaLabel,
-				'aria-labelledby': ariaLabelledBy,
-				shortcut,
-			} );
+		const {
+			contentChildren,
+			contentContextValue,
+			itemAriaProps,
+			shortcutDescriptionId,
+		} = useItemContent( children, {
+			'aria-describedby': ariaDescribedBy,
+			'aria-keyshortcuts': ariaKeyShortcuts,
+			'aria-label': ariaLabel,
+			'aria-labelledby': ariaLabelledBy,
+			shortcut,
+		} );
 
 		return (
 			<_Menu.CheckboxItem
@@ -61,7 +65,7 @@ const CheckboxItem = forwardRef< HTMLDivElement, CheckboxItemProps >(
 						shortcutDescriptionId={ shortcutDescriptionId }
 						suffix={ suffix }
 					>
-						{ children }
+						{ contentChildren }
 					</ItemContent>
 				</MenuItemContentContext.Provider>
 			</_Menu.CheckboxItem>

--- a/packages/ui/src/menu/context.tsx
+++ b/packages/ui/src/menu/context.tsx
@@ -13,7 +13,6 @@ const useMenuContext = () => useContext( MenuContext );
 
 type MenuItemContentContextValue = {
 	labelId?: string;
-	descriptionId?: string;
 	labelTrailing?: ReactNode;
 };
 

--- a/packages/ui/src/menu/item-description.tsx
+++ b/packages/ui/src/menu/item-description.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
-import { useMenuItemContentContext } from './context';
 import styles from './style.module.css';
 import type { ItemDescriptionProps } from './types';
 import { Text } from '../text';
@@ -11,14 +10,12 @@ import { Text } from '../text';
  */
 const ItemDescription = forwardRef< HTMLSpanElement, ItemDescriptionProps >(
 	function MenuItemDescription( { className, id, ...props }, ref ) {
-		const itemContentContext = useMenuItemContentContext();
-
 		return (
 			<Text
 				ref={ ref }
 				variant="body-sm"
 				{ ...props }
-				id={ id ?? itemContentContext?.descriptionId }
+				id={ id }
 				className={ clsx( styles[ 'item-description' ], className ) }
 			/>
 		);

--- a/packages/ui/src/menu/item.tsx
+++ b/packages/ui/src/menu/item.tsx
@@ -79,9 +79,12 @@ function useItemContent(
 		( descriptionId, index ) =>
 			descriptionId ?? `${ generatedDescriptionId }-${ index }`
 	);
-	const itemDescribedBy = [ ariaDescribedBy, ...resolvedDescriptionIds ]
-		.filter( Boolean )
-		.join( ' ' );
+	const itemDescribedBy = Array.from(
+		new Set( [
+			...( ariaDescribedBy?.split( /\s+/ ).filter( Boolean ) ?? [] ),
+			...resolvedDescriptionIds,
+		] )
+	).join( ' ' );
 	let descriptionIndex = 0;
 	// React widens the tuple while mapping; validation preserves the item-child
 	// contract and cloning changes only generated description IDs.

--- a/packages/ui/src/menu/item.tsx
+++ b/packages/ui/src/menu/item.tsx
@@ -2,10 +2,12 @@ import { Menu as _Menu } from '@base-ui/react/menu';
 import clsx from 'clsx';
 import {
 	Children,
+	cloneElement,
 	forwardRef,
 	isValidElement,
 	useId,
 } from '@wordpress/element';
+import type { ReactElement } from 'react';
 import resetStyles from '../utils/css/resets.module.css';
 import {
 	KeyboardShortcutDescription,
@@ -16,7 +18,7 @@ import styles from './style.module.css';
 import { MenuItemContentContext } from './context';
 import { ItemDescription } from './item-description';
 import { ItemLabel } from './item-label';
-import type { ItemProps } from './types';
+import type { ItemDescriptionProps, ItemProps } from './types';
 
 type ItemAriaProps = Pick<
 	ItemProps,
@@ -31,27 +33,28 @@ const VALIDATION_ENABLED = process.env.NODE_ENV !== 'production';
 
 function getItemContent( children: ItemProps[ 'children' ] ) {
 	const childArray = Children.toArray( children );
-	const [ label, description, ...unexpectedChildren ] = childArray;
+	const [ label, ...descriptions ] = childArray;
 	const hasLabel =
 		isValidElement< { id?: string } >( label ) && label.type === ItemLabel;
-	const hasDescription =
-		isValidElement< { id?: string } >( description ) &&
-		description.type === ItemDescription;
+	const descriptionElements = descriptions.filter(
+		( description ): description is ReactElement< ItemDescriptionProps > =>
+			isValidElement< ItemDescriptionProps >( description ) &&
+			description.type === ItemDescription
+	);
 
 	if (
 		VALIDATION_ENABLED &&
-		( ! hasLabel ||
-			( description !== undefined && ! hasDescription ) ||
-			unexpectedChildren.length > 0 )
+		( ! hasLabel || descriptionElements.length !== descriptions.length )
 	) {
 		throw new Error(
-			'Menu.ItemLabel must be the first direct child of every menu item, followed only by an optional Menu.ItemDescription.'
+			'Menu.ItemLabel must be the first direct child of every menu item, followed only by Menu.ItemDescription components.'
 		);
 	}
 
 	return {
-		descriptionId: hasDescription ? description.props.id : undefined,
-		hasDescription,
+		descriptionIds: descriptionElements.map(
+			( description ) => description.props.id
+		),
 		hasLabel,
 		labelId: hasLabel ? label.props.id : undefined,
 	};
@@ -70,18 +73,31 @@ function useItemContent(
 ) {
 	const generatedLabelId = useId();
 	const generatedDescriptionId = useId();
-	const { descriptionId, hasDescription, hasLabel, labelId } =
-		getItemContent( children );
+	const { descriptionIds, hasLabel, labelId } = getItemContent( children );
 	const resolvedLabelId = hasLabel ? labelId ?? generatedLabelId : undefined;
-	const resolvedDescriptionId = hasDescription
-		? descriptionId ?? generatedDescriptionId
-		: undefined;
-	const itemDescribedBy = [
-		ariaDescribedBy,
-		hasDescription && resolvedDescriptionId,
-	]
+	const resolvedDescriptionIds = descriptionIds.map(
+		( descriptionId, index ) =>
+			descriptionId ?? `${ generatedDescriptionId }-${ index }`
+	);
+	const itemDescribedBy = [ ariaDescribedBy, ...resolvedDescriptionIds ]
 		.filter( Boolean )
 		.join( ' ' );
+	let descriptionIndex = 0;
+	// React widens the tuple while mapping; validation preserves the item-child
+	// contract and cloning changes only generated description IDs.
+	const contentChildren = Children.map( children, ( child ) => {
+		if (
+			! isValidElement< ItemDescriptionProps >( child ) ||
+			child.type !== ItemDescription
+		) {
+			return child;
+		}
+
+		const descriptionId = resolvedDescriptionIds[ descriptionIndex++ ];
+		return child.props.id === descriptionId
+			? child
+			: cloneElement( child, { id: descriptionId } );
+	} ) as ItemProps[ 'children' ];
 	const {
 		descriptionId: shortcutDescriptionId,
 		targetProps: shortcutAriaProps,
@@ -100,8 +116,8 @@ function useItemContent(
 		ariaLabelledBy ?? ( ariaLabel ? undefined : resolvedLabelId );
 
 	return {
+		contentChildren,
 		contentContextValue: {
-			descriptionId: resolvedDescriptionId,
 			labelId: resolvedLabelId,
 			labelTrailing,
 		},
@@ -195,14 +211,18 @@ const Item = forwardRef< HTMLDivElement, ItemProps >( function MenuItem(
 	},
 	ref
 ) {
-	const { contentContextValue, itemAriaProps, shortcutDescriptionId } =
-		useItemContent( children, {
-			'aria-describedby': ariaDescribedBy,
-			'aria-keyshortcuts': ariaKeyShortcuts,
-			'aria-label': ariaLabel,
-			'aria-labelledby': ariaLabelledBy,
-			shortcut,
-		} );
+	const {
+		contentChildren,
+		contentContextValue,
+		itemAriaProps,
+		shortcutDescriptionId,
+	} = useItemContent( children, {
+		'aria-describedby': ariaDescribedBy,
+		'aria-keyshortcuts': ariaKeyShortcuts,
+		'aria-label': ariaLabel,
+		'aria-labelledby': ariaLabelledBy,
+		shortcut,
+	} );
 
 	return (
 		<_Menu.Item
@@ -222,7 +242,7 @@ const Item = forwardRef< HTMLDivElement, ItemProps >( function MenuItem(
 					shortcutDescriptionId={ shortcutDescriptionId }
 					suffix={ suffix }
 				>
-					{ children }
+					{ contentChildren }
 				</ItemContent>
 			</MenuItemContentContext.Provider>
 		</_Menu.Item>

--- a/packages/ui/src/menu/link-item.tsx
+++ b/packages/ui/src/menu/link-item.tsx
@@ -39,15 +39,19 @@ const LinkItem = forwardRef< Element, LinkItemProps >( function MenuLinkItem(
 			}
 		/>
 	) : null;
-	const { contentContextValue, itemAriaProps, shortcutDescriptionId } =
-		useItemContent( children, {
-			'aria-describedby': ariaDescribedBy,
-			'aria-keyshortcuts': ariaKeyShortcuts,
-			'aria-label': ariaLabel,
-			'aria-labelledby': ariaLabelledBy,
-			labelTrailing: externalLinkIndicator,
-			shortcut,
-		} );
+	const {
+		contentChildren,
+		contentContextValue,
+		itemAriaProps,
+		shortcutDescriptionId,
+	} = useItemContent( children, {
+		'aria-describedby': ariaDescribedBy,
+		'aria-keyshortcuts': ariaKeyShortcuts,
+		'aria-label': ariaLabel,
+		'aria-labelledby': ariaLabelledBy,
+		labelTrailing: externalLinkIndicator,
+		shortcut,
+	} );
 
 	return (
 		<_Menu.LinkItem
@@ -70,7 +74,7 @@ const LinkItem = forwardRef< Element, LinkItemProps >( function MenuLinkItem(
 					shortcutDescriptionId={ shortcutDescriptionId }
 					suffix={ suffix }
 				>
-					{ children }
+					{ contentChildren }
 				</ItemContent>
 			</MenuItemContentContext.Provider>
 		</_Menu.LinkItem>

--- a/packages/ui/src/menu/radio-item.tsx
+++ b/packages/ui/src/menu/radio-item.tsx
@@ -34,14 +34,18 @@ const RadioItem = forwardRef< HTMLDivElement, RadioItemProps >(
 		},
 		ref
 	) {
-		const { contentContextValue, itemAriaProps, shortcutDescriptionId } =
-			useItemContent( children, {
-				'aria-describedby': ariaDescribedBy,
-				'aria-keyshortcuts': ariaKeyShortcuts,
-				'aria-label': ariaLabel,
-				'aria-labelledby': ariaLabelledBy,
-				shortcut,
-			} );
+		const {
+			contentChildren,
+			contentContextValue,
+			itemAriaProps,
+			shortcutDescriptionId,
+		} = useItemContent( children, {
+			'aria-describedby': ariaDescribedBy,
+			'aria-keyshortcuts': ariaKeyShortcuts,
+			'aria-label': ariaLabel,
+			'aria-labelledby': ariaLabelledBy,
+			shortcut,
+		} );
 
 		return (
 			<_Menu.RadioItem
@@ -71,7 +75,7 @@ const RadioItem = forwardRef< HTMLDivElement, RadioItemProps >(
 						shortcutDescriptionId={ shortcutDescriptionId }
 						suffix={ suffix }
 					>
-						{ children }
+						{ contentChildren }
 					</ItemContent>
 				</MenuItemContentContext.Provider>
 			</_Menu.RadioItem>

--- a/packages/ui/src/menu/stories/index.story.tsx
+++ b/packages/ui/src/menu/stories/index.story.tsx
@@ -263,6 +263,9 @@ export const RichItems: Story = {
 					<Menu.Item>
 						<Menu.ItemLabel>Label</Menu.ItemLabel>
 						<Menu.ItemDescription>Help text</Menu.ItemDescription>
+						<Menu.ItemDescription>
+							Additional context
+						</Menu.ItemDescription>
 					</Menu.Item>
 					<Menu.Item>
 						<Menu.ItemLabel>

--- a/packages/ui/src/menu/submenu-trigger.tsx
+++ b/packages/ui/src/menu/submenu-trigger.tsx
@@ -28,14 +28,18 @@ const SubmenuTrigger = forwardRef< HTMLDivElement, SubmenuTriggerProps >(
 		},
 		ref
 	) {
-		const { contentContextValue, itemAriaProps, shortcutDescriptionId } =
-			useItemContent( children, {
-				'aria-describedby': ariaDescribedBy,
-				'aria-keyshortcuts': ariaKeyShortcuts,
-				'aria-label': ariaLabel,
-				'aria-labelledby': ariaLabelledBy,
-				shortcut,
-			} );
+		const {
+			contentChildren,
+			contentContextValue,
+			itemAriaProps,
+			shortcutDescriptionId,
+		} = useItemContent( children, {
+			'aria-describedby': ariaDescribedBy,
+			'aria-keyshortcuts': ariaKeyShortcuts,
+			'aria-label': ariaLabel,
+			'aria-labelledby': ariaLabelledBy,
+			shortcut,
+		} );
 
 		return (
 			<_Menu.SubmenuTrigger
@@ -63,7 +67,7 @@ const SubmenuTrigger = forwardRef< HTMLDivElement, SubmenuTriggerProps >(
 							/>
 						}
 					>
-						{ children }
+						{ contentChildren }
 					</ItemContent>
 				</MenuItemContentContext.Provider>
 			</_Menu.SubmenuTrigger>

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -847,6 +847,67 @@ describe( 'Menu', () => {
 		expect( screen.getByText( 'separate' ).tagName ).toBe( 'STRONG' );
 	} );
 
+	it( 'combines multiple item descriptions in DOM order', async () => {
+		const user = userEvent.setup();
+
+		function MenuWithMultipleDescriptions() {
+			const externalDescriptionId = useId();
+			const firstDescriptionId = useId();
+
+			return (
+				<Menu.Root>
+					<Menu.Trigger>Actions</Menu.Trigger>
+					<Menu.Popup>
+						<span id={ externalDescriptionId }>
+							Available offline.
+						</span>
+						<Menu.Item
+							aria-describedby={ externalDescriptionId }
+							shortcut={ {
+								displayShortcut: '⌘S',
+								ariaKeyShortcut: 'Meta+S',
+								label: 'Command S',
+							} }
+						>
+							<Menu.ItemLabel>Save</Menu.ItemLabel>
+							<Menu.ItemDescription id={ firstDescriptionId }>
+								Save to this device.
+							</Menu.ItemDescription>
+							<Menu.ItemDescription>
+								Keeps the current version.
+							</Menu.ItemDescription>
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+			);
+		}
+
+		render( <MenuWithMultipleDescriptions /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
+
+		const item = await screen.findByRole( 'menuitem', { name: 'Save' } );
+		const externalDescription = screen.getByText( 'Available offline.' );
+		const firstDescription = screen.getByText( 'Save to this device.' );
+		const secondDescription = screen.getByText(
+			'Keeps the current version.'
+		);
+		const shortcutDescription = screen.getByText(
+			'Keyboard shortcut: Command S'
+		);
+
+		expect( item ).toHaveAccessibleDescription(
+			'Available offline. Save to this device. Keeps the current version. Keyboard shortcut: Command S'
+		);
+		expect( firstDescription.id ).not.toBe( '' );
+		expect( secondDescription.id ).not.toBe( '' );
+		expect( secondDescription.id ).not.toBe( firstDescription.id );
+		expect( item ).toHaveAttribute(
+			'aria-describedby',
+			`${ externalDescription.id } ${ firstDescription.id } ${ secondDescription.id } ${ shortcutDescription.id }`
+		);
+	} );
+
 	it( 'requires an ItemLabel as a direct child of every item', () => {
 		expect( () =>
 			render(

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -908,6 +908,32 @@ describe( 'Menu', () => {
 		);
 	} );
 
+	it( 'deduplicates explicit and item description IDs', async () => {
+		const user = userEvent.setup();
+		const descriptionId = 'save-description';
+
+		render(
+			<Menu.Root>
+				<Menu.Trigger>Actions</Menu.Trigger>
+				<Menu.Popup>
+					<Menu.Item aria-describedby={ descriptionId }>
+						<Menu.ItemLabel>Save</Menu.ItemLabel>
+						<Menu.ItemDescription id={ descriptionId }>
+							Save the current file.
+						</Menu.ItemDescription>
+					</Menu.Item>
+				</Menu.Popup>
+			</Menu.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
+
+		const item = await screen.findByRole( 'menuitem', { name: 'Save' } );
+
+		expect( item ).toHaveAccessibleDescription( 'Save the current file.' );
+		expect( item ).toHaveAttribute( 'aria-describedby', descriptionId );
+	} );
+
 	it( 'requires an ItemLabel as a direct child of every item', () => {
 		expect( () =>
 			render(

--- a/packages/ui/src/menu/types.ts
+++ b/packages/ui/src/menu/types.ts
@@ -141,9 +141,9 @@ export interface ItemLabelProps extends ComponentProps< 'span' > {
 
 export interface ItemDescriptionProps extends ComponentProps< 'span' > {
 	/**
-	 * Optional supplementary content displayed below a menu item label. Use as
-	 * the second direct child, after `Menu.ItemLabel`. Content should be text or
-	 * non-interactive inline markup.
+	 * Supplementary content displayed below a menu item label. Use as a direct
+	 * child after `Menu.ItemLabel`. Content should be text or non-interactive
+	 * inline markup.
 	 */
 	children: ReactNode;
 }
@@ -152,7 +152,12 @@ type MenuItemChildren =
 	| ReactElement< ItemLabelProps >
 	| [
 			ReactElement< ItemLabelProps >,
-			ReactElement< ItemDescriptionProps > | false | null | undefined,
+			...(
+				| ReactElement< ItemDescriptionProps >
+				| false
+				| null
+				| undefined
+			)[],
 	  ];
 
 type MenuItemComponentProps< T extends ElementType > = Omit<
@@ -163,8 +168,8 @@ type MenuItemComponentProps< T extends ElementType > = Omit<
 export type ItemProps = MenuItemComponentProps< typeof _Menu.Item > &
 	MenuItemLayoutProps & {
 		/**
-		 * One direct `Menu.ItemLabel`, followed by an optional direct
-		 * `Menu.ItemDescription`.
+		 * One direct `Menu.ItemLabel`, followed by zero or more direct
+		 * `Menu.ItemDescription` components.
 		 */
 		children: MenuItemChildren;
 	};
@@ -183,8 +188,8 @@ export type LinkItemProps = Omit<
 		openInNewTab?: boolean;
 
 		/**
-		 * One direct `Menu.ItemLabel`, followed by an optional direct
-		 * `Menu.ItemDescription`.
+		 * One direct `Menu.ItemLabel`, followed by zero or more direct
+		 * `Menu.ItemDescription` components.
 		 */
 		children: MenuItemChildren;
 	};
@@ -194,8 +199,8 @@ export type CheckboxItemProps = MenuItemComponentProps<
 > &
 	MenuItemLayoutProps & {
 		/**
-		 * One direct `Menu.ItemLabel`, followed by an optional direct
-		 * `Menu.ItemDescription`.
+		 * One direct `Menu.ItemLabel`, followed by zero or more direct
+		 * `Menu.ItemDescription` components.
 		 */
 		children: MenuItemChildren;
 	};
@@ -203,8 +208,8 @@ export type CheckboxItemProps = MenuItemComponentProps<
 export type RadioItemProps = MenuItemComponentProps< typeof _Menu.RadioItem > &
 	MenuItemLayoutProps & {
 		/**
-		 * One direct `Menu.ItemLabel`, followed by an optional direct
-		 * `Menu.ItemDescription`.
+		 * One direct `Menu.ItemLabel`, followed by zero or more direct
+		 * `Menu.ItemDescription` components.
 		 */
 		children: MenuItemChildren;
 	};
@@ -214,8 +219,8 @@ export type SubmenuTriggerProps = MenuItemComponentProps<
 > &
 	MenuItemLayoutProps & {
 		/**
-		 * One direct `Menu.ItemLabel`, followed by an optional direct
-		 * `Menu.ItemDescription`.
+		 * One direct `Menu.ItemLabel`, followed by zero or more direct
+		 * `Menu.ItemDescription` components.
 		 */
 		children: MenuItemChildren;
 	};


### PR DESCRIPTION
Follow up to #79560.
Related: #81227.

## What?

Allows every Menu item variant to contain multiple direct `Menu.ItemDescription` components after its required `Menu.ItemLabel`.

## Why?

An item can need separate pieces of supplementary information, such as a short status and a longer explanation. Each description should contribute once to the item's accessible description, in the same order as the visible content.

## How?

- Expands the structured child type to one label followed by zero or more descriptions.
- Preserves custom description IDs and assigns indexed IDs where needed.
- Appends all direct description IDs to `aria-describedby` in DOM order.
- Preserves consumer-provided description IDs, removes duplicates, and keeps the generated keyboard-shortcut description last.
- Uses the same content helper for regular, link, checkbox, radio, and submenu-trigger items.

Unlike CollapsibleCard's arbitrary descendant descriptions in #81227, Menu descriptions must be direct children. Menu can therefore resolve their order and IDs synchronously without registration state or layout effects.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open **Design System / Components / Menu / Rich Items**.
3. Open the menu and confirm the first item displays both descriptions below its label.
4. Inspect that item in the browser accessibility tree and confirm its accessible description contains both descriptions once, in visible order.

### Testing Instructions for Keyboard

1. Open the Rich Items menu with Enter or Space.
2. Navigate to the item with multiple descriptions.
3. Confirm keyboard navigation and dismissal remain unchanged.

## Use of AI Tools

This PR was implemented with AI assistance in Codex and reviewed locally.
