### PR TITLE
e2e-test-utils-playwright: Update Lighthouse and web-vitals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10186,6 +10186,119 @@
 			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
 			"license": "MIT"
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/api-logs": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+			"integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/core": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+			"integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation": {
+			"version": "0.220.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+			"integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.220.0",
+				"import-in-the-middle": "^3.0.0",
+				"require-in-the-middle": "^8.0.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+			"integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.11.0.tgz",
+			"integrity": "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.11.0.tgz",
+			"integrity": "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/sdk-trace": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
 			"version": "0.127.0",
 			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
@@ -11236,10 +11349,14 @@
 			}
 		},
 		"node_modules/@paulirish/trace_engine": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.32.tgz",
-			"integrity": "sha512-KxWFdRNbv13U8bhYaQvH6gLG9CVEt2jKeosyOOYILVntWEVWhovbgDrbOiZ12pJO3vjZs0Zgbd3/Zgde98woEA==",
-			"license": "BSD-3-Clause"
+			"version": "0.0.65",
+			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.65.tgz",
+			"integrity": "sha512-Qsm6F5C8xf6ZzQXbQc2+wcpe6sggfs/gvc/ytqSurdvYg3kyW0ECHCqE0CWBKZpqgjVfPNX9c7SCS3r2nEIRGg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"legacy-javascript": "latest",
+				"third-party-web": "latest"
+			}
 		},
 		"node_modules/@peculiar/asn1-cms": {
 			"version": "2.6.1",
@@ -12513,6 +12630,195 @@
 				"url": "https://opencollective.com/preact"
 			}
 		},
+		"node_modules/@puppeteer/browsers": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.2.tgz",
+			"integrity": "sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"modern-tar": "^0.8.4",
+				"yargs": "^18.0.0"
+			},
+			"bin": {
+				"browsers": "lib/main-cli.js"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			},
+			"peerDependencies": {
+				"proxy-agent": ">=8.0.1",
+				"yauzl": "^2.10.0 || ^3.4.0"
+			},
+			"peerDependenciesMeta": {
+				"proxy-agent": {
+					"optional": true
+				},
+				"yauzl": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"node_modules/@puppeteer/browsers/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
 		"node_modules/@radix-ui/primitive": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -13258,83 +13564,115 @@
 			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
 			"license": "MIT"
 		},
