### PR TITLE
Update/add placeholder for title block in post editor

### DIFF
--- a/packages/block-library/src/post-title/edit.jsx
+++ b/packages/block-library/src/post-title/edit.jsx
@@ -66,7 +66,7 @@ export default function PostTitleEdit( {
 		titleElement = userCanEdit ? (
 			<PlainText
 				tagName={ TagName }
-				placeholder={ __( '(no title)' ) }
+				placeholder={ placeholder || __( '(no title)' ) }
 				value={ rawTitle }
 				onChange={ setTitle }
 				__experimentalVersion={ 2 }
@@ -92,7 +92,7 @@ export default function PostTitleEdit( {
 					target={ linkTarget }
 					rel={ rel }
 					placeholder={
-						! rawTitle.length ? __( '(no title)' ) : null
+						! rawTitle.length ? __( '(no title)' ) : placeholder
 					}
 					value={ rawTitle }
 					onChange={ setTitle }

--- a/packages/block-library/src/post-title/test/edit.tsx
+++ b/packages/block-library/src/post-title/test/edit.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import { useBlockProps } from '@wordpress/block-editor';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import PostTitleEdit from '../edit';
+
+// Fully mock the WordPress data/editor packages the component (and its shared
+// hooks) touch. Only the pieces actually used are provided; `PlainText` is
+// replaced with a simple input so its `placeholder` prop is queryable.
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: {},
+	useBlockProps: jest.fn( () => ( {} ) ),
+	useBlockEditingMode: jest.fn( () => 'disabled' ),
+	BlockControls: () => null,
+	InspectorControls: () => null,
+	HeadingLevelDropdown: () => null,
+	PlainText: ( { placeholder, value } ) => (
+		<input readOnly placeholder={ placeholder } value={ value } />
+	),
+} ) );
+
+// The settings UI (ToolsPanel etc.) lives in the un-rendered InspectorControls
+// branch; stub it out so the test does not pull in the full components package.
+jest.mock( '@wordpress/components', () => ( {
+	ToggleControl: () => null,
+	TextControl: () => null,
+	ExternalLink: () => null,
+	__experimentalToolsPanel: () => null,
+	__experimentalToolsPanelItem: () => null,
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: {},
+	useEntityProp: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+const defaultProps = {
+	attributes: {
+		level: 2,
+		levelOptions: undefined,
+		isLink: false,
+		rel: '',
+		linkTarget: '_self',
+		placeholder: undefined,
+	},
+	setAttributes: jest.fn(),
+	context: { postType: 'post', postId: 1, queryId: undefined },
+};
+
+/**
+ * Points `useEntityProp` at a given title. It is called twice by the
+ * component: once for `title` and once for `link`.
+ *
+ * @param {string} title The raw post title.
+ */
+function mockEntity( title = '' ) {
+	useEntityProp.mockImplementation( ( kind, name, prop ) => {
+		if ( prop === 'title' ) {
+			return [ title, jest.fn(), { rendered: title } ];
+		}
+		// `link`
+		return [ 'https://example.com' ];
+	} );
+}
+
+describe( 'PostTitleEdit', () => {
+	beforeEach( () => {
+		useBlockProps.mockImplementation( () => ( {} ) );
+		// The user can edit the entity (enables the editable PlainText path).
+		useSelect.mockReturnValue( true );
+		mockEntity( '' );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'uses a custom placeholder when one is set', () => {
+		render(
+			<PostTitleEdit
+				{ ...defaultProps }
+				attributes={ {
+					...defaultProps.attributes,
+					placeholder: 'Add a headline',
+				} }
+			/>
+		);
+
+		expect(
+			screen.getByPlaceholderText( 'Add a headline' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'falls back to the default placeholder when none is set', () => {
+		render( <PostTitleEdit { ...defaultProps } /> );
+
+		expect(
+			screen.getByPlaceholderText( '(no title)' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'uses a custom placeholder on the linked title when a title exists', () => {
+		mockEntity( 'An existing title' );
+		render(
+			<PostTitleEdit
+				{ ...defaultProps }
+				attributes={ {
+					...defaultProps.attributes,
+					isLink: true,
+					placeholder: 'Add a headline',
+				} }
+			/>
+		);
+
+		expect(
+			screen.getByPlaceholderText( 'Add a headline' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'falls back to the default placeholder on an empty linked title', () => {
+		render(
+			<PostTitleEdit
+				{ ...defaultProps }
+				attributes={ {
+					...defaultProps.attributes,
+					isLink: true,
+					placeholder: 'Add a headline',
+				} }
+			/>
+		);
+
+		expect(
+			screen.getByPlaceholderText( '(no title)' )
+		).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/81941

<!-- In a few words, what is the PR actually doing? -->

## Why?
As noted in the linked issue, the placeholder attribute for the title block is not working as expected in the Post Editor, while it works in the Site Editor as expected. See testing instructions and images in the issue.

## How?
This PR adds checks for the placeholder attribute and applies it if it exists.

## Testing Instructions
Either in the WP Playground with this PR, or locally, checkout this branch, build and do the following:

1. Open the Post Editor by creating a new Post or Page
2. Make sure the Title block is on the page (it should say "(no title)")
3. In the block's attributes (via Code Editor or block JSON), set e.g., "placeholder": "Add a post title", e.g.: `<!-- wp:post-title {"placeholder": "Add a post title", "level":1,"style":{"typography":{"textAlign":"center"}}} /-->`
4. Switch back to the visual editor
5. Expect the Post Title block to display "Add a post title" instead of the default "(no title)", image of expected output:
<img width="733" height="306" alt="image" src="https://github.com/user-attachments/assets/89d52c73-3815-4965-a4f6-096c5c7da118" />


### Testing Instructions for Keyboard
Repeat the testing instructions from above, using the Code Editor and Visual Editor toggle shortcuts, pasting in the example code:  `<!-- wp:post-title {"placeholder": "Add a post title", "level":1,"style":{"typography":{"textAlign":"center"}}} /-->`

|Before|After|
|-|-|
|<img width="733" height="306" alt="image" src="https://github.com/user-attachments/assets/f56b876b-808d-49d2-8e60-2c8fb62a7d4e" />|<img width="733" height="306" alt="image" src="https://github.com/user-attachments/assets/89d52c73-3815-4965-a4f6-096c5c7da118" />|

## Test suite added

Tests were added for this block in the `/test/edit.js` file.

To run these tests locally, run ` npm run test:unit -- packages/block-library/src/post-title/test/edit.js`

What the tests cover:
  1. When a custom placeholder attribute set
  2. When no placeholder is set falls back to the default (no title)
  3. The same two cases for when the title is linked

All four test pass: 

<img width="730" height="357" alt="image" src="https://github.com/user-attachments/assets/28e6d18a-4b2c-400d-8c85-c155656d9372" />


## Use of AI Tools

Well I edited the code on my own the test suite that is added for this was generated with AI, specifically using Claude Opus 4.8.
