### PR TITLE
Update Actions and Octokit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,43 +43,128 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+			"integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+			"license": "MIT",
 			"dependencies": {
-				"@actions/http-client": "^2.0.1",
-				"uuid": "^8.3.2"
+				"@actions/exec": "^3.0.0",
+				"@actions/http-client": "^4.0.0"
 			}
 		},
-		"node_modules/@actions/core/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
+		"node_modules/@actions/exec": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+			"integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+			"license": "MIT",
+			"dependencies": {
+				"@actions/io": "^3.0.2"
 			}
 		},
 		"node_modules/@actions/github": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
-			"integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
+			"integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
 			"license": "MIT",
 			"dependencies": {
-				"@actions/http-client": "^2.0.1",
-				"@octokit/core": "^3.6.0",
-				"@octokit/plugin-paginate-rest": "^2.17.0",
-				"@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+				"@actions/http-client": "^3.0.2",
+				"@octokit/core": "^7.0.6",
+				"@octokit/plugin-paginate-rest": "^14.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+				"@octokit/request": "^10.0.7",
+				"@octokit/request-error": "^7.1.0",
+				"undici": "^6.23.0"
 			}
 		},
-		"node_modules/@actions/http-client": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-			"integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+		"node_modules/@actions/github/node_modules/@actions/http-client": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+			"integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
 			"license": "MIT",
 			"dependencies": {
 				"tunnel": "^0.0.6",
-				"undici": "^5.25.4"
+				"undici": "^6.23.0"
 			}
+		},
+		"node_modules/@actions/github/node_modules/@octokit/endpoint": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+			"integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^17.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@actions/github/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@actions/github/node_modules/@octokit/request": {
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.14.tgz",
+			"integrity": "sha512-bgWgiSfFS689/AxQDarU+b3Qu1FYewfVr5vI/jhV84s7GQ3C2OsdRxukGGYKB37MCgwcS50UrfBLlHzhiG13sw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
+				"content-type": "^2.0.0",
+				"json-with-bigint": "^3.5.12",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@actions/github/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@actions/github/node_modules/content-type": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+			"integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@actions/github/node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+			"license": "ISC"
+		},
+		"node_modules/@actions/http-client": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+			"integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+			"license": "MIT",
+			"dependencies": {
+				"tunnel": "^0.0.6",
+				"undici": "^6.23.0"
+			}
+		},
+		"node_modules/@actions/io": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+			"license": "MIT"
 		},
 		"node_modules/@adobe/css-tools": {
 			"version": "4.4.0",
@@ -3454,14 +3539,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/@fastify/busboy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@flakiness/jest": {
@@ -9062,12 +9139,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/app/node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/@octokit/app/node_modules/@octokit/core/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -9091,12 +9162,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/app/node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/@octokit/app/node_modules/@octokit/graphql/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -9107,9 +9172,9 @@
 			}
 		},
 		"node_modules/@octokit/app/node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest": {
@@ -9141,12 +9206,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/app/node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/@octokit/app/node_modules/@octokit/request-error/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -9154,15 +9213,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
-			}
-		},
-		"node_modules/@octokit/app/node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
 			}
 		},
 		"node_modules/@octokit/auth-app": {
@@ -9320,11 +9370,12 @@
 			}
 		},
 		"node_modules/@octokit/auth-token": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-			"integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-			"dependencies": {
-				"@octokit/types": "^6.0.3"
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/auth-unauthenticated": {
@@ -9341,9 +9392,9 @@
 			}
 		},
 		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/request-error": {
@@ -9360,12 +9411,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/request-error/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -9375,51 +9420,93 @@
 				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
