### PR TITLE
Support third-party MediaPlaceholder block drops

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   `MediaPlaceholder`: Recognize non-core inserter media block drags when checking drop eligibility.
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).
 -   Grid: Keep child layout changes made with the resizer scoped to the selected viewport.

--- a/packages/block-editor/src/components/media-placeholder/test/is-media-drop-eligible.js
+++ b/packages/block-editor/src/components/media-placeholder/test/is-media-drop-eligible.js
@@ -21,9 +21,29 @@ describe( 'isMediaDropEligible', () => {
 		expect( result ).toBe( true );
 	} );
 
+	it( 'returns true for an allowed third-party inserter media block drag', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-block:plugin/audio' ],
+			[ 'audio' ],
+			true
+		);
+
+		expect( result ).toBe( true );
+	} );
+
 	it( 'returns false for a disallowed inserter block drag', () => {
 		const result = isMediaDropEligible(
 			[ 'wp-block:core/paragraph' ],
+			[ 'audio' ],
+			true
+		);
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false for a disallowed third-party inserter block drag', () => {
+		const result = isMediaDropEligible(
+			[ 'wp-block:plugin/paragraph' ],
 			[ 'audio' ],
 			true
 		);

--- a/packages/block-editor/src/components/media-placeholder/utils.js
+++ b/packages/block-editor/src/components/media-placeholder/utils.js
@@ -15,12 +15,12 @@ export function isMediaDropEligible(
 ) {
 	// This dropzone only accepts block drags from the inserter, not
 	// canvas block drags. Only the inserter publishes the dragged
-	// blocks' names, as wp-block:core/{name}, so no matches means it
+	// blocks' names, as wp-block:{namespace}/{name}, so no matches means it
 	// isn't an inserter drag.
-	const prefix = 'wp-block:core/';
+	const prefix = 'wp-block:';
 	const types = dataTransferTypes
 		.filter( ( type ) => type.startsWith( prefix ) )
-		.map( ( type ) => type.slice( prefix.length ) );
+		.map( ( type ) => type.slice( prefix.length ).split( '/' ).pop() );
 	return (
 		types.length > 0 &&
 		types.every( ( type ) => allowedTypes.includes( type ) ) &&


### PR DESCRIPTION
## What?
Allows `MediaPlaceholder` drop eligibility to recognize non-core inserter block drags.

## Why?
Inserter drags publish block names as `wp-block:{namespace}/{name}`. The current eligibility check only recognizes `wp-block:core/{name}`, so third-party media blocks are ignored even when their block name maps to an allowed media type.

## How?
Broadens the helper prefix to `wp-block:`, compares the block name segment after the namespace against `allowedTypes`, and adds unit coverage for allowed and disallowed third-party block drags.

## Testing Instructions
Run `npm run test:unit -- --no-coverage --modulePathIgnorePatterns '/.claude/' --testPathPatterns 'media-placeholder/test/is-media-drop-eligible'`.
Run `npm run lint:js -- packages/block-editor/src/components/media-placeholder/index.js packages/block-editor/src/components/media-placeholder/utils.js packages/block-editor/src/components/media-placeholder/test/is-media-drop-eligible.js`.

### Testing Instructions for Keyboard
No keyboard-specific behavior changes.

## Use of AI Tools
OpenAI Codex assisted with this follow-up.
