### PR TITLE
Ensure block style variation is available in the cached global stylesheet

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,7 @@
 			<group>fontsapi</group>
 		</exclude>
 	</groups>
+	<extensions>
+		<extension class="Gutenberg_Layout_Global_Styles_Cache_Setup" />
+	</extensions>
 </phpunit>

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1144,6 +1144,13 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that block style variations with blockGap values are applied to layout styles.
 	 *
+	 * gutenberg_render_layout_support_flag() memoizes global styles in a function
+	 * static that is populated on the first block render in the process and never
+	 * refreshed. If an earlier test file renders a block before this test's set_up()
+	 * registers the custom-gap variation, the memoized styles lack the variation.
+	 * The Gutenberg_Layout_Global_Styles_Cache_Setup extension primes the memoized
+	 * styles with the variation before any test runs.
+	 *
 	 * @covers ::wp_render_layout_support_flag
 	 */
 	public function test_layout_support_flag_uses_variation_block_gap_value() {

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -105,3 +105,6 @@ require $_tests_dir . '/includes/bootstrap.php';
 
 // Use existing behavior for wp_die during actual test execution.
 remove_filter( 'wp_die_handler', 'fail_if_died' );
+
+// Test suite extension that primes the layout global styles cache.
+require_once __DIR__ . '/fixtures/class-layout-global-styles-cache-setup.php';

--- a/phpunit/fixtures/class-layout-global-styles-cache-setup.php
+++ b/phpunit/fixtures/class-layout-global-styles-cache-setup.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Test suite extension that primes the layout global styles cache.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Primes the memoized global styles in gutenberg_render_layout_support_flag()
+ * before the first test runs.
+ *
+ * gutenberg_render_layout_support_flag() memoizes global styles in a function
+ * static on the first layout render of the PHPUnit process, and nothing
+ * invalidates that static on theme switches. Tests that rely on the `custom-gap`
+ * block style variation's blockGap value need that variation's data to be
+ * present in the memoized snapshot, so it must be registered before the first
+ * layout render — which can happen in any test file that renders a block with
+ * layout support, not just the layout test file itself.
+ *
+ * Registering the variation and rendering a group block with it here (before
+ * any test runs) ensures the snapshot is built while the variation is
+ * registered. The variation is unregistered again afterwards so the styles
+ * registry is clean for the rest of the suite; the layout test file registers
+ * and unregisters it per test as usual.
+ */
+class Gutenberg_Layout_Global_Styles_Cache_Setup implements PHPUnit\Runner\BeforeFirstTestHook {
+	/**
+	 * Receives a PHPUnit 'runFirstTest' signal.
+	 */
+	public function executeBeforeFirstTest(): void {
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'custom-gap',
+				'label'      => 'Custom Gap',
+				'style_data' => array(
+					'spacing' => array(
+						'blockGap' => '99px',
+					),
+				),
+			)
+		);
+
+		// Render a group block so the memoized global styles snapshot is built
+		// while the `custom-gap` variation is registered.
+		gutenberg_render_layout_support_flag(
+			'<div class="wp-block-group"></div>',
+			array(
+				'blockName' => 'core/group',
+				'attrs'     => array( 'layout' => array( 'type' => 'default' ) ),
+			)
+		);
+
+		unregister_block_style( 'core/group', 'custom-gap' );
+
+		// Clear the styles accumulated by the render above so they don't leak
+		// into tests that inspect the style engine output.
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Addresses test failures on #68002 by ensuring the block style variation used in the failing test is added to the global stylesheet at the point it's cached. Caching happens [in layout](https://github.com/WordPress/gutenberg/blob/fix/stupid-tests/lib/block-supports/layout.php#L1014) as soon as a block with layout is encountered; when #68002 added layout to the List block, the caching started happening in `phpunit/block-bindings-test.php` which runs before layout, so the block style variation registered in the layout tests never made it into the stylesheet.

I should add that running the failing test in a separate process won't work in Gutenberg because our test setup explicitly sets `WP_DEBUG=true` and that doesn't seem to go well with spinning up a new process (because we're redeclaring it)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

The PHP tests should pass.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Debugged and implemented with kimi 3.0/copilot.