### PR TITLE
Extensible Site Editor: Add a theme preview admin page

### DIFF
--- a/lib/experimental/extensible-site-editor.php
+++ b/lib/experimental/extensible-site-editor.php
@@ -2,21 +2,18 @@
 /**
  * Extensible Site Editor experiment integration.
  *
+ * Only loaded while the `gutenberg-extensible-site-editor` experiment is
+ * enabled (see lib/load.php).
+ *
  * @package gutenberg
  */
 
 /**
- * Redirect the Appearance > Design menu to the extensible site editor
- * when the experiment is enabled.
+ * Redirect the Appearance > Design menu to the extensible site editor.
  *
  * @global array $submenu WordPress admin submenu array.
  */
 function gutenberg_redirect_to_extensible_site_editor() {
-	// Only proceed if the experiment is enabled.
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
-		return;
-	}
-
 	// Update the Design submenu item to point to the extensible site editor.
 	global $submenu;
 	if ( $submenu && isset( $submenu['themes.php'] ) ) {
@@ -30,117 +27,3 @@ function gutenberg_redirect_to_extensible_site_editor() {
 	}
 }
 add_action( 'admin_menu', 'gutenberg_redirect_to_extensible_site_editor', 100 );
-
-/**
- * Registers the hidden wp-admin page that previews a block theme.
- *
- * The page renders the homepage of the theme named by the `wp_theme_preview`
- * query parameter. Core's `wp-includes/theme-previews.php` reads that same
- * parameter on every request: it filters `stylesheet`/`template`, attaches an
- * apiFetch middleware that forwards the parameter on every REST request, and
- * prints the activation nonce on `admin_head` — so the page needs no further
- * wiring beyond carrying the parameter in its URL.
- */
-function gutenberg_register_theme_preview_admin_page() {
-	// Only register the page when the extensible site editor experiment is enabled.
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
-		return;
-	}
-
-	// The render callback is generated into `build/pages` by the build; a
-	// build that predates the page cannot register it.
-	if ( ! function_exists( 'gutenberg_theme_preview_wp_admin_render_page' ) ) {
-		return;
-	}
-
-	// Register with an empty parent to create a hidden admin.php?page= route
-	// without adding an Appearance submenu item for a screen that requires a
-	// `wp_theme_preview` parameter.
-	$hook_suffix = add_submenu_page(
-		'',
-		__( 'Theme Preview', 'gutenberg' ),
-		__( 'Theme Preview', 'gutenberg' ),
-		'switch_themes',
-		'theme-preview-wp-admin',
-		'gutenberg_theme_preview_wp_admin_render_page'
-	);
-
-	if ( $hook_suffix ) {
-		add_action( "load-$hook_suffix", 'gutenberg_theme_preview_wp_admin_prepare_screen' );
-	}
-}
-add_action( 'admin_menu', 'gutenberg_register_theme_preview_admin_page' );
-
-/**
- * Prepares the admin chrome before wp-admin/admin-header.php renders.
- *
- * @global string $title        The admin page title.
- * @global string $parent_file  The current top-level menu item.
- * @global string $submenu_file The current submenu item.
- */
-function gutenberg_theme_preview_wp_admin_prepare_screen() {
-	global $title, $parent_file, $submenu_file;
-
-	// Hidden pages do not resolve a title from a visible menu item, so set one
-	// before admin-header.php formats the page title.
-	$title = __( 'Theme Preview', 'gutenberg' );
-
-	/*
-	 * Take the page out of the hidden `''` submenu bucket it was registered in.
-	 * Left in place, get_admin_page_parent() matches it there and resets
-	 * $parent_file to '' — and it does so *after* the `parent_file` filter runs,
-	 * so filtering cannot win. With no match it preserves a non-empty
-	 * $parent_file instead.
-	 *
-	 * Safe at this point: `load-` fires after the capability check in admin.php,
-	 * which needs the page registered, and before the menu is rendered.
-	 */
-	remove_submenu_page( '', 'theme-preview-wp-admin' );
-
-	// The preview is reached from the themes screen; keep Appearance current.
-	$parent_file  = 'themes.php';
-	$submenu_file = 'themes.php';
-}
-
-/**
- * Redirects block theme previews from the site editor to the theme preview page.
- *
- * The themes screen links block theme live previews to
- * `site-editor.php?wp_theme_preview=<stylesheet>`. When the extensible site
- * editor experiment is enabled, that preview belongs to the theme preview
- * page instead of site editor v1. Without the experiment, or for users the
- * preview filters ignore, site-editor.php behaves as before.
- */
-function gutenberg_redirect_theme_preview_to_theme_preview_page() {
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
-		return;
-	}
-
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading the same unauthenticated query arg Core's theme-previews.php reads to decide whether a preview is requested.
-	$stylesheet = isset( $_GET['wp_theme_preview'] ) && is_scalar( $_GET['wp_theme_preview'] ) ? sanitize_text_field( wp_unslash( $_GET['wp_theme_preview'] ) ) : '';
-	if ( '' === $stylesheet ) {
-		return;
-	}
-
-	// Core only applies the preview filters for users with `switch_themes`;
-	// for anyone else the site editor keeps showing the active theme, so
-	// leave them there.
-	if ( ! current_user_can( 'switch_themes' ) ) {
-		return;
-	}
-
-	// Without the generated page there is nowhere to redirect to.
-	if ( ! function_exists( 'gutenberg_theme_preview_wp_admin_render_page' ) ) {
-		return;
-	}
-
-	wp_safe_redirect(
-		add_query_arg(
-			'wp_theme_preview',
-			rawurlencode( $stylesheet ),
-			admin_url( 'admin.php?page=theme-preview-wp-admin' )
-		)
-	);
-	exit;
-}
-add_action( 'load-site-editor.php', 'gutenberg_redirect_theme_preview_to_theme_preview_page' );

--- a/lib/experimental/extensible-site-editor.php
+++ b/lib/experimental/extensible-site-editor.php
@@ -30,3 +30,117 @@ function gutenberg_redirect_to_extensible_site_editor() {
 	}
 }
 add_action( 'admin_menu', 'gutenberg_redirect_to_extensible_site_editor', 100 );
