### PR TITLE
Components: ItemGroup: draw one separator per item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   `ItemGroup`: Draw one separator per item when `isSeparated` is set, instead of one per element inside each item ([#81862](https://github.com/WordPress/gutenberg/pull/81862)).
 -   `Modal`: Prevent an Escape key press that dismisses the modal from propagating to underlying overlays. ([#81785](https://github.com/WordPress/gutenberg/pull/81785))
 -   `BoxControl`: Update the opposite side when ALT is held on the left or right input, which each updated themselves instead ([#81530](https://github.com/WordPress/gutenberg/pull/81530)).
 -   `InputControl`: Vertically center the value of date and time inputs in Safari ([#81361](https://github.com/WordPress/gutenberg/pull/81361)).

--- a/packages/components/src/item-group/style.module.scss
+++ b/packages/components/src/item-group/style.module.scss
@@ -23,12 +23,20 @@ $padding-y-large: calc((calc(#{$control-height} * 1.2) - #{$base-font-height} - 
 		border: 1px solid $surface-border-color;
 	}
 
+	/*
+	 * The separator and the rounded corners are applied to the element inside
+	 * each item wrapper (the element that carries the padding and the
+	 * background). Only the first child is targeted, so that consumers
+	 * rendering more than one element per item (e.g. a toggle plus an action
+	 * button) get a single separator for the whole item instead of one per
+	 * element.
+	 */
 	&.is-separated {
-		> *:not(marquee) > * {
+		> *:not(marquee) > *:first-child {
 			border-block-end: 1px solid $surface-border-color;
 		}
 
-		> *:last-of-type > * {
+		> *:last-of-type > *:first-child {
 			border-block-end-color: transparent;
 		}
 	}
@@ -36,12 +44,12 @@ $padding-y-large: calc((calc(#{$control-height} * 1.2) - #{$base-font-height} - 
 	&.is-rounded {
 		border-radius: var(--wpds-border-radius-sm);
 
-		> *:first-of-type > * {
+		> *:first-of-type > *:first-child {
 			border-start-start-radius: var(--wpds-border-radius-sm);
 			border-start-end-radius: var(--wpds-border-radius-sm);
 		}
 
-		> *:last-of-type > * {
+		> *:last-of-type > *:first-child {
 			border-end-start-radius: var(--wpds-border-radius-sm);
 			border-end-end-radius: var(--wpds-border-radius-sm);
 		}

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -188,10 +188,7 @@
 	right: 8px;
 	top: 8px;
 	opacity: 0;
-
-	&.global-styles-ui__shadow-editor__remove-button {
-		border: none;
-	}
+	border: none;
 
 	.global-styles-ui__shadow-editor__dropdown-toggle:hover + &,
 	&:focus,


### PR DESCRIPTION
## What?
Closes #81861

Makes `ItemGroup`'s `isSeparated` render one separator per item, instead of one per element inside each item.

## Why?
`isSeparated` is documented as rendering "a separator between each item", but the CSS targeted every element inside an item wrapper. `ItemGroup` accepts any `children`, not only `Item`, so any consumer rendering more than one element per item got extra separators.

In the shadow presets editor this shows up as a stray border under the "Remove shadow" button when hovering any row except the last. That editor puts a `Dropdown` with a toggle and a remove button straight into the group, so both matched the selector. It became visible after #80797, where the group selector gained a class and started winning over the specificity workaround the shadow editor used to hide it.

## How?
Scopes the `is-separated` and `is-rounded` rules to the first element in each item wrapper. Groups built from `Item` are unaffected, since `Item` always renders a single child per wrapper.

Also drops the now redundant `border: none` specificity workaround in the shadow editor.

## Testing Instructions
1. Go to Site Editor > Styles > Shadows.
2. Add a shadow preset, then open it.
3. Add two or more shadows to that preset.
4. Hover each row and confirm no border appears under the "Remove shadow" button, and that the separators between rows are unchanged.

Worth also checking a few `Item` based separated groups for regressions, e.g. Styles > Colors > Edit palette with several custom colors, and Styles > Typography.

### Testing Instructions for Keyboard
1. With the shadow editor open, Tab through the shadow rows.
2. Confirm the focused row's remove button is revealed without a stray border, and separators still appear between rows.

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="496" height="246" alt="81861-before" src="https://github.com/user-attachments/assets/aa762dbb-247d-489e-bba9-b048af1c294f" /> | <img width="496" height="246" alt="81861-after" src="https://github.com/user-attachments/assets/ff57e6a3-6718-4c25-bb85-c5d0b6987bba" /> |

## Use of AI Tools

Used Claude Code to help investigate the cause, draft the CSS change, and verify it in the browser. The change and the testing above were reviewed by me before opening this PR.
