### PR TITLE
TypeScript: Put route projects under the typecheck run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55593,7 +55593,8 @@
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
-				"@testing-library/react": "^16.3.2"
+				"@testing-library/react": "^16.3.2",
+				"@types/jest": "^30.0.0"
 			},
 			"peerDependencies": {
 				"react": "^18 || ^19"

--- a/packages/README.md
+++ b/packages/README.md
@@ -362,7 +362,7 @@ Both extend shared base configurations (comments are not necessary):
 }
 ```
 
-Register both projects at the root: `packages/<name>/tsconfig.build.json` in the root `tsconfig.build.json` references, and `packages/<name>` in the root `tsconfig.json` references. Route entry points under `routes/` with a `tsconfig.json` register it in the root `tsconfig.json` references only: their projects emit nothing and nothing else references them, so that registration is what puts them under `npm run typecheck`.
+Register both projects at the root: `packages/<name>/tsconfig.build.json` in the root `tsconfig.build.json` references, and `packages/<name>` in the root `tsconfig.json` references. Route entry points under `routes/` with a `tsconfig.json` register it in the root `tsconfig.json` references only: their projects emit nothing and nothing else references them, so that registration is what puts them under `npm run typecheck`. A route with TypeScript test files pairs it with a `tsconfig.test.json` covering them, registered the same way.
 
 Packages whose components feed the Storybook components manifest (`components`, `dataviews`, `ui`) carry a third project, `tsconfig.stories.json`, registered in the root `tsconfig.json` only. It type checks the stories against component sources without jest types. Storybook's component meta extractor reads props through the closest `tsconfig.json` that lists a story, or through its own inferred project when none does; the inferred project produces the complete manifest and the dev project does not, so stories stay out of `tsconfig.json`. The dev project cannot reference this one either, because a referenced project may not disable emit (TS6310), which is why it is registered at the root only.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -362,7 +362,7 @@ Both extend shared base configurations (comments are not necessary):
 }
 ```
 
-Register both projects at the root: `packages/<name>/tsconfig.build.json` in the root `tsconfig.build.json` references, and `packages/<name>` in the root `tsconfig.json` references.
+Register both projects at the root: `packages/<name>/tsconfig.build.json` in the root `tsconfig.build.json` references, and `packages/<name>` in the root `tsconfig.json` references. Route entry points under `routes/` with a `tsconfig.json` register it in the root `tsconfig.json` references only: their projects emit nothing and nothing else references them, so that registration is what puts them under `npm run typecheck`.
 
 Packages whose components feed the Storybook components manifest (`components`, `dataviews`, `ui`) carry a third project, `tsconfig.stories.json`, registered in the root `tsconfig.json` only. It type checks the stories against component sources without jest types. Storybook's component meta extractor reads props through the closest `tsconfig.json` that lists a story, or through its own inferred project when none does; the inferred project produces the complete manifest and the dev project does not, so stories stay out of `tsconfig.json`. The dev project cannot reference this one either, because a referenced project may not disable emit (TS6310), which is why it is registered at the root only.
 

--- a/routes/dashboard/package.json
+++ b/routes/dashboard/package.json
@@ -30,6 +30,7 @@
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
+		"@types/jest": "^30.0.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2"
 	},

--- a/routes/dashboard/tsconfig.json
+++ b/routes/dashboard/tsconfig.json
@@ -10,6 +10,24 @@
 		"noImplicitAny": false,
 		"types": [ "style-imports" ]
 	},
