### PR TITLE
Suggest mode: keep a marker's screen-reader announcement in one piece

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   Suggest mode: keep the code editor closed while the Suggest intent is active and while the post still carries unresolved inline suggestion markers, and identify a marker by its element rather than by a substring of the document ([#81662](https://github.com/WordPress/gutenberg/pull/81662)).
--   Suggest mode: Announce inline suggestion markers to screen readers. A marker's state was carried entirely by color and text decoration, so a run proposed for deletion was read aloud as ordinary prose. Each marker is now bracketed by an announcement naming the kind of change and the person who proposed it, and add and delete markers carry `role="insertion"` and `role="deletion"`; a formatting suggestion no longer claims to be a deletion. Suggestions over overlapping runs nest, and each is announced and attributed to the person who made it ([#81663](https://github.com/WordPress/gutenberg/pull/81663)).
+-   Suggest mode: Announce inline suggestion markers to screen readers. A marker's state was carried entirely by color and text decoration, so a run proposed for deletion was read aloud as ordinary prose. Each marker is now bracketed by an announcement naming the kind of change and the person who proposed it, and add and delete markers carry `role="insertion"` and `role="deletion"`; a formatting suggestion no longer claims to be a deletion. Suggestions over overlapping runs nest, and each is announced and attributed to the person who made it ([#81663](https://github.com/WordPress/gutenberg/pull/81663), [#81957](https://github.com/WordPress/gutenberg/pull/81957)).
 
 ## 14.53.0 (2026-08-12)
 

--- a/packages/editor/src/components/inline-suggestions/format.js
+++ b/packages/editor/src/components/inline-suggestions/format.js
@@ -147,6 +147,14 @@ export function getSuggestionA11yDescriptor( type ) {
  * element), so a marker gains exactly one nested role element. Where markers
  * nest, each run keeps its own decoration describing the marker that wraps it.
  *
+ * It is spliced in directly after the marker rather than pushed onto the end of
+ * the stack. `toTree` decides whether to reuse an element by comparing format
+ * stacks *by index*, so a bold run or link covering only part of a marker would
+ * shift a trailing decoration's index and split it into two elements - and two
+ * elements means the closing announcement is read out mid-suggestion and the
+ * opening one repeated. Sitting immediately inside the marker keeps its index
+ * fixed for the marker's whole run.
+ *
  * @param {Array} formats Per-character format stacks.
  * @return {Array} Format stacks with role decorations added.
  */
@@ -161,19 +169,20 @@ export function addSuggestionRoleFormats( formats ) {
 		const stack = formats[ i ];
 		/*
 		 * The innermost marker, not the first: overlapping runs from two
-		 * people serialize as nested markers, and the decoration is appended
-		 * last so it renders inside all of them. Describing an enclosing
-		 * marker would announce the wrong change - a deletion nested inside
-		 * someone else's addition read aloud as an addition.
+		 * people serialize as nested markers, and the decoration goes just
+		 * inside the deepest of them. Describing an enclosing marker would
+		 * announce the wrong change - a deletion nested inside someone else's
+		 * addition read aloud as an addition.
 		 */
-		const suggestion = Array.isArray( stack )
-			? stack.findLast( ( f ) => f.type === SUGGESTION_FORMAT_NAME )
-			: undefined;
-		if ( ! suggestion ) {
+		const markerIndex = Array.isArray( stack )
+			? stack.findLastIndex( ( f ) => f.type === SUGGESTION_FORMAT_NAME )
+			: -1;
+		if ( markerIndex === -1 ) {
 			lastSuggestion = null;
 			lastDecoration = null;
 			continue;
 		}
+		const suggestion = stack[ markerIndex ];
 		if ( ! out ) {
 			out = formats.slice();
 		}
@@ -205,7 +214,11 @@ export function addSuggestionRoleFormats( formats ) {
 				},
 			};
 		}
-		out[ i ] = [ ...stack, lastDecoration ];
+		out[ i ] = [
+			...stack.slice( 0, markerIndex + 1 ),
+			lastDecoration,
+			...stack.slice( markerIndex + 1 ),
+		];
 	}
 	return out ?? formats;
 }

