### PR TITLE
Pattern List: Import a pattern from JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54174,6 +54174,7 @@
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/notices": "file:../../packages/notices",
 				"@wordpress/patterns": "file:../../packages/patterns",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/routes-lock-unlock": "file:../lock-unlock",

--- a/routes/pattern-list/import-pattern-button.tsx
+++ b/routes/pattern-list/import-pattern-button.tsx
@@ -1,0 +1,71 @@
+import { Button } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import {
+	store as patternsStore,
+	// @ts-expect-error - No type declarations available for @wordpress/patterns
+} from '@wordpress/patterns';
+import { unlock } from '@wordpress/routes-lock-unlock';
+
+/**
+ * Header trigger for importing a pattern from a JSON file, offered next to
+ * the primary create button.
+ *
+ * The file reading, validation and pattern creation live in the patterns
+ * store action, shared with the classic site editor, so the two imports
+ * cannot drift apart.
+ */
+export default function ImportPatternButton() {
+	const inputRef = useRef< HTMLInputElement >( null );
+	const { createPatternFromFile } = unlock( useDispatch( patternsStore ) );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	return (
+		<>
+			<Button
+				variant="secondary"
+				size="compact"
+				onClick={ () => inputRef.current?.click() }
+			>
+				{ __( 'Import pattern from JSON' ) }
+			</Button>
+			<input
+				type="file"
+				accept=".json"
+				hidden
+				ref={ inputRef }
+				onChange={ async ( event ) => {
+					const file = event.target.files?.[ 0 ];
+					if ( ! file ) {
+						return;
+					}
+					try {
+						const pattern = await createPatternFromFile( file );
+						createSuccessNotice(
+							sprintf(
+								// translators: %s: The imported pattern's title.
+								__( 'Imported "%s" from JSON.' ),
+								pattern.title.raw
+							),
+							{
+								type: 'snackbar',
+								id: 'import-pattern-success',
+							}
+						);
+					} catch ( err ) {
+						createErrorNotice( ( err as Error ).message, {
+							type: 'snackbar',
+							id: 'import-pattern-error',
+						} );
+					} finally {
+						// Allow the same file to be picked again.
+						event.target.value = '';
+					}
+				} }
+			/>
+		</>
+	);
+}

--- a/routes/pattern-list/package.json
+++ b/routes/pattern-list/package.json
@@ -19,9 +19,10 @@
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
+		"@wordpress/notices": "file:../../packages/notices",
 		"@wordpress/patterns": "file:../../packages/patterns",
 		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/views": "file:../../packages/views"
 	}
 }

--- a/routes/pattern-list/stage.tsx
+++ b/routes/pattern-list/stage.tsx
@@ -29,6 +29,7 @@ import { patternStatusField } from './fields/sync-status';
 import { usePatternCategoryField } from './fields/category';
 import usePatterns, { useAugmentPatternsWithPermissions } from './use-patterns';
 import type { NormalizedPattern } from './use-patterns';
+import ImportPatternButton from './import-pattern-button';
 // Unlock WordPress private APIs
 const { usePostActions, patternTitleField } = unlock( editorPrivateApis );
 const { Tabs } = unlock( componentsPrivateApis );
@@ -260,13 +261,16 @@ function PatternList() {
 			actions={
 				labels?.add_new_item &&
 				canCreateRecord && (
-					<Button
-						variant="primary"
-						onClick={ () => setShowPatternModal( true ) }
-						size="compact"
-					>
-						{ labels.add_new_item }
-					</Button>
+					<>
+						<ImportPatternButton />
+						<Button
+							variant="primary"
+							onClick={ () => setShowPatternModal( true ) }
+							size="compact"
+						>
+							{ labels.add_new_item }
+						</Button>
+					</>
 				)
 			}
 			hasPadding={ false }

--- a/routes/pattern-list/tsconfig.json
+++ b/routes/pattern-list/tsconfig.json
@@ -21,6 +21,7 @@
 		{ "path": "../../packages/element/tsconfig.build.json" },
 		{ "path": "../../packages/i18n/tsconfig.build.json" },
 		{ "path": "../../packages/lazy-editor" },
+		{ "path": "../../packages/notices/tsconfig.build.json" },
 		{ "path": "../../packages/route" },
 		{ "path": "../../packages/views/tsconfig.build.json" }
 	],


### PR DESCRIPTION
## What?

Adds "Import pattern from JSON" to the extensible site editor's Patterns page, as a secondary button to the left of the primary create button.

## Why?

The classic site editor has offered pattern import since WordPress 6.4 (#54337), and pattern-sharing workflows depend on the JSON round trip. In the extensible site editor only half of it existed: export already works — it arrives as a shared DataViews action — but there was no way in. Patterns could leave but not enter.

## How?

A small trigger component: a secondary button and a hidden `.json` file input. Everything substantive — file reading, JSON validation, pattern creation — is `createPatternFromFile` from the `@wordpress/patterns` store, the same private action the classic site editor's importer calls, so the two imports cannot drift apart. Success and failure surface as snackbars with the classic editor's exact strings; no new translatable strings are introduced.

The button renders inside the same `labels?.add_new_item && canCreateRecord` gate as the create button — a user who cannot create patterns sees neither — and the `Page` header renders actions in a row `Stack`, which handles order and spacing.

Two deliberate divergences from the classic implementation, both scope choices:

- **No category auto-assignment.** The classic importer assigns the currently browsed category to the imported pattern (and otherwise navigates you to All patterns). Here the pattern imports uncategorized and the view stays put; the default All patterns view picks it up. If a category filter is active the imported pattern won't appear until the filter is cleared — worth adding later if it proves annoying, but it needs the category term-resolution glue and this PR stays minimal.
- **No navigation to the imported pattern.** The classic importer was a menu item on a hub page; here you are already on the list the pattern lands in.

## Testing Instructions

1. Enable **Gutenberg → Experiments → Extensible Site Editor** and open **Appearance → Design → Patterns**.
2. Confirm an **Import pattern from JSON** secondary button sits left of the create button.
3. Save this as `test-pattern.json` and import it:
   ```json
   { "__file": "wp_block", "title": "Imported test", "content": "<!-- wp:paragraph --><p>Imported.</p><!-- /wp:paragraph -->" }
   ```
4. Confirm the snackbar `Imported "Imported test" from JSON.` and that the pattern appears in the list.
5. Import a non-JSON file renamed to `.json` and confirm an error snackbar instead of a crash.
6. Import the same file twice in a row — the second attempt must work (the input resets after each pick).
7. As a user who cannot create patterns (e.g. Contributor), confirm neither button renders.
8. Export an existing pattern from the list's action menu, re-import the downloaded file, and confirm the round trip.

### Testing Instructions for Keyboard

Tab to the import button, activate with <kbd>Enter</kbd>, and confirm the file dialog opens. After the snackbar appears, confirm focus is not lost.

## Use of AI Tools

Authored with Claude Code (Claude Fable 5), including this description; reviewed by the PR author.

Verified: lint clean; `npm run lint:tsconfig` exits 0; the route type-checks with no new errors under an ad-hoc tsconfig (`routes/*` is outside the project graph — note the check surfaces 4 pre-existing `TS2306` errors on trunk from the `@wordpress/patterns` → `any-module.d.ts` path shim, which affects every importer of that package under such configs; my file adds one more instance of the same shim quirk and nothing else). Not verified: no browser pass — the steps above are unrun, including the assumption that the list refreshes via entity-record invalidation after the import saves.
