### PR TITLE
Block Settings Menu: Keep the options menu beneath the media modal

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -11,8 +11,11 @@
 -   `input-control`: Use `outset-ring__focus` for focus styling, WPDS tokens for border styling, and a hover border treatment aligned with `@wordpress/ui`. If you also define custom `:focus` box-shadow styles on the same selector, remove them to avoid duplicate focus rings ([#81357](https://github.com/WordPress/gutenberg/pull/81357)).
 -   `outset-ring__focus`: Use a `--focus-color` fallback in the outline instead of declaring the custom property locally, so ancestor overrides apply correctly ([#81242](https://github.com/WordPress/gutenberg/pull/81242)).
 
-## 12.1.0 (2026-08-12)
+### Bug Fixes
 
+-   Show the block settings menu beneath the media modal, so an open ⋮ menu no longer covers the media library when it is opened from the block behind it ([#54018](https://github.com/WordPress/gutenberg/issues/54018)).
+
+## 12.1.0 (2026-08-12)
 
 ## 12.0.0 (2026-07-29)
 
@@ -54,7 +57,7 @@
 ### Breaking Changes
 
 -   Remove the following entries from the `z-index()` helper ([#77773](https://github.com/WordPress/gutenberg/pull/77773)):
-   -   `.nux-dot-tip`
+-   `.nux-dot-tip`
 
 ## 9.0.0 (2026-05-27)
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -99,6 +99,9 @@ $z-layers: (
 	// Show media replace flow and similar popovers beneath the media modal when its open.
 	".components-popover.block-editor-media-replace-flow__options": 99999,
 	".components-popover.block-library-video-tracks-editor": 99999,
+	// The block settings menu stays open while the media modal has focus, since
+	// Dropdown keeps a popover mounted when focus moves into a separate dialog.
+	".block-editor-block-settings-menu__popover": 99999,
 
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
 	".components-popover.block-editor-inserter__popover": 99999,

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -1,0 +1,10 @@
+@use "@wordpress/base-styles/z-index" as *;
+
+// The block settings menu stays mounted while the media modal is open, because
+// Dropdown preserves a popover when focus moves into a separate dialog. Without
+// this the menu would render on top of the modal, since popovers sit well above
+// it. Changing the z-index of popovers permanently has wider implications, so
+// only lower it while the modal is open.
+.modal-open .block-editor-block-settings-menu__popover {
+	z-index: z-index(".block-editor-block-settings-menu__popover");
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -7,6 +7,7 @@
 @use "./components/block-icon/style.scss" as *;
 @use "./components/block-inspector/style.scss" as *;
 @use "./components/block-tools/style.scss" as *;
+@use "./components/block-settings-menu/style.scss" as *;
 @use "./components/block-lock/style.scss" as *;
 @use "./components/block-allowed-blocks/style.scss" as *;
 @use "./components/block-breadcrumb/style.scss" as *;

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -24,6 +24,56 @@ test.describe( 'Image', () => {
 		await requestUtils.deleteAllMedia();
 	} );
 
+	test( 'keeps the block settings menu beneath the media modal', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		await editor.selectBlocks(
+			editor.canvas.locator( 'role=document[name="Block: Image"i]' )
+		);
+
+		// Open the block settings menu and leave it open.
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
+		const settingsMenu = page.locator(
+			'.block-editor-block-settings-menu__popover'
+		);
+		await expect( settingsMenu ).toBeVisible();
+
+		// Open the media library from the placeholder behind the menu.
+		await editor.canvas
+			.getByRole( 'button', { name: 'Media Library' } )
+			.click();
+		await expect( page.locator( '.media-modal' ) ).toBeVisible();
+
+		// The menu stays mounted, because Dropdown keeps a popover open while
+		// focus is inside a separate dialog, but it must not cover the modal.
+		await expect
+			.poll( () =>
+				page.evaluate( () => {
+					const menu = document.querySelector(
+						'.block-editor-block-settings-menu__popover'
+					);
+					if ( ! menu ) {
+						return false;
+					}
+					const { x, y, width, height } =
+						menu.getBoundingClientRect();
+					const topmost = document.elementFromPoint(
+						x + width / 2,
+						y + height / 2
+					);
+					return !! topmost?.closest(
+						'.block-editor-block-settings-menu__popover'
+					);
+				} )
+			)
+			.toBe( false );
+	} );
+
 	test( 'can be inserted via image upload', async ( {
 		editor,
 		imageBlockUtils,


### PR DESCRIPTION
## What?

Closes #54018

With a block's ⋮ Options menu open, opening the media library from that block left the menu rendered on top of the modal. It now sits beneath it.

## Why?

`Dropdown` deliberately keeps a popover mounted when focus moves into a separate dialog (`closeIfFocusOutside` in `packages/components/src/dropdown/index.tsx`), so the menu staying open is intended — with the modal open, `document.activeElement` is inside `[role="dialog"].media-modal`.

The problem is stacking. Measured with the modal open, the menu popover computes to `z-index: 1000000` against the modal's `160000` and its backdrop's `159900`. It covers the media grid and still responds to hover, which puts Cut and Delete over the modal.

## How?

`_z-index.scss` already handles this for popovers that can be open alongside the media modal, under the comment "Show media replace flow and similar popovers beneath the media modal when its open" — `block-editor-media-replace-flow__options` and `block-library-video-tracks-editor` are demoted to 99999. The block settings menu had no entry.

This adds one, plus the rule that applies it, scoped to `.modal-open` — the class `wp.media` sets on `<body>` while its modal is open — so nothing changes during normal editing. Same shape as `media-replace-flow/style.scss`, whose comment notes that changing popover z-index permanently has wider implications.

The media replace flow is the reference case: open the media library from that dropdown instead and the modal already covers it correctly, at 99999.

## Testing Instructions

1. Add an Image block to a post.
2. Open the block toolbar's ⋮ Options menu and leave it open.
3. Click **Media Library** in the placeholder.
4. The modal covers the menu. Before this change the menu floated over it.

```
npm run test:e2e -- test/e2e/specs/editor/blocks/image.spec.js --grep "beneath the media modal"
```

- [x] Passes with the change, fails without it
- [x] `npm run lint:css` clean

Unrelated: `image.spec.js` → "allows rotating an image using the media editor modal" already fails on trunk without this change.

### Testing Instructions for Keyboard

The same steps work from the keyboard — select the block, open Options from the toolbar, then move to the Media Library button and activate it.

## Use of AI Tools

Authored with Claude Code under direction and review.