-		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+		"node_modules/@octokit/core": {
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+			"integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
-			}
-		},
-		"node_modules/@octokit/core": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-			"integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
-			"dependencies": {
-				"@octokit/auth-token": "^2.4.4",
-				"@octokit/graphql": "^4.5.8",
-				"@octokit/request": "^5.6.3",
-				"@octokit/request-error": "^2.0.5",
-				"@octokit/types": "^6.0.3",
-				"before-after-hook": "^2.2.0",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/auth-token": "^6.0.0",
+				"@octokit/graphql": "^9.0.4",
+				"@octokit/request": "^10.0.13",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
+				"before-after-hook": "^4.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/endpoint": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-			"integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+			"integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.0.3",
-				"is-plain-object": "^5.0.0",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/types": "^17.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
 		"node_modules/@octokit/core/node_modules/@octokit/request": {
-			"version": "5.6.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.14.tgz",
+			"integrity": "sha512-bgWgiSfFS689/AxQDarU+b3Qu1FYewfVr5vI/jhV84s7GQ3C2OsdRxukGGYKB37MCgwcS50UrfBLlHzhiG13sw==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^6.0.1",
-				"@octokit/request-error": "^2.1.0",
-				"@octokit/types": "^6.16.1",
-				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.7",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
+				"content-type": "^2.0.0",
+				"json-with-bigint": "^3.5.12",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/before-after-hook": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@octokit/core/node_modules/content-type": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+			"integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+			"license": "ISC"
 		},
 		"node_modules/@octokit/endpoint": {
 			"version": "9.0.6",
@@ -9450,37 +9537,82 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-			"integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+			"integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^5.6.0",
-				"@octokit/types": "^6.0.3",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/request": "^10.0.13",
+				"@octokit/types": "^17.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-			"integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+			"integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.0.3",
-				"is-plain-object": "^5.0.0",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/types": "^17.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/request": {
-			"version": "5.6.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.14.tgz",
+			"integrity": "sha512-bgWgiSfFS689/AxQDarU+b3Qu1FYewfVr5vI/jhV84s7GQ3C2OsdRxukGGYKB37MCgwcS50UrfBLlHzhiG13sw==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^6.0.1",
-				"@octokit/request-error": "^2.1.0",
-				"@octokit/types": "^6.16.1",
-				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.7",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
+				"content-type": "^2.0.0",
+				"json-with-bigint": "^3.5.12",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/content-type": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+			"integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+			"license": "ISC"
 		},
 		"node_modules/@octokit/oauth-app": {
 			"version": "6.1.0",
@@ -9626,9 +9758,9 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "12.11.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-			"integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-enterprise-rest": {
@@ -9651,21 +9783,39 @@
 			}
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "2.21.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-			"integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.40.0"
+				"@octokit/types": "^16.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=2"
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^27.0.0"
 			}
 		},
 		"node_modules/@octokit/plugin-request-log": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
 			"integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -9675,15 +9825,33 @@
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "5.16.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-			"integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+			"integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.39.0",
-				"deprecation": "^2.3.1"
+				"@octokit/types": "^16.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
 			},
 			"peerDependencies": {
-				"@octokit/core": ">=3"
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^27.0.0"
 			}
 		},
 		"node_modules/@octokit/plugin-retry": {
@@ -9748,21 +9916,6 @@
 				"@octokit/core": "^5.0.0"
 			}
 		},
-		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-			"license": "MIT"
-		},
-		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
-			}
-		},
 		"node_modules/@octokit/request": {
 			"version": "8.4.1",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
@@ -9779,13 +9932,30 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-			"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+			"integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.0.3",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
+				"@octokit/types": "^17.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
 			}
 		},
 		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
