### PR TITLE
Media Editor Route: Add missing dependency to media-editor route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55696,6 +55696,7 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/base-styles": "file:../../packages/base-styles",
 				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/editor": "file:../../packages/editor",

--- a/routes/media-editor/package.json
+++ b/routes/media-editor/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/base-styles": "file:../../packages/base-styles",
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/editor": "file:../../packages/editor",


### PR DESCRIPTION
## What?

Follow-up to:

* #81563

Add missing dependency to the media editor route's package.json

## Testing Instructions

If you really want to smoke test:

Enable the experiment:

<img width="1214" height="170" alt="image" src="https://github.com/user-attachments/assets/48fbbeee-1b91-45a2-a43d-306e340b99f8" />

Go to the Media library screen in wp-admin and click on an image or its "Edit" link, and it should open the media editor route.

## Use of AI Tools

Claude Code (Opus 5) — I really didn't need to use AI for this one, but it did the job.