-		"node_modules/@sentry-internal/tracing": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.1.tgz",
-			"integrity": "sha512-MwZlhQY27oM4V05m2Q46WB2F7jqFu8fewg14yRcjCuK3tdxvQoLsXOEPMZxLxpoXPTqPCm3Ig7mA4GwdlCL41w==",
+		"node_modules/@sentry/conventions": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+			"integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@sentry/core": "7.120.1",
-				"@sentry/types": "7.120.1",
-				"@sentry/utils": "7.120.1"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.1.tgz",
-			"integrity": "sha512-tXpJlf/8ngsSCpcRD+4DDvh4TqUbY0MlvE9Mpc/jO5GgYl/goAH2H1COw6W/UNfkr/l80P2jejS0HLPk0moi0A==",
+			"version": "10.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.73.0.tgz",
+			"integrity": "sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/types": "7.120.1",
-				"@sentry/utils": "7.120.1"
+				"@sentry/conventions": "^0.16.0"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/integrations": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.1.tgz",
-			"integrity": "sha512-dshhLZUN+pYpyZiS5QRYKaYSqvWYtmsbwmBlH4SCGOnN9sbY4nZn0h8njr+xKT8UFnPxoTlbZmkcrVY3qPVMfg==",
-			"license": "MIT",
-			"dependencies": {
-				"@sentry/core": "7.120.1",
-				"@sentry/types": "7.120.1",
-				"@sentry/utils": "7.120.1",
-				"localforage": "^1.8.1"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.1.tgz",
-			"integrity": "sha512-YF/TDUCtUOQeUMwL4vcUWGNv/8Qz9624xBnaL8nXW888xNBoSRr2vH/zMrmTup5zfmWAh9lVbp98BZFF6F0WJg==",
+			"version": "10.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.73.0.tgz",
+			"integrity": "sha512-jiMJ6GgXDw6UMGzJY+o0c8OoeA9OfHqZ/xEpHfDqy75hn+9CEkRkbNGCIdMvsc7wW/Se1Os394hHfTpU+YEskg==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry-internal/tracing": "7.120.1",
-				"@sentry/core": "7.120.1",
-				"@sentry/integrations": "7.120.1",
-				"@sentry/types": "7.120.1",
-				"@sentry/utils": "7.120.1"
+				"@opentelemetry/api": "^1.9.1",
+				"@opentelemetry/instrumentation": "^0.220.0",
+				"@opentelemetry/sdk-trace-base": "^2.9.0",
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.73.0",
+				"@sentry/node-core": "10.73.0",
+				"@sentry/opentelemetry": "10.73.0",
+				"@sentry/server-utils": "10.73.0",
+				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@sentry/types": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.1.tgz",
-			"integrity": "sha512-f/WT7YUH8SA2Jhez/hYz/dA351AJqr1Eht/URUdYsqMFecXr/blAcNKRVFccSsvQeTqWVV9HVQ9BXUSjPJOvFA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@sentry/utils": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.1.tgz",
-			"integrity": "sha512-4boeo5Y3zw3gFrWZmPHsYOIlTh//eBaGBgWL25FqLbLObO23gFE86G6O6knP1Gamm1DGX2IWH7w4MChYuBm6tA==",
+		"node_modules/@sentry/node-core": {
+			"version": "10.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.73.0.tgz",
+			"integrity": "sha512-GHAGUmZPmm6FKfxfv2maVVJ/A99YAmd7oFOuKMDmITI6O/Msl6JB3vPTEpopVAHLW0LYJQBOjddL9C7o+Jt44g==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/types": "7.120.1"
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.73.0",
+				"@sentry/opentelemetry": "10.73.0",
+				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+				"@opentelemetry/instrumentation": ">=0.57.1 <1",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/core": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-http": {
+					"optional": true
+				},
+				"@opentelemetry/instrumentation": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@sentry/opentelemetry": {
+			"version": "10.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.73.0.tgz",
+			"integrity": "sha512-fQouPQKsH0CQrw6oAn1k0Z2I+tgyochCovifr5qNS69i0OzjknLa03WJyiZ/IuzXc4AVa5jAKfOeE9slABz8Qw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.73.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+			}
+		},
+		"node_modules/@sentry/server-utils": {
+			"version": "10.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.73.0.tgz",
+			"integrity": "sha512-QskripdKFbM/+gipC6mpa2crLwL7+VbkX84IpHg2z9UlYQ1kNKd3aMT+Qk9NLRSw/zu1rSIAvlbWfx4D3rgNAA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.73.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@sigstore/bundle": {
@@ -15030,11 +15368,6 @@
 				"@testing-library/dom": ">=7.21.4"
 			}
 		},
-		"node_modules/@tootallnate/quickjs-emscripten": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
-		},
 		"node_modules/@tufjs/canonical-json": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -15863,15 +16196,6 @@
 			"version": "13.1.0",
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
 			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
-		},
-		"node_modules/@types/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-			"optional": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.57.1",
@@ -19641,6 +19965,16 @@
 				"node": ">= 4.5.0"
 			}
 		},
+		"node_modules/atomically": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+			"license": "MIT",
+			"dependencies": {
+				"stubborn-fs": "^2.0.0",
+				"when-exit": "^2.1.4"
+			}
+		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.21",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -19699,9 +20033,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.10.2",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-			"integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+			"integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
 			"license": "MPL-2.0",
 			"engines": {
 				"node": ">=4"
@@ -19765,11 +20099,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/b4a": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-			"integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
 		},
 		"node_modules/babel-jest": {
 			"version": "30.5.0",
@@ -20443,92 +20772,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
-		"node_modules/bare-events": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.1.tgz",
-			"integrity": "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==",
-			"license": "Apache-2.0",
-			"peerDependencies": {
-				"bare-abort-controller": "*"
-			},
-			"peerDependenciesMeta": {
-				"bare-abort-controller": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/bare-fs": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-			"integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-events": "^2.5.4",
-				"bare-path": "^3.0.0",
-				"bare-stream": "^2.6.4",
-				"bare-url": "^2.2.2",
-				"fast-fifo": "^1.3.2"
-			},
-			"engines": {
-				"bare": ">=1.16.0"
-			},
-			"peerDependencies": {
-				"bare-buffer": "*"
-			},
-			"peerDependenciesMeta": {
-				"bare-buffer": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/bare-os": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-			"integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
-			"license": "Apache-2.0",
-			"engines": {
-				"bare": ">=1.14.0"
-			}
-		},
-		"node_modules/bare-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-os": "^3.0.1"
-			}
-		},
-		"node_modules/bare-stream": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-			"integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"streamx": "^2.21.0"
-			},
-			"peerDependencies": {
-				"bare-buffer": "*",
-				"bare-events": "*"
-			},
-			"peerDependenciesMeta": {
-				"bare-buffer": {
-					"optional": true
-				},
-				"bare-events": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/bare-url": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.1.tgz",
-			"integrity": "sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-path": "^3.0.0"
-			}
-		},
 		"node_modules/base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