+	"references": [
+		{ "path": "../../packages/admin-ui/tsconfig.build.json" },
+		{ "path": "../../packages/api-fetch/tsconfig.build.json" },
+		{ "path": "../../packages/core-data/tsconfig.build.json" },
+		{ "path": "../../packages/data" },
+		{ "path": "../../packages/dataviews/tsconfig.build.json" },
+		{ "path": "../../packages/element/tsconfig.build.json" },
+		{ "path": "../../packages/hooks" },
+		{ "path": "../../packages/i18n/tsconfig.build.json" },
+		{ "path": "../../packages/icons/tsconfig.build.json" },
+		{ "path": "../../packages/notices/tsconfig.build.json" },
+		{ "path": "../../packages/preferences/tsconfig.build.json" },
+		{ "path": "../../packages/ui/tsconfig.build.json" },
+		{ "path": "../../packages/viewport" },
+		{ "path": "../../packages/warning" },
+		{ "path": "../../packages/widget-dashboard/tsconfig.build.json" },
+		{ "path": "../../packages/widget-primitives/tsconfig.build.json" }
+	],
 	"include": [ "**/*.ts", "**/*.tsx" ],
 	"exclude": [ "**/test/**", "build", "node_modules" ]
 }

--- a/routes/dashboard/tsconfig.test.json
+++ b/routes/dashboard/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.dev.base.json",
+	/* Route tests live beside the route sources, not under src. */
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"rootDir": ".",
+		"composite": false,
+		"types": [ "jest" ]
+	},
+	"include": [ "**/test/**/*.ts", "**/test/**/*.tsx" ],
+	"exclude": [ "build", "node_modules" ],
+	"references": [
+		{ "path": "../../packages/api-fetch/tsconfig.build.json" },
+		{ "path": "../../packages/data" },
+		{ "path": "../../packages/preferences/tsconfig.build.json" },
+		{ "path": "../../packages/widget-dashboard/tsconfig.build.json" }
+	]
+}

--- a/routes/site-health/tsconfig.json
+++ b/routes/site-health/tsconfig.json
@@ -9,6 +9,15 @@
 		"composite": false,
 		"types": []
 	},
+	"references": [
+		{ "path": "../../packages/admin-ui/tsconfig.build.json" },
+		{ "path": "../../packages/api-fetch/tsconfig.build.json" },
+		{ "path": "../../packages/dataviews/tsconfig.build.json" },
+		{ "path": "../../packages/dom" },
+		{ "path": "../../packages/element/tsconfig.build.json" },
+		{ "path": "../../packages/i18n/tsconfig.build.json" },
+		{ "path": "../../packages/ui/tsconfig.build.json" }
+	],
 	"include": [ "**/*.ts", "**/*.tsx" ],
 	"exclude": [ "build", "node_modules" ]
 }

--- a/tools/validation/validate-tsconfig.mjs
+++ b/tools/validation/validate-tsconfig.mjs
@@ -346,10 +346,34 @@ const routesWithTypes = glob
 for ( const routeName of routesWithTypes ) {
 	const routeDir = resolve( repoRoot, 'routes', routeName );
 	const routeProject = join( routeDir, 'tsconfig.json' );
+	const routeTestProject = join( routeDir, 'tsconfig.test.json' );
 
 	if ( ! rootSolutionReferences.has( routeProject ) ) {
 		reportError(
 			`Missing reference to "routes/${ routeName }" in tsconfig.json`
+		);
+	}
+
+	/*
+	 * The route project excludes test directories, so TypeScript test files
+	 * are only checked when a registered test project covers them.
+	 */
+	const hasTestFiles =
+		glob.sync( '**/{test,tests,__tests__}/**/*.{ts,tsx}', {
+			cwd: routeDir,
+			ignore: [ 'node_modules/**', 'build/**' ],
+		} ).length > 0;
+	if ( hasTestFiles && ! existsSync( routeTestProject ) ) {
+		reportError(
+			`Missing test project for the TypeScript test files of routes/${ routeName }`
+		);
+	}
+	if (
+		existsSync( routeTestProject ) &&
+		! rootSolutionReferences.has( routeTestProject )
+	) {
+		reportError(
+			`Missing reference to "routes/${ routeName }/tsconfig.test.json" in tsconfig.json`
 		);
 	}
 

--- a/tools/validation/validate-tsconfig.mjs
+++ b/tools/validation/validate-tsconfig.mjs
@@ -335,4 +335,53 @@ for ( const packageName of packagesWithTypes ) {
 	}
 }
 
