### PR TITLE
Duotone Picker: Stop the duotone bar offering to move its control points

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 -   `ConfirmDialog`: Preserve `title` as the dialog's accessible name when the header is hidden ([#81847](https://github.com/WordPress/gutenberg/pull/81847)).
 -   `DuotonePicker`: Do not render the custom controls wrapper when `disableCustomDuotone` is set, so a read-only picker no longer adds trailing padding below its swatches ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
--   `DuotonePicker`: Stop the duotone bar offering to move its control points. It announced that arrow keys and dragging change the gradient position, but a duotone is two colors with no positions, so the move was discarded. `CustomGradientBar` gains a `disablePositioning` prop for this ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER)).
+-   `DuotonePicker`: Stop the duotone bar offering to move its control points. It announced that arrow keys and dragging change the gradient position, but a duotone is two colors with no positions, so the move was discarded. `CustomGradientBar` gains a `disablePositioning` prop for this ([#81850](https://github.com/WordPress/gutenberg/pull/81850)).
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 -   `ConfirmDialog`: Preserve `title` as the dialog's accessible name when the header is hidden ([#81847](https://github.com/WordPress/gutenberg/pull/81847)).
 -   `DuotonePicker`: Do not render the custom controls wrapper when `disableCustomDuotone` is set, so a read-only picker no longer adds trailing padding below its swatches ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
+-   `DuotonePicker`: Stop the duotone bar offering to move its control points. It announced that arrow keys and dragging change the gradient position, but a duotone is two colors with no positions, so the move was discarded. `CustomGradientBar` gains a `disablePositioning` prop for this ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER)).
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
@@ -36,6 +36,7 @@ function ControlPointButton( {
 	isOpen,
 	position,
 	color,
+	disablePositioning,
 	...additionalProps
 }: WordPressComponentProps< ControlPointButtonProps, 'button', true > ) {
 	const instanceId = useInstanceId( ControlPointButton );
@@ -64,9 +65,11 @@ function ControlPointButton( {
 				{ ...additionalProps }
 			/>
 			<VisuallyHidden id={ descriptionId }>
-				{ __(
-					'Use your left or right arrow keys or drag and drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.'
-				) }
+				{ disablePositioning
+					? __( 'Press the button to change the color.' )
+					: __(
+							'Use your left or right arrow keys or drag and drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.'
+					  ) }
 			</VisuallyHidden>
 		</>
 	);
@@ -109,6 +112,7 @@ function GradientColorPickerDropdown( {
 function ControlPoints( {
 	disableRemove,
 	disableAlpha,
+	disablePositioning,
 	gradientPickerDomRef,
 	ignoreMarkerPosition,
 	value: controlPoints,
@@ -206,6 +210,9 @@ function ControlPoints( {
 										onToggle();
 									} }
 									onMouseDown={ () => {
+										if ( disablePositioning ) {
+											return;
+										}
 										if (
 											window &&
 											window.addEventListener
@@ -228,6 +235,9 @@ function ControlPoints( {
 										}
 									} }
 									onKeyDown={ ( event ) => {
+										if ( disablePositioning ) {
+											return;
+										}
 										if ( event.code === 'ArrowLeft' ) {
 											// Stop propagation of the key press event to avoid focus moving
 											// to another editor area.
@@ -263,6 +273,7 @@ function ControlPoints( {
 									isOpen={ isOpen }
 									position={ point.position }
 									color={ point.color }
+									disablePositioning={ disablePositioning }
 								/>
 							) }
 							renderContent={ ( { onClose } ) => (

--- a/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
@@ -236,6 +236,16 @@ function ControlPoints( {
 									} }
 									onKeyDown={ ( event ) => {
 										if ( disablePositioning ) {
+											// The point cannot move, but the
+											// arrow keys are still consumed so
+											// they do not bubble away and move
+											// focus to another editor area.
+											if (
+												event.code === 'ArrowLeft' ||
+												event.code === 'ArrowRight'
+											) {
+												event.stopPropagation();
+											}
 											return;
 										}
 										if ( event.code === 'ArrowLeft' ) {

--- a/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
@@ -74,6 +74,7 @@ export default function CustomGradientBar( {
 	onChange,
 	disableInserter = false,
 	disableAlpha = false,
+	disablePositioning = false,
 	__experimentalIsRenderedInSidebar = false,
 }: CustomGradientBarProps ) {
 	const gradientMarkersContainerDomRef = useRef< HTMLDivElement >( null );
@@ -169,6 +170,7 @@ export default function CustomGradientBar( {
 					}
 					disableAlpha={ disableAlpha }
 					disableRemove={ disableInserter }
+					disablePositioning={ disablePositioning }
 					gradientPickerDomRef={ gradientMarkersContainerDomRef }
 					ignoreMarkerPosition={
 						isInsertingControlPoint

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from '@wordpress/element';
 import CustomGradientPicker from '../';
+import CustomGradientBar from '../gradient-bar';
+import { KEYBOARD_CONTROL_POINT_VARIATION } from '../gradient-bar/constants';
 
 function ControlledCustomGradientPicker( {
 	initialValue = 'linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)',
@@ -176,5 +178,62 @@ describe( 'CustomGradientPicker', () => {
 				onChange.mock.calls[ onChange.mock.calls.length - 1 ][ 0 ];
 			expect( lastCall ).not.toContain( 'deg' );
 		} );
+	} );
+} );
+
+describe( 'CustomGradientBar', () => {
+	const POINTS = [
+		{ position: 0, color: 'rgb(0,0,0)' },
+		{ position: 100, color: 'rgb(255,255,255)' },
+	];
+
+	// The counterpart to the duotone bar's tests: positioning is on unless a
+	// consumer opts out, so arrow keys must still move a control point.
+	it( 'moves a control point with the arrow keys', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<CustomGradientBar
+				background="linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)"
+				hasGradient
+				value={ POINTS }
+				onChange={ onChange }
+			/>
+		);
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+		firstPoint.focus();
+		await user.keyboard( '[ArrowRight]' );
+
+		expect( onChange ).toHaveBeenCalledWith( [
+			{ position: KEYBOARD_CONTROL_POINT_VARIATION, color: 'rgb(0,0,0)' },
+			POINTS[ 1 ],
+		] );
+	} );
+
+	it( 'does not move a control point when positioning is disabled', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<CustomGradientBar
+				background="linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)"
+				hasGradient
+				disablePositioning
+				value={ POINTS }
+				onChange={ onChange }
+			/>
+		);
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+		firstPoint.focus();
+		await user.keyboard( '[ArrowRight]' );
+
+		expect( onChange ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -214,6 +214,74 @@ describe( 'CustomGradientBar', () => {
 		] );
 	} );
 
+	// Dragging is driven by window-level listeners attached on mousedown, and
+	// the position comes from the markers container's box, so that has to be
+	// given one in jsdom.
+	it( 'moves a control point when dragged', () => {
+		const onChange = jest.fn();
+
+		const { container } = render(
+			<CustomGradientBar
+				background="linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)"
+				hasGradient
+				value={ POINTS }
+				onChange={ onChange }
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		const markers = container.querySelector(
+			'.components-custom-gradient-picker__markers-container'
+		) as HTMLElement;
+		markers.getBoundingClientRect = () =>
+			( { x: 0, width: 200 } ) as DOMRect;
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+
+		fireEvent.mouseDown( firstPoint );
+		fireEvent.mouseMove( window, { clientX: 100 } );
+		fireEvent.mouseUp( window );
+
+		// 100px into a 200px container is 50%.
+		expect( onChange ).toHaveBeenCalledWith( [
+			{ position: 50, color: 'rgb(0,0,0)' },
+			POINTS[ 1 ],
+		] );
+	} );
+
+	it( 'does not move a control point when dragged and positioning is disabled', () => {
+		const onChange = jest.fn();
+
+		const { container } = render(
+			<CustomGradientBar
+				background="linear-gradient(90deg,rgb(0,0,0) 0%,rgb(255,255,255) 100%)"
+				hasGradient
+				disablePositioning
+				value={ POINTS }
+				onChange={ onChange }
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		const markers = container.querySelector(
+			'.components-custom-gradient-picker__markers-container'
+		) as HTMLElement;
+		markers.getBoundingClientRect = () =>
+			( { x: 0, width: 200 } ) as DOMRect;
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+
+		fireEvent.mouseDown( firstPoint );
+		fireEvent.mouseMove( window, { clientX: 100 } );
+		fireEvent.mouseUp( window );
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
 	it( 'does not move a control point when positioning is disabled', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();

--- a/packages/components/src/custom-gradient-picker/test/index.tsx
+++ b/packages/components/src/custom-gradient-picker/test/index.tsx
@@ -205,6 +205,13 @@ describe( 'CustomGradientBar', () => {
 		const [ firstPoint ] = screen.getAllByRole( 'button', {
 			name: /Gradient control point/,
 		} );
+
+		// The description still offers positioning and removal, which the
+		// duotone bar's shorter one drops.
+		expect( firstPoint ).toHaveAccessibleDescription(
+			/change the gradient position.+remove the control point/
+		);
+
 		firstPoint.focus();
 		await user.keyboard( '[ArrowRight]' );
 

--- a/packages/components/src/custom-gradient-picker/types.ts
+++ b/packages/components/src/custom-gradient-picker/types.ts
@@ -60,6 +60,14 @@ export type CustomGradientBarProps = {
 	onChange: ( newControlPoints: ControlPoint[] ) => void;
 	disableInserter?: boolean;
 	disableAlpha?: boolean;
+	/**
+	 * Whether control points are fixed in place. Set by consumers whose value
+	 * has no positions to store, such as a duotone, so the control does not
+	 * offer a move it cannot save.
+	 *
+	 * @default false
+	 */
+	disablePositioning?: boolean;
 	__experimentalIsRenderedInSidebar?: boolean;
 };
 
@@ -92,11 +100,13 @@ export type ControlPointButtonProps = {
 	isOpen: boolean;
 	position: ControlPoint[ 'position' ];
 	color: string;
+	disablePositioning?: boolean;
 };
 
 export type ControlPointsProps = {
 	disableRemove: boolean;
 	disableAlpha: boolean;
+	disablePositioning?: boolean;
 	gradientPickerDomRef: React.RefObject< HTMLDivElement | null >;
 	ignoreMarkerPosition?: number;
 	value: ControlPoint[];

--- a/packages/components/src/duotone-picker/custom-duotone-bar.tsx
+++ b/packages/components/src/duotone-picker/custom-duotone-bar.tsx
@@ -21,6 +21,7 @@ export default function CustomDuotoneBar( {
 	return (
 		<CustomGradientBar
 			disableInserter
+			disablePositioning
 			background={ background }
 			hasGradient={ hasGradient }
 			value={ controlPoints }

--- a/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
+++ b/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
@@ -34,4 +34,47 @@ describe( 'CustomDuotoneBar', () => {
 
 		expect( onChange ).not.toHaveBeenCalled();
 	} );
+
+	// The point cannot move, but the keys still have to be consumed. Letting
+	// them bubble would move focus out of the control, which is what the
+	// gradient bar's own `stopPropagation` guards against.
+	it( 'does not let arrow keys bubble out of the control', async () => {
+		const user = userEvent.setup();
+		const onAncestorKeyDown = jest.fn();
+
+		render(
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+			<div onKeyDown={ onAncestorKeyDown }>
+				<CustomDuotoneBar value={ VALUE } onChange={ jest.fn() } />
+			</div>
+		);
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+		firstPoint.focus();
+		await user.keyboard( '[ArrowLeft][ArrowRight]' );
+
+		expect( onAncestorKeyDown ).not.toHaveBeenCalled();
+	} );
+
+	it( 'still lets other keys bubble', async () => {
+		const user = userEvent.setup();
+		const onAncestorKeyDown = jest.fn();
+
+		render(
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+			<div onKeyDown={ onAncestorKeyDown }>
+				<CustomDuotoneBar value={ VALUE } onChange={ jest.fn() } />
+			</div>
+		);
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+		firstPoint.focus();
+		await user.keyboard( '[Escape]' );
+
+		expect( onAncestorKeyDown ).toHaveBeenCalled();
+	} );
 } );

--- a/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
+++ b/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
@@ -58,6 +58,24 @@ describe( 'CustomDuotoneBar', () => {
 		expect( onAncestorKeyDown ).not.toHaveBeenCalled();
 	} );
 
+	// Disabling positioning must not disable the one thing a duotone control
+	// point can still do.
+	it( 'still opens the color picker when a control point is clicked', async () => {
+		const user = userEvent.setup();
+
+		render( <CustomDuotoneBar value={ VALUE } onChange={ jest.fn() } /> );
+
+		await user.click(
+			screen.getAllByRole( 'button', {
+				name: /Gradient control point/,
+			} )[ 0 ]
+		);
+
+		expect(
+			await screen.findByRole( 'slider', { name: 'Color' } )
+		).toBeVisible();
+	} );
+
 	it( 'still lets other keys bubble', async () => {
 		const user = userEvent.setup();
 		const onAncestorKeyDown = jest.fn();

--- a/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
+++ b/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CustomDuotoneBar from '../custom-duotone-bar';
 
@@ -31,6 +31,22 @@ describe( 'CustomDuotoneBar', () => {
 		} );
 		firstPoint.focus();
 		await user.keyboard( '[ArrowRight][ArrowRight][ArrowLeft]' );
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores dragging a control point', () => {
+		const onChange = jest.fn();
+
+		render( <CustomDuotoneBar value={ VALUE } onChange={ onChange } /> );
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+
+		fireEvent.mouseDown( firstPoint );
+		fireEvent.mouseMove( window, { clientX: 50 } );
+		fireEvent.mouseUp( window );
 
 		expect( onChange ).not.toHaveBeenCalled();
 	} );

--- a/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
+++ b/packages/components/src/duotone-picker/test/custom-duotone-bar.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CustomDuotoneBar from '../custom-duotone-bar';
+
+const VALUE = [ '#000000', '#ffffff' ];
+
+describe( 'CustomDuotoneBar', () => {
+	it( 'does not offer to reposition control points, since a duotone has no positions to save', () => {
+		render( <CustomDuotoneBar value={ VALUE } onChange={ jest.fn() } /> );
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+
+		expect( firstPoint ).toHaveAccessibleDescription(
+			'Press the button to change the color.'
+		);
+		expect(
+			screen.queryByText( /change the gradient position/ )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'ignores arrow keys on a control point', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render( <CustomDuotoneBar value={ VALUE } onChange={ onChange } /> );
+
+		const [ firstPoint ] = screen.getAllByRole( 'button', {
+			name: /Gradient control point/,
+		} );
+		firstPoint.focus();
+		await user.keyboard( '[ArrowRight][ArrowRight][ArrowLeft]' );
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## What?

Stops the duotone bar telling users they can move its control points.

Closes #81799.

## Why?

Each control point is described as:

> Use your left or right arrow keys or drag and drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.

Both halves are wrong for a duotone:

-   **Position.** `CustomDuotoneBar` passes the stops through `getColorsFromColorStops()`, which keeps only the colors. A duotone is two colors with no positions, so a move is discarded.
-   **Removal.** It needs `controlPoints.length > 2`, and a duotone has exactly two.

Screen reader users get the whole sentence, so they are the ones told to perform operations that do nothing.

## How?

`CustomGradientBar` gains `disablePositioning`, set by `CustomDuotoneBar`. It guards the arrow key and drag handlers, and swaps the description for:

> Press the button to change the color.

Opt-in, so the gradient bar is unchanged.

Two notes on scope:

-   One flag, not two. `CustomDuotoneBar` is the only consumer that disables anything, and it is also the only place removal is unavailable, so a second axis would be untested.
-   The button's `aria-label` still reads "Gradient control point at position 0%…". It states a fact rather than promising an action, so it is left alone.

## Testing Instructions

### The duotone bar

Add an Image block, open the duotone control in the toolbar, pick a duotone. The bar appears below the swatches.

1. Focus a control point and press ← or →. Nothing moves. On trunk the stop shifts.
2. Drag a control point. Nothing moves. On trunk it drags, then snaps back.
3. Click a control point. The color picker still opens.

### Screen reader

With VoiceOver or NVDA, focus a control point.

-   Expected: "…Press the button to change the color."
-   On trunk: "…Use your left or right arrow keys or drag and drop with the mouse to change the gradient position. Press the button to change the color or remove the control point."

Without a screen reader, inspect the control point and follow `aria-describedby`.

### Gradient bar, unchanged

Site Editor → Styles → Colors → Edit palette → Gradient. Add a gradient, click its swatch.

1. Arrow keys move a stop.
2. Dragging works.
3. With three or more stops, "Remove control point" appears.
4. The description is still the original sentence.
