### PR TITLE
Global Styles: Group shadow editor rows as items

### DIFF
--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   Expose typography and color controls for citations, inputs, and selects in Global Styles ([#80852](https://github.com/WordPress/gutenberg/pull/80852)).
 -   Mark blocks that have user styles in the block list, and add a filter to show only those blocks ([#81373](https://github.com/WordPress/gutenberg/pull/81373)).
 
+### Bug Fixes
+
+-   Shadow editor: Group each row as one item so separators do not cross row actions ([#81871](https://github.com/WordPress/gutenberg/pull/81871)).
+
 ### Internal
 
 -   Exclude the JavaScript tests and story from the build project so their declarations are not published. ([#81516](https://github.com/WordPress/gutenberg/pull/81516))

--- a/packages/global-styles-ui/src/shadows-edit-panel.tsx
+++ b/packages/global-styles-ui/src/shadows-edit-panel.tsx
@@ -222,15 +222,16 @@ function ShadowEditor( { shadow, onChange }: ShadowEditorProps ) {
 			<Spacer />
 			<ItemGroup isBordered isSeparated>
 				{ shadowParts.map( ( part, index ) => (
-					<ShadowItem
-						key={ index }
-						shadow={ part }
-						onChange={ ( value ) =>
-							onChangeShadowPart( index, value )
-						}
-						canRemove={ shadowParts.length > 1 }
-						onRemove={ () => onRemoveShadowPart( index ) }
-					/>
+					<div key={ index } role="listitem">
+						<ShadowItem
+							shadow={ part }
+							onChange={ ( value ) =>
+								onChangeShadowPart( index, value )
+							}
+							canRemove={ shadowParts.length > 1 }
+							onRemove={ () => onRemoveShadowPart( index ) }
+						/>
+					</div>
 				) ) }
 			</ItemGroup>
 		</>

--- a/packages/global-styles-ui/src/style.scss
+++ b/packages/global-styles-ui/src/style.scss
@@ -189,10 +189,6 @@
 	top: 8px;
 	opacity: 0;
 
-	&.global-styles-ui__shadow-editor__remove-button {
-		border: none;
-	}
-
 	.global-styles-ui__shadow-editor__dropdown-toggle:hover + &,
 	&:focus,
 	&:hover {

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -3,6 +3,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Global styles sidebar', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.resetThemeGlobalStyles();
 	} );
 
 	test.beforeEach( async ( { admin } ) => {
@@ -14,7 +15,45 @@ test.describe( 'Global styles sidebar', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.resetThemeGlobalStyles();
 		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'does not apply the item separator to the shadow-row action button', async ( {
+		page,
+	} ) => {
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+		await editorSettings.getByRole( 'button', { name: 'Shadows' } ).click();
+		await editorSettings
+			.getByRole( 'button', { name: 'Add shadow' } )
+			.click();
+		await editorSettings
+			.getByRole( 'button', { name: 'Shadow 1' } )
+			.click();
+		await editorSettings
+			.getByRole( 'button', { name: 'Add shadow' } )
+			.click();
+
+		const removeButtons = editorSettings.getByRole( 'button', {
+			name: 'Remove shadow',
+		} );
+		const shadowList = editorSettings.getByRole( 'list' ).filter( {
+			has: page.getByRole( 'button', { name: 'Remove shadow' } ),
+		} );
+
+		await expect( removeButtons ).toHaveCount( 2 );
+		await expect( shadowList.getByRole( 'listitem' ) ).toHaveCount( 2 );
+		await expect( removeButtons.first() ).toHaveCSS(
+			'border-bottom-color',
+			'rgba(0, 0, 0, 0)'
+		);
 	} );
 
 	test( 'should filter blocks list results', async ( { page } ) => {

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -3,7 +3,6 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Global styles sidebar', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
-		await requestUtils.resetThemeGlobalStyles();
 	} );
 
 	test.beforeEach( async ( { admin } ) => {
@@ -15,45 +14,7 @@ test.describe( 'Global styles sidebar', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.resetThemeGlobalStyles();
 		await requestUtils.activateTheme( 'twentytwentyone' );
-	} );
-
-	test( 'does not apply the item separator to the shadow-row action button', async ( {
-		page,
-	} ) => {
-		const editorSettings = page.getByRole( 'region', {
-			name: 'Editor settings',
-		} );
-
-		await page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Styles' } )
-			.click();
-		await editorSettings.getByRole( 'button', { name: 'Shadows' } ).click();
-		await editorSettings
-			.getByRole( 'button', { name: 'Add shadow' } )
-			.click();
-		await editorSettings
-			.getByRole( 'button', { name: 'Shadow 1' } )
-			.click();
-		await editorSettings
-			.getByRole( 'button', { name: 'Add shadow' } )
-			.click();
-
-		const removeButtons = editorSettings.getByRole( 'button', {
-			name: 'Remove shadow',
-		} );
-		const shadowList = editorSettings.getByRole( 'list' ).filter( {
-			has: page.getByRole( 'button', { name: 'Remove shadow' } ),
-		} );
-
-		await expect( removeButtons ).toHaveCount( 2 );
-		await expect( shadowList.getByRole( 'listitem' ) ).toHaveCount( 2 );
-		await expect( removeButtons.first() ).toHaveCSS(
-			'border-bottom-color',
-			'rgba(0, 0, 0, 0)'
-		);
 	} );
 
 	test( 'should filter blocks list results', async ( { page } ) => {


### PR DESCRIPTION
## What?

Closes #81861.

Fixes the shadow editor so each shadow row gets one separator.

## Why?

`ItemGroup` styles expect the DOM shape produced by `Item`: a list-item wrapper around one inner surface. `ShadowItem` rendered a `Dropdown` directly, so the separator also targeted its remove button.

## How?

Wrap each `ShadowItem` in a `role="listitem"` element, leaving the dropdown as the inner surface. This fixes the consumer without changing the generic `ItemGroup` selector.

## Testing Instructions

1. Open Site Editor > Styles > Shadows.
2. Add and open a custom shadow, then add a second shadow row.
3. Hover a row and confirm there is one separator between rows and none across the remove button.

### Testing Instructions for Keyboard

Repeat the steps with Tab and Enter. Confirm each remove button receives focus and removes only its row.

### Screenshots

<img width="686" height="360" alt="Screenshot 2026-08-20 at 14 37 50" src="https://github.com/user-attachments/assets/83de4a66-72ee-4ad7-ae1b-28fb90fc8f08" />

## Use of AI Tools

Codex was used to analyze the issue, implement the change, and run verification.