@@ -20577,6 +20820,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -20602,15 +20846,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/basic-ftp": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/batch": {
@@ -21137,14 +21372,6 @@
 			"integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
 			"license": "MIT/X11"
 		},
-		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -21655,12 +21882,70 @@
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
+		"node_modules/chrome-launcher": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+			"integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/node": "*",
+				"escape-string-regexp": "^4.0.0",
+				"is-wsl": "^2.2.0",
+				"lighthouse-logger": "^2.0.1"
+			},
+			"bin": {
+				"print-chrome-path": "bin/print-chrome-path.cjs"
+			},
+			"engines": {
+				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chrome-launcher/node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"engines": {
 				"node": ">=6.0"
+			}
+		},
+		"node_modules/chromium-bidi": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+			"integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"mitt": "^3.0.1",
+				"zod": "^3.24.1"
+			},
+			"engines": {
+				"node": ">=20.19.0 <22.0.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"devtools-protocol": "*"
 			}
 		},
 		"node_modules/ci-info": {
@@ -22370,30 +22655,48 @@
 			}
 		},
 		"node_modules/configstore": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+			"integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"dot-prop": "^5.2.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"unique-string": "^2.0.0",
-				"write-file-atomic": "^3.0.0",
-				"xdg-basedir": "^4.0.0"
+				"atomically": "^2.0.3",
+				"dot-prop": "^9.0.0",
+				"graceful-fs": "^4.2.11",
+				"xdg-basedir": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/configstore/node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+		"node_modules/configstore/node_modules/dot-prop": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+			"integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+			"license": "MIT",
 			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
+				"type-fest": "^4.18.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/configstore/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/connect-history-api-fallback": {
@@ -23435,18 +23738,11 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/crypto-random-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/csp_evaluator": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.1.tgz",
-			"integrity": "sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw=="
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.8.tgz",
+			"integrity": "sha512-EwOnfYuNbTytvbMKsLixTrRgnjOa0WZCxGy8A9nnSYAicrdwn+T/epU/yjgymmOxlgKnvH+8wXt+7p/8ak5Feg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/css-declaration-sorter": {
 			"version": "6.4.1",
@@ -23714,14 +24010,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
-			"integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/data-urls": {
@@ -24118,32 +24406,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/degenerator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ast-types": "^0.13.4",
-				"escodegen": "^2.1.0",
-				"esprima": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/degenerator/node_modules/ast-types": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -24230,9 +24492,9 @@
 			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
 		},
 		"node_modules/devtools-protocol": {
-			"version": "0.0.1367902",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
-			"integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+			"version": "0.0.1663043",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1663043.tgz",
+			"integrity": "sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
@@ -24430,6 +24692,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
 			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
 			"dependencies": {
 				"is-obj": "^2.0.0"
 			},
@@ -24441,6 +24704,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -25041,34 +25305,6 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/escodegen": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/escodegen/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/eslint": {
 			"version": "10.8.1",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
@@ -25468,15 +25704,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"hermes-estree": "0.25.1"
-			}
-		},
-		"node_modules/eslint-plugin-react-hooks/node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks/node_modules/zod-validation-error": {
@@ -26143,15 +26370,6 @@
 				"node": ">=0.8.x"
 			}
 		},
-		"node_modules/events-universal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-events": "^2.7.0"
-			}
-		},
 		"node_modules/evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -26520,12 +26738,6 @@
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"license": "Apache-2.0"
 		},
-		"node_modules/fast-fifo": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-			"license": "MIT"
-		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -26672,14 +26884,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bser": "2.1.1"
-			}
-		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dependencies": {
-				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/fdir": {
@@ -27217,19 +27421,6 @@
 				"node": ">= 8.0.0"
 			}
 		},
-		"node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
 		"node_modules/fs-minipass": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
@@ -27560,20 +27751,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-			}
-		},
-		"node_modules/get-uri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.1.tgz",
-			"integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
-			"dependencies": {
-				"basic-ftp": "^5.0.2",
-				"data-uri-to-buffer": "^5.0.1",
-				"debug": "^4.3.4",
-				"fs-extra": "^8.1.0"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/get-value": {
@@ -28513,6 +28690,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -28558,12 +28736,6 @@
 			"resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
 			"integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg=="
 		},
-		"node_modules/immediate": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"license": "MIT"
-		},
 		"node_modules/immutable": {
 			"version": "5.1.8",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.8.tgz",
@@ -28592,6 +28764,26 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/import-in-the-middle": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.4.0.tgz",
+			"integrity": "sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cjs-module-lexer": "^2.2.0",
+				"es-module-lexer": "^2.2.0",
+				"module-details-from-path": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/import-in-the-middle/node_modules/es-module-lexer": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+			"integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+			"license": "MIT"
 		},
 		"node_modules/import-local": {
 			"version": "3.1.0",
@@ -28839,6 +29031,7 @@
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
 			"integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -29472,11 +29665,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
 		},
 		"node_modules/is-unicode-supported": {
 			"version": "0.1.0",
@@ -33668,14 +33856,6 @@
 			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
 			"license": "MIT"
 		},
