### PR TITLE
Cache the theme.json data merged from all origins

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1011,8 +1011,6 @@ function gutenberg_unique_id_from_values( array $data, string $prefix = '' ): st
  * @return string                Filtered block content.
  */
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
-	static $global_styles = null;
-
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
 	$style_attr            = gutenberg_resolve_style_state_aliases(
@@ -1229,10 +1227,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check style variation first, then block-specific styles, then fall back to root styles.
-		$block_name = $block['blockName'] ?? '';
-		if ( null === $global_styles ) {
-			$global_styles = gutenberg_get_global_styles();
-		}
+		$block_name    = $block['blockName'] ?? '';
+		$global_styles = gutenberg_get_global_styles();
 
 		// Check if the block has an active style variation with a blockGap value.
 		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -27,11 +27,22 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @var array
 	 */
 	protected static $blocks_cache = array(
-		'core'   => array(),
-		'blocks' => array(),
-		'theme'  => array(),
-		'user'   => array(),
+		'core'           => array(),
+		'blocks'         => array(),
+		'theme'          => array(),
+		'user'           => array(),
+		'merged_default' => array(),
+		'merged_blocks'  => array(),
+		'merged_theme'   => array(),
+		'merged_custom'  => array(),
 	);
+
+	/**
+	 * Container for the data merged from multiple origins, keyed by origin.
+	 *
+	 * @var array
+	 */
+	protected static $merged = array();
 
 	/**
 	 * Container for data coming from core.
@@ -602,24 +613,58 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
+		if ( ! in_array( $origin, array( 'default', 'blocks', 'theme', 'custom' ), true ) ) {
+			$origin = 'custom';
+		}
+
+		/*
+		 * The merged result is memoized per origin and refreshed when the set
+		 * of registered blocks changes, the same way each of the origins it
+		 * merges already is.
+		 */
+		if (
+			isset( static::$merged[ $origin ] ) &&
+			static::has_same_registered_blocks( 'merged_' . $origin )
+		) {
+			return clone static::$merged[ $origin ];
+		}
+
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( static::get_core_data() );
 		if ( 'default' === $origin ) {
-			return $result;
+			return static::cache_merged_data( $origin, $result );
 		}
 
 		$result->merge( static::get_block_data() );
 		if ( 'blocks' === $origin ) {
-			return $result;
+			return static::cache_merged_data( $origin, $result );
 		}
 
 		$result->merge( static::get_theme_data() );
 		if ( 'theme' === $origin ) {
-			return $result;
+			return static::cache_merged_data( $origin, $result );
 		}
 
 		$result->merge( static::get_user_data() );
-		return $result;
+		return static::cache_merged_data( $origin, $result );
+	}
+
+	/**
+	 * Stores the merged data for an origin and returns a copy of it.
+	 *
+	 * A copy is returned because callers are free to modify the result. In
+	 * particular {@see WP_Theme_JSON_Gutenberg::resolve_variables()} modifies
+	 * the object it is passed, and before this data was memoized every call
+	 * returned its own instance.
+	 *
+	 * @param string                 $origin     Origin the data was merged for.
+	 * @param WP_Theme_JSON_Gutenberg $theme_json Merged data.
+	 * @return WP_Theme_JSON_Gutenberg Copy of the merged data.
+	 */
+	protected static function cache_merged_data( $origin, $theme_json ) {
+		static::$merged[ $origin ] = $theme_json;
+
+		return clone $theme_json;
 	}
 
 	/**
@@ -693,11 +738,16 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		static::$core                     = null;
 		static::$blocks                   = null;
 		static::$blocks_cache             = array(
-			'core'   => array(),
-			'blocks' => array(),
-			'theme'  => array(),
-			'user'   => array(),
+			'core'           => array(),
+			'blocks'         => array(),
+			'theme'          => array(),
+			'user'           => array(),
+			'merged_default' => array(),
+			'merged_blocks'  => array(),
+			'merged_theme'   => array(),
+			'merged_custom'  => array(),
 		);
+		static::$merged                   = array();
 		static::$theme                    = null;
 		static::$user                     = null;
 		static::$user_custom_post_type_id = null;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -307,8 +307,6 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
-	static $global_styles = null;
-
 	// In dynamic mode the gallery's images are resolved at render time instead of
 	// being authored as inner blocks, so `save.js` persists at most the
 	// gallery-level caption — a bare `<figcaption>`, or nothing when there is no
@@ -402,9 +400,7 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 	// gap on the gallery.
 	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
 
-	if ( null === $global_styles ) {
-		$global_styles = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
-	}
+	$global_styles = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
 
 	$global_gallery_styles = $global_styles['blocks']['core/gallery'] ?? array();
 	$global_gallery_gap    = $global_gallery_styles['spacing']['blockGap'] ?? $fallback_gap;

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1448,4 +1448,90 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $actual, 'Merged variation styles do not match.' );
 	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_returns_a_separate_instance_per_call() {
+		$first  = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$second = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+
+		$this->assertNotSame( $first, $second, 'Each call should return its own instance.' );
+		$this->assertSameSetsWithIndex(
+			$first->get_raw_data(),
+			$second->get_raw_data(),
+			'Repeated calls should return equivalent data.'
+		);
+	}
+
+	/**
+	 * Callers are free to modify the returned data. WP_Theme_JSON_Gutenberg::resolve_variables()
+	 * does exactly that, so a modification must not be observable by the next caller.
+	 *
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_is_not_affected_by_modifying_the_result() {
+		/*
+		 * A theme with presets is required: resolving variables is a no-op when
+		 * the active theme's styles contain no variable references, which would
+		 * leave this test asserting nothing.
+		 */
+		switch_theme( 'twentytwentyfour' );
+
+		$before   = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+		$resolved = WP_Theme_JSON_Gutenberg::resolve_variables( WP_Theme_JSON_Resolver_Gutenberg::get_merged_data() )->get_raw_data();
+
+		$this->assertNotEquals(
+			$before['styles'],
+			$resolved['styles'],
+			'Resolving variables should change the styles, otherwise this test asserts nothing.'
+		);
+
+		$this->assertSameSetsWithIndex(
+			$before,
+			WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data(),
+			'Resolving variables should not affect subsequent calls.'
+		);
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_reflects_blocks_registered_after_a_previous_call() {
+		WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+
+		register_block_type(
+			'test/block-gap',
+			array(
+				'supports' => array(
+					'__experimentalStyle' => array(
+						'spacing' => array( 'blockGap' => '77px' ),
+					),
+				),
+			)
+		);
+
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data()['styles'];
+
+		unregister_block_type( 'test/block-gap' );
+
+		$this->assertSame(
+			'77px',
+			$styles['blocks']['test/block-gap']['spacing']['blockGap'] ?? null,
+			'Data for a block registered after a previous call should be present.'
+		);
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data
+	 */
+	public function test_clean_cached_data_refreshes_merged_data() {
+		switch_theme( 'block-theme' );
+		$before = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+
+		switch_theme( 'default' );
+		$after = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+
+		$this->assertNotEquals( $before, $after, 'Switching themes should refresh the merged data.' );
+	}
 }


