### PR TITLE
Update lerna to 10 and markdownlint-cli to 0.49.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35623,9 +35623,9 @@
 			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
 		},
 		"node_modules/markdownlint": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
-			"integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+			"version": "0.41.1",
+			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+			"integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
 			"license": "MIT",
 			"dependencies": {
 				"micromark": "4.0.2",
@@ -35636,45 +35636,46 @@
 				"micromark-extension-gfm-table": "2.1.1",
 				"micromark-extension-math": "3.1.0",
 				"micromark-util-types": "2.0.2",
-				"string-width": "8.1.0"
+				"string-width": "8.2.1"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/DavidAnson"
 			}
 		},
 		"node_modules/markdownlint-cli": {
-			"version": "0.48.0",
-			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
-			"integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.1.tgz",
+			"integrity": "sha512-qpYqJbSYf3jv57bdnFmCaZ/Wlu6IYHp2b6SOKrKBJ7OnPrDHIKmx4NERWH49QH9viTI6yO6raVDDn5nrf60VQQ==",
 			"license": "MIT",
 			"dependencies": {
-				"commander": "~14.0.3",
+				"commander": "~15.0.0",
 				"deep-extend": "~0.6.0",
-				"ignore": "~7.0.5",
-				"js-yaml": "~4.1.1",
+				"ignore": "~7.0.6",
+				"js-yaml": "~5.2.1",
 				"jsonc-parser": "~3.3.1",
 				"jsonpointer": "~5.0.1",
-				"markdown-it": "~14.1.1",
-				"markdownlint": "~0.40.0",
-				"minimatch": "~10.2.4",
-				"run-con": "~1.3.2",
-				"smol-toml": "~1.6.0",
-				"tinyglobby": "~0.2.15"
+				"markdown-it": "~14.3.0",
+				"markdownlint": "~0.41.1",
+				"minimatch": "~10.2.5",
+				"run-con": "~1.3.3",
+				"smol-toml": "~1.7.0",
+				"tinyglobby": "~0.2.17"
 			},
 			"bin": {
 				"markdownlint": "markdownlint.js"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
 		},
 		"node_modules/markdownlint-cli/node_modules/balanced-match": {
 			"version": "4.0.4",
@@ -35698,12 +35699,12 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=20"
+				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
@@ -35716,9 +35717,9 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
-			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+			"integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
 			"funding": [
 				{
 					"type": "github",
@@ -35734,7 +35735,7 @@
 				"argparse": "^2.0.1"
 			},
 			"bin": {
-				"js-yaml": "bin/js-yaml.js"
+				"js-yaml": "bin/js-yaml.mjs"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/minimatch": {
@@ -35752,6 +35753,18 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/markdownlint-cli/node_modules/smol-toml": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.2.tgz",
+			"integrity": "sha512-pXFZ9B2WinEPzxWkMmlYE/oYx2BP+qLrE95wP8tCuK901uLSMGdCb6QSr82z+wnhXkG4+cO+OMLbZB2Cn+97zw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
 		"node_modules/markdownlint/node_modules/ansi-regex": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
@@ -35765,13 +35778,13 @@
 			}
 		},
 		"node_modules/markdownlint/node_modules/string-width": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-			"integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+			"integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
 			"license": "MIT",
 			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"strip-ansi": "^7.1.0"
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
 				"node": ">=20"
@@ -42639,13 +42652,13 @@
 			}
 		},
 		"node_modules/run-con": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
-			"integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.3.tgz",
+			"integrity": "sha512-Lb7OKM9aaykzyoNiHGhSVCjZsvbyy6qDMp2vDXL+MoCfz3GfNJtHYH7uYsU3QNMyInBk++xx+EZ8xZ8Sxs5fNQ==",
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
 				"deep-extend": "^0.6.0",
-				"ini": "~4.1.0",
+				"ini": "~7.0.0",
 				"minimist": "^1.2.8",
 				"strip-json-comments": "~3.1.1"
 			},
@@ -42654,12 +42667,12 @@
 			}
 		},
 		"node_modules/run-con/node_modules/ini": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+			"integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -43888,6 +43901,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
 			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">= 18"
@@ -50206,11 +50220,47 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"packages/components/node_modules/framer-motion": {
+			"version": "11.15.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
+			"integrity": "sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==",
+			"dependencies": {
+				"motion-dom": "^11.14.3",
+				"motion-utils": "^11.14.3",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"packages/components/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
 			"license": "MIT"
+		},
+		"packages/components/node_modules/react-colorful": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
 		},
 		"packages/compose": {
 			"name": "@wordpress/compose",
@@ -53493,7 +53543,7 @@
 				"jest": "^30.5.0",
 				"jest-environment-jsdom": "^30.5.0",
 				"json2php": "^0.0.9",
-				"markdownlint-cli": "^0.48.0",
+				"markdownlint-cli": "^0.49.1",
 				"mini-css-extract-plugin": "^2.9.2",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
@@ -53505,7 +53555,6 @@
 				"read-pkg-up": "^7.0.1",
 				"resolve-bin": "^1.0.1",
 				"rtlcss": "^4.3.0",
-				"run-con": "1.3.2",
 				"sass": "^1.54.0",
 				"sass-loader": "^16.0.3",
 				"schema-utils": "^4.2.0",
@@ -53526,7 +53575,7 @@
 				"vitest": "^5.0.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || >=22.13.0",
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53505,6 +53505,7 @@
 				"read-pkg-up": "^7.0.1",
 				"resolve-bin": "^1.0.1",
 				"rtlcss": "^4.3.0",
+				"run-con": "1.3.2",
 				"sass": "^1.54.0",
 				"sass-loader": "^16.0.3",
 				"schema-utils": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"concurrently": "^9.2.1",
 				"cross-env": "^7.0.3",
 				"husky": "^7.0.0",
-				"lerna": "^9.0.7",
+				"lerna": "^10.0.1",
 				"lint-staged": "^16.4.0",
 				"patch-package": "^8.0.0",
 				"syncpack": "^15.3.1",
@@ -2425,6 +2425,36 @@
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
 			"license": "MIT"
 		},
+		"node_modules/@clack/core": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+			"integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-wrap-ansi": "^0.2.0",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 20.12.0"
+			}
+		},
+		"node_modules/@clack/prompts": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+			"integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@clack/core": "1.4.3",
+				"fast-string-width": "^3.0.2",
+				"fast-wrap-ansi": "^0.2.0",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 20.12.0"
+			}
+		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -2433,6 +2463,43 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@conventional-changelog/git-client": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.2.tgz",
+			"integrity": "sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/child-process-utils": "^2.0.0",
+				"@simple-libs/stream-utils": "^2.0.0",
+				"semver": "^7.5.2"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"peerDependencies": {
+				"conventional-commits-filter": "^6.0.1",
+				"conventional-commits-parser": "^7.1.2"
+			},
+			"peerDependenciesMeta": {
+				"conventional-commits-filter": {
+					"optional": true
+				},
+				"conventional-commits-parser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@conventional-changelog/template": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
+			"integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
@@ -3896,16 +3963,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@hutson/parse-repository-url": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
-			"integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@inquirer/ansi": {
@@ -7623,16 +7680,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@mawesome/dependency-audit/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@mawesome/dependency-audit/node_modules/glob": {
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -7841,23 +7888,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@mawesome/dependency-audit/node_modules/tar": {
-			"version": "7.5.22",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
-			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@mawesome/dependency-audit/node_modules/typescript": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -7880,16 +7910,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@mdx-js/react": {
@@ -9174,22 +9194,20 @@
 			}
 		},
 		"node_modules/@nx/devkit": {
-			"version": "22.7.5",
-			"resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.5.tgz",
-			"integrity": "sha512-/63ziS7kdHXYTLLhwWBu9hFwoFFT8xf+PkcQjsNdPqc5JmkYkSew0cE/vp5ORgBpGLWWnFPJgmfqjbJoO2C7jA==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-23.2.0.tgz",
+			"integrity": "sha512-srj04UsYqq2nG7Z9DxM00D8XpSpmSM7XQafCkD4FIOE2NPMCu0QvypJLe8S7a1/YAW9rqlnYrdadaQte687eAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@zkochan/js-yaml": "0.0.7",
 				"ejs": "5.0.1",
-				"enquirer": "~2.3.6",
 				"minimatch": "10.2.5",
 				"semver": "^7.6.3",
 				"tslib": "^2.3.0",
 				"yargs-parser": "21.1.1"
 			},
 			"peerDependencies": {
-				"nx": ">= 21 <= 23 || ^22.0.0-0"
+				"nx": ">= 22 <= 24 || ^23.0.0-0"
 			}
 		},
 		"node_modules/@nx/devkit/node_modules/balanced-match": {
@@ -9242,9 +9260,9 @@
 			}
 		},
 		"node_modules/@nx/nx-darwin-arm64": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.8.tgz",