+
+/**
+ * Registers the hidden wp-admin page that previews a block theme.
+ *
+ * The page renders the homepage of the theme named by the `wp_theme_preview`
+ * query parameter. Core's `wp-includes/theme-previews.php` reads that same
+ * parameter on every request: it filters `stylesheet`/`template`, attaches an
+ * apiFetch middleware that forwards the parameter on every REST request, and
+ * prints the activation nonce on `admin_head` — so the page needs no further
+ * wiring beyond carrying the parameter in its URL.
+ */
+function gutenberg_register_theme_preview_admin_page() {
+	// Only register the page when the extensible site editor experiment is enabled.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
+		return;
+	}
+
+	// The render callback is generated into `build/pages` by the build; a
+	// build that predates the page cannot register it.
+	if ( ! function_exists( 'gutenberg_theme_preview_wp_admin_render_page' ) ) {
+		return;
+	}
+
+	// Register with an empty parent to create a hidden admin.php?page= route
+	// without adding an Appearance submenu item for a screen that requires a
+	// `wp_theme_preview` parameter.
+	$hook_suffix = add_submenu_page(
+		'',
+		__( 'Theme Preview', 'gutenberg' ),
+		__( 'Theme Preview', 'gutenberg' ),
+		'switch_themes',
+		'theme-preview-wp-admin',
+		'gutenberg_theme_preview_wp_admin_render_page'
+	);
+
+	if ( $hook_suffix ) {
+		add_action( "load-$hook_suffix", 'gutenberg_theme_preview_wp_admin_prepare_screen' );
+	}
+}
+add_action( 'admin_menu', 'gutenberg_register_theme_preview_admin_page' );
+
+/**
+ * Prepares the admin chrome before wp-admin/admin-header.php renders.
+ *
+ * @global string $title        The admin page title.
+ * @global string $parent_file  The current top-level menu item.
+ * @global string $submenu_file The current submenu item.
+ */
+function gutenberg_theme_preview_wp_admin_prepare_screen() {
+	global $title, $parent_file, $submenu_file;
+
+	// Hidden pages do not resolve a title from a visible menu item, so set one
+	// before admin-header.php formats the page title.
+	$title = __( 'Theme Preview', 'gutenberg' );
+
+	/*
+	 * Take the page out of the hidden `''` submenu bucket it was registered in.
+	 * Left in place, get_admin_page_parent() matches it there and resets
+	 * $parent_file to '' — and it does so *after* the `parent_file` filter runs,
+	 * so filtering cannot win. With no match it preserves a non-empty
+	 * $parent_file instead.
+	 *
+	 * Safe at this point: `load-` fires after the capability check in admin.php,
+	 * which needs the page registered, and before the menu is rendered.
+	 */
+	remove_submenu_page( '', 'theme-preview-wp-admin' );
+
+	// The preview is reached from the themes screen; keep Appearance current.
+	$parent_file  = 'themes.php';
+	$submenu_file = 'themes.php';
+}
+
+/**
+ * Redirects block theme previews from the site editor to the theme preview page.
+ *
+ * The themes screen links block theme live previews to
+ * `site-editor.php?wp_theme_preview=<stylesheet>`. When the extensible site
+ * editor experiment is enabled, that preview belongs to the theme preview
+ * page instead of site editor v1. Without the experiment, or for users the
+ * preview filters ignore, site-editor.php behaves as before.
+ */
+function gutenberg_redirect_theme_preview_to_theme_preview_page() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
+		return;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading the same unauthenticated query arg Core's theme-previews.php reads to decide whether a preview is requested.
+	$stylesheet = isset( $_GET['wp_theme_preview'] ) && is_scalar( $_GET['wp_theme_preview'] ) ? sanitize_text_field( wp_unslash( $_GET['wp_theme_preview'] ) ) : '';
+	if ( '' === $stylesheet ) {
+		return;
+	}
+
+	// Core only applies the preview filters for users with `switch_themes`;
+	// for anyone else the site editor keeps showing the active theme, so
+	// leave them there.
+	if ( ! current_user_can( 'switch_themes' ) ) {
+		return;
+	}
+
+	// Without the generated page there is nowhere to redirect to.
+	if ( ! function_exists( 'gutenberg_theme_preview_wp_admin_render_page' ) ) {
+		return;
+	}
+
+	wp_safe_redirect(
+		add_query_arg(
+			'wp_theme_preview',
+			rawurlencode( $stylesheet ),
+			admin_url( 'admin.php?page=theme-preview-wp-admin' )
+		)
+	);
+	exit;
+}
+add_action( 'load-site-editor.php', 'gutenberg_redirect_theme_preview_to_theme_preview_page' );

