### PR TITLE
Try caching gutenberg_get_global_styles

### DIFF
--- a/backport-changelog/7.2/13214.md
+++ b/backport-changelog/7.2/13214.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13214
+
+* https://github.com/WordPress/gutenberg/pull/81889

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1011,8 +1011,6 @@ function gutenberg_unique_id_from_values( array $data, string $prefix = '' ): st
  * @return string                Filtered block content.
  */
 function gutenberg_render_layout_support_flag( $block_content, $block ) {
-	static $global_styles = null;
-
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, array( 'layout' ), false ) || block_has_support( $block_type, array( '__experimentalLayout' ), false );
 	$style_attr            = gutenberg_resolve_style_state_aliases(
@@ -1229,10 +1227,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check style variation first, then block-specific styles, then fall back to root styles.
-		$block_name = $block['blockName'] ?? '';
-		if ( null === $global_styles ) {
-			$global_styles = gutenberg_get_global_styles();
-		}
+		$block_name    = $block['blockName'] ?? '';
+		$global_styles = gutenberg_get_global_styles();
 
 		// Check if the block has an active style variation with a blockGap value.
 		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -338,7 +338,7 @@ function gutenberg_add_global_styles_for_blocks() {
 }
 
 /**
- * Private function to clean the caches used by gutenberg_get_global_settings method.
+ * Private function to clean the caches used by the theme JSON APIs.
  *
  * @access private
  */
@@ -347,6 +347,10 @@ function _gutenberg_clean_theme_json_caches() {
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_styles_custom', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_styles_custom_resolved', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_styles_theme', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_styles_theme_resolved', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_custom_css', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_styles_base_custom_css', 'theme_json' );
 	WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
@@ -393,11 +397,22 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 	&& is_array( $context['transforms'] )
 	&& in_array( 'resolve-variables', $context['transforms'], true );
 
-	$merged_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin );
+	$cache_group = 'theme_json';
+	$cache_key   = 'gutenberg_get_global_styles_' . $origin;
 	if ( $resolve_variables ) {
-		$merged_data = WP_Theme_JSON_Gutenberg::resolve_variables( $merged_data );
+		$cache_key .= '_resolved';
 	}
-	$styles = $merged_data->get_raw_data()['styles'];
+	$styles = wp_cache_get( $cache_key, $cache_group );
+
+	if ( false === $styles || WP_DEBUG ) {
+		$merged_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin );
+		if ( $resolve_variables ) {
+			$merged_data = WP_Theme_JSON_Gutenberg::resolve_variables( $merged_data );
+		}
+		$styles = $merged_data->get_raw_data()['styles'];
+		wp_cache_set( $cache_key, $styles, $cache_group );
+	}
+
 	return _wp_array_get( $styles, $path, $styles );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Alternative to #81852; trying to fix the test failures in #68002.

This attempt adds caching directly in `gutenberg_get_global_styles`, similarly to how it works in `gutenberg_get_global_settings`. This means we don't have to save the global styles in a static var in layout, and the cache gets refreshed on theme switch (not refreshing when tests switched themes is the cause of the failure in #68002)

I've pointed this branch at #68002 so we can verify the PHP tests pass on CI, but we can merge it into trunk if we're happy with it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Ensure tests pass on CI

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
Used codex/gpt 5.6 sol.