### PR TITLE
Try adding a Grid block variation to Gallery

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -399,7 +399,7 @@ Display multiple images in a rich gallery.
 -	**Name:** [core/gallery](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/core-block-gallery/)
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Allowed Blocks:** core/image
--	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (allowEditing, allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowJustification~~, ~~allowOrientation~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~, ~~allowWrap~~), listView, spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, aspectRatio, caption, columns, dynamicContent, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, navigationButtonType, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Enhancements
 
 -   Columns: Add transforms between Columns and the Row variation that preserve column widths through flex child sizing controls.
--   Gallery: Add an opt-in Grid layout while preserving the existing Flex layout for current galleries.
+-   Gallery: Add an opt-in Grid layout while preserving the existing Flex layout for current galleries.([#81909](https://github.com/WordPress/gutenberg/pull/81909)).
 
 ### Bug Fixes
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Enhancements
 
 -   Columns: Add transforms between Columns and the Row variation that preserve column widths through flex child sizing controls.
+-   Gallery: Add an opt-in Grid layout while preserving the existing Flex layout for current galleries.
 
 ### Bug Fixes
 

--- a/packages/block-library/src/gallery/README.md
+++ b/packages/block-library/src/gallery/README.md
@@ -55,7 +55,12 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`layout`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout):
   - [`allowSwitching`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowswitching): `false`
   - [`allowInheriting`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowinheriting): `false`
-  - [`allowEditing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowediting): `false`
+  - [`allowEditing`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowediting): `true`
+  - [`allowOrientation`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-alloworientation): `false`
+  - [`allowJustification`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowjustification): `false`
+  - [`allowVerticalAlignment`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowverticalalignment): `false`
+  - [`allowWrap`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowwrap): `false`
+  - [`allowSizingOnChildren`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowsizingonchildren): `true`
   - [`default`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-default): `{"type":"flex"}`
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -160,7 +160,12 @@
 		"layout": {
 			"allowSwitching": false,
 			"allowInheriting": false,
-			"allowEditing": false,
+			"allowEditing": true,
+			"allowOrientation": false,
+			"allowJustification": false,
+			"allowVerticalAlignment": false,
+			"allowWrap": false,
+			"allowSizingOnChildren": true,
 			"default": {
 				"type": "flex"
 			}

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -37,7 +37,11 @@ import {
 	fullscreen,
 } from '@wordpress/icons';
 import { sharedIcon } from './shared-icon';
-import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
+import {
+	defaultColumnsNumber,
+	isGalleryFlexLayout,
+	pickRelevantMediaFiles,
+} from './shared';
 import { getHrefAndDestination } from './utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import {
@@ -158,7 +162,9 @@ export default function GalleryEdit( props ) {
 		linkTo,
 		sizeSlug,
 		aspectRatio,
+		layout,
 	} = attributes;
+	const isFlexLayout = isGalleryFlexLayout( layout );
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -627,9 +633,10 @@ export default function GalleryEdit( props ) {
 				'blocks-gallery-grid',
 				{
 					[ `align${ align }` ]: align,
-					[ `columns-${ columns }` ]: columns !== undefined,
-					'columns-default': columns === undefined,
-					'is-cropped': imageCrop,
+					[ `columns-${ columns }` ]:
+						isFlexLayout && columns !== undefined,
+					'columns-default': isFlexLayout && columns === undefined,
+					'is-cropped': isFlexLayout && imageCrop,
 				},
 			]
 		),
@@ -711,9 +718,11 @@ export default function GalleryEdit( props ) {
 					resetAll={ () => {
 						setAttributes( {
 							navigationButtonType: 'icon',
-							columns: undefined,
-							imageCrop: true,
 							randomOrder: false,
+							...( isFlexLayout && {
+								columns: undefined,
+								imageCrop: true,
+							} ),
 						} );
 
 						setAspectRatio( 'auto' );
@@ -728,7 +737,7 @@ export default function GalleryEdit( props ) {
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
-					{ displayedImageCount > 1 && (
+					{ isFlexLayout && displayedImageCount > 1 && (
 						<ToolsPanelItem
 							isShownByDefault
 							label={ __( 'Columns' ) }
@@ -779,20 +788,22 @@ export default function GalleryEdit( props ) {
 							/>
 						</ToolsPanelItem>
 					) }
-					<ToolsPanelItem
-						isShownByDefault
-						label={ __( 'Crop images to fit' ) }
-						hasValue={ () => ! imageCrop }
-						onDeselect={ () =>
-							setAttributes( { imageCrop: true } )
-						}
-					>
-						<ToggleControl
+					{ isFlexLayout && (
+						<ToolsPanelItem
+							isShownByDefault
 							label={ __( 'Crop images to fit' ) }
-							checked={ !! imageCrop }
-							onChange={ toggleImageCrop }
-						/>
-					</ToolsPanelItem>
+							hasValue={ () => ! imageCrop }
+							onDeselect={ () =>
+								setAttributes( { imageCrop: true } )
+							}
+						>
+							<ToggleControl
+								label={ __( 'Crop images to fit' ) }
+								checked={ !! imageCrop }
+								onChange={ toggleImageCrop }
+							/>
+						</ToolsPanelItem>
+					) }
 					<ToolsPanelItem
 						isShownByDefault
 						label={ __( 'Randomize order' ) }
@@ -930,10 +941,12 @@ export default function GalleryEdit( props ) {
 						/>
 					</BlockControls>
 				) }
-				<GalleryGapCustomProperties
-					style={ attributes.style }
-					clientId={ clientId }
-				/>
+				{ isFlexLayout && (
+					<GalleryGapCustomProperties
+						style={ attributes.style }
+						clientId={ clientId }
+					/>
+				) }
 			</>
 			{ isDynamic ? (
 				<GalleryDynamicView

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -170,7 +170,6 @@ export default function GalleryEdit( props ) {
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
-		__unstableMarkLastChangeAsPersistent,
 		replaceInnerBlocks,
 		updateBlockAttributes,
 		selectBlock,
@@ -217,17 +216,7 @@ export default function GalleryEdit( props ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { layout: nextLayout } );
 		}
-
-		// Every switch between layout types only touches the `layout`
-		// attribute, so without this the next switch would be merged into
-		// this one instead of creating its own undo level.
-		__unstableMarkLastChangeAsPersistent();
-	}, [
-		layout,
-		setAttributes,
-		__unstableMarkNextChangeAsNotPersistent,
-		__unstableMarkLastChangeAsPersistent,
-	] );
+	}, [ layout, setAttributes, __unstableMarkNextChangeAsNotPersistent ] );
 
 	const { getBlock, getSettings, innerBlockImages, multiGallerySelection } =
 		useSelect(

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -40,6 +40,7 @@ import { sharedIcon } from './shared-icon';
 import {
 	defaultColumnsNumber,
 	isGalleryFlexLayout,
+	isObject,
 	pickRelevantMediaFiles,
 } from './shared';
 import { getHrefAndDestination } from './utils';
@@ -114,10 +115,6 @@ const PLACEHOLDER_TEXT = __(
 
 const DEFAULT_BLOCK = { name: 'core/image' };
 const EMPTY_ARRAY = [];
-
-function isObject( value ) {
-	return !! value && typeof value === 'object' && ! Array.isArray( value );
-}
 
 export default function GalleryEdit( props ) {
 	const {

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -115,7 +115,7 @@ const PLACEHOLDER_TEXT = __(
 const DEFAULT_BLOCK = { name: 'core/image' };
 const EMPTY_ARRAY = [];
 
-function isLayoutObject( value ) {
+function isObject( value ) {
 	return !! value && typeof value === 'object' && ! Array.isArray( value );
 }
 
@@ -187,8 +187,8 @@ export default function GalleryEdit( props ) {
 		previousLayoutRef.current = layout;
 
 		if (
-			! isLayoutObject( previousLayout ) ||
-			! isLayoutObject( layout ) ||
+			! isObject( previousLayout ) ||
+			! isObject( layout ) ||
 			previousLayout.type === layout.type
 		) {
 			return;

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -23,7 +23,7 @@ import {
 	MediaReplaceFlow,
 	useSettings,
 } from '@wordpress/block-editor';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -115,6 +115,10 @@ const PLACEHOLDER_TEXT = __(
 const DEFAULT_BLOCK = { name: 'core/image' };
 const EMPTY_ARRAY = [];
 
+function isLayoutObject( value ) {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
 export default function GalleryEdit( props ) {
 	const {
 		setAttributes,
@@ -165,6 +169,7 @@ export default function GalleryEdit( props ) {
 		layout,
 	} = attributes;
 	const isFlexLayout = isGalleryFlexLayout( layout );
+	const previousLayoutRef = useRef( layout );
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -174,6 +179,47 @@ export default function GalleryEdit( props ) {
 	} = useDispatch( blockEditorStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+
+	useEffect( () => {
+		// Variations replace the whole layout object. Carry Grid-only settings
+		// across a layout type change so switching back restores them.
+		const previousLayout = previousLayoutRef.current;
+		previousLayoutRef.current = layout;
+
+		if (
+			! isLayoutObject( previousLayout ) ||
+			! isLayoutObject( layout ) ||
+			previousLayout.type === layout.type
+		) {
+			return;
+		}
+
+		const nextLayout = { ...layout };
+		let hasPreservedGridSetting = false;
+
+		if (
+			! Object.hasOwn( layout, 'columnCount' ) &&
+			Number.isInteger( previousLayout.columnCount ) &&
+			previousLayout.columnCount > 0
+		) {
+			nextLayout.columnCount = previousLayout.columnCount;
+			hasPreservedGridSetting = true;
+		}
+
+		if (
+			! Object.hasOwn( layout, 'minimumColumnWidth' ) &&
+			typeof previousLayout.minimumColumnWidth === 'string'
+		) {
+			nextLayout.minimumColumnWidth = previousLayout.minimumColumnWidth;
+			hasPreservedGridSetting = true;
+		}
+
+		if ( hasPreservedGridSetting ) {
+			previousLayoutRef.current = nextLayout;
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( { layout: nextLayout } );
+		}
+	}, [ layout, setAttributes, __unstableMarkNextChangeAsNotPersistent ] );
 
 	const { getBlock, getSettings, innerBlockImages, multiGallerySelection } =
 		useSelect(

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -173,6 +173,7 @@ export default function GalleryEdit( props ) {
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
+		__unstableMarkLastChangeAsPersistent,
 		replaceInnerBlocks,
 		updateBlockAttributes,
 		selectBlock,
@@ -219,7 +220,17 @@ export default function GalleryEdit( props ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { layout: nextLayout } );
 		}
-	}, [ layout, setAttributes, __unstableMarkNextChangeAsNotPersistent ] );
+
+		// Every switch between layout types only touches the `layout`
+		// attribute, so without this the next switch would be merged into
+		// this one instead of creating its own undo level.
+		__unstableMarkLastChangeAsPersistent();
+	}, [
+		layout,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+		__unstableMarkLastChangeAsPersistent,
+	] );
 
 	const { getBlock, getSettings, innerBlockImages, multiGallerySelection } =
 		useSelect(

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -3,7 +3,7 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-// Adding `figure` to the selectors increases the specificity above the global
+// Adding `figure` to the selector increases the specificity above the global
 // styles specificity, which is levelled at 0-1-0. We should figure out why
 // `figure` is needed.
 :root :where(figure.wp-block-gallery.is-layout-flex) {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -3,10 +3,10 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-// Adding `figure` to the selector increases the specificity above the global
+// Adding `figure` to the selectors increases the specificity above the global
 // styles specificity, which is levelled at 0-1-0. We should figure out why
 // `figure` is needed.
-:root :where(figure.wp-block-gallery) {
+:root :where(figure.wp-block-gallery.is-layout-flex) {
 	// Override the default list style type _only in the editor_
 	// to avoid :not() selector specificity issues.
 	// See https://github.com/WordPress/gutenberg/pull/10358
@@ -16,7 +16,17 @@
 	> .blocks-gallery-caption {
 		flex: 0 0 100%;
 	}
+}
 
+:root :where(.wp-block-gallery.is-layout-grid) {
+	> .blocks-gallery-caption,
+	> .components-placeholder,
+	> .block-editor-media-placeholder {
+		grid-column: 1 / -1;
+	}
+}
+
+:root :where(figure.wp-block-gallery) {
 	// @todo this deserves a refactor, by being moved to the toolbar.
 	.block-editor-media-placeholder.is-appender {
 		.components-placeholder__label {

--- a/packages/block-library/src/gallery/gallery.jsx
+++ b/packages/block-library/src/gallery/gallery.jsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { Caption } from '../utils/caption';
+import { isGalleryFlexLayout } from './shared';
 
 export default function Gallery( props ) {
 	const {
@@ -14,7 +15,8 @@ export default function Gallery( props ) {
 		multiGallerySelection,
 	} = props;
 
-	const { align, columns, imageCrop } = attributes;
+	const { align, columns, imageCrop, layout } = attributes;
+	const isFlexLayout = isGalleryFlexLayout( layout );
 
 	return (
 		<figure
@@ -25,9 +27,11 @@ export default function Gallery( props ) {
 				'blocks-gallery-grid',
 				{
 					[ `align${ align }` ]: align,
-					[ `columns-${ columns }` ]: columns !== undefined,
-					[ `columns-default` ]: columns === undefined,
-					'is-cropped': imageCrop,
+					[ `columns-${ columns }` ]:
+						isFlexLayout && columns !== undefined,
+					[ `columns-default` ]:
+						isFlexLayout && columns === undefined,
+					'is-cropped': isFlexLayout && imageCrop,
 				}
 			) }
 		>

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -88,25 +88,6 @@ function block_core_gallery_get_column_gap_value( $gap, $fallback_gap ) {
 }
 
 /**
- * Checks whether a Gallery block should use its legacy Flex layout behavior.
- *
- * Gallery blocks created before layout variations existed do not have an
- * explicit layout attribute. Missing and malformed layout data therefore
- * falls back to Flex so existing galleries retain their current appearance.
- *
- * @since 7.1.0
- *
- * @param array $attributes Gallery block attributes.
- * @return bool Whether the Gallery uses its Flex layout.
- */
-function block_core_gallery_is_flex_layout( $attributes ) {
-	$layout      = isset( $attributes['layout'] ) && is_array( $attributes['layout'] ) ? $attributes['layout'] : array();
-	$layout_type = $layout['type'] ?? null;
-
-	return ! is_string( $layout_type ) || '' === $layout_type || 'flex' === $layout_type;
-}
-
-/**
  * Resolves a Gallery block's `dynamicContent` to an ordered list of image
  * attachment IDs.
  *
@@ -327,7 +308,13 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
 	static $global_styles = null;
-	$is_flex_layout       = block_core_gallery_is_flex_layout( $attributes );
+
+	// Gallery blocks created before layout variations existed do not have an
+	// explicit layout attribute. Missing and malformed layout data therefore
+	// falls back to Flex so existing galleries retain their current appearance.
+	$layout         = is_array( $attributes['layout'] ?? null ) ? $attributes['layout'] : array();
+	$layout_type    = $layout['type'] ?? null;
+	$is_flex_layout = ! is_string( $layout_type ) || '' === $layout_type || 'flex' === $layout_type;
 
 	// In dynamic mode the gallery's images are resolved at render time instead of
 	// being authored as inner blocks, so `save.jsx` persists at most the

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -88,6 +88,25 @@ function block_core_gallery_get_column_gap_value( $gap, $fallback_gap ) {
 }
 
 /**
+ * Checks whether a Gallery block should use its legacy Flex layout behavior.
+ *
+ * Gallery blocks created before layout variations existed do not have an
+ * explicit layout attribute. Missing and malformed layout data therefore
+ * falls back to Flex so existing galleries retain their current appearance.
+ *
+ * @since 7.1.0
+ *
+ * @param array $attributes Gallery block attributes.
+ * @return bool Whether the Gallery uses its Flex layout.
+ */
+function block_core_gallery_is_flex_layout( $attributes ) {
+	$layout      = isset( $attributes['layout'] ) && is_array( $attributes['layout'] ) ? $attributes['layout'] : array();
+	$layout_type = $layout['type'] ?? null;
+
+	return ! is_string( $layout_type ) || '' === $layout_type || 'flex' === $layout_type;
+}
+
+/**
  * Resolves a Gallery block's `dynamicContent` to an ordered list of image
  * attachment IDs.
  *
@@ -308,6 +327,7 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
 	static $global_styles = null;
+	$is_flex_layout       = block_core_gallery_is_flex_layout( $attributes );
 
 	// In dynamic mode the gallery's images are resolved at render time instead of
 	// being authored as inner blocks, so `save.jsx` persists at most the
@@ -357,16 +377,18 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 		// Build the wrapper rather than parsing/splicing saved markup.
 		// `get_block_wrapper_attributes()` supplies the block-support
 		// classes/styles (align, color, border, spacing, anchor id); the layout
-		// render filter adds the flex layout classes downstream — the same way a
+		// render filter adds the active layout classes downstream — the same way a
 		// static gallery's wrapper is composed (`useBlockProps.save()` plus that
 		// filter). Only the gallery-specific classes are added explicitly, and
 		// they mirror `save.jsx` (kept in sync deliberately — see that file).
-		$gallery_classes  = 'wp-block-gallery has-nested-images';
-		$gallery_classes .= isset( $attributes['columns'] )
-			? ' columns-' . (int) $attributes['columns']
-			: ' columns-default';
-		if ( $attributes['imageCrop'] ?? true ) {
-			$gallery_classes .= ' is-cropped';
+		$gallery_classes = 'wp-block-gallery has-nested-images';
+		if ( $is_flex_layout ) {
+			$gallery_classes .= isset( $attributes['columns'] )
+				? ' columns-' . (int) $attributes['columns']
+				: ' columns-default';
+			if ( $attributes['imageCrop'] ?? true ) {
+				$gallery_classes .= ' is-cropped';
+			}
 		}
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $gallery_classes ) );
 
@@ -377,103 +399,104 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 		$content = sprintf( '<figure %s>%s%s</figure>', $wrapper_attributes, $images_markup, $content );
 	}
 
-	// Adds a style tag for the --wp--style--unstable-gallery-gap var.
-	// The Gallery block needs to recalculate Image block width based on
-	// the current gap setting in order to maintain the number of flex columns
-	// so a css var is added to allow this.
-
-	$style_attr = is_array( $attributes['style'] ?? null )
-		? $attributes['style']
-		: array();
-	if (
-		defined( 'IS_GUTENBERG_PLUGIN' ) &&
-		IS_GUTENBERG_PLUGIN &&
-		function_exists( 'gutenberg_resolve_style_state_aliases' )
-	) {
-		$style_attr = gutenberg_resolve_style_state_aliases( $style_attr, 'core/gallery' );
-	}
-
-	$unique_gallery_classname = wp_unique_id( 'wp-block-gallery-' );
-	$processed_content        = new WP_HTML_Tag_Processor( $content );
+	$processed_content = new WP_HTML_Tag_Processor( $content );
 	$processed_content->next_tag();
-	$processed_content->add_class( $unique_gallery_classname );
 
-	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
-	// gap on the gallery.
-	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
-
-	if ( null === $global_styles ) {
-		$global_styles = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
-	}
-
-	$global_gallery_styles = $global_styles['blocks']['core/gallery'] ?? array();
-	$global_gallery_gap    = $global_gallery_styles['spacing']['blockGap'] ?? $fallback_gap;
-	$has_block_gap         = is_array( $style_attr['spacing'] ?? null ) && array_key_exists( 'blockGap', $style_attr['spacing'] );
-	// Prefer the block's own gap value, then Gallery global styles. Missing
-	// values fall back to the Gallery blockGap default.
-	$block_gap  = $has_block_gap
-		? $style_attr['spacing']['blockGap']
-		: $global_gallery_gap;
-	$gap_column = block_core_gallery_get_column_gap_value( $block_gap, $fallback_gap );
-
-	// Set the CSS variable to the column value for Gallery's flex width calculations.
-	$gallery_styles = array(
-		array(
-			'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
-			'declarations' => array(
-				'--wp--style--unstable-gallery-gap' => $gap_column,
-			),
-		),
-	);
-
-	$global_settings          = wp_get_global_settings();
-	$viewport_settings        = $global_settings['viewport'] ?? null;
-	$responsive_media_queries = array();
-	foreach ( array( 'WP_Theme_JSON_Gutenberg', 'WP_Theme_JSON' ) as $theme_json_class_name ) {
-		if ( method_exists( $theme_json_class_name, 'get_viewport_media_queries' ) ) {
-			$responsive_media_queries = $theme_json_class_name::get_viewport_media_queries( $viewport_settings );
-			break;
-		}
-	}
-
-	foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
-		$viewport_style                = $style_attr[ $breakpoint ] ?? null;
-		$has_viewport_block_gap        = is_array( $viewport_style ) &&
-			is_array( $viewport_style['spacing'] ?? null ) &&
-			array_key_exists( 'blockGap', $viewport_style['spacing'] );
-		$has_global_viewport_block_gap = is_array( $global_gallery_styles[ $breakpoint ]['spacing'] ?? null ) &&
-			array_key_exists( 'blockGap', $global_gallery_styles[ $breakpoint ]['spacing'] );
-
-		// Viewport-specific block values win. Gallery global viewport values
-		// only apply when the block has no base gap, so they do not override an instance value.
-		if ( $has_viewport_block_gap ) {
-			$viewport_gap = $viewport_style['spacing']['blockGap'];
-		} elseif ( ! $has_block_gap && $has_global_viewport_block_gap ) {
-			$viewport_gap = $global_gallery_styles[ $breakpoint ]['spacing']['blockGap'];
-		} else {
-			continue;
+	if ( $is_flex_layout ) {
+		// Add a style tag for the --wp--style--unstable-gallery-gap var. The
+		// Gallery's custom Flex layout recalculates Image block widths based on
+		// the current gap so it can maintain the selected number of columns.
+		$style_attr = is_array( $attributes['style'] ?? null )
+			? $attributes['style']
+			: array();
+		if (
+			defined( 'IS_GUTENBERG_PLUGIN' ) &&
+			IS_GUTENBERG_PLUGIN &&
+			function_exists( 'gutenberg_resolve_style_state_aliases' )
+		) {
+			$style_attr = gutenberg_resolve_style_state_aliases( $style_attr, 'core/gallery' );
 		}
 
-		if ( null === $viewport_gap ) {
-			continue;
+		$unique_gallery_classname = wp_unique_id( 'wp-block-gallery-' );
+		$processed_content->add_class( $unique_gallery_classname );
+
+		// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
+		// gap on the gallery.
+		$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
+
+		if ( null === $global_styles ) {
+			$global_styles = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
 		}
 
-		$gallery_styles[] = array(
-			'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
-			'declarations' => array(
-				'--wp--style--unstable-gallery-gap' => block_core_gallery_get_column_gap_value(
-					$viewport_gap,
-					$fallback_gap
+		$global_gallery_styles = $global_styles['blocks']['core/gallery'] ?? array();
+		$global_gallery_gap    = $global_gallery_styles['spacing']['blockGap'] ?? $fallback_gap;
+		$has_block_gap         = is_array( $style_attr['spacing'] ?? null ) && array_key_exists( 'blockGap', $style_attr['spacing'] );
+		// Prefer the block's own gap value, then Gallery global styles. Missing
+		// values fall back to the Gallery blockGap default.
+		$block_gap  = $has_block_gap
+			? $style_attr['spacing']['blockGap']
+			: $global_gallery_gap;
+		$gap_column = block_core_gallery_get_column_gap_value( $block_gap, $fallback_gap );
+
+		// Set the CSS variable to the column value for Gallery's flex width calculations.
+		$gallery_styles = array(
+			array(
+				'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
+				'declarations' => array(
+					'--wp--style--unstable-gallery-gap' => $gap_column,
 				),
 			),
-			'rules_group'  => $media_query,
+		);
+
+		$global_settings          = wp_get_global_settings();
+		$viewport_settings        = $global_settings['viewport'] ?? null;
+		$responsive_media_queries = array();
+		foreach ( array( 'WP_Theme_JSON_Gutenberg', 'WP_Theme_JSON' ) as $theme_json_class_name ) {
+			if ( method_exists( $theme_json_class_name, 'get_viewport_media_queries' ) ) {
+				$responsive_media_queries = $theme_json_class_name::get_viewport_media_queries( $viewport_settings );
+				break;
+			}
+		}
+
+		foreach ( $responsive_media_queries as $breakpoint => $media_query ) {
+			$viewport_style                = $style_attr[ $breakpoint ] ?? null;
+			$has_viewport_block_gap        = is_array( $viewport_style ) &&
+				is_array( $viewport_style['spacing'] ?? null ) &&
+				array_key_exists( 'blockGap', $viewport_style['spacing'] );
+			$has_global_viewport_block_gap = is_array( $global_gallery_styles[ $breakpoint ]['spacing'] ?? null ) &&
+				array_key_exists( 'blockGap', $global_gallery_styles[ $breakpoint ]['spacing'] );
+
+			// Viewport-specific block values win. Gallery global viewport values
+			// only apply when the block has no base gap, so they do not override an instance value.
+			if ( $has_viewport_block_gap ) {
+				$viewport_gap = $viewport_style['spacing']['blockGap'];
+			} elseif ( ! $has_block_gap && $has_global_viewport_block_gap ) {
+				$viewport_gap = $global_gallery_styles[ $breakpoint ]['spacing']['blockGap'];
+			} else {
+				continue;
+			}
+
+			if ( null === $viewport_gap ) {
+				continue;
+			}
+
+			$gallery_styles[] = array(
+				'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
+				'declarations' => array(
+					'--wp--style--unstable-gallery-gap' => block_core_gallery_get_column_gap_value(
+						$viewport_gap,
+						$fallback_gap
+					),
+				),
+				'rules_group'  => $media_query,
+			);
+		}
+
+		wp_style_engine_get_stylesheet_from_css_rules(
+			$gallery_styles,
+			array( 'context' => 'block-supports' )
 		);
 	}
-
-	wp_style_engine_get_stylesheet_from_css_rules(
-		$gallery_styles,
-		array( 'context' => 'block-supports' )
-	);
 
 	// The WP_HTML_Tag_Processor class calls get_updated_html() internally
 	// when the instance is treated as a string, but here we explicitly

--- a/packages/block-library/src/gallery/save.jsx
+++ b/packages/block-library/src/gallery/save.jsx
@@ -5,9 +5,11 @@ import {
 	useInnerBlocksProps,
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
+import { isGalleryFlexLayout } from './shared';
 
 export default function saveWithInnerBlocks( { attributes } ) {
-	const { caption, columns, imageCrop, dynamicContent } = attributes;
+	const { caption, columns, imageCrop, dynamicContent, layout } = attributes;
+	const isFlexLayout = isGalleryFlexLayout( layout );
 
 	const captionElement = ! RichText.isEmpty( caption ) && (
 		<RichText.Content
@@ -30,9 +32,9 @@ export default function saveWithInnerBlocks( { attributes } ) {
 	}
 
 	const className = clsx( 'has-nested-images', {
-		[ `columns-${ columns }` ]: columns !== undefined,
-		[ `columns-default` ]: columns === undefined,
-		'is-cropped': imageCrop,
+		[ `columns-${ columns }` ]: isFlexLayout && columns !== undefined,
+		[ `columns-default` ]: isFlexLayout && columns === undefined,
+		'is-cropped': isFlexLayout && imageCrop,
 	} );
 	const blockProps = useBlockProps.save( { className } );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -3,6 +3,16 @@ export function defaultColumnsNumber( imageCount ) {
 }
 
 /**
+ * Whether a value is a plain object (and not an array).
+ *
+ * @param {*} value The value to check.
+ * @return {boolean} Whether the value is a plain object.
+ */
+export function isObject( value ) {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+/**
  * Whether the Gallery should use its default Flex layout behavior.
  *
  * Gallery blocks created before layout variations existed do not have an
@@ -13,10 +23,7 @@ export function defaultColumnsNumber( imageCount ) {
  * @return {boolean} Whether the Gallery uses its Flex layout.
  */
 export function isGalleryFlexLayout( layout ) {
-	const layoutType =
-		layout && typeof layout === 'object' && ! Array.isArray( layout )
-			? layout.type
-			: undefined;
+	const layoutType = isObject( layout ) ? layout.type : undefined;
 
 	return (
 		typeof layoutType !== 'string' ||

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -2,6 +2,29 @@ export function defaultColumnsNumber( imageCount ) {
 	return imageCount ? Math.min( 3, imageCount ) : 3;
 }
 
+/**
+ * Whether the Gallery should use its legacy Flex layout behavior.
+ *
+ * Gallery blocks created before layout variations existed do not have an
+ * explicit layout attribute. Treat missing and malformed layout data as Flex
+ * so existing galleries keep their current appearance.
+ *
+ * @param {*} layout The Gallery layout attribute.
+ * @return {boolean} Whether the Gallery uses its Flex layout.
+ */
+export function isGalleryFlexLayout( layout ) {
+	const layoutType =
+		layout && typeof layout === 'object' && ! Array.isArray( layout )
+			? layout.type
+			: undefined;
+
+	return (
+		typeof layoutType !== 'string' ||
+		layoutType === '' ||
+		layoutType === 'flex'
+	);
+}
+
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	const imageProps = Object.fromEntries(
 		Object.entries( image ?? {} ).filter( ( [ key ] ) =>

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -3,7 +3,7 @@ export function defaultColumnsNumber( imageCount ) {
 }
 
 /**
- * Whether the Gallery should use its legacy Flex layout behavior.
+ * Whether the Gallery should use its default Flex layout behavior.
  *
  * Gallery blocks created before layout variations existed do not have an
  * explicit layout attribute. Treat missing and malformed layout data as Flex

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -11,6 +11,13 @@
 figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	align-items: normal;
 }
+
+// Grid items stretch to fill their row's height by default, which leaves the
+// figure taller than its image and detaches the absolutely positioned caption
+// overlay from the image it should sit on top of.
+// .wp-block-gallery.has-nested-images:where(.is-layout-grid) > figure.wp-block-image {
+// 	align-self: start;
+// }
 // Styles for the current Gallery block's custom Flex layout.
 .wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	// Need bogus :not(#individual-image) to override long :not()
@@ -24,7 +31,6 @@ figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 		display: flex;
 		flex-grow: 1;
 		justify-content: center;
-		position: relative;
 		flex-direction: column;
 		max-width: 100%;
 		// Prevents theme.json and global styles borders that apply to the outer
@@ -46,78 +52,6 @@ figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 			// wide or full alignment.
 			max-width: 100% !important;
 			width: auto;
-		}
-
-		// Position caption and scrim at the bottom.
-		&:has(figcaption)::before,
-		figcaption {
-			position: absolute;
-			bottom: 0;
-			right: 0;
-			left: 0;
-			max-height: 100%;
-		}
-
-		// Create a background blur layer.
-		&:has(figcaption)::before {
-			content: "";
-			height: 100%;
-			max-height: 3em;
-			pointer-events: none;
-
-			// Blur the background under the gradient scrim.
-			backdrop-filter: blur(3px);
-
-			// Crop the caption so the blur is only on the edge.
-			mask-image: linear-gradient(0deg, $black 20%, transparent 100%);
-		}
-
-		// Place the caption at the bottom.
-		figcaption {
-			color: $white;
-			text-shadow: 0 0 1.5px $black;
-			font-size: $default-font-size;
-			margin: 0;
-			overflow: auto;
-			padding: 1em;
-			text-align: center;
-			box-sizing: border-box;
-			@include custom-scrollbars-on-hover(transparent, rgba($white, 0.8));
-
-			// Dark gradient scrim.
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, transparent 100%);
-
-			img {
-				display: inline;
-			}
-
-			a {
-				color: inherit;
-			}
-		}
-
-		&.has-custom-border img {
-			box-sizing: border-box;
-		}
-
-		&.is-style-rounded,
-		&.has-custom-border {
-			> div,
-			> a {
-				flex: 1 1 auto;
-			}
-			figcaption {
-				flex: initial;
-				background: none;
-				color: inherit;
-				margin: 0;
-				padding: 10px 10px 9px;
-				position: relative;
-				text-shadow: none;
-			}
-			&::before {
-				content: none;
-			}
 		}
 	}
 
@@ -192,6 +126,85 @@ figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	// If the gallery is centered, center the content inside as well.
 	&.aligncenter {
 		justify-content: center;
+	}
+}
+
+// Styles for overlaying image captions, shared between the Flex and Grid layouts.
+.wp-block-gallery.has-nested-images {
+	figure.wp-block-image {
+		position: relative;
+
+		// Position caption and scrim at the bottom.
+		&:has(figcaption)::before,
+		figcaption {
+			position: absolute;
+			bottom: 0;
+			right: 0;
+			left: 0;
+			max-height: 100%;
+		}
+
+		// Create a background blur layer.
+		&:has(figcaption)::before {
+			content: "";
+			height: 100%;
+			max-height: 3em;
+			pointer-events: none;
+
+			// Blur the background under the gradient scrim.
+			backdrop-filter: blur(3px);
+
+			// Crop the caption so the blur is only on the edge.
+			mask-image: linear-gradient(0deg, $black 20%, transparent 100%);
+		}
+
+		// Place the caption at the bottom.
+		figcaption {
+			color: $white;
+			text-shadow: 0 0 1.5px $black;
+			font-size: $default-font-size;
+			margin: 0;
+			overflow: auto;
+			padding: 1em;
+			text-align: center;
+			box-sizing: border-box;
+			@include custom-scrollbars-on-hover(transparent, rgba($white, 0.8));
+
+			// Dark gradient scrim.
+			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.4) 0%, transparent 100%);
+
+			img {
+				display: inline;
+			}
+
+			a {
+				color: inherit;
+			}
+		}
+
+		&.has-custom-border img {
+			box-sizing: border-box;
+		}
+
+		&.is-style-rounded,
+		&.has-custom-border {
+			> div,
+			> a {
+				flex: 1 1 auto;
+			}
+			figcaption {
+				flex: initial;
+				background: none;
+				color: inherit;
+				margin: 0;
+				padding: 10px 10px 9px;
+				position: relative;
+				text-shadow: none;
+			}
+			&::before {
+				content: none;
+			}
+		}
 	}
 }
 

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -210,4 +210,5 @@ figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 
 :where(.wp-block-gallery.has-nested-images.is-layout-grid) > .blocks-gallery-caption {
 	grid-column: 1 / -1;
+	text-align: center;
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -8,11 +8,11 @@
 
 // The following is a temporary override until flex layout supports
 // an align items setting of normal.
-figure.wp-block-gallery.has-nested-images.is-layout-flex {
+figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	align-items: normal;
 }
 // Styles for the current Gallery block's custom Flex layout.
-.wp-block-gallery.has-nested-images.is-layout-flex {
+.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
@@ -195,6 +195,6 @@ figure.wp-block-gallery.has-nested-images.is-layout-flex {
 	}
 }
 
-.wp-block-gallery.has-nested-images.is-layout-grid > .blocks-gallery-caption {
+:where(.wp-block-gallery.has-nested-images.is-layout-grid) > .blocks-gallery-caption {
 	grid-column: 1 / -1;
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -8,11 +8,11 @@
 
 // The following is a temporary override until flex layout supports
 // an align items setting of normal.
-figure.wp-block-gallery.has-nested-images {
+figure.wp-block-gallery.has-nested-images.is-layout-flex {
 	align-items: normal;
 }
-// Styles for current version of gallery block.
-.wp-block-gallery.has-nested-images {
+// Styles for the current Gallery block's custom Flex layout.
+.wp-block-gallery.has-nested-images.is-layout-flex {
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
@@ -193,4 +193,8 @@ figure.wp-block-gallery.has-nested-images {
 	&.aligncenter {
 		justify-content: center;
 	}
+}
+
+.wp-block-gallery.has-nested-images.is-layout-grid > .blocks-gallery-caption {
+	grid-column: 1 / -1;
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -12,12 +12,6 @@ figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	align-items: normal;
 }
 
-// Grid items stretch to fill their row's height by default, which leaves the
-// figure taller than its image and detaches the absolutely positioned caption
-// overlay from the image it should sit on top of.
-// .wp-block-gallery.has-nested-images:where(.is-layout-grid) > figure.wp-block-image {
-// 	align-self: start;
-// }
 // Styles for the current Gallery block's custom Flex layout.
 .wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 	// Need bogus :not(#individual-image) to override long :not()

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -127,6 +127,7 @@ figure.wp-block-gallery.has-nested-images:where(.is-layout-flex) {
 .wp-block-gallery.has-nested-images {
 	figure.wp-block-image {
 		position: relative;
+		margin: 0;
 
 		// Position caption and scrim at the bottom.
 		&:has(figcaption)::before,

--- a/packages/block-library/src/gallery/test/edit.js
+++ b/packages/block-library/src/gallery/test/edit.js
@@ -93,7 +93,7 @@ describe( 'Gallery block', () => {
 					},
 				} )
 			);
-			await selectBlock( 'Block: Grid Gallery' );
+			await selectBlock( 'Block: Gallery Grid' );
 
 			expect(
 				screen.queryByLabelText( 'Crop images to fit' )
@@ -102,7 +102,7 @@ describe( 'Gallery block', () => {
 				screen.queryByRole( 'slider', { name: 'Columns' } )
 			).not.toBeInTheDocument();
 			expect(
-				screen.getByRole( 'radio', { name: 'Grid Gallery' } )
+				screen.getByRole( 'radio', { name: 'Gallery Grid' } )
 			).toBeChecked();
 
 			await userEvent.click(
@@ -122,7 +122,7 @@ describe( 'Gallery block', () => {
 
 			await userEvent.click(
 				screen.getByRole( 'radio', {
-					name: 'Transform to Grid Gallery',
+					name: 'Transform to Gallery Grid',
 				} )
 			);
 			await userEvent.click(

--- a/packages/block-library/src/gallery/test/edit.js
+++ b/packages/block-library/src/gallery/test/edit.js
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createBlock } from '@wordpress/blocks';
 import {
 	initializeEditor,
@@ -52,6 +53,74 @@ describe( 'Gallery block', () => {
 			expect(
 				screen.getByRole( 'button', { name: 'Align block' } )
 			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Layout', () => {
+		const createGallery = ( attributes = {} ) =>
+			createBlock( 'core/gallery', attributes, [
+				createBlock( 'core/image', IMAGE_ATTRIBUTES ),
+				createBlock( 'core/image', {
+					...IMAGE_ATTRIBUTES,
+					id: 2,
+				} ),
+			] );
+
+		test( 'keeps the custom Gallery controls for the default Flex layout', async () => {
+			await setup( createGallery() );
+			await selectBlock( 'Block: Gallery' );
+
+			expect(
+				await screen.findByRole( 'slider', { name: 'Columns' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByLabelText( 'Crop images to fit' )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Min. column width' )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'uses the Grid variation without the custom Flex controls', async () => {
+			await setup(
+				createGallery( {
+					columns: 2,
+					imageCrop: false,
+					layout: { type: 'flex' },
+				} )
+			);
+			await selectBlock( 'Block: Gallery' );
+
+			await userEvent.click(
+				await screen.findByRole( 'radio', {
+					name: 'Transform to Grid Gallery',
+				} )
+			);
+
+			expect(
+				screen.queryByLabelText( 'Crop images to fit' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'slider', { name: 'Columns' } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'radio', { name: 'Grid Gallery' } )
+			).toBeChecked();
+
+			await userEvent.click(
+				screen.getByRole( 'radio', {
+					name: 'Transform to Gallery',
+				} )
+			);
+
+			// Switching layouts only changes the layout attribute. The Gallery's
+			// previous Flex settings are restored when switching back.
+			expect(
+				screen.getByRole( 'slider', { name: 'Columns' } )
+			).toHaveValue( '2' );
+			expect(
+				screen.getByLabelText( 'Crop images to fit' )
+			).not.toBeChecked();
 		} );
 	} );
 } );

--- a/packages/block-library/src/gallery/test/edit.js
+++ b/packages/block-library/src/gallery/test/edit.js
@@ -81,21 +81,19 @@ describe( 'Gallery block', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		test( 'uses the Grid variation without the custom Flex controls', async () => {
+		test( 'preserves layout settings when switching Gallery variations', async () => {
 			await setup(
 				createGallery( {
 					columns: 2,
 					imageCrop: false,
-					layout: { type: 'flex' },
+					layout: {
+						type: 'grid',
+						columnCount: 4,
+						minimumColumnWidth: '10rem',
+					},
 				} )
 			);
-			await selectBlock( 'Block: Gallery' );
-
-			await userEvent.click(
-				await screen.findByRole( 'radio', {
-					name: 'Transform to Grid Gallery',
-				} )
-			);
+			await selectBlock( 'Block: Grid Gallery' );
 
 			expect(
 				screen.queryByLabelText( 'Crop images to fit' )
@@ -108,7 +106,7 @@ describe( 'Gallery block', () => {
 			).toBeChecked();
 
 			await userEvent.click(
-				screen.getByRole( 'radio', {
+				await screen.findByRole( 'radio', {
 					name: 'Transform to Gallery',
 				} )
 			);
@@ -121,6 +119,24 @@ describe( 'Gallery block', () => {
 			expect(
 				screen.getByLabelText( 'Crop images to fit' )
 			).not.toBeChecked();
+
+			await userEvent.click(
+				screen.getByRole( 'radio', {
+					name: 'Transform to Grid Gallery',
+				} )
+			);
+			await userEvent.click(
+				screen.getByRole( 'tab', { name: 'Styles' } )
+			);
+
+			expect(
+				await screen.findByRole( 'spinbutton', { name: 'Columns' } )
+			).toHaveDisplayValue( '4' );
+			expect(
+				await screen.findByRole( 'spinbutton', {
+					name: 'Minimum column width',
+				} )
+			).toHaveDisplayValue( '10' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/gallery/test/shared.js
+++ b/packages/block-library/src/gallery/test/shared.js
@@ -1,0 +1,22 @@
+import { isGalleryFlexLayout } from '../shared';
+
+describe( 'isGalleryFlexLayout', () => {
+	it.each( [
+		[ 'missing', undefined ],
+		[ 'null', null ],
+		[ 'a string', 'grid' ],
+		[ 'an array', [ 'grid' ] ],
+		[ 'an object without a type', {} ],
+		[ 'an object with an empty type', { type: '' } ],
+		[ 'an explicit Flex layout', { type: 'flex' } ],
+	] )( 'treats %s layout data as Flex', ( label, layout ) => {
+		expect( isGalleryFlexLayout( layout ) ).toBe( true );
+	} );
+
+	it.each( [
+		[ 'Grid', { type: 'grid' } ],
+		[ 'another explicit layout type', { type: 'constrained' } ],
+	] )( 'does not treat %s as Flex', ( label, layout ) => {
+		expect( isGalleryFlexLayout( layout ) ).toBe( false );
+	} );
+} );

--- a/packages/block-library/src/gallery/test/variations.js
+++ b/packages/block-library/src/gallery/test/variations.js
@@ -17,7 +17,7 @@ describe( 'Gallery layout variations', () => {
 		expect( gridVariation.isActive( {} ) ).toBe( false );
 	} );
 
-	it( 'activates only the Grid variation for a Grid Gallery', () => {
+	it( 'activates only the Grid variation for a Gallery Grid', () => {
 		const attributes = { layout: { type: 'grid' } };
 
 		expect( flexVariation.isActive( attributes ) ).toBe( false );

--- a/packages/block-library/src/gallery/test/variations.js
+++ b/packages/block-library/src/gallery/test/variations.js
@@ -1,0 +1,26 @@
+import variations from '../variations';
+
+const getVariation = ( name ) =>
+	variations.find( ( variation ) => variation.name === name );
+
+describe( 'Gallery layout variations', () => {
+	const flexVariation = getVariation( 'gallery-flex' );
+	const gridVariation = getVariation( 'gallery-grid' );
+
+	it( 'exposes Flex and Grid only as transforms', () => {
+		expect( flexVariation.scope ).toEqual( [ 'transform' ] );
+		expect( gridVariation.scope ).toEqual( [ 'transform' ] );
+	} );
+
+	it( 'keeps an attribute-less Gallery on the Flex variation', () => {
+		expect( flexVariation.isActive( {} ) ).toBe( true );
+		expect( gridVariation.isActive( {} ) ).toBe( false );
+	} );
+
+	it( 'activates only the Grid variation for a Grid Gallery', () => {
+		const attributes = { layout: { type: 'grid' } };
+
+		expect( flexVariation.isActive( attributes ) ).toBe( false );
+		expect( gridVariation.isActive( attributes ) ).toBe( true );
+	} );
+} );

--- a/packages/block-library/src/gallery/variations.js
+++ b/packages/block-library/src/gallery/variations.js
@@ -43,7 +43,7 @@ const variations = [
 	},
 	{
 		name: 'gallery-grid',
-		title: __( 'Grid Gallery' ),
+		title: __( 'Gallery Grid' ),
 		description: __( 'Arrange images in a grid.' ),
 		icon: grid,
 		attributes: {

--- a/packages/block-library/src/gallery/variations.js
+++ b/packages/block-library/src/gallery/variations.js
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
+import { gallery, grid } from '@wordpress/icons';
 import { ATTACHED_MEDIA } from './dynamic-source';
+import { isGalleryFlexLayout } from './shared';
 
 const variations = [
 	{
@@ -24,6 +26,34 @@ const variations = [
 		// of scope. Revisit adding `'inserter'` in a follow-up as the feature grows
 		// beyond the post-attached source.
 		scope: [],
+	},
+	{
+		name: 'gallery-flex',
+		title: __( 'Gallery' ),
+		description: __( 'Arrange images in flexible rows.' ),
+		icon: gallery,
+		attributes: {
+			layout: {
+				type: 'flex',
+			},
+		},
+		isActive: ( blockAttributes ) =>
+			isGalleryFlexLayout( blockAttributes.layout ),
+		scope: [ 'transform' ],
+	},
+	{
+		name: 'gallery-grid',
+		title: __( 'Grid Gallery' ),
+		description: __( 'Arrange images in a grid.' ),
+		icon: grid,
+		attributes: {
+			layout: {
+				type: 'grid',
+			},
+		},
+		isActive: ( blockAttributes ) =>
+			blockAttributes.layout?.type === 'grid',
+		scope: [ 'transform' ],
 	},
 ];
 

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -121,6 +121,23 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_dynamic_grid_uses_only_standard_grid_layout_classes() {
+		$output = $this->render_in_loop(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"},"layout":{"type":"grid","columnCount":2},"columns":2,"imageCrop":true} /-->'
+		);
+
+		$this->assertStringContainsString( 'is-layout-grid', $output );
+		$this->assertStringNotContainsString( 'is-layout-flex', $output );
+		$this->assertStringNotContainsString( 'columns-2', $output );
+		$this->assertStringNotContainsString( 'columns-default', $output );
+		$this->assertStringNotContainsString( 'is-cropped', $output );
+		$this->assertDoesNotMatchRegularExpression(
+			'/\bwp-block-gallery-\d+\b/',
+			$output,
+			'Grid galleries should not receive the unique class used by the custom Flex gap calculation.'
+		);
+	}
+
 	public function test_dynamic_attached_to_post_honours_order() {
 		$asc  = $this->render_in_loop(
 			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media","args":{"orderBy":"date","order":"asc"}}} /-->'

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -189,11 +189,11 @@ test.describe( 'Gallery', () => {
 		await editor.selectBlocks( gallery );
 		await editor.openDocumentSettingsSidebar();
 		await page
-			.getByRole( 'radio', { name: 'Transform to Grid Gallery' } )
+			.getByRole( 'radio', { name: 'Transform to Gallery Grid' } )
 			.click();
 
 		await expect(
-			page.getByRole( 'radio', { name: 'Grid Gallery' } )
+			page.getByRole( 'radio', { name: 'Gallery Grid' } )
 		).toBeChecked();
 		await page.getByRole( 'tab', { name: 'Settings' } ).click();
 		await expect( page.getByLabel( 'Crop images to fit' ) ).toHaveCount(

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -152,6 +152,129 @@ test.describe( 'Gallery', () => {
 			);
 	} );
 
+	test( 'Grid layout uses native controls without Gallery Flex child styles', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				caption: 'Gallery caption',
+				columns: 2,
+				imageCrop: true,
+				layout: { type: 'flex' },
+			},
+			innerBlocks: [
+				{
+					name: 'core/image',
+					attributes: {
+						id: uploadedMedia.id,
+						url: uploadedMedia.source_url,
+						caption: 'Image caption',
+					},
+				},
+				{
+					name: 'core/image',
+					attributes: {
+						id: uploadedMedia.id,
+						url: uploadedMedia.source_url,
+					},
+				},
+			],
+		} );
+
+		const gallery = editor.canvas.locator( '.wp-block-gallery' );
+		await editor.selectBlocks( gallery );
+		await editor.openDocumentSettingsSidebar();
+		await page
+			.getByRole( 'radio', { name: 'Transform to Grid Gallery' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'radio', { name: 'Grid Gallery' } )
+		).toBeChecked();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await expect( page.getByLabel( 'Crop images to fit' ) ).toHaveCount(
+			0
+		);
+		await page.getByRole( 'tab', { name: 'Styles' } ).click();
+		await expect( page.getByText( 'Max. columns' ) ).toBeVisible();
+
+		await expect( gallery ).toHaveClass( /is-layout-grid/ );
+		await expect( gallery ).not.toHaveClass( /columns-2|is-cropped/ );
+
+		const image = gallery.locator( '.wp-block-image' ).first();
+		const imageCaption = image.locator( 'figcaption' );
+		const galleryCaption = gallery.locator(
+			':scope > .blocks-gallery-caption'
+		);
+
+		expect(
+			await image.evaluate(
+				( element ) => window.getComputedStyle( element ).display
+			)
+		).not.toBe( 'flex' );
+		expect(
+			await imageCaption.evaluate(
+				( element ) => window.getComputedStyle( element ).position
+			)
+		).not.toBe( 'absolute' );
+		expect(
+			await galleryCaption.evaluate(
+				( element ) => window.getComputedStyle( element ).gridColumnEnd
+			)
+		).toBe( '-1' );
+
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: { layout: { type: 'grid' } },
+		} );
+		const emptyGalleryPlaceholder = editor.canvas
+			.locator( '.wp-block-gallery' )
+			.last()
+			.locator( '.block-editor-media-placeholder' );
+		expect(
+			await emptyGalleryPlaceholder.evaluate(
+				( element ) => window.getComputedStyle( element ).gridColumnEnd
+			)
+		).toBe( '-1' );
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+
+		const renderedGallery = page
+			.locator( '.wp-block-gallery.is-layout-grid' )
+			.first();
+		await expect( renderedGallery ).not.toHaveClass(
+			/columns-2|is-cropped|wp-block-gallery-\d+/
+		);
+		expect(
+			await renderedGallery
+				.locator( '.wp-block-image' )
+				.first()
+				.evaluate(
+					( element ) => window.getComputedStyle( element ).display
+				)
+		).not.toBe( 'flex' );
+		expect(
+			await renderedGallery
+				.locator( '.wp-block-image figcaption' )
+				.evaluate(
+					( element ) => window.getComputedStyle( element ).position
+				)
+		).not.toBe( 'absolute' );
+		expect(
+			await renderedGallery
+				.locator( ':scope > .blocks-gallery-caption' )
+				.evaluate(
+					( element ) =>
+						window.getComputedStyle( element ).gridColumnEnd
+				)
+		).toBe( '-1' );
+	} );
+
 	test( "uploaded images' captions can be edited", async ( {
 		admin,
 		editor,

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -220,7 +220,7 @@ test.describe( 'Gallery', () => {
 			await imageCaption.evaluate(
 				( element ) => window.getComputedStyle( element ).position
 			)
-		).not.toBe( 'absolute' );
+		).toBe( 'absolute' );
 		expect(
 			await galleryCaption.evaluate(
 				( element ) => window.getComputedStyle( element ).gridColumnEnd
@@ -264,7 +264,7 @@ test.describe( 'Gallery', () => {
 				.evaluate(
 					( element ) => window.getComputedStyle( element ).position
 				)
-		).not.toBe( 'absolute' );
+		).toBe( 'absolute' );
 		expect(
 			await renderedGallery
 				.locator( ':scope > .blocks-gallery-caption' )

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -167,8 +167,8 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		// It should display a different allowed block list.
 		await expect( blockListBox.getByRole( 'option' ) ).toHaveText( [
-			'Gallery',
 			'List',
+			'Gallery',
 			'Video',
 		] );
 	} );

--- a/test/integration/fixtures/blocks/core__gallery__grid.html
+++ b/test/integration/fixtures/blocks/core__gallery__grid.html
@@ -1,0 +1,23 @@
+<!-- wp:gallery {"linkTo":"none","layout":{"type":"grid","columnCount":2}} -->
+<figure class="wp-block-gallery has-nested-images">
+	<!-- wp:image {"id":1421,"sizeSlug":"large","linkDestination":"none"} -->
+	<figure class="wp-block-image size-large">
+		<img
+			src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190"
+			alt="Image gallery image"
+			class="wp-image-1421"
+		/>
+	</figure>
+	<!-- /wp:image -->
+
+	<!-- wp:image {"id":1440,"sizeSlug":"large","linkDestination":"none"} -->
+	<figure class="wp-block-image size-large">
+		<img
+			src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580"
+			alt="Image gallery image"
+			class="wp-image-1440"
+		/>
+	</figure>
+	<!-- /wp:image -->
+</figure>
+<!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__grid.json
+++ b/test/integration/fixtures/blocks/core__gallery__grid.json
@@ -1,0 +1,54 @@
+[
+	{
+		"name": "core/gallery",
+		"isValid": true,
+		"attributes": {
+			"images": [],
+			"ids": [],
+			"navigationButtonType": "icon",
+			"shortCodeTransforms": [],
+			"caption": "",
+			"imageCrop": true,
+			"randomOrder": false,
+			"fixedHeight": true,
+			"linkTo": "none",
+			"sizeSlug": "large",
+			"allowResize": false,
+			"aspectRatio": "auto",
+			"layout": {
+				"type": "grid",
+				"columnCount": 2
+			}
+		},
+		"innerBlocks": [
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190",
+					"alt": "Image gallery image",
+					"caption": "",
+					"id": 1421,
+					"sizeSlug": "large",
+					"linkDestination": "none",
+					"isDecorative": false
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580",
+					"alt": "Image gallery image",
+					"caption": "",
+					"id": 1440,
+					"sizeSlug": "large",
+					"linkDestination": "none",
+					"isDecorative": false
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__gallery__grid.parsed.json
+++ b/test/integration/fixtures/blocks/core__gallery__grid.parsed.json
@@ -1,0 +1,48 @@
+[
+	{
+		"blockName": "core/gallery",
+		"attrs": {
+			"linkTo": "none",
+			"layout": {
+				"type": "grid",
+				"columnCount": 2
+			}
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 1421,
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 1440,
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<figure class=\"wp-block-gallery has-nested-images\">\n\t\n\n\t\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-gallery has-nested-images\">\n\t",
+			null,
+			"\n\n\t",
+			null,
+			"\n</figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__gallery__grid.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__grid.serialized.html
@@ -1,0 +1,9 @@
+<!-- wp:gallery {"linkTo":"none","layout":{"type":"grid","columnCount":2}} -->
+<figure class="wp-block-gallery has-nested-images"><!-- wp:image {"id":1421,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":1440,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #42240.

Should also fix #55231!

Adds a Grid Gallery block variation so we can switch between the default custom, non-editable flex layout and a fully customisable grid layout.

The block variation comes with the handy inspector UI for switching between variations:


<img width="280" height="142" alt="Screenshot 2026-08-24 at 6 21 35 pm" src="https://github.com/user-attachments/assets/2177a985-0451-48c0-94c1-bb48a6d8261f" />

Layout properties set on the Gallery or its children are preserved across switches, so trying out a variation doesn't wipe out the previous state.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Gallery block with a bunch of images to a post.
2. Try switching between variations
3. In Grid variation, try changing size of children
4. Add a Dynamic Gallery and check both layout variations (children shouldn't be editable on this one)


https://github.com/user-attachments/assets/45d45275-a182-47b0-9fc4-4f491c13dbed


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
used codex/gpt 5.6 sol