### PR TITLE
Hide layout panel when no controls are available

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 
+-   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled.
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Bug Fixes
 
--   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled.
+-   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).
 -   Never apply Spotlight mode in a preview canvas, which cannot be edited and so rendered most of its content faded ([#81615](https://github.com/WordPress/gutenberg/pull/81615)).

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -98,6 +98,42 @@ export function getLayoutStateOverrides(
 	} );
 }
 
+/**
+ * Checks whether the layout panel has any controls to display.
+ *
+ * @param {Object}  options                                 Options.
+ * @param {Object}  options.layoutType                      Active layout type.
+ * @param {Object}  options.constrainedType                 Constrained layout type.
+ * @param {Object}  options.layoutBlockSupport              Layout support settings.
+ * @param {boolean} options.showInheritToggle               Whether to show the inherit toggle.
+ * @param {boolean} options.showLayoutTypeSwitcher          Whether to show the layout type switcher.
+ * @param {boolean} options.displayControlsForLegacyLayouts Whether to show legacy layout controls.
+ *
+ * @return {boolean} Whether the layout panel has controls.
+ */
+export function hasLayoutPanelControls( {
+	layoutType,
+	constrainedType,
+	layoutBlockSupport,
+	showInheritToggle,
+	showLayoutTypeSwitcher,
+	displayControlsForLegacyLayouts,
+} ) {
+	const hasActiveLayoutControls =
+		layoutType?.name !== 'default' &&
+		layoutType?.hasInspectorControls( layoutBlockSupport );
+	const hasLegacyLayoutControls =
+		displayControlsForLegacyLayouts &&
+		constrainedType?.hasInspectorControls( layoutBlockSupport );
+
+	return !! (
+		showInheritToggle ||
+		showLayoutTypeSwitcher ||
+		hasActiveLayoutControls ||
+		hasLegacyLayoutControls
+	);
+}
+
 function getLayoutContainerValues( layout = {} ) {
 	return Object.fromEntries(
 		Object.entries( layout || {} ).filter(
@@ -453,6 +489,14 @@ function LayoutPanelPure( {
 		isDefaultBlockStyleState( selectedState ) &&
 		! inherit &&
 		allowSwitching;
+	const showLayoutPanel = hasLayoutPanelControls( {
+		layoutType,
+		constrainedType,
+		layoutBlockSupport: blockSupportAndThemeSettings,
+		showInheritToggle,
+		showLayoutTypeSwitcher,
+		displayControlsForLegacyLayouts,
+	} );
 
 	const onChangeLayout = ( newLayout ) => {
 		if ( isViewportLayoutState ) {
@@ -488,79 +532,81 @@ function LayoutPanelPure( {
 
 	return (
 		<>
-			<InspectorControls
-				group="layout"
-				resetAllFilter={ resetLayoutFilter }
-			>
-				{ showInheritToggle && (
-					<ToolsPanelItem
-						label={ __( 'Use content width' ) }
-						hasValue={ hasInheritToggleValue }
-						onDeselect={ resetInheritToggle }
-						isShownByDefault
-						panelId={ clientId }
-					>
-						<ToggleControl
-							label={ __( 'Inner blocks use content width' ) }
-							checked={ isUsingContentWidth() }
-							onChange={ () =>
-								onChangeLayout( {
-									type: isUsingContentWidth()
-										? 'default'
-										: 'constrained',
-								} )
-							}
-							help={
-								isUsingContentWidth()
-									? __(
-											'Nested blocks use content width with options for full and wide widths.'
-									  )
-									: __(
-											'Nested blocks will fill the width of this container.'
-									  )
-							}
-						/>
-					</ToolsPanelItem>
-				) }
+			{ showLayoutPanel && (
+				<InspectorControls
+					group="layout"
+					resetAllFilter={ resetLayoutFilter }
+				>
+					{ showInheritToggle && (
+						<ToolsPanelItem
+							label={ __( 'Use content width' ) }
+							hasValue={ hasInheritToggleValue }
+							onDeselect={ resetInheritToggle }
+							isShownByDefault
+							panelId={ clientId }
+						>
+							<ToggleControl
+								label={ __( 'Inner blocks use content width' ) }
+								checked={ isUsingContentWidth() }
+								onChange={ () =>
+									onChangeLayout( {
+										type: isUsingContentWidth()
+											? 'default'
+											: 'constrained',
+									} )
+								}
+								help={
+									isUsingContentWidth()
+										? __(
+												'Nested blocks use content width with options for full and wide widths.'
+										  )
+										: __(
+												'Nested blocks will fill the width of this container.'
+										  )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
 
-				{ showLayoutTypeSwitcher && (
-					<ToolsPanelItem
-						label={ __( 'Layout type' ) }
-						hasValue={ hasLayoutTypeValue }
-						onDeselect={ resetLayout }
-						isShownByDefault
-						panelId={ clientId }
-					>
-						<LayoutTypeSwitcher
-							type={ blockLayoutType }
-							onChange={ onChangeType }
-						/>
-					</ToolsPanelItem>
-				) }
+					{ showLayoutTypeSwitcher && (
+						<ToolsPanelItem
+							label={ __( 'Layout type' ) }
+							hasValue={ hasLayoutTypeValue }
+							onDeselect={ resetLayout }
+							isShownByDefault
+							panelId={ clientId }
+						>
+							<LayoutTypeSwitcher
+								type={ blockLayoutType }
+								onChange={ onChangeType }
+							/>
+						</ToolsPanelItem>
+					) }
 
-				{ layoutType && layoutType.name !== 'default' && (
-					<layoutType.inspectorControls
-						layout={ usedLayout }
-						value={ layout }
-						onChange={ onChangeLayout }
-						layoutBlockSupport={ blockSupportAndThemeSettings }
-						resetLayout={ resetLayoutDefaults }
-						name={ blockName }
-						clientId={ clientId }
-					/>
-				) }
-				{ constrainedType && displayControlsForLegacyLayouts && (
-					<constrainedType.inspectorControls
-						layout={ usedLayout }
-						value={ layout }
-						onChange={ onChangeLayout }
-						layoutBlockSupport={ blockSupportAndThemeSettings }
-						resetLayout={ resetLayoutDefaults }
-						name={ blockName }
-						clientId={ clientId }
-					/>
-				) }
-			</InspectorControls>
+					{ layoutType && layoutType.name !== 'default' && (
+						<layoutType.inspectorControls
+							layout={ usedLayout }
+							value={ layout }
+							onChange={ onChangeLayout }
+							layoutBlockSupport={ blockSupportAndThemeSettings }
+							resetLayout={ resetLayoutDefaults }
+							name={ blockName }
+							clientId={ clientId }
+						/>
+					) }
+					{ constrainedType && displayControlsForLegacyLayouts && (
+						<constrainedType.inspectorControls
+							layout={ usedLayout }
+							value={ layout }
+							onChange={ onChangeLayout }
+							layoutBlockSupport={ blockSupportAndThemeSettings }
+							resetLayout={ resetLayoutDefaults }
+							name={ blockName }
+							clientId={ clientId }
+						/>
+					) }
+				</InspectorControls>
+			) }
 			{ ! inherit && layoutType && (
 				<layoutType.toolBarControls
 					layout={ usedLayout }

--- a/packages/block-editor/src/hooks/test/layout.js
+++ b/packages/block-editor/src/hooks/test/layout.js
@@ -2,9 +2,36 @@ import {
 	getLayoutStateOverrides,
 	getResetLayout,
 	getResponsiveLayoutStyles,
+	hasLayoutPanelControls,
 } from '../layout';
+import { getLayoutType } from '../../layouts';
 
 describe( 'layout', () => {
+	describe( 'hasLayoutPanelControls()', () => {
+		it( 'does not show the layout panel when every flex layout control is disabled', () => {
+			expect(
+				hasLayoutPanelControls( {
+					layoutType: getLayoutType( 'flex' ),
+					constrainedType: getLayoutType( 'constrained' ),
+					layoutBlockSupport: {
+						allowSwitching: false,
+						allowInheriting: false,
+						allowEditing: true,
+						allowOrientation: false,
+						allowJustification: false,
+						allowVerticalAlignment: false,
+						allowWrap: false,
+						allowSizingOnChildren: true,
+						default: { type: 'flex' },
+					},
+					showInheritToggle: false,
+					showLayoutTypeSwitcher: false,
+					displayControlsForLegacyLayouts: false,
+				} )
+			).toBe( false );
+		} );
+	} );
+
 	describe( 'getResetLayout()', () => {
 		it( 'should reset to variation layout defaults', () => {
 			const layout = getResetLayout(

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -29,6 +29,14 @@ const GLOBAL_WIDE_SIZE = 'var(--wp--style--global--wide-size, none)';
 export default {
 	name: 'constrained',
 	label: __( 'Constrained' ),
+	hasInspectorControls( layoutBlockSupport = {} ) {
+		const {
+			allowJustification = true,
+			allowCustomContentAndWideSize = true,
+		} = layoutBlockSupport;
+
+		return allowJustification || allowCustomContentAndWideSize;
+	},
 	inspectorControls: function DefaultLayoutInspectorControls( {
 		layout,
 		onChange,

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -88,6 +88,21 @@ const flexWrapOptions = [ 'wrap', 'nowrap' ];
 export default {
 	name: 'flex',
 	label: __( 'Flex' ),
+	hasInspectorControls( layoutBlockSupport = {} ) {
+		const {
+			allowOrientation = true,
+			allowJustification = true,
+			allowVerticalAlignment = true,
+			allowWrap = true,
+		} = layoutBlockSupport;
+
+		return (
+			allowOrientation ||
+			allowJustification ||
+			allowVerticalAlignment ||
+			allowWrap
+		);
+	},
 	inspectorControls: function FlexLayoutInspectorControls( {
 		layout = {},
 		onChange,

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -7,6 +7,9 @@ import { LAYOUT_DEFINITIONS } from './definitions';
 export default {
 	name: 'default',
 	label: __( 'Flow' ),
+	hasInspectorControls() {
+		return false;
+	},
 	inspectorControls: function DefaultLayoutInspectorControls() {
 		return null;
 	},

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -59,6 +59,9 @@ const units = [
 export default {
 	name: 'grid',
 	label: __( 'Grid' ),
+	hasInspectorControls() {
+		return true;
+	},
 	inspectorControls: function GridLayoutInspectorControls( {
 		layout = {},
 		onChange,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

If all the controls for a given layout are disabled, the layout panel shouldn't render empty:

<img width="282" height="74" alt="Screenshot 2026-08-24 at 1 59 35 pm" src="https://github.com/user-attachments/assets/4437d53a-4109-4f79-8372-f5dd199f331a" />

The parent branch for this PR adds a grid variation to the Gallery block. Gallery disables all controls for its default flex variation, but for grid we want the controls to show, so we set `allowEditing` to true and disable all the flex controls. This was causing a sadly empty Layout panel.

This PR adds a few checks to ensure the panel never renders if all its controls are disabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert Gallery block
2. Switch between its two variations and see layout panel appearing and disappearing


https://github.com/user-attachments/assets/29df5ff1-1f61-4cda-ba55-d9ea34cf34a9


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
used codex gpt5.6 sol