### PR TITLE
Validation: Update dependency-audit to 0.4.6 and ignore the dataviews ./wp bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7142,9 +7142,9 @@
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
 		},
 		"node_modules/@mawesome/dependency-audit": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@mawesome/dependency-audit/-/dependency-audit-0.4.5.tgz",
-			"integrity": "sha512-zU7XmZpZ0cQhijNvjeQbTAnAI2CRT+4V7t8K52H+qaewBpYgHTB2xh/egMbbTiHNnOrDfqxcEP6cMTuveR7uwg==",
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/@mawesome/dependency-audit/-/dependency-audit-0.4.6.tgz",
+			"integrity": "sha512-DZjMeeChWpk3GfgaSO5MWIl3uiTm/wdlLkVJ4kmPU//pAKQ6CrbUADRl3HgTHWk1XvErdvzRcng+3IoqksUCUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -56464,7 +56464,7 @@
 				"wp-validate-package-contents": "validate-package-contents.mjs"
 			},
 			"devDependencies": {
-				"@mawesome/dependency-audit": "^0.4.5",
+				"@mawesome/dependency-audit": "^0.4.6",
 				"@wordpress/create-block": "file:../../packages/create-block",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"chalk": "^4.1.1",

--- a/tools/validation/dependency-audit.config.json
+++ b/tools/validation/dependency-audit.config.json
@@ -24,6 +24,11 @@
 			"comment": "@wordpress/e2e-tests ships test-fixture plugins under plugins/ (imports of @wordpress/connectors as test data and sibling `test/*` script-modules registered by the harness, not real npm packages). Scoped to that package and path so it can never mask a real finding elsewhere.",
 			"target": "@wordpress/e2e-tests",
 			"path": "plugins/**"
+		},
+		{
+			"comment": "@wordpress/dataviews `./wp` bundle (build-wp/, built by packages/dataviews/build.cjs) inlines other @wordpress/* packages but keeps their third-party imports external, so they are undeclared. Not fixing: the bundle is about to be removed along with the private APIs, see https://github.com/WordPress/gutenberg/pull/81843#issuecomment-5354950365",
+			"target": "@wordpress/dataviews",
+			"path": "build-wp/**"
 		}
 	]
 }

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -24,7 +24,7 @@
 		"wp-validate-package-contents": "./validate-package-contents.mjs"
 	},
 	"devDependencies": {
-		"@mawesome/dependency-audit": "^0.4.5",
+		"@mawesome/dependency-audit": "^0.4.6",
 		"@wordpress/create-block": "file:../../packages/create-block",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"chalk": "^4.1.1",


### PR DESCRIPTION
## What?
Supersedes #81843. See #67864.

Updates `@mawesome/dependency-audit` to 0.4.6 in `@wordpress/validation-tools` and adds an ignore rule for the `@wordpress/dataviews` `./wp` bundle.

## Why?
0.4.6 scans static imports in `.js` ESM bundles even when the package has no `"type": "module"` ([changelog](https://github.com/manzoorwanijk/mawesome/blob/trunk/packages/dependency-audit/CHANGELOG.md#046)). With that fix, `npm run lint:published-deps` reports 24 undeclared runtime imports in `packages/dataviews/build-wp/index.js`: [build.cjs](https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/build.cjs) inlines other `@wordpress/*` packages but keeps their third-party imports external, and `@wordpress/dataviews` never declared them.

#81843 declared those dependencies, but per https://github.com/WordPress/gutenberg/pull/81843#issuecomment-5354950365 the `./wp` bundle is about to be removed with the private APIs, so declaring them is not worth it.

## How?
The ignore rule in [dependency-audit.config.json](https://github.com/WordPress/gutenberg/blob/trunk/tools/validation/dependency-audit.config.json) is scoped to `target: @wordpress/dataviews` and `path: build-wp/**`, so it cannot mask the same specifiers elsewhere, and the tool warns once it stops matching.

## Testing Instructions
1. Run `npm run build -- --skip-types`.
2. Run `npm run lint:published-deps` and confirm it reports 0 findings, 38 ignored.

## Use of AI Tools
Authored with Claude Code assistance; reviewed and tested by the author.