--- a/lib/experimental/theme-preview/load.php
+++ b/lib/experimental/theme-preview/load.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Bootstraps the block theme preview page in wp-admin.
+ *
+ * Part of the extensible site editor experiment: only loaded while the
+ * `gutenberg-extensible-site-editor` experiment is enabled (see lib/load.php).
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Builds the theme preview page URL for a theme.
+ *
+ * The page renders the site's frontend with the theme named by the
+ * `wp_theme_preview` query parameter. Core's `wp-includes/theme-previews.php`
+ * reads that parameter on every request: it filters `stylesheet`/`template`
+ * (for users with `switch_themes`), attaches an apiFetch middleware that
+ * forwards the parameter on every REST request, and prints the activation
+ * nonce on `admin_head` — so the page needs no further wiring beyond carrying
+ * the parameter in its URL.
+ *
+ * @param string $stylesheet Stylesheet (directory name) of the theme to preview.
+ * @return string Theme preview page URL, not escaped for output.
+ */
+function gutenberg_get_theme_preview_url( $stylesheet ) {
+	static $base = null;
+	if ( null === $base ) {
+		$base = admin_url( 'admin.php?page=theme-preview-wp-admin' );
+	}
+
+	return add_query_arg(
+		'wp_theme_preview',
+		// `add_query_arg` does not encode new values, so encode subdirectory
+		// theme stylesheets like `parent/child` here.
+		rawurlencode( $stylesheet ),
+		$base
+	);
+}
+
+/**
+ * Registers the hidden wp-admin page that previews a block theme.
+ */
+function gutenberg_register_theme_preview_admin_page() {
+	// Register with an empty parent to create a hidden admin.php?page= route
+	// without adding an Appearance submenu item for a screen that requires a
+	// `wp_theme_preview` parameter.
+	$hook_suffix = add_submenu_page(
+		'',
+		__( 'Theme Preview', 'gutenberg' ),
+		__( 'Theme Preview', 'gutenberg' ),
+		'switch_themes',
+		'theme-preview-wp-admin',
+		'gutenberg_theme_preview_wp_admin_render_page'
+	);
+
+	if ( $hook_suffix ) {
+		add_action( "load-$hook_suffix", 'gutenberg_theme_preview_wp_admin_prepare_screen' );
+	}
+}
+
+/**
+ * Prepares the admin chrome before wp-admin/admin-header.php renders.
+ *
+ * @global string $title        The admin page title.
+ * @global string $parent_file  The current top-level menu item.
+ * @global string $submenu_file The current submenu item.
+ */
+function gutenberg_theme_preview_wp_admin_prepare_screen() {
+	global $title, $parent_file, $submenu_file;
+
+	// Hidden pages do not resolve a title from a visible menu item, so set one
+	// before admin-header.php formats the page title.
+	$title = __( 'Theme Preview', 'gutenberg' );
+
+	/*
+	 * Take the page out of the hidden `''` submenu bucket it was registered in.
+	 * Left in place, get_admin_page_parent() matches it there and resets
+	 * $parent_file to '' — and it does so *after* the `parent_file` filter runs,
+	 * so filtering cannot win. With no match it preserves a non-empty
+	 * $parent_file instead.
+	 *
+	 * Safe at this point: `load-` fires after the capability check in admin.php,
+	 * which needs the page registered, and before the menu is rendered.
+	 */
+	remove_submenu_page( '', 'theme-preview-wp-admin' );
+
+	// The preview is reached from the themes screen; keep Appearance current.
+	$parent_file  = 'themes.php';
+	$submenu_file = 'themes.php';
+}
+
+/**
+ * Points the themes screen's block theme live preview links at the theme
+ * preview page.
+ *
+ * Core builds those links as `site-editor.php?wp_theme_preview=<stylesheet>`;
+ * rewriting them here saves the round trip through site-editor.php that the
+ * redirect below would otherwise take. The active theme's entry is left
+ * alone: it carries no `wp_theme_preview` parameter and links to the site
+ * editor as a customize action.
+ *
+ * @param array $prepared_themes Themes prepared for the themes screen.
+ * @return array Themes with rewritten live preview links.
+ */
+function gutenberg_use_theme_preview_page_for_live_preview_links( $prepared_themes ) {
+	if ( ! current_user_can( 'switch_themes' ) ) {
+		return $prepared_themes;
+	}
+
+	$current_stylesheet = get_stylesheet();
+	foreach ( $prepared_themes as $stylesheet => $theme_data ) {
+		if (
+			$stylesheet === $current_stylesheet
+			|| empty( $theme_data['blockTheme'] )
+			|| empty( $theme_data['actions']['customize'] )
+		) {
+			continue;
+		}
+		$prepared_themes[ $stylesheet ]['actions']['customize'] = esc_url( gutenberg_get_theme_preview_url( $stylesheet ) );
+	}
+
+	return $prepared_themes;
+}
+
+/**
+ * Redirects block theme previews from the site editor to the theme preview page.
+ *
+ * The links the filter above rewrites no longer reach site-editor.php; this
+ * catches the remaining entry points — bookmarks, hand-typed URLs, and the
+ * live preview link the theme installer renders after installing a theme.
+ * For users the preview filters ignore, site-editor.php behaves as before.
+ */
+function gutenberg_redirect_theme_preview_to_theme_preview_page() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading the same unauthenticated query arg Core's theme-previews.php reads to decide whether a preview is requested.
+	$stylesheet = isset( $_GET['wp_theme_preview'] ) ? sanitize_text_field( wp_unslash( $_GET['wp_theme_preview'] ) ) : '';
+	if ( '' === $stylesheet ) {
+		return;
+	}
+
+	// Core only applies the preview filters for users with `switch_themes`;
+	// for anyone else the site editor keeps showing the active theme, so
+	// leave them there.
+	if ( ! current_user_can( 'switch_themes' ) ) {
+		return;
+	}
+
+	wp_safe_redirect( gutenberg_get_theme_preview_url( $stylesheet ) );
+	exit;
+}
+
+// The render callback is generated into `build/pages`, which lib/load.php
+// requires before this file: a build that predates the page has nothing to
+// register, link, or redirect to.
+if ( function_exists( 'gutenberg_theme_preview_wp_admin_render_page' ) ) {
+	add_action( 'admin_menu', 'gutenberg_register_theme_preview_admin_page' );
+	add_filter( 'wp_prepare_themes_for_js', 'gutenberg_use_theme_preview_page_for_live_preview_links' );
+	add_action( 'load-site-editor.php', 'gutenberg_redirect_theme_preview_to_theme_preview_page' );
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -137,8 +137,12 @@ require __DIR__ . '/experimental/navigation-theme-opt-in.php';
 require __DIR__ . '/experimental/kses.php';
 require __DIR__ . '/experimental/script-modules.php';
 require __DIR__ . '/experimental/pages/site-editor.php';
-require __DIR__ . '/experimental/extensible-site-editor.php';
 require __DIR__ . '/experimental/collaboration/meta-box-rtc-compat.php';
+
+if ( gutenberg_is_experiment_enabled( 'gutenberg-extensible-site-editor' ) ) {
+	require __DIR__ . '/experimental/extensible-site-editor.php';
+	require __DIR__ . '/experimental/theme-preview/load.php';
+}
 
 if ( gutenberg_is_experiment_enabled( 'gutenberg-dataform-inspector' ) ) {
 	require __DIR__ . '/experimental/dataform-inspector-preload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -18010,6 +18010,10 @@
 			"resolved": "packages/theme",
 			"link": true
 		},
+		"node_modules/@wordpress/theme-preview-route": {
+			"resolved": "routes/theme-preview",
+			"link": true
+		},
 		"node_modules/@wordpress/token-list": {
 			"resolved": "packages/token-list",
 			"link": true
@@ -55939,6 +55943,23 @@
 				"@wordpress/views": "file:../../packages/views",
 				"clsx": "^2.1.1",
 				"dequal": "^2.0.3"
+			}
+		},
+		"routes/theme-preview": {
+			"name": "@wordpress/theme-preview-route",
+			"version": "1.0.0",
+			"dependencies": {
+				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/components": "file:../../packages/components",
+				"@wordpress/core-data": "file:../../packages/core-data",
+				"@wordpress/data": "file:../../packages/data",
+				"@wordpress/element": "file:../../packages/element",
+				"@wordpress/html-entities": "file:../../packages/html-entities",
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/notices": "file:../../packages/notices",
+				"@wordpress/route": "file:../../packages/route",
+				"@wordpress/url": "file:../../packages/url"
 			}
 		},
 		"storybook": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55949,6 +55949,7 @@
 			"name": "@wordpress/theme-preview-route",
 			"version": "1.0.0",
 			"dependencies": {
+				"@wordpress/a11y": "file:../../packages/a11y",
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
 				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/core-data": "file:../../packages/core-data",
@@ -55956,8 +55957,6 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/url": "file:../../packages/url"
 			}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
 					"@wordpress/edit-site-init"
 				],
 				"experimental": true
