### PR TITLE
Replace the Storybook test runner with the Vitest integration

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -67,12 +67,14 @@ jobs:
                   NODE_ENV: test
               run: npm run storybook:e2e:build
 
-            # The Storybook test runner only launches Chromium.
+            # The story tests only launch Chromium.
             - name: Install Playwright browsers
               uses: ./.github/setup-playwright
               with:
                   workspace: '@wordpress/storybook'
                   browsers: chromium
 
-            - name: Serve Storybook and run tests
+            # Vitest renders every story in Chromium through the Storybook
+            # plugin. A render or play function error fails the job.
+            - name: Run story tests
               run: npm run --workspace @wordpress/storybook test:smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -3608,13 +3608,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@hapi/address/node_modules/@hapi/hoek": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-			"integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/@hapi/formula": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
@@ -3623,10 +3616,11 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@hapi/hoek": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-			"integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-			"dev": true
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+			"integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@hapi/pinpoint": {
 			"version": "2.0.1",
@@ -3643,15 +3637,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@hapi/topo": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-			"integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-			"dev": true,
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -4883,58 +4868,6 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
-		},
-		"node_modules/@jest/create-cache-key-function": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.4.1.tgz",
-			"integrity": "sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.4.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/create-cache-key-function/node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.4.0",
-				"@jest/schemas": "30.4.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/create-cache-key-function/node_modules/@sinclair/typebox": {
-			"version": "0.34.52",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-			"integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@jest/diff-sequences": {
 			"version": "30.0.1",
@@ -13182,27 +13115,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@sideway/address": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-			"integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-			"dev": true,
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
-		"node_modules/@sideway/formula": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-			"integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-			"dev": true
-		},
-		"node_modules/@sideway/pinpoint": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-			"dev": true
-		},
 		"node_modules/@sigstore/bundle": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -13657,6 +13569,42 @@
 				}
 			}
 		},
+		"node_modules/@storybook/addon-vitest": {
+			"version": "10.5.9",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.5.9.tgz",
+			"integrity": "sha512-TgHczbDANprH9bEj+Z/DZ4b2LaCHpNrBdMOWK7gd+ZRGZz0ZZnGm8H5WoIh2uW4AHYibZmYCyWDSf69Plblz2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@storybook/global": "^5.0.0",
+				"@storybook/icons": "^2.0.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "^3.0.0 || ^4.0.0",
+				"@vitest/browser-playwright": "^4.0.0",
+				"@vitest/runner": "^3.0.0 || ^4.0.0",
+				"storybook": "^10.5.9",
+				"vitest": "^3.0.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/runner": {
+					"optional": true
+				},
+				"vitest": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@storybook/builder-vite": {
 			"version": "10.5.8",
 			"resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.8.tgz",
@@ -13847,141 +13795,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/@storybook/test-runner": {
-			"version": "0.24.4",
-			"resolved": "https://registry.npmjs.org/@storybook/test-runner/-/test-runner-0.24.4.tgz",
-			"integrity": "sha512-xm04bba5N7QyHHc+wD4xmPZx0vKK/PIpmTFypy445HrWOj0nFK4pYg5dE6H4ppqMt7qZAnb5GfHTvBwJtywJ4A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.22.5",
-				"@babel/generator": "^7.22.5",
-				"@babel/template": "^7.22.5",
-				"@babel/types": "^7.22.5",
-				"@jest/types": "^30.0.1",
-				"@swc/core": "^1.5.22",
-				"@swc/jest": "^0.2.38",
-				"expect-playwright": "^0.8.0",
-				"jest": "^30.0.4",
-				"jest-circus": "^30.0.4",
-				"jest-environment-node": "^30.0.4",
-				"jest-junit": "^16.0.0",
-				"jest-process-manager": "^0.4.0",
-				"jest-runner": "^30.0.4",
-				"jest-serializer-html": "^7.1.0",
-				"jest-watch-typeahead": "^3.0.1",
-				"nyc": "^15.1.0",
-				"playwright": "^1.14.0",
-				"playwright-core": ">=1.2.0",
-				"rimraf": "^3.0.2",
-				"uuid": "^8.3.2"
-			},
-			"bin": {
-				"test-storybook": "dist/test-storybook.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"storybook": "^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0"
-			}
-		},
-		"node_modules/@storybook/test-runner/node_modules/@jest/schemas": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@storybook/test-runner/node_modules/@jest/types": {
-			"version": "30.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.4.0",
-				"@jest/schemas": "30.4.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@storybook/test-runner/node_modules/@sinclair/typebox": {
-			"version": "0.34.52",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-			"integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@storybook/test-runner/node_modules/jest-junit": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-			"integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"mkdirp": "^1.0.4",
-				"strip-ansi": "^6.0.1",
-				"uuid": "^8.3.2",
-				"xml": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10.12.0"
-			}
-		},
-		"node_modules/@storybook/test-runner/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@storybook/test-runner/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@storybook/test-runner/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin": {
@@ -14378,286 +14191,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@swc/core": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
-			"integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@swc/counter": "^0.1.3",
-				"@swc/types": "^0.1.27"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/swc"
-			},
-			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.15.47",
-				"@swc/core-darwin-x64": "1.15.47",
-				"@swc/core-linux-arm-gnueabihf": "1.15.47",
-				"@swc/core-linux-arm64-gnu": "1.15.47",
-				"@swc/core-linux-arm64-musl": "1.15.47",
-				"@swc/core-linux-ppc64-gnu": "1.15.47",
-				"@swc/core-linux-s390x-gnu": "1.15.47",
-				"@swc/core-linux-x64-gnu": "1.15.47",
-				"@swc/core-linux-x64-musl": "1.15.47",
-				"@swc/core-win32-arm64-msvc": "1.15.47",
-				"@swc/core-win32-ia32-msvc": "1.15.47",
-				"@swc/core-win32-x64-msvc": "1.15.47"
-			},
-			"peerDependencies": {
-				"@swc/helpers": ">=0.5.17"
-			},
-			"peerDependenciesMeta": {
-				"@swc/helpers": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
-			"integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
-			"integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
-			"integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
-			"integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
-			"integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-ppc64-gnu": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
-			"integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-s390x-gnu": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
-			"integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
-			"integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
-			"integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
-			"integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
-			"integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.15.47",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
-			"integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/counter": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/@swc/jest": {
-			"version": "0.2.39",
-			"resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
-			"integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/create-cache-key-function": "^30.0.0",
-				"@swc/counter": "^0.1.3",
-				"jsonc-parser": "^3.2.0"
-			},
-			"engines": {
-				"npm": ">= 7.0.0"
-			},
-			"peerDependencies": {
-				"@swc/core": "*"
-			}
-		},
-		"node_modules/@swc/types": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
-			"integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@swc/counter": "^0.1.3"
 			}
 		},
 		"node_modules/@szmarczak/http-timer": {
@@ -15741,16 +15274,6 @@
 			"dependencies": {
 				"@types/node": "*",
 				"@types/unist": "*"
-			}
-		},
-		"node_modules/@types/wait-on": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
-			"integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/yargs": {
@@ -19015,31 +18538,11 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/append-transform": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"default-require-extensions": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
-		},
-		"node_modules/archy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -19402,13 +18905,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/async": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/async-each": {
 			"version": "1.0.6",
