### PR TITLE
Preserve layout and style attributes on Column transform

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   Columns: Preserve individual Column styles and layouts, including implicit flow layouts, when transforming to Row or Grid.
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 -   Playlist: Attach the inner block drop zone to the track list, so Playlist Track blocks show insertion markers while being reordered.
 -   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
--   Columns: Preserve individual Column styles and layouts, including implicit flow layouts, when transforming to Row or Grid.
+-   Columns: Preserve individual Column attributes supported by Group, including styles and layouts, when transforming to Row or Grid.
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 -   Playlist: Attach the inner block drop zone to the track list, so Playlist Track blocks show insertion markers while being reordered.
 -   Playlist Track: Mark track media fields as content so toolbar inserters add an empty track instead of duplicating the selected track.

--- a/packages/block-library/src/columns/test/transforms.js
+++ b/packages/block-library/src/columns/test/transforms.js
@@ -380,6 +380,50 @@ describe( 'transforms', () => {
 		}
 	);
 
+	it.each( [
+		[ 'Grid', 'group-grid' ],
+		[ 'Row', 'group-row' ],
+	] )(
+		'preserves Group-supported Column attributes when transforming Columns to %s',
+		( _variationTitle, variationName ) => {
+			const block = createBlock( 'core/columns', {}, [
+				createBlock(
+					'core/column',
+					{
+						anchor: 'column-anchor',
+						lock: { move: true, remove: true },
+						templateLock: 'insert',
+						verticalAlignment: 'center',
+						width: '320px',
+					},
+					[ createBlock( 'core/paragraph' ) ]
+				),
+			] );
+
+			const transformedBlocks = switchToBlockType(
+				block,
+				'core/group',
+				variationName
+			);
+			const transformedColumn = transformedBlocks[ 0 ].innerBlocks[ 0 ];
+
+			expect( transformedColumn ).toMatchObject( {
+				name: 'core/group',
+				attributes: {
+					anchor: 'column-anchor',
+					lock: { move: true, remove: true },
+					templateLock: 'insert',
+				},
+			} );
+			expect( transformedColumn.attributes ).not.toHaveProperty(
+				'verticalAlignment'
+			);
+			expect( transformedColumn.attributes ).not.toHaveProperty(
+				'width'
+			);
+		}
+	);
+
 	it( 'migrates Column widths to Row child sizing controls', () => {
 		const block = createBlock( 'core/columns', {}, [
 			createBlock( 'core/column', { width: '320px' }, [

--- a/packages/block-library/src/columns/test/transforms.js
+++ b/packages/block-library/src/columns/test/transforms.js
@@ -346,6 +346,40 @@ describe( 'transforms', () => {
 		}
 	);
 
+	it.each( [
+		[ 'Grid', 'group-grid' ],
+		[ 'Row', 'group-row' ],
+	] )(
+		'preserves root-level style attributes when transforming Columns to %s',
+		( _variationTitle, variationName ) => {
+			const rootStyleAttributes = {
+				backgroundColor: 'primary',
+				borderColor: 'accent',
+				className: 'is-style-example custom-class',
+				fontFamily: 'heading',
+				fontSize: 'large',
+				gradient: 'vivid-cyan-blue-to-vivid-purple',
+				textColor: 'contrast',
+			};
+			const block = createBlock( 'core/columns', {}, [
+				createBlock( 'core/column', rootStyleAttributes, [
+					createBlock( 'core/paragraph' ),
+				] ),
+			] );
+
+			const transformedBlocks = switchToBlockType(
+				block,
+				'core/group',
+				variationName
+			);
+
+			expect( transformedBlocks[ 0 ].innerBlocks[ 0 ] ).toMatchObject( {
+				name: 'core/group',
+				attributes: rootStyleAttributes,
+			} );
+		}
+	);
+
 	it( 'migrates Column widths to Row child sizing controls', () => {
 		const block = createBlock( 'core/columns', {}, [
 			createBlock( 'core/column', { width: '320px' }, [

--- a/packages/block-library/src/columns/test/transforms.js
+++ b/packages/block-library/src/columns/test/transforms.js
@@ -87,7 +87,7 @@ describe( 'transforms', () => {
 		} );
 		expect( transformedBlocks[ 0 ].innerBlocks[ 1 ] ).toMatchObject( {
 			name: 'core/group',
-			attributes: { layout: { type: 'constrained' } },
+			attributes: { layout: { type: 'default' } },
 			innerBlocks: [
 				expect.objectContaining( {
 					name: 'core/paragraph',
@@ -99,6 +99,46 @@ describe( 'transforms', () => {
 				} ),
 			],
 		} );
+	} );
+
+	it( "preserves each Column block's styles when transforming Columns to Grid", () => {
+		const block = createBlock( 'core/columns', {}, [
+			createBlock(
+				'core/column',
+				{ style: { color: { background: '#123456' } } },
+				[ createBlock( 'core/paragraph', { content: 'One' } ) ]
+			),
+			createBlock(
+				'core/column',
+				{ style: { spacing: { padding: { top: '10px' } } } },
+				[
+					createBlock( 'core/paragraph', { content: 'Two' } ),
+					createBlock( 'core/paragraph', { content: 'Three' } ),
+				]
+			),
+		] );
+
+		const transformedBlocks = switchToBlockType(
+			block,
+			'core/group',
+			'group-grid'
+		);
+
+		expect(
+			transformedBlocks[ 0 ].innerBlocks.map( ( innerBlock ) => ( {
+				name: innerBlock.name,
+				style: innerBlock.attributes.style,
+			} ) )
+		).toEqual( [
+			{
+				name: 'core/group',
+				style: { color: { background: '#123456' } },
+			},
+			{
+				name: 'core/group',
+				style: { spacing: { padding: { top: '10px' } } },
+			},
+		] );
 	} );
 
 	it( 'transforms Columns to the Row variation of Group with one child for each column', () => {
@@ -151,7 +191,7 @@ describe( 'transforms', () => {
 		} );
 		expect( transformedBlocks[ 0 ].innerBlocks[ 1 ] ).toMatchObject( {
 			name: 'core/group',
-			attributes: { layout: { type: 'constrained' } },
+			attributes: { layout: { type: 'default' } },
 			innerBlocks: [
 				expect.objectContaining( {
 					name: 'core/paragraph',
@@ -165,10 +205,146 @@ describe( 'transforms', () => {
 		} );
 		expect( transformedBlocks[ 0 ].innerBlocks[ 2 ] ).toMatchObject( {
 			name: 'core/group',
-			attributes: { layout: { type: 'constrained' } },
+			attributes: { layout: { type: 'default' } },
 			innerBlocks: [],
 		} );
 	} );
+
+	it( "preserves each Column block's styles when transforming Columns to Row", () => {
+		const block = createBlock( 'core/columns', {}, [
+			createBlock(
+				'core/column',
+				{
+					width: '320px',
+					style: {
+						color: { background: '#123456' },
+						layout: { columnSpan: 2 },
+					},
+				},
+				[ createBlock( 'core/paragraph', { content: 'One' } ) ]
+			),
+			createBlock(
+				'core/column',
+				{
+					width: '50%',
+					style: { spacing: { padding: { top: '10px' } } },
+				},
+				[
+					createBlock( 'core/paragraph', { content: 'Two' } ),
+					createBlock( 'core/paragraph', { content: 'Three' } ),
+				]
+			),
+		] );
+
+		const transformedBlocks = switchToBlockType(
+			block,
+			'core/group',
+			'group-row'
+		);
+
+		expect(
+			transformedBlocks[ 0 ].innerBlocks.map( ( innerBlock ) => ( {
+				name: innerBlock.name,
+				style: innerBlock.attributes.style,
+			} ) )
+		).toEqual( [
+			{
+				name: 'core/group',
+				style: {
+					color: { background: '#123456' },
+					layout: {
+						columnSpan: 2,
+						selfStretch: 'fixed',
+						flexSize: '320px',
+					},
+				},
+			},
+			{
+				name: 'core/group',
+				style: {
+					spacing: { padding: { top: '10px' } },
+					layout: {
+						selfStretch: 'fixed',
+						flexSize: '50%',
+					},
+				},
+			},
+		] );
+	} );
+
+	it.each( [
+		[ 'Grid', 'group-grid' ],
+		[ 'Row', 'group-row' ],
+	] )(
+		"preserves each Column block's layout attributes when transforming Columns to %s",
+		( _variationTitle, variationName ) => {
+			const columnLayouts = [
+				{
+					type: 'constrained',
+					contentSize: '640px',
+					wideSize: '1200px',
+				},
+				{
+					type: 'flex',
+					orientation: 'vertical',
+					justifyContent: 'center',
+				},
+			];
+			const block = createBlock(
+				'core/columns',
+				{},
+				columnLayouts.map( ( layout ) =>
+					createBlock( 'core/column', { layout }, [
+						createBlock( 'core/paragraph' ),
+					] )
+				)
+			);
+
+			const transformedBlocks = switchToBlockType(
+				block,
+				'core/group',
+				variationName
+			);
+
+			expect(
+				transformedBlocks[ 0 ].innerBlocks.map( ( innerBlock ) => ( {
+					name: innerBlock.name,
+					layout: innerBlock.attributes.layout,
+				} ) )
+			).toEqual(
+				columnLayouts.map( ( layout ) => ( {
+					name: 'core/group',
+					layout,
+				} ) )
+			);
+		}
+	);
+
+	it.each( [
+		[ 'Grid', 'group-grid' ],
+		[ 'Row', 'group-row' ],
+	] )(
+		'transforms an implicitly flow-layout Column to a flow Group in %s',
+		( _variationTitle, variationName ) => {
+			const block = createBlock( 'core/columns', {}, [
+				createBlock( 'core/column', {}, [
+					createBlock( 'core/paragraph', { content: 'One' } ),
+					createBlock( 'core/paragraph', { content: 'Two' } ),
+				] ),
+			] );
+
+			const transformedBlocks = switchToBlockType(
+				block,
+				'core/group',
+				variationName
+			);
+
+			expect( transformedBlocks[ 0 ].innerBlocks[ 0 ] ).toMatchObject( {
+				name: 'core/group',
+				attributes: { layout: { type: 'default' } },
+			} );
+		}
+	);
 
 	it( 'migrates Column widths to Row child sizing controls', () => {
 		const block = createBlock( 'core/columns', {}, [

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -8,6 +8,7 @@ const MAXIMUM_SELECTED_BLOCKS = 6;
 const COLUMN_VERTICAL_ALIGNMENTS = [ 'top', 'center', 'bottom' ];
 const ROW_VERTICAL_ALIGNMENTS = [ ...COLUMN_VERTICAL_ALIGNMENTS, 'stretch' ];
 const FLEX_SIZE_LAYOUT_VALUES = [ 'fixed', 'fixedNoShrink' ];
+const DEFAULT_COLUMN_LAYOUT = { type: 'default' };
 
 const getObjectValue = ( value ) =>
 	value && typeof value === 'object' && ! Array.isArray( value ) ? value : {};
@@ -71,11 +72,26 @@ const getColumnBlocksFromRow = ( innerBlocks ) =>
 const getGridInnerBlocks = ( innerBlocks ) =>
 	innerBlocks.flatMap( ( column ) => {
 		const columnInnerBlocks = column.innerBlocks || [];
-		if ( columnInnerBlocks.length > 1 ) {
+		const columnStyle = getObjectValue( column?.attributes?.style );
+		const columnLayout = getObjectValue( column?.attributes?.layout );
+		const hasColumnStyle = Object.keys( columnStyle ).length > 0;
+		const hasColumnLayout = Object.keys( columnLayout ).length > 0;
+		if (
+			columnInnerBlocks.length > 1 ||
+			hasColumnStyle ||
+			hasColumnLayout
+		) {
 			return [
 				createBlock(
 					'core/group',
-					{ layout: { type: 'constrained' } },
+					{
+						layout: hasColumnLayout
+							? columnLayout
+							: DEFAULT_COLUMN_LAYOUT,
+						...( hasColumnStyle && {
+							style: columnStyle,
+						} ),
+					},
 					columnInnerBlocks
 				),
 			];
@@ -104,8 +120,16 @@ const getRowInnerBlocks = ( innerBlocks ) => {
 		const childLayout = columnWidth
 			? { selfStretch: 'fixed', flexSize: columnWidth }
 			: { selfStretch: 'fill' };
+		const columnStyle = getObjectValue( column?.attributes?.style );
+		const columnLayout = getObjectValue( column?.attributes?.layout );
+		const hasColumnStyle = Object.keys( columnStyle ).length > 0;
+		const hasColumnLayout = Object.keys( columnLayout ).length > 0;
 
-		if ( columnInnerBlocks.length === 1 ) {
+		if (
+			columnInnerBlocks.length === 1 &&
+			! hasColumnStyle &&
+			! hasColumnLayout
+		) {
 			const innerBlock = columnInnerBlocks[ 0 ];
 			const style = getObjectValue( innerBlock.attributes?.style );
 			const layout = getObjectValue( style.layout );
@@ -125,8 +149,14 @@ const getRowInnerBlocks = ( innerBlocks ) => {
 		return createBlock(
 			'core/group',
 			{
-				layout: { type: 'constrained' },
-				style: { layout: childLayout },
+				layout: hasColumnLayout ? columnLayout : DEFAULT_COLUMN_LAYOUT,
+				style: {
+					...columnStyle,
+					layout: {
+						...getObjectValue( columnStyle.layout ),
+						...childLayout,
+					},
+				},
 			},
 			columnInnerBlocks
 		);

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -2,6 +2,7 @@ import {
 	cloneSanitizedBlock,
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
+	getBlockType,
 } from '@wordpress/blocks';
 
 const MAXIMUM_SELECTED_BLOCKS = 6;
@@ -9,27 +10,22 @@ const COLUMN_VERTICAL_ALIGNMENTS = [ 'top', 'center', 'bottom' ];
 const ROW_VERTICAL_ALIGNMENTS = [ ...COLUMN_VERTICAL_ALIGNMENTS, 'stretch' ];
 const FLEX_SIZE_LAYOUT_VALUES = [ 'fixed', 'fixedNoShrink' ];
 const DEFAULT_COLUMN_LAYOUT = { type: 'default' };
-const ROOT_STYLE_ATTRIBUTE_NAMES = [
-	'backgroundColor',
-	'borderColor',
-	'className',
-	'fontFamily',
-	'fontSize',
-	'gradient',
-	'textColor',
-];
 
 const getObjectValue = ( value ) =>
 	value && typeof value === 'object' && ! Array.isArray( value ) ? value : {};
 
-const getRootStyleAttributes = ( attributes ) => {
+const getGroupAttributes = ( attributes ) => {
+	const groupAttributeDefinitions = getBlockType( 'core/group' )?.attributes;
+	if ( ! groupAttributeDefinitions ) {
+		return {};
+	}
 	const normalizedAttributes = getObjectValue( attributes );
-	return ROOT_STYLE_ATTRIBUTE_NAMES.reduce( ( rootStyleAttributes, name ) => {
-		if ( typeof normalizedAttributes[ name ] === 'string' ) {
-			rootStyleAttributes[ name ] = normalizedAttributes[ name ];
-		}
-		return rootStyleAttributes;
-	}, {} );
+
+	return Object.fromEntries(
+		Object.entries( normalizedAttributes ).filter( ( [ name ] ) =>
+			Object.hasOwn( groupAttributeDefinitions, name )
+		)
+	);
 };
 
 const getColumnWidth = ( width ) => {
@@ -91,26 +87,27 @@ const getColumnBlocksFromRow = ( innerBlocks ) =>
 const getGridInnerBlocks = ( innerBlocks ) =>
 	innerBlocks.flatMap( ( column ) => {
 		const columnInnerBlocks = column.innerBlocks || [];
-		const columnStyle = getObjectValue( column?.attributes?.style );
-		const columnLayout = getObjectValue( column?.attributes?.layout );
-		const rootStyleAttributes = getRootStyleAttributes(
-			column?.attributes
-		);
+		const {
+			layout: layoutAttribute,
+			style: styleAttribute,
+			...groupAttributes
+		} = getGroupAttributes( column?.attributes );
+		const columnStyle = getObjectValue( styleAttribute );
+		const columnLayout = getObjectValue( layoutAttribute );
+		const hasGroupAttributes = Object.keys( groupAttributes ).length > 0;
 		const hasColumnStyle = Object.keys( columnStyle ).length > 0;
 		const hasColumnLayout = Object.keys( columnLayout ).length > 0;
-		const hasRootStyleAttributes =
-			Object.keys( rootStyleAttributes ).length > 0;
 		if (
 			columnInnerBlocks.length > 1 ||
+			hasGroupAttributes ||
 			hasColumnStyle ||
-			hasColumnLayout ||
-			hasRootStyleAttributes
+			hasColumnLayout
 		) {
 			return [
 				createBlock(
 					'core/group',
 					{
-						...rootStyleAttributes,
+						...groupAttributes,
 						layout: hasColumnLayout
 							? columnLayout
 							: DEFAULT_COLUMN_LAYOUT,
@@ -146,21 +143,22 @@ const getRowInnerBlocks = ( innerBlocks ) => {
 		const childLayout = columnWidth
 			? { selfStretch: 'fixed', flexSize: columnWidth }
 			: { selfStretch: 'fill' };
-		const columnStyle = getObjectValue( column?.attributes?.style );
-		const columnLayout = getObjectValue( column?.attributes?.layout );
-		const rootStyleAttributes = getRootStyleAttributes(
-			column?.attributes
-		);
+		const {
+			layout: layoutAttribute,
+			style: styleAttribute,
+			...groupAttributes
+		} = getGroupAttributes( column?.attributes );
+		const columnStyle = getObjectValue( styleAttribute );
+		const columnLayout = getObjectValue( layoutAttribute );
+		const hasGroupAttributes = Object.keys( groupAttributes ).length > 0;
 		const hasColumnStyle = Object.keys( columnStyle ).length > 0;
 		const hasColumnLayout = Object.keys( columnLayout ).length > 0;
-		const hasRootStyleAttributes =
-			Object.keys( rootStyleAttributes ).length > 0;
 
 		if (
 			columnInnerBlocks.length === 1 &&
+			! hasGroupAttributes &&
 			! hasColumnStyle &&
-			! hasColumnLayout &&
-			! hasRootStyleAttributes
+			! hasColumnLayout
 		) {
 			const innerBlock = columnInnerBlocks[ 0 ];
 			const style = getObjectValue( innerBlock.attributes?.style );
@@ -181,7 +179,7 @@ const getRowInnerBlocks = ( innerBlocks ) => {
 		return createBlock(
 			'core/group',
 			{
-				...rootStyleAttributes,
+				...groupAttributes,
 				layout: hasColumnLayout ? columnLayout : DEFAULT_COLUMN_LAYOUT,
 				style: {
 					...columnStyle,

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -9,9 +9,28 @@ const COLUMN_VERTICAL_ALIGNMENTS = [ 'top', 'center', 'bottom' ];
 const ROW_VERTICAL_ALIGNMENTS = [ ...COLUMN_VERTICAL_ALIGNMENTS, 'stretch' ];
 const FLEX_SIZE_LAYOUT_VALUES = [ 'fixed', 'fixedNoShrink' ];
 const DEFAULT_COLUMN_LAYOUT = { type: 'default' };
+const ROOT_STYLE_ATTRIBUTE_NAMES = [
+	'backgroundColor',
+	'borderColor',
+	'className',
+	'fontFamily',
+	'fontSize',
+	'gradient',
+	'textColor',
+];
 
 const getObjectValue = ( value ) =>
 	value && typeof value === 'object' && ! Array.isArray( value ) ? value : {};
+
+const getRootStyleAttributes = ( attributes ) => {
+	const normalizedAttributes = getObjectValue( attributes );
+	return ROOT_STYLE_ATTRIBUTE_NAMES.reduce( ( rootStyleAttributes, name ) => {
+		if ( typeof normalizedAttributes[ name ] === 'string' ) {
+			rootStyleAttributes[ name ] = normalizedAttributes[ name ];
+		}
+		return rootStyleAttributes;
+	}, {} );
+};
 
 const getColumnWidth = ( width ) => {
 	if ( Number.isFinite( width ) ) {
@@ -74,17 +93,24 @@ const getGridInnerBlocks = ( innerBlocks ) =>
 		const columnInnerBlocks = column.innerBlocks || [];
 		const columnStyle = getObjectValue( column?.attributes?.style );
 		const columnLayout = getObjectValue( column?.attributes?.layout );
+		const rootStyleAttributes = getRootStyleAttributes(
+			column?.attributes
+		);
 		const hasColumnStyle = Object.keys( columnStyle ).length > 0;
 		const hasColumnLayout = Object.keys( columnLayout ).length > 0;
+		const hasRootStyleAttributes =
+			Object.keys( rootStyleAttributes ).length > 0;
 		if (
 			columnInnerBlocks.length > 1 ||
 			hasColumnStyle ||
-			hasColumnLayout
+			hasColumnLayout ||
+			hasRootStyleAttributes
 		) {
 			return [
 				createBlock(
 					'core/group',
 					{
+						...rootStyleAttributes,
 						layout: hasColumnLayout
 							? columnLayout
 							: DEFAULT_COLUMN_LAYOUT,
@@ -122,13 +148,19 @@ const getRowInnerBlocks = ( innerBlocks ) => {
 			: { selfStretch: 'fill' };
 		const columnStyle = getObjectValue( column?.attributes?.style );
 		const columnLayout = getObjectValue( column?.attributes?.layout );
+		const rootStyleAttributes = getRootStyleAttributes(
+			column?.attributes
+		);
 		const hasColumnStyle = Object.keys( columnStyle ).length > 0;
 		const hasColumnLayout = Object.keys( columnLayout ).length > 0;
+		const hasRootStyleAttributes =
+			Object.keys( rootStyleAttributes ).length > 0;
 
 		if (
 			columnInnerBlocks.length === 1 &&
 			! hasColumnStyle &&
-			! hasColumnLayout
+			! hasColumnLayout &&
+			! hasRootStyleAttributes
 		) {
 			const innerBlock = columnInnerBlocks[ 0 ];
 			const style = getObjectValue( innerBlock.attributes?.style );
@@ -149,6 +181,7 @@ const getRowInnerBlocks = ( innerBlocks ) => {
 		return createBlock(
 			'core/group',
 			{
+				...rootStyleAttributes,
 				layout: hasColumnLayout ? columnLayout : DEFAULT_COLUMN_LAYOUT,
 				style: {
 					...columnStyle,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up from #81802 and #78713, which added transforms to Row and Grid to the Columns block, but neglected to preserve layout and style attributes set on individual Column blocks.

This PR fixes that by ensuring the attributes get copied across to the Group wrappers that replace each Column.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a few Columns blocks with different styles (e.g. colors, typography) and layout types on each (Column supports both flow and constrained)
2. Try transforming them to Rows and Grids. For better comparison, duplicate each original Columns block and transform the duplicate, so you can see both side by side. All styles and layout should be maintained after the transform.


https://github.com/user-attachments/assets/6910bdc3-e0e6-425b-9431-a97e3e07a0ab



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Used codex/GPT 5.6 sol