### PR TITLE
Login/out: Add a custom login URL setting

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -503,7 +503,7 @@ Show login & logout links.
 -	**Name:** [core/loginout](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-loginout/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Supports:** anchor, className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** displayLoginAsForm, redirectToCurrent
+-	**Attributes:** displayLoginAsForm, loginUrl, redirectToCurrent
 
 ## Math
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Login/out: Add a custom login URL setting, so the log in link can point at a custom login page instead of `wp-login.php`.
+
 ### Internal
 
 -   Heading: Declare the heading level and paragraph keyboard shortcuts on the block's variations and transforms, rather than in a `BlockKeyboardShortcuts` component that every editor had to render. The `BlockKeyboardShortcuts` private export has been removed ([#81588](https://github.com/WordPress/gutenberg/pull/81588)).

--- a/packages/block-library/src/loginout/README.md
+++ b/packages/block-library/src/loginout/README.md
@@ -17,6 +17,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 |-----------|------|---------|-------------|
 | `displayLoginAsForm` | `boolean` | `false` | — |
 | `redirectToCurrent` | `boolean` | `true` | — |
+| `loginUrl` | `string` | `""` | — |
 
 ## Supports
 

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -15,6 +15,10 @@
 		"redirectToCurrent": {
 			"type": "boolean",
 			"default": true
+		},
+		"loginUrl": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"example": {

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -1,5 +1,6 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
+	TextControl,
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -8,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function LoginOutEdit( { attributes, setAttributes } ) {
-	const { displayLoginAsForm, redirectToCurrent } = attributes;
+	const { displayLoginAsForm, redirectToCurrent, loginUrl } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -20,6 +21,7 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 						setAttributes( {
 							displayLoginAsForm: false,
 							redirectToCurrent: true,
+							loginUrl: '',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -60,6 +62,28 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 							}
 						/>
 					</ToolsPanelItem>
+					{ ! displayLoginAsForm && (
+						<ToolsPanelItem
+							label={ __( 'Custom login URL' ) }
+							hasValue={ () => !! loginUrl }
+							onDeselect={ () =>
+								setAttributes( { loginUrl: '' } )
+							}
+						>
+							<TextControl
+								label={ __( 'Custom login URL' ) }
+								type="url"
+								autoComplete="off"
+								value={ loginUrl }
+								onChange={ ( value ) =>
+									setAttributes( { loginUrl: value } )
+								}
+								help={ __(
+									'Send visitors to a custom login page instead of the default WordPress login page.'
+								) }
+							/>
+						</ToolsPanelItem>
+					) }
 				</ToolsPanel>
 			</InspectorControls>
 			<div

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -23,15 +23,22 @@ function render_block_core_loginout( $attributes ) {
 	 */
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
+	$login_url      = isset( $attributes['loginUrl'] ) && is_string( $attributes['loginUrl'] ) ? trim( $attributes['loginUrl'] ) : '';
 	$user_logged_in = is_user_logged_in();
+	$redirect       = isset( $attributes['redirectToCurrent'] ) && $attributes['redirectToCurrent'] ? $current_url : '';
 
-	$classes  = $user_logged_in ? 'logged-in' : 'logged-out';
-	$contents = wp_loginout(
-		isset( $attributes['redirectToCurrent'] ) && $attributes['redirectToCurrent'] ? $current_url : '',
-		false
-	);
+	$classes = $user_logged_in ? 'logged-in' : 'logged-out';
 
-	// If logged-out and displayLoginAsForm is true, show the login form.
+	if ( ! $user_logged_in && '' !== $login_url ) {
+		if ( '' !== $redirect ) {
+			$login_url = add_query_arg( 'redirect_to', rawurlencode( $redirect ), $login_url );
+		}
+
+		$contents = apply_filters( 'loginout', '<a href="' . esc_url( $login_url ) . '">' . __( 'Log in' ) . '</a>' );
+	} else {
+		$contents = wp_loginout( $redirect, false );
+	}
+
 	if ( ! $user_logged_in && ! empty( $attributes['displayLoginAsForm'] ) ) {
 		// Add a class.
 		$classes .= ' has-login-form';

--- a/phpunit/blocks/render-block-loginout-test.php
+++ b/phpunit/blocks/render-block-loginout-test.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for core/loginout Gutenberg block.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Class for testing the core/loginout Gutenberg block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Loginout extends WP_UnitTestCase {
+
+	/**
+	 * The `$_SERVER` superglobal as it was before the test ran.
+	 *
+	 * @var array
+	 */
+	private $original_server;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_server  = $_SERVER;
+		$_SERVER['HTTP_HOST']   = 'example.org';
+		$_SERVER['REQUEST_URI'] = '/members/';
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		$_SERVER = $this->original_server;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns the `href` of the first link in the given markup.
+	 *
+	 * @param string $html The rendered block.
+	 * @return string|null The link target, or null when there is no link.
+	 */
+	private function get_link_href( $html ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+
+		if ( ! $processor->next_tag( 'A' ) ) {
+			return null;
+		}
+
+		return $processor->get_attribute( 'href' );
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_custom_login_url_replaces_the_default_login_page() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => 'https://example.org/sign-in/',
+				'redirectToCurrent' => false,
+			)
+		);
+
+		$this->assertSame( 'https://example.org/sign-in/', $this->get_link_href( $html ) );
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_custom_login_url_keeps_the_redirect_to_current_url() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => 'https://example.org/sign-in/',
+				'redirectToCurrent' => true,
+			)
+		);
+
+		$this->assertSame(
+			'https://example.org/sign-in/?redirect_to=' . rawurlencode( 'http://example.org/members/' ),
+			$this->get_link_href( $html )
+		);
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_custom_login_url_is_appended_to_an_existing_query_string() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => 'https://example.org/account/?tab=login',
+				'redirectToCurrent' => true,
+			)
+		);
+
+		$this->assertSame(
+			'https://example.org/account/?tab=login&redirect_to=' . rawurlencode( 'http://example.org/members/' ),
+			$this->get_link_href( $html )
+		);
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_empty_custom_login_url_falls_back_to_the_default_login_page() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => '',
+				'redirectToCurrent' => false,
+			)
+		);
+
+		$this->assertSame( wp_login_url(), $this->get_link_href( $html ) );
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_non_string_custom_login_url_falls_back_to_the_default_login_page() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => array( 'https://example.org/sign-in/' ),
+				'redirectToCurrent' => false,
+			)
+		);
+
+		$this->assertSame( wp_login_url(), $this->get_link_href( $html ) );
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_unsafe_custom_login_url_is_not_rendered() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => 'javascript:alert(1)',
+				'redirectToCurrent' => false,
+			)
+		);
+
+		$this->assertSame( '', $this->get_link_href( $html ) );
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_custom_login_url_does_not_affect_the_logout_link() {
+		wp_set_current_user( self::factory()->user->create() );
+
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'          => 'https://example.org/sign-in/',
+				'redirectToCurrent' => false,
+			)
+		);
+
+		$this->assertStringContainsString( 'action=logout', $this->get_link_href( $html ) );
+	}
+
+	/**
+	 * @covers ::render_block_core_loginout
+	 */
+	public function test_custom_login_url_is_ignored_when_the_login_form_is_displayed() {
+		$html = gutenberg_render_block_core_loginout(
+			array(
+				'loginUrl'           => 'https://example.org/sign-in/',
+				'displayLoginAsForm' => true,
+				'redirectToCurrent'  => false,
+			)
+		);
+
+		$this->assertStringContainsString( 'id="loginform"', $html );
+		$this->assertStringNotContainsString( 'https://example.org/sign-in/', $html );
+	}
+}

