### PR TITLE
Playlist: Refactor track metadata controls

### DIFF
--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -32,6 +32,132 @@ import { useUploadMediaFromBlobURL } from '../utils/hooks';
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const TRACK_IMAGE_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
+function TrackImageControl( {
+	image,
+	hasImage,
+	imageAlt,
+	onSelectImage,
+	onRemoveImage,
+	onChangeImageAlt,
+	imageButtonRef,
+} ) {
+	return (
+		<>
+			<MediaUploadCheck>
+				<BaseControl>
+					<BaseControl.VisualLabel>
+						{ __( 'Track image' ) }
+					</BaseControl.VisualLabel>
+					<div className="editor-video-poster-control">
+						{ !! image && (
+							<img
+								src={ image }
+								alt={ __( 'Preview of the track image' ) }
+							/>
+						) }
+						<MediaUpload
+							title={ __( 'Select image' ) }
+							onSelect={ onSelectImage }
+							allowedTypes={ TRACK_IMAGE_ALLOWED_MEDIA_TYPES }
+							render={ ( { open } ) => (
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									onClick={ open }
+									ref={ imageButtonRef }
+								>
+									{ ! hasImage
+										? __( 'Select' )
+										: __( 'Replace' ) }
+								</Button>
+							) }
+						/>
+						{ hasImage && (
+							<Button
+								__next40pxDefaultSize
+								onClick={ onRemoveImage }
+								variant="tertiary"
+							>
+								{ __( 'Remove' ) }
+							</Button>
+						) }
+					</div>
+				</BaseControl>
+			</MediaUploadCheck>
+			{ hasImage && (
+				<TextareaControl
+					label={ __( 'Alternative text' ) }
+					value={ imageAlt }
+					onChange={ onChangeImageAlt }
+					help={
+						<Link
+							openInNewTab
+							href={
+								// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+								__(
+									'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+								)
+							}
+						>
+							{ __( 'Describe the purpose of the image.' ) }
+						</Link>
+					}
+				/>
+			) }
+		</>
+	);
+}
+
+function TrackInspectorControls( {
+	panelTitle,
+	artist,
+	onChangeArtist,
+	album,
+	onChangeAlbum,
+	title,
+	onChangeTitle,
+	image,
+	hasImage,
+	imageAlt,
+	onSelectImage,
+	onRemoveImage,
+	onChangeImageAlt,
+	imageButtonRef,
+} ) {
+	return (
+		<InspectorControls>
+			<PanelBody title={ panelTitle }>
+				{ onChangeTitle && (
+					<TextControl
+						label={ __( 'Title' ) }
+						value={ stripHTML( title || '' ) }
+						onChange={ onChangeTitle }
+					/>
+				) }
+				<TextControl
+					label={ __( 'Artist' ) }
+					value={ stripHTML( artist || '' ) }
+					onChange={ onChangeArtist }
+				/>
+				<TextControl
+					label={ __( 'Album' ) }
+					value={ stripHTML( album || '' ) }
+					onChange={ onChangeAlbum }
+				/>
+				<TrackImageControl
+					image={ image }
+					hasImage={ hasImage }
+					imageAlt={ imageAlt }
+					onSelectImage={ onSelectImage }
+					onRemoveImage={ onRemoveImage }
+					onChangeImageAlt={ onChangeImageAlt }
+					imageButtonRef={ imageButtonRef }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
 const PlaylistTrackEdit = ( {
 	attributes,
 	setAttributes,
@@ -156,100 +282,30 @@ const PlaylistTrackEdit = ( {
 					variant="toolbar"
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<TextControl
-						label={ __( 'Artist' ) }
-						value={ artist ? stripHTML( artist ) : '' }
-						onChange={ ( artistValue ) => {
-							setAttributes( { artist: artistValue } );
-						} }
-					/>
-					<TextControl
-						label={ __( 'Album' ) }
-						value={ album ? stripHTML( album ) : '' }
-						onChange={ ( albumValue ) => {
-							setAttributes( { album: albumValue } );
-						} }
-					/>
-					<TextControl
-						label={ __( 'Title' ) }
-						value={ title ? stripHTML( title ) : '' }
-						onChange={ ( titleValue ) => {
-							setAttributes( { title: titleValue } );
-						} }
-					/>
-					<MediaUploadCheck>
-						<BaseControl>
-							<BaseControl.VisualLabel>
-								{ __( 'Track image' ) }
-							</BaseControl.VisualLabel>
-							<div className="editor-video-poster-control">
-								{ !! image && (
-									<img
-										src={ image }
-										alt={ __(
-											'Preview of the track image'
-										) }
-									/>
-								) }
-								<MediaUpload
-									title={ __( 'Select image' ) }
-									onSelect={ onSelectTrackImage }
-									allowedTypes={
-										TRACK_IMAGE_ALLOWED_MEDIA_TYPES
-									}
-									render={ ( { open } ) => (
-										<Button
-											__next40pxDefaultSize
-											variant="primary"
-											onClick={ open }
-											ref={ imageButton }
-										>
-											{ ! image
-												? __( 'Select' )
-												: __( 'Replace' ) }
-										</Button>
-									) }
-								/>
-								{ !! image && (
-									<Button
-										__next40pxDefaultSize
-										onClick={ onRemoveTrackImage }
-										variant="tertiary"
-									>
-										{ __( 'Remove' ) }
-									</Button>
-								) }
-							</div>
-						</BaseControl>
-					</MediaUploadCheck>
-					{ !! image && (
-						<TextareaControl
-							label={ __( 'Alternative text' ) }
-							value={ imageAlt || '' }
-							onChange={ ( value ) =>
-								setAttributes( { imageAlt: value } )
-							}
-							help={
-								<Link
-									openInNewTab
-									href={
-										// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-										__(
-											'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-										)
-									}
-								>
-									{ __(
-										'Describe the purpose of the image.'
-									) }
-								</Link>
-							}
-						/>
-					) }
-				</PanelBody>
-			</InspectorControls>
+			<TrackInspectorControls
+				panelTitle={ __( 'Settings' ) }
+				artist={ artist }
+				onChangeArtist={ ( artistValue ) => {
+					setAttributes( { artist: artistValue } );
+				} }
+				album={ album }
+				onChangeAlbum={ ( albumValue ) => {
+					setAttributes( { album: albumValue } );
+				} }
+				title={ title }
+				onChangeTitle={ ( titleValue ) => {
+					setAttributes( { title: titleValue } );
+				} }
+				image={ image }
+				hasImage={ !! image }
+				imageAlt={ imageAlt || '' }
+				onSelectImage={ onSelectTrackImage }
+				onRemoveImage={ onRemoveTrackImage }
+				onChangeImageAlt={ ( value ) =>
+					setAttributes( { imageAlt: value } )
+				}
+				imageButtonRef={ imageButton }
+			/>
 			<li { ...blockProps }>
 				<button
 					className="wp-block-playlist-track__button"

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -103,6 +103,18 @@ describe( 'PlaylistTrackEdit', () => {
 		useUploadMediaFromBlobURL.mockClear();
 	} );
 
+	it( 'shows the title before artist and album controls', () => {
+		renderEdit();
+
+		const formFields = screen.getAllByRole( 'textbox' );
+
+		expect( formFields.slice( 0, 3 ) ).toEqual( [
+			screen.getByRole( 'textbox', { name: 'Title' } ),
+			screen.getByRole( 'textbox', { name: 'Artist' } ),
+			screen.getByRole( 'textbox', { name: 'Album' } ),
+		] );
+	} );
+
 	it( 'allows the track image alternative text to be edited', () => {
 		const { setAttributes } = renderEdit();
 

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -103,18 +103,6 @@ describe( 'PlaylistTrackEdit', () => {
 		useUploadMediaFromBlobURL.mockClear();
 	} );
 
-	it( 'shows the title before artist and album controls', () => {
-		renderEdit();
-
-		const formFields = screen.getAllByRole( 'textbox' );
-
-		expect( formFields.slice( 0, 3 ) ).toEqual( [
-			screen.getByRole( 'textbox', { name: 'Title' } ),
-			screen.getByRole( 'textbox', { name: 'Artist' } ),
-			screen.getByRole( 'textbox', { name: 'Album' } ),
-		] );
-	} );
-
 	it( 'allows the track image alternative text to be edited', () => {
 		const { setAttributes } = renderEdit();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactors the Playlist Track sidebar metadata controls into reusable `TrackInspectorControls` and `TrackImageControl` components.

## Why?
This separates the component cleanup from the bulk metadata editing changes so the feature PR (#81441) can be reviewed on top of a smaller base change.

## How?
Moves the existing single-track title, artist, album, track image, and alternative text controls into shared components while preserving the same editing callbacks and media upload behavior.

## Testing Instructions
1. Open a post or page.
2. Insert a Playlist block with an audio track.
3. Select the Playlist Track block.
4. Confirm the sidebar still shows Title, Artist, Album, Track image, and Alternative text controls.
5. Edit each field and confirm the track metadata updates.

## Use of AI Tools

This PR was authored with assistance from OpenAI Codex; the generated changes were reviewed and tested locally.