+			},
+			{
+				"id": "theme-preview",
+				"experimental": true
 			}
 		]
 	},

--- a/routes/theme-preview/package.json
+++ b/routes/theme-preview/package.json
@@ -9,6 +9,7 @@
 		]
 	},
 	"dependencies": {
+		"@wordpress/a11y": "file:../../packages/a11y",
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
 		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/core-data": "file:../../packages/core-data",
@@ -16,8 +17,6 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/i18n": "file:../../packages/i18n",
-		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/route": "file:../../packages/route",
 		"@wordpress/url": "file:../../packages/url"
 	}

--- a/routes/theme-preview/package.json
+++ b/routes/theme-preview/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@wordpress/theme-preview-route",
+	"version": "1.0.0",
+	"private": true,
+	"route": {
+		"path": "/",
+		"page": [
+			"theme-preview"
+		]
+	},
+	"dependencies": {
+		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/components": "file:../../packages/components",
+		"@wordpress/core-data": "file:../../packages/core-data",
+		"@wordpress/data": "file:../../packages/data",
+		"@wordpress/element": "file:../../packages/element",
+		"@wordpress/html-entities": "file:../../packages/html-entities",
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+		"@wordpress/notices": "file:../../packages/notices",
+		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/url": "file:../../packages/url"
+	}
+}

--- a/routes/theme-preview/preview-navigation.ts
+++ b/routes/theme-preview/preview-navigation.ts
@@ -1,0 +1,116 @@
+import { speak } from '@wordpress/a11y';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Keeps navigation inside the previewed theme.
+ *
+ * Core renders frontend links and forms without the preview parameters, so a
+ * plain click would silently land on the active theme. This mirrors the
+ * Customizer's preview interception (`wp-includes/js/customize-preview.js`),
+ * adapted to a same-origin iframe that navigates itself instead of messaging
+ * a controlling pane:
+ *
+ * - Previewable links get the preview parameters injected into their query
+ *   string — on load, and via a MutationObserver for links added later.
+ * - Unpreviewable links (other sites, wp-admin, wp-login) get a `not-allowed`
+ *   cursor and are blocked on click, with an announcement — spoken from the
+ *   admin document, the only one `speak` can reach.
+ * - GET form submissions to previewable URLs carry the parameters via hidden
+ *   inputs; anything else (like POST comment forms) is blocked.
+ */
+
+const LINK_SELECTOR = 'a[href], area[href]';
+const DEFAULT_PORTS = /:(80|443)$/;
+
+type LinkLocation = Pick< HTMLAnchorElement, 'protocol' | 'host' | 'pathname' >;
+type PreviewLink = HTMLAnchorElement | HTMLAreaElement;
+
+export function setupPreviewNavigation(
+	doc: Document,
+	homeUrl: string,
+	previewArgs: Record< string, string >
+) {
+	/*
+	 * The previewed site's boundary, anchored to the server-authored home
+	 * URL, matched like the Customizer's `isLinkPreviewable`: protocol, host,
+	 * and path prefix, excluding login/signup and wp-admin/includes/content.
+	 */
+	const allowed = new URL( homeUrl );
+	const allowedHost = allowed.host.replace( DEFAULT_PORTS, '' );
+	const allowedPath = allowed.pathname.replace( /\/$/, '' );
+	const isPreviewable = ( location: LinkLocation ) =>
+		location.protocol === allowed.protocol &&
+		location.host.replace( DEFAULT_PORTS, '' ) === allowedHost &&
+		location.pathname.startsWith( allowedPath ) &&
+		! /\/wp-(login|signup)\.php$/.test( location.pathname ) &&
+		! /\/wp-(admin|includes|content)(\/|$)/.test( location.pathname );
+
+	// Rewrites a link for previewing; false means the link must not be
+	// followed from the preview.
+	const prepareLink = ( link: PreviewLink ) => {
+		const href = link.getAttribute( 'href' );
+		// Leave jump links and non-web protocols (mailto:, javascript:) alone.
+		if (
+			! href ||
+			href.startsWith( '#' ) ||
+			! /^https?:$/.test( link.protocol )
+		) {
+			return true;
+		}
+		if ( ! isPreviewable( link ) ) {
+			link.style.cursor = 'not-allowed';
+			return false;
+		}
+		link.style.cursor = '';
+		link.href = addQueryArgs( link.href, previewArgs );
+		return true;
+	};
+
+	const prepareLinksIn = ( node: ParentNode ) =>
+		node
+			.querySelectorAll< PreviewLink >( LINK_SELECTOR )
+			.forEach( ( link ) => prepareLink( link ) );
+
+	prepareLinksIn( doc );
+	new MutationObserver( ( mutations ) => {
+		new Set( mutations.map( ( mutation ) => mutation.target ) ).forEach(
+			( target ) => prepareLinksIn( target as ParentNode )
+		);
+	} ).observe( doc.documentElement, { childList: true, subtree: true } );
+
+	doc.addEventListener( 'click', ( event ) => {
+		const link = ( event.target as Element | null )?.closest?.(
+			LINK_SELECTOR
+		) as PreviewLink | null;
+		if ( link && ! prepareLink( link ) ) {
+			speak( __( 'This link is not live-previewable.' ) );
+			event.preventDefault();
+		}
+	} );
+
+	doc.addEventListener( 'submit', ( event ) => {
+		const form = event.target as HTMLFormElement;
+		// An anchor rather than `new URL()`: it resolves relative actions
+		// against the document and never throws on malformed ones.
+		const action = doc.createElement( 'a' );
+		action.href = form.getAttribute( 'action' ) ?? '';
+		if (
+			'GET' !== form.method.toUpperCase() ||
+			! isPreviewable( action )
+		) {
+			speak( __( 'Form submission not previewable.' ) );
+			event.preventDefault();
+			return;
+		}
+		Object.entries( previewArgs ).forEach( ( [ name, value ] ) => {
+			if ( ! form.elements.namedItem( name ) ) {
+				const input = doc.createElement( 'input' );
+				input.type = 'hidden';
+				input.name = name;
+				input.value = value;
+				form.appendChild( input );
+			}
+		} );
+	} );
+}

