### PR TITLE
Playlist Track: Add toolbar delete action

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   Columns: Add transforms between Columns and the Row variation that preserve column widths through flex child sizing controls.
+-   Playlist Track: Add a toolbar button for deleting the selected track.
 
 ### Bug Fixes
 

--- a/packages/block-library/src/playlist-track/edit.js
+++ b/packages/block-library/src/playlist-track/edit.js
@@ -10,6 +10,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	PlainText,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	Button,
@@ -18,12 +19,13 @@ import {
 	TextareaControl,
 	BaseControl,
 	Spinner,
+	ToolbarButton,
 } from '@wordpress/components';
 import { Link } from '@wordpress/ui';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
-import { audio as icon } from '@wordpress/icons';
+import { audio as icon, trash } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { PlaylistContext } from '../playlist/context';
 import { getTrackAttributes, getTrackImageAttributes } from '../playlist/utils';
@@ -49,6 +51,11 @@ const PlaylistTrackEdit = ( {
 	const { currentTrackClientId, setCurrentTrackClientId } =
 		useContext( PlaylistContext );
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { removeBlock } = useDispatch( blockEditorStore );
+	const canRemoveTrack = useSelect(
+		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+		[ clientId ]
+	);
 	function onUploadError( message ) {
 		createErrorNotice( message, { type: 'snackbar' } );
 	}
@@ -155,6 +162,14 @@ const PlaylistTrackEdit = ( {
 					onError={ onUploadError }
 					variant="toolbar"
 				/>
+				{ canRemoveTrack && (
+					<ToolbarButton
+						icon={ trash }
+						label={ __( 'Delete track' ) }
+						onClick={ () => removeBlock( clientId ) }
+						isDestructive
+					/>
+				) }
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a direct toolbar delete action to selected Playlist Track blocks.

## Why?
Deleting playlist tracks currently requires opening the block options menu, which makes a common track-management action harder to discover.

## How?
Uses block-editor `removeBlock` and `canRemoveBlock` in the Playlist Track edit UI, and records the enhancement in the block-library changelog.

## Testing Instructions
1. Open the editor.
2. Insert a Playlist block with at least one track.
3. Select an individual Playlist Track block.
4. Confirm the block toolbar includes a delete track button and that activating it removes the selected track.

### Testing Instructions for Keyboard
1. Use the keyboard to select an individual Playlist Track block.
2. Navigate to the block toolbar.
3. Confirm the delete track button is reachable and removes the selected track when activated.

## Screenshots or screencast <!-- if applicable -->
<img width="708" height="183" alt="Screenshot 2026-08-20 at 15 57 46" src="https://github.com/user-attachments/assets/3bdef957-9921-4fc8-a5aa-1612213ed332" />

## Use of AI Tools

Created with assistance from ChatGPT/Codex; the resulting diff was reviewed before opening this PR.