-			"integrity": "sha512-IM1geDyWPFsS565de9dByYNZ5I3j8FQZvNUp9LIYw1dNu70sCWbAT0glw0anholOwlAb7JWEscoUeV7ouRBW0A==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-23.2.0.tgz",
+			"integrity": "sha512-nael5WwtqBX/YZDU0iv8M4rJ8auF9kF+sU5pYpronIbvu/LdDptq31vWT06ivW8eXRaLxDqFmpXR8tS5IYDmdw==",
 			"cpu": [
 				"arm64"
 			],
@@ -9256,9 +9274,9 @@
 			]
 		},
 		"node_modules/@nx/nx-darwin-x64": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.8.tgz",
-			"integrity": "sha512-X/AyooJCmAwHyp9f//bspkAmtaPsv2lPEKe6OiOScsyxJITP4nw+rOfIAJ4Ar64WQcMAY8WLP+ys4ah0K6DZSw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-23.2.0.tgz",
+			"integrity": "sha512-jZ7c6ktp8Wdroru6lj8WxvYDiK70B2cE3GdV9pcgCcVQvK6PLJXgOaHvQjALMINraYhzlsWX/FkWMy4eMMlJzg==",
 			"cpu": [
 				"x64"
 			],
@@ -9270,9 +9288,9 @@
 			]
 		},
 		"node_modules/@nx/nx-freebsd-x64": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.8.tgz",
-			"integrity": "sha512-mgdqiFag8txon4XugDtNj+hq+X9Whn8LBMuqwJSez93L1fralzpQFSUip7XnE7ejQRr5Zewg3BFscGlsk8Cy3A==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-23.2.0.tgz",
+			"integrity": "sha512-5MDLl4q0kYZcX6CLu5x1YEq5YUUmo6CqoWApgC/2Ky2kEX9Kz+9fuTJlKlwwSlAxlb3TyQVKXrjGfwF0M30ygA==",
 			"cpu": [
 				"x64"
 			],
@@ -9284,9 +9302,9 @@
 			]
 		},
 		"node_modules/@nx/nx-linux-arm-gnueabihf": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.8.tgz",
-			"integrity": "sha512-g7ojIloHGFI7wuMnUdg7io42EL7C7ae4zAolNVj7eXZM54amn3qoNjwbyqaVbBQvUNRiAKJizGyn1IhKpzvG9A==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-23.2.0.tgz",
+			"integrity": "sha512-YBY7VGEyrzWNPG6M1knOjykMbsHmX/uN5TywwtLYp2mp6PaDC9MNO9z2BDaVmdS+Y8u030RrDpESwLkB0f9d4g==",
 			"cpu": [
 				"arm"
 			],
@@ -9298,13 +9316,16 @@
 			]
 		},
 		"node_modules/@nx/nx-linux-arm64-gnu": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.8.tgz",
-			"integrity": "sha512-Kws8e7W4epfqpTWYaV7KLKaj33o+9JtJa2rErx/XFTtMXhfVzOs5hC4oIrZsYpgk1DuT0APp7UDvX06q2kdAVQ==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-23.2.0.tgz",
+			"integrity": "sha512-CzDkhtI+HYKGWPbjfMhslrgGpWer/qGd6MOFwkjxI8JYdqRV0BYivnAuqogsyPpBDNzalxK8xM55MD/f+edQ+w==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9312,13 +9333,16 @@
 			]
 		},
 		"node_modules/@nx/nx-linux-arm64-musl": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.8.tgz",
-			"integrity": "sha512-fpnyVFL+mSqLdKBPk8+n/rHUEXiem7Xwr9cIOd2Dd5zxQ5wcwj4qSYTNRsBPI2qDFo3esHliwaoFJZULbTHldw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-23.2.0.tgz",
+			"integrity": "sha512-poDmLBCX4WHcYwlklFingeqHVSaTdeUe5jhuQhR6BygDpFdVk4kibovEHh4A5LRkPag4SACNRy1VRBKoaoEyUA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9326,13 +9350,16 @@
 			]
 		},
 		"node_modules/@nx/nx-linux-x64-gnu": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.8.tgz",
-			"integrity": "sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-23.2.0.tgz",
+			"integrity": "sha512-8E8IAkJJw1+eF9UNZKZnc1UDDNOmRaGQbb/AXL8Ix0MP3LObDjIyX9NLYxrtcb9HUcWrygcuKsySum+E5C4s3w==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9340,13 +9367,16 @@
 			]
 		},
 		"node_modules/@nx/nx-linux-x64-musl": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.8.tgz",
-			"integrity": "sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-23.2.0.tgz",
+			"integrity": "sha512-X/i1GfhqeOM1pGNBDDeIDKhtpXKnYjBR8hv8YoVW9pHQXAJ2iUux6SCP1Gg5tIKUYTdZRvsknf0g7KEw3p1sug==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9354,9 +9384,9 @@
 			]
 		},
 		"node_modules/@nx/nx-win32-arm64-msvc": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.8.tgz",
-			"integrity": "sha512-yYDu3pj7AXu7LtN/T/bA4TMWWWbmvEE4wa8UW8ZU5JeWYblyXQA7HyYpPAb4fLzCtHb/dIrNDghVBRIeAAcnSw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-23.2.0.tgz",
+			"integrity": "sha512-MSXbpHVSduWYnCu8MyPs88H6XnbU20jHWUvtPFDFkxgA8Slhl09hzpp2xq8TS4M8dS2OxK4QWcZyszqRMkwQrw==",
 			"cpu": [
 				"arm64"
 			],
@@ -9368,9 +9398,9 @@
 			]
 		},
 		"node_modules/@nx/nx-win32-x64-msvc": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.8.tgz",
-			"integrity": "sha512-cSr0qMt/GgM2aOBFsapxllnIv55j0gAz/6eWvqEOx5sS8d3X1G0IgazZnPbjW2c8gfSYaBZ9UmYnfapWIO/jqg==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-23.2.0.tgz",
+			"integrity": "sha512-OZKEU4d5YmOht1id5wyWhVfvuNEo0hl4DYRFzDh/r94nbTqfNEPcY0bTDfvtjZ79ZM5tPC1Z1k8/L4dkhMpFhw==",
 			"cpu": [
 				"x64"
 			],
@@ -14052,6 +14082,78 @@
 				"@simple-git/args-pathspec": "^1.0.3"
 			}
 		},
+		"node_modules/@simple-libs/child-process-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+			"integrity": "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/@simple-libs/hosted-git-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-2.0.0.tgz",
+			"integrity": "sha512-55XwK/GYgV58PuN8lZFhI1qRxdKoMLJocXl/yM1EPqazFDmM4QWY7q6BxPCPDNKTNunj794DSD4h0H7SrqUdMg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/@simple-libs/normalize-package-data": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/normalize-package-data/-/normalize-package-data-1.0.0.tgz",
+			"integrity": "sha512-/EOmFBekV9tGee8gac/k+5Ox3twkypNqh5TfxA9vTkmcJkjm6f1xqrlstDNOrEhTvnYyVtU6Du2ZhY/IV1+9GA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/hosted-git-info": "^2.0.0",
+				"semver": "^7.8.5"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/@simple-libs/normalize-package-data/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@simple-libs/stream-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+			"integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.12",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
@@ -15576,6 +15678,15 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -15960,6 +16071,12 @@
 				"@types/ms": "*",
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/katex": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/keyv": {
 			"version": "3.1.4",
@@ -19321,13 +19438,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/add-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/adm-zip": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
@@ -19567,6 +19677,19 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
+		"node_modules/argue-cli": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.2.0.tgz",
+			"integrity": "sha512-VipTB0gXgGIFO2Rg9yEVN5wLt2AurJcZqDbgmYSwPwsykhLrQhs240/bfceev4w68lI8JshoOJIk9uW7tFzROw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
 		"node_modules/aria-hidden": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -19635,13 +19758,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-		},
-		"node_modules/array-ify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.9",
@@ -20075,16 +20191,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/axios/node_modules/proxy-from-env": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/axobject-query": {
@@ -21411,16 +21517,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/byte-size": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.1.tgz",
-			"integrity": "sha512-tUkzZWK0M/qdoLEqikxBWe4kumyuwjl3HO6zHTr4yEI23EojPtLYXdG1+AQY7MN0cGyNDvEaJ8wiYQm6P2bPxg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.17"
-			}
-		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -22405,16 +22501,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
-		"node_modules/color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"color-support": "bin.js"
-			}
-		},
 		"node_modules/colord": {
 			"version": "2.9.4",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.4.tgz",
@@ -22500,17 +22586,6 @@
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
 			"dev": true
-		},
-		"node_modules/compare-func": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-ify": "^1.0.0",
-				"dot-prop": "^5.1.0"
-			}
 		},
 		"node_modules/component-emitter": {
 			"version": "1.2.1",
@@ -22709,13 +22784,6 @@
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
 			"dev": true
 		},
