### PR TITLE
Components: Support wrapperClassName on Item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
--   `Item`: Add a `wrapperClassName` prop for styling the wrapper element the component renders around its contents. The prop was already reaching the wrapper as an unknown prop, but it replaced the wrapper's own class, dropping the layout `ItemGroup` relies on for its borders and rounded corners.
+-   `Item`: Add a `wrapperClassName` prop for styling the wrapper element the component renders around its contents. The prop already reached the wrapper as an unknown prop, but it replaced the wrapper's own class instead of being added to it.
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
--   `Item`: Add a `wrapperClassName` prop for styling the wrapper element the component renders around its contents. The prop already reached the wrapper as an unknown prop, but it replaced the wrapper's own class instead of being added to it.
+-   `Item`: Add a `wrapperClassName` prop for styling the wrapper element the component renders around its contents. The prop already reached the wrapper as an unknown prop, but it replaced the wrapper's own class instead of being added to it ([#81860](https://github.com/WordPress/gutenberg/pull/81860)).
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   `Item`: Add a `wrapperClassName` prop for styling the wrapper element the component renders around its contents. The prop was already reaching the wrapper as an unknown prop, but it replaced the wrapper's own class, dropping the layout `ItemGroup` relies on for its borders and rounded corners.
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/src/item-group/item/README.md
+++ b/packages/components/src/item-group/item/README.md
@@ -42,7 +42,7 @@ Determines the amount of padding within the component.
 
 ### `wrapperClassName`: `string`
 
-A CSS class to add to the wrapper element that `Item` renders around its contents. The class is added alongside the wrapper's own class, which [`ItemGroup`](/packages/components/src/item-group/item-group/README.md) relies on for its borders and rounded corners.
+A CSS class to add to the wrapper element that `Item` renders around its contents. It is added alongside the wrapper's own class rather than replacing it.
 
 - Required: No
 

--- a/packages/components/src/item-group/item/README.md
+++ b/packages/components/src/item-group/item/README.md
@@ -40,6 +40,12 @@ Determines the amount of padding within the component.
 - Required: No
 - Default: `medium`
 
+### `wrapperClassName`: `string`
+
+A CSS class to add to the wrapper element that `Item` renders around its contents. The class is added alongside the wrapper's own class, which [`ItemGroup`](/packages/components/src/item-group/item-group/README.md) relies on for its borders and rounded corners.
+
+- Required: No
+
 ### Context
 
 `Item` is connected to [the `<ItemGroup />` parent component](/packages/components/src/item-group/item-group/README.md) using [Context](https://reactjs.org/docs/context.html). Therefore, `Item` receives the `size` prop from the `ItemGroup` parent component.

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -18,6 +18,7 @@ export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 		onClick,
 		role = 'listitem',
 		size: sizeProp,
+		wrapperClassName: wrapperClassNameProp,
 		...otherProps
 	} = useContextSystem( props, 'Item' );
 
@@ -36,7 +37,10 @@ export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 		className
 	);
 
-	const wrapperClassName = styles[ 'item-wrapper' ];
+	const wrapperClassName = clsx(
+		styles[ 'item-wrapper' ],
+		wrapperClassNameProp
+	);
 
 	return {
 		as,

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -134,5 +134,20 @@ describe( 'ItemGroup', () => {
 
 			expect( mediumSize ).toMatchDiffSnapshot( largeSize );
 		} );
+
+		it( 'should add `wrapperClassName` to the wrapper element without replacing its own class', () => {
+			const { rerender } = render( <Item>Code is poetry</Item> );
+
+			const ownClassName = screen.getByRole( 'listitem' ).className;
+			expect( ownClassName ).not.toBe( '' );
+
+			rerender(
+				<Item wrapperClassName="my-wrapper">Code is poetry</Item>
+			);
+
+			const wrapper = screen.getByRole( 'listitem' );
+			expect( wrapper ).toHaveClass( ownClassName );
+			expect( wrapper ).toHaveClass( 'my-wrapper' );
+		} );
 	} );
 } );

