### PR TITLE
Block Library: Fix failing test in playlist block

### DIFF
--- a/packages/block-library/src/playlist-track/test/edit.js
+++ b/packages/block-library/src/playlist-track/test/edit.js
@@ -264,7 +264,10 @@ describe( 'PlaylistTrackEdit', () => {
 		const removeBlock = jest.fn();
 		useDispatch.mockReturnValue( { createErrorNotice, removeBlock } );
 
-		const { setAttributes } = renderEdit( { clientId: 'existing-track' } );
+		const { setAttributes } = renderEdit( {
+			clientId: 'existing-track',
+			isSelected: true,
+		} );
 
 		// A failed replacement is reported by MediaReplaceFlow, not the
 		// blob uploader, which never runs for a track that has a source.


### PR DESCRIPTION
## What?

Fixes test failure in playlist block on `trunk`.

Example failure: https://github.com/WordPress/gutenberg/actions/runs/32531901148/job/96925408261

Related: #81878, #81441

## Why?

Trunk should be green.

## How?

Provides `isSelected: true` when rendering block.

The issue is due to merge timing between #81441 and #81878, where #81441 conditionally rendered `MediaReplaceFlow` based on `isSelected`. So without `isSelected`, the expected component path doesn't render.

## Testing Instructions

```
npm run test:unit packages/block-library/src/playlist-track/test/edit.js
```

## Use of AI Tools

Cursor IDE + Auto model to identify fix and root cause, reviewed manually.