-		"node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
 		"node_modules/jsonify": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
@@ -33855,6 +34035,12 @@
 				"picocolors": "^1.1.1",
 				"shell-quote": "^1.8.4"
 			}
+		},
+		"node_modules/legacy-javascript": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+			"integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/lerna": {
 			"version": "9.0.7",
@@ -34952,46 +35138,35 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/lie": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-			"integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-			"license": "MIT",
-			"dependencies": {
-				"immediate": "~3.0.5"
-			}
-		},
 		"node_modules/lighthouse": {
-			"version": "12.2.2",
-			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.2.2.tgz",
-			"integrity": "sha512-avoiiFeGN1gkWhp/W1schJoXOsTPxRKWV3+uW/rGHuov2g/HGB+4SN9J/av1GNSh13sEYgkHL3iJOp1+mBVKYQ==",
+			"version": "13.4.1",
+			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.4.1.tgz",
+			"integrity": "sha512-fDu8lt3QLK/lTqIxtp1HkzQNJ32rsFHhbadYOepcMZFLgA8oINhxutMbMv8XXnpTOvZ0TXCo4JCk1LDTWaRLnA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@paulirish/trace_engine": "0.0.32",
-				"@sentry/node": "^7.0.0",
-				"axe-core": "^4.10.2",
-				"chrome-launcher": "^1.1.2",
-				"configstore": "^5.0.1",
-				"csp_evaluator": "1.1.1",
-				"devtools-protocol": "0.0.1312386",
+				"@paulirish/trace_engine": "0.0.65",
+				"@sentry/node": "^10.0.0",
+				"axe-core": "^4.12.1",
+				"chrome-launcher": "^1.2.1",
+				"configstore": "^7.0.0",
+				"csp_evaluator": "1.1.8",
+				"devtools-protocol": "0.0.1663043",
 				"enquirer": "^2.3.6",
 				"http-link-header": "^1.1.1",
 				"intl-messageformat": "^10.5.3",
 				"jpeg-js": "^0.4.4",
 				"js-library-detector": "^6.7.0",
-				"lighthouse-logger": "^2.0.1",
-				"lighthouse-stack-packs": "1.12.2",
+				"lighthouse-logger": "^2.0.2",
+				"lighthouse-stack-packs": "1.12.3",
 				"lodash-es": "^4.17.21",
 				"lookup-closest-locale": "6.2.0",
-				"metaviewport-parser": "0.3.0",
 				"open": "^8.4.0",
-				"parse-cache-control": "1.0.1",
-				"puppeteer-core": "^23.8.0",
+				"puppeteer-core": "^25.3.0",
 				"robots-parser": "^3.0.1",
-				"semver": "^5.3.0",
 				"speedline-core": "^1.4.3",
-				"third-party-web": "^0.26.1",
-				"tldts-icann": "^6.1.16",
+				"third-party-web": "^0.29.2",
+				"tldts-icann": "^7.4.9",
+				"web-features": "^3.34.0",
 				"ws": "^7.0.0",
 				"yargs": "^17.3.1",
 				"yargs-parser": "^21.0.0"
@@ -35002,88 +35177,24 @@
 				"smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
 			},
 			"engines": {
-				"node": ">=18.16"
+				"node": ">=22.19"
 			}
 		},
-		"node_modules/lighthouse-stack-packs": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.2.tgz",
-			"integrity": "sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==",
-			"license": "Apache-2.0"
-		},
-		"node_modules/lighthouse/node_modules/chrome-launcher": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.1.2.tgz",
-			"integrity": "sha512-YclTJey34KUm5jB1aEJCq807bSievi7Nb/TU4Gu504fUYi3jw3KCIaH6L7nFWQhdEgH3V+wCh+kKD1P5cXnfxw==",
+		"node_modules/lighthouse-logger": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+			"integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@types/node": "*",
-				"escape-string-regexp": "^4.0.0",
-				"is-wsl": "^2.2.0",
-				"lighthouse-logger": "^2.0.1"
-			},
-			"bin": {
-				"print-chrome-path": "bin/print-chrome-path.js"
-			},
-			"engines": {
-				"node": ">=12.13.0"
-			}
-		},
-		"node_modules/lighthouse/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/lighthouse/node_modules/devtools-protocol": {
-			"version": "0.0.1312386",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-			"integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/lighthouse/node_modules/escape-string-regexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lighthouse/node_modules/is-wsl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-			"dependencies": {
-				"is-docker": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lighthouse/node_modules/lighthouse-logger": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.1.tgz",
-			"integrity": "sha512-ioBrW3s2i97noEmnXxmUq7cjIcVRjT5HBpAYy8zE11CxU9HqlWHHeRxfeN1tn8F7OEMVPIC9x1f8t3Z7US9ehQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^2.6.9",
+				"debug": "^4.4.1",
 				"marky": "^1.2.2"
 			}
 		},