--- a/packages/components/src/item-group/types.ts
+++ b/packages/components/src/item-group/types.ts
@@ -40,8 +40,8 @@ export interface ItemProps {
 	size?: ItemSize;
 	/**
 	 * A CSS class to add to the wrapper element that `Item` renders around its
-	 * contents. The class is added alongside the wrapper's own class, which
-	 * `ItemGroup` relies on for its borders and rounded corners.
+	 * contents. It is added alongside the wrapper's own class rather than
+	 * replacing it.
 	 */
 	wrapperClassName?: string;
 	/**

--- a/packages/components/src/item-group/types.ts
+++ b/packages/components/src/item-group/types.ts
@@ -39,6 +39,12 @@ export interface ItemProps {
 	 */
 	size?: ItemSize;
 	/**
+	 * A CSS class to add to the wrapper element that `Item` renders around its
+	 * contents. The class is added alongside the wrapper's own class, which
+	 * `ItemGroup` relies on for its borders and rounded corners.
+	 */
+	wrapperClassName?: string;
+	/**
 	 * The children elements.
 	 */
 	children: React.ReactNode;

--- a/storybook/components-manifest.yml
+++ b/storybook/components-manifest.yml
@@ -544,6 +544,7 @@
             - as
             - children
             - size
+            - wrapperClassName
 - name: KeyboardShortcuts
   props:
       - bindGlobal


### PR DESCRIPTION
> **Edit:** the original description claimed `ItemGroup`'s borders and rounded corners depend on the wrapper's class. That is wrong — they are positional selectors. Corrected below, and the impact is smaller than I first wrote.

## What?

Adds a documented `wrapperClassName` prop to `Item`, for styling the wrapper element the component renders around its contents, and merges it with the wrapper's own class instead of replacing it.

## Why?

`Item` renders a wrapper element around its contents, and consumers who need to style that wrapper have no supported way to do so. Downstream, [media-experiments](https://github.com/swissspidy/media-experiments) reaches for it by casting:

```ts
const ItemWithWrapper = Item as ComponentType<
	ComponentProps< typeof Item > & { wrapperClassName?: string }
>;
```

```css
.mexp-bulk-optimization-row > .components-item { padding: 0; }
```

Two things are true about that today:

1. The prop **does** reach the wrapper and the styling works — it just isn't in the published types, which is why the cast exists.
2. It gets there by accident. `wrapperClassName` is the one key `useItem` returns that it does *not* destructure out of the incoming props, so a caller-supplied value falls into `otherProps`, which is spread *after* the internal value and overwrites it:

```ts
const wrapperClassName = styles[ 'item-wrapper' ];
return { as, className: classes, onClick, wrapperClassName, role, ...otherProps };
```

The wrapper therefore loses `styles[ 'item-wrapper' ]` entirely. In practice that costs only `width: 100%; display: block`, which is what a block-level `div` resolves to anyway, so nothing visibly breaks in the default layout — but the prop's effect depends on spread order rather than on intent, and it silently drops styles the component meant to apply.

To be explicit about what is **not** affected: `ItemGroup`'s separators and rounded corners are positional (`> *:not(marquee) > *`, `> *:first-of-type > *`), so they key off the wrapper element's position in the DOM, not its class. Replacing the class does not disturb them.

## How?

`useItem` destructures `wrapperClassName` out of the incoming props and merges it with the internal class through `clsx`, the way `className` is already handled for the item itself:

```ts
const wrapperClassName = clsx( styles[ 'item-wrapper' ], wrapperClassNameProp );
```

The prop is added to `ItemProps` and to the `Item` README, and the Storybook manifest snapshot is regenerated. As a side effect the prop also stops leaking onto the inner `View` as an unknown DOM prop.

`ItemGroup`/`Item` is marked `status: 'recommended'` in its Storybook metadata, so this is an addition to a supported component rather than to a deprecated one.

## Testing Instructions

1. `npx wp-scripts test-unit-js --config test/unit/jest.config.js packages/components/src/item-group` passes, including the new case. Existing snapshots are unchanged, since no `wrapperClassName` is passed in them.
2. Reverting `item/hook.ts` makes the new test fail, showing the class the prop currently replaces:

```
expect(element).toHaveClass("style-item-wrapper")
Expected the element to have class:
Received:
```

3. In Storybook, give an `Item` a `wrapperClassName` and inspect the wrapper element. Before this change it carries only the custom class; after it, both.

### Testing Instructions for Keyboard

N/A — the change adds a styling hook and does not alter focus order, roles or interaction.

## Use of AI Tools

This pull request was authored by Claude Code (Opus) under my direction and review. I reviewed the diff, confirmed the overwrite behaviour by running the new test against the unpatched hook, and ran the package's unit tests and the type check locally. The first version of this description overstated the consequences of that overwrite; I have corrected it above. I take responsibility for the change.