### PR TITLE
Accordion: Render collapsed panels as hidden on the server

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   Playlist: Stop sharing the parent "Add track" toolbar control with selected Playlist Track child blocks ([#81432](https://github.com/WordPress/gutenberg/pull/81432)).
 -   Term Description: Apply the term description display filters when rendering with term context inside a Terms Query loop, so multi-paragraph descriptions keep their paragraphs and match the taxonomy archive rendering ([#81290](https://github.com/WordPress/gutenberg/pull/81290)).
 -   Accordion: Resolve the URL fragment with the `:target` pseudo-class instead of decoding `window.location.hash`, so a hash containing malformed percent-encoding no longer throws a `URIError` when a panel is opened ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
+-   Accordion: Render collapsed panels as `hidden` on the server so the page is not laid out with every panel expanded, which shifted the content away from the target of an anchor link ([#81882](https://github.com/WordPress/gutenberg/pull/81882)).
 
 ## 10.4.0 (2026-08-12)
 

--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -18,14 +18,18 @@ function block_core_accordion_item_render( array $attributes, string $content ):
 	$p         = new WP_HTML_Tag_Processor( $content );
 	$unique_id = wp_unique_id( 'accordion-item-' );
 
-	// Initialize the state of the item on the server using a closure,
+	// Initialize the state of the item on the server using closures,
 	// since we need to get derived state based on the current context.
 	wp_interactivity_state(
 		'core/accordion',
 		array(
-			'isOpen' => function () {
+			'isOpen'   => function () {
 				$context = wp_interactivity_get_context();
 				return $context['openByDefault'];
+			},
+			'isHidden' => function () {
+				$context = wp_interactivity_get_context();
+				return $context['openByDefault'] ? null : 'until-found';
 			},
 		)
 	);

--- a/packages/block-library/src/accordion/view.js
+++ b/packages/block-library/src/accordion/view.js
@@ -4,23 +4,22 @@ import { store, getContext } from '@wordpress/interactivity';
 // This is used to prevent the hash from being handled multiple times.
 let hashHandled = false;
 
-const { actions } = store(
+const { state, actions } = store(
 	'core/accordion',
 	{
 		state: {
 			get isOpen() {
-				const { id, accordionItems } = getContext();
+				const { id, accordionItems, openByDefault } = getContext();
 				const accordionItem = accordionItems.find(
 					( item ) => item.id === id
 				);
-				return accordionItem ? accordionItem.isOpen : false;
+				// Until the item registers itself on init, fall back to the
+				// initial state so hydration matches the server-rendered
+				// markup and no layout shift occurs.
+				return accordionItem ? accordionItem.isOpen : openByDefault;
 			},
 			get isHidden() {
-				const { id, accordionItems } = getContext();
-				const accordionItem = accordionItems.find(
-					( item ) => item.id === id
-				);
-				return accordionItem?.isOpen ? null : 'until-found';
+				return state.isOpen ? null : 'until-found';
 			},
 		},
 		actions: {

--- a/phpunit/blocks/render-block-accordion-test.php
+++ b/phpunit/blocks/render-block-accordion-test.php
@@ -108,4 +108,50 @@ class Tests_Blocks_Render_Accordion extends WP_UnitTestCase {
 
 		$this->assertFalse( $processor->next_tag( array( 'className' => 'wp-block-accordion' ) ) );
 	}
+
+	/**
+	 * Collapsed panels must be hidden in the server-rendered markup, otherwise the
+	 * browser lays the page out with every panel expanded and the subsequent
+	 * client-side collapse shifts the content out from under the anchor target.
+	 *
+	 * @covers ::block_core_accordion_item_render
+	 */
+	public function test_should_hide_collapsed_panels_in_server_rendered_markup(): void {
+		$accordion_block = <<<'BLOCK_CONTENT'
+			<!-- wp:accordion -->
+			<div role="group" class="wp-block-accordion"><!-- wp:accordion-item -->
+			<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
+			<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Closed</span></button></h3>
+			<!-- /wp:accordion-heading -->
+
+			<!-- wp:accordion-panel -->
+			<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
+			<p>Closed panel content</p>
+			<!-- /wp:paragraph --></div>
+			<!-- /wp:accordion-panel --></div>
+			<!-- /wp:accordion-item -->
+
+			<!-- wp:accordion-item {"openByDefault":true} -->
+			<div class="wp-block-accordion-item is-open"><!-- wp:accordion-heading -->
+			<h3 class="wp-block-accordion-heading"><button type="button" class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Open</span></button></h3>
+			<!-- /wp:accordion-heading -->
+
+			<!-- wp:accordion-panel -->
+			<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
+			<p>Open panel content</p>
+			<!-- /wp:paragraph --></div>
+			<!-- /wp:accordion-panel --></div>
+			<!-- /wp:accordion-item --></div>
+			<!-- /wp:accordion -->
+		BLOCK_CONTENT;
+
+		$rendered_block = do_blocks( $accordion_block );
+
+		$processor = new WP_HTML_Tag_Processor( $rendered_block );
+		$this->assertTrue( $processor->next_tag( array( 'class_name' => 'wp-block-accordion-panel' ) ) );
+		$this->assertSame( 'until-found', $processor->get_attribute( 'hidden' ), 'Expected the collapsed panel to be rendered with hidden="until-found".' );
+
+		$this->assertTrue( $processor->next_tag( array( 'class_name' => 'wp-block-accordion-panel' ) ) );
+		$this->assertNull( $processor->get_attribute( 'hidden' ), 'Expected the panel opened by default not to be rendered as hidden.' );
+	}
 }

--- a/test/e2e/specs/editor/blocks/accordion.spec.js
+++ b/test/e2e/specs/editor/blocks/accordion.spec.js
@@ -235,4 +235,59 @@ test.describe( 'Accordion', () => {
 		await expect( accordionPanel ).toBeVisible();
 		await expect( targetParagraph ).toBeInViewport();
 	} );
+
+	test( 'should scroll to an anchor target below the accordion', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a tall spacer block to ensure anchor scrolling behaves as expected.
+		await editor.insertBlock( {
+			name: 'core/spacer',
+			attributes: { height: '1000px' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/accordion',
+			innerBlocks: [
+				{
+					name: 'core/accordion-item',
+					innerBlocks: [
+						{
+							name: 'core/accordion-heading',
+							attributes: { title: 'Accordion Title' },
+						},
+						{
+							name: 'core/accordion-panel',
+							innerBlocks: [
+								{
+									name: 'core/spacer',
+									attributes: { height: '2000px' },
+								},
+							],
+						},
+					],
+				},
+			],
+		} );
+		// The anchor target sits after the accordion, so collapsing the panel
+		// after the page has been laid out would move it out of the viewport.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { anchor: 'target', content: 'Target' },
+		} );
+		// Keep the page scrollable past the target, so the browser cannot clamp
+		// the scroll position back to the target when the page gets shorter.
+		await editor.insertBlock( {
+			name: 'core/spacer',
+			attributes: { height: '3000px' },
+		} );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }#target` );
+
+		const accordionPanel = page.getByRole( 'region', {
+			name: 'Accordion Title',
+		} );
+		await expect( accordionPanel ).toBeHidden();
+		await expect( page.locator( '#target' ) ).toBeInViewport();
+	} );
 } );


### PR DESCRIPTION

## What?

Closes #81869. 

Renders collapsed Accordion panels as `hidden` in the server output, so navigating to a URL with an anchor no longer lands the viewport in the wrong place.

## Why?

The Accordion Panel binds its `hidden` attribute to `state.isHidden`:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/accordion-item/index.php

but `isHidden` is only defined in the client store. `wp_interactivity_state()` registers `isOpen` and nothing else, so server-side `data_wp_bind_processor` evaluates the binding to `null` and removes the attribute. Every panel is sent to the browser expanded.

That gives this sequence on load:

1. The browser lays out the page with all panel content expanded and scrolls to the fragment.
2. Interactivity hydration sets `hidden="until-found"` on the collapsed panels.
3. The page shrinks by the height of that content and the target slides out of the viewport.

#73357 already handles an anchor *inside* a panel, which is why this went unnoticed, the reported case is a target that sits **below** the accordion, where no panel claims the hash.

## How?

- Register `isHidden` alongside `isOpen` in `wp_interactivity_state()`, returning   `'until-found'` for collapsed items and `null` for open ones, so the attribute is present in   the initial HTML.
- Fall back to `openByDefault` in the client `isOpen` getter. The item is not pushed into   `accordionItems` until the `data-wp-init` effect runs, so during hydration the getter reported every item as closed, which would now re-hide panels that were open by default. With the fallback the hydrated state matches the server markup exactly and the DOM does not
  change on load.
- `isHidden` derives from `isOpen` rather than repeating the lookup.

## Testing Instructions

1. Create a page with, in order: a 1000px Spacer; an Accordion with one **collapsed** item whose panel contains a 2000px Spacer; a paragraph with the HTML anchor `target`; a 3000px Spacer.
2. Publish and open `<page-url>#target` in a new tab.
3. The viewport should land on the "target" paragraph. On trunk it lands well past it.

Also confirm the existing behaviour still holds:

- An anchor pointing *inside* a collapsed panel still opens that panel and scrolls to it.
- Items with **Open by default** enabled are still expanded on load, with no flash of the panel closing and reopening.
- Toggling panels, and `autoclose`, work as before.
