### PR TITLE
Playlist: Update tracklist settings copy

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   Columns: Add transforms between Columns and the Row variation that preserve column widths through flex child sizing controls.
+-   Playlist: Shorten, indent, and hide tracklist inspector controls when the tracklist is disabled.
 
 ### Bug Fixes
 

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -525,7 +525,7 @@ const PlaylistEdit = ( {
 					{ showTracklist && (
 						<>
 							<ToolsPanelItem
-								label={ __( 'Show artist name in tracklist' ) }
+								label={ __( 'Show artist name' ) }
 								isShownByDefault
 								hasValue={ () => showArtists !== true }
 								onDeselect={ () =>
@@ -533,9 +533,8 @@ const PlaylistEdit = ( {
 								}
 							>
 								<ToggleControl
-									label={ __(
-										'Show artist name in tracklist'
-									) }
+									className="wp-block-playlist__tracklist-setting"
+									label={ __( 'Show artist name' ) }
 									onChange={ toggleAttribute(
 										'showArtists'
 									) }
@@ -543,9 +542,7 @@ const PlaylistEdit = ( {
 								/>
 							</ToolsPanelItem>
 							<ToolsPanelItem
-								label={ __(
-									'Show track numbers in tracklist'
-								) }
+								label={ __( 'Show track numbers' ) }
 								isShownByDefault
 								hasValue={ () => showNumbers !== true }
 								onDeselect={ () =>
@@ -553,9 +550,8 @@ const PlaylistEdit = ( {
 								}
 							>
 								<ToggleControl
-									label={ __(
-										'Show track numbers in tracklist'
-									) }
+									className="wp-block-playlist__tracklist-setting"
+									label={ __( 'Show track numbers' ) }
 									onChange={ toggleAttribute(
 										'showNumbers'
 									) }
@@ -563,9 +559,7 @@ const PlaylistEdit = ( {
 								/>
 							</ToolsPanelItem>
 							<ToolsPanelItem
-								label={ __(
-									'Show track duration in tracklist'
-								) }
+								label={ __( 'Show duration' ) }
 								isShownByDefault
 								hasValue={ () => showTrackLength !== true }
 								onDeselect={ () =>
@@ -573,33 +567,33 @@ const PlaylistEdit = ( {
 								}
 							>
 								<ToggleControl
-									label={ __(
-										'Show track duration in tracklist'
-									) }
+									className="wp-block-playlist__tracklist-setting"
+									label={ __( 'Show duration' ) }
 									onChange={ toggleAttribute(
 										'showTrackLength'
 									) }
 									checked={ showTrackLength }
 								/>
 							</ToolsPanelItem>
+							<ToolsPanelItem
+								label={ __( 'Show images' ) }
+								isShownByDefault
+								hasValue={ () => showImages !== true }
+								onDeselect={ () =>
+									setAttributes( { showImages: true } )
+								}
+							>
+								<ToggleControl
+									className="wp-block-playlist__tracklist-setting"
+									label={ __( 'Show images' ) }
+									onChange={ toggleAttribute( 'showImages' ) }
+									checked={ showImages }
+								/>
+							</ToolsPanelItem>
 						</>
 					) }
 					<ToolsPanelItem
-						label={ __( 'Show tracklist images' ) }
-						isShownByDefault
-						hasValue={ () => showImages !== true }
-						onDeselect={ () =>
-							setAttributes( { showImages: true } )
-						}
-					>
-						<ToggleControl
-							label={ __( 'Show tracklist images' ) }
-							onChange={ toggleAttribute( 'showImages' ) }
-							checked={ showImages }
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						label={ __( 'Show track image on play button' ) }
+						label={ __( 'Show image on play button' ) }
 						isShownByDefault
 						hasValue={ () => showPlayButtonArtwork === true }
 						onDeselect={ () =>
@@ -607,7 +601,7 @@ const PlaylistEdit = ( {
 						}
 					>
 						<ToggleControl
-							label={ __( 'Show track image on play button' ) }
+							label={ __( 'Show image on play button' ) }
 							onChange={ toggleAttribute(
 								'showPlayButtonArtwork'
 							) }

--- a/packages/block-library/src/playlist/editor.scss
+++ b/packages/block-library/src/playlist/editor.scss
@@ -3,3 +3,7 @@
 	grid-column: 1 / -1;
 	row-gap: 0;
 }
+
+.wp-block-playlist__tracklist-setting {
+	padding-left: 16px;
+}


### PR DESCRIPTION
## What?
Updates the Playlist block inspector settings by shortening and indenting the tracklist option labels while keeping them in the existing Settings panel.

## Why?
The current controls repeat "in tracklist" across several labels and show tracklist-specific toggles even when the tracklist itself is disabled, making the inspector harder to scan.

## How?
Conditionally renders artist name, track numbers, duration, and images only when Show tracklist is enabled, and indents those dependent toggles within the same Settings panel. The general Settings panel still owns all playlist controls, including the panel reset behavior.

## Testing Instructions
1. Open a post or page.
2. Insert a Playlist block with audio tracks.
3. Open the block inspector settings.
4. Confirm the Settings panel includes Show tracklist, Show image on play button, and Order.
5. Confirm enabling Show tracklist shows indented Show artist name, Show track numbers, Show duration, and Show images controls in the same Settings panel.
6. Toggle Show tracklist off and confirm those tracklist-specific controls are hidden.

### Testing Instructions for Keyboard
1. Open a post or page.
2. Insert or select a Playlist block.
3. Use the keyboard to navigate to the block inspector.
4. Tab through the Settings controls and confirm each visible toggle can be focused and changed with the keyboard.
5. Toggle Show tracklist off and confirm keyboard navigation skips the hidden tracklist-specific controls.

## Screenshots or screencast
<img width="282" height="554" alt="Screenshot 2026-08-21 at 15 23 29" src="https://github.com/user-attachments/assets/e6ed7fb9-c9b5-426c-a3ea-3a1f82165196" />


## Use of AI Tools
This PR was prepared with assistance from OpenAI Codex in Conductor. The changes and PR details were reviewed before submission.