### PR TITLE
Build Scripts: Force tsc --pretty so CI reports the project behind global diagnostics

### DIFF
--- a/tools/build-scripts/typecheck.mjs
+++ b/tools/build-scripts/typecheck.mjs
@@ -6,11 +6,19 @@ import spawn from 'cross-spawn';
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const ROOT_DIR = path.resolve( __dirname, '../..' );
 
-/* Same failure hint as the build, so a red CI run points at the fix. */
-const result = spawn.sync( 'tsc', [ '--build', ...process.argv.slice( 2 ) ], {
-	cwd: ROOT_DIR,
-	stdio: 'inherit',
-} );
+/*
+ * Same failure hint as the build, so a red CI run points at the fix.
+ * `--pretty` keeps related info (e.g. the tsconfig behind a bad `types`
+ * entry) that tsc drops when stdout is not a TTY, as in CI.
+ */
+const result = spawn.sync(
+	'tsc',
+	[ '--build', '--pretty', ...process.argv.slice( 2 ) ],
+	{
+		cwd: ROOT_DIR,
+		stdio: 'inherit',
+	}
+);
 
 if ( result.status !== 0 ) {
 	console.error(


### PR DESCRIPTION
## What?

Pass `--pretty` to `tsc --build` in [tools/build-scripts/typecheck.mjs](https://github.com/WordPress/gutenberg/blob/fix/typecheck-pretty-output/tools/build-scripts/typecheck.mjs) so `npm run typecheck` reports the project behind a global diagnostic in CI.

## Why?

A global diagnostic such as TS2688 (a `types` entry that cannot be resolved) is not attached to a source file. The non-pretty formatter tsc uses when stdout is not a TTY also drops related information, so in CI the error names no file or project at all. Surfaced by #75814, where isolated installs stop hoisting `@types/jest` into `storybook`; see [this failing job](https://github.com/WordPress/gutenberg/actions/runs/32493673465/job/96806973274?pr=75814).

Before:

```
error TS2688: Cannot find type definition file for 'jest'.
  The file is in the program because:
    Entry point of type library 'jest' specified in compilerOptions
```

After:

```
error TS2688: Cannot find type definition file for 'jest'.
  The file is in the program because:
    Entry point of type library 'jest' specified in compilerOptions
  storybook/tsconfig.json:8:14 - File is entry point of type library specified here.
    8   "types": [ "jest" ]
                   ~~~~~~

Found 1 error.
```

## How?

The pretty formatter includes related information, which carries the attribution. GitHub's log viewer renders the ANSI colors. Local runs are unchanged since a TTY already implied `--pretty`.

## Testing Instructions

1. In `storybook/tsconfig.json`, change `"types": [ "jest" ]` to `"types": [ "nope" ]`.
2. Run `npm run typecheck | cat`.
3. Confirm the error points at `storybook/tsconfig.json:8:14`, then revert the change.

## Use of AI Tools

Written with Claude Code; reviewed and tested by the author.
