### PR TITLE
Editor: Migrate hierarchical term selector to @wordpress/ui

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -10,14 +10,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import {
 	Button,
 	CheckboxControl,
-	TextControl,
 	TreeSelect,
 	withFilters,
-	Flex,
-	FlexItem,
 	SearchControl,
-	Spinner,
 } from '@wordpress/components';
+import { InputControl, Spinner, Stack } from '@wordpress/ui';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useDebounce, useEvent } from '@wordpress/compose';
 import {
@@ -428,7 +425,7 @@ export function HierarchicalTermSelector( { slug } ) {
 	const showFilter = availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER;
 
 	return (
-		<Flex direction="column" gap="4">
+		<Stack direction="column" gap="lg">
 			{ showFilter && ! loading && (
 				<SearchControl
 					label={ filterLabel }
@@ -438,7 +435,7 @@ export function HierarchicalTermSelector( { slug } ) {
 				/>
 			) }
 			{ loading && (
-				<Flex
+				<Stack
 					justify="center"
 					style={ {
 						// Match SearchControl height to prevent layout shift.
@@ -446,7 +443,7 @@ export function HierarchicalTermSelector( { slug } ) {
 					} }
 				>
 					<Spinner />
-				</Flex>
+				</Stack>
 			) }
 			<div
 				className="editor-post-taxonomies__hierarchical-terms-list"
@@ -464,26 +461,24 @@ export function HierarchicalTermSelector( { slug } ) {
 				) ) }
 			</div>
 			{ ! loading && hasCreateAction && (
-				<FlexItem>
-					<Button
-						__next40pxDefaultSize
-						onClick={ onToggleForm }
-						className="editor-post-taxonomies__hierarchical-terms-add"
-						aria-expanded={ showForm }
-						variant="link"
-					>
-						{ newTermButtonLabel }
-					</Button>
-				</FlexItem>
+				<Button
+					__next40pxDefaultSize
+					onClick={ onToggleForm }
+					className="editor-post-taxonomies__hierarchical-terms-add"
+					aria-expanded={ showForm }
+					variant="link"
+				>
+					{ newTermButtonLabel }
+				</Button>
 			) }
 			{ showForm && (
 				<form onSubmit={ onAddTerm }>
-					<Flex direction="column" gap="4">
-						<TextControl
+					<Stack direction="column" gap="lg">
+						<InputControl
 							className="editor-post-taxonomies__hierarchical-terms-input"
 							label={ newTermLabel }
 							value={ formName }
-							onChange={ onChangeFormName }
+							onValueChange={ onChangeFormName }
 							required
 						/>
 						{ !! availableTerms.length && (
@@ -495,20 +490,18 @@ export function HierarchicalTermSelector( { slug } ) {
 								tree={ availableTermsTree }
 							/>
 						) }
-						<FlexItem>
-							<Button
-								__next40pxDefaultSize
-								variant="secondary"
-								type="submit"
-								className="editor-post-taxonomies__hierarchical-terms-submit"
-							>
-								{ newTermSubmitLabel }
-							</Button>
-						</FlexItem>
-					</Flex>
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							type="submit"
+							className="editor-post-taxonomies__hierarchical-terms-submit"
+						>
+							{ newTermSubmitLabel }
+						</Button>
+					</Stack>
 				</form>
 			) }
-		</Flex>
+		</Stack>
 	);
 }
 

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -18,6 +18,11 @@
 	}
 }
 
+.editor-post-taxonomies__hierarchical-terms-add,
+.editor-post-taxonomies__hierarchical-terms-submit {
+	align-self: flex-start;
+}
+
 .editor-post-taxonomies__hierarchical-terms-subchoices {
 	margin-top: $grid-unit-10;
 	margin-left: $grid-unit-20;

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1413,11 +1413,6 @@
 			"count": 2
 		}
 	},
-	"packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 3
-		}
-	},
 	"packages/editor/src/components/post-template/create-new-template-modal.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 3


### PR DESCRIPTION
## What?
Swaps the not-recommended `@wordpress/components` primitives in the hierarchical term selector (Categories panel) for their `@wordpress/ui` equivalents: `Flex`/`FlexItem` to `Stack`, `TextControl` to `InputControl`, `Spinner` to `Spinner`.

No behavior change. The "Add Category" form field and the loading spinner pick up design token styling.

## Testing Instructions
1. Open a post.
2. Confirm the Categories panel in the sidebar looks and works as before.

## Screenshots or screencast <!-- if applicable -->

<img width="288" height="560" alt="CleanShot 2026-08-20 at 07 47 36" src="https://github.com/user-attachments/assets/7c9168ab-0306-4c34-a109-67f2987ff5d7" />


## Use of AI Tools

Assisted by Claude.