+/*
+ * Route projects emit nothing and no other project references them, so only
+ * the root solution registration puts them under `npm run typecheck`.
+ */
+const routesWithTypes = glob
+	.sync( 'routes/*/tsconfig.json', { cwd: repoRoot } )
+	.map( ( tsconfigPath ) => basename( dirname( tsconfigPath ) ) );
+
+for ( const routeName of routesWithTypes ) {
+	const routeDir = resolve( repoRoot, 'routes', routeName );
+	const routeProject = join( routeDir, 'tsconfig.json' );
+
+	if ( ! rootSolutionReferences.has( routeProject ) ) {
+		reportError(
+			`Missing reference to "routes/${ routeName }" in tsconfig.json`
+		);
+	}
+
+	const packageJsonPath = join( routeDir, 'package.json' );
+	if ( ! existsSync( packageJsonPath ) ) {
+		continue;
+	}
+	const references = referencedProjects( routeProject );
+	const packageJson = JSON.parse( readFileSync( packageJsonPath, 'utf8' ) );
+	for ( const dependency of Object.keys( packageJson.dependencies ?? {} ) ) {
+		if ( ! dependency.startsWith( '@wordpress/' ) ) {
+			continue;
+		}
+		const dependencyPackageName = dependency.slice( '@wordpress/'.length );
+		if ( ! packagesWithTypes.includes( dependencyPackageName ) ) {
+			continue;
+		}
+		const dependencyProject = packageProjects(
+			dependencyPackageName
+		).srcProject;
+		if ( ! dependencyProject ) {
+			continue;
+		}
+		if ( ! references.has( dependencyProject ) ) {
+			reportError(
+				`Missing reference to "${ relative(
+					routeDir,
+					dependencyProject
+				) }" in ${ relative( repoRoot, routeProject ) }`
+			);
+		}
+	}
+}
+
 process.exit( hasErrors ? 1 : 0 );

--- a/tools/validation/validate-tsconfig.test.js
+++ b/tools/validation/validate-tsconfig.test.js
@@ -2,7 +2,7 @@
 const { spawnSync } = require( 'node:child_process' );
 const { mkdtempSync, mkdirSync, rmSync, writeFileSync } = require( 'node:fs' );
 const { tmpdir } = require( 'node:os' );
-const { join } = require( 'node:path' );
+const { dirname, join } = require( 'node:path' );
 
 const validatorPath = join( __dirname, 'validate-tsconfig.mjs' );
 const temporaryRoots = [];
