### PR TITLE
UI: Expose keyboard shortcut presentation utilities

### DIFF
--- a/packages/boot/CHANGELOG.md
+++ b/packages/boot/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Enhancements
 
+-   Save button: Use the shared UI keyboard shortcut utilities for its tooltip and accessibility metadata. ([#81826](https://github.com/WordPress/gutenberg/pull/81826))
 -   Contain a failure to the surface it happened in, so a stage, inspector or canvas that throws leaves the rest of the screen working ([#81622](https://github.com/WordPress/gutenberg/pull/81622)).
 -   Warn before leaving the page with unsaved changes ([#81625](https://github.com/WordPress/gutenberg/pull/81625)).
 -   Keep the editor's device preview in step with a `viewport` search param, so an entity that asks to be edited at a particular width — a navigation overlay meant for mobile — opens there and restores the previous width on the way back ([#81617](https://github.com/WordPress/gutenberg/pull/81617)).

--- a/packages/boot/src/components/save-button/index.tsx
+++ b/packages/boot/src/components/save-button/index.tsx
@@ -2,11 +2,20 @@ import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
+import {
+	ariaKeyShortcut,
+	displayShortcut,
+	shortcutAriaLabel,
+} from '@wordpress/keycodes';
 import { check } from '@wordpress/icons';
 import { EntitiesSavedStates } from '@wordpress/editor';
 import { Button, Modal } from '@wordpress/components';
-import { Tooltip } from '@wordpress/ui';
+import {
+	KeyboardShortcutDescription,
+	KeyboardShortcutDisplay,
+	Tooltip,
+	useKeyboardShortcutProps,
+} from '@wordpress/ui';
 import './style.scss';
 import useSaveShortcut from '../save-panel/use-save-shortcut';
 
@@ -53,6 +62,14 @@ export default function SaveButton() {
 	const shouldShowButton = hasChanges || showSavedState;
 
 	useSaveShortcut( { openSavePanel: () => setIsSaveViewOpened( true ) } );
+	const shortcut = {
+		displayShortcut: displayShortcut.primary( 's' ),
+		ariaKeyShortcut: ariaKeyShortcut.primary( 's' ),
+		label: shortcutAriaLabel.primary( 's' ),
+	};
+	const { descriptionId, targetProps } = useKeyboardShortcutProps( {
+		shortcut,
+	} );
 
 	if ( ! shouldShowButton ) {
 		return null;
@@ -76,12 +93,12 @@ export default function SaveButton() {
 		);
 	};
 	const label = getLabel();
-	const shortcut = displayShortcut.primary( 's' );
 
 	return (
 		<>
 			<Tooltip.Root>
 				<Tooltip.Trigger
+					{ ...targetProps }
 					render={
 						<Button
 							variant="primary"
@@ -91,20 +108,25 @@ export default function SaveButton() {
 							disabled={ disabled }
 							accessibleWhenDisabled
 							isBusy={ isSaving }
-							aria-keyshortcuts={ rawShortcut.primary( 's' ) }
 							className="boot-save-button"
 							icon={ isInSavedState ? check : undefined }
-						>
-							{ label }
-						</Button>
+						/>
 					}
-				/>
+				>
+					{ label }
+					{ descriptionId && (
+						<KeyboardShortcutDescription
+							descriptionId={ descriptionId }
+							shortcut={ shortcut }
+						/>
+					) }
+				</Tooltip.Trigger>
 				<Tooltip.Popup>
 					{ hasChanges && <span>{ label }</span> }
-					{ /* TODO: replace with a future `@wordpress/ui` `Shortcut` primitive once available */ }
-					<span className="boot-save-button__shortcut">
-						{ shortcut }
-					</span>
+					<KeyboardShortcutDisplay
+						className="boot-save-button__shortcut"
+						shortcut={ shortcut }
+					/>
 				</Tooltip.Popup>
 			</Tooltip.Root>
 			{ isSaveViewOpen && (

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Allow the public `@wordpress/ui` keyboard shortcut utilities in the `use-recommended-components` rule. ([#81826](https://github.com/WordPress/gutenberg/pull/81826))
 -   Update `use-recommended-components` rule to mark `Input`, `InputControl`, and `InputLayout` from `@wordpress/ui` as recommended, and to prefer `@wordpress/ui` `InputControl` over legacy `@wordpress/components` `InputControl` and `TextControl` ([#81658](https://github.com/WordPress/gutenberg/pull/81658)).
 
 ## 25.9.0 (2026-08-12)

--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -26,6 +26,7 @@ ruleTester.run( 'use-recommended-components', rule, {
 		"import { Text } from '@wordpress/ui';",
 		"import { Badge, Icon, Link, Stack, Tabs, Text, Tooltip } from '@wordpress/ui';",
 		"import { Spinner } from '@wordpress/ui';",
+		"import { KeyboardShortcutDescription, KeyboardShortcutDisplay, useKeyboardShortcutProps } from '@wordpress/ui';",
 
 		// Unlocked private APIs are only checked for denied names.
 		"import { privateApis } from '@wordpress/components'; import { unlock } from '../../lock-unlock'; const { SomethingElse } = unlock( privateApis );",

--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -26,6 +26,8 @@ const ALLOWLIST = {
 			'Input',
 			'InputControl',
 			'InputLayout',
+			'KeyboardShortcutDescription',
+			'KeyboardShortcutDisplay',
 			'Link',
 			'RangeCalendar',
 			'Skeleton',
@@ -37,6 +39,7 @@ const ALLOWLIST = {
 			'TextareaControl',
 			'Tooltip',
 			'VisuallyHidden',
+			'useKeyboardShortcutProps',
 		],
 		message:
 			'`{{ name }}` from `{{ source }}` is not yet recommended for use in a WordPress environment.',

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Enhancements
 
 -   Add `TextareaControl` component ([#81359](https://github.com/WordPress/gutenberg/pull/81359)).
+-   Export shared keyboard shortcut presentation and accessibility utilities. ([#81826](https://github.com/WordPress/gutenberg/pull/81826))
 -   `Menu`: Add shortcut display and accessibility metadata support. ([#79560](https://github.com/WordPress/gutenberg/pull/79560))
 -   `Select.Item`, `Combobox.Item`, and `Autocomplete.Item`: Default item height is now 32px (previously 40px) ([#81354](https://github.com/WordPress/gutenberg/pull/81354)).
 

--- a/packages/ui/src/button/stories/index.story.tsx
+++ b/packages/ui/src/button/stories/index.story.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useId } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { wordpress } from '@wordpress/icons';
 import {
@@ -6,9 +6,13 @@ import {
 	shortcutAriaLabel,
 	ariaKeyShortcut,
 } from '@wordpress/keycodes';
+import {
+	KeyboardShortcutDescription,
+	KeyboardShortcutDisplay,
+	useKeyboardShortcutProps,
+} from '@wordpress/ui';
 import { Button } from '../index';
 import * as Tooltip from '../../tooltip';
-import { VisuallyHidden } from '../../visually-hidden';
 
 const meta: Meta< typeof Button > = {
 	title: 'Design System/Components/Button',
@@ -191,8 +195,8 @@ export const Pressed: Story = {
 };
 
 /**
- * `Button` has no dedicated `shortcut` prop, so keyboard shortcuts must be
- * composed manually: a visual hint in the tooltip, `aria-keyshortcuts` for
+ * `Button` has no dedicated `shortcut` prop. Use the keyboard shortcut
+ * utilities to compose a visual hint in the tooltip, `aria-keyshortcuts` for
  * assistive technology, and a visually hidden description. Consumers remain
  * responsible for registering the shortcut and handling the corresponding
  * keyboard event.
@@ -200,37 +204,41 @@ export const Pressed: Story = {
 export const WithKeyboardShortcut: Story = {
 	args: {
 		children: 'Save',
-		'aria-keyshortcuts': ariaKeyShortcut.primary( 's' ),
 	},
 	render: ( {
 		children,
 		'aria-describedby': consumerDescribedBy,
+		'aria-keyshortcuts': consumerKeyShortcuts,
 		...args
 	} ) => {
-		const descriptionId = useId();
+		const shortcut = {
+			displayShortcut: displayShortcut.primary( 's' ),
+			ariaKeyShortcut: ariaKeyShortcut.primary( 's' ),
+			label: shortcutAriaLabel.primary( 's' ),
+		};
+		const { descriptionId, targetProps } = useKeyboardShortcutProps( {
+			'aria-describedby': consumerDescribedBy,
+			'aria-keyshortcuts': consumerKeyShortcuts,
+			shortcut,
+		} );
 
 		return (
 			<Tooltip.Root>
 				<Tooltip.Trigger
 					render={ <Button { ...args } /> }
-					aria-describedby={ [ consumerDescribedBy, descriptionId ]
-						.filter( Boolean )
-						.join( ' ' ) }
+					{ ...targetProps }
 				>
 					{ children }
-					<VisuallyHidden
-						id={ descriptionId }
-						aria-hidden="true"
-						render={ <span /> }
-					>
-						Keyboard shortcut: { shortcutAriaLabel.primary( 's' ) }
-					</VisuallyHidden>
+					{ descriptionId && (
+						<KeyboardShortcutDescription
+							descriptionId={ descriptionId }
+							shortcut={ shortcut }
+						/>
+					) }
 				</Tooltip.Trigger>
 				<Tooltip.Popup>
 					{ children }{ ' ' }
-					<span aria-hidden="true" dir="ltr">
-						{ displayShortcut.primary( 's' ) }
-					</span>
+					<KeyboardShortcutDisplay shortcut={ shortcut } />
 				</Tooltip.Popup>
 			</Tooltip.Root>
 		);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,6 +22,11 @@ export * from './stack';
 export * as Tabs from './tabs';
 export * from './text';
 export * as Tooltip from './tooltip';
+export {
+	KeyboardShortcutDescription,
+	KeyboardShortcutDisplay,
+	useKeyboardShortcutProps,
+} from './utils/keyboard-shortcut';
 export { getWpCompatOverlaySlot } from './utils/wp-compat-overlay-slot';
 export { useEnableWpCompatOverlaySlot } from './utils/use-enable-wp-compat-overlay-slot';
 export * from './visually-hidden';

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -31,6 +31,12 @@ type ShortcutAriaProps = Pick<
 	'aria-describedby' | 'aria-keyshortcuts'
 >;
 
+/**
+ * Returns shortcut accessibility metadata for an interactive element.
+ *
+ * Render `KeyboardShortcutDescription` with the returned `descriptionId` when
+ * a shortcut is provided.
+ */
 function useKeyboardShortcutProps( {
 	'aria-describedby': ariaDescribedBy,
 	'aria-keyshortcuts': ariaKeyShortcuts,
@@ -51,6 +57,9 @@ function useKeyboardShortcutProps( {
 	};
 }
 
+/**
+ * Renders a localized, visually hidden description for a keyboard shortcut.
+ */
 function KeyboardShortcutDescription( {
 	descriptionId,
 	shortcut,
@@ -73,6 +82,10 @@ function KeyboardShortcutDescription( {
 	);
 }
 
+/**
+ * Renders a visual keyboard shortcut while hiding it from assistive
+ * technology.
+ */
 function KeyboardShortcutDisplay( {
 	className,
 	shortcut,

--- a/packages/ui/src/utils/keyboard-shortcut.tsx
+++ b/packages/ui/src/utils/keyboard-shortcut.tsx
@@ -1,5 +1,5 @@
 import type { AriaAttributes } from 'react';
-import { useId } from '@wordpress/element';
+import { forwardRef, useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { VisuallyHidden } from '../visually-hidden';
 
@@ -60,18 +60,18 @@ function useKeyboardShortcutProps( {
 /**
  * Renders a localized, visually hidden description for a keyboard shortcut.
  */
-function KeyboardShortcutDescription( {
-	descriptionId,
-	shortcut,
-}: {
-	descriptionId: string;
-	shortcut: KeyboardShortcut;
-} ) {
+const KeyboardShortcutDescription = forwardRef<
+	HTMLSpanElement,
+	{
+		descriptionId: string;
+		shortcut: KeyboardShortcut;
+	}
+>( function KeyboardShortcutDescription( { descriptionId, shortcut }, ref ) {
 	return (
 		<VisuallyHidden
 			id={ descriptionId }
 			aria-hidden="true"
-			render={ <span /> }
+			render={ <span ref={ ref } /> }
 		>
 			{ sprintf(
 				/* translators: %s: keyboard shortcut. */
@@ -80,25 +80,25 @@ function KeyboardShortcutDescription( {
 			) }
 		</VisuallyHidden>
 	);
-}
+} );
 
 /**
  * Renders a visual keyboard shortcut while hiding it from assistive
  * technology.
  */
-function KeyboardShortcutDisplay( {
-	className,
-	shortcut,
-}: {
-	className?: string;
-	shortcut: KeyboardShortcut;
-} ) {
+const KeyboardShortcutDisplay = forwardRef<
+	HTMLSpanElement,
+	{
+		className?: string;
+		shortcut: KeyboardShortcut;
+	}
+>( function KeyboardShortcutDisplay( { className, shortcut }, ref ) {
 	return (
-		<span aria-hidden="true" className={ className } dir="ltr">
+		<span ref={ ref } aria-hidden="true" className={ className } dir="ltr">
 			{ shortcut.displayShortcut }
 		</span>
 	);
-}
+} );
 
 export {
 	KeyboardShortcutDescription,

--- a/packages/ui/src/utils/test/keyboard-shortcut.test.tsx
+++ b/packages/ui/src/utils/test/keyboard-shortcut.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { useId } from '@wordpress/element';
+import { createRef, useId } from '@wordpress/element';
 import {
 	KeyboardShortcutDescription,
 	KeyboardShortcutDisplay,
@@ -61,6 +61,33 @@ function ShortcutTargetWithExternalDescription( {
 }
 
 describe( 'keyboard shortcut utilities', () => {
+	it( 'forwards the description ref to its span', () => {
+		const ref = createRef< HTMLSpanElement >();
+		const descriptionId = 'shortcut-description';
+
+		render(
+			<KeyboardShortcutDescription
+				ref={ ref }
+				descriptionId={ descriptionId }
+				shortcut={ shortcut }
+			/>
+		);
+
+		expect( ref.current ).toBe(
+			screen.getByText( 'Keyboard shortcut: Command S' )
+		);
+		expect( ref.current ).toBeInstanceOf( HTMLSpanElement );
+	} );
+
+	it( 'forwards the display ref to its span', () => {
+		const ref = createRef< HTMLSpanElement >();
+
+		render( <KeyboardShortcutDisplay ref={ ref } shortcut={ shortcut } /> );
+
+		expect( ref.current ).toBe( screen.getByText( '⌘S' ) );
+		expect( ref.current ).toBeInstanceOf( HTMLSpanElement );
+	} );
+
 	it( 'adds shortcut metadata and a human-readable accessible description to the target', () => {
 		render( <ShortcutTarget /> );
 

--- a/packages/ui/src/utils/test/keyboard-shortcut.test.tsx
+++ b/packages/ui/src/utils/test/keyboard-shortcut.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { useId } from '@wordpress/element';
+import {
+	KeyboardShortcutDescription,
+	KeyboardShortcutDisplay,
+	useKeyboardShortcutProps,
+} from '../keyboard-shortcut';
+
+const shortcut = {
+	displayShortcut: '⌘S',
+	ariaKeyShortcut: 'Meta+S',
+	label: 'Command S',
+};
+
+function ShortcutTarget( {
+	'aria-describedby': ariaDescribedBy,
+	'aria-keyshortcuts': ariaKeyShortcuts,
+	withShortcut = true,
+}: {
+	'aria-describedby'?: string;
+	'aria-keyshortcuts'?: string;
+	withShortcut?: boolean;
+} ) {
+	const activeShortcut = withShortcut ? shortcut : undefined;
+	const { descriptionId, targetProps } = useKeyboardShortcutProps( {
+		'aria-describedby': ariaDescribedBy,
+		'aria-keyshortcuts': ariaKeyShortcuts,
+		shortcut: activeShortcut,
+	} );
+
+	return (
+		<button { ...targetProps }>
+			Save
+			{ activeShortcut && descriptionId && (
+				<KeyboardShortcutDescription
+					descriptionId={ descriptionId }
+					shortcut={ activeShortcut }
+				/>
+			) }
+		</button>
+	);
+}
+
+function ShortcutTargetWithExternalDescription( {
+	withShortcut = true,
+}: {
+	withShortcut?: boolean;
+} ) {
+	const descriptionId = useId();
+
+	return (
+		<>
+			<span id={ descriptionId }>Available offline.</span>
+			<ShortcutTarget
+				aria-describedby={ descriptionId }
+				aria-keyshortcuts="Meta+S"
+				withShortcut={ withShortcut }
+			/>
+		</>
+	);
+}
+
+describe( 'keyboard shortcut utilities', () => {
+	it( 'adds shortcut metadata and a human-readable accessible description to the target', () => {
+		render( <ShortcutTarget /> );
+
+		const button = screen.getByRole( 'button', {
+			name: 'Save',
+			description: 'Keyboard shortcut: Command S',
+		} );
+		expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
+	} );
+
+	it( 'preserves a consumer-provided accessible description', () => {
+		render( <ShortcutTargetWithExternalDescription /> );
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Save',
+				description: 'Available offline. Keyboard shortcut: Command S',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'preserves direct ARIA props when shortcut metadata is omitted', () => {
+		render(
+			<ShortcutTargetWithExternalDescription withShortcut={ false } />
+		);
+
+		const button = screen.getByRole( 'button', {
+			name: 'Save',
+			description: 'Available offline.',
+		} );
+		expect( button ).toHaveAttribute( 'aria-keyshortcuts', 'Meta+S' );
+	} );
+
+	it( 'renders visual shortcut text left-to-right and hides it from assistive technology', () => {
+		render( <KeyboardShortcutDisplay shortcut={ shortcut } /> );
+
+		const display = screen.getByText( '⌘S' );
+		expect( display ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( display ).toHaveAttribute( 'dir', 'ltr' );
+	} );
+} );


### PR DESCRIPTION
Follow-up to #80321 and #80407.

Closes https://github.com/WordPress/gutenberg/issues/80321

## What?

Exports `KeyboardShortcutDescription`, `KeyboardShortcutDisplay`, and `useKeyboardShortcutProps` from `@wordpress/ui`, then uses them in the Button story and Boot save button.

## Why?

Provides reusable shortcut presentation and accessibility without a wrapper controlling the consumer's button or tooltip.

## How?

Reuses the metadata shape shared by `IconButton` and `Menu`, and allows the exports in the ESLint rule. This does not add a public shortcut type or formatter.

## Testing Instructions

1. Run `npm run storybook:dev` and open **Design System / Components / Button / With Keyboard Shortcut**.
2. Confirm the tooltip and shortcut accessibility metadata are correct.
3. On a Boot-based admin page, make an entity dirty and focus the sidebar save button.
4. Confirm its tooltip and metadata match the story, then use the save shortcut and confirm the review modal opens.

### Testing Instructions for Keyboard

Tab to both buttons, confirm the tooltip and focus indicator appear, then use the platform save shortcut.

## Follow-ups

Explore an aggregated formatter in #80321, incorporating the related [#81564 feedback](https://github.com/WordPress/gutenberg/pull/81564#issuecomment-5323277218) and the [#74205 legacy key-value limitation](https://github.com/WordPress/gutenberg/pull/74205#issuecomment-3711278028).

## Use of AI Tools

Codex helped implement, test, review, and draft this pull request. The author reviewed the resulting changes.