@@ -20355,19 +19851,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/basic-ftp": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
@@ -21107,35 +20590,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
-			}
-		},
-		"node_modules/caching-transform": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-			"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hasha": "^5.0.0",
-				"make-dir": "^3.0.0",
-				"package-hash": "^4.0.0",
-				"write-file-atomic": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/caching-transform/node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"node_modules/call-bind": {
@@ -22987,16 +22441,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
 		},
-		"node_modules/corser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-			"integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/cosmiconfig": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -23447,20 +22891,6 @@
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
-		"node_modules/cwd": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
-			"integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-pkg": "^0.1.2",
-				"fs-exists-sync": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/cyclist": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.2.tgz",
@@ -23781,22 +23211,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/default-require-extensions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
-			"integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -24042,16 +23456,6 @@
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
 			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
 			"license": "MIT"
-		},
-		"node_modules/diffable-html": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-4.1.0.tgz",
-			"integrity": "sha512-++kyNek+YBLH8cLXS+iTj/Hiy2s5qkRJEJ8kgu/WHbFrVY2vz9xPFUT+fii2zGF0m1CaojDlQJjkfrCt7YWM1g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"htmlparser2": "^3.9.2"
-			}
 		},
 		"node_modules/diffie-hellman": {
 			"version": "5.0.3",
@@ -24743,13 +24147,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.2",
@@ -26020,15 +25417,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/exit-x": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -26089,19 +25477,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/expand-tilde": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-			"integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"os-homedir": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -26118,14 +25493,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/expect-playwright": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/expect-playwright/-/expect-playwright-0.8.0.tgz",
-			"integrity": "sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==",
-			"deprecated": "⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/expect-type": {
 			"version": "1.4.0",
@@ -26805,62 +26172,10 @@
 				"semver": "bin/semver"
 			}
 		},
-		"node_modules/find-file-up": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
-			"integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fs-exists-sync": "^0.1.0",
-				"resolve-dir": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/find-parent-dir": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
 			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ="
-		},
-		"node_modules/find-pkg": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
-			"integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-file-up": "^0.1.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/find-process": {
-			"version": "1.4.11",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.11.tgz",
-			"integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "~4.1.2",
-				"commander": "^12.1.0",
-				"loglevel": "^1.9.2"
-			},
-			"bin": {
-				"find-process": "bin/find-process.js"
-			}
-		},
-		"node_modules/find-process/node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/find-root": {
 			"version": "1.1.0",
@@ -27067,43 +26382,12 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
-		"node_modules/fromentries": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/fs-exists-sync": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/fs-ext": {
 			"version": "2.1.1",
@@ -27296,16 +26580,6 @@
 			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/get-package-type": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/get-pkg-repo": {
@@ -27982,33 +27256,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"node_modules/hasha": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-			"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-stream": "^2.0.0",
-				"type-fest": "^0.8.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/hasha/node_modules/type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/hashery": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
@@ -28031,16 +27278,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"he": "bin/he"
 			}
 		},
 		"node_modules/header-case": {
@@ -28082,19 +27319,6 @@
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
 			"dependencies": {
 				"react-is": "^16.7.0"
-			}
-		},
-		"node_modules/homedir-polyfill": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"parse-passwd": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/hookified": {
@@ -28248,105 +27472,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/htmlparser2/node_modules/domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"domelementtype": "1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/domutils": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/htmlparser2/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -28462,74 +27587,6 @@
 				"@types/express": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/http-server": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
-			"integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"basic-auth": "^2.0.1",
-				"chalk": "^4.1.2",
-				"corser": "^2.0.1",
-				"he": "^1.2.0",
-				"html-encoding-sniffer": "^3.0.0",
-				"http-proxy": "^1.18.1",
-				"mime": "^1.6.0",
-				"minimist": "^1.2.6",
-				"opener": "^1.5.1",
-				"portfinder": "^1.0.28",
-				"secure-compare": "3.0.1",
-				"union": "~0.5.0",
-				"url-join": "^4.0.1"
-			},
-			"bin": {
-				"http-server": "bin/http-server"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/http-server/node_modules/html-encoding-sniffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-encoding": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/http-server/node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/http-server/node_modules/whatwg-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/http2-wrapper": {
@@ -29733,19 +28790,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/istanbul-lib-hook": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"append-transform": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/istanbul-lib-instrument": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
@@ -29769,65 +28813,6 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/istanbul-lib-processinfo": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
-			"integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"archy": "^1.0.0",
-				"cross-spawn": "^7.0.3",
-				"istanbul-lib-coverage": "^3.2.0",
-				"p-map": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"uuid": "^8.3.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-processinfo/node_modules/p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/istanbul-lib-report": {
@@ -31910,46 +30895,6 @@
 				}
 			}
 		},
