### PR TITLE
Block States: Resolve legacy block feature selectors for state styles

### DIFF
--- a/lib/block-supports/states.php
+++ b/lib/block-supports/states.php
@@ -369,6 +369,47 @@ function gutenberg_add_block_state_style_rule( &$css_rules, $state, $selector, $
 }
 
 /**
+ * Builds a feature selectors map from a block's legacy selector supports.
+ *
+ * Blocks registered before the selectors API declare their feature selectors
+ * under `supports.<feature>.__experimentalSelector`. State styles read the
+ * modern `selectors` map only, so without this those blocks have their state
+ * rules applied to the block wrapper rather than the element the block's base
+ * styles target, producing a duplicate of the styled property.
+ *
+ * `wp_get_block_css_selector()` consults the legacy property only when a block
+ * declares no `selectors` map, and this mirrors that: a block using the
+ * selectors API is left alone.
+ *
+ * @param WP_Block_Type $block_type   Block type.
+ * @param array         $state_styles Map of state to style array.
+ * @return array Selectors map keyed by feature.
+ */
+function gutenberg_get_legacy_block_state_selectors( $block_type, $state_styles ) {
+	$features = array( 'root' );
+
+	foreach ( $state_styles as $state_style ) {
+		if ( ! is_array( $state_style ) ) {
+			continue;
+		}
+
+		$features = array_merge( $features, array_keys( $state_style ) );
+	}
+
+	$selectors = array();
+
+	foreach ( array_unique( $features ) as $feature ) {
+		$selector = wp_get_block_css_selector( $block_type, $feature );
+
+		if ( is_string( $selector ) && '' !== $selector ) {
+			$selectors[ $feature ] = $selector;
+		}
+	}
+
+	return $selectors;
+}
+
+/**
  * Builds compiled state style rules, preserving the selector each rule targets.
  *
  * @param array         $state_styles Map of state to style array.
@@ -381,6 +422,10 @@ function gutenberg_get_block_state_style_rules( $state_styles, $block_type, $rul
 	$block_selectors = isset( $block_type->selectors ) && is_array( $block_type->selectors )
 		? $block_type->selectors
 		: array();
+
+	if ( empty( $block_selectors ) ) {
+		$block_selectors = gutenberg_get_legacy_block_state_selectors( $block_type, $state_styles );
+	}
 
 	foreach ( $state_styles as $state => $state_style ) {
 		if ( empty( $state_style ) || ! is_array( $state_style ) ) {

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   `RichText`: Handle Enter using the current record, so pressing it right after moving the caret splits at the caret's new position instead of the previous one ([#81696](https://github.com/WordPress/gutenberg/pull/81696)).
 -   `useInnerBlocksProps`: Resolve the manual grid placement check that disables the standard drop zone against a layout passed through the options, when provided, instead of always using the block edit context layout ([#81120](https://github.com/WordPress/gutenberg/pull/81120)).
 -   `BorderPanel`: Match a chosen drop shadow against the presets from every origin rather than the first origin that defines any, so theme and default presets keep being stored as `var:preset|shadow|<slug>` once a custom preset exists ([#81346](https://github.com/WordPress/gutenberg/pull/81346)).
+-   Block states: Resolve a block's state style selector through `getBlockSelector()`, so a block that declares its feature selector with the legacy `__experimentalSelector` support, such as the Calendar, has its pseudo-state and responsive rules applied to the same element as its base styles instead of to the block wrapper ([#81971](https://github.com/WordPress/gutenberg/pull/81971)).
 
 ### Internal
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -2,6 +2,7 @@ import { useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
 import {
+	getBlockSelector,
 	mergeGlobalStyles,
 	privateApis as globalStylesEnginePrivateApis,
 } from '@wordpress/global-styles-engine';
@@ -285,8 +286,48 @@ function addStyleGroup( groups, selector, style ) {
 	} );
 }
 
+/**
+ * Builds a feature selectors map from a block's legacy selector supports.
+ *
+ * Blocks registered before the selectors API declare their feature selectors
+ * under `supports.<feature>.__experimentalSelector`. State styles read the
+ * modern `selectors` map only, so without this those blocks have their state
+ * rules applied to the block wrapper rather than the element the block's base
+ * styles target, producing a duplicate of the styled property.
+ *
+ * `getBlockSelector()` consults the legacy property only when a block declares
+ * no `selectors` map, and this mirrors that: a block using the selectors API is
+ * left alone.
+ *
+ * @param {Object} blockType   Block type.
+ * @param {Object} stateStyles State style object.
+ * @return {Object} Selectors map keyed by feature.
+ */
+function getLegacyBlockStateSelectors( blockType, stateStyles ) {
+	const selectors = {};
+
+	[ 'root', ...Object.keys( stateStyles || {} ) ].forEach( ( feature ) => {
+		if ( selectors[ feature ] ) {
+			return;
+		}
+
+		const selector = getBlockSelector( blockType, feature );
+
+		if ( selector ) {
+			selectors[ feature ] = selector;
+		}
+	} );
+
+	return selectors;
+}
+
 function getStateStyleGroups( stateStyles, name ) {
-	const blockSelectors = getBlockType( name )?.selectors || {};
+	const blockType = getBlockType( name );
+	const declaredSelectors = blockType?.selectors || {};
+	const blockSelectors =
+		blockType && ! Object.keys( declaredSelectors ).length
+			? getLegacyBlockStateSelectors( blockType, stateStyles )
+			: declaredSelectors;
 	const groups = new Map();
 
 	Object.entries( stateStyles || {} ).forEach(

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -367,6 +367,76 @@ describe( 'getBlockStateStylesCSS', () => {
 	} );
 } );
 