@@ -9818,157 +9988,127 @@
 			}
 		},
 		"node_modules/@octokit/rest": {
-			"version": "16.43.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
-			"integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
+			"version": "20.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+			"integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-token": "^2.4.0",
-				"@octokit/plugin-paginate-rest": "^1.1.1",
-				"@octokit/plugin-request-log": "^1.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "2.4.0",
-				"@octokit/request": "^5.2.0",
-				"@octokit/request-error": "^1.0.2",
-				"atob-lite": "^2.0.0",
-				"before-after-hook": "^2.0.0",
-				"btoa-lite": "^1.0.0",
-				"deprecation": "^2.0.0",
-				"lodash.get": "^4.4.2",
-				"lodash.set": "^4.3.2",
-				"lodash.uniq": "^4.5.0",
-				"octokit-pagination-methods": "^1.1.0",
-				"once": "^1.4.0",
-				"universal-user-agent": "^4.0.0"
+				"@octokit/core": "^5.0.2",
+				"@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+				"@octokit/plugin-request-log": "^4.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-			"integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+		"node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/core": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.0.3",
-				"is-plain-object": "^5.0.0",
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/rest/node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-			"version": "6.41.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+		"node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^12.11.0"
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/rest/node_modules/@octokit/endpoint/node_modules/universal-user-agent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"license": "ISC"
+		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
-			"integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+			"version": "11.4.4-cjs.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+			"integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^2.0.1"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"license": "MIT",
+				"@octokit/types": "^13.7.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
 			"peerDependencies": {
-				"@octokit/core": ">=3"
+				"@octokit/core": "5"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
-			"integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+			"version": "13.3.2-cjs.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+			"integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^2.0.1",
-				"deprecation": "^2.3.1"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/request": {
-			"version": "5.6.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/endpoint": "^6.0.1",
-				"@octokit/request-error": "^2.1.0",
-				"@octokit/types": "^6.16.1",
-				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.7",
-				"universal-user-agent": "^6.0.0"
+				"@octokit/types": "^13.8.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
-			"integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
-			"dependencies": {
-				"@octokit/types": "^2.0.0",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/request/node_modules/@octokit/request-error": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-			"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^6.0.3",
+				"@octokit/types": "^13.1.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/request/node_modules/@octokit/types": {
-			"version": "6.41.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^12.11.0"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/request/node_modules/universal-user-agent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"license": "ISC"
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/types": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-			"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
 			"dependencies": {
-				"@types/node": ">= 8"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/universal-user-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
-			"integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
-			"license": "ISC",
-			"dependencies": {
-				"os-name": "^3.1.0"
+				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "6.41.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^12.11.0"
+				"@octokit/openapi-types": "^20.0.0"
 			}
 		},
 		"node_modules/@octokit/webhooks": {
@@ -9986,16 +10126,10 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/webhooks-methods": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-2.0.0.tgz",
-			"integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig==",
-			"license": "MIT"
-		},
 		"node_modules/@octokit/webhooks-types": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
-			"integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/webhooks/node_modules/@octokit/openapi-types": {
@@ -10035,12 +10169,6 @@
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/@octokit/webhooks/node_modules/@octokit/webhooks-types": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
-			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
-			"license": "MIT"
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
 			"version": "0.127.0",
@@ -19557,11 +19685,6 @@
 				"node": ">= 4.5.0"
 			}
 		},
-		"node_modules/atob-lite": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
-		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.21",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -20760,9 +20883,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -33756,9 +33879,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "17.13.4",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
-			"integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+			"version": "17.13.6",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.6.tgz",
+			"integrity": "sha512-ImNZaq/LSysofih+xIGYfR0WUXMA9GLUNB//YTCSrZptoRmVgaNAdJyi6K1kXi9pkLEoSkoI8I4UwtNiu/D7nw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -33972,6 +34095,12 @@
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/json-with-bigint": {
+			"version": "3.5.12",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
+			"integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==",
+			"license": "MIT"
 		},
 		"node_modules/json2md": {
 			"version": "2.0.1",
@@ -34307,130 +34436,6 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/auth-token": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/core": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/auth-token": "^4.0.0",
-				"@octokit/graphql": "^7.1.0",
-				"@octokit/request": "^8.4.1",
-				"@octokit/request-error": "^5.1.1",
-				"@octokit/types": "^13.0.0",
-				"before-after-hook": "^2.2.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/graphql": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/request": "^8.4.1",
-				"@octokit/types": "^13.0.0",
-				"universal-user-agent": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lerna/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "11.4.4-cjs.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
-			"integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^13.7.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": "5"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "13.3.2-cjs.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
-			"integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^13.8.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": "^5"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/request-error": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^13.1.0",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/rest": {
-			"version": "20.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
-			"integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/core": "^5.0.2",
-				"@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
-				"@octokit/plugin-request-log": "^4.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/lerna/node_modules/@octokit/types": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
 		"node_modules/lerna/node_modules/@sinclair/typebox": {
@@ -36157,11 +36162,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -36225,11 +36225,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.pullall/-/lodash.pullall-4.2.0.tgz",
 			"integrity": "sha512-VhqxBKH0ZxPpLhiu68YD1KnHmbhQJQctcipvmFnqIBDYzcIHzf3Zpu0tpeOKtR4x76p9yohc506eGdOjTmyIBg=="
-		},
-		"node_modules/lodash.set": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
 		},
 		"node_modules/lodash.truncate": {
 			"version": "4.4.2",
@@ -36495,18 +36490,6 @@
 			"dev": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
-			}
-		},
-		"node_modules/macos-release": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
-			"integrity": "sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/magic-string": {
@@ -37966,7 +37949,8 @@
 		"node_modules/nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
 		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
@@ -38106,16 +38090,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/node-gyp/node_modules/undici": {
-			"version": "6.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-			"integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.17"
 			}
 		},
 		"node_modules/node-gyp/node_modules/which": {
@@ -39909,11 +39883,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/octokit-pagination-methods": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
-		},
 		"node_modules/octokit/node_modules/@octokit/auth-token": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