--- a/routes/theme-preview/previewed-theme.ts
+++ b/routes/theme-preview/previewed-theme.ts
@@ -1,0 +1,47 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { getQueryArg } from '@wordpress/url';
+
+/*
+ * The previewed theme's stylesheet, from the `wp_theme_preview` query
+ * parameter ('' when absent), read once per page load.
+ *
+ * Deliberately read from `window.location` rather than the router: the
+ * router parses only the client path inside the `p` parameter, while Core
+ * reads `$_GET['wp_theme_preview']` from the real request URL — so the
+ * parameter must live outside `p`. The router preserves it across client
+ * navigations, so it cannot change without a full page load.
+ */
+const previewedStylesheet = ( () => {
+	const value = getQueryArg( window.location.href, 'wp_theme_preview' );
+	return typeof value === 'string' ? value : '';
+} )();
+
+export function getPreviewedStylesheet() {
+	return previewedStylesheet;
+}
+
+/**
+ * Query arguments that make a frontend request render the previewed theme.
+ *
+ * @param stylesheet The previewed theme's stylesheet.
+ */
+export const getPreviewQueryArgs = ( stylesheet: string ) => ( {
+	wp_theme_preview: stylesheet,
+	// Parameter for hiding the admin bar.
+	wp_site_preview: '1',
+} );
+
+/**
+ * Formats the screen title for a previewed theme.
+ *
+ * @param themeName The previewed theme's decoded name, when known.
+ */
+export function getPreviewTitle( themeName?: string ) {
+	return themeName
+		? sprintf(
+				/* translators: %s: Theme name. */
+				__( 'Previewing %s' ),
+				themeName
+		  )
+		: __( 'Theme Preview' );
+}