-		"node_modules/console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/constant-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -22770,283 +22838,117 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/conventional-changelog-angular": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-			"integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"compare-func": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/conventional-changelog-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-5.0.1.tgz",
-			"integrity": "sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==",
+		"node_modules/conventional-changelog": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-8.1.0.tgz",
+			"integrity": "sha512-idt1JK+3+Nt7gqH/d/sEYWdDeR+5XPov/jssmFN6XxmYSRlonTWSDWhWUPkmm0zbwYjtVdt+4My5aiPkKyvocw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"add-stream": "^1.0.0",
-				"conventional-changelog-writer": "^6.0.0",
-				"conventional-commits-parser": "^4.0.0",
-				"dateformat": "^3.0.3",
-				"get-pkg-repo": "^4.2.1",
-				"git-raw-commits": "^3.0.0",
-				"git-remote-origin-url": "^2.0.0",
-				"git-semver-tags": "^5.0.0",
-				"normalize-package-data": "^3.0.3",
-				"read-pkg": "^3.0.0",
-				"read-pkg-up": "^3.0.0"
+				"@conventional-changelog/git-client": "^3.1.0",
+				"@simple-libs/hosted-git-info": "^2.0.0",
+				"@simple-libs/normalize-package-data": "^1.0.0",
+				"argue-cli": "^3.1.0",
+				"conventional-changelog-preset-loader": "^6.0.1",
+				"conventional-changelog-writer": "^9.2.0",
+				"conventional-commits-parser": "^7.1.0",
+				"fd-package-json": "^2.0.0"
 			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/load-json-file": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/read-pkg": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-			"integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/read-pkg-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"node_modules/conventional-changelog-core/node_modules/read-pkg/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
 			"bin": {
-				"semver": "bin/semver"
+				"conventional-changelog": "dist/cli/index.js"
+			},
+			"engines": {
+				"node": ">=22"
 			}
 		},
-		"node_modules/conventional-changelog-core/node_modules/strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+		"node_modules/conventional-changelog-angular": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+			"integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
 			"dev": true,
-			"license": "MIT",
+			"license": "ISC",
+			"dependencies": {
+				"@conventional-changelog/template": "^1.2.1"
+			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-changelog-preset-loader": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-3.0.0.tgz",
-			"integrity": "sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-6.0.1.tgz",
+			"integrity": "sha512-GZ8E3RQzXQb3JFy0pKl8oeSf7ENIhvAMvJr+PlWkavZOesLHHdhkfNJ4SvW35eo1Fu2+EyVxWQ1tVvtzAG2iWg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=14"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-changelog-writer": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
-			"integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-9.2.1.tgz",
+			"integrity": "sha512-StlYSmW3wLedRaqohJMpP3YuWiAqtgD0/cpsai9frdDkXv7rxj0hRbpJrubPYvJxJsjplONsOobEQnPuS9UgCg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"conventional-commits-filter": "^3.0.0",
-				"dateformat": "^3.0.3",
-				"handlebars": "^4.7.7",
-				"json-stringify-safe": "^5.0.1",
-				"meow": "^8.1.2",
-				"semver": "^7.0.0",
-				"split": "^1.0.1"
+				"@conventional-changelog/template": "^1.3.0",
+				"@simple-libs/stream-utils": "^2.0.0",
+				"argue-cli": "^3.1.0",
+				"conventional-commits-filter": "^6.0.1",
+				"semver": "^7.5.2"
 			},
 			"bin": {
-				"conventional-changelog-writer": "cli.js"
+				"conventional-changelog-writer": "dist/cli/index.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-commits-filter": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
-			"integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+			"integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"lodash.ismatch": "^4.4.0",
-				"modify-values": "^1.0.1"
-			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-commits-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
-			"integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+			"integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-text-path": "^1.0.1",
-				"JSONStream": "^1.3.5",
-				"meow": "^8.1.2",
-				"split2": "^3.2.2"
+				"@simple-libs/stream-utils": "^2.0.0",
+				"argue-cli": "^3.1.0"
 			},
 			"bin": {
-				"conventional-commits-parser": "cli.js"
+				"conventional-commits-parser": "dist/cli/index.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-recommended-bump": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-7.0.1.tgz",
-			"integrity": "sha512-Ft79FF4SlOFvX4PkwFDRnaNiIVX7YbmqGU0RwccUaiGvgp3S0a8ipR2/Qxk31vclDNM+GSdJOVs2KrsUCjblVA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-12.1.0.tgz",
+			"integrity": "sha512-HTNG3kEZXOOfKwrEx54ljURU9bG4nVPQzXMyCSeUcA/PE8EpNpQNujSrbXNBI8QZyN35zM+pVw+FuQk4KqHSHg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"concat-stream": "^2.0.0",
-				"conventional-changelog-preset-loader": "^3.0.0",
-				"conventional-commits-filter": "^3.0.0",
-				"conventional-commits-parser": "^4.0.0",
-				"git-raw-commits": "^3.0.0",
-				"git-semver-tags": "^5.0.0",
-				"meow": "^8.1.2"
+				"@conventional-changelog/git-client": "^3.1.0",
+				"argue-cli": "^3.1.0",
+				"conventional-changelog-preset-loader": "^6.0.1",
+				"conventional-commits-filter": "^6.0.1",
+				"conventional-commits-parser": "^7.1.0"
 			},
 			"bin": {
-				"conventional-recommended-bump": "cli.js"
+				"conventional-recommended-bump": "dist/cli/index.js"
 			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/conventional-recommended-bump/node_modules/concat-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-			"dev": true,
-			"engines": [
-				"node >= 6.0"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.0.2",
-				"typedarray": "^0.0.6"
-			}
-		},
-		"node_modules/conventional-recommended-bump/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
+				"node": ">=22"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -23655,15 +23557,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cross-spawn/node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/cross-spawn/node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -23998,16 +23891,6 @@
 			"integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
 			"license": "BSD-2-Clause"
 		},
-		"node_modules/dargs": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/data-urls": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -24116,16 +23999,6 @@
 				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
-		"node_modules/dateformat": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -24182,6 +24055,29 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"license": "MIT"
+		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/decode-named-character-reference/node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/decode-uri-component": {
 			"version": "0.2.2",
@@ -24245,6 +24141,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -24271,9 +24168,9 @@
 			}
 		},
 		"node_modules/default-browser": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
 			"license": "MIT",
 			"dependencies": {
 				"bundle-name": "^4.1.0",
@@ -24287,9 +24184,9 @@
 			}
 		},
 		"node_modules/default-browser-id": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -24487,6 +24384,19 @@
 			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
 			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
 		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1663043",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1663043.tgz",
@@ -24682,27 +24592,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"dev": true,
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/dot-prop/node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/dotenv": {
@@ -26776,6 +26665,23 @@
 			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
 		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
