### PR TITLE
Core Data: Discard entity list responses superseded by a newer request

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#81809](https://github.com/WordPress/gutenberg/pull/81809)).
 -   Allow keyless entities to be addressed without a record ID in the entity record selectors and actions ([#81857](https://github.com/WordPress/gutenberg/pull/81857)).
 -   `getEntityRecord`: Discard a REST response that is delivered after a newer response for the same request. Invalidating a resolution starts a second request while the first may still be in flight, and the store kept whichever one arrived last, so a record read from the database before an update could overwrite the updated one ([#81846](https://github.com/WordPress/gutenberg/pull/81846)).
+-   `getEntityRecords`: Discard a list response that is delivered after a newer response for the same query, so a list read from the database before an update — as happens when a batch upload invalidates the attachment list once per file — can no longer replace a fresher one, overwrite the records it contains, or mark their resolutions finished ([#81888](https://github.com/WordPress/gutenberg/pull/81888)).
 
 ### Internal
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#81809](https://github.com/WordPress/gutenberg/pull/81809)).
 -   Allow keyless entities to be addressed without a record ID in the entity record selectors and actions ([#81857](https://github.com/WordPress/gutenberg/pull/81857)).
 -   `getEntityRecord`: Discard a REST response that is delivered after a newer response for the same request. Invalidating a resolution starts a second request while the first may still be in flight, and the store kept whichever one arrived last, so a record read from the database before an update could overwrite the updated one ([#81846](https://github.com/WordPress/gutenberg/pull/81846)).
--   `getEntityRecords`: Discard a list response that is delivered after a newer response for the same query, so a list read from the database before an update — as happens when a batch upload invalidates the attachment list once per file — can no longer replace a fresher one, overwrite the records it contains, or mark their resolutions finished ([#81888](https://github.com/WordPress/gutenberg/pull/81888)).
+-   `getEntityRecords`: Discard a list response that is delivered after a newer response for the same query, so a list read from the database before an update — as happens when a batch upload invalidates the attachment list once per file — can no longer replace a fresher one, overwrite the records it contains, or mark their resolutions finished ([#81886](https://github.com/WordPress/gutenberg/pull/81886)).
 
 ### Internal
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -21,25 +21,28 @@ import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
 import { setCachedBlocks } from './parsed-blocks-cache';
 
 /**
- * Sequence number handed to each record request, and the highest sequence
- * number whose response has already been written to the store, per registry
- * and per resolution.
+ * Sequence number handed to each record or list request, and the highest
+ * sequence number whose response has already been written to the store, per
+ * registry and per resolution.
  */
 let responseSequence = 0;
 const lastReceivedResponse = new WeakMap();
 
 /**
- * Reserves a slot in the response order for a record request that is about to
- * be made, and returns a predicate telling whether that request's response is
- * still the freshest one for the same resolution.
+ * Reserves a slot in the response order for a record or list request that is
+ * about to be made, and returns a predicate telling whether that request's
+ * response is still the freshest one for the same resolution.
  *
- * `invalidateResolution` starts a second request for a record while the first
- * one may still be in flight, and the store keeps whichever response is
- * *delivered* last - even when its body was read from the database before the
- * newer one. Client-side media uploads hit this: the record fetched while
+ * `invalidateResolution` starts a second request for a record or a list while
+ * the first one may still be in flight, and the store keeps whichever response
+ * is *delivered* last - even when its body was read from the database before
+ * the newer one. Client-side media uploads hit this: the record fetched while
  * sub-sizes are still being generated carries an empty `media_details.sizes`,
- * and when it lands after the post-upload refetch it hides the sizes again.
- * See https://github.com/WordPress/gutenberg/issues/81844.
+ * and when it lands after the post-upload refetch it hides the sizes again;
+ * likewise a batch upload invalidates the attachment list once per file, and a
+ * list read before an upload could replace the refetched one that already
+ * contains it. See https://github.com/WordPress/gutenberg/issues/81844 and
+ * https://github.com/WordPress/gutenberg/issues/81885.
  *
  * Only responses to an identical request are compared, so a request for a
  * different set of `_fields` never discards another one's data.
@@ -448,6 +451,11 @@ export const getEntityRecords =
 		const rawQuery = { ...query };
 		const key = entityConfig.key || DEFAULT_ENTITY_KEY;
 
+		const isFreshestResponse = claimResponseOrder(
+			registry,
+			JSON.stringify( [ kind, name, rawQuery ] )
+		);
+
 		function getResolutionsArgs( records, recordsQuery ) {
 			const normalizedQuery = normalizeQueryForResolution( recordsQuery );
 			return records
@@ -541,6 +549,15 @@ export const getEntityRecords =
 						};
 					}
 
+					// A response to the same query has been received since
+					// this run's last delivery, so its remaining pages are
+					// known to be out of date. The pages it already delivered
+					// were overwritten by that newer response.
+					if ( ! isFreshestResponse() ) {
+						dispatch.__unstableReleaseStoreLock( lock );
+						return;
+					}
+
 					records.push( ...pageRecords );
 					registry.batch( () => {
 						dispatch.receiveEntityRecords(
@@ -565,6 +582,16 @@ export const getEntityRecords =
 					totalItems: records.length,
 					totalPages: 1,
 				};
+			}
+
+			// A response to the same query has already been received since
+			// this one was made, so these records are known to be out of
+			// date. Discarding them also keeps the stale list from writing
+			// its records over fresher individual ones and from marking
+			// their resolutions finished below.
+			if ( ! isFreshestResponse() ) {
+				dispatch.__unstableReleaseStoreLock( lock );
+				return;
 			}
 
 			if ( entityConfig.syncConfig && -1 === query.per_page ) {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -982,6 +982,229 @@ describe( 'getEntityRecords', () => {
 			expect.objectContaining( { totalItems: 5, totalPages: 1 } )
 		);
 	} );
+
+	it( 'ignores a list response delivered after a newer one for the same query', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			receiveUserPermissions: jest.fn(),
+			finishResolutions: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
+
+		const STALE_RECORDS = [ { id: 1 } ];
+		const FRESH_RECORDS = [ { id: 1 }, { id: 2 } ];
+		const QUERY = { media_type: 'image' };
+
+		let deliverStaleResponse;
+		const staleResponseGate = new Promise( ( resolve ) => {
+			deliverStaleResponse = resolve;
+		} );
+
+		const headers = new Map( [
+			[ 'X-WP-Total', '2' ],
+			[ 'X-WP-TotalPages', '1' ],
+		] );
+		triggerFetch
+			.mockImplementationOnce( () => ( {
+				json: () => staleResponseGate.then( () => STALE_RECORDS ),
+				headers,
+			} ) )
+			.mockImplementationOnce( () => ( {
+				json: () => Promise.resolve( FRESH_RECORDS ),
+				headers,
+			} ) );
+
+		// A first request is made and stays in flight...
+		const staleRequest = getEntityRecords(
+			'postType',
+			'attachment',
+			QUERY
+		)( { dispatch, registry, resolveSelect } );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		// ...while the resolution is invalidated and requested again.
+		await getEntityRecords(
+			'postType',
+			'attachment',
+			QUERY
+		)( { dispatch, registry, resolveSelect } );
+
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			FRESH_RECORDS,
+			QUERY,
+			false,
+			undefined,
+			{ totalItems: 2, totalPages: 1 }
+		);
+
+		// The late response must not overwrite the list received since,
+		// nor rewrite its records' individual resolutions.
+		deliverStaleResponse();
+		await staleRequest;
+
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.finishResolutions ).toHaveBeenCalledTimes( 1 );
+
+		// The lock is still released for the discarded request.
+		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
+			2
+		);
+	} );
+
+	it( 'does not discard a list response because a different query was received', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			receiveUserPermissions: jest.fn(),
+			finishResolutions: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
+
+		const IMAGES = [ { id: 1 } ];
+		const VIDEOS = [ { id: 2 } ];
+
+		let deliverImagesResponse;
+		const imagesResponseGate = new Promise( ( resolve ) => {
+			deliverImagesResponse = resolve;
+		} );
+
+		const headers = new Map( [
+			[ 'X-WP-Total', '1' ],
+			[ 'X-WP-TotalPages', '1' ],
+		] );
+		triggerFetch
+			.mockImplementationOnce( () => ( {
+				json: () => imagesResponseGate.then( () => IMAGES ),
+				headers,
+			} ) )
+			.mockImplementationOnce( () => ( {
+				json: () => Promise.resolve( VIDEOS ),
+				headers,
+			} ) );
+
+		// One query's request stays in flight while another one completes.
+		const imagesRequest = getEntityRecords( 'postType', 'attachment', {
+			media_type: 'image',
+		} )( { dispatch, registry, resolveSelect } );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		await getEntityRecords( 'postType', 'attachment', {
+			media_type: 'video',
+		} )( { dispatch, registry, resolveSelect } );
+
+		deliverImagesResponse();
+		await imagesRequest;
+
+		// Lists are only superseded by a newer response for the same query,
+		// so both are received.
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 2 );
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			VIDEOS,
+			{ media_type: 'video' },
+			false,
+			undefined,
+			{ totalItems: 1, totalPages: 1 }
+		);
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			IMAGES,
+			{ media_type: 'image' },
+			false,
+			undefined,
+			{ totalItems: 1, totalPages: 1 }
+		);
+	} );
+
+	it( 'stops delivering intermediate pages once a newer response for the same query arrives', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			finishResolutions: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+		} );
+
+		const QUERY = { per_page: -1, [ RECEIVE_INTERMEDIATE_RESULTS ]: true };
+
+		let deliverStalePage;
+		const stalePageGate = new Promise( ( resolve ) => {
+			deliverStalePage = resolve;
+		} );
+
+		triggerFetch
+			// The stale run's first page, delivered normally.
+			.mockImplementationOnce( () => ( {
+				json: () => Promise.resolve( [ { id: 1 } ] ),
+				headers: new Map( [
+					[ 'X-WP-Total', '2' ],
+					[ 'X-WP-TotalPages', '2' ],
+				] ),
+			} ) )
+			// The stale run's second page, held in flight.
+			.mockImplementationOnce( () =>
+				stalePageGate.then( () => ( {
+					json: () => Promise.resolve( [ { id: 2 } ] ),
+					headers: new Map( [
+						[ 'X-WP-Total', '2' ],
+						[ 'X-WP-TotalPages', '2' ],
+					] ),
+				} ) )
+			)
+			// The fresh run's single page.
+			.mockImplementationOnce( () => ( {
+				json: () => Promise.resolve( [ { id: 10 } ] ),
+				headers: new Map( [
+					[ 'X-WP-Total', '1' ],
+					[ 'X-WP-TotalPages', '1' ],
+				] ),
+			} ) );
+
+		// A first progressive run delivers its first page, then parks on the
+		// second one...
+		const staleRequest = getEntityRecords(
+			'postType',
+			'attachment',
+			QUERY
+		)( { dispatch, registry, resolveSelect } );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		// ...while the resolution is invalidated and a newer run completes.
+		await getEntityRecords(
+			'postType',
+			'attachment',
+			QUERY
+		)( { dispatch, registry, resolveSelect } );
+
+		const callsBeforeStalePage =
+			dispatch.receiveEntityRecords.mock.calls.length;
+
+		// The stale run's remaining pages must not be delivered.
+		deliverStalePage();
+		await staleRequest;
+
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes(
+			callsBeforeStalePage
+		);
+		expect( dispatch.receiveEntityRecords ).toHaveBeenLastCalledWith(
+			'postType',
+			'attachment',
+			[ { id: 10 } ],
+			QUERY,
+			false,
+			undefined,
+			expect.objectContaining( { totalItems: 1, totalPages: 1 } )
+		);
+
+		// The lock is still released for the superseded run.
+		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
+			2
+		);
+	} );
 } );
 
 describe( 'taxonomy pagination', () => {

--- a/test/e2e/specs/editor/various/entity-records-response-order.spec.js
+++ b/test/e2e/specs/editor/various/entity-records-response-order.spec.js
@@ -1,0 +1,147 @@
+const path = require( 'path' );
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/*
+ * The exact query the inserter's Media tab resolves for its "Images" source:
+ * `per_page` and `search` come from the media panel, `media_type` and
+ * `orderBy` are added by the editor's core media category. The test resolves
+ * the same query so it races (and asserts) the same cached resolution the
+ * panel reads.
+ */
+const IMAGES_QUERY = {
+	per_page: 20,
+	search: '',
+	media_type: 'image',
+	orderBy: 'date',
+};
+
+test.describe( 'Entity records response order', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test( 'keeps a fresher attachment list over a stale response delivered late', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		/*
+		 * Regression test for https://github.com/WordPress/gutenberg/issues/81885.
+		 *
+		 * `invalidateResolution` starts a second request for the same list
+		 * while the first may still be in flight, and the store used to keep
+		 * whichever response was *delivered* last. Batch uploads invalidate
+		 * the attachment list once per file, so a list read before an upload
+		 * finished could be delivered after the refetch that already contains
+		 * the new attachment, and silently hide it everywhere the list is
+		 * shown.
+		 *
+		 * Simulate that worst-case ordering deterministically: hold the first
+		 * list request's response (reading its stale body immediately),
+		 * upload a new image, let a refetch deliver a fresher list, and only
+		 * then deliver the stale one.
+		 */
+		await admin.createNewPost();
+
+		const LIST_REQUEST_MATCHER = /wp\/v2\/media\?.*media_type=image/;
+
+		let holding = false;
+		let staleBodyRead = () => {};
+		const staleBodyReadGate = new Promise( ( resolve ) => {
+			staleBodyRead = resolve;
+		} );
+		let releaseStaleResponse = () => {};
+		const staleResponseGate = new Promise( ( resolve ) => {
+			releaseStaleResponse = resolve;
+		} );
+		let staleResponseDelivered = Promise.resolve();
+
+		await page.route( LIST_REQUEST_MATCHER, async ( route ) => {
+			if ( route.request().method() !== 'GET' || holding ) {
+				await route.continue();
+				return;
+			}
+			holding = true;
+			// Read the (stale) body now, deliver it later.
+			const response = await route.fetch();
+			const body = await response.body();
+			staleBodyRead();
+			staleResponseDelivered = ( async () => {
+				await staleResponseGate;
+				await route.fulfill( { response, body } );
+			} )();
+			await staleResponseDelivered;
+		} );
+
+		// Start resolving the attachment list; its response stays in flight,
+		// with a body read before the upload below exists.
+		await page.evaluate( ( query ) => {
+			window.wp.data
+				.resolveSelect( 'core' )
+				.getEntityRecords( 'postType', 'attachment', query );
+		}, IMAGES_QUERY );
+		await staleBodyReadGate;
+
+		// A new image is uploaded while that response is held.
+		const media = await requestUtils.uploadMedia(
+			path.join(
+				__dirname,
+				'..',
+				'..',
+				'..',
+				'assets',
+				'10x10_e2e_test_image_z9T8jK.png'
+			)
+		);
+
+		// The upload invalidates the list, and the refetch delivers a
+		// fresher response that already contains the new attachment.
+		await page.evaluate( async ( query ) => {
+			window.wp.data
+				.dispatch( 'core' )
+				.invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'attachment',
+					query,
+				] );
+			await window.wp.data
+				.resolveSelect( 'core' )
+				.getEntityRecords( 'postType', 'attachment', query );
+		}, IMAGES_QUERY );
+
+		const listContainsUpload = () =>
+			page.evaluate(
+				( { query, id } ) =>
+					!! window.wp.data
+						.select( 'core' )
+						.getEntityRecords( 'postType', 'attachment', query )
+						?.some( ( record ) => record.id === id ),
+				{ query: IMAGES_QUERY, id: media.id }
+			);
+
+		await expect.poll( listContainsUpload ).toBe( true );
+
+		// Deliver the stale response last and wait until the page has fully
+		// received it. The bounded wait lets the page finish processing the
+		// late response; the assertions below then check that it had no
+		// lasting effect.
+		releaseStaleResponse();
+		await staleResponseDelivered;
+		await new Promise( ( resolve ) => setTimeout( resolve, 1500 ) );
+
+		// The stale list must not replace the fresher one…
+		expect( await listContainsUpload() ).toBe( true );
+
+		// …so the inserter's Media tab still shows the uploaded image.
+		await page.getByLabel( 'Block Inserter' ).click();
+		await page.getByRole( 'tab', { name: 'Media' } ).click();
+		await page.getByRole( 'tab', { name: 'Images', exact: true } ).click();
+		await expect( page.getByLabel( media.title.raw ) ).toBeVisible();
+
+		await page.unroute( LIST_REQUEST_MATCHER );
+	} );
+} );


### PR DESCRIPTION
[![Test this PR in WordPress Playground](https://img.shields.io/badge/Test%20in-WordPress%20Playground-3858e9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=81886)

_Claude took on the follow-up it flagged in #81846, fix and tests below:_

Fixes https://github.com/WordPress/gutenberg/issues/81885

> [!NOTE]
> Stacked on #81846, which must land first - only the last two commits here are new.

## What?

`getEntityRecords` now discards a list response once a newer response for the same query has already been received - the list counterpart of the record guard added in #81846.

## Why?

`invalidateResolution` starts a second request for the same list while the first may still be in flight, and the store keeps whichever response is **delivered** last. A list read from the database before an update can therefore replace the refetched one that already reflects it - and nothing invalidates it afterwards.

Batch uploads are where this bites. Uploading several files at once invalidates the attachment list once per file, so several list refetches are in flight together, and the odds of one arriving out of order grow with every extra file. A stale one delivered late makes an already-uploaded image vanish from the inserter's Media tab.

The damage also reaches past the list itself. The resolver writes every record it received through `receiveEntityRecords` and ends by calling `finishResolutions( 'getEntityRecord', ... )` for each of them, so a stale list response can overwrite fresher *individual* records and mark their resolutions finished. That write never goes through the `getEntityRecord` resolver, so the per-record guard from #81846 cannot catch it.

As with #81846: Playground serializes PHP requests, so responses cannot arrive out of order there - this only reproduces on real installations.

## How?

The same mechanism as #81846 - reserve a sequence number before the request goes out, and drop the response once a newer one for the same query has been received. `getEntityRecords` needed three decisions on top of that:

- **One guard covers all three fetch branches.** The paginated, progressive, and plain branches all funnel into a single check placed before the store writes, so the trailing `finishResolutions` and `receiveUserPermissions` calls are covered along with the list write.
- **A superseded progressive run stops mid-loop.** Progressive loading dispatches `receiveEntityRecords` per page, so each page checks the guard before delivering. Pages a superseded run already delivered were overwritten by the newer response's deliveries, so stopping is enough.
- **The store lock is still released** on every discarded path.

The guard keeps the conservative properties from #81846: only responses to an identical query are compared, so a different `_fields` set or query never discards another one's data, and a newer request that fails discards nothing.

## Testing Instructions

All tests were verified to fail without the change and pass with it.

Unit - the ordering guard across the fetch branches:

```
npm run test:unit -- packages/core-data/src/test/resolvers.js -t "same query"
```

E2e - the race reproduced deterministically against a real editor. It holds the inserter Media tab's attachment list request at the network layer (reading its stale body immediately), uploads a new image while it is held, lets the post-upload refetch deliver a fresher list, and only then delivers the stale one. The fresher list must survive in the store, and the Media tab must keep showing the new upload:

```
npm run test:e2e -- test/e2e/specs/editor/various/entity-records-response-order.spec.js
```

Manual reproduction needs an unlucky response ordering on a busy installation - see the reproduction notes in the issue.

## AI Use

Claude Code did the typing here, I did the asking. I will review and test.