@@ -39941,12 +39910,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/octokit/node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/octokit/node_modules/@octokit/core/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -39970,12 +39933,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/octokit/node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/octokit/node_modules/@octokit/graphql/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -39986,9 +39943,9 @@
 			}
 		},
 		"node_modules/octokit/node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/octokit/node_modules/@octokit/plugin-paginate-rest": {
@@ -40035,12 +39992,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/octokit/node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"license": "MIT"
-		},
 		"node_modules/octokit/node_modules/@octokit/request-error/node_modules/@octokit/types": {
 			"version": "13.10.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
@@ -40048,15 +39999,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
-			}
-		},
-		"node_modules/octokit/node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
 			}
 		},
 		"node_modules/on-finished": {
@@ -40317,19 +40259,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/os-name": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
-			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
-			"license": "MIT",
-			"dependencies": {
-				"macos-release": "^2.2.0",
-				"windows-release": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/own-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -40428,6 +40357,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -41473,6 +41403,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -44314,9 +44245,9 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"node_modules/sass": {
-			"version": "1.102.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
-			"integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
+			"version": "1.103.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.103.0.tgz",
+			"integrity": "sha512-+QpdXUDw19lVqRDlYIyje1Lq/0gHsnNHIl4x1CqeUg13zRhaQN11UvTvouwHWLXc9Q3rQVT6oBhFGRYJ5Z8gHw==",
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^5.0.0",
@@ -45237,6 +45168,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dev": true,
 			"dependencies": {
 				"shebang-regex": "^1.0.0"
 			},
@@ -45248,6 +45180,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -46577,15 +46510,6 @@
 			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/strip-final-newline": {
@@ -48105,6 +48029,7 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
 			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
 			}
@@ -48348,15 +48273,12 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+			"integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
 			"license": "MIT",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
 			"engines": {
-				"node": ">=14.0"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {
@@ -49426,9 +49348,9 @@
 			}
 		},
 		"node_modules/wait-on/node_modules/joi": {
-			"version": "18.2.4",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.4.tgz",
-			"integrity": "sha512-5AxF2kdKOcmF3hg4xAyXqihV6A8pEOrsj71Ta7Clk5OJotLqXH9/QepFDqGEFTfatT5merg0KH0W/8cy4/IE+g==",
+			"version": "18.2.5",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.5.tgz",
+			"integrity": "sha512-+gEA7rLfaNWx9JzawWPrPetSZwT16NUqHtECDgjyAJreXcs4TM7tx2Pa+VVJJK0YHM83ybrVdaT6UekHH50FJQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -50570,107 +50492,6 @@
 			"integrity": "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/windows-release": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
-			"integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
-			"license": "MIT",
-			"dependencies": {
-				"execa": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/windows-release/node_modules/cross-spawn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-			"license": "MIT",
-			"dependencies": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"engines": {
-				"node": ">=4.8"
-			}
-		},
-		"node_modules/windows-release/node_modules/execa": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/windows-release/node_modules/get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"license": "MIT",
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/windows-release/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/windows-release/node_modules/npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/windows-release/node_modules/pump": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-			"license": "MIT",
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"node_modules/windows-release/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
@@ -54120,31 +53941,16 @@
 			"version": "2.53.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@actions/core": "^1.9.1",
-				"@actions/github": "^5.0.1",
-				"@octokit/request-error": "^2.1.0",
-				"@octokit/types": "^6.34.0",
-				"@octokit/webhooks": "^9.26.3",
-				"@octokit/webhooks-types": "^5.8.0"
+				"@actions/core": "^3.0.1",
+				"@actions/github": "^9.1.1",
+				"@octokit/webhooks-types": "^7.6.1"
 			},
 			"devDependencies": {
 				"@types/node": "^20.19.39"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"packages/project-management-automation/node_modules/@octokit/webhooks": {
-			"version": "9.26.3",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.3.tgz",
-			"integrity": "sha512-DLGk+gzeVq5oK89Bo601txYmyrelMQ7Fi5EnjHE0Xs8CWicy2xkmnJMKptKJrBJpstqbd/9oeDFi/Zj2pudBDQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/request-error": "^2.0.2",
-				"@octokit/webhooks-methods": "^2.0.0",
-				"@octokit/webhooks-types": "5.8.0",
-				"aggregate-error": "^3.1.0"
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"packages/react-i18n": {
@@ -54214,10 +54020,10 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@actions/core": "^1.9.1",
-				"@actions/github": "^5.0.1",
+				"@actions/core": "^3.0.1",
+				"@actions/github": "^9.1.1",
 				"@jest/test-result": "^30.4.1",
-				"@octokit/webhooks-types": "^5.8.0",
+				"@octokit/webhooks-types": "^7.6.1",
 				"@playwright/test": "^1.62.1",
 				"jest-message-util": "^30.4.1"
 			},
@@ -54226,8 +54032,8 @@
 				"@types/node": "^20.19.39"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"packages/report-flaky-tests/node_modules/@jest/schemas": {
@@ -56430,7 +56236,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@octokit/rest": "^16.26.0",
+				"@octokit/rest": "^20.1.2",
 				"chalk": "^4.1.1",
 				"commander": "^9.2.0",
 				"execa": "^4.0.2",

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Increase the minimum required Node.js version to 20.10.0.
+-   Convert the package to ES modules. It can no longer be loaded with `require()`.
+
+### Internal
+
+-   Update `@actions/core` to `^3.0.1`, `@actions/github` to `^9.1.1`, and `@octokit/webhooks-types` to `^7.6.1`. Remove the unused `@octokit/request-error`, `@octokit/types`, and `@octokit/webhooks` dependencies.
+-   Run the GitHub Action on the `node24` runtime.
+
 ## 2.53.0 (2026-08-12)
 
 

--- a/packages/project-management-automation/action.yml
+++ b/packages/project-management-automation/action.yml
@@ -6,5 +6,5 @@ inputs:
         description: Secret GitHub API token to use for making API requests.
         required: true
 runs:
-    using: node20
+    using: node24
     main: lib/index.js

--- a/packages/project-management-automation/lib/debug.js
+++ b/packages/project-management-automation/lib/debug.js
@@ -9,4 +9,4 @@ function debug( message ) {
 	}
 }
 
-module.exports = debug;
+export default debug;

--- a/packages/project-management-automation/lib/get-associated-pull-request.js
+++ b/packages/project-management-automation/lib/get-associated-pull-request.js
@@ -36,4 +36,4 @@ function getAssociatedPullRequest( commit ) {
 	return match && Number( match[ 1 ] );
 }
 
-module.exports = getAssociatedPullRequest;
+export default getAssociatedPullRequest;

--- a/packages/project-management-automation/lib/has-wordpress-profile.js
+++ b/packages/project-management-automation/lib/has-wordpress-profile.js
@@ -1,4 +1,4 @@
-const { request } = require( 'https' );
+import { request } from 'node:https';
 
 /**
  * Endpoint hostname for WordPress.org profile lookup by GitHub username.
@@ -40,4 +40,4 @@ async function hasWordPressProfile( githubUsername ) {
 	} );
 }
 
-module.exports = hasWordPressProfile;
+export default hasWordPressProfile;

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -1,10 +1,10 @@
-const { setFailed, getInput } = require( '@actions/core' );
-const { getOctokit, context } = require( '@actions/github' );
-const assignFixedIssues = require( './tasks/assign-fixed-issues' );
-const firstTimeContributorAccountLink = require( './tasks/first-time-contributor-account-link' );
-const firstTimeContributorLabel = require( './tasks/first-time-contributor-label' );
-const addMilestone = require( './tasks/add-milestone' );
-const debug = require( './debug' );
+import { setFailed, getInput } from '@actions/core';
+import { getOctokit, context } from '@actions/github';
+import assignFixedIssues from './tasks/assign-fixed-issues/index.js';
+import firstTimeContributorAccountLink from './tasks/first-time-contributor-account-link/index.js';
+import firstTimeContributorLabel from './tasks/first-time-contributor-label/index.js';
+import addMilestone from './tasks/add-milestone/index.js';
+import debug from './debug.js';
 
 /**
  * Automation task function.

--- a/packages/project-management-automation/lib/tasks/add-milestone/index.js
+++ b/packages/project-management-automation/lib/tasks/add-milestone/index.js
@@ -1,7 +1,6 @@
-const debug = require( '../../debug' );
-const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
+import debug from '../../debug.js';
+import getAssociatedPullRequest from '../../get-associated-pull-request.js';
 
-/** @typedef {import('@octokit/request-error').RequestError} RequestError */
 /** @typedef {ReturnType<typeof import('@actions/github').getOctokit>} GitHub */
 /** @typedef {import('@octokit/webhooks-types').EventPayloadMap['push']} WebhookPayloadPush */
 
@@ -199,4 +198,4 @@ async function addMilestone( payload, octokit ) {
 	} );
 }
 
-module.exports = addMilestone;
+export default addMilestone;

--- a/packages/project-management-automation/lib/tasks/assign-fixed-issues/index.js
+++ b/packages/project-management-automation/lib/tasks/assign-fixed-issues/index.js
@@ -1,4 +1,4 @@
-const debug = require( '../../debug' );
+import debug from '../../debug.js';
 
 /** @typedef {ReturnType<typeof import('@actions/github').getOctokit>} GitHub */
 /** @typedef {import('@octokit/webhooks-types').EventPayloadMap['pull_request']} WebhookPayloadPullRequest */
@@ -44,4 +44,4 @@ async function assignFixedIssues( payload, octokit ) {
 	}
 }
 
-module.exports = assignFixedIssues;
+export default assignFixedIssues;

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
@@ -1,10 +1,10 @@
-const debug = require( '../../debug' );
-const getAssociatedPullRequest = require( '../../get-associated-pull-request' );
-const hasWordPressProfile = require( '../../has-wordpress-profile' );
+import debug from '../../debug.js';
+import getAssociatedPullRequest from '../../get-associated-pull-request.js';
+import hasWordPressProfile from '../../has-wordpress-profile.js';
 
 /** @typedef {ReturnType<typeof import('@actions/github').getOctokit>} GitHub */
 /** @typedef {import('@octokit/webhooks-types').EventPayloadMap['push']} WebhookPayloadPush */
-/** @typedef {import('../../get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
+/** @typedef {import('../../get-associated-pull-request.js').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
 
 /**
  * Returns the message text to be used for the comment prompting contributor to
@@ -120,4 +120,4 @@ async function firstTimeContributorAccountLink( payload, octokit ) {
 	} );
 }
 
-module.exports = firstTimeContributorAccountLink;
+export default firstTimeContributorAccountLink;

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -1,4 +1,4 @@
-const debug = require( '../../debug' );
+import debug from '../../debug.js';
 
 /** @typedef {ReturnType<typeof import('@actions/github').getOctokit>} GitHub */
 /** @typedef {import('@octokit/webhooks-types').EventPayloadMap['pull_request']} WebhookPayloadPullRequest */
@@ -82,4 +82,4 @@ async function firstTimeContributorLabel( payload, octokit ) {
 	} );
 }
 