--- a/packages/editor/src/components/inline-suggestions/test/format.js
+++ b/packages/editor/src/components/inline-suggestions/test/format.js
@@ -1,6 +1,7 @@
 import {
 	RichTextData,
 	create,
+	toHTMLString,
 	registerFormatType,
 	unregisterFormatType,
 	store as richTextStore,
@@ -369,5 +370,53 @@ describe( 'nested suggestion markers', () => {
 		expect( html ).not.toContain( 'wp-suggestion-a11y' );
 		expect( html ).toContain( 'data-author="4"' );
 		expect( html ).toContain( 'data-author="7"' );
+	} );
+} );
+
+describe( 'announcement element boundaries', () => {
+	beforeAll( () => {
+		registerSuggestionFormat();
+	} );
+
+	afterAll( () => {
+		for ( const name of [
+			SUGGESTION_FORMAT_NAME,
+			SUGGESTION_A11Y_FORMAT_NAME,
+		] ) {
+			if ( select( richTextStore ).getFormatType( name ) ) {
+				unregisterFormatType( name );
+			}
+		}
+	} );
+
+	/**
+	 * Serialize a marker through the editable-tree preparation pass and count
+	 * the announcement elements it produced.
+	 *
+	 * @param {string} html Marker HTML.
+	 * @return {number} Number of `.wp-suggestion-a11y` elements rendered.
+	 */
+	function countAnnouncements( html ) {
+		const value = create( { html } );
+		const rendered = toHTMLString( {
+			value: {
+				...value,
+				formats: addSuggestionRoleFormats( value.formats ),
+			},
+		} );
+		return ( rendered.match( /wp-suggestion-a11y/g ) ?? [] ).length;
+	}
+
+	it.each( [
+		[ 'a bold run', '<strong>bold</strong> tail' ],
+		[ 'a link', '<a href="https://w.org">link</a> tail' ],
+		[ 'a trailing format', 'head <em>italic</em>' ],
+		[ 'an interior format', 'head <em>mid</em> tail' ],
+	] )( 'brackets a marker containing %s exactly once', ( _label, inner ) => {
+		expect(
+			countAnnouncements(
+				`<mark class="wp-suggestion" data-suggestion-id="1" data-suggestion-type="del" data-author="2">${ inner }</mark>`
+			)
+		).toBe( 1 );
 	} );
 } );

--- a/test/e2e/specs/editor/various/suggestion-mode-a11y.spec.js
+++ b/test/e2e/specs/editor/various/suggestion-mode-a11y.spec.js
@@ -27,6 +27,25 @@ async function switchIntent( page, intentLabel ) {
 	await page.keyboard.press( 'Escape' );
 }
 