@@ -44,7 +44,7 @@ function createRepo( { packages, routes, build, root } ) {
 
 	for ( const [
 		name,
-		{ tsconfigs, dependencies, devDependencies, manifest = true },
+		{ tsconfigs, dependencies, devDependencies, manifest = true, files },
 	] of Object.entries( routes ?? {} ) ) {
 		const routeDir = join( repoRoot, 'routes', name );
 		mkdirSync( routeDir, { recursive: true } );
@@ -60,6 +60,12 @@ function createRepo( { packages, routes, build, root } ) {
 			writeJson( join( routeDir, fileName ), {
 				references: references.map( ( path ) => ( { path } ) ),
 			} );
+		}
+		for ( const file of files ?? [] ) {
+			mkdirSync( join( routeDir, dirname( file ) ), {
+				recursive: true,
+			} );
+			writeFileSync( join( routeDir, file ), 'export {};\n' );
 		}
 	}
 
@@ -711,6 +717,74 @@ test( 'ignores route devDependencies and routes without a manifest', () => {
 				'packages/blob',
 				'routes/dashboard',
 				'routes/site-health',
+			],
+		} )
+	);
+	expect( stderr ).toBe( '' );
+	expect( status ).toBe( 0 );
+} );
+
+test( 'fails when a route has TypeScript test files but no test project', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: {},
+			routes: {
+				dashboard: {
+					tsconfigs: { 'tsconfig.json': [] },
+					files: [ 'hooks/test/layout.test.ts' ],
+				},
+			},
+			build: [],
+			root: [ './tsconfig.build.json', 'routes/dashboard' ],
+		} )
+	);
+	expect( stderr ).toContain(
+		'Missing test project for the TypeScript test files of routes/dashboard'
+	);
+	expect( status ).toBe( 1 );
+} );
+
+test( 'fails when a route test project is missing from the root solution', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: {},
+			routes: {
+				dashboard: {
+					tsconfigs: {
+						'tsconfig.json': [],
+						'tsconfig.test.json': [],
+					},
+					files: [ 'hooks/test/layout.test.ts' ],
+				},
+			},
+			build: [],
+			root: [ './tsconfig.build.json', 'routes/dashboard' ],
+		} )
+	);
+	expect( stderr ).toContain(
+		'Missing reference to "routes/dashboard/tsconfig.test.json" in tsconfig.json'
+	);
+	expect( status ).toBe( 1 );
+} );
+
+test( 'passes when a route test project covers the test files', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: {},
+			routes: {
+				dashboard: {
+					tsconfigs: {
+						'tsconfig.json': [],
+						'tsconfig.test.json': [],
+					},
+					files: [ 'hooks/test/layout.test.ts' ],
+				},
+			},
+			build: [],
+			root: [
+				'./tsconfig.build.json',
+				'routes/dashboard',
+				'routes/dashboard/tsconfig.test.json',
 			],
 		} )
 	);

--- a/tools/validation/validate-tsconfig.test.js
+++ b/tools/validation/validate-tsconfig.test.js
@@ -23,11 +23,12 @@ function writeJson( path, contents ) {
  *
  * @param {Object} repo          Repository description.
  * @param {Object} repo.packages Package name to `{ tsconfigs, dependencies }`.
+ * @param {Object} [repo.routes] Route name to `{ tsconfigs, dependencies }`.
  * @param {Array}  repo.build    References of the build solution.
  * @param {Array}  repo.root     References of the root solution.
  * @return {string} Path of the created repository root.
  */
-function createRepo( { packages, build, root } ) {
+function createRepo( { packages, routes, build, root } ) {
 	const repoRoot = mkdtempSync( join( tmpdir(), 'validate-tsconfig-' ) );
 	temporaryRoots.push( repoRoot );
 
@@ -40,6 +41,23 @@ function createRepo( { packages, build, root } ) {
 	writeJson( join( repoRoot, 'tsconfig.json' ), {
 		references: root.map( ( path ) => ( { path } ) ),
 	} );
+
+	for ( const [ name, { tsconfigs, dependencies } ] of Object.entries(
+		routes ?? {}
+	) ) {
+		const routeDir = join( repoRoot, 'routes', name );
+		mkdirSync( routeDir, { recursive: true } );
+		writeJson( join( routeDir, 'package.json' ), {
+			name: `@wordpress/route-${ name }`,
+			version: '1.0.0',
+			...( dependencies && { dependencies } ),
+		} );
+		for ( const [ fileName, references ] of Object.entries( tsconfigs ) ) {
+			writeJson( join( routeDir, fileName ), {
+				references: references.map( ( path ) => ( { path } ) ),
+			} );
+		}
+	}
 
 	for ( const [ name, { tsconfigs, dependencies } ] of Object.entries(
 		packages
@@ -565,4 +583,78 @@ test( 'fails when a package with TypeScript test files has no dev project', () =
 	expect( result.stderr ).toContain(
 		'Missing dev project for the TypeScript test or story files of packages/blob'
 	);
+} );
+
+test( 'passes when a route is registered and references its dependencies', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: { blob: splitPackage },
+			routes: {
+				dashboard: {
+					tsconfigs: {
+						'tsconfig.json': [
+							'../../packages/blob/tsconfig.build.json',
+						],
+					},
+					dependencies: { '@wordpress/blob': 'file:../..' },
+				},
+			},
+			build: [ 'packages/blob/tsconfig.build.json' ],
+			root: [
+				'./tsconfig.build.json',
+				'packages/blob',
+				'routes/dashboard',
+			],
+		} )
+	);
+	expect( stderr ).toBe( '' );
+	expect( status ).toBe( 0 );
+} );
+
+test( 'fails when a route is missing from the root solution', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: { blob: splitPackage },
+			routes: {
+				dashboard: {
+					tsconfigs: {
+						'tsconfig.json': [
+							'../../packages/blob/tsconfig.build.json',
+						],
+					},
+					dependencies: { '@wordpress/blob': 'file:../..' },
+				},
+			},
+			build: [ 'packages/blob/tsconfig.build.json' ],
+			root: [ './tsconfig.build.json', 'packages/blob' ],
+		} )
+	);
+	expect( stderr ).toContain(
+		'Missing reference to "routes/dashboard" in tsconfig.json'
+	);
+	expect( status ).toBe( 1 );
+} );
+
+test( 'fails when a route does not reference a dependency', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: { blob: splitPackage },
+			routes: {
+				dashboard: {
+					tsconfigs: { 'tsconfig.json': [] },
+					dependencies: { '@wordpress/blob': 'file:../..' },
+				},
+			},
+			build: [ 'packages/blob/tsconfig.build.json' ],
+			root: [
+				'./tsconfig.build.json',
+				'packages/blob',
+				'routes/dashboard',
+			],
+		} )
+	);
+	expect( stderr ).toContain(
+		'Missing reference to "../../packages/blob/tsconfig.build.json" in routes/dashboard/tsconfig.json'
+	);
+	expect( status ).toBe( 1 );
 } );