-		"node_modules/lighthouse/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"bin": {
-				"semver": "bin/semver"
-			}
+		"node_modules/lighthouse-stack-packs": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.3.tgz",
+			"integrity": "sha512-d8IsOpE83kbANgnM+Tp8+x6HcMpX9o2ITBiUERssgzAIFdZCQzs/f4k6D0DLQTE59enml9mbAOU52Wu35exWtg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/ws": {
 			"version": "7.5.13",
@@ -35616,15 +35727,6 @@
 			},
 			"engines": {
 				"node": ">=8.9.0"
-			}
-		},
-		"node_modules/localforage": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-			"integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"lie": "3.1.1"
 			}
 		},
 		"node_modules/locate-path": {
@@ -36487,9 +36589,10 @@
 			}
 		},
 		"node_modules/marky": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -36698,11 +36801,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/metaviewport-parser": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
-			"integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ=="
 		},
 		"node_modules/methods": {
 			"version": "1.1.2",
@@ -37288,6 +37386,15 @@
 				"css-mediaquery": "^0.1.2"
 			}
 		},
+		"node_modules/modern-tar": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.5.tgz",
+			"integrity": "sha512-snEhs+6G5Tjd4I7tLCDOaoln2RgE0bD19RzEKgvgK2hZ5VKy3MpLhLTZ2fWpXSTg4K2cyPwp+VHATFJhxfnOeA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -37297,6 +37404,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/module-details-from-path": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+			"license": "MIT"
 		},
 		"node_modules/moment": {
 			"version": "2.29.4",
@@ -37516,15 +37629,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-		},
-		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
 		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
@@ -39610,38 +39714,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/pac-proxy-agent": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
-			"integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/quickjs-emscripten": "^0.23.0",
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"get-uri": "^6.0.1",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.6",
-				"pac-resolver": "^7.0.1",
-				"socks-proxy-agent": "^8.0.5"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-resolver": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-			"license": "MIT",
-			"dependencies": {
-				"degenerator": "^5.0.0",
-				"netmask": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -40153,11 +40225,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/parse-cache-control": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-			"integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
-		},
 		"node_modules/parse-conflict-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-4.0.0.tgz",
@@ -40607,11 +40674,6 @@
 			"engines": {
 				"node": ">=0.10"
 			}
-		},
-		"node_modules/pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
 		},
 		"node_modules/phpegjs": {
 			"version": "1.0.0-beta7",
@@ -41562,14 +41624,6 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/promise-all-reject-late": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
@@ -41652,11 +41706,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-		},
 		"node_modules/prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -41720,141 +41769,27 @@
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "23.10.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.10.1.tgz",
-			"integrity": "sha512-ey6NwixHYEUnhCA/uYi7uQQ4a0CZw4k+MatbHXGl5GEzaiRQziYUxc2HGpdQZ/gnh4KQWAKkocyIg1/dIm5d0g==",
+			"version": "25.10.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.10.0.tgz",
+			"integrity": "sha512-Hy5eMQshOEMil4JUUx03h5pw1HYkYCso1RG/gcpPlFSd4cYPOcopxcXEAxpLPOkOPJb9LIJtwxuj66bSdvknFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.5.0",
-				"chromium-bidi": "0.8.0",
-				"debug": "^4.3.7",
-				"devtools-protocol": "0.0.1367902",
-				"typed-query-selector": "^2.12.0",
-				"ws": "^8.18.0"
+				"@puppeteer/browsers": "3.2.2",
+				"chromium-bidi": "17.0.2",
+				"devtools-protocol": "0.0.1666840",
+				"typed-query-selector": "^2.12.2",
+				"webdriver-bidi-protocol": "0.4.3",
+				"ws": "^8.21.3"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22.12.0"
 			}
 		},