+/*
+ * Returns a promise for the debounced suggestion auto-save REST call. Call
+ * this BEFORE performing the edit that triggers the auto-save: creating the
+ * listener after the edit races the debounce on slow CI - the response can
+ * land before `waitForResponse` attaches and the wait then times out.
+ *
+ * The authored announcements only exist once the note thread this creates has
+ * been saved and read back, so every announcement assertion has to wait for it
+ * rather than spend its poll budget on the debounce.
+ */
+function suggestionSavedPromise( page ) {
+	return page.waitForResponse(
+		( response ) =>
+			/\/wp\/v2\/comments(\?|$|\/)/.test( response.url() ) &&
+			[ 'POST', 'PUT' ].includes( response.request().method() ) &&
+			response.ok()
+	);
+}
+
 /**
  * Reads what a screen reader gets at a marker's boundaries: the announcements
  * are painted as CSS generated content, so they live in the computed style
@@ -74,6 +93,7 @@ test.describe( 'Suggestion mode marker accessibility', () => {
 			.first();
 		await paragraph.click();
 		await page.keyboard.press( 'End' );
+		const saved = suggestionSavedPromise( page );
 		await page.keyboard.type( ' world' );
 
 		const marker = paragraph.locator(
@@ -96,7 +116,9 @@ test.describe( 'Suggestion mode marker accessibility', () => {
 			window.wp.data.select( 'core' ).getCurrentUser()
 		);
 		// The per-author rules are injected asynchronously with the note
-		// threads, so poll rather than reading once.
+		// threads, so wait for the thread to save and then poll for the
+		// refetch that carries it back.
+		await saved;
 		await expect
 			.poll( async () => ( await announcementsOf( decoration ) ).before )
 			.toBe( `"Start of suggested addition by ${ authorName }."` );
@@ -131,6 +153,7 @@ test.describe( 'Suggestion mode marker accessibility', () => {
 		await paragraph.click();
 		await page.keyboard.press( 'End' );
 		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 5 } );
+		const saved = suggestionSavedPromise( page );
 		await page.keyboard.press( 'Backspace' );
 
 		const decoration = paragraph.locator(
@@ -138,6 +161,7 @@ test.describe( 'Suggestion mode marker accessibility', () => {
 		);
 		await expect( decoration ).toHaveCount( 1 );
 		await expect( decoration ).toHaveAttribute( 'role', 'deletion' );
+		await saved;
 		await expect
 			.poll( async () => ( await announcementsOf( decoration ) ).before )
 			.toMatch( /^"Start of suggested deletion by / );
@@ -164,6 +188,7 @@ test.describe( 'Suggestion mode marker accessibility', () => {
 		await paragraph.click();
 		await page.keyboard.press( 'End' );
 		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 5 } );
+		const saved = suggestionSavedPromise( page );
 		await pageUtils.pressKeys( 'primary+b' );
 
 		const marker = paragraph.locator(
@@ -174,8 +199,45 @@ test.describe( 'Suggestion mode marker accessibility', () => {
 		const decoration = marker.locator( 'span.wp-suggestion-a11y' );
 		await expect( decoration ).toHaveCount( 1 );
 		expect( await decoration.getAttribute( 'role' ) ).toBeNull();
+		await saved;
 		await expect
 			.poll( async () => ( await announcementsOf( decoration ) ).before )
 			.toMatch( /^"Start of suggested formatting change by / );
+	} );
+
+	test( 'a marker spanning a formatting boundary is bracketed once, not once per run', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// The decoration sits directly inside the marker so its position in
+		// the format stack is the same for every character of the run. Nested
+		// at the end instead, a bold run covering only part of the marker
+		// shifts it and rich-text emits a second element - the closing
+		// announcement then lands in the middle of the suggestion and the
+		// opening one is repeated.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Hello <strong>bold</strong> world' },
+		} );
+
+		await switchIntent( page, 'Suggesting' );
+
+		const paragraph = editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.first();
+		await paragraph.click();
+		await page.keyboard.press( 'End' );
+		// "bold world" - half inside the bold run, half outside it.
+		await pageUtils.pressKeys( 'shift+ArrowLeft', { times: 10 } );
+		await page.keyboard.press( 'Backspace' );
+
+		const marker = paragraph.locator(
+			'mark.wp-suggestion[data-suggestion-type="del"]'
+		);
+		await expect( marker ).toContainText( 'bold world' );
+		await expect( marker.locator( 'span.wp-suggestion-a11y' ) ).toHaveCount(
+			1
+		);
 	} );
 } );


### PR DESCRIPTION
## What

Follow up to https://github.com/WordPress/gutenberg/pull/81663 (finding **F-23** in the Suggest mode guided testing run), from a code review pass over that PR after it merged.

Part of the Suggest mode stack for https://github.com/WordPress/gutenberg/issues/73411. Based on `suggest/inline-wiring` (https://github.com/WordPress/gutenberg/pull/80433), the top of the stack.

## The problem

`addSuggestionRoleFormats` pushes the announcement decoration onto the end of each character's format stack, so it sits innermost inside the marker. That is fine as long as every character of the marker carries exactly the same formats - which is what both the doc comment ("a marker gains exactly one nested role element") and the e2e `toHaveCount( 1 )` assertions were resting on.

It stops being true the moment anything else starts or ends partway through the marker. `toTree` decides whether to reuse an element by comparing format stacks **by index** (`isEqualUntil` in `packages/rich-text/src/to-tree.js`), so a bold run or a link covering only part of the marker shifts the decoration's index and rich-text closes and reopens it.

Take `Hello <strong>bold</strong> world`, select `bold world` in Suggesting mode and press Backspace. Inside the one `del` marker the stacks are `[suggestion, strong, decoration]` for `bold` and `[suggestion, decoration]` for ` world`. They diverge at index 1, so two `.wp-suggestion-a11y` spans come out of a single marker and a screen reader hears:

> Start of suggested deletion by Edith. bold End of suggested deletion by Edith. Start of suggested deletion by Edith. world End of suggested deletion by Edith.

A closing announcement in the middle of the run and a spurious reopening. Before #81663 the same split only duplicated a silent `role`, so it was harmless - now it produces contradictory speech. Links, italics and partially overlapping note annotations all trigger it too.

## The fix

Splice the decoration in directly after the marker rather than pushing it last. The innermost suggestion format's index is constant for the whole marker run, so the decoration's index is too, and `isEqualUntil` reuses the same element from one end of the marker to the other. The decoration is still inside every marker that covers the run, so nested markers from two people still each get their own correctly attributed announcement.

The change is `findLast` to `findLastIndex` plus a splice, in `packages/editor/src/components/inline-suggestions/format.js`.

Second, smaller thing in the same area: the three e2e tests assert on the authored announcement, which only exists once the suggestion has been debounce-saved as a note comment and `useNoteThreads` has read it back. None of them waited for that round trip - they leaned on `expect.poll`'s default 5s, and `test/e2e/playwright.config.ts` sets no `expect.timeout`. `suggestion-mode.spec.js` already has a `suggestionSavedPromise` helper for exactly this, with a comment noting that creating the listener after the edit races the debounce on slow CI. Same helper, same use here, so the poll budget goes on the refetch rather than on the debounce.

Nothing about what reaches post content changes - the decoration is still editor-only.

## Testing instructions

Enable the Suggest mode experiment (Gutenberg -> Experiments -> Suggest mode).

1. Add a paragraph reading `Hello bold world` with `bold` bolded.
2. Options -> Mode -> **Suggesting**.
3. Put the caret at the end of the paragraph and select back over `bold world` (Shift+Left ten times), then press Backspace.
4. Inspect the `mark.wp-suggestion` in DevTools.
   - **Before:** two `span.wp-suggestion-a11y` elements inside the one marker. Read the computed `::before` / `::after` on each and you get the announcement pair twice.
   - **After:** one span wrapping the whole run, announced once.
5. With VoiceOver or NVDA on, read the paragraph and listen for the closing announcement landing mid-run.

## Automated coverage

Four unit cases in `packages/editor/src/components/inline-suggestions/test/format.js` serialize a marker through the preparation pass and count the announcement elements: a marker containing a bold run, a link, a trailing format and an interior format. On the base branch they return 2, 2, 2 and 3 against an expected 1; with the fix all four return 1.

One e2e case in `test/e2e/specs/editor/various/suggestion-mode-a11y.spec.js` - `a marker spanning a formatting boundary is bracketed once, not once per run` - covers the same thing through the real editor, since the existing `toHaveCount( 1 )` assertions all happened to use uniformly formatted runs and so never caught it.

Regression runs against this branch: the `inline-suggestions` and `suggestion-mode` unit suites (451 tests) and the Suggest mode e2e specs.

## AI Use

Claude Code found this in a review pass over #81663 and wrote the fix. I will review and test.
