### PR TITLE
Quick Inserter: Standardize the design of the Browse all button

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -103,20 +103,22 @@ export default function QuickInserter( {
 					selectBlockOnInsert={ selectBlockOnInsert }
 					isQuick
 				/>
+				{ setInserterIsOpened && (
+					<div className="block-editor-inserter__quick-inserter-expand">
+						<Button
+							className="block-editor-inserter__quick-inserter-expand-toggle"
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ onBrowseAll }
+							aria-label={ __(
+								'Browse all. This will open the main inserter panel in the editor toolbar.'
+							) }
+						>
+							{ __( 'Browse all' ) }
+						</Button>
+					</div>
+				) }
 			</div>
-
-			{ setInserterIsOpened && (
-				<Button
-					__next40pxDefaultSize
-					className="block-editor-inserter__quick-inserter-expand"
-					onClick={ onBrowseAll }
-					aria-label={ __(
-						'Browse all. This will open the main inserter panel in the editor toolbar.'
-					) }
-				>
-					{ __( 'Browse all' ) }
-				</Button>
-			) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -369,27 +369,12 @@ $block-inserter-tabs-height: 44px;
 	padding: 0;
 }
 
-.block-editor-inserter__quick-inserter-expand.components-button {
-	display: block;
-	background: $gray-900;
-	color: $white;
+.block-editor-inserter__quick-inserter-expand {
+	padding: 0 $grid-unit-20 $grid-unit-20;
+}
+.block-editor-inserter__quick-inserter-expand-toggle {
 	width: 100%;
-	border-radius: 0;
-
-	&:hover {
-		color: $white;
-	}
-
-	&:active {
-		color: $gray-400;
-	}
-
-	// Specificity is needed for the border color.
-	&.components-button:focus:not(:disabled) {
-		box-shadow: none;
-		background: var(--wp-admin-theme-color);
-		border-color: var(--wp-admin-theme-color);
-	}
+	justify-content: center;
 }
 
 .block-editor-block-patterns-explorer__sidebar {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -372,6 +372,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__quick-inserter-expand {
 	padding: 0 $grid-unit-20 $grid-unit-20;
 }
+
 .block-editor-inserter__quick-inserter-expand-toggle {
 	width: 100%;
 	justify-content: center;


### PR DESCRIPTION
Related to #81778

## What?
Removes the custom design of the "Browse all" button in the quick inserter and uses a standard design system button instead.

## Why?
The button is currently a full-width dark bar attached to the bottom edge of the popover. Because there is no offset around it, the focus outline has no room to render and gets clipped by the popover edge.

## How?
Moves the button inside the inserter panel with padding around it, and renders it as a `primary` variant `Button`. I understand this is a significant design change, but we need to find a way to fix the clipping of the focus ring.

## Testing Instructions
1. Open a post or page.
2. Click the block appender to open the quick inserter.
3. Confirm the "Browse all" button is displayed as a standard primary button with padding around it.
4. Click it and confirm the main inserter panel opens.

## Screenshots or screencast

| |Before|After|
|-|-|-|
| | <img width="376" height="352" alt="image" src="https://github.com/user-attachments/assets/6a78d524-9740-41c5-b07a-2a6a50a8369e" />| <img width="367" height="370" alt="image" src="https://github.com/user-attachments/assets/017a6875-23a0-42cf-be05-0cf5fd469c8b" />|
| Focused | <img width="377" height="355" alt="image" src="https://github.com/user-attachments/assets/e908d17c-3646-4642-a57d-dbc345ee64c8" /> |<img width="377" height="375" alt="image" src="https://github.com/user-attachments/assets/3ec46890-b16f-4f3b-8db6-86891d178569" /> |
| No results | <img width="380" height="247" alt="image" src="https://github.com/user-attachments/assets/293cc5b3-1bf1-478e-b34d-d33e8525db3d" /> | <img width="375" height="263" alt="image" src="https://github.com/user-attachments/assets/fdc91ec1-2c10-4cd2-a630-73ee62567a71" /> |


## Use of AI Tools

Claude Code was used to write the commits and this pull request description. The implementation was authored and reviewed by me.