### PR DESCRIPTION
> [!WARNING]
> **Draft / prototype.** Opened for discussion of the approach, not for merge. See [Status](#status) for exactly what has and has not been validated.

## What

`WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` constructs a new `WP_Theme_JSON_Gutenberg` and merges four origins on **every** call. Each origin is already memoized and refreshed when the registered blocks change (`has_same_registered_blocks()`, from [WordPress/wordpress-develop@r54493](https://core.trac.wordpress.org/changeset/54493)); only the merge on top of them is not. It costs ~0.3ms per call.

This memoizes the merged result per origin behind that same guard, resets it in `clean_cached_data()`, and returns a copy on each call.

## Why callers keep working around this

Two render paths memoize the result in a function-static that nothing can invalidate:

- `gutenberg_render_layout_support_flag()` — `lib/block-supports/layout.php` (from #74828)
- `block_core_gallery_render()` — `packages/block-library/src/gallery/index.php` (from #80030)

Consequences of an uninvalidatable static: a layout rendered after `switch_theme()` keeps the previous `blockGap` for the rest of the request; `wp_is_development_mode( 'theme' )` is ignored, so theme developers see stale gaps; and the value is not scoped per site on multisite. Both statics are removed here.

The pattern is spreading — #80030's review explicitly recommended copying it from `layout.php` — which is the real motivation for fixing the layer underneath rather than each caller.

## Why here rather than in `gutenberg_get_global_styles()`

`gutenberg_get_global_styles()` is the only `theme_json`-group accessor without an object cache, and adding one there was the obvious alternative. Two reasons this is better:

1. **It covers every consumer**, not just the three callers of `gutenberg_get_global_styles()`. Notably `gutenberg_render_block_style_variation_support_styles()` runs on `render_block_data` for **every block carrying an `is-style-*` class** and calls `get_merged_data()` directly — an accessor-level cache does nothing for it.
2. **It keeps the existing invalidation rules.** An accessor cache sits *in front of* `has_same_registered_blocks()` and defeats it, so a block registered after first access would no longer be reflected. It would also add four more keys to the hand-maintained list in `_gutenberg_clean_theme_json_caches()` — the accretion [spacedmonkey warned about on #45372](https://github.com/WordPress/gutenberg/pull/45372#discussion_r1031920217).

I prototyped both and measured them; numbers below.

## Why a copy is returned

Callers are free to modify the result, and `WP_Theme_JSON_Gutenberg::resolve_variables()` modifies the object it is passed. Before memoization every call received its own instance, so returning the shared one would be a behaviour change. `WP_Theme_JSON_Gutenberg` holds a single array property, so the copy is shallow and copy-on-write makes it effectively free (~20ns). A test covers this, and it fails if the `clone` is removed.

## Numbers

1,000 iterations, median of five runs:

| | before | after |
| --- | --- | --- |
| `get_merged_data()` | 286.78ms | 0.36ms |
| `wp_get_global_styles()` | 284.34ms | 0.42ms |
| `render_block_data` variation path | 282.25ms | 0.54ms |
| `wp_render_layout_support_flag()` | 14.63ms | 15.19ms |

The render path pays ~0.6µs per call for the guard plus copy, which is what the removed static was buying.

## Status

**Measured and tested against the equivalent change in `wordpress-develop` trunk, not in this repo.** The two implementations are line-for-line equivalent modulo the `_Gutenberg` suffixes, but that is a proxy and should not be taken as validation of this branch.

What was verified there:

- Full single-site suite: 30,875 tests — failure set **identical** to trunk.
- Full multisite suite: 31,675 tests — failure set **identical** to trunk (an initial run showed 3 extra `wp_http_validate_url` failures; they did not reproduce and pass in isolation on both sides — DNS flakes).
- The four new tests pass on trunk as well as with the change, since this is behaviour-preserving; they are invariant guards. The mutation-isolation one fails if `clone` is removed, verified.
- WordPress PHPCS clean.

Not yet done:

- This branch's own PHPUnit run.
- E2E / performance CI.
- A `changelog` entry.

Also worth flagging: an earlier version of one test silently asserted nothing, because `resolve_variables()` is a no-op under the test suite's default theme. It now switches to a theme with presets and asserts the resolution actually changed something before checking isolation. Reviewers may want the same guard applied elsewhere.

## Open questions

- Is memoizing per origin at this layer acceptable, or is there a reason the merge was deliberately left uncached that I have not found? I looked and found none — [#45171](https://github.com/WordPress/gutenberg/issues/45171) listed "`wp_get_global_styles`: add object cache. Needs PR" in 2022 and it was simply never picked up — but absence of evidence is not proof.
- `has_same_registered_blocks()` detects block *additions* only, not removals. This inherits that; it does not make it worse.
- If this is directionally right, the same change is needed in `wordpress-develop`, and #62794 overlaps in intent (though it takes a different approach — a persistent site transient).
