### PR TITLE
Playlist: Add album display option

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -636,7 +636,7 @@ Embed a simple playlist.
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/playlist-track
 -	**Supports:** align, anchor, color (background, gradients, link, text), interactivity, spacing (margin, padding), typography (fontSize)
--	**Attributes:** caption, order, showArtists, showImages, showNumbers, showPlayButtonArtwork, showTrackLength, showTracklist, type, waveformBackgroundColor, waveformBackgroundGradient, waveformColor, waveformGradient, waveformStyle
+-	**Attributes:** caption, order, showAlbum, showArtists, showImages, showNumbers, showPlayButtonArtwork, showTrackLength, showTracklist, type, waveformBackgroundColor, waveformBackgroundGradient, waveformColor, waveformGradient, waveformStyle
 
 ## Playlist track
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   Columns: Add transforms between Columns and the Row variation that preserve column widths through flex child sizing controls.
+-   Playlist: Add an option to show track album names.
 
 ### Bug Fixes
 

--- a/packages/block-library/src/playlist-track/README.md
+++ b/packages/block-library/src/playlist-track/README.md
@@ -46,6 +46,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 
 **Uses context:**
 
+- `showAlbum`
 - `showArtists`
 - `showImages`
 

--- a/packages/block-library/src/playlist-track/block.json
+++ b/packages/block-library/src/playlist-track/block.json
@@ -8,7 +8,7 @@
 	"description": "Playlist track.",
 	"keywords": [ "music", "sound" ],
 	"textdomain": "default",
