### PR TITLE
Refactor MediaPlaceholder drop eligibility

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Internal
 
+-   `MediaPlaceholder`: Extract media drop eligibility logic into a helper.
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81516](https://github.com/WordPress/gutenberg/pull/81516))
 
 ## 16.2.0 (2026-08-12)

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -18,7 +18,7 @@ import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
 import { store as blockEditorStore } from '../../store';
 import { parseDropEvent } from '../use-on-block-drop';
-import { getComputedAcceptAttribute } from './utils';
+import { getComputedAcceptAttribute, isMediaDropEligible } from './utils';
 const noop = () => {};
 
 const InsertFromURLPopover = ( {
@@ -371,26 +371,13 @@ export function MediaPlaceholder( {
 			<DropZone
 				onFilesDrop={ onFilesUpload }
 				onDrop={ handleBlocksDrop }
-				isEligible={ ( dataTransfer ) => {
-					// This dropzone only accepts block drags from the inserter, not
-					// canvas block drags. Only the inserter publishes the dragged
-					// blocks' names, as wp-block:core/{name}, so no matches means it
-					// isn't an inserter drag.
-					const prefix = 'wp-block:core/';
-					const types = [];
-					for ( const type of dataTransfer.types ) {
-						if ( type.startsWith( prefix ) ) {
-							types.push( type.slice( prefix.length ) );
-						}
-					}
-					return (
-						types.length > 0 &&
-						types.every( ( type ) =>
-							allowedTypes.includes( type )
-						) &&
-						( multiple ? true : types.length === 1 )
-					);
-				} }
+				isEligible={ ( dataTransfer ) =>
+					isMediaDropEligible(
+						dataTransfer.types,
+						allowedTypes,
+						multiple
+					)
+				}
 			/>
 		);
 	};

--- a/packages/block-editor/src/components/media-placeholder/test/is-media-drop-eligible.js
+++ b/packages/block-editor/src/components/media-placeholder/test/is-media-drop-eligible.js
@@ -1,0 +1,53 @@
+import { isMediaDropEligible } from '../utils';
+
+describe( 'isMediaDropEligible', () => {
+	it( 'returns false for a canvas block-reorder drag', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-blocks' ],
+			[ 'audio' ],
+			true
+		);
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true for an allowed inserter media block drag', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-block:core/audio' ],
+			[ 'audio' ],
+			true
+		);
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false for a disallowed inserter block drag', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-block:core/paragraph' ],
+			[ 'audio' ],
+			true
+		);
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false for multiple inserter media block drags when multiple is false', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-block:core/audio', 'wp-block:core/image' ],
+			[ 'audio', 'image' ],
+			false
+		);
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true for a single inserter media block drag when multiple is false', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-block:core/audio' ],
+			[ 'audio' ],
+			false
+		);
+
+		expect( result ).toBe( true );
+	} );
+} );

--- a/packages/block-editor/src/components/media-placeholder/utils.js
+++ b/packages/block-editor/src/components/media-placeholder/utils.js
@@ -1,4 +1,34 @@
 /**
+ * Determines whether a block drag over a media placeholder's drop zone should
+ * be treated as an eligible media drop.
+ *
+ * @param {Array}   dataTransferTypes The drag's `dataTransfer.types`.
+ * @param {Array}   allowedTypes      Allowed media types (e.g. `['audio']`).
+ * @param {boolean} multiple          Whether multiple items may be dropped.
+ *
+ * @return {boolean} Whether the drag is an eligible media drop.
+ */
+export function isMediaDropEligible(
+	dataTransferTypes,
+	allowedTypes = [],
+	multiple
+) {
+	// This dropzone only accepts block drags from the inserter, not
+	// canvas block drags. Only the inserter publishes the dragged
+	// blocks' names, as wp-block:core/{name}, so no matches means it
+	// isn't an inserter drag.
+	const prefix = 'wp-block:core/';
+	const types = dataTransferTypes
+		.filter( ( type ) => type.startsWith( prefix ) )
+		.map( ( type ) => type.slice( prefix.length ) );
+	return (
+		types.length > 0 &&
+		types.every( ( type ) => allowedTypes.includes( type ) ) &&
+		( multiple ? true : types.length === 1 )
+	);
+}
+
+/**
  * Computes the accept attribute for file inputs based on allowed types
  * and server-supported MIME types.
  *


### PR DESCRIPTION
## What?
Extracts `MediaPlaceholder` block-drop eligibility into an `isMediaDropEligible` helper.

## Why?
This keeps the recently added drop eligibility guard easier to read and test without changing behavior.

## How?
Moves the existing `wp-block:core/` filtering and allowed type checks into `utils.js`, expresses the type collection with `filter().map()`, and adds focused unit coverage for the current behavior.

## Testing Instructions
Run `npm run test:unit -- --no-coverage --modulePathIgnorePatterns '/.claude/' --testPathPatterns 'media-placeholder/test/is-media-drop-eligible'`.
Run `npm run lint:js -- packages/block-editor/src/components/media-placeholder/index.js packages/block-editor/src/components/media-placeholder/utils.js packages/block-editor/src/components/media-placeholder/test/is-media-drop-eligible.js`.

### Testing Instructions for Keyboard
No keyboard-specific behavior changes.

## Use of AI Tools
OpenAI Codex assisted with this code-quality follow-up.