-		"node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.5.0.tgz",
-			"integrity": "sha512-6TQAc/5uRILE6deixJ1CR8rXyTbzXIXNgO1D0Woi9Bqicz2FV5iKP3BHYEg6o4UATCMcbQQ0jbmeaOkn/HQk2w==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^4.3.7",
-				"extract-zip": "^2.0.1",
-				"progress": "^2.0.3",
-				"proxy-agent": "^6.4.0",
-				"semver": "^7.6.3",
-				"tar-fs": "^3.0.6",
-				"unbzip2-stream": "^1.4.3",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"browsers": "lib/cjs/main-cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
-			"integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"mitt": "3.0.1",
-				"urlpattern-polyfill": "10.0.0",
-				"zod": "3.23.8"
-			},
-			"peerDependencies": {
-				"devtools-protocol": "*"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/proxy-agent": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"http-proxy-agent": "^7.0.1",
-				"https-proxy-agent": "^7.0.6",
-				"lru-cache": "^7.14.1",
-				"pac-proxy-agent": "^7.1.0",
-				"proxy-from-env": "^1.1.0",
-				"socks-proxy-agent": "^8.0.5"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/pump": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-			"license": "MIT",
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/tar-fs": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-			"integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
-			"license": "MIT",
-			"dependencies": {
-				"pump": "^3.0.0",
-				"tar-stream": "^3.1.5"
-			},
-			"optionalDependencies": {
-				"bare-fs": "^4.0.1",
-				"bare-path": "^3.0.0"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/tar-stream": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-			"integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-			"license": "MIT",
-			"dependencies": {
-				"b4a": "^1.6.4",
-				"bare-fs": "^4.5.5",
-				"fast-fifo": "^1.2.0",
-				"streamx": "^2.15.0"
-			}
+		"node_modules/puppeteer-core/node_modules/devtools-protocol": {
+			"version": "0.0.1666840",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+			"integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/pure-rand": {
 			"version": "7.0.1",
@@ -42625,6 +42560,19 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-in-the-middle": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.5",
+				"module-details-from-path": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
 			}
 		},
 		"node_modules/requireindex": {
@@ -44262,6 +44210,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
@@ -44458,6 +44407,7 @@
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
 			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ip-address": "^10.1.1",
@@ -44472,6 +44422,7 @@
 			"version": "8.0.5",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
 			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.2",
@@ -44981,17 +44932,6 @@
 			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 			"dev": true
 		},
-		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
-			"license": "MIT",
-			"dependencies": {
-				"events-universal": "^1.0.0",
-				"fast-fifo": "^1.3.2",
-				"text-decoder": "^1.1.0"
-			}
-		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -45274,6 +45214,21 @@
 			"dependencies": {
 				"anynum": "^1.0.1"
 			}
+		},
+		"node_modules/stubborn-fs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+			"integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+			"license": "MIT",
+			"dependencies": {
+				"stubborn-utils": "^1.0.1"
+			}
+		},
+		"node_modules/stubborn-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+			"integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+			"license": "MIT"
 		},
 		"node_modules/style-search": {
 			"version": "0.1.0",
@@ -46440,15 +46395,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"b4a": "^1.6.4"
-			}
-		},
 		"node_modules/text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -46497,15 +46443,16 @@
 			}
 		},
 		"node_modules/third-party-web": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.2.tgz",
-			"integrity": "sha512-taJ0Us0lKoYBqcbccMuDElSUPOxmBfwlHe1OkHQ3KFf+RwovvBHdXhbFk9XJVQE2vHzxbTwvwg5GFsT9hbDokQ==",
+			"version": "0.29.2",
+			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.29.2.tgz",
+			"integrity": "sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==",
 			"license": "MIT"
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"dev": true
 		},
 		"node_modules/through2": {
 			"version": "2.0.5",
@@ -46636,13 +46583,19 @@
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "6.1.66",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.66.tgz",
-			"integrity": "sha512-f4AgNXjymBX3/EXYrnvjyBhXVQ+NWyPzXjqRb17vr0b6SprZKVNnsWNFJAPI6JkPHCm7dHhFDgyneHQEq5uJRA==",
+			"version": "7.4.12",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.12.tgz",
+			"integrity": "sha512-KYMFombFttNwGKI9GhqlHBn/+QROOk2bvh5p+aVmRSF8VH+YYVS9fEq0ux099jzw0JXmk2yRErCiviveSL/QhA==",
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.66"
+				"tldts-core": "^7.4.12"
 			}
+		},
+		"node_modules/tldts-icann/node_modules/tldts-core": {
+			"version": "7.4.12",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+			"integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
+			"license": "MIT"
 		},
 		"node_modules/tmp": {
 			"version": "0.2.7",
@@ -47089,23 +47042,16 @@
 			}
 		},
 		"node_modules/typed-query-selector": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-			"integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+			"integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+			"license": "MIT"
 		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true
-		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
-			}
 		},
 		"node_modules/typescript": {
 			"name": "@typescript/typescript6",
@@ -47178,38 +47124,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"dependencies": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
-			}
-		},
-		"node_modules/unbzip2-stream/node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/undici": {
@@ -47353,17 +47267,6 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"node_modules/unique-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-			"dependencies": {
-				"crypto-random-string": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/unist-util-is": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
@@ -47425,14 +47328,6 @@
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
 			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
 			"license": "ISC"
-		},
-		"node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -47719,12 +47614,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
 			"dev": true