-		"node_modules/jest-process-manager": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/jest-process-manager/-/jest-process-manager-0.4.0.tgz",
-			"integrity": "sha512-80Y6snDyb0p8GG83pDxGI/kQzwVTkCxc7ep5FPe/F6JYdvRDhwr6RzRmPSP7SEwuLhxo80lBS/NqOdUIbHIfhw==",
-			"deprecated": "⚠️ The 'jest-process-manager' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/wait-on": "^5.2.0",
-				"chalk": "^4.1.0",
-				"cwd": "^0.10.0",
-				"exit": "^0.1.2",
-				"find-process": "^1.4.4",
-				"prompts": "^2.4.1",
-				"signal-exit": "^3.0.3",
-				"spawnd": "^5.0.0",
-				"tree-kill": "^1.2.2",
-				"wait-on": "^7.0.0"
-			}
-		},
-		"node_modules/jest-process-manager/node_modules/wait-on": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-			"integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"axios": "^1.6.1",
-				"joi": "^17.11.0",
-				"lodash": "^4.17.21",
-				"minimist": "^1.2.8",
-				"rxjs": "^7.8.1"
-			},
-			"bin": {
-				"wait-on": "bin/wait-on"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/jest-regex-util": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -33397,16 +32342,6 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-serializer-html": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-7.1.0.tgz",
-			"integrity": "sha512-xYL2qC7kmoYHJo8MYqJkzrl/Fdlx+fat4U1AqYg+kafqwcKPiMkOcjWHPKhueuNEgr+uemhGc+jqXYiwCyRyLA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"diffable-html": "^4.1.0"
-			}
-		},
 		"node_modules/jest-snapshot": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
@@ -33859,20 +32794,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/joi": {
-			"version": "17.13.6",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.6.tgz",
-			"integrity": "sha512-ImNZaq/LSysofih+xIGYfR0WUXMA9GLUNB//YTCSrZptoRmVgaNAdJyi6K1kXi9pkLEoSkoI8I4UwtNiu/D7nw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^9.3.0",
-				"@hapi/topo": "^5.1.0",
-				"@sideway/address": "^4.1.5",
-				"@sideway/formula": "^3.0.1",
-				"@sideway/pinpoint": "^2.0.0"
-			}
-		},
 		"node_modules/jpeg-js": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -34234,16 +33155,6 @@
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.11"
-			}
-		},
-		"node_modules/kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/klona": {
@@ -36254,13 +35165,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
 			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
 		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -36518,20 +35422,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/loglevel": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-			"integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6.0"
-			},
-			"funding": {
-				"type": "tidelift",
-				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
 		},
 		"node_modules/longest-streak": {
@@ -38301,19 +37191,6 @@
 			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
 			"dev": true
 		},
-		"node_modules/node-preload": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-			"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"process-on-spawn": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.50",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -39544,276 +38421,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/nyc": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"caching-transform": "^4.0.0",
-				"convert-source-map": "^1.7.0",
-				"decamelize": "^1.2.0",
-				"find-cache-dir": "^3.2.0",
-				"find-up": "^4.1.0",
-				"foreground-child": "^2.0.0",
-				"get-package-type": "^0.1.0",
-				"glob": "^7.1.6",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-hook": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.0",
-				"istanbul-lib-processinfo": "^2.0.2",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"make-dir": "^3.0.0",
-				"node-preload": "^0.2.1",
-				"p-map": "^3.0.0",
-				"process-on-spawn": "^1.0.0",
-				"resolve-from": "^5.0.0",
-				"rimraf": "^3.0.0",
-				"signal-exit": "^3.0.2",
-				"spawn-wrap": "^2.0.0",
-				"test-exclude": "^6.0.0",
-				"yargs": "^15.0.2"
-			},
-			"bin": {
-				"nyc": "bin/nyc.js"
-			},
-			"engines": {
-				"node": ">=8.9"
-			}
-		},
-		"node_modules/nyc/node_modules/cliui": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^6.2.0"
-			}
-		},
-		"node_modules/nyc/node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-			}
-		},
-		"node_modules/nyc/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/nyc/node_modules/istanbul-lib-instrument": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/core": "^7.7.5",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.0.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/nyc/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/nyc/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/nyc/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/nyc/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/nyc/node_modules/yargs": {
-			"version": "15.4.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^6.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^4.1.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^4.2.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/yargs-parser": {
-			"version": "18.1.3",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -40432,16 +39039,6 @@
 			"integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
 			"dev": true
 		},
-		"node_modules/os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/os-name": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -40729,22 +39326,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/package-hash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"graceful-fs": "^4.1.15",
-				"hasha": "^5.0.0",
-				"lodash.flattendeep": "^4.4.0",
-				"release-zalgo": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -41325,16 +39906,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse-passwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/parse-path": {
@@ -41934,20 +40505,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.19.0"
-			}
-		},
-		"node_modules/portfinder": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
-			"integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"async": "^3.2.6",
-				"debug": "^4.3.6"
-			},
-			"engines": {
-				"node": ">= 10.12"
 			}
 		},
 		"node_modules/posix-character-classes": {
@@ -42687,19 +41244,6 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
-		"node_modules/process-on-spawn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
-			"integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fromentries": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/proggy": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/proggy/-/proggy-3.0.0.tgz",
@@ -42756,20 +41300,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/prompts": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/promzard": {
@@ -43676,19 +42206,6 @@
 				"regjsparser": "bin/parser"
 			}
 		},