-module.exports = firstTimeContributorLabel;
+export default firstTimeContributorLabel;

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -20,9 +20,10 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=18.12.0",
-		"npm": ">=8.19.2"
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
 	},
+	"type": "module",
 	"main": "lib/index.js",
 	"exports": {
 		".": "./lib/index.js",
@@ -30,12 +31,9 @@
 	},
 	"types": "build-types",
 	"dependencies": {
-		"@actions/core": "^1.9.1",
-		"@actions/github": "^5.0.1",
-		"@octokit/request-error": "^2.1.0",
-		"@octokit/types": "^6.34.0",
-		"@octokit/webhooks": "^9.26.3",
-		"@octokit/webhooks-types": "^5.8.0"
+		"@actions/core": "^3.0.1",
+		"@actions/github": "^9.1.1",
+		"@octokit/webhooks-types": "^7.6.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.19.39"

--- a/packages/report-flaky-tests/CHANGELOG.md
+++ b/packages/report-flaky-tests/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 -   Flaky tests are no longer reported to GitHub issues, and are no longer reported on pushes. The action now only comments the detected tests, together with their errors, on the pull request. The `label` input has been removed as a result.
 -   The action now runs straight from its TypeScript sources on Node's type stripping, instead of from a bundle. Relative imports must carry their `.ts` extension, and the syntax must be erasable — no enums, namespaces, parameter properties or decorators.
+-   Increase the minimum required Node.js version to 20.10.0.
 
 ### Internal
 
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81517](https://github.com/WordPress/gutenberg/pull/81517))
+-   Update `@actions/core` to `^3.0.1`, `@actions/github` to `^9.1.1`, and `@octokit/webhooks-types` to `^7.6.1`.
 
 -- Initial version of the package.

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -20,8 +20,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=18.12.0",
-		"npm": ">=8.19.2"
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
 	},
 	"type": "module",
 	"main": "src/index.ts",