-	"usesContext": [ "showArtists", "showImages" ],
+	"usesContext": [ "showAlbum", "showArtists", "showImages" ],
 	"attributes": {
 		"blob": {
 			"type": "string",

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -42,6 +42,8 @@ const PlaylistTrackEdit = ( {
 	const { id, src, album, artist, image, imageAlt, length, title } =
 		attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
+	const albumValue = typeof album === 'string' ? album : '';
+	const showAlbum = context?.showAlbum ?? false;
 	const showArtists = context?.showArtists;
 	const showImages = context?.showImages ?? true;
 	const imageButton = useRef();
@@ -167,9 +169,9 @@ const PlaylistTrackEdit = ( {
 					/>
 					<TextControl
 						label={ __( 'Album' ) }
-						value={ album ? stripHTML( album ) : '' }
-						onChange={ ( albumValue ) => {
-							setAttributes( { album: albumValue } );
+						value={ albumValue ? stripHTML( albumValue ) : '' }
+						onChange={ ( value ) => {
+							setAttributes( { album: value } );
 						} }
 					/>
 					<TextControl
@@ -286,6 +288,19 @@ const PlaylistTrackEdit = ( {
 								placeholder={ __( 'Track artist' ) }
 								onChange={ ( value ) =>
 									setAttributes( { artist: value } )
+								}
+								__experimentalVersion={ 2 }
+							/>
+						) }
+						{ showAlbum && (
+							<PlainText
+								tagName="span"
+								className="wp-block-playlist-track__album"
+								value={ albumValue }
+								aria-label={ __( 'Track album' ) }
+								placeholder={ __( 'Track album' ) }
+								onChange={ ( value ) =>
+									setAttributes( { album: value } )
 								}
 								__experimentalVersion={ 2 }
 							/>

--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -26,9 +26,15 @@ function render_block_core_playlist_track( $attributes, $content = '', $block = 
 	if ( $block instanceof WP_Block && isset( $block->context['showImages'] ) ) {
 		$show_images = $block->context['showImages'];
 	}
+	$show_album = false;
+	if ( $block instanceof WP_Block && isset( $block->context['showAlbum'] ) ) {
+		$show_album = true === $block->context['showAlbum'];
+	}
 
 	$track_image = $attributes['image'] ?? null;
 	$image       = is_string( $track_image ) ? $track_image : '';
+	$track_album = $attributes['album'] ?? null;
+	$album       = is_string( $track_album ) ? $track_album : '';
 	$artist      = $attributes['artist'] ?? '';
 	$alt         = $attributes['imageAlt'] ?? '';
 	$length      = $attributes['length'] ?? '';
@@ -47,6 +53,9 @@ function render_block_core_playlist_track( $attributes, $content = '', $block = 
 	}
 	if ( $artist ) {
 		$html .= '<span class="wp-block-playlist-track__artist">' . esc_html( $artist ) . '</span>';
+	}
+	if ( $show_album && $album ) {
+		$html .= '<span class="wp-block-playlist-track__album">' . esc_html( $album ) . '</span>';
 	}
 	$html .= '</span>';
 

--- a/packages/block-library/src/playlist-track/index.php
+++ b/packages/block-library/src/playlist-track/index.php
@@ -28,7 +28,7 @@ function render_block_core_playlist_track( $attributes, $content = '', $block = 
 	}
 	$show_album = false;
 	if ( $block instanceof WP_Block && isset( $block->context['showAlbum'] ) ) {
-		$show_album = true === $block->context['showAlbum'];
+		$show_album = $block->context['showAlbum'];
 	}
 
 	$track_image = $attributes['image'] ?? null;

--- a/packages/block-library/src/playlist-track/style.scss
+++ b/packages/block-library/src/playlist-track/style.scss
@@ -35,6 +35,7 @@
 
 		.wp-block-playlist-track__image {
 			flex: 0 0 50px;
+			align-self: flex-start;
 			width: 50px;
 			height: 50px;
 			margin-right: var(--wp--preset--spacing--20, 0.5em);
@@ -52,7 +53,8 @@
 			display: block;
 		}
 
-		.wp-block-playlist-track__artist {
+		.wp-block-playlist-track__artist,
+		.wp-block-playlist-track__album {
 			display: block;
 			font-size: 0.85em;
 			opacity: 0.7;

--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -81,6 +81,7 @@ function renderEdit( props = {} ) {
 				} }
 				setAttributes={ setAttributes }
 				context={ {
+					showAlbum: false,
 					showArtists: true,
 					showImages: true,
 					...props.context,
@@ -137,6 +138,34 @@ describe( 'PlaylistTrackEdit', () => {
 
 		expect(
 			screen.queryByLabelText( 'Alternative text' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the track album when album display is enabled', () => {
+		renderEdit( {
+			context: {
+				showAlbum: true,
+			},
+		} );
+
+		const trackButton = screen.getByRole( 'button', {
+			name: /Song One/,
+		} );
+
+		expect( within( trackButton ).getByText( 'Great Album' ) ).toHaveClass(
+			'wp-block-playlist-track__album'
+		);
+	} );
+
+	it( 'does not render the track album when album display is disabled', () => {
+		renderEdit();
+
+		const trackButton = screen.getByRole( 'button', {
+			name: /Song One/,
+		} );
+
+		expect(
+			within( trackButton ).queryByText( 'Great Album' )
 		).not.toBeInTheDocument();
 	} );
 

--- a/packages/block-library/src/playlist/README.md
+++ b/packages/block-library/src/playlist/README.md
@@ -26,6 +26,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `showImages` | `boolean` | `true` | — |
 | `showPlayButtonArtwork` | `boolean` | `false` | — |
 | `showArtists` | `boolean` | `true` | — |
+| `showAlbum` | `boolean` | `false` | — |
 | `showNumbers` | `boolean` | `true` | — |
 | `showTrackLength` | `boolean` | `true` | — |
 | `waveformStyle` | `string` | `"bars"` | [Enum](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#enum-validation): `bars`, `mirror`, `line`, `blocks`, `dots`, `seekbar` |
@@ -57,6 +58,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 
 **Provides context:**
 
+- `showAlbum` → attribute `showAlbum`
 - `showArtists` → attribute `showArtists`
 - `showImages` → attribute `showImages`
 

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -33,6 +33,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"showAlbum": {
+			"type": "boolean",
+			"default": false
+		},
 		"showNumbers": {
 			"type": "boolean",
 			"default": true
@@ -63,6 +67,7 @@
 		}
 	},
 	"providesContext": {
+		"showAlbum": "showAlbum",
 		"showArtists": "showArtists",
 		"showImages": "showImages"
 	},

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -29,7 +29,7 @@ import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { WaveformPlayer } from '../utils/waveform-player';
 import { PlaylistContext } from './context';
-import { getTrackAttributes } from './utils';
+import { getTrackAttributes, getWaveformArtistText } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const AUDIO_FILE_EXTENSION =
@@ -76,6 +76,7 @@ const PlaylistEdit = ( {
 		showImages,
 		showPlayButtonArtwork,
 		showArtists,
+		showAlbum,
 		showTrackLength,
 		waveformStyle = DEFAULT_WAVEFORM_STYLE,
 		waveformColor,
@@ -499,6 +500,7 @@ const PlaylistEdit = ( {
 						setAttributes( {
 							showTracklist: true,
 							showArtists: true,
+							showAlbum: false,
 							showNumbers: true,
 							showTrackLength: true,
 							showImages: true,
@@ -540,6 +542,20 @@ const PlaylistEdit = ( {
 										'showArtists'
 									) }
 									checked={ showArtists }
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								label={ __( 'Show album name' ) }
+								isShownByDefault
+								hasValue={ () => showAlbum !== false }
+								onDeselect={ () =>
+									setAttributes( { showAlbum: false } )
+								}
+							>
+								<ToggleControl
+									label={ __( 'Show album name' ) }
+									onChange={ toggleAttribute( 'showAlbum' ) }
+									checked={ showAlbum }
 								/>
 							</ToolsPanelItem>
 							<ToolsPanelItem
@@ -691,7 +707,10 @@ const PlaylistEdit = ( {
 					<WaveformPlayer
 						src={ currentTrackData?.src }
 						title={ currentTrackData?.title }
-						artist={ currentTrackData?.artist }
+						artist={ getWaveformArtistText(
+							currentTrackData,
+							showAlbum === true
+						) }
 						image={ currentTrackData?.image }
 						imageAlt={ currentTrackData?.imageAlt }
 						waveformStyle={ waveformStyle }

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -545,20 +545,6 @@ const PlaylistEdit = ( {
 								/>
 							</ToolsPanelItem>
 							<ToolsPanelItem
-								label={ __( 'Show album name' ) }
-								isShownByDefault
-								hasValue={ () => showAlbum !== false }
-								onDeselect={ () =>
-									setAttributes( { showAlbum: false } )
-								}
-							>
-								<ToggleControl
-									label={ __( 'Show album name' ) }
-									onChange={ toggleAttribute( 'showAlbum' ) }
-									checked={ showAlbum }
-								/>
-							</ToolsPanelItem>
-							<ToolsPanelItem
 								label={ __(
 									'Show track numbers in tracklist'
 								) }
@@ -600,6 +586,20 @@ const PlaylistEdit = ( {
 							</ToolsPanelItem>
 						</>
 					) }
+					<ToolsPanelItem
+						label={ __( 'Show album name' ) }
+						isShownByDefault
+						hasValue={ () => showAlbum !== false }
+						onDeselect={ () =>
+							setAttributes( { showAlbum: false } )
+						}
+					>
+						<ToggleControl
+							label={ __( 'Show album name' ) }
+							onChange={ toggleAttribute( 'showAlbum' ) }
+							checked={ showAlbum }
+						/>
+					</ToolsPanelItem>
 					<ToolsPanelItem
 						label={ __( 'Show tracklist images' ) }
 						isShownByDefault

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -709,7 +709,7 @@ const PlaylistEdit = ( {
 						title={ currentTrackData?.title }
 						artist={ getWaveformArtistText(
 							currentTrackData,
-							showAlbum === true
+							showAlbum
 						) }
 						image={ currentTrackData?.image }
 						imageAlt={ currentTrackData?.imageAlt }

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -21,6 +21,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 	$playlist_tracks          = array();
 	$tracks_data              = array();
 	$show_play_button_artwork = ! empty( $attributes['showPlayButtonArtwork'] );
+	$show_album               = ! empty( $attributes['showAlbum'] );
 
 	// Parse inner blocks to extract track data.
 	// This approach avoids duplicating track data in the HTML output.
@@ -167,6 +168,7 @@ function render_block_core_playlist( $attributes, $content, $block ) {
 				'tracks'                => $playlist_tracks,
 				'waveformStyle'         => $waveform_style,
 				'showPlayButtonArtwork' => $show_play_button_artwork,
+				'showAlbum'             => $show_album,
 				'labelPauseTrack'       => __( 'Pause' ),
 				'labelSelectTrack'      => __( 'Play' ),
 			)

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -4,6 +4,7 @@ import PlaylistEdit from '../edit';
 
 let mediaPlaceholderProps;
 let mediaReplaceFlowProps;
+let waveformPlayerProps;
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: {},
@@ -91,7 +92,10 @@ jest.mock( '../../utils/hooks', () => ( {
 } ) );
 
 jest.mock( '../../utils/waveform-player', () => ( {
-	WaveformPlayer: () => <div />,
+	WaveformPlayer: ( props ) => {
+		waveformPlayerProps = props;
+		return <div />;
+	},
 } ) );
 
 const defaultAttributes = {
@@ -101,6 +105,7 @@ const defaultAttributes = {
 	showImages: true,
 	showPlayButtonArtwork: false,
 	showArtists: true,
+	showAlbum: false,
 	showTrackLength: true,
 };
 
@@ -111,6 +116,7 @@ describe( 'PlaylistEdit', () => {
 	beforeEach( () => {
 		mediaPlaceholderProps = undefined;
 		mediaReplaceFlowProps = undefined;
+		waveformPlayerProps = undefined;
 		replaceInnerBlocks = jest.fn();
 		selectBlock = jest.fn();
 		useDispatch.mockReturnValue( {
@@ -126,6 +132,8 @@ describe( 'PlaylistEdit', () => {
 						id: 1,
 						src: 'https://example.com/audio.mp3',
 						title: 'Sample track',
+						artist: 'The Artist',
+						album: 'Great Album',
 					},
 				},
 			],
@@ -184,6 +192,23 @@ describe( 'PlaylistEdit', () => {
 			'wp-block-playlist__tracklist-is-hidden'
 		);
 		expect( screen.getByTestId( 'playlist-track' ) ).toBeInTheDocument();
+	} );
+
+	it( 'passes the album name to the waveform player when album display is enabled', () => {
+		render(
+			<PlaylistEdit
+				attributes={ {
+					...defaultAttributes,
+					showAlbum: true,
+				} }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		expect( waveformPlayerProps.artist ).toBe( 'The Artist - Great Album' );
 	} );
 
 	it( 'adds tracks from the add track control', () => {

--- a/packages/block-library/src/playlist/test/edit-component.js
+++ b/packages/block-library/src/playlist/test/edit-component.js
@@ -60,7 +60,21 @@ jest.mock( '@wordpress/blob', () => ( {
 jest.mock( '@wordpress/components', () => ( {
 	Disabled: ( { children } ) => <div>{ children }</div>,
 	SelectControl: () => <div />,
-	ToggleControl: () => <div />,
+	ToggleControl: ( { checked, label } ) => {
+		const id = `toggle-${ label.replaceAll( ' ', '-' ).toLowerCase() }`;
+
+		return (
+			<label htmlFor={ id }>
+				<input
+					id={ id }
+					type="checkbox"
+					checked={ !! checked }
+					readOnly
+				/>
+				{ label }
+			</label>
+		);
+	},
 	__experimentalToolsPanel: ( { children } ) => <div>{ children }</div>,
 	__experimentalToolsPanelItem: ( { children } ) => <div>{ children }</div>,
 } ) );
@@ -192,6 +206,28 @@ describe( 'PlaylistEdit', () => {
 			'wp-block-playlist__tracklist-is-hidden'
 		);
 		expect( screen.getByTestId( 'playlist-track' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the album display control available when the tracklist is hidden', () => {
+		render(
+			<PlaylistEdit
+				attributes={ {
+					...defaultAttributes,
+					showAlbum: true,
+					showTracklist: false,
+				} }
+				clientId="playlist-1"
+				insertBlocksAfter={ jest.fn() }
+				isSelected={ false }
+				setAttributes={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Show album name',
+			} )
+		).toBeChecked();
 	} );
 
 	it( 'passes the album name to the waveform player when album display is enabled', () => {

--- a/packages/block-library/src/playlist/test/edit.js
+++ b/packages/block-library/src/playlist/test/edit.js
@@ -1,4 +1,4 @@
-import { getTrackAttributes } from '../utils';
+import { getTrackAttributes, getWaveformArtistText } from '../utils';
 
 describe( 'Playlist block edit utilities', () => {
 	describe( 'getTrackAttributes', () => {
@@ -160,6 +160,32 @@ describe( 'Playlist block edit utilities', () => {
 
 			expect( result.image ).toBe( 'https://example.com/cover.jpg' );
 			expect( result.imageAlt ).toBe( 'A black and white portrait' );
+		} );
+	} );
+
+	describe( 'getWaveformArtistText', () => {
+		it( 'should include the album when album display is enabled', () => {
+			const result = getWaveformArtistText(
+				{
+					artist: 'The Artist',
+					album: 'Great Album',
+				},
+				true
+			);
+
+			expect( result ).toBe( 'The Artist - Great Album' );
+		} );
+
+		it( 'should exclude the album when album display is disabled', () => {
+			const result = getWaveformArtistText(
+				{
+					artist: 'The Artist',
+					album: 'Great Album',
+				},
+				false
+			);
+
+			expect( result ).toBe( 'The Artist' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/playlist/utils.js
+++ b/packages/block-library/src/playlist/utils.js
@@ -83,5 +83,7 @@ export function getWaveformArtistText( track, showAlbum = false ) {
 	const album =
 		showAlbum && typeof track?.album === 'string' ? track.album : '';
 
+	// The separator is not translatable because this util is shared with the
+	// frontend view module, which avoids importing `@wordpress/i18n`.
 	return [ artist, album ].filter( Boolean ).join( ' - ' );
 }

--- a/packages/block-library/src/playlist/utils.js
+++ b/packages/block-library/src/playlist/utils.js
@@ -70,3 +70,18 @@ export function getTrackAttributes( media ) {
 		...getTrackImageAttributes( media?.image ),
 	};
 }
+
+/**
+ * Get the metadata text displayed in the waveform player's secondary line.
+ *
+ * @param {Object}  track     Track attributes.
+ * @param {boolean} showAlbum Whether to include the album name.
+ * @return {string} Secondary metadata text.
+ */
+export function getWaveformArtistText( track, showAlbum = false ) {
+	const artist = typeof track?.artist === 'string' ? track.artist : '';
+	const album =
+		showAlbum && typeof track?.album === 'string' ? track.album : '';
+
+	return [ artist, album ].filter( Boolean ).join( ' - ' );
+}

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -5,6 +5,7 @@ import {
 	setupPlayButtonArtwork,
 	updateSeekControlLabel,
 } from '../utils/waveform-utils';
+import { getWaveformArtistText } from './utils';
 
 /**
  * Store player state for each element.
@@ -98,6 +99,10 @@ const { state } = store(
 function initPlayer( ref, track, shouldAutoPlay, context ) {
 	const existing = playerState.get( ref );
 	const showPlayButtonArtwork = context.showPlayButtonArtwork === true;
+	const artistText = getWaveformArtistText(
+		track,
+		context.showAlbum === true
+	);
 	const playerArtwork = showPlayButtonArtwork ? '' : track.image;
 
 	// If a player already exists, load the new track without recreating.
@@ -111,7 +116,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 		} else {
 			playlistPlayerState.set( context.playlistId, existing );
 			existing.instance
-				.loadTrack( track.url, track.title, track.artist, {
+				.loadTrack( track.url, track.title, artistText, {
 					artwork: playerArtwork,
 					artworkAlt: playerArtwork ? track.imageAlt : '',
 				} )
@@ -152,7 +157,7 @@ function initPlayer( ref, track, shouldAutoPlay, context ) {
 	const player = initWaveformPlayer( ref, {
 		src: track.url,
 		title: track.title,
-		artist: track.artist,
+		artist: artistText,
 		image: track.image,
 		imageAlt: track.imageAlt,
 		waveformColor: ref.dataset.waveformPlayerColor,

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -402,6 +402,56 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::render_block_core_playlist
+	 * @covers ::render_block_core_playlist_track
+	 */
+	public function test_tracklist_renders_track_album_when_show_album_is_enabled() {
+		$markup = $this->build_playlist_markup(
+			array( 'showAlbum' => true ),
+			array(
+				array(
+					'id'    => 1,
+					'title' => 'Song One',
+					'album' => 'Album One',
+					'src'   => 'http://example.com/song1.mp3',
+				),
+			)
+		);
+
+		$output = do_blocks( $markup );
+		$p      = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( 'figure' );
+		$context = json_decode( $p->get_attribute( 'data-wp-context' ), true );
+
+		$this->assertTrue( $context['showAlbum'] );
+		$this->assertStringContainsString( 'class="wp-block-playlist-track__album"', $output );
+		$this->assertStringContainsString( '>Album One</span>', $output );
+	}
+
+	/**
+	 * @covers ::render_block_core_playlist
+	 * @covers ::render_block_core_playlist_track
+	 */
+	public function test_tracklist_does_not_render_track_album_by_default() {
+		$markup = $this->build_playlist_markup(
+			array(),
+			array(
+				array(
+					'id'    => 1,
+					'title' => 'Song One',
+					'album' => 'Album One',
+					'src'   => 'http://example.com/song1.mp3',
+				),
+			)
+		);
+
+		$output = do_blocks( $markup );
+
+		$this->assertStringNotContainsString( 'wp-block-playlist-track__album', $output );
+		$this->assertStringNotContainsString( '>Album One</span>', $output );
+	}
+
+	/**
 	 * @covers ::render_block_core_playlist_track
 	 */
 	public function test_playlist_track_renders_without_block_context() {

--- a/phpunit/blocks/render-block-playlist-test.php
+++ b/phpunit/blocks/render-block-playlist-test.php
@@ -429,29 +429,6 @@ class Tests_Blocks_Render_Playlist extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::render_block_core_playlist
-	 * @covers ::render_block_core_playlist_track
-	 */
-	public function test_tracklist_does_not_render_track_album_by_default() {
-		$markup = $this->build_playlist_markup(
-			array(),
-			array(
-				array(
-					'id'    => 1,
-					'title' => 'Song One',
-					'album' => 'Album One',
-					'src'   => 'http://example.com/song1.mp3',
-				),
-			)
-		);
-
-		$output = do_blocks( $markup );
-
-		$this->assertStringNotContainsString( 'wp-block-playlist-track__album', $output );
-		$this->assertStringNotContainsString( '>Album One</span>', $output );
-	}
-
-	/**
 	 * @covers ::render_block_core_playlist_track
 	 */
 	public function test_playlist_track_renders_without_block_context() {

--- a/test/integration/fixtures/blocks/core__playlist.json
+++ b/test/integration/fixtures/blocks/core__playlist.json
@@ -9,6 +9,7 @@
 			"showImages": true,
 			"showPlayButtonArtwork": false,
 			"showArtists": true,
+			"showAlbum": false,
 			"showNumbers": true,
 			"showTrackLength": true,
 			"waveformStyle": "bars",


### PR DESCRIPTION
## What?
Adds a Playlist "Show album name" setting that displays track album metadata in the tracklist and waveform player.

## Why?
Playlist tracks already store album metadata, but that metadata could not be displayed.

## How?
Adds a `showAlbum` Playlist attribute/context value, renders album text in Playlist Track when enabled, passes the same album-aware metadata into the waveform player, and updates generated docs, fixtures, tests, and changelog.

## Testing Instructions
1. Insert a Playlist block with an audio track that has an album value.
2. In the Playlist block settings, enable "Show album name".
3. Confirm the album appears in the tracklist and in the waveform player's secondary metadata line.
4. Switch tracks and confirm the waveform player metadata updates for the selected track.

Tested with `npm run test:unit -- packages/block-library/src/playlist/test/edit.js packages/block-library/src/playlist/test/edit-component.js`, `npm run test:unit -- packages/block-library/src/playlist-track/test/edit.js`, `npm run test:unit -- packages/block-library/src/utils/test/waveform-player.js`, `npm run test:unit -- test/integration/full-content/full-content.test.js --runInBand`, targeted JS/CSS linting, `git diff --check`, and PHP syntax checks; PHPUnit could not run because Docker is unavailable in this environment.

## Screenshots or screencast
<img width="1054" height="863" alt="Screenshot 2026-08-20 at 15 50 28" src="https://github.com/user-attachments/assets/fd7d7b19-fab6-4d04-8efe-a492a078ed22" />


## Use of AI Tools

This PR was authored with assistance from OpenAI Codex; the changes were reviewed and verified locally.
