### PR TITLE
Build: Emit TypeScript declarations with --noCheck

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -74,4 +74,4 @@ jobs:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   pattern: '{build/scripts/**/*.min.js,build/styles/**/*.css,build/modules/**/*.min.js}'
                   clean-script: 'distclean'
-                  build-script: 'build -- --skip-types'
+                  build-script: 'build'

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -38,7 +38,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Npm build
-              run: npm run build -- --skip-types
+              run: npm run build
 
             # Wider than the `build*` directories, because the build also emits
             # generated files next to sources: the block parsers, the icon

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -123,7 +123,7 @@ jobs:
               run: npm run check:type-declarations
 
             - name: Build packages
-              run: npm run build -- --skip-types
+              run: npm run build
 
             - name: Validate package contents
               run: npm run lint:package-contents

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -209,7 +209,7 @@ jobs:
               uses: ./.github/setup-node
 
             - name: Run build scripts
-              run: npm run build -- --skip-types
+              run: npm run build
 
             - name: Upload built JavaScript assets
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,6 @@ npm run wp-env-test start       # Only start if not already running.
 # Development
 npm start     # Development with watch
 npm run build # Production build
-npm run build -- --skip-types # Faster build; skips type generation
 ```
 
 ### Key Directories

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ npm run wp-env-test start       # Only start if not already running.
 
 # Development
 npm start     # Development with watch
-npm run build # Production build
+npm run build # Production build; emits types with --noCheck, does NOT type check
 ```
+
+`npm run build` never fails on type errors. After changing TypeScript or checked JS, run `npm run typecheck`.
 
 ### Key Directories
 
@@ -71,7 +73,7 @@ For full architecture details, see `docs/explanations/architecture/`.
 -   Never invoke WordPress's forked or local CLIs through `npx` (e.g. `npx prettier`, `npx wp-scripts`). WordPress ships its own `wp-prettier` fork, and `wp-scripts` is the bin name of `@wordpress/scripts`. A bare `npx wp-scripts` can resolve to an unrelated third-party package on the public registry, not the local tool. Use the npm scripts instead (`npm run format`, `npm run lint:js`, `npm run lint:css` and so on), which run the binaries from local `node_modules`.
 -   PHP function and class names are renamed at build time (`gutenberg_*` prefix, `*_Gutenberg` suffix) to avoid conflicts with WordPress Core — the built names, not the source names, are what runs (and what tests must call). See `docs/contributors/code/build-system-function-prefixing.md`.
 -   Production code changes in a package require an entry in that package's `CHANGELOG.md`. See `docs/contributors/code/managing-packages.md`.
--   Packages with TypeScript dev files split their configs: `tsconfig.build.json` (src only, emits `build-types`) and the default `tsconfig.json` (dev project: tests and stories, `noEmit`, jest types). Packages without dev files keep a single `tsconfig.json` build project, and a few packages deviate (a dev-only project with handwritten declarations, or specialized build projects); see the TypeScript section in `packages/README.md`. Reference a split package by `../<pkg>/tsconfig.build.json` and an unsplit one by `../<pkg>`. `npm run build` never type checks dev files; use `npm run typecheck` for that, and never add jest types to a build project.
+-   Packages with TypeScript dev files split their configs: `tsconfig.build.json` (src only, emits `build-types`) and the default `tsconfig.json` (dev project: tests and stories, `noEmit`, jest types). Packages without dev files keep a single `tsconfig.json` build project, and a few packages deviate (a dev-only project with handwritten declarations, or specialized build projects); see the TypeScript section in `packages/README.md`. Reference a split package by `../<pkg>/tsconfig.build.json` and an unsplit one by `../<pkg>`. `npm run build` never type checks (it emits declarations with `--noCheck`); use `npm run typecheck`, and never add jest types to a build project.
 -   A rejected `apiFetch` is not always an `Error`: a REST error arrives as a plain object (`{ code, message, data }`), `parse: false` rejects with the `Response` (which carries `status`, not `message`), an aborted request rethrows an `AbortError`, and a handler set via `setFetchHandler` can reject anything. Do not interpolate the rejection into a string (`` `${ error }` `` gives `[object Object]`) or branch on `instanceof Error`. Normalise it to a message before showing the user anything, and supply your own copy when there is none — `ensureError` in `packages/core-data/src/private-actions.js` is the reference implementation, though it is local to that file rather than exported.
 
 ## PR instructions

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -78,7 +78,7 @@ status "Installing dependencies... 📦"
 npm cache verify
 npm ci
 status "Generating build... 👷‍♀️"
-npm run build -- --skip-types
+npm run build
 
 # Only including public icons when building for WordPress Core.
 #

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"rtc:ws": "node ./test/e2e/bin/rtc-dev.mjs --mode=websockets",
 		"rtc:ws:slow": "cross-env RTC_WS_DELAY=50 npm run rtc:ws",
 		"start": "npm run dev",
-		"prestorybook:build": "npm run build -- --skip-types",
+		"prestorybook:build": "npm run build",
 		"storybook:build": "npm run --workspace @wordpress/storybook storybook:build",
 		"storybook:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && npm run --workspace @wordpress/storybook storybook:dev\"",
 		"storybook:e2e:dev": "concurrently \"npm run dev\" \"wait-on .dev-ready && npm run --workspace @wordpress/storybook-playwright storybook:dev\"",