--- a/routes/theme-preview/route.ts
+++ b/routes/theme-preview/route.ts
@@ -1,23 +1,30 @@
-import { __ } from '@wordpress/i18n';
+import { store as coreStore } from '@wordpress/core-data';
+import { resolveSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 import { notFound } from '@wordpress/route';
-import { getQueryArg } from '@wordpress/url';
+import { getPreviewedStylesheet, getPreviewTitle } from './previewed-theme';
 
 /**
  * Route configuration for the block theme preview screen.
  *
  * The screen previews the theme named by the `wp_theme_preview` query
- * parameter. WordPress Core reads that same parameter on every request to
- * resolve the previewed theme (see `wp-includes/theme-previews.php`): it
- * filters `stylesheet`/`template` and registers an apiFetch middleware that
- * forwards the parameter on every REST request, so all entities on this
- * screen resolve against the previewed theme.
+ * parameter, which Core resolves on every request — REST requests included —
+ * so entities like the current theme resolve against the previewed theme.
+ * See `gutenberg_get_theme_preview_url()` for the full account.
  */
 export const route = {
 	beforeLoad: () => {
 		// Without the parameter there is no theme to preview.
-		if ( ! getQueryArg( window.location.href, 'wp_theme_preview' ) ) {
+		if ( ! getPreviewedStylesheet() ) {
 			throw notFound();
 		}
 	},
-	title: () => __( 'Theme Preview' ),
+	title: async () => {
+		const theme = await resolveSelect( coreStore ).getCurrentTheme();
+		return getPreviewTitle(
+			theme?.name?.rendered
+				? decodeEntities( theme.name.rendered )
+				: undefined
+		);
+	},
 };

--- a/routes/theme-preview/route.ts
+++ b/routes/theme-preview/route.ts
@@ -1,0 +1,23 @@
+import { __ } from '@wordpress/i18n';
+import { notFound } from '@wordpress/route';
+import { getQueryArg } from '@wordpress/url';
+
+/**
+ * Route configuration for the block theme preview screen.
+ *
+ * The screen previews the theme named by the `wp_theme_preview` query
+ * parameter. WordPress Core reads that same parameter on every request to
+ * resolve the previewed theme (see `wp-includes/theme-previews.php`): it
+ * filters `stylesheet`/`template` and registers an apiFetch middleware that
+ * forwards the parameter on every REST request, so all entities on this
+ * screen resolve against the previewed theme.
+ */
+export const route = {
+	beforeLoad: () => {
+		// Without the parameter there is no theme to preview.
+		if ( ! getQueryArg( window.location.href, 'wp_theme_preview' ) ) {
+			throw notFound();
+		}
+	},
+	title: () => __( 'Theme Preview' ),
+};

--- a/routes/theme-preview/stage.tsx
+++ b/routes/theme-preview/stage.tsx
@@ -128,13 +128,11 @@ function ThemePreviewStage() {
 		);
 	} else {
 		content = (
-			<div className={ styles.frame }>
-				<Preview
-					content={ template.content?.raw }
-					blocks={ template.blocks }
-					description={ previewDescription }
-				/>
-			</div>
+			<Preview
+				content={ template.content?.raw }
+				blocks={ template.blocks }
+				description={ previewDescription }
+			/>
 		);
 	}
 

--- a/routes/theme-preview/stage.tsx
+++ b/routes/theme-preview/stage.tsx
@@ -1,0 +1,177 @@
+import { Page } from '@wordpress/admin-ui';
+import { Button, Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import type { WpTemplate } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import { Preview } from '@wordpress/lazy-editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import styles from './style.module.scss';
+
+declare global {
+	interface Window {
+		/**
+		 * Nonce for activating the previewed theme, printed on `admin_head`
+		 * by Core's `wp_block_theme_activate_nonce()` whenever the request
+		 * carries a `wp_theme_preview` parameter.
+		 */
+		WP_BLOCK_THEME_ACTIVATE_NONCE?: string;
+	}
+}
+
+const FRONT_PAGE_TEMPLATE_QUERY = { slug: 'front-page' };
+
+function ThemePreviewStage() {
+	const previewParam = getQueryArg(
+		window.location.href,
+		'wp_theme_preview'
+	);
+	const previewedStylesheet =
+		typeof previewParam === 'string' ? previewParam : '';
+	const [ isActivating, setIsActivating ] = useState( false );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const { themeName, templateId, template } = useSelect( ( select ) => {
+		const { getCurrentTheme, getDefaultTemplateId, getEntityRecord } =
+			select( coreStore );
+		// Every REST request on this screen carries the `wp_theme_preview`
+		// parameter, so the "current" theme is the previewed one, and the
+		// front page template resolves through the previewed theme's own
+		// template hierarchy (front-page → home → index).
+		const currentTheme = getCurrentTheme() as
+			| { name?: { rendered?: string } }
+			| null
+			| undefined;
+		const _templateId = getDefaultTemplateId(
+			FRONT_PAGE_TEMPLATE_QUERY
+		) as string | undefined;
+		return {
+			themeName: currentTheme?.name?.rendered
+				? decodeEntities( currentTheme.name.rendered )
+				: undefined,
+			templateId: _templateId,
+			template: _templateId
+				? ( getEntityRecord(
+						'postType',
+						'wp_template',
+						_templateId
+				  ) as WpTemplate | undefined )
+				: undefined,
+		};
+	}, [] );
+
+	const activateTheme = async () => {
+		setIsActivating( true );
+		try {
+			// There is no REST endpoint for activating a theme, so this goes
+			// through the classic themes screen action, authorized by the
+			// nonce Core prints for the previewed theme.
+			const response = await window.fetch(
+				addQueryArgs( 'themes.php', {
+					action: 'activate',
+					stylesheet: previewedStylesheet,
+					_wpnonce: window.WP_BLOCK_THEME_ACTIVATE_NONCE,
+				} )
+			);
+			if ( ! response.ok ) {
+				throw new Error( response.statusText );
+			}
+			window.location.href = addQueryArgs( 'themes.php', {
+				activated: 'true',
+			} );
+		} catch {
+			setIsActivating( false );
+			createErrorNotice( __( 'Theme activation failed.' ), {
+				id: 'theme-preview-activate-error',
+				type: 'snackbar',
+			} );
+		}
+	};
+
+	const previewDescription = __(
+		'A preview of your site’s homepage with this theme.'
+	);
+
+	let activateLabel;
+	if ( ! themeName ) {
+		activateLabel = __( 'Activate' );
+	} else if ( isActivating ) {
+		activateLabel = sprintf(
+			/* translators: %s: Theme name. */
+			__( 'Activating %s' ),
+			themeName
+		);
+	} else {
+		activateLabel = sprintf(
+			/* translators: %s: Theme name. */
+			__( 'Activate %s' ),
+			themeName
+		);
+	}
+
+	let content;
+	if ( templateId === '' ) {
+		// The lookup resolved and the previewed theme has no block templates.
+		content = (
+			<p className={ styles.empty }>
+				{ __( 'This theme has no templates to preview.' ) }
+			</p>
+		);
+	} else if ( ! template ) {
+		content = (
+			<div className={ styles.loading }>
+				<Spinner />
+			</div>
+		);
+	} else {
+		content = (
+			<div className={ styles.frame }>
+				<Preview
+					content={ template.content?.raw }
+					blocks={ template.blocks }
+					description={ previewDescription }
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<Page
+			ariaLabel={ __( 'Theme Preview' ) }
+			title={
+				themeName
+					? sprintf(
+							/* translators: %s: Theme name. */
+							__( 'Previewing %s' ),
+							themeName
+					  )
+					: __( 'Theme Preview' )
+			}
+			subTitle={ previewDescription }
+			actions={
+				<>
+					<Button size="compact" variant="tertiary" href="themes.php">
+						{ __( 'Back to themes' ) }
+					</Button>
+					<Button
+						size="compact"
+						variant="primary"
+						isBusy={ isActivating }
+						disabled={ isActivating }
+						accessibleWhenDisabled
+						onClick={ activateTheme }
+					>
+						{ activateLabel }
+					</Button>
+				</>
+			}
+		>
+			<div className={ styles.content }>{ content }</div>
+		</Page>
+	);
+}
+
+export const stage = ThemePreviewStage;

--- a/routes/theme-preview/stage.tsx
+++ b/routes/theme-preview/stage.tsx
@@ -1,154 +1,77 @@
 import { Page } from '@wordpress/admin-ui';
-import { Button, Spinner } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import type { WpTemplate } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import type { Theme } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { Preview } from '@wordpress/lazy-editor';
-import { store as noticesStore } from '@wordpress/notices';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { addQueryArgs } from '@wordpress/url';
+import { setupPreviewNavigation } from './preview-navigation';
+import {
+	getPreviewQueryArgs,
+	getPreviewTitle,
+	getPreviewedStylesheet,
+} from './previewed-theme';
 import styles from './style.module.scss';
 
 declare global {
 	interface Window {
-		/**
-		 * Nonce for activating the previewed theme, printed on `admin_head`
-		 * by Core's `wp_block_theme_activate_nonce()` whenever the request
-		 * carries a `wp_theme_preview` parameter.
-		 */
+		// Theme activation nonce, printed on `admin_head` by Core's
+		// `wp_block_theme_activate_nonce()` for `wp_theme_preview` requests.
 		WP_BLOCK_THEME_ACTIVATE_NONCE?: string;
 	}
 }
 
-const FRONT_PAGE_TEMPLATE_QUERY = { slug: 'front-page' };
-
 function ThemePreviewStage() {
-	const previewParam = getQueryArg(
-		window.location.href,
-		'wp_theme_preview'
-	);
-	const previewedStylesheet =
-		typeof previewParam === 'string' ? previewParam : '';
+	const stylesheet = getPreviewedStylesheet();
 	const [ isActivating, setIsActivating ] = useState( false );
-	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const { themeName, templateId, template } = useSelect( ( select ) => {
-		const { getCurrentTheme, getDefaultTemplateId, getEntityRecord } =
-			select( coreStore );
-		// Every REST request on this screen carries the `wp_theme_preview`
-		// parameter, so the "current" theme is the previewed one, and the
-		// front page template resolves through the previewed theme's own
-		// template hierarchy (front-page → home → index).
-		const currentTheme = getCurrentTheme() as
-			| { name?: { rendered?: string } }
-			| null
-			| undefined;
-		const _templateId = getDefaultTemplateId(
-			FRONT_PAGE_TEMPLATE_QUERY
-		) as string | undefined;
+	const { themeName, homeUrl } = useSelect( ( select ) => {
+		const { getCurrentTheme, getEntityRecord } = select( coreStore );
+		// The "current" theme is the previewed one: every REST request on
+		// this screen carries the `wp_theme_preview` parameter.
+		const theme = getCurrentTheme() as Theme | null | undefined;
 		return {
-			themeName: currentTheme?.name?.rendered
-				? decodeEntities( currentTheme.name.rendered )
+			themeName: theme?.name?.rendered
+				? decodeEntities( theme.name.rendered )
 				: undefined,
-			templateId: _templateId,
-			template: _templateId
-				? ( getEntityRecord(
-						'postType',
-						'wp_template',
-						_templateId
-				  ) as WpTemplate | undefined )
-				: undefined,
+			homeUrl: getEntityRecord< { home?: string } >(
+				'root',
+				'__unstableBase',
+				undefined
+			)?.home,
 		};
 	}, [] );
 
-	const activateTheme = async () => {
-		setIsActivating( true );
-		try {
-			// There is no REST endpoint for activating a theme, so this goes
-			// through the classic themes screen action, authorized by the
-			// nonce Core prints for the previewed theme.
-			const response = await window.fetch(
-				addQueryArgs( 'themes.php', {
-					action: 'activate',
-					stylesheet: previewedStylesheet,
-					_wpnonce: window.WP_BLOCK_THEME_ACTIVATE_NONCE,
-				} )
-			);
-			if ( ! response.ok ) {
-				throw new Error( response.statusText );
-			}
-			window.location.href = addQueryArgs( 'themes.php', {
-				activated: 'true',
-			} );
-		} catch {
-			setIsActivating( false );
-			createErrorNotice( __( 'Theme activation failed.' ), {
-				id: 'theme-preview-activate-error',
-				type: 'snackbar',
-			} );
-		}
-	};
-
-	const previewDescription = __(
-		'A preview of your site’s homepage with this theme.'
+	const previewArgs = useMemo(
+		() => getPreviewQueryArgs( stylesheet ),
+		[ stylesheet ]
+	);
+	const previewSrc = useMemo(
+		() => ( homeUrl ? addQueryArgs( homeUrl, previewArgs ) : undefined ),
+		[ homeUrl, previewArgs ]
 	);
 
-	let activateLabel;
-	if ( ! themeName ) {
-		activateLabel = __( 'Activate' );
-	} else if ( isActivating ) {
-		activateLabel = sprintf(
-			/* translators: %s: Theme name. */
-			__( 'Activating %s' ),
-			themeName
-		);
-	} else {
-		activateLabel = sprintf(
-			/* translators: %s: Theme name. */
-			__( 'Activate %s' ),
-			themeName
-		);
-	}
-
-	let content;
-	if ( templateId === '' ) {
-		// The lookup resolved and the previewed theme has no block templates.
-		content = (
-			<p className={ styles.empty }>
-				{ __( 'This theme has no templates to preview.' ) }
-			</p>
-		);
-	} else if ( ! template ) {
-		content = (
-			<div className={ styles.loading }>
-				<Spinner />
-			</div>
-		);
-	} else {
-		content = (
-			<Preview
-				content={ template.content?.raw }
-				blocks={ template.blocks }
-				description={ previewDescription }
-			/>
-		);
-	}
+	const activateTheme = () => {
+		setIsActivating( true );
+		// There is no REST endpoint for activating a theme, so this follows
+		// the classic themes screen action, authorized by the nonce Core
+		// prints for the previewed theme. Core redirects to the themes
+		// screen, which announces the activation; failures like an expired
+		// nonce render Core's standard error screen, exactly as the themes
+		// screen's own Activate link does.
+		window.location.href = addQueryArgs( 'themes.php', {
+			action: 'activate',
+			stylesheet,
+			_wpnonce: window.WP_BLOCK_THEME_ACTIVATE_NONCE,
+		} );
+	};
 
 	return (
 		<Page
-			ariaLabel={ __( 'Theme Preview' ) }
-			title={
-				themeName
-					? sprintf(
-							/* translators: %s: Theme name. */
-							__( 'Previewing %s' ),
-							themeName
-					  )
-					: __( 'Theme Preview' )
-			}
-			subTitle={ previewDescription }
+			title={ getPreviewTitle( themeName ) }
+			subTitle={ __( 'A preview of your site with this theme.' ) }
 			actions={
 				<>
 					<Button size="compact" variant="tertiary" href="themes.php">
@@ -162,12 +85,33 @@ function ThemePreviewStage() {
 						accessibleWhenDisabled
 						onClick={ activateTheme }
 					>
-						{ activateLabel }
+						{ themeName
+							? sprintf(
+									/* translators: %s: Theme name. */
+									__( 'Activate %s' ),
+									themeName
+							  )
+							: __( 'Activate' ) }
 					</Button>
 				</>
 			}
 		>
-			<div className={ styles.content }>{ content }</div>
+			{ previewSrc && (
+				<iframe
+					className={ styles.preview }
+					src={ previewSrc }
+					title={ __( 'Theme Preview' ) }
+					onLoad={ ( event ) => {
+						const doc = ( event.target as HTMLIFrameElement )
+							.contentDocument;
+						// Not readable when the site is served from another
+						// origin; navigation then leaves the previewed theme.
+						if ( doc && homeUrl ) {
+							setupPreviewNavigation( doc, homeUrl, previewArgs );
+						}
+					} }
+				/>
+			) }
 		</Page>
 	);
 }

--- a/routes/theme-preview/style.module.scss
+++ b/routes/theme-preview/style.module.scss
@@ -5,15 +5,6 @@
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
-	padding: $grid-unit-30;
-}
-
-.frame {
-	border: $border-width solid $gray-300;
-	border-radius: $radius-large;
-	overflow: hidden;
-	max-width: 1200px;
-	margin: 0 auto;
 }
 
 .loading {

--- a/routes/theme-preview/style.module.scss
+++ b/routes/theme-preview/style.module.scss
@@ -1,21 +1,6 @@
-@use "@wordpress/base-styles/colors" as *;
-@use "@wordpress/base-styles/variables" as *;
-
-.content {
+.preview {
 	flex: 1;
 	min-height: 0;
-	overflow-y: auto;
-}
-
-.loading {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
-}
-
-.empty {
-	color: $gray-700;
-	text-align: center;
-	margin: $grid-unit-40 0;
+	border: 0;
+	background: #fff;
 }

--- a/routes/theme-preview/style.module.scss
+++ b/routes/theme-preview/style.module.scss
@@ -1,0 +1,30 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.content {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: $grid-unit-30;
+}
+
+.frame {
+	border: $border-width solid $gray-300;
+	border-radius: $radius-large;
+	overflow: hidden;
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+.loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}
+
+.empty {
+	color: $gray-700;
+	text-align: center;
+	margin: $grid-unit-40 0;
+}

--- a/routes/theme-preview/tsconfig.json
+++ b/routes/theme-preview/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"rootDir": ".",
+		"noEmit": true,
+		"emitDeclarationOnly": false,
+		"composite": false,
+		"types": [ "style-imports" ]
+	},
+	"include": [ "**/*.ts", "**/*.tsx" ],
+	"exclude": [ "build", "node_modules" ]
+}


### PR DESCRIPTION
## What?

Adds an experimental wp-admin page for block theme previews, and points block theme live previews at it (today they load site editor v1 via `site-editor.php?wp_theme_preview=<stylesheet>`) while the `gutenberg-extensible-site-editor` experiment is enabled. This closes the last large gap between `edit-site` (v1) and the extensible site editor.

The page shows the **real site frontend** rendered with the previewed (not yet active) theme, browsable — clicking around stays inside the previewed theme — with a header call to action to activate it.

## Why?

With the extensible site editor experiment enabled, the Appearance → Design entry already points at the new site editor, but block theme previews still booted the old one. Theme previews don't need a site editor at all: the frontend itself, rendered with the previewed theme, is the most faithful preview there is.

## How?

The mechanism is almost entirely Core's. `wp-includes/theme-previews.php` hooks `plugins_loaded` on **every** request — frontend included — so `?wp_theme_preview=<stylesheet>` filters `stylesheet`/`template` for any user with `switch_themes`, and `?wp_site_preview=1` (the site editor's existing frame parameter) hides the admin bar. The stage therefore just renders an iframe of the site's `home` URL carrying both parameters.

**Navigation** (`routes/theme-preview/preview-navigation.ts`): Core renders frontend links without the preview parameters, so a plain click would silently land back on the active theme. The module mirrors the Customizer's preview interception (`customize-preview.js`), adapted to a same-origin iframe that navigates itself instead of messaging a pane:

- Previewable links get the parameters injected into their query string — on load, and via a MutationObserver for links added later.
- Unpreviewable links (other sites, `wp-login`/`wp-signup`, `wp-admin`/`wp-includes`/`wp-content`) get a `not-allowed` cursor and are blocked on click, with a spoken announcement — same boundary rules as `isLinkPreviewable`, anchored to the server-authored `home` URL (protocol + host + path prefix, so subdirectory installs resolve correctly).
- GET form submissions (search) carry the parameters via hidden inputs; anything else (like POST comment forms) is blocked, as in the Customizer.

**Activation** follows v1's mechanics — `themes.php?action=activate` with the `WP_BLOCK_THEME_ACTIVATE_NONCE` Core prints on `admin_head` for preview requests (there is still no REST endpoint for activating themes) — as a plain navigation, so Core's redirect lands on the themes screen, which announces the activation.

**PHP** (`lib/experimental/theme-preview/load.php`, loaded with the experiment in `lib/load.php`):

- Registers the hidden page (`admin.php?page=theme-preview-wp-admin`, `switch_themes`, empty parent — the media editor's pattern, including the admin-chrome handling).
- Rewrites the themes screen's block theme Live Preview links at the source via the `wp_prepare_themes_for_js` filter, so the normal path never round-trips through `site-editor.php`. The active theme's "Customize" entry and classic themes are untouched.
- Keeps a `load-site-editor.php` redirect as a backstop for bookmarks and the theme installer's post-install live preview link.
- All three hooks sit behind one `function_exists` check on the generated render callback, so a `build/` that predates the page degrades to current behavior instead of fataling.

Since the preview is the real frontend, classic themes render fine too if pointed at the page — though Core only generates these live preview links for block themes.

## Testing Instructions

Requires a fresh `npm run build` (it generates `build/pages/theme-preview/` and the route bundles).

1. Enable the "Extensible site editor" experiment (Gutenberg → Experiments).
2. Activate any theme other than the one to preview.
3. Go to Appearance → Themes and click "Live Preview" on a block theme: the preview page opens with "Previewing <Theme>" and the site's homepage rendered with that theme.
4. Browse: internal links and search stay inside the previewed theme; links leaving the site (or into wp-admin) show a `not-allowed` cursor and don't navigate.
5. Click "Activate <Theme>": you land on the themes screen with the theme active and Core's "New theme activated" notice.
6. Disable the experiment: "Live Preview" loads site editor v1 as before.

### Testing Instructions for Keyboard

1. On the themes screen, Tab to a block theme and open "Live Preview" with Enter.
2. On the preview page, Tab reaches "Back to themes" and "Activate <Theme>"; Enter on the latter activates the theme. Blocked links inside the preview announce "This link is not live-previewable." via the admin document's live region.

## Screenshots or screencast

Pending a build.

## Follow-ups (out of scope here)

- Extract a shared `gutenberg_register_hidden_admin_page()` helper — `lib/experimental/media-editor/load.php` now has a second verbatim copy of the hidden-page registration/`prepare_screen` dance.
- Unify the three frontend-iframe embed sites (`packages/boot`'s `SitePreview`, `packages/edit-site`'s, and this page) around one `wp_site_preview` URL builder.
- Consider having the boot router expose the outer query string (beyond `p`) as router search params, which would let routes like this one stop reading `window.location`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