--- a/test/integration/fixtures/blocks/core__loginout.json
+++ b/test/integration/fixtures/blocks/core__loginout.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"displayLoginAsForm": false,
-			"redirectToCurrent": true
+			"redirectToCurrent": true,
+			"loginUrl": ""
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Closes #58234

Adds a `loginUrl` attribute to the Login/out block, so the log in link can point at a custom login page instead of `wp-login.php`.

## Why?
The block currently hardcodes the default WordPress login page via `wp_loginout()`. Sites that use a membership plugin (or any plugin providing its own front-end login page) have no way to send visitors there from this block, and no way to keep the default login screen out of their navigation. Plugins used to fill this gap, but the issue reports they no longer work, so the option belongs in the block itself.

## Testing Instructions
1. Create a page to act as the custom login page (e.g. `/sign-in/`), or note the URL of one your login plugin provides.
2. In the editor, insert a **Login/out** block into a template or post.
3. Open the block's **Settings** panel in the inspector, click the options menu, and enable **Custom login URL**.
4. Enter the URL from step 1. Leave **Redirect to current URL** enabled.
5. Save, then view the page as a **logged-out** visitor (a private window is easiest).
6. Confirm the "Log in" link points at your custom URL with `?redirect_to=` set to the current page. Following it should land on your custom login page.
7. Turn **Redirect to current URL** off and reload, the link should be the bare custom URL, with no `redirect_to`.
8. Clear the **Custom login URL** field and reload, the link should return to the default `wp-login.php`.
9. Log back in and reload, the "Log out" link should be unchanged and still work.
10. With a custom URL set, enable **Display login as form**. The URL field is hidden, and a logged-out visitor sees the standard login form as before. Disabling the toggle brings the field back with its value intact.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/de606e66-c4c2-4fb7-adfe-3d72f50e6a6b

## Use of AI Tools
This pull request was authored with help of Claude.