### PR TITLE
Block editor: Move `isElementVisible` changelog entry to Unreleased

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Internal
 
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81516](https://github.com/WordPress/gutenberg/pull/81516))
+-   Expose `isElementVisible` via private APIs so `@wordpress/editor`'s collaboration overlay can detect content hidden by a collapsed container (e.g. a closed `core/details` panel) without duplicating the visibility check ([#81322](https://github.com/WordPress/gutenberg/pull/81322)).
 
 ## 16.2.0 (2026-08-12)
 
@@ -58,7 +59,6 @@
 ### Internal
 
 -   `ListView`: Reimplement the Firefox description-recomputation workaround in `AriaReferencedText` by keying the element on its text, so React replaces it instead of updating the existing text node in place ([#80929](https://github.com/WordPress/gutenberg/pull/80929).
--   Expose `isElementVisible` via private APIs so `@wordpress/editor`'s collaboration overlay can detect content hidden by a collapsed container (e.g. a closed `core/details` panel) without duplicating the visibility check ([#79641](https://github.com/WordPress/gutenberg/issues/79641)).
 
 ### Bug Fixes
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The [#81322](https://github.com/WordPress/gutenberg/pull/81322) changelog line in `@wordpress/block-editor` set under the already-published 16.2.0 section and linked issue [#79641](https://github.com/WordPress/gutenberg/issues/79641).

## Why?
New package changelog items belong under Unreleased. `16.2.0` shipped on 12 Aug;  [#81322](https://github.com/WordPress/gutenberg/pull/81322) merged on 20 Aug, so that change is not part of 16.2.0. Changelog entries should cite the PR that landed the work, not the tracking issue.

## How?
Moved the `isElementVisible` private-API line to Unreleased → Internal and pointed it at  [#81322](https://github.com/WordPress/gutenberg/pull/81322).

## Testing Instructions
- None (Only documentation changes are included)

## Use of AI Tools
- No
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