-		"node_modules/release-zalgo": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-			"integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"es6-error": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/remark": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
@@ -43805,13 +42322,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/requireindex": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -43881,60 +42391,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-dir": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-			"integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expand-tilde": "^1.2.2",
-				"global-modules": "^0.2.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve-dir/node_modules/global-modules": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-			"integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"global-prefix": "^0.1.4",
-				"is-windows": "^0.2.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve-dir/node_modules/global-prefix": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-			"integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"homedir-polyfill": "^1.0.0",
-				"ini": "^1.3.4",
-				"is-windows": "^0.2.0",
-				"which": "^1.2.12"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve-dir/node_modules/is-windows": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-			"integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-file-extension": {
@@ -44898,13 +43354,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/secure-compare": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-			"integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -45108,13 +43557,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -45482,13 +43924,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -45727,11 +44162,16 @@
 			}
 		},
 		"node_modules/sockjs/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/socks": {
@@ -45852,84 +44292,6 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"deprecated": "See https://github.com/lydell/source-map-url#deprecated",
 			"dev": true
-		},
-		"node_modules/spawn-wrap": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-			"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"make-dir": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"signal-exit": "^3.0.2",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/spawn-wrap/node_modules/foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/spawn-wrap/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/spawn-wrap/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/spawnd": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/spawnd/-/spawnd-5.0.0.tgz",
-			"integrity": "sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"exit": "^0.1.2",
-				"signal-exit": "^3.0.3",
-				"tree-kill": "^1.2.2",
-				"wait-port": "^0.2.9"
-			}
 		},
 		"node_modules/spdx-correct": {
 			"version": "3.0.0",
@@ -48450,18 +46812,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/union": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
-			"integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
-			"dev": true,
-			"dependencies": {
-				"qs": "^6.4.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -48793,13 +47143,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/url-loader": {
 			"version": "4.1.1",
@@ -49421,13 +47764,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/wait-on/node_modules/@hapi/hoek": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-			"integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/wait-on/node_modules/@hapi/topo": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
@@ -49456,59 +47792,6 @@
 			"engines": {
 				"node": ">= 20"
 			}
-		},
-		"node_modules/wait-port": {
-			"version": "0.2.14",
-			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.14.tgz",
-			"integrity": "sha512-kIzjWcr6ykl7WFbZd0TMae8xovwqcqbx6FM9l+7agOgUByhzdjfzZBPK2CPufldTOMxbUivss//Sh9MFawmPRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^2.4.2",
-				"commander": "^3.0.2",
-				"debug": "^4.1.1"
-			},
-			"bin": {
-				"wait-port": "bin/wait-port.js"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wait-port/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/wait-port/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/wait-port/node_modules/commander": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-			"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/walk-up-path": {
 			"version": "4.0.0",
@@ -50537,13 +48820,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/which-module": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.19",
@@ -56074,13 +54350,14 @@
 				"@emotion/styled": "^11.14.1",
 				"@storybook/addon-a11y": "^10.5.3",
 				"@storybook/addon-docs": "^10.5.3",
+				"@storybook/addon-vitest": "^10.5.3",
 				"@storybook/icons": "^2.0.1",
 				"@storybook/react-vite": "^10.5.3",
-				"@storybook/test-runner": "^0.24.2",
 				"@types/babel__core": "^7.20.5",
 				"@types/js-yaml": "^3.12.10",
 				"@types/react": "^18.3.27",
 				"@vitejs/plugin-react": "^6.0.5",
+				"@vitest/browser-playwright": "^4.1.10",
 				"@wordpress/admin-ui": "file:../packages/admin-ui",
 				"@wordpress/base-styles": "file:../packages/base-styles",
 				"@wordpress/block-editor": "file:../packages/block-editor",
@@ -56106,8 +54383,6 @@
 				"@wordpress/theme": "file:../packages/theme",
 				"@wordpress/ui": "file:../packages/ui",
 				"clsx": "^2.1.1",
-				"concurrently": "^9.2.1",
-				"http-server": "^14.1.1",
 				"js-yaml": "^3.15.0",
 				"playwright": "^1.62.1",
 				"prettier": "npm:wp-prettier@^3.0.3",
@@ -56119,7 +54394,7 @@
 				"terser": "^5.37.0",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vite": "^8.2.1",
-				"wait-on": "^8.0.1"
+				"vitest": "^4.1.10"
 			}
 		},
 		"test/e2e": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,10 @@
 		"wait-on": "^8.0.1"
 	},
 	"overrides": {
-		"jsdom": "26.1.0"
+		"jsdom": "26.1.0",
+		"sockjs": {
+			"uuid": "^11.1.1"
+		}
 	},
 	"scripts": {
 		"agents:setup": "npm run --workspace @wordpress/agent-tools setup --",

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,7 +28,7 @@
 -   `RichText`: Handle Enter using the current record, so pressing it right after moving the caret splits at the caret's new position instead of the previous one ([#81696](https://github.com/WordPress/gutenberg/pull/81696)).
 -   `useInnerBlocksProps`: Resolve the manual grid placement check that disables the standard drop zone against a layout passed through the options, when provided, instead of always using the block edit context layout ([#81120](https://github.com/WordPress/gutenberg/pull/81120)).
 -   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists ([#81346](https://github.com/WordPress/gutenberg/pull/81346)).
--   `InserterMenu`: Cancel the animation frame that focuses the active tab when the menu unmounts before it runs, so an unmount right after mount no longer throws.
+-   `InserterMenu`: Cancel the animation frame that focuses the active tab when the menu unmounts before it runs, so an unmount right after mount no longer throws [#81918](https://github.com/WordPress/gutenberg/pull/81918).
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `RichText`: Handle Enter using the current record, so pressing it right after moving the caret splits at the caret's new position instead of the previous one ([#81696](https://github.com/WordPress/gutenberg/pull/81696)).
 -   `useInnerBlocksProps`: Resolve the manual grid placement check that disables the standard drop zone against a layout passed through the options, when provided, instead of always using the block edit context layout ([#81120](https://github.com/WordPress/gutenberg/pull/81120)).
 -   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists ([#81346](https://github.com/WordPress/gutenberg/pull/81346)).
+-   `InserterMenu`: Cancel the animation frame that focuses the active tab when the menu unmounts before it runs, so an unmount right after mount no longer throws.
 
 ### Internal
 

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -333,13 +333,15 @@ function InserterMenu(
 	// Focus first active tab, if any
 	const tabsRef = useRef();
 	useLayoutEffect( () => {
-		if ( tabsRef.current ) {
-			window.requestAnimationFrame( () => {
-				tabsRef.current
-					.querySelector( '[role="tab"][aria-selected="true"]' )
-					?.focus();
-			} );
+		if ( ! tabsRef.current ) {
+			return;
 		}
+		const frame = window.requestAnimationFrame( () => {
+			tabsRef.current
+				?.querySelector( '[role="tab"][aria-selected="true"]' )
+				?.focus();
+		} );
+		return () => window.cancelAnimationFrame( frame );
 	}, [] );
 
 	return (

--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -242,6 +242,7 @@ export const DynamicHeight: StoryObj< typeof Popover > = {
 	],
 	args: {
 		...Default.args,
+		animate: false,
 		children: (
 			<div
 				style={ {

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -6,8 +6,8 @@ import { IconButton } from '../../../icon-button';
 import { InputLayout } from '../../primitives/input-layout';
 import { Stack } from '../../../stack';
 import {
-	WithPrefix,
-	WithSuffixControl,
+	WithPrefix as InputWithPrefix,
+	WithSuffixControl as InputWithSuffixControl,
 } from '../../primitives/input/stories/index.story';
 import {
 	WITH_DETAILS_DESCRIPTION,
@@ -61,25 +61,22 @@ export const WithDetails: Story = {
 	},
 };
 
-WithPrefix.args = {
-	...WithPrefix.args,
-	...Default.args,
-};
-// Copied rather than mutated: the story object is shared with the Input story,
-// which opts out of the accessibility test because it shows the control
-// without a label. This story does label the control, so it opts back in.
-const InputControlWithSuffixControl: typeof WithSuffixControl = {
-	...WithSuffixControl,
+export const WithPrefix: Story = {
 	args: {
-		...WithSuffixControl.args,
 		...Default.args,
+		prefix: InputWithPrefix.args?.prefix,
+	},
+};
+
+export const WithSuffixControl: Story = {
+	args: {
+		...Default.args,
+		suffix: InputWithSuffixControl.args?.suffix,
 	},
 	parameters: {
-		...WithSuffixControl.parameters,
 		a11y: { test: 'error' },
 	},
 };
-export { WithPrefix, InputControlWithSuffixControl as WithSuffixControl };
 
 export const Password: Story = {
 	render: function Template( args ) {

--- a/packages/ui/src/form/input-control/stories/index.story.tsx
+++ b/packages/ui/src/form/input-control/stories/index.story.tsx
@@ -63,15 +63,17 @@ export const WithDetails: Story = {
 
 export const WithPrefix: Story = {
 	args: {
+		...InputWithPrefix.args,
+		ref: undefined,
 		...Default.args,
-		prefix: InputWithPrefix.args?.prefix,
 	},
 };
 
 export const WithSuffixControl: Story = {
 	args: {
+		...InputWithSuffixControl.args,
+		ref: undefined,
 		...Default.args,
-		suffix: InputWithSuffixControl.args?.suffix,
 	},
 	parameters: {
 		a11y: { test: 'error' },

--- a/packages/ui/src/form/primitives/input/stories/index.story.tsx
+++ b/packages/ui/src/form/primitives/input/stories/index.story.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Input } from '../index';
 import { InputLayout } from '../../input-layout';
-import { WithSuffixControl } from '../../input-layout/stories/index.story';
+import { WithSuffixControl as InputLayoutWithSuffixControl } from '../../input-layout/stories/index.story';
 
 const meta: Meta< typeof Input > = {
 	tags: [ 'manifest' ],
@@ -46,14 +46,9 @@ export const WithPrefix: Story = {
 	},
 };
 
-// Copied rather than mutated: the story object is shared with the InputLayout
-// and InputControl stories, and assigning to it would apply these args and
-// parameters to their copies of the story too.
-const InputWithSuffixControl: typeof WithSuffixControl = {
-	...WithSuffixControl,
+export const WithSuffixControl: Story = {
 	args: {
-		...WithSuffixControl.args,
-		children: undefined,
+		suffix: InputLayoutWithSuffixControl.args?.suffix,
 	},
 	parameters: {
 		// FIXME: Story shows Input without a visible label (label).
@@ -61,7 +56,6 @@ const InputWithSuffixControl: typeof WithSuffixControl = {
 		a11y: { test: 'todo' },
 	},
 };
-export { InputWithSuffixControl as WithSuffixControl };
 
 export const Disabled: Story = {
 	args: {

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -85,7 +85,8 @@
 		"postmanifest-snapshot": "prettier --write components-manifest.yml",
 		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c . -o ./build && node ./scripts/inject-legacy-docgen.mjs ./build/manifests/components.json",
 		"storybook:dev": "storybook dev -c . -p 50240",
-		"test:smoke": "vitest run --config vitest.config.ts",
+		"test:smoke": "npm run test:smoke:build && vitest run --config vitest.config.ts",
+		"test:smoke:build": "node ./scripts/smoke-static-build.mjs",
 		"test:smoke:setup": "playwright install chromium --with-deps"
 	}
 }

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -31,13 +31,14 @@
 		"@emotion/styled": "^11.14.1",
 		"@storybook/addon-a11y": "^10.5.3",
 		"@storybook/addon-docs": "^10.5.3",
+		"@storybook/addon-vitest": "^10.5.3",
 		"@storybook/icons": "^2.0.1",
 		"@storybook/react-vite": "^10.5.3",
-		"@storybook/test-runner": "^0.24.2",
 		"@types/babel__core": "^7.20.5",
 		"@types/js-yaml": "^3.12.10",
 		"@types/react": "^18.3.27",
 		"@vitejs/plugin-react": "^6.0.5",
+		"@vitest/browser-playwright": "^4.1.10",
 		"@wordpress/admin-ui": "file:../packages/admin-ui",
 		"@wordpress/base-styles": "file:../packages/base-styles",
 		"@wordpress/block-editor": "file:../packages/block-editor",
@@ -63,8 +64,6 @@
 		"@wordpress/theme": "file:../packages/theme",
 		"@wordpress/ui": "file:../packages/ui",
 		"clsx": "^2.1.1",
-		"concurrently": "^9.2.1",
-		"http-server": "^14.1.1",
 		"js-yaml": "^3.15.0",
 		"playwright": "^1.62.1",
 		"prettier": "npm:wp-prettier@^3.0.3",
@@ -76,7 +75,7 @@
 		"terser": "^5.37.0",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vite": "^8.2.1",
-		"wait-on": "^8.0.1"
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public"
@@ -86,7 +85,7 @@
 		"postmanifest-snapshot": "prettier --write components-manifest.yml",
 		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c . -o ./build && node ./scripts/inject-legacy-docgen.mjs ./build/manifests/components.json",
 		"storybook:dev": "storybook dev -c . -p 50240",
-		"test:smoke": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"http-server ./build --port 50240 --silent\" \"wait-on tcp:127.0.0.1:50240 && test-storybook --url http://localhost:50240 --config-dir .\"",
+		"test:smoke": "vitest run --config vitest.config.ts",
 		"test:smoke:setup": "playwright install chromium --with-deps"
 	}
 }

--- a/storybook/scripts/smoke-static-build.mjs
+++ b/storybook/scripts/smoke-static-build.mjs
@@ -1,0 +1,71 @@
+import path from 'node:path';
+import { chromium } from 'playwright';
+import { preview } from 'vite';
+
+const storybookDir = path.resolve( import.meta.dirname, '..' );
+const storyId = 'design-system-components-button--default';
+const storybookUrl = 'http://127.0.0.1:50240';
+/** @type { string[] } */
+const failedResponses = [];
+/** @type { string[] } */
+const pageErrors = [];
+let browser;
+let server;
+
+try {
+	server = await preview( {
+		root: storybookDir,
+		build: { outDir: path.resolve( storybookDir, 'build' ) },
+		preview: { host: '127.0.0.1', port: 50240, strictPort: true },
+	} );
+
+	const indexResponse = await fetch( `${ storybookUrl }/index.json` );
+	if ( ! indexResponse.ok ) {
+		throw new Error(
+			`Static Storybook index returned ${ indexResponse.status }.`
+		);
+	}
+
+	const { entries } = await indexResponse.json();
+	if ( entries?.[ storyId ]?.type !== 'story' ) {
+		throw new Error( `Static Storybook does not contain ${ storyId }.` );
+	}
+
+	browser = await chromium.launch( { headless: true } );
+	const page = await browser.newPage();
+	page.on( 'pageerror', ( error ) => pageErrors.push( error.message ) );
+	page.on( 'response', ( response ) => {
+		if ( response.status() >= 400 ) {
+			failedResponses.push(
+				`${ response.status() } ${ response.url() }`
+			);
+		}
+	} );
+
+	const response = await page.goto(
+		`${ storybookUrl }/iframe.html?id=${ storyId }&viewMode=story`,
+		{ waitUntil: 'networkidle' }
+	);
+	if ( ! response?.ok() ) {
+		throw new Error(
+			`Static Storybook iframe returned ${
+				response?.status() ?? 'no response'
+			}.`
+		);
+	}
+
+	await page.waitForFunction(
+		() => document.querySelector( '#storybook-root' )?.childNodes.length,
+		undefined,
+		{ timeout: 15_000 }
+	);
+
+	if ( failedResponses.length || pageErrors.length ) {
+		throw new Error( [ ...failedResponses, ...pageErrors ].join( '\n' ) );
+	}
+
+	console.log( `Rendered ${ storyId } from the static Storybook build.` );
+} finally {
+	await browser?.close();
+	await server?.close();
+}

--- a/storybook/scripts/smoke-static-build.mjs
+++ b/storybook/scripts/smoke-static-build.mjs
@@ -3,12 +3,10 @@ import { chromium } from 'playwright';
 import { preview } from 'vite';
 
 const storybookDir = path.resolve( import.meta.dirname, '..' );
-const storyId = 'design-system-components-button--default';
 const storybookUrl = 'http://127.0.0.1:50240';
-/** @type { string[] } */
-const failedResponses = [];
-/** @type { string[] } */
-const pageErrors = [];
+const maxConcurrentStories = 4;
+const storyTimeout = 15_000;
+/** @type {import('playwright').Browser | undefined} */
 let browser;
 let server;
 
@@ -26,13 +24,90 @@ try {
 		);
 	}
 
+	/**
+	 * @type {{ entries: Record<string, { id: string, type: string, tags?: string[] }> }}
+	 */
 	const { entries } = await indexResponse.json();
-	if ( entries?.[ storyId ]?.type !== 'story' ) {
-		throw new Error( `Static Storybook does not contain ${ storyId }.` );
+	const storyIds = Object.values( entries )
+		.filter(
+			( entry ) =>
+				entry.type === 'story' && entry.tags?.includes( 'test' )
+		)
+		.map( ( entry ) => entry.id );
+	if ( ! storyIds.length ) {
+		throw new Error(
+			'Static Storybook does not contain testable stories.'
+		);
 	}
 
-	browser = await chromium.launch( { headless: true } );
-	const page = await browser.newPage();
+	const launchedBrowser = await chromium.launch( { headless: true } );
+	browser = launchedBrowser;
+	/** @type {string[]} */
+	const failures = [];
+	let nextStoryIndex = 0;
+	let renderedStories = 0;
+	const workerCount = Math.min( maxConcurrentStories, storyIds.length );
+
+	await Promise.all(
+		Array.from( { length: workerCount }, async () => {
+			const context = await launchedBrowser.newContext();
+
+			try {
+				while ( nextStoryIndex < storyIds.length ) {
+					const storyId = storyIds[ nextStoryIndex++ ];
+
+					try {
+						await renderStory( context, storyId );
+					} catch ( error ) {
+						failures.push(
+							`${ storyId }: ${
+								error instanceof Error
+									? error.message
+									: String( error )
+							}`
+						);
+					}
+
+					renderedStories++;
+					if ( renderedStories % 50 === 0 ) {
+						console.log(
+							`Rendered ${ renderedStories }/${ storyIds.length } static stories.`
+						);
+					}
+				}
+			} finally {
+				await context.close();
+			}
+		} )
+	);
+
+	if ( failures.length ) {
+		throw new Error(
+			`Static Storybook failed to render ${
+				failures.length
+			} stories:\n${ failures.join( '\n' ) }`
+		);
+	}
+
+	console.log(
+		`Rendered all ${ storyIds.length } testable stories from the static Storybook build.`
+	);
+} finally {
+	await browser?.close();
+	await server?.close();
+}
+
+/**
+ * @param {import('playwright').BrowserContext} context
+ * @param {string}                              storyId
+ */
+async function renderStory( context, storyId ) {
+	const page = await context.newPage();
+	/** @type {string[]} */
+	const failedResponses = [];
+	/** @type {string[]} */
+	const pageErrors = [];
+
 	page.on( 'pageerror', ( error ) => pageErrors.push( error.message ) );
 	page.on( 'response', ( response ) => {
 		if ( response.status() >= 400 ) {
@@ -42,30 +117,50 @@ try {
 		}
 	} );
 
-	const response = await page.goto(
-		`${ storybookUrl }/iframe.html?id=${ storyId }&viewMode=story`,
-		{ waitUntil: 'networkidle' }
-	);
-	if ( ! response?.ok() ) {
-		throw new Error(
-			`Static Storybook iframe returned ${
-				response?.status() ?? 'no response'
-			}.`
+	try {
+		const response = await page.goto(
+			`${ storybookUrl }/iframe.html?id=${ encodeURIComponent(
+				storyId
+			) }&viewMode=story`,
+			{ waitUntil: 'domcontentloaded' }
 		);
+		if ( ! response?.ok() ) {
+			throw new Error(
+				`Iframe returned ${ response?.status() ?? 'no response' }.`
+			);
+		}
+
+		const storyResult = await page.waitForFunction(
+			/** @param {string} expectedStoryId */
+			( expectedStoryId ) => {
+				const channel =
+					/** @type {{ last: (eventName: string) => [{ storyId?: string, status?: string }] | undefined } | undefined} */ (
+						// @ts-expect-error Storybook exposes its channel on the preview global.
+						globalThis.__STORYBOOK_ADDONS_CHANNEL__
+					);
+				const result = channel?.last( 'storyFinished' )?.[ 0 ];
+
+				if ( result?.storyId !== expectedStoryId ) {
+					return false;
+				}
+
+				return { status: result.status };
+			},
+			storyId,
+			{ timeout: storyTimeout }
+		);
+		const storyResultValue = await storyResult.jsonValue();
+		const status = storyResultValue && storyResultValue.status;
+
+		if ( status !== 'success' ) {
+			throw new Error( 'Storybook reported a test failure.' );
+		}
+		if ( failedResponses.length || pageErrors.length ) {
+			throw new Error(
+				[ ...failedResponses, ...pageErrors ].join( '\n' )
+			);
+		}
+	} finally {
+		await page.close();
 	}
-
-	await page.waitForFunction(
-		() => document.querySelector( '#storybook-root' )?.childNodes.length,
-		undefined,
-		{ timeout: 15_000 }
-	);
-
-	if ( failedResponses.length || pageErrors.length ) {
-		throw new Error( [ ...failedResponses, ...pageErrors ].join( '\n' ) );
-	}
-
-	console.log( `Rendered ${ storyId } from the static Storybook build.` );
-} finally {
-	await browser?.close();
-	await server?.close();
 }

--- a/storybook/vitest-story-index-reporter.ts
+++ b/storybook/vitest-story-index-reporter.ts
@@ -1,0 +1,89 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+	Reporter,
+	TestCase,
+	TestModule,
+	TestRunEndReason,
+} from 'vitest/node';
+
+type StoryIndexEntry = {
+	id: string;
+	tags?: string[];
+	type: string;
+};
+
+type StoryIndex = {
+	entries: Record< string, StoryIndexEntry >;
+};
+
+const storyIndexPath = path.resolve( import.meta.dirname, 'build/index.json' );
+
+export default class StoryIndexReporter implements Reporter {
+	readonly #vitestStoryIds = new Set< string >();
+
+	onTestCaseResult( testCase: TestCase ) {
+		const { storyId } = testCase.meta() as { storyId?: unknown };
+
+		if ( typeof storyId === 'string' ) {
+			this.#vitestStoryIds.add( storyId );
+		}
+	}
+
+	async onTestRunEnd(
+		_testModules: readonly TestModule[],
+		_unhandledErrors: readonly unknown[],
+		reason: TestRunEndReason
+	) {
+		if ( reason !== 'passed' ) {
+			return;
+		}
+
+		const storyIndex = JSON.parse(
+			await readFile( storyIndexPath, 'utf8' )
+		) as StoryIndex;
+		const storybookStoryIds = new Set(
+			Object.values( storyIndex.entries )
+				.filter(
+					( entry ) =>
+						entry.type === 'story' && entry.tags?.includes( 'test' )
+				)
+				.map( ( entry ) => entry.id )
+		);
+		const missingFromVitest = [ ...storybookStoryIds ].filter(
+			( storyId ) => ! this.#vitestStoryIds.has( storyId )
+		);
+		const missingFromStorybook = [ ...this.#vitestStoryIds ].filter(
+			( storyId ) => ! storybookStoryIds.has( storyId )
+		);
+
+		if ( missingFromVitest.length || missingFromStorybook.length ) {
+			throw new Error(
+				[
+					'Storybook and Vitest discovered different story IDs.',
+					formatDifference(
+						'Missing from Vitest',
+						missingFromVitest
+					),
+					formatDifference(
+						'Missing from Storybook',
+						missingFromStorybook
+					),
+				]
+					.filter( Boolean )
+					.join( '\n' )
+			);
+		}
+	}
+}
+
+function formatDifference( label: string, storyIds: string[] ) {
+	if ( ! storyIds.length ) {
+		return '';
+	}
+
+	return `${ label } (${ storyIds.length }):\n${ storyIds
+		.sort()
+		.map( ( storyId ) => `- ${ storyId }` )
+		.join( '\n' ) }`;
+}

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import { configDefaults, defineConfig } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+
+const configDir = import.meta.dirname;
+
+export default defineConfig( {
+	// The story globs in `main.ts` reach into `../packages`, so the Vite root
+	// has to be the repository root for Vitest to match them.
+	root: path.resolve( configDir, '..' ),
+	plugins: [
+		storybookTest( {
+			configDir,
+			storybookUrl: 'http://localhost:50240',
+		} ),
+	],
+	test: {
+		name: 'storybook',
+		// The plugin excludes MDX relative to the working directory, which is
+		// this workspace rather than the root. Exclude it everywhere.
+		exclude: [ ...configDefaults.exclude, '**/*.mdx' ],
+		browser: {
+			enabled: true,
+			headless: true,
+			provider: playwright(),
+			instances: [ { browser: 'chromium' } ],
+		},
+	},
+} );

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig( {
 	],
 	test: {
 		name: 'storybook',
+		reporters: [
+			'default',
+			path.resolve( configDir, 'vitest-story-index-reporter.ts' ),
+		],
 		// The plugin excludes MDX relative to the working directory, which is
 		// this workspace rather than the root. Exclude it everywhere.
 		exclude: [ ...configDefaults.exclude, '**/*.mdx' ],

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -20,10 +20,14 @@ export default defineConfig( {
 		// The plugin excludes MDX relative to the working directory, which is
 		// this workspace rather than the root. Exclude it everywhere.
 		exclude: [ ...configDefaults.exclude, '**/*.mdx' ],
+		// Runs a garbage collection before each file; see the setup file.
+		setupFiles: [ path.resolve( configDir, 'vitest.setup.ts' ) ],
 		browser: {
 			enabled: true,
 			headless: true,
-			provider: playwright(),
+			provider: playwright( {
+				launchOptions: { args: [ '--js-flags=--expose-gc' ] },
+			} ),
 			instances: [ { browser: 'chromium' } ],
 		},
 	},

--- a/storybook/vitest.setup.ts
+++ b/storybook/vitest.setup.ts
@@ -6,4 +6,10 @@
  * garbage collection before each file keeps the page healthy. `gc` is exposed
  * by the `--js-flags=--expose-gc` launch argument in `vitest.config.ts`.
  */
-globalThis.gc?.();
+if ( typeof globalThis.gc !== 'function' ) {
+	throw new Error(
+		'Storybook tests require Chromium to expose garbage collection.'
+	);
+}
+
+globalThis.gc();

--- a/storybook/vitest.setup.ts
+++ b/storybook/vitest.setup.ts
@@ -1,0 +1,9 @@
+/**
+ * Vitest keeps one browser page per worker and runs each story file in a new
+ * iframe inside it. Chromium is slow to reclaim the detached iframes, and once
+ * enough of them pile up it drops the page's connection to Vitest, which fails
+ * the run with "Browser connection was closed while running tests". A full
+ * garbage collection before each file keeps the page healthy. `gc` is exposed
+ * by the `--js-flags=--expose-gc` launch argument in `vitest.config.ts`.
+ */
+globalThis.gc?.();


### PR DESCRIPTION
Related: #80855

## What?

Replaces `@storybook/test-runner` with Storybook's Vitest integration and removes the obsolete runner dependencies.

The smoke workflow now:

- builds Storybook and renders every testable story from the static build in Chromium;
- runs every testable story through Vitest and Playwright;
- verifies that the static Storybook index and Vitest discovered the same story IDs.

This also updates the temporary `sockjs > uuid` override, fixes an inserter animation-frame callback after unmount, stabilizes the Popover story accessibility test, updates affected `@wordpress/ui` story composition, and regenerates `package-lock.json`.

## Why?

The old runner retains outdated Jest and `uuid` dependencies. Vitest uses the existing Storybook Vite configuration, but rendering only through Vite could miss differences in the production build or silently skip stories. The static-build smoke test and discovery parity check preserve those safeguards and support the live-discovery direction discussed in #80855.

## How?

Vitest renders the stories in headless Chromium. Chromium exposes garbage collection to keep its long-lived test page stable. A separate, bounded static-build check loads every testable story, waits for Storybook to finish it, and reports failures by story ID. Story re-exports that Vitest cannot index are declared locally instead.

## Testing Instructions

1. Run `npm run storybook:build`.
2. Run `npm run --workspace @wordpress/storybook test:smoke`.
3. Confirm the static phase reports all 785 testable stories rendered and Vitest reports 219 files / 785 tests passed.
4. Run `npm run storybook:e2e:build`.
5. For the `uuid` override, run `npm run test:create-block`, start the scaffold with `wp-scripts start --hot`, and confirm edits rebuild successfully.

## Use of AI Tools

Prepared with Claude Code and Codex for dependency analysis, implementation, review, and verification. The changes were reviewed and tested by the contributor.
