### PR TITLE
Editor: Use UI Menu for post actions

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -74,7 +74,7 @@
 
 ### Internal
 
--   Post actions: Use the public `Menu` from `@wordpress/ui` instead of the private Components API.
+-   Post actions: Use the public `Menu` from `@wordpress/ui` instead of the private Components API ([#81922](https://github.com/WordPress/gutenberg/pull/81922)).
 -   Check the `window.__experimentalEnableRealTimeCollaboration` flag set by the Real-Time Collaboration experiment, instead of `window._wpCollaborationEnabled`, when determining whether collaboration is enabled for the current post ([#80658](https://github.com/WordPress/gutenberg/pull/80658)).
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 ### Internal
 
+-   Post actions: Use the public `Menu` from `@wordpress/ui` instead of the private Components API.
 -   Check the `window.__experimentalEnableRealTimeCollaboration` flag set by the Real-Time Collaboration experiment, instead of `window._wpCollaborationEnabled`, when determining whether collaboration is enabled for the current post ([#80658](https://github.com/WordPress/gutenberg/pull/80658)).
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   `MediaUpload`: Coerce `multiple` to a boolean before passing it to the experimental media modal; callers such as the playlist block and the inserter media tab pass the legacy media frame's `'add'` mode. ([#82715](https://github.com/WordPress/gutenberg/pull/82715))
 -   Document bar: Preserve the subdued template-preview icon color after the icon became stroke-based. ([#82540](https://github.com/WordPress/gutenberg/pull/82540))
 
+### Internal
+
+-   Post actions: Use the public `Menu` from `@wordpress/ui` instead of the private Components API ([#81922](https://github.com/WordPress/gutenberg/pull/81922)).
+
 ## 15.0.0 (2026-09-10)
 
 ### Breaking Changes
@@ -74,7 +78,6 @@
 
 ### Internal
 
--   Post actions: Use the public `Menu` from `@wordpress/ui` instead of the private Components API ([#81922](https://github.com/WordPress/gutenberg/pull/81922)).
 -   Check the `window.__experimentalEnableRealTimeCollaboration` flag set by the Real-Time Collaboration experiment, instead of `window._wpCollaborationEnabled`, when determining whether collaboration is enabled for the current post ([#80658](https://github.com/WordPress/gutenberg/pull/80658)).
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
 

--- a/packages/editor/src/components/post-actions/index.jsx
+++ b/packages/editor/src/components/post-actions/index.jsx
@@ -1,18 +1,14 @@
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	privateApis as componentsPrivateApis,
-	Button,
-	Modal,
-} from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { kebabCase } from '@wordpress/kebab-case';
+// eslint-disable-next-line @wordpress/use-recommended-components -- Intentional early adoption of the new Menu, pending WordPress/gutenberg#76135.
+import { Menu } from '@wordpress/ui';
 import { unlock } from '../../lock-unlock';
 import { usePostActions } from './actions';
-
-const { Menu } = unlock( componentsPrivateApis );
 
 export default function PostActions( { postType, postId, onActionPerformed } ) {
 	const [ activeModalAction, setActiveModalAction ] = useState( null );
@@ -50,8 +46,8 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 
 	return (
 		<>
-			<Menu placement="bottom-end">
-				<Menu.TriggerButton
+			<Menu.Root disabled={ ! actions.length }>
+				<Menu.Trigger
 					render={
 						<Button
 							size="small"
@@ -63,14 +59,16 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 						/>
 					}
 				/>
-				<Menu.Popover>
+				<Menu.Popup
+					positioner={ <Menu.Positioner side="bottom" align="end" /> }
+				>
 					<ActionsDropdownMenuGroup
 						actions={ actions }
 						items={ [ itemWithPermissions ] }
 						setActiveModalAction={ setActiveModalAction }
 					/>
-				</Menu.Popover>
-			</Menu>
+				</Menu.Popup>
+			</Menu.Root>
 			{ !! activeModalAction && (
 				<ActionModal
 					action={ activeModalAction }

--- a/packages/editor/src/components/post-actions/test/index.browser.test.tsx
+++ b/packages/editor/src/components/post-actions/test/index.browser.test.tsx
@@ -1,37 +1,48 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
 import { useSelect } from '@wordpress/data';
 import PostActions from '../';
 import { usePostActions } from '../actions';
 
-jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
-jest.mock( '../actions', () => ( { usePostActions: jest.fn() } ) );
+vi.mock( import( '@wordpress/data' ), { spy: true } );
+vi.mock( import( '../actions' ), () => ( { usePostActions: vi.fn() } ) );
+
+const mockedUseSelect = vi.mocked( useSelect );
+const mockedUsePostActions = vi.mocked( usePostActions );
 
 const item = { id: 123, title: { raw: 'Test post' } };
 
-function renderPostActions() {
-	useSelect.mockReturnValue( {
+async function renderPostActions() {
+	mockedUseSelect.mockReturnValue( {
 		item,
 		permissions: { canUpdate: true },
 	} );
 
-	return render( <PostActions postType="post" postId={ item.id } /> );
+	await render(
+		<PostActions
+			postType="post"
+			postId={ item.id }
+			onActionPerformed={ undefined }
+		/>
+	);
 }
 
 describe( 'PostActions', () => {
 	beforeEach( () => {
-		usePostActions.mockReset();
+		mockedUsePostActions.mockReset();
 	} );
 
 	it( 'keeps the unavailable actions trigger focusable and closed', async () => {
 		const user = userEvent.setup();
-		usePostActions.mockReturnValue( [] );
-		renderPostActions();
+		mockedUsePostActions.mockReturnValue( [] );
+		await renderPostActions();
 
 		const trigger = screen.getByRole( 'button', { name: 'Actions' } );
 		expect( trigger ).toHaveAttribute( 'aria-disabled', 'true' );
 
-		trigger.focus();
+		await user.tab();
 		expect( trigger ).toHaveFocus();
 
 		await user.keyboard( '{Enter}' );
@@ -40,11 +51,11 @@ describe( 'PostActions', () => {
 
 	it( 'performs an action, closes the menu, and restores trigger focus', async () => {
 		const user = userEvent.setup();
-		const callback = jest.fn();
-		usePostActions.mockReturnValue( [
+		const callback = vi.fn();
+		mockedUsePostActions.mockReturnValue( [
 			{ id: 'duplicate', label: 'Duplicate', callback },
 		] );
-		renderPostActions();
+		await renderPostActions();
 
 		const trigger = screen.getByRole( 'button', { name: 'Actions' } );
 		await user.click( trigger );
@@ -64,16 +75,16 @@ describe( 'PostActions', () => {
 
 	it( 'moves focus to a modal action and returns it after cancellation', async () => {
 		const user = userEvent.setup();
-		usePostActions.mockReturnValue( [
+		mockedUsePostActions.mockReturnValue( [
 			{
 				id: 'delete',
 				label: 'Delete',
-				RenderModal: ( { closeModal } ) => (
+				RenderModal: ( { closeModal }: { closeModal: () => void } ) => (
 					<button onClick={ closeModal }>Cancel</button>
 				),
 			},
 		] );
-		renderPostActions();
+		await renderPostActions();
 
 		const trigger = screen.getByRole( 'button', { name: 'Actions' } );
 		await user.click( trigger );

--- a/packages/editor/src/components/post-actions/test/index.js
+++ b/packages/editor/src/components/post-actions/test/index.js
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelect } from '@wordpress/data';
+import PostActions from '../';
+import { usePostActions } from '../actions';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '../actions', () => ( { usePostActions: jest.fn() } ) );
+
+const item = { id: 123, title: { raw: 'Test post' } };
+
+function renderPostActions() {
+	useSelect.mockReturnValue( {
+		item,
+		permissions: { canUpdate: true },
+	} );
+
+	return render( <PostActions postType="post" postId={ item.id } /> );
+}
+
+describe( 'PostActions', () => {
+	beforeEach( () => {
+		usePostActions.mockReset();
+	} );
+
+	it( 'keeps the unavailable actions trigger focusable and closed', async () => {
+		const user = userEvent.setup();
+		usePostActions.mockReturnValue( [] );
+		renderPostActions();
+
+		const trigger = screen.getByRole( 'button', { name: 'Actions' } );
+		expect( trigger ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		trigger.focus();
+		expect( trigger ).toHaveFocus();
+
+		await user.keyboard( '{Enter}' );
+		expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'performs an action, closes the menu, and restores trigger focus', async () => {
+		const user = userEvent.setup();
+		const callback = jest.fn();
+		usePostActions.mockReturnValue( [
+			{ id: 'duplicate', label: 'Duplicate', callback },
+		] );
+		renderPostActions();
+
+		const trigger = screen.getByRole( 'button', { name: 'Actions' } );
+		await user.click( trigger );
+		await user.click(
+			await screen.findByRole( 'menuitem', { name: 'Duplicate' } )
+		);
+
+		expect( callback ).toHaveBeenCalledWith(
+			[ { ...item, permissions: { canUpdate: true } } ],
+			expect.objectContaining( { registry: expect.any( Object ) } )
+		);
+		await waitFor( () => {
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+		} );
+		expect( trigger ).toHaveFocus();
+	} );
+
+	it( 'moves focus to a modal action and returns it after cancellation', async () => {
+		const user = userEvent.setup();
+		usePostActions.mockReturnValue( [
+			{
+				id: 'delete',
+				label: 'Delete',
+				RenderModal: ( { closeModal } ) => (
+					<button onClick={ closeModal }>Cancel</button>
+				),
+			},
+		] );
+		renderPostActions();
+
+		const trigger = screen.getByRole( 'button', { name: 'Actions' } );
+		await user.click( trigger );
+		await user.click(
+			await screen.findByRole( 'menuitem', { name: 'Delete' } )
+		);
+
+		const cancelButton = await screen.findByRole( 'button', {
+			name: 'Cancel',
+		} );
+		await waitFor( () => expect( cancelButton ).toHaveFocus() );
+
+		await user.click( cancelButton );
+		await waitFor( () => {
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+		expect( trigger ).toHaveFocus();
+	} );
+} );


### PR DESCRIPTION
See #76135. Related: #78031.

## What?

Replaces the private Components `Menu` in the Editor post-actions control with the public `Menu` from `@wordpress/ui`.

Public consumer APIs remain unchanged.

## Why?

The Editor should use the public Menu composition instead of unlocking a private Components API.

## How?

Uses `Menu.Root`, `Menu.Trigger`, `Menu.Positioner`, and `Menu.Popup`. The root owns the disabled state so the icon trigger remains focusable but cannot open when there are no eligible actions. A logical bottom/end position preserves the existing placement. Existing action callbacks, modal actions, labels, and closure behavior remain unchanged.

Focused regression tests cover the disabled Button trigger and focus handoff between Menu and the Components Modal.

## Testing Instructions

1. Start the Gutenberg development environment and open a post in the editor.
2. Open the post settings sidebar.
3. Open **Actions** and confirm **View**, **Duplicate**, **Rename**, and **Trash** appear.
4. Confirm the menu is positioned below and aligned with the inline end of the trigger.
5. Click outside the menu and confirm it closes.
6. Choose **Rename**. Confirm the menu closes and focus moves to the name field in the modal.
7. Cancel the modal and confirm focus returns to **Actions**.
8. Repeat at a narrow viewport and compare the menu placement and labels with trunk.

### Testing Instructions for Keyboard

1. Tab to **Actions** and open it with Enter, Space, or Arrow Down.
2. Use Arrow Up and Arrow Down to move through the items.
3. Type `r` and confirm **Rename** is focused.
4. Press Escape and confirm the menu closes and focus returns to **Actions**.
5. Reopen the menu, activate **Rename** with Enter, then cancel the modal. Confirm focus returns to **Actions**.

## Screenshots or screencast

<img width="568" height="562" alt="Screenshot 2026-09-14 at 12 35 02" src="https://github.com/user-attachments/assets/26acad74-1b24-4b9a-b1bd-851eaac2b88a" />
<img width="1080" height="1110" alt="Screenshot 2026-09-14 at 12 35 31" src="https://github.com/user-attachments/assets/e8d9d32c-3454-4f3c-a480-fbc7f4f76dcb" />


## Use of AI Tools

Codex was used to implement, test, and review this change and to draft this pull request description.