--- a/tools/validation/validate-tsconfig.test.js
+++ b/tools/validation/validate-tsconfig.test.js
@@ -23,7 +23,7 @@ function writeJson( path, contents ) {
  *
  * @param {Object} repo          Repository description.
  * @param {Object} repo.packages Package name to `{ tsconfigs, dependencies }`.
- * @param {Object} [repo.routes] Route name to `{ tsconfigs, dependencies }`.
+ * @param {Object} [repo.routes] Route name to `{ tsconfigs, dependencies, devDependencies, manifest }`.
  * @param {Array}  repo.build    References of the build solution.
  * @param {Array}  repo.root     References of the root solution.
  * @return {string} Path of the created repository root.
@@ -42,16 +42,20 @@ function createRepo( { packages, routes, build, root } ) {
 		references: root.map( ( path ) => ( { path } ) ),
 	} );
 
-	for ( const [ name, { tsconfigs, dependencies } ] of Object.entries(
-		routes ?? {}
-	) ) {
+	for ( const [
+		name,
+		{ tsconfigs, dependencies, devDependencies, manifest = true },
+	] of Object.entries( routes ?? {} ) ) {
 		const routeDir = join( repoRoot, 'routes', name );
 		mkdirSync( routeDir, { recursive: true } );
-		writeJson( join( routeDir, 'package.json' ), {
-			name: `@wordpress/route-${ name }`,
-			version: '1.0.0',
-			...( dependencies && { dependencies } ),
-		} );
+		if ( manifest ) {
+			writeJson( join( routeDir, 'package.json' ), {
+				name: `@wordpress/route-${ name }`,
+				version: '1.0.0',
+				...( dependencies && { dependencies } ),
+				...( devDependencies && { devDependencies } ),
+			} );
+		}
 		for ( const [ fileName, references ] of Object.entries( tsconfigs ) ) {
 			writeJson( join( routeDir, fileName ), {
 				references: references.map( ( path ) => ( { path } ) ),
@@ -657,4 +661,59 @@ test( 'fails when a route does not reference a dependency', () => {
 		'Missing reference to "../../packages/blob/tsconfig.build.json" in routes/dashboard/tsconfig.json'
 	);
 	expect( status ).toBe( 1 );
+} );
+
+test( 'passes when a route references an unsplit dependency by directory', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: {
+				hooks: { tsconfigs: { 'tsconfig.json': [] } },
+				'jest-console': devOnlyPackage,
+			},
+			routes: {
+				dashboard: {
+					tsconfigs: { 'tsconfig.json': [ '../../packages/hooks' ] },
+					dependencies: {
+						'@wordpress/hooks': 'file:../..',
+						'@wordpress/jest-console': 'file:../..',
+					},
+				},
+			},
+			build: [ 'packages/hooks' ],
+			root: [
+				'./tsconfig.build.json',
+				'packages/jest-console',
+				'routes/dashboard',
+			],
+		} )
+	);
+	expect( stderr ).toBe( '' );
+	expect( status ).toBe( 0 );
+} );
+
+test( 'ignores route devDependencies and routes without a manifest', () => {
+	const { status, stderr } = runValidator(
+		createRepo( {
+			packages: { blob: splitPackage },
+			routes: {
+				dashboard: {
+					tsconfigs: { 'tsconfig.json': [] },
+					devDependencies: { '@wordpress/blob': 'file:../..' },
+				},
+				'site-health': {
+					tsconfigs: { 'tsconfig.json': [] },
+					manifest: false,
+				},
+			},
+			build: [ 'packages/blob/tsconfig.build.json' ],
+			root: [
+				'./tsconfig.build.json',
+				'packages/blob',
+				'routes/dashboard',
+				'routes/site-health',
+			],
+		} )
+	);
+	expect( stderr ).toBe( '' );
+	expect( status ).toBe( 0 );
 } );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,6 +58,8 @@
 		{ "path": "packages/widget-primitives" },
 		{ "path": "packages/wordcount" },
 		{ "path": "packages/worker-threads" },
