### PR TITLE
Editor: Remove FlexItem usage from NoteCard

### DIFF
--- a/packages/editor/src/components/collab-sidebar/note-card.js
+++ b/packages/editor/src/components/collab-sidebar/note-card.js
@@ -1,4 +1,3 @@
-import { FlexItem } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { NoteByline } from './note-byline';
 
@@ -13,14 +12,14 @@ export function NoteCard( { note, actions, className, children, ...props } ) {
 					userId={ note?.author }
 				/>
 				{ actions && (
-					<FlexItem
+					<Stack
+						direction="row"
+						align="center"
 						className="editor-collab-sidebar-panel__note-actions"
 						onClick={ ( event ) => event.stopPropagation() }
 					>
-						<Stack direction="row" align="center">
-							{ actions }
-						</Stack>
-					</FlexItem>
+						{ actions }
+					</Stack>
 				) }
 			</Stack>
 			{ children }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1290,11 +1290,6 @@
 			"count": 1
 		}
 	},
-	"packages/editor/src/components/collab-sidebar/note-card.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/editor/src/components/document-bar/index.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?
Swaps the not-recommended @wordpress/components primitives in `NoteCard`. The existing `Stack` wrapper absorbs the responsibility.


## Testing Instructions
1. Open a post or page.
2. Add a note to a block.
3. Confirm that note actions are rendered as before.

### Testing Instructions for Keyboard
Same.

## Screenshot

<img width="245" height="468" alt="CleanShot 2026-08-20 at 08 25 04" src="https://github.com/user-attachments/assets/651b1e14-40a1-4739-b71d-1baabf864952" />

## Use of AI Tools

None.
