### PR TITLE
Group Block: Add aspect ratio control

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -408,7 +408,7 @@ Gather blocks in a layout container.
 
 -	**Name:** [core/group](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-design/core-block-group/)
 -	**Category:** [design](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-design/)
--	**Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize, gradient), color (background, button, gradients, heading, link, text), dimensions (minHeight, minWidth), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), allowedBlocks, anchor, ariaLabel, background (backgroundImage, backgroundSize, gradient), color (background, button, gradients, heading, link, text), dimensions (aspectRatio, minHeight, minWidth), interactivity (clientNavigation), layout (allowSizingOnChildren), position (sticky), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName, templateLock
 
 ## Heading

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Group: Add an aspect ratio control to the Group block and its Row, Stack, and Grid variations. The control is hidden by default, and content taller than the ratio expands the block rather than overflowing it.
 -   Columns: Add transforms between Columns and the Row variation that preserve column widths through flex child sizing controls.
 
 ### Bug Fixes

--- a/packages/block-library/src/group/README.md
+++ b/packages/block-library/src/group/README.md
@@ -41,6 +41,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
   - `padding`: `true`
   - `blockGap`: `["horizontal","vertical"]`
 - [`dimensions`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#dimensions):
+  - `aspectRatio`: `true`
   - `minHeight`: `true`
   - `minWidth`: `true`
 - [`position`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#position):

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -54,8 +54,12 @@
 			}
 		},
 		"dimensions": {
+			"aspectRatio": true,
 			"minHeight": true,
-			"minWidth": true
+			"minWidth": true,
+			"__experimentalDefaultControls": {
+				"aspectRatio": false
+			}
 		},
 		"__experimentalBorder": {
 			"color": true,


### PR DESCRIPTION
## What?
Closes #61326

Adds the `dimensions.aspectRatio` block support to the Group block, so Group and its Row, Stack, and Grid variations can be sized to an aspect ratio. The control is hidden by default in the Dimensions panel.

## Why?
The aspect ratio control currently only exists on the Cover block. The useful pattern content that stretches to fill a ratio-constrained container, isn't achievable on Group today without workarounds, and Cover can't do it either because Cover doesn't flex.

## Testing Instructions
1. Create a new post and insert a **Group** block, then add a paragraph inside it.
2. Select the Group. In the sidebar, open the **Dimensions** panel and click its options button.
3. Confirm **Aspect Ratio** is listed but **not** enabled by default. Enable it.
4. Set the aspect ratio to **16:9**. The Group should resize to a 16:9 box in the editor.
5. Save and view the post on the front end. Confirm the Group renders at 16:9.
6. Back in the editor, add enough content to exceed the ratio (several paragraphs, or an image). **Confirm the Group grows to fit the content instead of the content overflowing.** Check the front end too.
7. Set a **Min height** on the same Group. Confirm the aspect ratio is cleared. Then set an aspect ratio again and confirm the min height is cleared.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/89aba9a7-5c6e-4d8f-8243-ee32a7d63bce

## Use of AI Tools
This PR was developed with Claude (Opus). It was used to explore the existing aspect ratio block support.