@@ -26791,6 +26697,16 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+			"integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
 		},
 		"node_modules/fast-xml-builder": {
 			"version": "1.2.0",
@@ -26880,6 +26796,16 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bser": "2.1.1"
+			}
+		},
+		"node_modules/fd-package-json": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+			"integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"walk-up-path": "^4.0.0"
 			}
 		},
 		"node_modules/fdir": {
@@ -27169,19 +27095,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
 			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
-		},
-		"node_modules/find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/find-yarn-workspace-root": {
 			"version": "2.0.0",
@@ -27583,84 +27496,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/get-pkg-repo": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
-			"integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@hutson/parse-repository-url": "^3.0.0",
-				"hosted-git-info": "^4.0.0",
-				"through2": "^2.0.0",
-				"yargs": "^16.2.0"
-			},
-			"bin": {
-				"get-pkg-repo": "src/cli.js"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/get-pkg-repo/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/get-pkg-repo/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/get-pkg-repo/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/get-pkg-repo/node_modules/yargs": {
-			"version": "16.2.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
-			"integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/get-port": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
@@ -27683,17 +27518,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/get-stdin": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
-			"integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-stream": {
@@ -27767,57 +27591,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"node_modules/git-raw-commits": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
-			"integrity": "sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==",
-			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"dargs": "^7.0.0",
-				"meow": "^8.1.2",
-				"split2": "^3.2.2"
-			},
-			"bin": {
-				"git-raw-commits": "cli.js"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/git-remote-origin-url": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"gitconfiglocal": "^1.0.0",
-				"pify": "^2.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/git-semver-tags": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-5.0.1.tgz",
-			"integrity": "sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==",
-			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"meow": "^8.1.2",
-				"semver": "^7.0.0"
-			},
-			"bin": {
-				"git-semver-tags": "cli.js"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/git-up": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
@@ -27837,16 +27610,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"git-up": "^7.0.0"
-			}
-		},
-		"node_modules/gitconfiglocal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
-			"dev": true,
-			"license": "BSD",
-			"dependencies": {
-				"ini": "^1.3.2"
 			}
 		},
 		"node_modules/gl-matrix": {
@@ -28145,13 +27908,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/has-value": {
 			"version": "1.0.0",
@@ -29632,19 +29388,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-text-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"text-extensions": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-typed-array": {
@@ -33805,13 +33548,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/json-with-bigint": {
 			"version": "3.5.12",
 			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
@@ -33871,21 +33607,13 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/JSONStream": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
-			"license": "(MIT OR Apache-2.0)",
-			"dependencies": {
-				"jsonparse": "^1.2.0",
-				"through": ">=2.2.7 <3"
-			},
-			"bin": {
-				"JSONStream": "bin.js"
-			},
+		"node_modules/jsonpointer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+			"integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+			"license": "MIT",
 			"engines": {
-				"node": "*"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -33965,6 +33693,31 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/katex": {
+			"version": "0.16.47",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+			"integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -34039,45 +33792,38 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lerna": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-9.0.7.tgz",
-			"integrity": "sha512-PMjbSWYfwL1yZ5c1D2PZuFyzmtYhLdn0f76uG8L25g6eYy34j+2jPb4Q6USx1UJvxVtxkdVEeAAWS/WxgJ8VZA==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-10.0.1.tgz",
+			"integrity": "sha512-ibmMaBmH/sR2HpZzgvpEI5/6bCgMp0AISIFZ/cQcCzRVH2EgPapBYHXS6A6NgI6vRJNE4pgnxQbNiSq00HVSjA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@npmcli/arborist": "9.1.6",
 				"@npmcli/package-json": "7.0.2",
 				"@npmcli/run-script": "10.0.3",
-				"@nx/devkit": ">=21.5.2 < 23.0.0",
+				"@nx/devkit": ">=23.1.0 < 24.0.0",
 				"@octokit/plugin-enterprise-rest": "6.0.1",
 				"@octokit/rest": "20.1.2",
-				"aproba": "2.0.0",
-				"byte-size": "8.1.1",
-				"chalk": "4.1.0",
 				"ci-info": "4.3.1",
 				"cmd-shim": "6.0.3",
-				"color-support": "1.1.3",
 				"columnify": "1.6.0",
-				"console-control-strings": "^1.1.0",
-				"conventional-changelog-angular": "7.0.0",
-				"conventional-changelog-core": "5.0.1",
-				"conventional-recommended-bump": "7.0.1",
+				"conventional-changelog": "8.1.0",
+				"conventional-changelog-angular": "9.2.1",
+				"conventional-commits-filter": "6.0.1",
+				"conventional-commits-parser": "7.1.2",
+				"conventional-recommended-bump": "12.1.0",
 				"cosmiconfig": "9.0.0",
 				"dedent": "1.5.3",
 				"envinfo": "7.13.0",
 				"execa": "5.0.0",
 				"fs-extra": "^11.2.0",
-				"get-stream": "6.0.0",
 				"git-url-parse": "14.0.0",
-				"glob-parent": "6.0.2",
-				"has-unicode": "2.0.1",
+				"handlebars": "4.7.9",
 				"import-local": "3.1.0",
 				"ini": "^1.3.8",
 				"init-package-json": "8.2.2",
 				"inquirer": "12.9.6",
-				"is-ci": "3.0.1",
-				"jest-diff": ">=30.0.0 < 31",
-				"js-yaml": "4.1.1",
+				"js-yaml": "4.3.0",
 				"libnpmaccess": "10.0.3",
 				"libnpmpublish": "11.1.2",
 				"load-json-file": "6.2.0",
@@ -34086,75 +33832,28 @@
 				"npm-package-arg": "13.0.1",
 				"npm-packlist": "10.0.3",
 				"npm-registry-fetch": "19.1.0",
-				"nx": ">=21.5.3 < 23.0.0",
+				"nx": ">=23.1.0 < 24.0.0",
 				"p-map": "4.0.0",
-				"p-map-series": "2.1.0",
-				"p-pipe": "3.1.0",
 				"p-queue": "6.6.2",
-				"p-reduce": "2.1.0",
-				"p-waterfall": "2.1.1",
 				"pacote": "21.0.1",
 				"read-cmd-shim": "4.0.0",
 				"semver": "7.7.2",
 				"signal-exit": "3.0.7",
-				"slash": "3.0.0",
 				"ssri": "12.0.0",
 				"string-width": "^4.2.3",
-				"tar": "7.5.11",
-				"through": "2.3.8",
+				"tar": "7.5.22",
 				"tinyglobby": "0.2.12",
-				"typescript": ">=3 < 6",
-				"upath": "2.0.1",
 				"validate-npm-package-license": "3.0.4",
 				"validate-npm-package-name": "6.0.2",
-				"wide-align": "1.1.5",
 				"write-file-atomic": "5.0.1",
-				"yargs": "17.7.2",
-				"yargs-parser": "21.1.1"
+				"yargs": "17.7.2"
 			},
 			"bin": {
 				"lerna": "dist/cli.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": "^22.13.0 || ^24.0.0 || ^26.0.0"
 			}
-		},
-		"node_modules/lerna/node_modules/@jest/diff-sequences": {
-			"version": "30.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.5.0.tgz",
-			"integrity": "sha512-OsqBjHXCn8cadasoAZBP6nWYvMsRhpMzGXTpxJ5aO04NlbdhIz+FVe3q49l0AwVhsz/cEmIpBes6gAFl1/dWQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/@jest/schemas": {
-			"version": "30.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.5.0.tgz",
-			"integrity": "sha512-/hunigyNpc4RCjC0VaW3f5RCUZVM2+WQ65qP7z083Gmvac7or2LI50XVNOtE4YPgBpV0yxYiAgorAPGniCoJmg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/@sinclair/typebox": {
-			"version": "0.34.52",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-			"integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lerna/node_modules/aproba": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/lerna/node_modules/argparse": {
 			"version": "2.0.1",
@@ -34184,23 +33883,6 @@
 			},
 			"engines": {
 				"node": "20 || >=22"
-			}
-		},
-		"node_modules/lerna/node_modules/chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/lerna/node_modules/ci-info": {
@@ -34296,19 +33978,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lerna/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/lerna/node_modules/hosted-git-info": {
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
@@ -34360,72 +34029,21 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/lerna/node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
-			}
-		},
-		"node_modules/lerna/node_modules/is-ci/node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+		"node_modules/lerna/node_modules/js-yaml": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
 					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
 				}
 			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lerna/node_modules/jest-diff": {
-			"version": "30.5.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.5.0.tgz",
-			"integrity": "sha512-QjCfDMwdPFvLxTQmS4/Dswx3PUCiqmSXVLGljMC3SU7YG1qHVoR6b86IH/O2G9k9OMyKXz2vS2Q60VnAozNDwA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.5.0",
-				"@jest/get-type": "30.5.0",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.5.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/jest-diff/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/lerna/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -34525,35 +34143,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/lerna/node_modules/pretty-format": {
-			"version": "30.5.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.5.0.tgz",
-			"integrity": "sha512-mzNzBErpHwM0zpmWS7ExOv62yhQhvd546nUuFqVR0dmnJB59tfrw9sjDF0DJknwsr59OXP0buwJ7PaKguczHSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/react-is-18": "npm:react-is@^18.3.1",
-				"@jest/react-is-19": "npm:react-is@^19.2.5",
-				"@jest/schemas": "30.5.0",
-				"ansi-styles": "^5.2.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/pretty-format/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/lerna/node_modules/semver": {
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -34597,20 +34186,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/lerna/node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
 		"node_modules/lerna/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -34618,16 +34193,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/lerna/node_modules/upath": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-			"dev": true,
-			"engines": {
-				"node": ">=4",
-				"yarn": "*"
 			}
 		},
 		"node_modules/lerna/node_modules/validate-npm-package-name": {
@@ -34663,16 +34228,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/lerna/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/level": {
@@ -35507,11 +35062,22 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
 		},
 		"node_modules/linkify-it": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
-				"uc.micro": "^1.0.1"
+				"uc.micro": "^2.0.0"
 			}
 		},
 		"node_modules/lint-staged": {
@@ -35725,20 +35291,6 @@
 				"node": ">=8.9.0"
 			}
 		},
-		"node_modules/locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/lodash": {
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -35794,13 +35346,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
 			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-			"license": "MIT"
-		},
-		"node_modules/lodash.ismatch": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.isnumber": {
@@ -36389,32 +35934,37 @@
 			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
 		},
 		"node_modules/markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+			"version": "14.3.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+			"integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
+				"entities": "^4.5.0",
+				"linkify-it": "^5.0.2",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
 			"bin": {
-				"markdown-it": "bin/markdown-it.js"
+				"markdown-it": "bin/markdown-it.mjs"
 			}
 		},
 		"node_modules/markdown-it/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-		},
