### PR TITLE
Docs: Fix broken skip ahead anchor on the custom block editor guide.

### DIFF
--- a/docs/how-to-guides/platform/custom-block-editor.md
+++ b/docs/how-to-guides/platform/custom-block-editor.md
@@ -76,7 +76,7 @@ Perfect, this is the main package you will use to create the custom block editor
 Let's begin by creating a custom page within WordPress admin that will house the custom block editor instance.
 
 <div class="callout callout-info">
-	If you're already comfortable with the process of creating custom admin pages in WordPress, you might want to <a href="#registering-and-rendering-our-custom-block-editor">skip ahead</a>.
+	If you're already comfortable with the process of creating custom admin pages in WordPress, you might want to <a href="#registering-and-rendering-the-custom-block-editor">skip ahead</a>.
 </div>
 
 ### Registering the page


### PR DESCRIPTION
The "skip ahead" link on the building a custom block editor guide points to the anchor `#registering-and-rendering-our-custom-block-editor`, but the heading of that section is "Registering and rendering the custom block editor", so the link doesn't work. This PR updates the anchor to match the heading.

## Testing Instructions

On https://github.com/WordPress/gutenberg/blob/aa87f950c552804a4abdc3b70c48f2e147d0e757/docs/how-to-guides/platform/custom-block-editor.md#registering-and-rendering-the-custom-block-editor, click the "skip ahead" link under "Creating the custom "Block Editor" page" and verify it jumps to the "Registering and rendering the custom block editor" section.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
