### PR TITLE
Blocks: Make BlockTransform a discriminated union over its type

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 -   `BlockTransform` is now a discriminated union over its `type`, so that each kind of transform declares its own fields: `shortcode` transforms accept `tag` and `attributes` with `shortcode` matchers, `enter` transforms `regExp`, `prefix` transforms `prefix`, and `raw` transforms `selector` and `schema`. `blocks`, `variationName` and `shortcuts` now belong to `block` transforms only, and `blocks` is required there. This fixes type errors when registering blocks with documented shortcode transforms, but reading a variant field off a `BlockTransform` that has not been narrowed on its `type` no longer compiles — including the result of `findTransform` ([#81811](https://github.com/WordPress/gutenberg/issues/81811)).
+-   Removed the `transforms.supportedMobileTransforms` block type property, along with the `supportedMobileTransforms` and `usingMobileTransformations` properties of a block transform. They were only meaningful to the React Native implementation, removed in [#78747](https://github.com/WordPress/gutenberg/pull/78747), and nothing reads them any more. Note that the filter they drove was not platform-gated: a block type still declaring `supportedMobileTransforms` had its transforms filtered everywhere, and `getBlockTransforms` no longer filters them at all ([#81831](https://github.com/WordPress/gutenberg/pull/81831)).
 
 ### Bug Fixes
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `getBlockAttributes` no longer breaks when a block has no content to parse, such as a self-closing shortcode: missing content is treated as empty markup instead of reaching the attribute matchers ([#81831](https://github.com/WordPress/gutenberg/pull/81831)).
+-   `BlockTransform` is now a discriminated union over its `type`, so that each kind of transform declares its own fields: `shortcode` transforms accept `tag` and `attributes` with `shortcode` matchers, `enter` transforms `regExp`, `prefix` transforms `prefix`, and `raw` transforms `selector` and `schema`. This fixes type errors when registering blocks with documented shortcode transforms ([#81811](https://github.com/WordPress/gutenberg/issues/81811)).
+
 ## 15.27.0 (2026-08-26)
 
 ### New Features
 
 -   Block variations and `block` type block transforms accept a `shortcut` property, declaring a keyboard shortcut that applies the variation or transform to the selected block. See the [block variations](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/) and [block transforms](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-transforms/) documentation ([#81588](https://github.com/WordPress/gutenberg/pull/81588)).
-
-### Bug Fixes
-
--   `BlockTransform` is now a discriminated union over its `type`, so that each kind of transform declares its own fields: `shortcode` transforms accept `tag` and `attributes` with `shortcode` matchers, `enter` transforms `regExp`, `prefix` transforms `prefix`, and `raw` transforms `selector` and `schema`. This fixes type errors when registering blocks with documented shortcode transforms ([#81811](https://github.com/WordPress/gutenberg/issues/81811)).
 
 ## 15.26.0 (2026-08-12)
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 -   Block variations and `block` type block transforms accept a `shortcut` property, declaring a keyboard shortcut that applies the variation or transform to the selected block. See the [block variations](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/) and [block transforms](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-transforms/) documentation ([#81588](https://github.com/WordPress/gutenberg/pull/81588)).
 
+### Bug Fixes
+
+-   `BlockTransform` is now a discriminated union over its `type`, so that each kind of transform declares its own fields: `shortcode` transforms accept `tag` and `attributes` with `shortcode` matchers, `enter` transforms `regExp`, `prefix` transforms `prefix`, and `raw` transforms `selector` and `schema`. This fixes type errors when registering blocks with documented shortcode transforms ([#81811](https://github.com/WordPress/gutenberg/issues/81811)).
+
 ## 15.26.0 (2026-08-12)
 
 ### Internal

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `BlockTransform` is now a discriminated union over its `type`, so that each kind of transform declares its own fields: `shortcode` transforms accept `tag` and `attributes` with `shortcode` matchers, `enter` transforms `regExp`, `prefix` transforms `prefix`, and `raw` transforms `selector` and `schema`. `blocks`, `variationName` and `shortcuts` now belong to `block` transforms only, and `blocks` is required there. This fixes type errors when registering blocks with documented shortcode transforms, but reading a variant field off a `BlockTransform` that has not been narrowed on its `type` no longer compiles — including the result of `findTransform` ([#81811](https://github.com/WordPress/gutenberg/issues/81811)).
+
 ### Bug Fixes
 
 -   `getBlockAttributes` no longer breaks when a block has no content to parse, such as a self-closing shortcode: missing content is treated as empty markup instead of reaching the attribute matchers ([#81831](https://github.com/WordPress/gutenberg/pull/81831)).
--   `BlockTransform` is now a discriminated union over its `type`, so that each kind of transform declares its own fields: `shortcode` transforms accept `tag` and `attributes` with `shortcode` matchers, `enter` transforms `regExp`, `prefix` transforms `prefix`, and `raw` transforms `selector` and `schema`. This fixes type errors when registering blocks with documented shortcode transforms ([#81811](https://github.com/WordPress/gutenberg/issues/81811)).
 
 ## 15.27.0 (2026-08-26)
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -110,7 +110,7 @@ Returns the block attributes of a registered block node given its type.
 _Parameters_
 
 -   _blockTypeOrName_ `string | BlockType`: Block type or name.
--   _innerHTML_ `string | Node`: Raw block content.
+-   _innerHTML_ `string | Node | undefined`: Raw block content.
 -   _attributes_ `Record< string, unknown >`: Known block attributes (from delimiters).
 
 _Returns_
@@ -488,7 +488,7 @@ Given a block's raw content and an attribute's schema returns the attribute's va
 
 _Parameters_
 
--   _innerHTML_ `string | Node`: Block's raw content.
+-   _innerHTML_ `string | Node | undefined`: Block's raw content.
 -   _attributeSchema_ `BlockAttribute`: Attribute's schema.
 
 _Returns_

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -501,11 +501,11 @@ Converts an HTML string to known blocks. Strips everything else.
 
 _Parameters_
 
--   _options_ `{ HTML?: string; plainText?: string; mode?: 'AUTO' | 'INLINE' | 'BLOCKS'; tagName?: string; }`:
--   _options.HTML_ `string`: The HTML to convert.
--   _options.plainText_ `string`: Plain text version.
--   _options.mode_ `'AUTO' | 'INLINE' | 'BLOCKS'`: Handle content as blocks or inline content. _ 'AUTO': Decide based on the content passed. _ 'INLINE': Always handle as inline content, and return string. \* 'BLOCKS': Always handle as blocks, and return array of blocks.
--   _options.tagName_ `string`: The tag into which content will be inserted.
+-   _options_ `RawHandlerOptions`:
+-   _options.HTML_ `RawHandlerOptions[ 'HTML' ]`: The HTML to convert.
+-   _options.plainText_ `RawHandlerOptions[ 'plainText' ]`: Plain text version.
+-   _options.mode_ `RawHandlerOptions[ 'mode' ]`: Handle content as blocks or inline content. _ 'AUTO': Decide based on the content passed. _ 'INLINE': Always handle as inline content, and return string. \* 'BLOCKS': Always handle as blocks, and return array of blocks.
+-   _options.tagName_ `RawHandlerOptions[ 'tagName' ]`: The tag into which content will be inserted.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -96,12 +96,12 @@ Given an array of transforms, returns the highest-priority transform where the p
 
 _Parameters_
 
--   _transforms_ `BlockTransform[]`: Transforms to search.
--   _predicate_ `( transform: BlockTransform ) => boolean`: Function returning true on matching transform.
+-   _transforms_ `T[]`: Transforms to search.
+-   _predicate_ `( transform: T ) => boolean`: Function returning true on matching transform.
 
 _Returns_
 
--   `BlockTransform | null`: Highest-priority transform candidate.
+-   `T | null`: Highest-priority transform candidate.
 
 ### getBlockAttributes
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -223,7 +223,7 @@ _Parameters_
 
 _Returns_
 
--   `BlockTransform[]`: Block transforms for direction.
+-   `NormalizedBlockTransform[]`: Block transforms for direction.
 
 ### getBlockType
 

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -43,7 +43,7 @@ const isBlockTypeTransform = (
 
 const getBlockTypeWithTransformMetadata = (
 	blockType: BlockType,
-	transform: BlockTransform
+	transform: BlockBlockTransform
 ): BlockTypeWithTransformMetadata =>
 	transform.variationName
 		? { ...blockType, variationName: transform.variationName }
@@ -240,7 +240,7 @@ const isPossibleTransformForSource = (
 	transform: BlockTransform,
 	direction: 'from' | 'to',
 	blocks: Block[]
-): boolean => {
+): transform is BlockBlockTransform => {
 	if ( ! blocks.length ) {
 		return false;
 	}
@@ -276,7 +276,7 @@ const isPossibleTransformForSource = (
 	const sourceBlock = blocks[ 0 ];
 	const hasMatchingName =
 		direction !== 'from' ||
-		transform.blocks!.indexOf( sourceBlock.name ) !== -1 ||
+		transform.blocks.indexOf( sourceBlock.name ) !== -1 ||
 		isWildcardBlockTransform( transform );
 	if ( ! hasMatchingName ) {
 		return false;
@@ -366,7 +366,7 @@ const getBlockTypesForPossibleToTransforms = (
 	// Map block names to block types.
 	return possibleTransforms
 		.flatMap( ( transformation ) => {
-			return ( transformation.blocks || [] ).map( ( name ) => {
+			return ( transformation.blocks ?? [] ).map( ( name ) => {
 				const transformedBlockType = getBlockType( name );
 				return transformedBlockType
 					? getBlockTypeWithTransformMetadata(
@@ -611,7 +611,7 @@ export function switchToBlockType(
 			( t ) =>
 				isMatchingVariation( t ) &&
 				( isWildcardBlockTransform( t ) ||
-					t.blocks!.indexOf( name ) !== -1 ) &&
+					t.blocks.indexOf( name ) !== -1 ) &&
 				( ! isMultiBlock || !! t.isMultiBlock ) &&
 				maybeCheckTransformIsMatch( t, blocksArray )
 		) ||
@@ -620,7 +620,7 @@ export function switchToBlockType(
 			( t ) =>
 				isMatchingVariation( t ) &&
 				( isWildcardBlockTransform( t ) ||
-					t.blocks!.indexOf( sourceName ) !== -1 ) &&
+					t.blocks.indexOf( sourceName ) !== -1 ) &&
 				( ! isMultiBlock || !! t.isMultiBlock ) &&
 				maybeCheckTransformIsMatch( t, blocksArray )
 		);

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -12,7 +12,12 @@ import {
 	normalizeBlockType,
 	sanitizeBlockAttributes,
 } from './utils';
-import type { Block, BlockType, BlockTransform } from '../types';
+import type {
+	Block,
+	BlockBlockTransform,
+	BlockTransform,
+	BlockType,
+} from '../types';
 
 type BlockTypeWithTransformMetadata = BlockType & {
 	variationName?: string;
@@ -24,6 +29,17 @@ type TemplateBlock = [
 	Array< unknown >?,
 	Array< string | null >?,
 ];
+
+/**
+ * Returns whether a transform is a transform from or to another block type.
+ *
+ * @param transform The transform object to test.
+ *
+ * @return Whether the transform is of type `block`.
+ */
+const isBlockTypeTransform = (
+	transform: BlockTransform
+): transform is BlockBlockTransform => transform.type === 'block';
 
 const getBlockTypeWithTransformMetadata = (
 	blockType: BlockType,
@@ -229,6 +245,11 @@ const isPossibleTransformForSource = (
 		return false;
 	}
 
+	// Only consider 'block' type transforms as valid.
+	if ( ! isBlockTypeTransform( transform ) ) {
+		return false;
+	}
+
 	// If multiple blocks are selected, only multi block transforms
 	// or wildcard transforms are allowed.
 	const isMultiBlock = blocks.length > 1;
@@ -247,12 +268,6 @@ const isPossibleTransformForSource = (
 		! isWildcardBlockTransform( transform ) &&
 		! blocks.every( ( block ) => block.name === firstBlockName )
 	) {
-		return false;
-	}
-
-	// Only consider 'block' type transforms as valid.
-	const isBlockType = transform.type === 'block';
-	if ( ! isBlockType ) {
 		return false;
 	}
 
@@ -377,7 +392,7 @@ export const isWildcardBlockTransform = (
 	t: BlockTransform | null | undefined
 ): boolean =>
 	!! t &&
-	t.type === 'block' &&
+	isBlockTypeTransform( t ) &&
 	Array.isArray( t.blocks ) &&
 	t.blocks.includes( '*' );
 
@@ -445,10 +460,10 @@ export function getPossibleBlockTransformations(
  *
  * @return Highest-priority transform candidate.
  */
-export function findTransform(
-	transforms: BlockTransform[],
-	predicate: ( transform: BlockTransform ) => boolean
-): BlockTransform | null {
+export function findTransform< T extends BlockTransform >(
+	transforms: T[],
+	predicate: ( transform: T ) => boolean
+): T | null {
 	// The hooks library already has built-in mechanisms for managing priority
 	// queue, so leverage via locally-defined instance.
 	const hooks = createHooks();
@@ -466,7 +481,7 @@ export function findTransform(
 	}
 
 	// Filter name is arbitrarily chosen but consistent with above aggregation.
-	return hooks.applyFilters( 'transform', null ) as BlockTransform | null;
+	return hooks.applyFilters( 'transform', null ) as T | null;
 }
 
 /**
@@ -545,7 +560,7 @@ export function getBlockTransforms(
  * @return True if given blocks are a match for the transform.
  */
 function maybeCheckTransformIsMatch(
-	transform: BlockTransform,
+	transform: BlockBlockTransform,
 	blocks: Block[]
 ): boolean {
 	if ( typeof transform.isMatch !== 'function' ) {
@@ -581,16 +596,19 @@ export function switchToBlockType(
 
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
-	const transformationsFrom = getBlockTransforms( 'from', name );
-	const transformationsTo = getBlockTransforms( 'to', sourceName );
-	const isMatchingVariation = ( t: BlockTransform ) =>
+	const transformationsFrom = getBlockTransforms( 'from', name ).filter(
+		isBlockTypeTransform
+	);
+	const transformationsTo = getBlockTransforms( 'to', sourceName ).filter(
+		isBlockTypeTransform
+	);
+	const isMatchingVariation = ( t: BlockBlockTransform ) =>
 		variationName ? t.variationName === variationName : ! t.variationName;
 
 	const transformation =
 		findTransform(
 			transformationsTo,
 			( t ) =>
-				t.type === 'block' &&
 				isMatchingVariation( t ) &&
 				( isWildcardBlockTransform( t ) ||
 					t.blocks!.indexOf( name ) !== -1 ) &&
@@ -600,7 +618,6 @@ export function switchToBlockType(
 		findTransform(
 			transformationsFrom,
 			( t ) =>
-				t.type === 'block' &&
 				isMatchingVariation( t ) &&
 				( isWildcardBlockTransform( t ) ||
 					t.blocks!.indexOf( sourceName ) !== -1 ) &&

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -17,6 +17,7 @@ import type {
 	BlockBlockTransform,
 	BlockTransform,
 	BlockType,
+	NormalizedBlockTransform,
 } from '../types';
 
 type BlockTypeWithTransformMetadata = BlockType & {
@@ -37,9 +38,9 @@ type TemplateBlock = [
  *
  * @return Whether the transform is of type `block`.
  */
-const isBlockTypeTransform = (
-	transform: BlockTransform
-): transform is BlockBlockTransform => transform.type === 'block';
+const isBlockTypeTransform = < Transform extends BlockTransform >(
+	transform: Transform
+): transform is Transform & BlockBlockTransform => transform.type === 'block';
 
 const getBlockTypeWithTransformMetadata = (
 	blockType: BlockType,
@@ -237,10 +238,10 @@ export function cloneBlock(
  * @return Is the transform possible?
  */
 const isPossibleTransformForSource = (
-	transform: BlockTransform,
+	transform: NormalizedBlockTransform,
 	direction: 'from' | 'to',
 	blocks: Block[]
-): transform is BlockBlockTransform => {
+): transform is NormalizedBlockTransform< BlockBlockTransform > => {
 	if ( ! blocks.length ) {
 		return false;
 	}
@@ -288,7 +289,7 @@ const isPossibleTransformForSource = (
 		! isMultiBlock &&
 		direction === 'from' &&
 		isContainerGroupBlock( sourceBlock.name ) &&
-		isContainerGroupBlock( transform.blockName! )
+		isContainerGroupBlock( transform.blockName )
 	) {
 		return false;
 	}
@@ -498,7 +499,7 @@ export function findTransform< T extends BlockTransform >(
 export function getBlockTransforms(
 	direction: 'to' | 'from',
 	blockTypeOrName?: string | BlockType
-): BlockTransform[] {
+): NormalizedBlockTransform[] {
 	// When retrieving transforms for all block types, recurse into self.
 	if ( blockTypeOrName === undefined ) {
 		return getBlockTypes()
@@ -508,9 +509,8 @@ export function getBlockTransforms(
 
 	// Validate that block type exists and has array of direction.
 	const blockType = normalizeBlockType( blockTypeOrName );
-	const { name: blockName, transforms } = blockType || {};
-	const directionTransforms = transforms?.[ direction ];
-	if ( ! transforms || ! Array.isArray( directionTransforms ) ) {
+	const directionTransforms = blockType?.transforms?.[ direction ];
+	if ( ! blockType || ! Array.isArray( directionTransforms ) ) {
 		return [];
 	}
 
@@ -546,7 +546,7 @@ export function getBlockTransforms(
 	// Map transforms to normal form.
 	return filteredTransforms.map( ( transform ) => ( {
 		...transform,
-		blockName,
+		blockName: blockType.name,
 		usingMobileTransformations,
 	} ) );
 }

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -514,40 +514,10 @@ export function getBlockTransforms(
 		return [];
 	}
 
-	const usingMobileTransformations =
-		transforms.supportedMobileTransforms &&
-		Array.isArray( transforms.supportedMobileTransforms );
-	const filteredTransforms = usingMobileTransformations
-		? directionTransforms.filter( ( t ) => {
-				if ( t.type === 'raw' ) {
-					return true;
-				}
-
-				if ( t.type === 'prefix' ) {
-					return true;
-				}
-
-				if ( ! t.blocks || ! t.blocks.length ) {
-					return false;
-				}
-
-				if ( isWildcardBlockTransform( t ) ) {
-					return true;
-				}
-
-				return t.blocks.every( ( transformBlockName ) =>
-					transforms.supportedMobileTransforms!.includes(
-						transformBlockName
-					)
-				);
-		  } )
-		: directionTransforms;
-
 	// Map transforms to normal form.
-	return filteredTransforms.map( ( transform ) => ( {
+	return directionTransforms.map( ( transform ) => ( {
 		...transform,
 		blockName: blockType.name,
-		usingMobileTransformations,
 	} ) );
 }
 

--- a/packages/blocks/src/api/factory.ts
+++ b/packages/blocks/src/api/factory.ts
@@ -39,8 +39,8 @@ type TemplateBlock = [
  * @return Whether the transform is of type `block`.
  */
 const isBlockTypeTransform = < Transform extends BlockTransform >(
-	transform: Transform
-): transform is Transform & BlockBlockTransform => transform.type === 'block';
+	transform: Transform | null | undefined
+): transform is Transform & BlockBlockTransform => transform?.type === 'block';
 
 const getBlockTypeWithTransformMetadata = (
 	blockType: BlockType,
@@ -238,16 +238,11 @@ export function cloneBlock(
  * @return Is the transform possible?
  */
 const isPossibleTransformForSource = (
-	transform: NormalizedBlockTransform,
+	transform: NormalizedBlockTransform< BlockBlockTransform >,
 	direction: 'from' | 'to',
 	blocks: Block[]
-): transform is NormalizedBlockTransform< BlockBlockTransform > => {
+): boolean => {
 	if ( ! blocks.length ) {
-		return false;
-	}
-
-	// Only consider 'block' type transforms as valid.
-	if ( ! isBlockTypeTransform( transform ) ) {
 		return false;
 	}
 
@@ -324,6 +319,7 @@ const getBlockTypesForPossibleFromTransforms = (
 		( blockType ) => {
 			const fromTransforms = getBlockTransforms( 'from', blockType.name );
 			return fromTransforms
+				.filter( isBlockTypeTransform )
 				.filter( ( transform ) =>
 					isPossibleTransformForSource( transform, 'from', blocks )
 				)
@@ -358,11 +354,11 @@ const getBlockTypesForPossibleToTransforms = (
 		: [];
 
 	// filter all 'to' transforms to find those that are possible.
-	const possibleTransforms = transformsTo.filter( ( transform ) => {
-		return (
-			transform && isPossibleTransformForSource( transform, 'to', blocks )
+	const possibleTransforms = transformsTo
+		.filter( isBlockTypeTransform )
+		.filter( ( transform ) =>
+			isPossibleTransformForSource( transform, 'to', blocks )
 		);
-	} );
 
 	// Map block names to block types.
 	return possibleTransforms
@@ -392,7 +388,6 @@ const getBlockTypesForPossibleToTransforms = (
 export const isWildcardBlockTransform = (
 	t: BlockTransform | null | undefined
 ): boolean =>
-	!! t &&
 	isBlockTypeTransform( t ) &&
 	Array.isArray( t.blocks ) &&
 	t.blocks.includes( '*' );

--- a/packages/blocks/src/api/parser/get-block-attributes.ts
+++ b/packages/blocks/src/api/parser/get-block-attributes.ts
@@ -103,7 +103,7 @@ export function getBlockAttribute(
 	attributeSchema: BlockAttribute,
 	innerDOM: Node,
 	commentAttributes: Record< string, unknown >,
-	innerHTML: string | Node
+	innerHTML: string | Node | undefined
 ): unknown {
 	let value;
 
@@ -249,12 +249,20 @@ export const matcherFromSource = memoize(
 /**
  * Parse a HTML string into DOM tree.
  *
+ * Content is missing whenever there is nothing to parse, such as a self-closing
+ * shortcode, and is treated as empty markup: `hpq` hands anything that is not a
+ * string straight to the matcher, so passing it through would give the matchers
+ * a missing node to work with.
+ *
  * @param innerHTML HTML string or already parsed DOM node.
  *
  * @return Parsed DOM node.
  */
-function parseHtml( innerHTML: string | Node ): Element {
-	return hpqParse( innerHTML as string | Element, ( h: Element ) => h );
+function parseHtml( innerHTML: string | Node | undefined ): Element {
+	return hpqParse(
+		( innerHTML ?? '' ) as string | Element,
+		( h: Element ) => h
+	);
 }
 
 /**
@@ -267,7 +275,7 @@ function parseHtml( innerHTML: string | Node ): Element {
  * @return Attribute value.
  */
 export function parseWithAttributeSchema(
-	innerHTML: string | Node,
+	innerHTML: string | Node | undefined,
 	attributeSchema: BlockAttribute
 ): unknown {
 	return matcherFromSource( attributeSchema )!(
@@ -286,7 +294,7 @@ export function parseWithAttributeSchema(
  */
 export function getBlockAttributes(
 	blockTypeOrName: string | BlockType,
-	innerHTML: string | Node,
+	innerHTML: string | Node | undefined,
 	attributes: Record< string, unknown > = {}
 ): Record< string, unknown > {
 	const doc = parseHtml( innerHTML );

--- a/packages/blocks/src/api/raw-handling/get-raw-transforms.ts
+++ b/packages/blocks/src/api/raw-handling/get-raw-transforms.ts
@@ -1,5 +1,5 @@
 import { getBlockTransforms } from '../factory';
-import type { BlockRawTransform } from '../../types';
+import type { BlockRawTransform, NormalizedBlockTransform } from '../../types';
 import type { RawTransform } from './types';
 
 export { type RawTransform } from './types';
@@ -7,12 +7,13 @@ export { type RawTransform } from './types';
 export function getRawTransforms(): RawTransform[] {
 	return getBlockTransforms( 'from' )
 		.filter(
-			( transform ): transform is BlockRawTransform =>
+			(
+				transform
+			): transform is NormalizedBlockTransform< BlockRawTransform > =>
 				transform.type === 'raw'
 		)
 		.map( ( transform ) => ( {
 			...transform,
-			blockName: transform.blockName!,
 			isMatch:
 				transform.isMatch ??
 				( ( node: Element ) =>

--- a/packages/blocks/src/api/raw-handling/get-raw-transforms.ts
+++ b/packages/blocks/src/api/raw-handling/get-raw-transforms.ts
@@ -1,19 +1,22 @@
 import { getBlockTransforms } from '../factory';
+import type { BlockRawTransform } from '../../types';
 import type { RawTransform } from './types';
 
 export { type RawTransform } from './types';
 
 export function getRawTransforms(): RawTransform[] {
-	return ( getBlockTransforms( 'from' ) as any[] )
-		.filter( ( { type } ) => type === 'raw' )
-		.map( ( transform ) => {
-			return transform.isMatch
-				? transform
-				: {
-						...transform,
-						isMatch: ( node: Element ) =>
-							transform.selector &&
-							node.matches( transform.selector ),
-				  };
-		} );
+	return getBlockTransforms( 'from' )
+		.filter(
+			( transform ): transform is BlockRawTransform =>
+				transform.type === 'raw'
+		)
+		.map( ( transform ) => ( {
+			...transform,
+			blockName: transform.blockName!,
+			isMatch:
+				transform.isMatch ??
+				( ( node: Element ) =>
+					!! transform.selector &&
+					node.matches( transform.selector ) ),
+		} ) );
 }

--- a/packages/blocks/src/api/raw-handling/html-to-blocks.ts
+++ b/packages/blocks/src/api/raw-handling/html-to-blocks.ts
@@ -24,13 +24,9 @@ export function htmlToBlocks(
 
 	return Array.from( doc.body.children ).flatMap( ( node ) => {
 		const transforms = getRawTransforms();
-		const rawTransform = findTransform(
-			transforms as unknown as Parameters< typeof findTransform >[ 0 ],
-			( ( t: unknown ) => {
-				const transform = t as ( typeof transforms )[ number ];
-				return transform.isMatch( node );
-			} ) as Parameters< typeof findTransform >[ 1 ]
-		) as unknown as ( typeof transforms )[ number ] | null;
+		const rawTransform = findTransform( transforms, ( transform ) =>
+			transform.isMatch( node )
+		);
 
 		if ( ! rawTransform ) {
 			return createBlock(
@@ -53,8 +49,8 @@ export function htmlToBlocks(
 		}
 
 		return createBlock(
-			blockName!,
-			getBlockAttributes( blockName!, node.outerHTML )
+			blockName,
+			getBlockAttributes( blockName, node.outerHTML )
 		);
 	} );
 }

--- a/packages/blocks/src/api/raw-handling/html-to-blocks.ts
+++ b/packages/blocks/src/api/raw-handling/html-to-blocks.ts
@@ -38,6 +38,10 @@ export function htmlToBlocks( html: string, handler: RawHandler ): Block[] {
 		const { transform, blockName } = rawTransform;
 
 		if ( transform ) {
+			// A raw transform may return several blocks, in which case it is
+			// unclear which of them the node's class belongs on, so only the
+			// single-block case is handled. No core raw transform returns an
+			// array today; one that did would already have thrown here.
 			const block = transform( node, handler ) as Block;
 			if ( node.hasAttribute( 'class' ) ) {
 				block.attributes.className = node.getAttribute( 'class' );

--- a/packages/blocks/src/api/raw-handling/html-to-blocks.ts
+++ b/packages/blocks/src/api/raw-handling/html-to-blocks.ts
@@ -1,7 +1,7 @@
 import { createBlock, findTransform } from '../factory';
 import { getBlockAttributes } from '../parser/get-block-attributes';
 import { getRawTransforms } from './get-raw-transforms';
-import type { Block } from '../../types';
+import type { Block, RawHandler } from '../../types';
 
 /**
  * Converts HTML directly to blocks. Looks for a matching transform for each
@@ -14,10 +14,7 @@ import type { Block } from '../../types';
  *
  * @return An array of blocks.
  */
-export function htmlToBlocks(
-	html: string,
-	handler: ( options: { HTML: string } ) => Block[] | string
-): Block[] {
+export function htmlToBlocks( html: string, handler: RawHandler ): Block[] {
 	const doc = document.implementation.createHTMLDocument( '' );
 
 	doc.body.innerHTML = html;

--- a/packages/blocks/src/api/raw-handling/paste-handler.ts
+++ b/packages/blocks/src/api/raw-handling/paste-handler.ts
@@ -29,7 +29,7 @@ import slackParagraphCorrector from './slack-paragraph-corrector';
 import isLatexMathMode from './latex-to-math';
 import { createBlock } from '../factory';
 import headingTransformer from './heading-transformer';
-import type { Block } from '../../types';
+import type { Block, RawHandlerOptions } from '../../types';
 
 const log = ( ...args: unknown[] ): void => window?.console?.log?.( ...args );
 
@@ -87,12 +87,7 @@ export function pasteHandler( {
 	plainText = '',
 	mode = 'AUTO',
 	tagName,
-}: {
-	HTML?: string;
-	plainText?: string;
-	mode?: 'AUTO' | 'INLINE' | 'BLOCKS';
-	tagName?: string;
-} ): Block[] | string {
+}: RawHandlerOptions ): Block[] | string {
 	// Allows us to ask for this information when we get a report.
 	log( 'Received HTML (pasteHandler):\n\n', HTML );
 	log( 'Received plain text (pasteHandler):\n\n', plainText );

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.ts
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.ts
@@ -3,7 +3,11 @@ import { createBlock, getBlockTransforms, findTransform } from '../factory';
 import { getBlockType } from '../registration';
 import { getBlockAttributes } from '../parser/get-block-attributes';
 import { applyBuiltInValidationFixes } from '../parser/apply-built-in-validation-fixes';
-import type { Block, BlockShortcodeTransform } from '../../types';
+import type {
+	Block,
+	BlockShortcodeTransform,
+	ShortcodeTransformAttribute,
+} from '../../types';
 
 const castArray = < T >( maybeArray: T | T[] ): T[] =>
 	Array.isArray( maybeArray ) ? maybeArray : [ maybeArray ];
@@ -103,8 +107,20 @@ function segmentHTMLToShortcodeBlock(
 			);
 		} );
 	} else {
+		const blockType = getBlockType( transformation.blockName! );
+		if ( ! blockType ) {
+			return [ HTML ];
+		}
+
+		// A shortcode transform without its own attributes sources them from
+		// the block type it produces.
+		const transformAttributes: Record<
+			string,
+			ShortcodeTransformAttribute
+		> = transformation.attributes ?? blockType.attributes;
+
 		const attributes = Object.fromEntries(
-			Object.entries( transformation.attributes ?? {} )
+			Object.entries( transformAttributes )
 				.filter( ( [ , schema ] ) => schema.shortcode )
 				// Passing all of `match` as second argument is intentionally broad
 				// but shouldn't be too relied upon.
@@ -116,14 +132,9 @@ function segmentHTMLToShortcodeBlock(
 				] )
 		);
 
-		const blockType = getBlockType( transformation.blockName! );
-		if ( ! blockType ) {
-			return [ HTML ];
-		}
-
 		const transformationBlockType = {
 			...blockType,
-			attributes: transformation.attributes ?? {},
+			attributes: transformAttributes,
 		};
 
 		let block = createBlock(

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.ts
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.ts
@@ -3,19 +3,7 @@ import { createBlock, getBlockTransforms, findTransform } from '../factory';
 import { getBlockType } from '../registration';
 import { getBlockAttributes } from '../parser/get-block-attributes';
 import { applyBuiltInValidationFixes } from '../parser/apply-built-in-validation-fixes';
-import type { Block } from '../../types';
-
-interface ShortcodeTransform {
-	type: string;
-	blockName: string;
-	tag: string | string[];
-	isMatch?: ( attrs: unknown ) => boolean;
-	transform?: ( ...args: unknown[] ) => Block | Block[];
-	attributes: Record<
-		string,
-		{ shortcode?: ( ...args: unknown[] ) => unknown }
-	>;
-}
+import type { Block, BlockShortcodeTransform } from '../../types';
 
 const castArray = < T >( maybeArray: T | T[] ): T[] =>
 	Array.isArray( maybeArray ) ? maybeArray : [ maybeArray ];
@@ -29,23 +17,19 @@ function segmentHTMLToShortcodeBlock(
 	excludedBlockNames: string[] = []
 ): Array< string | Block > {
 	// Get all matches.
-	const transformsFrom = getBlockTransforms(
-		'from'
-	) as unknown as ShortcodeTransform[];
+	const transformsFrom = getBlockTransforms( 'from' ).filter(
+		( transform ): transform is BlockShortcodeTransform =>
+			transform.type === 'shortcode'
+	);
 
 	const transformation = findTransform(
-		transformsFrom as unknown as Parameters< typeof findTransform >[ 0 ],
-		( ( transform: unknown ) => {
-			const t = transform as ShortcodeTransform;
-			return (
-				excludedBlockNames.indexOf( t.blockName ) === -1 &&
-				t.type === 'shortcode' &&
-				castArray( t.tag ).some( ( tag: string ) =>
-					regexp( tag ).test( HTML )
-				)
-			);
-		} ) as Parameters< typeof findTransform >[ 1 ]
-	) as unknown as ShortcodeTransform | null;
+		transformsFrom,
+		( transform ) =>
+			excludedBlockNames.indexOf( transform.blockName! ) === -1 &&
+			castArray( transform.tag ).some( ( tag ) =>
+				regexp( tag ).test( HTML )
+			)
+	);
 
 	if ( ! transformation ) {
 		return [ HTML ];
@@ -56,123 +40,117 @@ function segmentHTMLToShortcodeBlock(
 		regexp( tag ).test( HTML )
 	);
 
-	let match: any;
 	const previousIndex = lastIndex;
 
-	if ( ( match = next( transformTag!, HTML, lastIndex ) ) ) {
-		lastIndex = match.index + match.content.length;
-		const beforeHTML = HTML.substr( 0, match.index );
-		const afterHTML = HTML.substr( lastIndex );
+	const match = next( transformTag!, HTML, lastIndex );
 
-		// If the shortcode content does not contain HTML and the shortcode is
-		// not on a new line (or in paragraph from Markdown converter),
-		// consider the shortcode as inline text, and thus skip conversion for
-		// this segment.
-		if (
-			! match.shortcode.content?.includes( '<' ) &&
-			! (
-				beforeLineRegexp.test( beforeHTML ) &&
-				afterLineRegexp.test( afterHTML )
-			)
-		) {
-			return segmentHTMLToShortcodeBlock( HTML, lastIndex );
-		}
-
-		// If a transformation's `isMatch` predicate fails for the inbound
-		// shortcode, try again by excluding the current block type.
-		//
-		// This is the only call to `segmentHTMLToShortcodeBlock` that should
-		// ever carry over `excludedBlockNames`. Other calls in the module
-		// should skip that argument as a way to reset the exclusion state, so
-		// that one `isMatch` fail in an HTML fragment doesn't prevent any
-		// valid matches in subsequent fragments.
-		if (
-			transformation.isMatch &&
-			! transformation.isMatch( match.shortcode.attrs )
-		) {
-			return segmentHTMLToShortcodeBlock( HTML, previousIndex, [
-				...excludedBlockNames,
-				transformation.blockName!,
-			] );
-		}
-
-		let blocks: Block[] = [];
-		if ( typeof transformation.transform === 'function' ) {
-			// Passing all of `match` as second argument is intentionally broad
-			// but shouldn't be too relied upon.
-			//
-			// See: https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
-			blocks = ( [] as Block[] ).concat(
-				transformation.transform( match.shortcode.attrs, match ) as
-					| Block
-					| Block[]
-			);
-
-			// Applying the built-in fixes can enhance the attributes with missing content like "className".
-			blocks = blocks.map( ( block: Block ) => {
-				block.originalContent = match.shortcode.content;
-				return applyBuiltInValidationFixes(
-					block,
-					getBlockType( block.name )!
-				);
-			} );
-		} else {
-			const attributes = Object.fromEntries(
-				Object.entries( transformation.attributes )
-					.filter( ( [ , schema ] ) => schema.shortcode )
-					// Passing all of `match` as second argument is intentionally broad
-					// but shouldn't be too relied upon.
-					//
-					// See: https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
-					.map( ( [ key, schema ] ) => [
-						key,
-						schema.shortcode!( match.shortcode.attrs, match ),
-					] )
-			);
-
-			const blockType = getBlockType( transformation.blockName );
-			if ( ! blockType ) {
-				return [ HTML ];
-			}
-
-			const transformationBlockType = {
-				...blockType,
-				attributes: transformation.attributes,
-			};
-
-			let block = createBlock(
-				transformation.blockName,
-				getBlockAttributes(
-					transformationBlockType as unknown as string,
-					match.shortcode.content,
-					attributes
-				)
-			);
-
-			// Applying the built-in fixes can enhance the attributes with missing content like "className".
-			block.originalContent = match.shortcode.content;
-			block = applyBuiltInValidationFixes(
-				block,
-				transformationBlockType as unknown as Parameters<
-					typeof applyBuiltInValidationFixes
-				>[ 1 ]
-			);
-
-			blocks = [ block ];
-		}
-
-		return [
-			...segmentHTMLToShortcodeBlock(
-				beforeHTML.replace( beforeLineRegexp, '' )
-			),
-			...blocks,
-			...segmentHTMLToShortcodeBlock(
-				afterHTML.replace( afterLineRegexp, '' )
-			),
-		];
+	if ( ! match ) {
+		return [ HTML ];
 	}
 
-	return [ HTML ];
+	lastIndex = match.index + match.content.length;
+	const beforeHTML = HTML.substr( 0, match.index );
+	const afterHTML = HTML.substr( lastIndex );
+
+	// If the shortcode content does not contain HTML and the shortcode is
+	// not on a new line (or in paragraph from Markdown converter),
+	// consider the shortcode as inline text, and thus skip conversion for
+	// this segment.
+	if (
+		! match.shortcode.content?.includes( '<' ) &&
+		! (
+			beforeLineRegexp.test( beforeHTML ) &&
+			afterLineRegexp.test( afterHTML )
+		)
+	) {
+		return segmentHTMLToShortcodeBlock( HTML, lastIndex );
+	}
+
+	// If a transformation's `isMatch` predicate fails for the inbound
+	// shortcode, try again by excluding the current block type.
+	//
+	// This is the only call to `segmentHTMLToShortcodeBlock` that should
+	// ever carry over `excludedBlockNames`. Other calls in the module
+	// should skip that argument as a way to reset the exclusion state, so
+	// that one `isMatch` fail in an HTML fragment doesn't prevent any
+	// valid matches in subsequent fragments.
+	if (
+		transformation.isMatch &&
+		! transformation.isMatch( match.shortcode.attrs )
+	) {
+		return segmentHTMLToShortcodeBlock( HTML, previousIndex, [
+			...excludedBlockNames,
+			transformation.blockName!,
+		] );
+	}
+
+	let blocks: Block[] = [];
+	if ( typeof transformation.transform === 'function' ) {
+		// Passing all of `match` as second argument is intentionally broad
+		// but shouldn't be too relied upon.
+		//
+		// See: https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
+		blocks = ( [] as Block[] ).concat(
+			transformation.transform( match.shortcode.attrs, match )
+		);
+
+		// Applying the built-in fixes can enhance the attributes with missing content like "className".
+		blocks = blocks.map( ( block: Block ) => {
+			block.originalContent = match.shortcode.content;
+			return applyBuiltInValidationFixes(
+				block,
+				getBlockType( block.name )!
+			);
+		} );
+	} else {
+		const attributes = Object.fromEntries(
+			Object.entries( transformation.attributes ?? {} )
+				.filter( ( [ , schema ] ) => schema.shortcode )
+				// Passing all of `match` as second argument is intentionally broad
+				// but shouldn't be too relied upon.
+				//
+				// See: https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
+				.map( ( [ key, schema ] ) => [
+					key,
+					schema.shortcode!( match.shortcode.attrs, match ),
+				] )
+		);
+
+		const blockType = getBlockType( transformation.blockName! );
+		if ( ! blockType ) {
+			return [ HTML ];
+		}
+
+		const transformationBlockType = {
+			...blockType,
+			attributes: transformation.attributes ?? {},
+		};
+
+		let block = createBlock(
+			transformation.blockName!,
+			getBlockAttributes(
+				transformationBlockType,
+				match.shortcode.content ?? '',
+				attributes
+			)
+		);
+
+		// Applying the built-in fixes can enhance the attributes with missing content like "className".
+		block.originalContent = match.shortcode.content;
+		block = applyBuiltInValidationFixes( block, transformationBlockType );
+
+		blocks = [ block ];
+	}
+
+	return [
+		...segmentHTMLToShortcodeBlock(
+			beforeHTML.replace( beforeLineRegexp, '' )
+		),
+		...blocks,
+		...segmentHTMLToShortcodeBlock(
+			afterHTML.replace( afterLineRegexp, '' )
+		),
+	];
 }
 
 export default segmentHTMLToShortcodeBlock;

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.ts
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.ts
@@ -130,7 +130,7 @@ function segmentHTMLToShortcodeBlock(
 			transformation.blockName!,
 			getBlockAttributes(
 				transformationBlockType,
-				match.shortcode.content ?? '',
+				match.shortcode.content,
 				attributes
 			)
 		);

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.ts
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.ts
@@ -6,6 +6,7 @@ import { applyBuiltInValidationFixes } from '../parser/apply-built-in-validation
 import type {
 	Block,
 	BlockShortcodeTransform,
+	NormalizedBlockTransform,
 	ShortcodeTransformAttribute,
 } from '../../types';
 
@@ -22,14 +23,16 @@ function segmentHTMLToShortcodeBlock(
 ): Array< string | Block > {
 	// Get all matches.
 	const transformsFrom = getBlockTransforms( 'from' ).filter(
-		( transform ): transform is BlockShortcodeTransform =>
+		(
+			transform
+		): transform is NormalizedBlockTransform< BlockShortcodeTransform > =>
 			transform.type === 'shortcode'
 	);
 
 	const transformation = findTransform(
 		transformsFrom,
 		( transform ) =>
-			excludedBlockNames.indexOf( transform.blockName! ) === -1 &&
+			excludedBlockNames.indexOf( transform.blockName ) === -1 &&
 			castArray( transform.tag ).some( ( tag ) =>
 				regexp( tag ).test( HTML )
 			)
@@ -84,7 +87,7 @@ function segmentHTMLToShortcodeBlock(
 	) {
 		return segmentHTMLToShortcodeBlock( HTML, previousIndex, [
 			...excludedBlockNames,
-			transformation.blockName!,
+			transformation.blockName,
 		] );
 	}
 
@@ -107,7 +110,7 @@ function segmentHTMLToShortcodeBlock(
 			);
 		} );
 	} else {
-		const blockType = getBlockType( transformation.blockName! );
+		const blockType = getBlockType( transformation.blockName );
 		if ( ! blockType ) {
 			return [ HTML ];
 		}
@@ -138,7 +141,7 @@ function segmentHTMLToShortcodeBlock(
 		};
 
 		let block = createBlock(
-			transformation.blockName!,
+			transformation.blockName,
 			getBlockAttributes(
 				transformationBlockType,
 				match.shortcode.content,

--- a/packages/blocks/src/api/raw-handling/types.ts
+++ b/packages/blocks/src/api/raw-handling/types.ts
@@ -1,11 +1,10 @@
-import type { BlockRawTransform } from '../../types';
+import type { BlockRawTransform, NormalizedBlockTransform } from '../../types';
 
 /**
- * A raw transform as returned by `getRawTransforms`, where the declaring block
- * name and a matcher are always present.
+ * A raw transform as returned by `getRawTransforms`, where a matcher is always
+ * present: transforms declaring only a `selector` get one built from it.
  */
-export type RawTransform = BlockRawTransform & {
-	blockName: string;
+export type RawTransform = NormalizedBlockTransform< BlockRawTransform > & {
 	isMatch: NonNullable< BlockRawTransform[ 'isMatch' ] >;
 };
 

--- a/packages/blocks/src/api/raw-handling/types.ts
+++ b/packages/blocks/src/api/raw-handling/types.ts
@@ -1,13 +1,13 @@
-export interface RawTransform {
-	type: string;
+import type { BlockRawTransform } from '../../types';
+
+/**
+ * A raw transform as returned by `getRawTransforms`, where the declaring block
+ * name and a matcher are always present.
+ */
+export type RawTransform = BlockRawTransform & {
 	blockName: string;
-	selector?: string;
-	schema?:
-		| Record< string, unknown >
-		| ( ( args: Record< string, unknown > ) => Record< string, unknown > );
-	isMatch: ( node: Element ) => boolean;
-	transform?: ( node: Node, handler: Function ) => unknown;
-}
+	isMatch: NonNullable< BlockRawTransform[ 'isMatch' ] >;
+};
 
 export type NodeFilterFunction = (
 	node: Node,

--- a/packages/blocks/src/store/private-selectors.ts
+++ b/packages/blocks/src/store/private-selectors.ts
@@ -342,10 +342,13 @@ export const getBlockKeyboardShortcuts = createSelector(
 			const transforms = state.blockTypes[ blockName ]?.transforms;
 
 			for ( const transform of transforms?.to ?? [] ) {
+				if ( transform.type !== 'block' ) {
+					continue;
+				}
 				// A `to` transform can list several target blocks, but a shortcut
 				// can only produce one of them. The first is used.
 				const targetBlockName = transform.blocks?.[ 0 ];
-				if ( transform.type !== 'block' || ! targetBlockName ) {
+				if ( ! targetBlockName ) {
 					continue;
 				}
 				for ( const shortcut of transform.shortcuts ?? [] ) {

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -219,6 +219,9 @@ export interface BlockAttribute {
 
 /**
  * The properties shared by every kind of block transform.
+ *
+ * Internal: consumers narrow a `BlockTransform` on its `type` and get one of the
+ * variants below, or write helpers generic over `BlockTransform` itself.
  */
 interface BlockTransformBase {
 	/**
@@ -226,12 +229,6 @@ interface BlockTransformBase {
 	 * Defaults to `10`.
 	 */
 	priority?: number;
-	/**
-	 * The name of the block type declaring the transform. Added by
-	 * `getBlockTransforms` when normalizing a transform, not declared by the
-	 * block type itself.
-	 */
-	blockName?: string;
 }
 
 /**

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -330,6 +330,39 @@ export interface BlockPrefixTransform extends BlockTransformBase {
 }
 
 /**
+ * Options accepted by the raw handlers, `rawHandler` and `pasteHandler`.
+ */
+export interface RawHandlerOptions {
+	/**
+	 * The HTML to convert.
+	 */
+	HTML?: string;
+	/**
+	 * Plain text version of the content.
+	 */
+	plainText?: string;
+	/**
+	 * Whether to handle the content as blocks or as inline content.
+	 *
+	 * - `AUTO`: decide based on the content passed.
+	 * - `INLINE`: always handle as inline content, and return a string.
+	 * - `BLOCKS`: always handle as blocks, and return an array of blocks.
+	 */
+	mode?: 'AUTO' | 'INLINE' | 'BLOCKS';
+	/**
+	 * The tag into which the content will be inserted.
+	 */
+	tagName?: string;
+}
+
+/**
+ * A raw handler, either `rawHandler` or `pasteHandler`. A `raw` transform
+ * receives one as the second argument of its `transform`, to convert nested
+ * content the same way the surrounding content is converted.
+ */
+export type RawHandler = ( options: RawHandlerOptions ) => Block[] | string;
+
+/**
  * A transform from raw HTML, used when pasting content into the editor.
  */
 export interface BlockRawTransform extends BlockTransformBase {
@@ -350,10 +383,7 @@ export interface BlockRawTransform extends BlockTransformBase {
 				isPaste: boolean;
 		  } ) => Record< string, unknown > );
 	isMatch?: ( node: Element ) => boolean;
-	transform?: (
-		node: Node,
-		handler: ( options: { HTML: string } ) => Block[] | string
-	) => Block | Block[];
+	transform?: ( node: Element, handler: RawHandler ) => Block | Block[];
 }
 
 /**

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -1,5 +1,6 @@
 import type { ComponentType, ReactElement } from 'react';
 import type { WPKeycodeModifier } from '@wordpress/keycodes';
+import type { ShortcodeAttrs, ShortcodeMatch } from '@wordpress/shortcode';
 
 /**
  * An icon type definition. One of a Dashicon slug, an element,
@@ -217,12 +218,14 @@ export interface BlockAttribute {
 }
 
 /**
- * A block transform object.
+ * The properties shared by every kind of block transform.
  */
-export interface BlockTransform<
-	Attributes extends Record< string, unknown > = Record< string, unknown >,
-> {
-	type: 'block' | 'enter' | 'files' | 'prefix' | 'raw' | 'shortcode';
+interface BlockTransformBase {
+	/**
+	 * The names of the block types the transform applies to (`from`) or
+	 * produces (`to`). A single entry of `*` makes it a wildcard transform,
+	 * matching any block type. Only meaningful on transforms of type `block`.
+	 */
 	blocks?: string[];
 	/**
 	 * The target block variation name for block transforms that produce a
@@ -241,18 +244,168 @@ export interface BlockTransform<
 	 * variation without appearing more than once in the block switcher.
 	 */
 	shortcuts?: BlockShortcut[];
+	/**
+	 * The transform's priority. A lower number means a higher priority.
+	 * Defaults to `10`.
+	 */
 	priority?: number;
+	/**
+	 * The name of the block type declaring the transform. Added by
+	 * `getBlockTransforms` when normalizing a transform, not declared by the
+	 * block type itself.
+	 */
+	blockName?: string;
+	/**
+	 * Whether the transforms of the declaring block type are filtered by
+	 * `transforms.supportedMobileTransforms`. Added by `getBlockTransforms`
+	 * when normalizing a transform, not declared by the block type itself.
+	 */
+	usingMobileTransformations?: boolean;
+	/**
+	 * The transformations available for mobile devices.
+	 */
+	supportedMobileTransforms?: string[];
+}
+
+/**
+ * A transform from or to another block type, shown in the block switcher.
+ */
+export interface BlockBlockTransform<
+	Attributes extends Record< string, unknown > = Record< string, unknown >,
+> extends BlockTransformBase {
+	type: 'block';
+	/**
+	 * Whether the transform applies to a selection of multiple blocks, in which
+	 * case `isMatch` and `transform` receive arrays.
+	 */
 	isMultiBlock?: boolean;
 	isMatch?: (
 		attributes: Attributes | Attributes[],
 		block: Block | Block[]
 	) => boolean;
-	transform?: ( ...args: unknown[] ) => Block | Block[];
+	transform?: (
+		attributes: Attributes | Attributes[],
+		innerBlocks: Block[] | Block[][]
+	) => Block | Block[];
+	/**
+	 * Takes over the conversion entirely, receiving the source blocks instead
+	 * of their attributes. Used by the Group block.
+	 */
 	__experimentalConvert?: ( blocks: Block | Block[] ) => Block | Block[];
-	blockName?: string;
-	usingMobileTransformations?: boolean;
-	supportedMobileTransforms?: string[];
 }
+
+/**
+ * A transform triggered by typing a value in a block and pressing Enter.
+ */
+export interface BlockEnterTransform extends BlockTransformBase {
+	type: 'enter';
+	/**
+	 * The pattern the typed value has to match for the transform to apply.
+	 */
+	regExp: RegExp;
+	transform?: ( value: { content: string } ) => Block | Block[];
+}
+
+/**
+ * A transform from files dropped or pasted into the editor.
+ */
+export interface BlockFilesTransform extends BlockTransformBase {
+	type: 'files';
+	isMatch?: ( files: File[] ) => boolean;
+	transform?: (
+		files: File[],
+		onChange?: ( id: string, attributes: Record< string, unknown > ) => void
+	) => Block | Block[];
+}
+
+/**
+ * A transform triggered by typing a prefix followed by a space.
+ */
+export interface BlockPrefixTransform extends BlockTransformBase {
+	type: 'prefix';
+	/**
+	 * The prefix that triggers the transform, e.g. `#` or `>`.
+	 */
+	prefix: string;
+	transform?: ( content: string ) => Block | Block[];
+}
+
+/**
+ * A transform from raw HTML, used when pasting content into the editor.
+ */
+export interface BlockRawTransform extends BlockTransformBase {
+	type: 'raw';
+	/**
+	 * A CSS selector the pasted node has to match. Used as a fallback when
+	 * `isMatch` is not provided.
+	 */
+	selector?: string;
+	/**
+	 * The HTML the transform is allowed to keep, either as a schema or as a
+	 * function returning one.
+	 */
+	schema?:
+		| Record< string, unknown >
+		| ( ( args: {
+				phrasingContentSchema: Record< string, unknown >;
+				isPaste: boolean;
+		  } ) => Record< string, unknown > );
+	isMatch?: ( node: Element ) => boolean;
+	transform?: (
+		node: Node,
+		handler: ( options: { HTML: string } ) => Block[] | string
+	) => Block | Block[];
+}
+
+/**
+ * A block attribute of a shortcode transform, which may source its value from
+ * the matched shortcode instead of the block's markup.
+ */
+export interface ShortcodeTransformAttribute extends BlockAttribute {
+	/**
+	 * Returns the attribute value for the matched shortcode.
+	 */
+	shortcode?: (
+		attributes: ShortcodeAttrs,
+		match: ShortcodeMatch
+	) => unknown;
+}
+
+/**
+ * A transform from a shortcode found in the pasted or raw content.
+ */
+export interface BlockShortcodeTransform extends BlockTransformBase {
+	type: 'shortcode';
+	/**
+	 * The shortcode tag, or tags, the transform matches. Each entry is used as
+	 * a regular expression, so it may match a family of tags.
+	 */
+	tag: string | string[];
+	/**
+	 * The block attributes to source from the matched shortcode. Ignored when
+	 * `transform` is provided.
+	 */
+	attributes?: Record< string, ShortcodeTransformAttribute >;
+	isMatch?: ( attributes: ShortcodeAttrs ) => boolean;
+	transform?: (
+		attributes: ShortcodeAttrs,
+		match: ShortcodeMatch
+	) => Block | Block[];
+}
+
+/**
+ * A block transform object. The `type` property discriminates between the kinds
+ * of transform, each of which declares its own fields.
+ */
+export type BlockTransform<
+	Attributes extends Record< string, unknown > = Record< string, unknown >,
+> =
+	| BlockBlockTransform< Attributes >
+	| BlockEnterTransform
+	| BlockFilesTransform
+	| BlockPrefixTransform
+	| BlockRawTransform
+	| BlockShortcodeTransform;
 
 /**
  * Internal type for the innerBlocks property inside of the example.

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -437,6 +437,14 @@ export type BlockTransform<
 	| BlockShortcodeTransform;
 
 /**
+ * A block transform as returned by `getBlockTransforms`, which stamps the name
+ * of the block type declaring the transform onto it.
+ */
+export type NormalizedBlockTransform<
+	Transform extends BlockTransform = BlockTransform,
+> = Transform & { blockName: string };
+
+/**
  * Internal type for the innerBlocks property inside of the example.
  *
  * @see BlockType.example

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -232,16 +232,6 @@ interface BlockTransformBase {
 	 * block type itself.
 	 */
 	blockName?: string;
-	/**
-	 * Whether the transforms of the declaring block type are filtered by
-	 * `transforms.supportedMobileTransforms`. Added by `getBlockTransforms`
-	 * when normalizing a transform, not declared by the block type itself.
-	 */
-	usingMobileTransformations?: boolean;
-	/**
-	 * The transformations available for mobile devices.
-	 */
-	supportedMobileTransforms?: string[];
 }
 
 /**
@@ -667,10 +657,6 @@ export interface BlockType<
 		 * Transforms from this block type to another block type.
 		 */
 		to?: BlockTransform[];
-		/**
-		 * The transformations available for mobile devices.
-		 */
-		supportedMobileTransforms?: string[];
 	};
 	/**
 	 * Array of the names of context values to inherit from

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -222,29 +222,6 @@ export interface BlockAttribute {
  */
 interface BlockTransformBase {
 	/**
-	 * The names of the block types the transform applies to (`from`) or
-	 * produces (`to`). A single entry of `*` makes it a wildcard transform,
-	 * matching any block type. Only meaningful on transforms of type `block`.
-	 */
-	blocks?: string[];
-	/**
-	 * The target block variation name for block transforms that produce a
-	 * variation of the transformed block type.
-	 */
-	variationName?: string;
-	/**
-	 * Keyboard shortcuts that apply this transform to the selected block. Only
-	 * supported on transforms of type `block`.
-	 *
-	 * On a `to` transform they apply to the block declaring it, and produce the
-	 * first entry of `blocks`. On a `from` transform they apply to any block
-	 * listed in `blocks`, and produce the block declaring it. Each shortcut may
-	 * target a different variation of the produced block through its own
-	 * `variationName`, which is what lets one transform carry a shortcut per
-	 * variation without appearing more than once in the block switcher.
-	 */
-	shortcuts?: BlockShortcut[];
-	/**
 	 * The transform's priority. A lower number means a higher priority.
 	 * Defaults to `10`.
 	 */
@@ -274,6 +251,28 @@ export interface BlockBlockTransform<
 	Attributes extends Record< string, unknown > = Record< string, unknown >,
 > extends BlockTransformBase {
 	type: 'block';
+	/**
+	 * The names of the block types the transform applies to (`from`) or
+	 * produces (`to`). A single entry of `*` makes it a wildcard transform,
+	 * matching any block type.
+	 */
+	blocks: string[];
+	/**
+	 * The target block variation name for transforms that produce a variation
+	 * of the transformed block type.
+	 */
+	variationName?: string;
+	/**
+	 * Keyboard shortcuts that apply this transform to the selected block.
+	 *
+	 * On a `to` transform they apply to the block declaring it, and produce the
+	 * first entry of `blocks`. On a `from` transform they apply to any block
+	 * listed in `blocks`, and produce the block declaring it. Each shortcut may
+	 * target a different variation of the produced block through its own
+	 * `variationName`, which is what lets one transform carry a shortcut per
+	 * variation without appearing more than once in the block switcher.
+	 */
+	shortcuts?: BlockShortcut[];
 	/**
 	 * Whether the transform applies to a selection of multiple blocks, in which
 	 * case `isMatch` and `transform` receive arrays.


### PR DESCRIPTION
## What?

Closes #81811

Turns the `BlockTransform` type in `@wordpress/blocks` into a discriminated union over its `type` field, so each kind of transform declares its own fields, and removes the internal type assertions that existed only to work around the old flat type.

## Why?

`BlockTransform` accepted `'block' | 'enter' | 'files' | 'prefix' | 'raw' | 'shortcode'` as its `type`, but only ever declared the fields of a `block` transform. Registering a block with a documented `shortcode` transform therefore failed to type check, even though it works at runtime. The same applied to `regExp` on `enter` transforms, `prefix` on `prefix` transforms, and `selector`/`schema` on `raw` transforms. This is a regression for projects migrating from the deprecated `@types/wordpress__blocks`, which modelled transforms as a union.

Internally the mismatch was papered over: `shortcode-converter.ts` carried its own private `ShortcodeTransform` interface plus six `as unknown` casts, `html-to-blocks.ts` had three more, and `get-raw-transforms.ts` used `as any[]`.

## How?

`BlockTransform` is now a union of one interface per `type`, all extending a shared `BlockTransformBase` that holds the two fields every transform has, `priority` and `blockName`:

- `BlockBlockTransform` — `blocks` (required), `variationName`, `shortcuts`, `isMultiBlock`, attribute-based `isMatch`/`transform`, `__experimentalConvert`
- `BlockEnterTransform` — `regExp`
- `BlockFilesTransform` — `File[]`-based `isMatch`/`transform`
- `BlockPrefixTransform` — `prefix`
- `BlockRawTransform` — `selector`, `schema`, `Element`-based `isMatch`/`transform`
- `BlockShortcodeTransform` — `tag`, `attributes` (typed as `ShortcodeTransformAttribute extends BlockAttribute`, so a matcher-carrying attribute map is still a valid block attribute map), `isMatch`/`transform`

Each variant's `isMatch` and `transform` are typed for what that kind of transform actually receives, instead of the previous `( ...args: unknown[] )`. Existing types are reused rather than re-described: shortcode callbacks take `ShortcodeAttrs` and `ShortcodeMatch` from `@wordpress/shortcode`, and `RawTransform` in `raw-handling/types.ts` is derived from `BlockRawTransform` instead of duplicating it. A raw transform's `handler` argument is a new exported `RawHandler`, built on an exported `RawHandlerOptions` (`HTML`, `plainText`, `mode`, `tagName`) that `pasteHandler` and `htmlToBlocks` now share, so the documented `handler( { HTML, mode: 'BLOCKS' } )` call type checks.

`getBlockTransforms` stamps `blockName` onto every transform it returns and bails out early when there is no block type, so its return type is a new exported `NormalizedBlockTransform< T > = T & { blockName: string }`. That is what lets the consumers below read `blockName` without assertions.

Narrowing on `type` then replaces the assertions:

- `findTransform` is generic (`<T extends BlockTransform>`), so a caller that has already filtered its transforms keeps the narrowed type in both the predicate and the result.
- A module-private, generic `isBlockTypeTransform` guard covers the `block`-only paths in `factory.ts` (`switchToBlockType`, `isPossibleTransformForSource`, `isWildcardBlockTransform`, `maybeCheckTransformIsMatch`), preserving `blockName` through the narrowing.
- `shortcode-converter.ts` loses its local interface and all six casts; the `match: any` assignment-in-condition became an early return so `next()`'s real return type flows through the closures below it.
- `html-to-blocks.ts` loses three casts; `get-raw-transforms.ts` loses `as any[]`. No `blockName!` assertion remains on a transform.

The runtime reads stay defensive where they already were (`transform.blocks ?? []`, `transform.blocks?.[ 0 ]`): a registered block type is third-party data, and `store/test/private-selectors.js` deliberately covers a `block` transform declaring no `blocks`.

### Behavior changes

Two came out of review, both in the shortcode path:

- `getBlockAttributes` no longer breaks when there is nothing to parse. `parseHtml` treats missing content as empty markup, instead of handing a non-string to `hpq`, which passes it straight to the attribute matchers. A self-closing shortcode (`[gallery ids="1,2"]`) reaches this. Attribute values are unchanged: the converter still passes the content through as-is, so a `source: 'raw'` attribute still falls back to its default.
- A shortcode transform declaring neither `transform` nor `attributes` used to throw a `TypeError`. It now sources attributes from the block type it produces, rather than parsing the shortcode with an empty schema.

### Breaking changes

The changelog entries have the detail; in short:

- Object literals still assign, but reading a variant field off a `BlockTransform` that has not been narrowed on its `type` no longer compiles — including the result of `findTransform`. `blocks` is required on `block` transforms, and `blocks`/`variationName`/`shortcuts` are no longer accepted on the other kinds.
- The React Native only `transforms.supportedMobileTransforms` block type property is removed, along with `supportedMobileTransforms` and `usingMobileTransformations` on a transform, as requested in review. Nothing has read them since #78747 removed the React Native implementation. Worth knowing: the filter they drove was never platform-gated, so a block type still declaring `supportedMobileTransforms` had its transforms filtered everywhere, and `getBlockTransforms` no longer filters them at all. That removal is the last commit on the branch and depends on nothing else here, so it can be split out if reviewers prefer.

## Use of AI Tools

This PR was authored with AI assistance: the type refactor, the follow-on removal of the internal assertions, and this description were AI-generated. I have reviewed the resulting code line by line and take responsibility for it.
