### PR TITLE
Font Library: Handle font loading errors gracefully

### DIFF
--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Font Library: Handle font loading errors gracefully so fonts that fail browser validation (e.g., Chrome's OpenType Sanitizer) can still be installed server-side ([#72265](https://github.com/WordPress/gutenberg/issues/72265)).
 -   Revisions: close the screen on the first click of the back arrow after a revision has been selected, instead of requiring a second click ([#81897](https://github.com/WordPress/gutenberg/pull/81897)).
 -   Revisions: close the screen after applying a revision, which stopped happening when the screen moved into this package ([#81897](https://github.com/WordPress/gutenberg/pull/81897)).
 -   Color palette panel: do not render the theme colors wrapper when the theme provides no colors, which left an empty gap above the Custom section ([#81894](https://github.com/WordPress/gutenberg/pull/81894)).

--- a/packages/global-styles-ui/src/font-library/utils/index.ts
+++ b/packages/global-styles-ui/src/font-library/utils/index.ts
@@ -114,7 +114,16 @@ export async function loadFontFaceInBrowser(
 		}
 	);
 
-	const loadedFace = await newFont.load();
+	let loadedFace;
+	try {
+		loadedFace = await newFont.load();
+	} catch {
+		// Some fonts may fail to load in the browser due to
+		// strict validation (e.g., Chrome's OpenType Sanitizer
+		// rejecting non-standard tables). This is acceptable
+		// since the font can still be installed server-side.
+		return;
+	}
 
 	if ( addTo === 'document' || addTo === 'all' ) {
 		document.fonts.add( loadedFace );


### PR DESCRIPTION
## Summary

Some TrueType fonts fail to load in the browser due to strict validation by Chrome's OpenType Sanitizer (OTS), which rejects fonts with non-standard tables (e.g., unsupported `vhea` table versions). This causes the Font Library upload to fail with an uncaught `SyntaxError: Invalid font data in ArrayBuffer`.

This PR wraps the `FontFace.load()` call in a try-catch block and returns early on failure, allowing the font to still be installed server-side even if the browser cannot preview it.

## Test Plan

- [ ] Upload a TTF font that triggers Chrome OTS rejection (e.g., fonts with non-standard vertical metrics tables)
- [ ] Verify the font installs successfully with message "Fonts were installed successfully"
- [ ] Verify the font appears in the Library tab
- [ ] Verify no uncaught promise rejection errors in the console

Fixes #72265

🤖 Generated with [Claude Code](https://claude.com/claude-code)