@@ -34,10 +34,10 @@
 	},
 	"types": "build-types",
 	"dependencies": {
-		"@actions/core": "^1.9.1",
-		"@actions/github": "^5.0.1",
+		"@actions/core": "^3.0.1",
+		"@actions/github": "^9.1.1",
 		"@jest/test-result": "^30.4.1",
-		"@octokit/webhooks-types": "^5.8.0",
+		"@octokit/webhooks-types": "^7.6.1",
 		"@playwright/test": "^1.62.1",
 		"jest-message-util": "^30.4.1"
 	},

--- a/packages/report-flaky-tests/src/__tests__/run.test.ts
+++ b/packages/report-flaky-tests/src/__tests__/run.test.ts
@@ -34,17 +34,28 @@ const mockGetContext = jest.fn(
 	(): typeof mockPushEventContext | typeof mockPullRequestEventContext =>
 		mockPullRequestEventContext
 );
-jest.mock( '@actions/github', () => ( {
-	get context() {
-		return mockGetContext();
-	},
-} ) );
+// `@actions/github` and `@actions/core` are ESM-only, and their `exports`
+// maps hide them from Jest's CommonJS resolver. The factories replace the
+// modules in full, so mark the mocks virtual to skip resolving the real ones.
+jest.mock(
+	'@actions/github',
+	() => ( {
+		get context() {
+			return mockGetContext();
+		},
+	} ),
+	{ virtual: true }
+);
 