+describe( 'getBlockStateStylesCSS with legacy selectors', () => {
+	beforeEach( () => {
+		registerBlockType( 'test/legacy-selector', {
+			apiVersion: 3,
+			title: 'Legacy Selector',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			supports: {
+				color: {
+					background: true,
+					__experimentalSelector: 'table, th',
+				},
+			},
+		} );
+
+		registerBlockType( 'test/modern-and-legacy-selector', {
+			apiVersion: 3,
+			title: 'Modern And Legacy Selector',
+			category: 'text',
+			attributes: {},
+			edit: () => null,
+			save: () => null,
+			selectors: {
+				root: '.wp-block-modern-and-legacy-selector',
+			},
+			supports: {
+				color: {
+					background: true,
+					__experimentalSelector: 'table, th',
+				},
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		unregisterBlockType( 'test/legacy-selector' );
+		unregisterBlockType( 'test/modern-and-legacy-selector' );
+	} );
+
+	it( 'routes state styles through a legacy feature selector', () => {
+		expect(
+			getBlockStateStylesCSS(
+				{ color: { background: '#00ff00' } },
+				{
+					name: 'test/legacy-selector',
+					baseSelector: '.wp-elements-abc123',
+				}
+			)
+		).toBe(
+			'.wp-elements-abc123 table, .wp-elements-abc123 th { background-color: #00ff00 !important; }\n.wp-elements-abc123 table, .wp-elements-abc123 th { background-image: unset !important; }'
+		);
+	} );
+
+	it( 'ignores legacy selectors when the block declares the selectors API', () => {
+		expect(
+			getBlockStateStylesCSS(
+				{ color: { background: '#00ff00' } },
+				{
+					name: 'test/modern-and-legacy-selector',
+					baseSelector: '.wp-elements-abc123',
+				}
+			)
+		).toBe(
+			'.wp-elements-abc123 { background-color: #00ff00 !important; }\n.wp-elements-abc123 { background-image: unset !important; }'
+		);
+	} );
+} );
+
 describe( 'getResponsiveStateCSSRules', () => {
 	beforeEach( () => {
 		registerBlockType( 'test/state-button', {

--- a/phpunit/block-supports/states-test.php
+++ b/phpunit/block-supports/states-test.php
@@ -1143,6 +1143,105 @@ class WP_Block_Supports_States_Test extends WP_UnitTestCase {
 		);
 	}
 
+
+	/**
+	 * Tests that state styles use a block's legacy `__experimentalSelector`.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_state_routes_legacy_experimental_selector() {
+		$this->ensure_block_registered(
+			'test/legacy-selector',
+			array(),
+			array(
+				'color' => array(
+					'background'                      => true,
+					'__experimentalSelector'          => 'table, th',
+					'__experimentalSkipSerialization' => array( 'text', 'background' ),
+				),
+			)
+		);
+
+		$block_content = '<div class="wp-block-legacy-selector"><table><th>Head</th></table></div>';
+		$block         = array(
+			'blockName' => 'test/legacy-selector',
+			'attrs'     => array(
+				'style' => array(
+					'@mobile' => array(
+						'color' => array(
+							'background' => '#00ff00',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$this->assertNotEmpty( $matches, 'A state class should be added to the block wrapper.' );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'.' . $matches[0] . ' table, .' . $matches[0] . ' th{background-color:#00ff00 !important;',
+			$actual_stylesheet
+		);
+		$this->assertStringNotContainsString(
+			'.' . $matches[0] . '{background-color:#00ff00',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a block declaring the selectors API ignores legacy selectors.
+	 *
+	 * `wp_get_block_css_selector()` only consults `__experimentalSelector` when a
+	 * block declares no `selectors` map, and state styles follow the same rule.
+	 *
+	 * @covers ::gutenberg_render_block_states_support
+	 */
+	public function test_responsive_state_ignores_legacy_selector_when_selectors_declared() {
+		$this->ensure_block_registered(
+			'test/modern-and-legacy-selector',
+			array(
+				'root' => '.wp-block-modern-and-legacy-selector',
+			),
+			array(
+				'color' => array(
+					'background'             => true,
+					'__experimentalSelector' => 'table, th',
+				),
+			)
+		);
+
+		$block_content = '<div class="wp-block-modern-and-legacy-selector"><table><th>Head</th></table></div>';
+		$block         = array(
+			'blockName' => 'test/modern-and-legacy-selector',
+			'attrs'     => array(
+				'style' => array(
+					'@mobile' => array(
+						'color' => array(
+							'background' => '#00ff00',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = gutenberg_render_block_states_support( $block_content, $block );
+
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$this->assertNotEmpty( $matches, 'A state class should be added to the block wrapper.' );
+
+		$actual_stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'.' . $matches[0] . '{background-color:#00ff00 !important;',
+			$actual_stylesheet
+		);
+	}
+
 	/**
 	 * Tests that a responsive block gap state generates layout spacing CSS.
 	 *


### PR DESCRIPTION
## What?

See #81888

State styles now resolve a block's feature selector through `wp_get_block_css_selector()` / `getBlockSelector()`, so blocks that declare their selectors with the legacy `__experimentalSelector` support get their pseudo-state and responsive rules on the same element as their base styles.

## Why?

`gutenberg_get_block_state_style_rules()` and `getStateStyleGroups()` read `$block_type->selectors` only. Calendar declares no `selectors` map — its selector lives in `supports.color.__experimentalSelector: "table, th"` — so its base colour lands on the table:

```html
<table style="background-color:#ff0000;" id="wp-calendar">
```

while the mobile colour lands on the wrapper:

```css
@media (width <= 480px){.wp-states-fb6a76f5{background-color:#00ff00 !important;}}
```

Two backgrounds, and the wrapper one is `!important`. That is the second half of #81888; the first half, whether state styles should honour `__experimentalSkipSerialization`, is a separate design question still under discussion on the issue.

## How?

When a block declares no `selectors` map, the feature selectors are built from `wp_get_block_css_selector()` (PHP) and `getBlockSelector()` (JS), which already resolve the legacy fallback. Both helpers consult `__experimentalSelector` only when a block has no `selectors` map, so a block using the selectors API is untouched — Search and Accordion Heading, which have both, keep today's behaviour. A test in each suite pins that.

`core/calendar` is the only core block affected.

## Testing Instructions

1. Add a Calendar block to a page.
2. Give it a background colour, then a different background colour on the Mobile breakpoint.
3. View the page under 480px wide.
4. The table takes the mobile colour. Before this change the wrapper took it as well, showing behind and around the table.

```
npm run test:unit:php:base -- --filter WP_Block_Supports_States_Test
npm run test:unit -- packages/block-editor/src/hooks/test/style.js
```

- [x] Both new tests fail without the source changes
- [x] Full PHP suite passes (2280 tests)
- [x] `packages/block-editor/src/hooks` passes (285 tests)

### Testing Instructions for Keyboard

No UI changes.

## Use of AI Tools

Authored with Claude Code under direction and review.
