### PR TITLE
Updated broken links in document files

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -94,7 +94,7 @@ Write imports as one contiguous block. Do not separate dependency types with com
 
 #### External dependencies
 
-An external dependency is third-party code that is not maintained by WordPress contributors, but instead [included in WordPress as a default script](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress) or referenced from an outside package manager like [npm](https://www.npmjs.com/).
+An external dependency is third-party code that is not maintained by WordPress contributors, but instead [included in WordPress as a default script](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-and-js-libraries-included-and-registered-by-wordpress) or referenced from an outside package manager like [npm](https://www.npmjs.com/).
 
 Example:
 

--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -6,7 +6,7 @@ A block development environment includes the tools you need on your computer to 
 
 - [Block Development Environment](#block-development-environment)
   - [Code editor](#code-editor)
-  - [Node.js development tools](#nodejs-development-tools)
+  - [Node.js development tools](#node-js-development-tools)
   - [Local WordPress environment](#local-wordpress-environment)
 
 <div class="callout callout-info">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a broken links in the `coding-guidelines.md` and `devenv/README.md`

<!-- In a few words, what is the PR actually doing? -->

## Why?
The old links are broken

## How?
Updated  broken links in both files.

## Testing Instructions
- Open `coding-guidelines.md` and `devenv/README.md` files
- See links in both links [included in WordPress as a default script] in `coding-guidelines.md` file and  [Node.js development tools] link in `devenv/README.md` file

## Use of AI Tools
- No

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