-		},
-		"node_modules/urlpattern-polyfill": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-			"integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-			"license": "MIT"
 		},
 		"node_modules/use": {
 			"version": "3.1.1",
@@ -48663,6 +48552,18 @@
 				"defaults": "^1.0.3"
 			}
 		},
+		"node_modules/web-features": {
+			"version": "3.37.0",
+			"resolved": "https://registry.npmjs.org/web-features/-/web-features-3.37.0.tgz",
+			"integrity": "sha512-47x5zchtpsvvH/EEQ0h3d3E9kZyFxFyk6LkmYHXDZjLF0RAa3OV2s8dMRqphp/PTxxrd/iZwz37dte6xWgV7mQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/webdriver-bidi-protocol": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.3.tgz",
+			"integrity": "sha512-uuN0goWfxP22B7J/uAgBpOYNPttC+XVseYE+rSY5+rQ+YBeVz/VORw8WbmLVcqW78zNg5A4qnjNXYUWR3il2ig==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -49289,6 +49190,12 @@
 				"webidl-conversions": "^3.0.0"
 			}
 		},
+		"node_modules/when-exit": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+			"integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+			"license": "MIT"
+		},
 		"node_modules/which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -49621,11 +49528,15 @@
 			"integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
 		},
 		"node_modules/xdg-basedir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+			"integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xml-name-validator": {
@@ -49813,15 +49724,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dependencies": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
 		"node_modules/yjs": {
 			"version": "13.6.29",
 			"resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
@@ -49863,9 +49765,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.23.8",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -51338,7 +51240,7 @@
 			"dependencies": {
 				"change-case": "^4.1.2",
 				"get-port": "^5.1.1",
-				"lighthouse": "^12.2.2",
+				"lighthouse": "^13.4.1",
 				"mime": "^3.0.0",
 				"web-vitals": "^4.2.1"
 			},
@@ -51347,7 +51249,7 @@
 				"@types/node": "^24.13.3"
 			},
 			"engines": {
-				"node": ">=18.12.0",
+				"node": ">=22.19.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48558,6 +48558,12 @@
 			"integrity": "sha512-47x5zchtpsvvH/EEQ0h3d3E9kZyFxFyk6LkmYHXDZjLF0RAa3OV2s8dMRqphp/PTxxrd/iZwz37dte6xWgV7mQ==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/web-vitals": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+			"integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/webdriver-bidi-protocol": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.3.tgz",
@@ -51242,7 +51248,7 @@
 				"get-port": "^5.1.1",
 				"lighthouse": "^13.4.1",
 				"mime": "^3.0.0",
-				"web-vitals": "^4.2.1"
+				"web-vitals": "^4.2.4"
 			},
 			"devDependencies": {
 				"@types/mime": "^2.0.3",
@@ -51256,12 +51262,6 @@
 				"@playwright/test": ">=1",
 				"@types/node": ">=20"
 			}