--- a/packages/README.md
+++ b/packages/README.md
@@ -329,7 +329,7 @@ These packages benefit from type checking and produced type declarations in the 
 
 A package opts in to TypeScript tooling with a build project registered in the root `tsconfig.build.json` references: `tsconfig.json` for a package without TypeScript dev files, `tsconfig.build.json` for one that splits. Packages that emit declarations through this standard layout and have TypeScript test or story files split into two projects:
 
--   `tsconfig.build.json` is the build project: it covers `src`, emits declarations to `build-types`, and is what other packages and `npm run build` consume.
+-   `tsconfig.build.json` is the build project: it covers `src`, emits declarations to `build-types`, and is what other packages and `npm run build` consume. `npm run build` emits those declarations with `--noCheck`, so it only reports parse and declaration emit errors; `npm run typecheck` is where type errors surface.
 -   `tsconfig.json` is the dev project: it covers test and story files with `noEmit`, so `npm run typecheck` and the IDE can check them without their declarations ending up in the published package.
 
 Both extend shared base configurations (comments are not necessary):

--- a/tools/build-scripts/build.mjs
+++ b/tools/build-scripts/build.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { fileURLToPath } from 'url';
-import { parseArgs } from 'util';
 import path from 'path';
 import spawn from 'cross-spawn';
 
@@ -75,14 +74,6 @@ function exec( command, args = [], options = {} ) {
  * Main build orchestration function.
  */
 async function build() {
-	const { values } = parseArgs( {
-		options: {
-			'skip-types': { type: 'boolean', default: false },
-		},
-		strict: false,
-	} );
-	const skipTypes = values[ 'skip-types' ];
-
 	console.log( '🔨 Starting build process...\n' );
 
 	const startTime = Date.now();
@@ -134,28 +125,24 @@ async function build() {
 			path.join( __dirname, 'packages/generate-worker-placeholders.mjs' ),
 		] );
 
-		if ( ! skipTypes ) {
-			console.log( '\n📘 Building TypeScript types...\n' );
-			const tsStartTime = Date.now();
-			await exec( 'tsc', [ '--build', 'tsconfig.build.json' ] ).catch(
-				() => {
-					console.error(
-						'\n❌ TypeScript compilation failed. Try cleaning up first: `npm run clean:package-types`'
-					);
-					throw new Error( 'TypeScript compilation failed' );
-				}
+		/*
+		 * Emit declarations without type checking; `npm run typecheck` owns
+		 * that. Only parse and declaration emit errors can fail this step.
+		 */
+		console.log( '\n📘 Building TypeScript types...\n' );
+		const tsStartTime = Date.now();
+		await exec( 'tsc', [
+			'--build',
+			'tsconfig.build.json',
+			'--noCheck',
+		] ).catch( () => {
+			console.error(
+				'\n❌ TypeScript declaration emit failed. Try cleaning up first: `npm run clean:package-types`'
 			);
-			const buildTime = Date.now() - tsStartTime;
-			console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
-
-			console.log( '\n✅ Checking type declaration files...' );
-			await exec( 'node', [
-				path.join(
-					__dirname,
-					'packages/check-build-type-declaration-files.cjs'
-				),
-			] );
-		}
+			throw new Error( 'TypeScript declaration emit failed' );
+		} );
+		const buildTime = Date.now() - tsStartTime;
+		console.log( `   ✔ Built TypeScript types (${ buildTime }ms)` );
 
 		console.log( '\n📦 Building vendor files...' );
 		await exec( 'node', [
@@ -163,10 +150,7 @@ async function build() {
 		] );
 
 		console.log( '\n📦 Building packages (production mode)...' );
-		const buildArgs = process.argv
-			.slice( 2 )
-			.filter( ( arg ) => arg !== '--skip-types' );
-		await exec( 'wp-build', buildArgs, {
+		await exec( 'wp-build', process.argv.slice( 2 ), {
 			env: { ...process.env, NODE_ENV: 'production' },
 		} );
 


### PR DESCRIPTION
## What?

See https://github.com/WordPress/gutenberg/issues/81473#issuecomment-5344137664

Emit TypeScript declarations in `npm run build` with `--noCheck` and remove `--skip-types` from the build and its callers. `npm run typecheck` now owns type checking.

## Why?

The build only needs the declaration files; CI runs `npm run typecheck` separately. `--noCheck` more than halves a fresh build's types step.

## How?

- [build.mjs](https://github.com/WordPress/gutenberg/blob/build/emit-types-with-nocheck/tools/build-scripts/build.mjs) always runs `tsc --build tsconfig.build.json --noCheck`, dropping `--skip-types` and the declaration-files check (CI runs `check:type-declarations` after `typecheck`).
- `--skip-types` removed from the four workflows, `bin/build-plugin-zip.sh`, `prestorybook:build`, and `AGENTS.md`.
- `npm start` keeps full checking in watch mode; `tools/release/commands/performance.js` keeps the flag for older branches.

Emitted `build-types` are byte-identical; `npm run typecheck` still surfaces errors afterward.

Whole `npm run build`, M-series MacBook, two runs each (rebuild types step ~150ms both ways):

| | Fresh (after `clean:package-types`) | Rebuild |
|-|-|-|
| trunk | 30-31s (types 7.1-7.3s) | 24s |
| this PR | 27-28s (types 3.2-3.3s) | 23s |

## Testing Instructions

1. `npm run clean:package-types && npm run build`: succeeds, types step ~3s.
2. Add a type error to a package source: `npm run build` still passes, `npm run typecheck` fails.

## Use of AI Tools

Claude Code, reviewed and tested by me.