-		"node_modules/markdown-it/node_modules/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
 		},
 		"node_modules/markdown-table": {
 			"version": "1.1.3",
@@ -36422,37 +35972,52 @@
 			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
 		},
 		"node_modules/markdownlint": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
-			"integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+			"integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+			"license": "MIT",
 			"dependencies": {
-				"markdown-it": "12.3.2"
+				"micromark": "4.0.2",
+				"micromark-core-commonmark": "2.0.3",
+				"micromark-extension-directive": "4.0.0",
+				"micromark-extension-gfm-autolink-literal": "2.1.0",
+				"micromark-extension-gfm-footnote": "2.1.0",
+				"micromark-extension-gfm-table": "2.1.1",
+				"micromark-extension-math": "3.1.0",
+				"micromark-util-types": "2.0.2",
+				"string-width": "8.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/DavidAnson"
 			}
 		},
 		"node_modules/markdownlint-cli": {
-			"version": "0.31.1",
-			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
-			"integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+			"integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+			"license": "MIT",
 			"dependencies": {
-				"commander": "~9.0.0",
-				"get-stdin": "~9.0.0",
-				"glob": "~7.2.0",
-				"ignore": "~5.2.0",
-				"js-yaml": "^4.1.0",
-				"jsonc-parser": "~3.0.0",
-				"markdownlint": "~0.25.1",
-				"markdownlint-rule-helpers": "~0.16.0",
-				"minimatch": "~3.0.5",
-				"run-con": "~1.2.10"
+				"commander": "~14.0.3",
+				"deep-extend": "~0.6.0",
+				"ignore": "~7.0.5",
+				"js-yaml": "~4.1.1",
+				"jsonc-parser": "~3.3.1",
+				"jsonpointer": "~5.0.1",
+				"markdown-it": "~14.1.1",
+				"markdownlint": "~0.40.0",
+				"minimatch": "~10.2.4",
+				"run-con": "~1.3.2",
+				"smol-toml": "~1.6.0",
+				"tinyglobby": "~0.2.15"
 			},
 			"bin": {
 				"markdownlint": "markdownlint.js"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/argparse": {
@@ -36460,12 +36025,43 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
-		"node_modules/markdownlint-cli/node_modules/commander": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
-			"integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+		"node_modules/markdownlint-cli/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || >=14"
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/ignore": {
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+			"integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
@@ -36490,27 +36086,63 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/markdownlint-cli/node_modules/jsonc-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-			"integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
-			"license": "MIT"
-		},
 		"node_modules/markdownlint-cli/node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
-				"node": "*"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/markdownlint-rule-helpers": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
-			"integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
+		"node_modules/markdownlint/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/markdownlint/node_modules/string-width": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+			"integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.3.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdownlint/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
 		},
 		"node_modules/marked": {
 			"version": "18.0.3",
@@ -36649,9 +36281,10 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+			"integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+			"license": "MIT"
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -36705,61 +36338,6 @@
 				"readable-stream": "^2.0.1"
 			}
 		},
-		"node_modules/meow": {
-			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-			"integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/merge-anything": {
 			"version": "5.1.7",
 			"resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
@@ -36805,6 +36383,600 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-directive": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+			"integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"parse-entities": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-directive/node_modules/parse-entities": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-math": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+			"integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/katex": "^0.16.0",
+				"devlop": "^1.0.0",
+				"katex": "^0.16.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -37389,16 +37561,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/modify-values": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/module-details-from-path": {
@@ -38341,15 +38503,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm-run-path/node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -38368,13 +38521,15 @@
 			"license": "MIT"
 		},
 		"node_modules/nx": {
-			"version": "22.7.8",
-			"resolved": "https://registry.npmjs.org/nx/-/nx-22.7.8.tgz",
-			"integrity": "sha512-ceEhmaGCvY7oi7L7G/Nm/UZSnbfwaJxU1XbDLro7CTmVcnrmxAnxExCp0J/Tpf1xQaMZtwxgV7QATdKA/7vLQw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/nx/-/nx-23.2.0.tgz",
+			"integrity": "sha512-EWscwgKDr40bpsy2Dpijx0+wdkQjF8Z5Gvo91qLh3Ot2qkoYCznAzrqT2hXkkc1USC1TvX64t5IgsQq0Wtg1nA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
+				"@clack/core": "1.4.3",
+				"@clack/prompts": "1.7.0",
 				"@emnapi/core": "1.4.5",
 				"@emnapi/runtime": "1.4.5",
 				"@emnapi/wasi-threads": "1.0.4",
@@ -38384,7 +38539,6 @@
 				"@yarnpkg/lockfile": "1.1.0",
 				"@zkochan/js-yaml": "0.0.7",
 				"agent-base": "6.0.2",
-				"ansi-colors": "4.1.3",
 				"ansi-regex": "5.0.1",
 				"ansi-styles": "4.3.0",
 				"argparse": "2.0.1",
@@ -38393,8 +38547,9 @@
 				"balanced-match": "4.0.3",
 				"base64-js": "1.5.1",
 				"bl": "4.1.0",
-				"brace-expansion": "5.0.8",
+				"brace-expansion": "5.0.9",
 				"buffer": "5.7.1",
+				"bundle-name": "4.1.0",
 				"call-bind-apply-helpers": "1.0.2",
 				"chalk": "4.1.2",
 				"cli-cursor": "3.1.0",
@@ -38405,8 +38560,10 @@
 				"color-name": "1.1.4",
 				"combined-stream": "1.0.8",
 				"debug": "4.4.3",
+				"default-browser": "5.2.1",
+				"default-browser-id": "5.0.0",
 				"defaults": "1.0.4",
-				"define-lazy-prop": "2.0.0",
+				"define-lazy-prop": "3.0.0",
 				"delayed-stream": "1.0.0",
 				"dotenv": "16.4.7",
 				"dotenv-expand": "12.0.3",
@@ -38414,13 +38571,15 @@
 				"ejs": "5.0.1",
 				"emoji-regex": "8.0.0",
 				"end-of-stream": "1.4.5",
-				"enquirer": "2.3.6",
 				"es-define-property": "1.0.1",
 				"es-errors": "1.3.0",
 				"es-object-atoms": "1.1.1",
 				"es-set-tostringtag": "2.1.0",
 				"escalade": "3.2.0",
 				"escape-string-regexp": "1.0.5",
+				"fast-string-truncated-width": "3.0.3",
+				"fast-string-width": "3.0.2",
+				"fast-wrap-ansi": "0.2.0",
 				"figures": "3.2.0",
 				"flat": "5.0.2",
 				"follow-redirects": "1.16.0",
@@ -38439,13 +38598,15 @@
 				"ieee754": "1.2.1",
 				"ignore": "7.0.5",
 				"inherits": "2.0.4",
-				"is-docker": "2.2.1",
+				"is-docker": "3.0.0",
 				"is-fullwidth-code-point": "3.0.0",
+				"is-inside-container": "1.0.0",
 				"is-interactive": "1.0.0",
 				"is-unicode-supported": "0.1.0",
-				"is-wsl": "2.2.0",
+				"is-wsl": "3.1.0",
+				"isexe": "2.0.0",
 				"json5": "2.2.3",
-				"jsonc-parser": "3.2.0",
+				"jsonc-parser": "3.3.1",
 				"lines-and-columns": "2.0.3",
 				"log-symbols": "4.1.0",
 				"math-intrinsics": "1.1.0",
@@ -38458,8 +38619,8 @@
 				"npm-run-path": "4.0.1",
 				"once": "1.4.0",
 				"onetime": "5.1.2",
-				"open": "8.4.2",
-				"ora": "5.3.0",
+				"open": "10.1.0",
+				"ora": "5.4.1",
 				"path-key": "3.1.1",
 				"picocolors": "1.1.1",
 				"proxy-from-env": "2.1.0",
@@ -38467,9 +38628,11 @@
 				"require-directory": "2.1.1",
 				"resolve.exports": "2.0.3",
 				"restore-cursor": "3.1.0",
+				"run-applescript": "7.0.0",
 				"safe-buffer": "5.2.1",
-				"semver": "7.7.4",
+				"semver": "7.8.4",
 				"signal-exit": "3.0.7",
+				"sisteransi": "1.0.5",
 				"smol-toml": "1.6.1",
 				"string_decoder": "1.3.0",
 				"string-width": "4.2.3",
@@ -38478,11 +38641,11 @@
 				"supports-color": "7.2.0",
 				"tar-stream": "2.2.0",
 				"tmp": "0.2.7",
-				"tree-kill": "1.2.2",
 				"tsconfig-paths": "4.2.0",
 				"tslib": "2.8.1",
 				"util-deprecate": "1.0.2",
 				"wcwidth": "1.0.1",
+				"which": "3.0.1",
 				"wrap-ansi": "7.0.0",
 				"wrappy": "1.0.2",
 				"y18n": "5.0.8",
@@ -38495,16 +38658,16 @@
 				"nx-cloud": "dist/bin/nx-cloud.js"
 			},
 			"optionalDependencies": {
-				"@nx/nx-darwin-arm64": "22.7.8",
-				"@nx/nx-darwin-x64": "22.7.8",
-				"@nx/nx-freebsd-x64": "22.7.8",
-				"@nx/nx-linux-arm-gnueabihf": "22.7.8",
-				"@nx/nx-linux-arm64-gnu": "22.7.8",
-				"@nx/nx-linux-arm64-musl": "22.7.8",
-				"@nx/nx-linux-x64-gnu": "22.7.8",
-				"@nx/nx-linux-x64-musl": "22.7.8",
-				"@nx/nx-win32-arm64-msvc": "22.7.8",
-				"@nx/nx-win32-x64-msvc": "22.7.8"
+				"@nx/nx-darwin-arm64": "23.2.0",
+				"@nx/nx-darwin-x64": "23.2.0",
+				"@nx/nx-freebsd-x64": "23.2.0",
+				"@nx/nx-linux-arm-gnueabihf": "23.2.0",
+				"@nx/nx-linux-arm64-gnu": "23.2.0",
+				"@nx/nx-linux-arm64-musl": "23.2.0",
+				"@nx/nx-linux-x64-gnu": "23.2.0",
+				"@nx/nx-linux-x64-musl": "23.2.0",
+				"@nx/nx-win32-arm64-msvc": "23.2.0",
+				"@nx/nx-win32-x64-msvc": "23.2.0"
 			},
 			"peerDependencies": {
 				"@swc-node/register": "^1.11.1",
@@ -38550,9 +38713,9 @@
 			}
 		},
 		"node_modules/nx/node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -38620,6 +38783,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nx/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/nx/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -38658,25 +38834,37 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/nx/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/nx/node_modules/is-wsl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-docker": "^2.0.0"