+		{ "path": "routes/dashboard" },
+		{ "path": "routes/site-health" },
 		{ "path": "storybook" },
 		{ "path": "test/e2e" },
 		{ "path": "test/performance" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,6 +59,7 @@
 		{ "path": "packages/wordcount" },
 		{ "path": "packages/worker-threads" },
 		{ "path": "routes/dashboard" },
+		{ "path": "routes/dashboard/tsconfig.test.json" },
 		{ "path": "routes/site-health" },
 		{ "path": "storybook" },
 		{ "path": "test/e2e" },


### PR DESCRIPTION
## What?

See #81473. Registers the two existing route projects, `routes/dashboard` and `routes/site-health`, in the root `tsconfig.json`, so `npm run typecheck` checks them.

## Why?

The route projects emit nothing and no other project references them, so they were registered nowhere and `npm run typecheck` never saw them. Verified by injecting a type error into `routes/site-health/route.ts`: before this change typecheck stayed green, after it the run fails.

## How?

Each route `tsconfig.json` gains references to its `@wordpress/*` dependencies' build projects, derived from its `package.json`, so `tsc --build` orders them after their dependencies. The validator now requires both: root registration for every `routes/*/tsconfig.json` and a reference for each TypeScript dependency (3 new tests). `packages/README.md` documents the registration.

23 more routes have TypeScript files and no `tsconfig.json` at all; bringing them under the type check is follow-up work tracked in #81473.

## Testing Instructions

1. `npm run typecheck` passes.
2. Add `const bad: number = 'x';` to `routes/site-health/route.ts` and rerun: it fails.
3. `npm run lint:tsconfig` passes; remove the `routes/dashboard` entry from the root `tsconfig.json` and it fails.

## Use of AI Tools

Written with the help of an AI assistant, reviewed and edited by the author.