-jest.mock( '@actions/core', () => ( {
-	error: jest.fn(),
-	info: jest.fn(),
-	getInput: jest.fn(),
-} ) );
+jest.mock(
+	'@actions/core',
+	() => ( {
+		error: jest.fn(),
+		info: jest.fn(),
+		getInput: jest.fn(),
+	} ),
+	{ virtual: true }
+);
 
 const mockAPI = {
 	createCommentOnPR: jest.fn(),

--- a/tools/release/commands/changelog.js
+++ b/tools/release/commands/changelog.js
@@ -12,10 +12,10 @@ const manifest = require( '../../../package.json' );
 
 const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';
 
-/** @typedef {import('@octokit/rest')} GitHub */
-/** @typedef {import('@octokit/rest').IssuesListForRepoResponseItem} IssuesListForRepoResponseItem */
-/** @typedef {import('@octokit/rest').IssuesListMilestonesForRepoResponseItem} OktokitIssuesListMilestonesForRepoResponseItem */
-/** @typedef {import('@octokit/rest').ReposListReleasesResponseItem} ReposListReleasesResponseItem */
+/** @typedef {import('@octokit/rest').Octokit} GitHub */
+/** @typedef {import('@octokit/rest').RestEndpointMethodTypes} RestEndpointMethodTypes */
+/** @typedef {RestEndpointMethodTypes['issues']['listForRepo']['response']['data'][number]} IssuesListForRepoResponseItem */
+/** @typedef {RestEndpointMethodTypes['repos']['listReleases']['response']['data'][number]} ReposListReleasesResponseItem */
 
 /**
  * @typedef WPChangelogCommandOptions
@@ -670,7 +670,7 @@ async function getLatestReleaseInSeries( octokit, owner, repo, series ) {
 	let latestReleaseForMilestone;
 
 	/**
-	 * @type {AsyncIterableIterator<import('@octokit/rest').Response<import('@octokit/rest').ReposListReleasesResponse>>}
+	 * @type {AsyncIterableIterator<{ data: ReposListReleasesResponseItem[] }>}
 	 */
 	const releases = octokit.paginate.iterator( releaseOptions );
 

--- a/tools/release/generate-php-sync-issue.mjs
+++ b/tools/release/generate-php-sync-issue.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import nodePath, { dirname } from 'path';
-import Octokit from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 
 function getArg( argName ) {
 	const arg = process.argv.find( ( _arg ) =>

--- a/tools/release/lib/milestone.js
+++ b/tools/release/lib/milestone.js
@@ -1,6 +1,7 @@
-/** @typedef {import('@octokit/rest')} GitHub */
-/** @typedef {import('@octokit/rest').IssuesListForRepoResponseItem} IssuesListForRepoResponseItem */
-/** @typedef {import('@octokit/rest').IssuesListMilestonesForRepoResponseItem} OktokitIssuesListMilestonesForRepoResponseItem */
+/** @typedef {import('@octokit/rest').Octokit} GitHub */
+/** @typedef {import('@octokit/rest').RestEndpointMethodTypes} RestEndpointMethodTypes */
+/** @typedef {RestEndpointMethodTypes['issues']['listForRepo']['response']['data'][number]} IssuesListForRepoResponseItem */
+/** @typedef {RestEndpointMethodTypes['issues']['listMilestones']['response']['data'][number]} OktokitIssuesListMilestonesForRepoResponseItem */
 
 /**
  * @typedef {"open"|"closed"|"all"} IssueState
@@ -17,13 +18,13 @@
  * @return {Promise<OktokitIssuesListMilestonesForRepoResponseItem|void>} Promise resolving to milestone, if exists.
  */
 async function getMilestoneByTitle( octokit, owner, repo, title ) {
-	const options = octokit.issues.listMilestonesForRepo.endpoint.merge( {
+	const options = octokit.issues.listMilestones.endpoint.merge( {
 		owner,
 		repo,
 	} );
 
 	/**
-	 * @type {AsyncIterableIterator<import('@octokit/rest').Response<import('@octokit/rest').IssuesListMilestonesForRepoResponse>>}
+	 * @type {AsyncIterableIterator<{ data: OktokitIssuesListMilestonesForRepoResponseItem[] }>}
 	 */
 	const responses = octokit.paginate.iterator( options );
 
@@ -70,12 +71,12 @@ async function getIssuesByMilestone(
 	} );
 
 	/**
-	 * @type {AsyncIterableIterator<import('@octokit/rest').Response<import('@octokit/rest').IssuesListForRepoResponse>>}
+	 * @type {AsyncIterableIterator<{ data: IssuesListForRepoResponseItem[] }>}
 	 */
 	const responses = octokit.paginate.iterator( options );
 
 	/**
-	 * @type {import('@octokit/rest').IssuesListForRepoResponse}
+	 * @type {IssuesListForRepoResponseItem[]}
 	 */
 	const pulls = [];
 
@@ -90,15 +91,7 @@ async function getIssuesByMilestone(
 		return pulls.filter(
 			( pull ) =>
 				pull.closed_at &&
-				closedSinceTimestamp <
-					new Date(
-						// The ugly `as unknown as string` cast is required because of
-						// https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/64
-						// Fixed in Octokit v18.1.1, see https://github.com/WordPress/gutenberg/pull/29043
-						/** @type {string} */ (
-							/** @type {unknown} */ ( pull.closed_at )
-						)
-					)
+				closedSinceTimestamp < new Date( pull.closed_at )
 		);
 	}
 

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -24,7 +24,7 @@
 	},
 	"dependencies": {
 		"@inquirer/prompts": "^7.2.0",
-		"@octokit/rest": "^16.26.0",
+		"@octokit/rest": "^20.1.2",
 		"chalk": "^4.1.1",
 		"commander": "^9.2.0",
 		"execa": "^4.0.2",


### PR DESCRIPTION
## What?

Updates the GitHub Actions and Octokit dependencies:

- `packages/project-management-automation` and `packages/report-flaky-tests`: **`@actions/core` ^1.9.1 → ^3.0.1**, **`@actions/github` ^5.0.1 → ^9.1.1**, **`@octokit/webhooks-types` ^5.8.0 → ^7.6.1**
- `packages/project-management-automation`: remove the unused `@octokit/request-error`, `@octokit/types`, and `@octokit/webhooks`; convert the package to ES modules (the new `@actions/*` lines are ESM-only, and the last CommonJS line, `@actions/github` 8, ships type declarations that do not resolve under `moduleResolution: bundler`); run the action on the `node24` runtime (GitHub has run `node20` actions on Node 24 by default since June 2026 and removes Node 20 from the runner this fall)
- `tools/release`: **`@octokit/rest` ^16.26.0 → ^20.1.2** (the last CommonJS line); `issues.listMilestonesForRepo` → `issues.listMilestones`, named `Octokit` import in `generate-php-sync-issue.mjs`
- Both published packages now declare `node >=20.10.0` (`@octokit/core` 7 requires Node 20). `@wordpress/project-management-automation` gets a major bump (ESM only).

This removes `lodash.set`, `@octokit/request` 5, `@octokit/request-error` 1 and 2, `@octokit/plugin-paginate-rest` 1 and 2, and `undici` 5 from the lockfile. It also performs `npm dedupe`, which may result in additional upgrades.

## Testing Instructions

CI passing should be sufficient for the unit tests, typecheck, and lint. Verified locally as well: 137 unit tests across the three workspaces, `npm run typecheck`, `npm run lint:js`, `npm run lint:deps`, `npm run build`; `node packages/project-management-automation/lib/index.js` fails with the expected missing-input error instead of a module resolution error; `node tools/release/cli.js --help` prints usage.

The `pull-request-automation` workflow checks out `trunk` (`pull_request_target`), so the converted action only runs after merge. Watch the first run on a new pull request. `report-flaky-tests` runs on the e2e workflow of this PR only when a flaky test is reported.

## Use of AI Tools

Prepared with Claude Code (Claude Fable 5): dependency analysis per workspace, the code changes, and the local verification above.