+				"is-inside-container": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/nx/node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/nx/node_modules/lines-and-columns": {
 			"version": "2.0.3",
@@ -38727,19 +38915,39 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/nx/node_modules/ora": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-			"integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+		"node_modules/nx/node_modules/open": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+			"integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"bl": "^4.0.3",
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/nx/node_modules/ora": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.1.0",
 				"chalk": "^4.1.0",
 				"cli-cursor": "^3.1.0",
 				"cli-spinners": "^2.5.0",
 				"is-interactive": "^1.0.0",
-				"log-symbols": "^4.0.0",
+				"is-unicode-supported": "^0.1.0",
+				"log-symbols": "^4.1.0",
 				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1"
 			},
@@ -38748,26 +38956,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/nx/node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nx/node_modules/proxy-from-env": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/nx/node_modules/readable-stream": {
@@ -38853,6 +39041,22 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/nx/node_modules/which": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+			"integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/nx/node_modules/wrap-ansi": {
@@ -39582,32 +39786,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/p-locate/node_modules/p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/p-map": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -39619,28 +39797,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-map-series": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-2.1.0.tgz",
-			"integrity": "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/p-pipe": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-3.1.0.tgz",
-			"integrity": "sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -39663,15 +39819,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-reduce": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-			"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/p-timeout": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -39683,31 +39830,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/p-waterfall": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-waterfall/-/p-waterfall-2.1.1.tgz",
-			"integrity": "sha512-RRTnDb2TBG/epPRI2yYXsimO0v3BXC8Yd3ogr1545IaqKK17VGhbWVeGGN+XfCm/08OK8635nH31c8bATkHuSw==",
-			"dev": true,
-			"dependencies": {
-				"p-reduce": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -40557,6 +40679,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -40583,27 +40714,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
 			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"license": "MIT"
-		},
-		"node_modules/path-type": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-			"dev": true,
-			"dependencies": {
-				"pify": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/path-type/node_modules/pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -41702,6 +41812,16 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -41760,6 +41880,15 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -42954,9 +43083,9 @@
 			}
 		},
 		"node_modules/run-applescript": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+			"integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -42976,13 +43105,14 @@
 			}
 		},
 		"node_modules/run-con": {
-			"version": "1.2.10",
-			"resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.10.tgz",
-			"integrity": "sha512-n7PZpYmMM26ZO21dd8y3Yw1TRtGABjRtgPSgFS/nhzfvbJMXFtJhJVyEgayMiP+w/23craJjsnfDvx4W4ue/HQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+			"integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
 				"deep-extend": "^0.6.0",
-				"ini": "~2.0.0",
-				"minimist": "^1.2.5",
+				"ini": "~4.1.0",
+				"minimist": "^1.2.8",
 				"strip-json-comments": "~3.1.1"
 			},
 			"bin": {
@@ -42990,11 +43120,12 @@
 			}
 		},
 		"node_modules/run-con/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+			"license": "ISC",
 			"engines": {
-				"node": ">=10"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -43604,9 +43735,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -44136,6 +44267,13 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/skin-tone": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -44216,7 +44354,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
 			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">= 18"
@@ -44611,19 +44748,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"through": "2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -44634,31 +44758,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/split2": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"readable-stream": "^3.0.0"
-			}
-		},
-		"node_modules/split2/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -46147,9 +46246,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-			"integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+			"version": "7.5.22",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -46391,16 +46490,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-extensions": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -46443,12 +46532,6 @@
 			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.29.2.tgz",
 			"integrity": "sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==",
 			"license": "MIT"
-		},
-		"node_modules/through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-			"dev": true
 		},
 		"node_modules/through2": {
 			"version": "2.0.5",
@@ -47089,9 +47172,10 @@
 			}
 		},
 		"node_modules/uc.micro": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"license": "MIT"
 		},
 		"node_modules/uglify-js": {
 			"version": "3.19.3",
@@ -49213,16 +49297,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
-			}
-		},
 		"node_modules/wildcard": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
@@ -49248,7 +49322,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/worker-farm": {
 			"version": "1.7.0",
@@ -53884,7 +53959,7 @@
 				"jest": "^30.5.0",
 				"jest-environment-jsdom": "^30.5.0",
 				"json2php": "^0.0.9",
-				"markdownlint-cli": "^0.31.1",
+				"markdownlint-cli": "^0.48.0",
 				"mini-css-extract-plugin": "^2.9.2",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,9 +215,9 @@
 			"dev": true
 		},
 		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -7605,36 +7605,6 @@
 				"node": "^20.19.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@mawesome/dependency-audit/node_modules/@npmcli/fs": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-			"integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/@npmcli/installed-package-contents": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
