### PR TITLE
Remove redundant pre publish headings, alt

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -120,7 +120,14 @@
 		margin-right: -$grid-unit-20;
 	}
 
-	.editor-post-visibility__dialog-legend {
+	// Each panel's own title already names the section, so the heading that
+	// `InspectorPopoverHeader` renders inside it repeats what is directly
+	// above. Hide the heading rather than the whole header, which also carries
+	// the publish date's "Now" action. `display: none` takes it out of the
+	// accessibility tree too, so it is not a duplicate for screen readers
+	// either. This replaces the same rule for the `<legend>` the visibility
+	// options used before the heading existed.
+	.block-editor-inspector-popover-header {
 		display: none;
 	}
 


### PR DESCRIPTION
## What?

Simpler alternative to #81806. 

Removes redundant headings from the pre-publish sidebar, both under Visibility and Publish.

Unlike the other PR which is bigger and has props, this one is a single CSS change. 

<img width="282" height="723" alt="image" src="https://github.com/user-attachments/assets/0bd7294f-dc93-4633-a388-ee5979ce6276" />

The big decision: this one also hides entirely the "Now" button. The motivation: "Now" is only useful if you are scheduling a post and want to undo it, which is arguably a flow that you are engaging with _before_ you've pressed the Publish button. This keeps the PR simple and minimal, in making that decision. It's the "Now" button that caused the other PR to balloon.