### PR TITLE
Docs: Align @param tag columns in test/ docblocks

### DIFF
--- a/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/ForbiddenFunctionsAndClassesSniff.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Sniffs/CodeAnalysis/ForbiddenFunctionsAndClassesSniff.php
@@ -65,8 +65,8 @@ final class ForbiddenFunctionsAndClassesSniff implements Sniff {
 	 * Detects whether a given string token represents a function call or class usage.
 	 * It then delegates further processing based on the type of usage detected.
 	 *
-	 * @param File $phpcs_file The file being scanned.
-	 * @param int  $stack_pointer  The position of the current token in the token stack.
+	 * @param File $phpcs_file    The file being scanned.
+	 * @param int  $stack_pointer The position of the current token in the token stack.
 	 */
 	private function process_string_token( File $phpcs_file, $stack_pointer ) {
 		if ( empty( $this->forbidden_functions ) && empty( $this->forbidden_classes ) ) {


### PR DESCRIPTION
## What?

See #81898 — follow-up in the same spirit.

Aligns the type, variable name, and description columns of `@param` tags in PHP docblocks under `test/`, so they follow the [WordPress PHP documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/). 1 files, 2 changed lines.

This is one of four PRs splitting the same cleanup by area (`lib/`, `packages/`, `phpunit/`, `test/`) so each can be reviewed independently. They share no lines and can merge in any order.

## Why?

Across the repo, 60 docblocks had `@param` columns that did not line up, and a further 24 lone `@param` tags carried stray padding (`@param  string $path`):

```php
 * @param float $number The number to clamp.
 * @param float $min   The minimum value.     // one space short
```

The standard asks for the type, `$var`, and description columns to line up within a docblock. `phpcs.xml.dist` does not include `Squiz.Commenting.FunctionComment`, so CI never flagged any of this.

## How?

- Pads the type and `$var` columns to the widest entry in each docblock and normalises separators to a single space.
- Collapses stray padding on lone `@param` tags.
- Re-indents wrapped description lines to follow their new column.
- Removes `@return` padding left orphaned by the above, in the same docblocks.

Deliberately preserved:

- Hash-notation bodies (`{ ... }`) keep their fixed four-space indent rather than tracking the description column.
- Types containing spaces (`array<int, mixed>`, `array{ width?: non-negative-int }`) are kept as written.
- `@return` tags in docblocks this PR does not otherwise touch are left alone, since `@return` aligns independently of `@param`.

A single sniff fixture under `test/php/gutenberg-coding-standards/`. Happy to fold this into the `phpunit/` PR if a separate one is not worth the review overhead.

## Testing Instructions

This is a comment-only change; no runtime behaviour is affected. There is nothing to exercise in the editor.

```bash
vendor/bin/phpcs -s --standard=WordPress-Docs \
  --sniffs=Squiz.Commenting.FunctionComment $(git diff --name-only trunk)
```

Verified on this branch in isolation:

| Check | Result |
|---|---|
| `WordPress-Docs` param-alignment sniffs | 0 violations |
| `vendor/bin/phpcs` (project ruleset) | 0 errors |
| `php -l` on all 1 files | clean |
| `git diff --check` | clean |

The diff is exactly balanced (2 insertions / 2 deletions) and every changed line sits inside a docblock.

### Testing Instructions for Keyboard

N/A — no user interface changes.

## Screenshots or screencast

N/A — no user interface changes.

## Use of AI Tools

This PR was authored with AI assistance (Claude Code). The misalignments were located with a script, the rewrite was applied mechanically by a second script, and the result was verified with `WordPress-Docs` phpcs sniffs, the project `phpcs` ruleset, and `php -l`. I have reviewed the full diff and take responsibility for its contents.

No `CHANGELOG.md` entries added, as these are docblock comments rather than production code changes — happy to add them if preferred.