-			"integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-bundled": "^5.0.0",
-				"npm-normalize-package-bin": "^5.0.0"
-			},
-			"bin": {
-				"installed-package-contents": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@mawesome/dependency-audit/node_modules/balanced-match": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -7658,59 +7628,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/@mawesome/dependency-audit/node_modules/cacache": {
-			"version": "20.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-			"integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^5.0.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^13.0.0",
-				"lru-cache": "^11.1.0",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^7.0.2",
-				"ssri": "^13.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/glob": {
-			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"minimatch": "^10.2.2",
-				"minipass": "^7.1.3",
-				"path-scurry": "^2.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/hosted-git-info": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^11.1.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@mawesome/dependency-audit/node_modules/ignore-walk": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
@@ -7722,16 +7639,6 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/lru-cache": {
-			"version": "11.5.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@mawesome/dependency-audit/node_modules/minimatch": {
@@ -7750,45 +7657,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@mawesome/dependency-audit/node_modules/npm-bundled": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
-			"integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-normalize-package-bin": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/npm-normalize-package-bin": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-			"integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/npm-package-arg": {
-			"version": "13.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-			"integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"hosted-git-info": "^9.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^7.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@mawesome/dependency-audit/node_modules/npm-packlist": {
 			"version": "10.0.4",
 			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
@@ -7803,87 +7671,12 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@mawesome/dependency-audit/node_modules/p-map": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
-			"integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/pacote": {
-			"version": "21.5.1",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
-			"integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/git": "^7.0.0",
-				"@npmcli/installed-package-contents": "^4.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/promise-spawn": "^9.0.0",
-				"@npmcli/run-script": "^10.0.0",
-				"cacache": "^20.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^13.0.0",
-				"npm-packlist": "^10.0.1",
-				"npm-pick-manifest": "^11.0.1",
-				"npm-registry-fetch": "^19.0.0",
-				"proc-log": "^6.0.0",
-				"sigstore": "^4.0.0",
-				"ssri": "^13.0.0",
-				"tar": "^7.4.3"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/path-scurry": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^11.0.0",
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@mawesome/dependency-audit/node_modules/proc-log": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
 			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/ssri": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
 			}
@@ -7900,16 +7693,6 @@
 			},
 			"engines": {
 				"node": ">=14.17"
-			}
-		},
-		"node_modules/@mawesome/dependency-audit/node_modules/validate-npm-package-name": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-			"integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@mdx-js/react": {
@@ -8206,19 +7989,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/ignore-walk": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
-			"integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minimatch": "^10.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/lru-cache": {
 			"version": "11.5.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -8243,29 +8013,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/npm-bundled": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
-			"integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-normalize-package-bin": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/npm-normalize-package-bin": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-			"integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/npm-package-arg": {
@@ -8294,30 +8041,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/npm-packlist": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
-			"integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"ignore-walk": "^8.0.0",
-				"proc-log": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/npm-packlist/node_modules/proc-log": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/p-map": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
@@ -8329,78 +8052,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/pacote": {
-			"version": "21.5.1",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
-			"integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/git": "^7.0.0",
-				"@npmcli/installed-package-contents": "^4.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/promise-spawn": "^9.0.0",
-				"@npmcli/run-script": "^10.0.0",
-				"cacache": "^20.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^13.0.0",
-				"npm-packlist": "^10.0.1",
-				"npm-pick-manifest": "^11.0.1",
-				"npm-registry-fetch": "^19.0.0",
-				"proc-log": "^6.0.0",
-				"sigstore": "^4.0.0",
-				"ssri": "^13.0.0",
-				"tar": "^7.4.3"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/pacote/node_modules/@npmcli/installed-package-contents": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
-			"integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-bundled": "^5.0.0",
-				"npm-normalize-package-bin": "^5.0.0"
-			},
-			"bin": {
-				"installed-package-contents": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/pacote/node_modules/proc-log": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/pacote/node_modules/ssri": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/path-scurry": {
@@ -14762,9 +14413,9 @@
 			}
 		},
 		"node_modules/@svgr/core/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"funding": [
 				{
 					"type": "github",
@@ -14879,9 +14530,9 @@
 			}
 		},
 		"node_modules/@svgr/plugin-svgo/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"funding": [
 				{
 					"type": "github",
@@ -33391,9 +33042,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+			"integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
@@ -34030,9 +33681,9 @@
 			}
 		},
 		"node_modules/lerna/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"dev": true,
 			"funding": [
 				{
@@ -36065,9 +35716,9 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"funding": [
 				{
 					"type": "github",
@@ -38199,9 +37850,9 @@
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"funding": [
 				{
 					"type": "github",
@@ -39839,28 +39490,28 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/pacote": {
-			"version": "21.0.1",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.1.tgz",
-			"integrity": "sha512-LHGIUQUrcDIJUej53KJz1BPvUuHrItrR2yrnN0Kl9657cJ0ZT6QJHk9wWPBnQZhYT5KLyZWrk9jaYc2aKDu4yw==",
+			"version": "21.5.1",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+			"integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
 				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
 				"@npmcli/run-script": "^10.0.0",
 				"cacache": "^20.0.0",
 				"fs-minipass": "^3.0.0",
 				"minipass": "^7.0.2",
 				"npm-package-arg": "^13.0.0",
 				"npm-packlist": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
+				"npm-pick-manifest": "^11.0.1",
 				"npm-registry-fetch": "^19.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
+				"proc-log": "^6.0.0",
 				"sigstore": "^4.0.0",
-				"ssri": "^12.0.0",
+				"ssri": "^13.0.0",
 				"tar": "^7.4.3"
 			},
 			"bin": {
@@ -39883,37 +39534,21 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/pacote/node_modules/@npmcli/git": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
-			"integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
+		"node_modules/pacote/node_modules/@npmcli/installed-package-contents": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+			"integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/promise-spawn": "^8.0.0",
-				"ini": "^5.0.0",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^5.0.0"
+				"npm-bundled": "^5.0.0",
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/@npmcli/promise-spawn": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-8.0.3.tgz",
-			"integrity": "sha512-Yb00SWaL4F8w+K8YGhQ55+xE4RUNdMHV43WZGsiTM92gS+lC0mGsn7I4hLug7pbao035S6bj3Y3w0cUNGLfmkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/pacote/node_modules/balanced-match": {
@@ -39971,19 +39606,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/pacote/node_modules/cacache/node_modules/ssri": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/pacote/node_modules/glob": {
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -40038,26 +39660,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/pacote/node_modules/ini": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
-			"integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/pacote/node_modules/minimatch": {
 			"version": "10.2.6",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -40074,14 +39676,27 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/pacote/node_modules/npm-bundled": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+			"integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/pacote/node_modules/npm-normalize-package-bin": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
-			"integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+			"integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/pacote/node_modules/npm-package-arg": {
@@ -40100,16 +39715,6 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/pacote/node_modules/npm-package-arg/node_modules/proc-log": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
 		"node_modules/pacote/node_modules/npm-packlist": {
 			"version": "10.0.4",
 			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
@@ -40122,71 +39727,6 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-packlist/node_modules/proc-log": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-pick-manifest": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
-			"integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-install-checks": "^7.1.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
-			"integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
-			"integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/pacote/node_modules/p-map": {
@@ -40229,17 +39769,27 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/pacote/node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/pacote/node_modules/ssri": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
-			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+			"integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/pacote/node_modules/validate-npm-package-name": {
@@ -40250,22 +39800,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/pacote/node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/pako": {
@@ -45735,9 +45269,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -106,10 +106,11 @@
 			"uuid": "^11.1.1"
 		},
 		"lerna": {
-			"js-yaml": "4.3.1"
+			"js-yaml": "4.3.2",
+			"pacote": "21.5.1"
 		},
 		"markdownlint-cli": {
-			"js-yaml": "~4.3.1",
+			"js-yaml": "~4.3.2",
 			"markdown-it": "~14.3.0",
 			"run-con": "1.3.2"
 		}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"concurrently": "^9.2.1",
 		"cross-env": "^7.0.3",
 		"husky": "^7.0.0",
-		"lerna": "^9.0.7",
+		"lerna": "^10.0.1",
 		"lint-staged": "^16.4.0",
 		"patch-package": "^8.0.0",
 		"syncpack": "^15.3.1",
@@ -104,6 +104,14 @@
 		"jsdom": "26.1.0",
 		"sockjs": {
 			"uuid": "^11.1.1"
+		},
+		"lerna": {
+			"js-yaml": "4.3.1"
+		},
+		"markdownlint-cli": {
+			"js-yaml": "~4.3.1",
+			"markdown-it": "~14.3.0",
+			"run-con": "1.3.2"
 		}
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -108,10 +108,6 @@
 		"lerna": {
 			"js-yaml": "4.3.2",
 			"pacote": "21.5.1"
-		},
-		"markdownlint-cli": {
-			"js-yaml": "~4.3.2",
-			"markdown-it": "~14.3.0"
 		}
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -111,8 +111,7 @@
 		},
 		"markdownlint-cli": {
 			"js-yaml": "~4.3.2",
-			"markdown-it": "~14.3.0",
-			"run-con": "1.3.2"
+			"markdown-it": "~14.3.0"
 		}
 	},
 	"scripts": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 -   Require Node.js `^20.19.0 || >=22.13.0` and upgrade the bundled Stylelint to `^17.14.1` ([#80738](https://github.com/WordPress/gutenberg/pull/80738)).
+-   Update the bundled `markdownlint-cli` from `^0.31.1` to `^0.48.0`, which moves `markdownlint` from 0.25 to 0.40. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names. `markdownlint-cli` 0.48 requires Node.js 20 or later ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
 
 ### Bug Fixes
 
@@ -16,6 +17,7 @@
 ### Enhancements
 
 -   Include `.jsx` unit tests in the default lint configuration ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
+-   `lint-md-docs`: Detect `.markdownlint.jsonc` so the bundled default config is not used when one is present ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
 
 ### Internal
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 -   Require Node.js `^20.19.0 || >=22.13.0` and upgrade the bundled Stylelint to `^17.14.1` ([#80738](https://github.com/WordPress/gutenberg/pull/80738)).
--   Update the bundled `markdownlint-cli` from `^0.31.1` to `^0.48.0`, which moves `markdownlint` from 0.25 to 0.40. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names. `markdownlint-cli` 0.48 requires Node.js 20 or later ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
+-   Update the bundled `markdownlint-cli` from `^0.31.1` to `^0.48.0`, which moves `markdownlint` from 0.25 to 0.40. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names. `markdownlint-cli` 0.48 requires Node.js 20 or later. The package pins `run-con` to 1.3.2 so supported Node.js 20 installations do not resolve `ini` 7, which does not support Node.js 20 ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
 
 ### Bug Fixes
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 -   Require Node.js `^20.19.0 || >=22.13.0` and upgrade the bundled Stylelint to `^17.14.1` ([#80738](https://github.com/WordPress/gutenberg/pull/80738)).
--   Update the bundled `markdownlint-cli` from `^0.31.1` to `^0.48.0`, which moves `markdownlint` from 0.25 to 0.40. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names. `markdownlint-cli` 0.48 requires Node.js 20 or later. The package pins `run-con` to 1.3.2 so supported Node.js 20 installations do not resolve `ini` 7, which does not support Node.js 20 ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
+-   Require Node.js `^22.22.2 || ^24.15.0 || >=26.0.0` and update the bundled `markdownlint-cli` from `^0.31.1` to `^0.49.1`, which moves `markdownlint` from 0.25 to 0.41. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
 
 ### Bug Fixes
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Require Node.js `^22.22.2 || ^24.15.0 || >=26.0.0` and update the bundled `markdownlint-cli` from `^0.31.1` to `^0.49.1`, which moves `markdownlint` from 0.25 to 0.41. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
+
+### Enhancements
+
+-   `lint-md-docs`: Detect `.markdownlint.jsonc` so the bundled default config is not used when one is present ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
+
 ## 35.0.0 (2026-09-10)
 
 ### Breaking Changes
 
 -   Require Node.js `^20.19.0 || >=22.13.0` and upgrade the bundled Stylelint to `^17.14.1` ([#80738](https://github.com/WordPress/gutenberg/pull/80738)).
--   Require Node.js `^22.22.2 || ^24.15.0 || >=26.0.0` and update the bundled `markdownlint-cli` from `^0.31.1` to `^0.49.1`, which moves `markdownlint` from 0.25 to 0.41. `lint-md-docs` now runs the rules added since then (MD051 through MD060) by default, so projects may see new reports. The `header` rule aliases (for example `header-increment`) no longer work in configuration files; use the `heading` names ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
 
 ### Bug Fixes
 
@@ -17,7 +24,6 @@
 ### Enhancements
 
 -   Include `.jsx` unit tests in the default lint configuration ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
--   `lint-md-docs`: Detect `.markdownlint.jsonc` so the bundled default config is not used when one is present ([#81917](https://github.com/WordPress/gutenberg/pull/81917)).
 
 ### Internal
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -63,7 +63,7 @@
 		"jest": "^30.5.0",
 		"jest-environment-jsdom": "^30.5.0",
 		"json2php": "^0.0.9",
-		"markdownlint-cli": "^0.31.1",
+		"markdownlint-cli": "^0.48.0",
 		"mini-css-extract-plugin": "^2.9.2",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^6.4.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -75,6 +75,7 @@
 		"read-pkg-up": "^7.0.1",
 		"resolve-bin": "^1.0.1",
 		"rtlcss": "^4.3.0",
+		"run-con": "1.3.2",
 		"sass": "^1.54.0",
 		"sass-loader": "^16.0.3",
 		"schema-utils": "^4.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": "^20.19.0 || >=22.13.0",
+		"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
 		"npm": ">=8.19.2"
 	},
 	"files": [
@@ -63,7 +63,7 @@
 		"jest": "^30.5.0",
 		"jest-environment-jsdom": "^30.5.0",
 		"json2php": "^0.0.9",
-		"markdownlint-cli": "^0.48.0",
+		"markdownlint-cli": "^0.49.1",
 		"mini-css-extract-plugin": "^2.9.2",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^6.4.0",
@@ -75,7 +75,6 @@
 		"read-pkg-up": "^7.0.1",
 		"resolve-bin": "^1.0.1",
 		"rtlcss": "^4.3.0",
-		"run-con": "1.3.2",
 		"sass": "^1.54.0",
 		"sass-loader": "^16.0.3",
 		"schema-utils": "^4.2.0",

--- a/packages/scripts/scripts/lint-md-docs.js
+++ b/packages/scripts/scripts/lint-md-docs.js
@@ -17,6 +17,7 @@ const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '**/*.md' ];
 const hasLintConfig =
 	hasArgInCLI( '-c' ) ||
 	hasArgInCLI( '--config' ) ||
+	hasProjectFile( '.markdownlint.jsonc' ) ||
 	hasProjectFile( '.markdownlint.json' ) ||
 	hasProjectFile( '.markdownlint.yaml' ) ||
 	hasProjectFile( '.markdownlint.yml' ) ||

--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -40,6 +40,13 @@ export default {
 	],
 	semverGroups: [
 		{
+			label: '`@wordpress/scripts` pins run-con 1.3.2 because 1.3.3 does not support Node.js 20.',
+			dependencies: [ 'run-con' ],
+			packages: [ '@wordpress/scripts' ],
+			dependencyTypes: [ 'prod' ],
+			range: '',
+		},
+		{
 			label: 'Prerelease dependencies (e.g. alpha or beta) should be pinned to exact versions to avoid auto-upgrades that can include breaking changes. Remove entries once the dependency reaches a stable release.',
 			dependencies: [ '@modelcontextprotocol/server' ],
 			packages: [ '**' ],

--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -40,13 +40,6 @@ export default {
 	],
 	semverGroups: [
 		{
-			label: '`@wordpress/scripts` pins run-con 1.3.2 because 1.3.3 does not support Node.js 20.',
-			dependencies: [ 'run-con' ],
-			packages: [ '@wordpress/scripts' ],
-			dependencyTypes: [ 'prod' ],
-			range: '',
-		},
-		{
 			label: 'Prerelease dependencies (e.g. alpha or beta) should be pinned to exact versions to avoid auto-upgrades that can include breaking changes. Remove entries once the dependency reaches a stable release.',
 			dependencies: [ '@modelcontextprotocol/server' ],
 			packages: [ '**' ],


### PR DESCRIPTION
Follow-up to #81912.

## What?

-   Update root `lerna` from `^9.0.7` to `^10.0.1`, including the latest compatible Nx 23 release.
-   Update the `@wordpress/scripts` bundled `markdownlint-cli` from `^0.31.1` to `^0.49.1` and detect `.markdownlint.jsonc` project configuration.
-   Apply compatible repository security patches for `js-yaml` and `pacote`, and keep the lockfile refresh limited to the related dependency graph.

## Why?

Trunk now requires Node.js 24, so Lerna 10 can become the repository release tool.

`markdownlint-cli` 0.48 retained Node.js 20 support, but its transitive ranges cannot reach current fixes for `js-yaml`, `markdown-it`, and `smol-toml`. Pinning `run-con` and adding root overrides protected the npm-based repository install, but did not protect published `@wordpress/scripts` consumers across package managers. Updating to 0.49.1 gives consumers a patched dependency graph, with a corresponding increase to the package's Node.js requirement.

## How?

Lerna resolves Nx 23.2.0. Scoped root overrides keep Lerna on patched `js-yaml` and `pacote` versions.

`@wordpress/scripts` now requires Node.js `^22.22.2 || ^24.15.0 || >=26.0.0`, matching the requirements of the updated Markdownlint dependency graph. This removes the incomplete Node.js 20 `run-con` workaround and the related Syncpack exception.

Lerna 10's stricter CI check now fails `version` or `publish` when the local branch is behind its remote. The release tool already fetches and verifies its release branches before committing, so this keeps the release process fail-closed.

The lockfile was regenerated with trunk's Node.js 24 and npm 11 toolchain. The refresh preserves the nested `framer-motion` and `react-colorful` versions used by Components instead of folding unrelated runtime upgrades into this PR.

## Recommended merge timing

> [!NOTE]
> Merge this after the Gutenberg 24.0 RC1 package publication. The `release/24.0` branch is now cut, so Lerna 10 can run through a full trunk and `next` release cycle before it handles the next production `latest` publication.

## Testing Instructions

1. Run `npm ci --ignore-scripts` and `npm run prepare`.
2. Run `npm run test:unit:vitest -- tools/release/commands/test/packages.js`.
3. Run `npm run lint:pkg-json`, `npm run lint:deps`, `npm run lint:lockfile`, `npm run lint:published-deps`, `npm run typecheck`, and `npm run build`.
4. Run `npm exec --no -- lerna run build --scope @wordpress/babel-preset-default` to exercise Lerna's Nx task runner.
5. Pack `@wordpress/scripts` and install it in isolated npm and Yarn Classic projects using a supported Node.js version. Add a commented `.markdownlint.jsonc` with `"default": false`, then run `wp-scripts lint-md-docs`. It should load that project config and pass a Markdown file without headings.
6. With strict engine checking enabled, confirm that the packed package rejects Node.js 20 and installs under the declared Node.js ranges.

<details>
<summary>Additional migration verification</summary>

-   A disposable package release completed `lerna version patch --no-private --no-push --yes`, including its release commit and tag.
-   Isolated npm and Yarn Classic consumers installed the packed package under Node.js 24 and passed the JSONC lint smoke test. Node.js 20 was rejected by the declared package engine.
-   The resolved Markdownlint graph uses patched `js-yaml`, `markdown-it`, and `smol-toml` versions.
-   `npm run lint:md:docs` is not currently run in CI. The updated rules expose existing reports across the repository, so this PR records the behavior change without combining it with a repository-wide documentation cleanup.

</details>

## Use of AI Tools

The original migration was prepared with Claude Code. The rebase, dependency and release-note audit, compatibility work, dedupe, security updates, and verification were completed with Codex. All changes were reviewed by the author.