-		},
-		"packages/e2e-test-utils-playwright/node_modules/web-vitals": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.1.tgz",
-			"integrity": "sha512-U6bAxeudnhDqcXNl50JC4hLlqox9DZnngxfISZm3DMZnonW35xtJOVUc091L+DOY+6hVZVpKXoiCP0RiT6339Q==",
-			"license": "Apache-2.0"
 		},
 		"packages/e2e-tests": {
 			"name": "@wordpress/e2e-tests",

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Increase the minimum required Node.js version to v22.19.0. The `lighthouse` dependency is now `^13.4.1`, which requires it. Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
+-   Increase the minimum required Node.js version to v22.19.0. The `lighthouse` dependency is now `^13.4.1`, which requires it. Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases) ([#81916](https://github.com/WordPress/gutenberg/pull/81916)).
 -   `Editor.switchEditorTool()`: Remove the helper. It clicked the Write/Design "Tools" toolbar button, which the editor no longer renders since [#72193](https://github.com/WordPress/gutenberg/pull/72193) ([#82677](https://github.com/WordPress/gutenberg/pull/82677)).
 
 ### New Features
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   `Metrics.initWebVitals()`: Resolve `web-vitals` from the installed dependency so published consumers can load it outside the Gutenberg monorepo. Update to 4.2.4 to fix interaction counts after back/forward cache restores and prevent repeated input-listener registration ([#81916](https://github.com/WordPress/gutenberg/pull/81916)).
 -   `Editor.saveSiteEditorEntities()`: Wait for the save button to mount before deciding between its `Save` and `Publish` variants, instead of sampling visibility immediately — the extensible site editor only renders it once an entity is dirty.
 
 ### Internal

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   Increase the minimum required Node.js version to v22.19.0. The `lighthouse` dependency is now `^13.4.1`, which requires it. Learn more about [Node.js releases](https://nodejs.org/en/about/previous-releases).
 -   `Editor.switchEditorTool()`: Remove the helper. It clicked the Write/Design "Tools" toolbar button, which the editor no longer renders since [#72193](https://github.com/WordPress/gutenberg/pull/72193) ([#82677](https://github.com/WordPress/gutenberg/pull/82677)).
 
 ### New Features

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=18.12.0",
+		"node": ">=22.19.0",
 		"npm": ">=8.19.2"
 	},
 	"files": [
@@ -39,7 +39,7 @@
 	"dependencies": {
 		"change-case": "^4.1.2",
 		"get-port": "^5.1.1",
-		"lighthouse": "^12.2.2",
+		"lighthouse": "^13.4.1",
 		"mime": "^3.0.0",
 		"web-vitals": "^4.2.1"
 	},

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -41,7 +41,7 @@
 		"get-port": "^5.1.1",
 		"lighthouse": "^13.4.1",
 		"mime": "^3.0.0",
-		"web-vitals": "^4.2.1"
+		"web-vitals": "^4.2.4"
 	},
 	"devDependencies": {
 		"@types/mime": "^2.0.3",

--- a/packages/e2e-test-utils-playwright/src/metrics/index.ts
+++ b/packages/e2e-test-utils-playwright/src/metrics/index.ts
@@ -437,10 +437,7 @@ export class Metrics {
 	 */
 	async initWebVitals( reload = true ) {
 		await this.page.addInitScript( {
-			path: join(
-				__dirname,
-				'../../../../node_modules/web-vitals/dist/web-vitals.umd.cjs'
-			),
+			path: require.resolve( 'web-vitals' ),
 		} );
 
 		await this.page.exposeFunction(


### PR DESCRIPTION
## What?

-   Update `lighthouse` from `^12.2.2` to the latest compatible release, `^13.4.1`.
-   Raise this package's Node.js requirement from `>=18.12.0` to Lighthouse's minimum, `>=22.19.0`.
-   Update `web-vitals` from `^4.2.1` to `^4.2.4` and make `Metrics.initWebVitals()` resolve the installed dependency correctly in published consumers.

## Why?

Gutenberg now requires Node.js 24, so the repository can adopt [Lighthouse 13](https://developer.chrome.com/blog/lighthouse-13-0). The published test-utils package keeps Lighthouse's lower Node.js 22.19 minimum to avoid an unnecessary additional breaking change for consumers.

The update also removes the vulnerable old Puppeteer download chain (`lighthouse`, `puppeteer-core`, `@puppeteer/browsers`, and `extract-zip`) reported by `npm audit`.

The existing `web-vitals` path assumed Gutenberg's monorepo layout. Packed consumers instead resolved a nonexistent `node_modules/node_modules` path, and could select the wrong major when their dependency tree differed.

## How?

The Lighthouse fixture keeps its existing five-audit contract and CommonJS entry point. `Metrics.initWebVitals()` now uses `require.resolve( 'web-vitals' )`, which follows the installed package boundary. The patch update to `web-vitals` includes its back/forward-cache interaction-count and repeated-listener fixes.

The regenerated lockfile hoists `web-vitals` 4.2.4. A package-scoped dedupe reports no further changes, so this PR does not include unrelated root toolchain deduplication.

## Testing Instructions

1. Use Node.js 22.19 and build `@wordpress/e2e-test-utils-playwright`.
2. Run a Playwright test that calls the `lighthouse` fixture against a local WordPress page.
3. Confirm that the report contains numeric LCP, TBT, TTI, CLS, and INP values.
4. Pack the package and install it in a temporary consumer alongside `web-vitals` 6.
5. Call `Metrics.initWebVitals( false )` and confirm that it loads the package's `web-vitals` 4.2.4 file, not the consumer's incompatible major.

<details>
<summary>Verification completed</summary>

-   Workspace build, repository typecheck, targeted lint, and package-scoped dedupe check pass.
-   Lighthouse returned LCP, TBT, TTI, CLS, and INP values against a local WordPress site.
-   A packed consumer with root `web-vitals` 6.2.1 loaded the package's nested 4.2.4 file.
-   `npm audit` reports 64 findings on this branch versus 68 on the frozen trunk base, with four high-severity findings removed and none added.

</details>

## Use of AI Tools

The original Lighthouse update and runtime checks were prepared with Claude Code (Claude Fable 5). The rebase, release audit, related-dependency assessment, `web-vitals` fix, and final verification were prepared with Codex (GPT-5).
