### PR TITLE
Media Editor: tab strip in the settings panel

### DIFF
--- a/packages/media-editor/CHANGELOG.md
+++ b/packages/media-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `MediaEditor`: replace the single Details panel with a tab strip, so the settings panel can hold more than one pane. Past `maxTabs` (4 by default) the strip collapses to a select naming the current panel, rather than becoming a row that scrolls or hides tabs with no indication of how many. The new `maxTabs` prop lowers that count for languages whose tab labels translate longer ([#81972](https://github.com/WordPress/gutenberg/pull/81972)).
 -   `MediaEditor`: move rotate, flip, zoom and aspect ratio out of the sidebar to a toolbar under the canvas, at every viewport. Frees the sidebar for Details alone ([#81840](https://github.com/WordPress/gutenberg/pull/81840)).
 -   `MediaEditor`: replace `ComplementaryArea` and `InterfaceSkeleton` with a layout the media editor owns. Both were built for the post and site editors and imposed breakpoints the media editor could not control ([#81840](https://github.com/WordPress/gutenberg/pull/81840)).
 -   `MediaEditor`: widen the docked details panel to 400px and dock it above the `large` breakpoint; below that it takes the whole body ([#81840](https://github.com/WordPress/gutenberg/pull/81840)).

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -4,7 +4,7 @@ import {
 	Spinner,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
-import { Stack, VisuallyHidden } from '@wordpress/ui';
+import { Stack, Tabs, Text } from '@wordpress/ui';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -18,8 +18,15 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { close, drawerRight, keyboard, redo, undo } from '@wordpress/icons';
+import { __, isRTL } from '@wordpress/i18n';
+import {
+	close,
+	drawerLeft,
+	drawerRight,
+	keyboard,
+	redo,
+	undo,
+} from '@wordpress/icons';
 import {
 	displayShortcut,
 	isAppleOS,
@@ -57,11 +64,59 @@ const ATTACHMENT_EMBED_QUERY = { _embed: 'author,wp:attached-to' } as const;
 const PLACEMENT_CONTROL_IDLE_MS = 300;
 
 /**
- * Identifier for the details panel. The sidebar tracks which panel is open
- * rather than whether one is, so a second panel is a new id here and a new
- * entry wherever panels are rendered — not a change to the state's shape.
+ * The tabs the sidebar shows, in display order. Tabs are named for their
+ * contents.
+ *
+ * Details leads: it is what the panel opens on, and the fields people most
+ * often came to fill in. Crop, Filters and Enhance are placeholders that
+ * exist only to load-test the strip at its four-tab ceiling — none of the
+ * three has shipped work behind it yet, which real tabs should not do:
+ * an unshipped feature earns its tab when it ships, not a disabled
+ * placeholder before it.
+ *
+ * Four is the ceiling this list is already at. A fifth capability should
+ * join an existing tab rather than add one; if the strip genuinely needs to
+ * grow past four, it becomes a select naming the current panel, not a
+ * scrolling row.
  */
-const DETAILS_PANEL = 'details';
+interface MediaEditorTab {
+	id: string;
+	title: string;
+	render: () => JSX.Element;
+}
+
+const TABS: MediaEditorTab[] = [
+	{
+		id: 'details',
+		title: __( 'Details' ),
+		render: () => <MediaForm />,
+	},
+	{
+		id: 'crop',
+		title: __( 'Crop' ),
+		// Placeholder. The numeric crop controls — size, position, scale and
+		// the proportion lock — are their own change; this tab exists so the
+		// strip has something real to switch between.
+		render: () => <Text>{ __( 'Crop options will appear here.' ) }</Text>,
+	},
+	{
+		id: 'filters',
+		title: __( 'Filters' ),
+		// Placeholder, to load-test the strip at three and four tabs. Not a
+		// real feature yet.
+		render: () => <Text>{ __( 'Filters will appear here.' ) }</Text>,
+	},
+	{
+		id: 'enhance',
+		title: __( 'Enhance' ),
+		// Placeholder. Provisional name for AI-assisted tools; not a real
+		// feature yet.
+		render: () => <Text>{ __( 'Enhance tools will appear here.' ) }</Text>,
+	},
+];
+
+/** The tab a newly opened panel starts on. */
+const DEFAULT_TAB = TABS[ 0 ].id;
 
 export interface MediaEditorFrameProps {
 	children: ReactNode;
@@ -113,23 +168,55 @@ export interface MediaEditorProps {
 }
 
 interface MediaEditorSidebarProps {
-	/** Names the panel's region, and its heading for screen readers. */
-	title: string;
-	children: ReactNode;
+	activeTab: string;
+	onSelectTab: ( tab: string ) => void;
 }
 
-function MediaEditorSidebar( { title, children }: MediaEditorSidebarProps ) {
+function MediaEditorSidebar( {
+	activeTab,
+	onSelectTab,
+}: MediaEditorSidebarProps ) {
 	return (
-		<NavigableRegion className="media-editor__sidebar" ariaLabel={ title }>
-			{ /* No visible heading and no close button: the header's pressed
-			     toggle names the open panel and dismisses it at every width, so
-			     a second control inside would be the same job twice. The
-			     heading stays for screen readers, which do not read a pressed
-			     button in the header as this region's title. */ }
-			<VisuallyHidden render={ <h2 /> }>{ title }</VisuallyHidden>
-			<Stack className="media-editor__panel" direction="column" gap="lg">
-				{ children }
-			</Stack>
+		<NavigableRegion
+			className="media-editor__sidebar"
+			ariaLabel={ __( 'Media settings' ) }
+		>
+			{ /* No close button in here: the header's pressed toggle opens and
+			     dismisses the panel at every width, so a second control would
+			     be the same job twice. The tab strip only chooses what the
+			     open panel shows. */ }
+			<Tabs.Root
+				className="media-editor__sidebar-tabs"
+				value={ activeTab }
+				onValueChange={ ( value ) => onSelectTab( value as string ) }
+			>
+				<Tabs.List variant="minimal">
+					{ TABS.map( ( tab ) => (
+						<Tabs.Tab key={ tab.id } value={ tab.id }>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.List>
+				{ TABS.map( ( tab ) => (
+					// `keepMounted` so a half-typed field survives a tab
+					// switch: alt text in progress must still be there on the
+					// way back from Crop.
+					<Tabs.Panel
+						key={ tab.id }
+						value={ tab.id }
+						keepMounted
+						tabIndex={ -1 }
+					>
+						<Stack
+							className="media-editor__panel"
+							direction="column"
+							gap="lg"
+						>
+							{ tab.render() }
+						</Stack>
+					</Tabs.Panel>
+				) ) }
+			</Tabs.Root>
 		</NavigableRegion>
 	);
 }
@@ -149,10 +236,10 @@ interface MediaEditorFrameContextValue {
 	aspectRatioPresets?: AspectRatioPreset[];
 	/** `true` above `large`, where the panel docks beside the canvas. */
 	isWide: boolean;
-	/** The open panel's id, or `null` when none is. */
-	activePanel: string | null;
-	/** Opens the given panel, or closes the open one when passed `null`. */
-	onSelectPanel: ( panel: string | null ) => void;
+	/** Whether the settings panel is showing. */
+	isSidebarOpen: boolean;
+	/** Shows or hides the settings panel. */
+	onToggleSidebar: () => void;
 	onCancel: () => void;
 	onSave: () => void;
 	onReset: () => void;
@@ -189,9 +276,14 @@ export interface HeaderActionsProps {
 }
 
 function HeaderActions( { showCloseButton = false }: HeaderActionsProps ) {
-	const { isImage, isSaving, onCancel, isWide, activePanel, onSelectPanel } =
-		useMediaEditorFrameContext();
-	const isDetailsOpen = activePanel === DETAILS_PANEL;
+	const {
+		isImage,
+		isSaving,
+		onCancel,
+		isWide,
+		isSidebarOpen,
+		onToggleSidebar,
+	} = useMediaEditorFrameContext();
 	const [ isShortcutsModalOpen, setIsShortcutsModalOpen ] = useState( false );
 	return (
 		<Stack
@@ -210,16 +302,22 @@ function HeaderActions( { showCloseButton = false }: HeaderActionsProps ) {
 			) }
 			<Button
 				size="compact"
-				icon={ drawerRight }
-				label={ __( 'Details' ) }
-				isPressed={ isDetailsOpen }
+				icon={ isRTL() ? drawerLeft : drawerRight }
+				isPressed={ isSidebarOpen }
 				// Only a docked column really expands beside the canvas; below
 				// that the panel replaces the view, which the pressed state
 				// already describes.
-				aria-expanded={ isWide ? isDetailsOpen : undefined }
-				onClick={ () =>
-					onSelectPanel( isDetailsOpen ? null : DETAILS_PANEL )
+				aria-expanded={ isWide ? isSidebarOpen : undefined }
+				// Says what the click will do rather than naming the panel: a
+				// static "Settings" reads the same whether the panel is open
+				// or shut, which is the one thing the tooltip should tell you.
+				label={
+					isSidebarOpen
+						? __( 'Hide media settings' )
+						: __( 'Show media settings' )
 				}
+				showTooltip
+				onClick={ onToggleSidebar }
 			/>
 			{ showCloseButton && (
 				<Button
@@ -241,7 +339,7 @@ function HeaderActions( { showCloseButton = false }: HeaderActionsProps ) {
 }
 
 function HistoryActions() {
-	const { isImage, isUndoRedoDisabled, onReset, isWide, activePanel } =
+	const { isImage, isUndoRedoDisabled, onReset, isWide, isSidebarOpen } =
 		useMediaEditorFrameContext();
 	const {
 		reset,
@@ -261,7 +359,7 @@ function HistoryActions() {
 	// (Metadata edits have no undo of their own; a history spanning both is a
 	// larger change than hiding these.) Checked after the hooks above so the
 	// hook order stays stable across renders.
-	if ( ! isImage || ( ! isWide && !! activePanel ) ) {
+	if ( ! isImage || ( ! isWide && isSidebarOpen ) ) {
 		return null;
 	}
 	const handleUndo = () => {
@@ -393,18 +491,19 @@ function MediaEditorContent( {
 	// people in the first place. Within one opening it does hold — see
 	// `hasChosenPanelRef` below.
 	const isWide = useViewportMatch( 'large' );
-	// `null` when nothing is open, otherwise the open panel's id.
-	const [ activePanel, setActivePanel ] = useState< string | null >(
-		isWide ? DETAILS_PANEL : null
-	);
-	// Width picks the starting panel, but only until the user picks one. After
+	// Two separate questions: whether the panel is showing, and what it shows.
+	// The header toggle answers the first, the tab strip the second, so a tab
+	// chosen before closing the panel is still selected when it reopens.
+	const [ isSidebarOpen, setIsSidebarOpen ] = useState( isWide );
+	const [ activeTab, setActiveTab ] = useState( DEFAULT_TAB );
+	// Width picks the starting state, but only until the user picks one. After
 	// that their choice holds for the rest of the session: closing the panel
 	// and then resizing — or crossing the breakpoint by rotating a tablet —
 	// should not reopen something they just dismissed.
 	const hasChosenPanelRef = useRef( false );
-	const selectPanel = useCallback( ( panel: string | null ) => {
+	const toggleSidebar = useCallback( () => {
 		hasChosenPanelRef.current = true;
-		setActivePanel( panel );
+		setIsSidebarOpen( ( open ) => ! open );
 	}, [] );
 	// Until then, follow the breakpoint: dragging a window narrow hands the
 	// canvas the full width instead of leaving a panel wedged beside it.
@@ -412,7 +511,7 @@ function MediaEditorContent( {
 		if ( hasChosenPanelRef.current ) {
 			return;
 		}
-		setActivePanel( isWide ? DETAILS_PANEL : null );
+		setIsSidebarOpen( isWide );
 	}, [ isWide ] );
 	// One layout at every width now that the image controls sit under the
 	// canvas; retained for the frame contract.
@@ -614,9 +713,11 @@ function MediaEditorContent( {
 				) : (
 					<div
 						className={ clsx( 'media-editor__body', {
-							'has-panel-open': !! activePanel,
+							'has-panel-open': isSidebarOpen,
 						} ) }
-						data-active-panel={ activePanel ?? undefined }
+						data-active-panel={
+							isSidebarOpen ? activeTab : undefined
+						}
 					>
 						<NavigableRegion
 							className="media-editor__content"
@@ -646,10 +747,11 @@ function MediaEditorContent( {
 								</div>
 							) }
 						</NavigableRegion>
-						{ activePanel === DETAILS_PANEL && (
-							<MediaEditorSidebar title={ __( 'Details' ) }>
-								<MediaForm />
-							</MediaEditorSidebar>
+						{ isSidebarOpen && (
+							<MediaEditorSidebar
+								activeTab={ activeTab }
+								onSelectTab={ setActiveTab }
+							/>
 						) }
 					</div>
 				) }
@@ -684,8 +786,8 @@ function MediaEditorContent( {
 		isUndoRedoDisabled: isCropInteractionActive,
 		aspectRatioPresets,
 		isWide,
-		activePanel,
-		onSelectPanel: selectPanel,
+		isSidebarOpen,
+		onToggleSidebar: toggleSidebar,
 		onCancel: handleRequestClose,
 		onSave: saveMediaEditor,
 		onReset: resetCropOptions,
@@ -696,7 +798,7 @@ function MediaEditorContent( {
 			{ renderFrame( {
 				children,
 				isImage,
-				hasCanvas: isWide || ! activePanel,
+				hasCanvas: isWide || ! isSidebarOpen,
 				layout,
 				onRequestClose: handleRequestClose,
 				onKeyDown: handleKeyDown,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -4,7 +4,8 @@ import {
 	Spinner,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
-import { Stack, Tabs, Text } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components -- load-testing the strip's collapse-to-select behaviour with @wordpress/ui's experimental SelectControl; not yet a shipped choice.
+import { SelectControl, Stack, Tabs, Text } from '@wordpress/ui';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -113,7 +114,34 @@ const TABS: MediaEditorTab[] = [
 		// feature yet.
 		render: () => <Text>{ __( 'Enhance tools will appear here.' ) }</Text>,
 	},
+	{
+		id: 'advanced',
+		title: __( 'Advanced' ),
+		// Placeholder, to push the strip past its four-tab ceiling and test
+		// the collapse to a select. Not a real feature yet.
+		render: () => (
+			<Text>{ __( 'Advanced options will appear here.' ) }</Text>
+		),
+	},
+	{
+		id: 'annotate',
+		title: __( 'Annotate' ),
+		// Placeholder, load-testing the strip at six tabs. Not a real
+		// feature yet.
+		render: () => (
+			<Text>{ __( 'Annotation tools will appear here.' ) }</Text>
+		),
+	},
 ];
+
+// `SelectControl`'s `value`/`onValueChange` operate on the item objects
+// passed to `items` (Base UI's convention), not the raw tab id, so the
+// collapsed-to-select panel switcher maps `TABS` to that shape once and
+// reuses it both ways.
+const selectItems = TABS.map( ( tab ) => ( {
+	value: tab.id,
+	label: tab.title,
+} ) );
 
 /** The tab a newly opened panel starts on. */
 const DEFAULT_TAB = TABS[ 0 ].id;
@@ -155,6 +183,17 @@ export interface MediaEditorProps {
 	noticesPortalElement?: Element | null;
 	shouldCloseOnEsc?: boolean;
 	/**
+	 * How many tabs the settings panel's switcher shows as a strip before it
+	 * collapses to a select naming the current panel. A strip that overflows
+	 * hides an unknown number of tabs with no indication of how many, so a
+	 * fixed count picks the fallback rather than letting it happen silently —
+	 * but the right count depends on how long the tab labels translate to, so
+	 * a caller in a language with longer labels can lower it.
+	 *
+	 * @default 4
+	 */
+	maxTabs?: number;
+	/**
 	 * Formerly the `@wordpress/interface` scope for the details sidebar, which
 	 * persisted the panel's open state per scope to user meta.
 	 *
@@ -170,12 +209,55 @@ export interface MediaEditorProps {
 interface MediaEditorSidebarProps {
 	activeTab: string;
 	onSelectTab: ( tab: string ) => void;
+	maxTabs: number;
 }
+
+// Default for `MediaEditorProps.maxTabs`. Up to this many tabs the switcher
+// is a tablist; past it, it collapses to a select naming the current panel.
+const DEFAULT_MAX_TABS = 4;
 
 function MediaEditorSidebar( {
 	activeTab,
 	onSelectTab,
+	maxTabs,
 }: MediaEditorSidebarProps ) {
+	const isCollapsedToSelect = TABS.length > maxTabs;
+
+	// `Tabs.Root` throws in dev when its registered Tab count and Panel count
+	// disagree, and a select has no Tabs to register — so the collapsed
+	// state can't keep the panels inside `Tabs.Root` and swap only the
+	// switcher above it.
+	if ( isCollapsedToSelect ) {
+		return (
+			<NavigableRegion
+				className="media-editor__sidebar"
+				ariaLabel={ __( 'Media settings' ) }
+			>
+				<SelectControl
+					className="media-editor__sidebar-select"
+					label={ __( 'Panel' ) }
+					hideLabelFromVision
+					items={ selectItems }
+					value={
+						selectItems.find(
+							( item ) => item.value === activeTab
+						) ?? null
+					}
+					onValueChange={ ( item ) =>
+						onSelectTab( item?.value ?? activeTab )
+					}
+				/>
+				<Stack
+					className="media-editor__panel"
+					direction="column"
+					gap="lg"
+				>
+					{ TABS.find( ( tab ) => tab.id === activeTab )?.render() }
+				</Stack>
+			</NavigableRegion>
+		);
+	}
+
 	return (
 		<NavigableRegion
 			className="media-editor__sidebar"
@@ -479,6 +561,7 @@ function MediaEditorContent( {
 	noticesClassName = 'media-editor__snackbar',
 	noticesPortalElement,
 	shouldCloseOnEsc = false,
+	maxTabs = DEFAULT_MAX_TABS,
 }: MediaEditorProps ) {
 	const cropper = useMediaEditor();
 	// Width decides whether the Details panel docks beside the canvas or takes
@@ -751,6 +834,7 @@ function MediaEditorContent( {
 							<MediaEditorSidebar
 								activeTab={ activeTab }
 								onSelectTab={ setActiveTab }
+								maxTabs={ maxTabs }
 							/>
 						) }
 					</div>

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -38,7 +38,7 @@
 		flex-direction: column;
 		min-width: 0;
 		min-height: 0;
-		margin: $grid-unit-30 $grid-unit-30 $grid-unit-10 $grid-unit-30;
+		margin: 0 $grid-unit-30 $grid-unit-10 $grid-unit-30;
 
 		// Docked beside the 400px panel, the canvas keeps a workable crop area.
 		// The figure has to close at the dock breakpoint itself: at 960px the
@@ -113,11 +113,9 @@
 		flex-direction: column;
 		min-width: 0;
 		min-height: 0;
-		overflow-y: auto;
-		// Equal inline gutter so focus rings (outline + offset) sit inside the
-		// panel rather than being clipped by the scroll container.
-		padding-inline: $grid-unit-20;
-		padding-bottom: $grid-unit-30;
+		// No inline padding here: the tab strip spans the panel edge to edge,
+		// so the gutter belongs to the strip and the panes individually rather
+		// than to the column that holds them.
 
 		// 400px rather than the 280px `$sidebar-width`: four editable fields
 		// plus the file facts do not fit a 280px column without every field
@@ -126,7 +124,6 @@
 		@include break-large() {
 			flex: none;
 			width: 400px;
-			padding-inline: $grid-unit-20;
 		}
 	}
 
@@ -143,8 +140,52 @@
 		}
 	}
 
+	// The strip stays put while a long form scrolls beneath it, so the tab
+	// names are reachable without scrolling back up.
+	.media-editor__sidebar-tabs {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		min-height: 0;
+
+		// The strip shares the fields' inline gutter, so the first tab lines
+		// up with the labels below it rather than sitting flush against the
+		// modal edge while every field sits inset.
+		// NOTE: overrides `@wordpress/ui` internals — `Tabs.List` sets
+		// `width: fit-content` on horizontal strips so it can measure its own
+		// overflow. Its styles are in `@layer wp-ui`, so this unlayered rule
+		// wins without `!important`.
+		> [role="tablist"] {
+			width: auto;
+			padding-inline: $grid-unit-20;
+		}
+
+		// Same rule the editor's panel headers draw, so the strip reads as
+		// panel chrome rather than as content. Drawn on the pane rather than
+		// under the strip: the selected-tab indicator is absolutely
+		// positioned at the strip's `bottom: 0`, so a border there would
+		// share that baseline and read as one broken line.
+		//
+		// Inset to the same gutter as the fields below it, so the rule's ends
+		// land under the same edges the tab labels and field labels do —
+		// spanning to the panel's outer edge reads as overflow once the
+		// fields (inset) are on screen next to it.
+		> [role="tabpanel"] {
+			flex: 1;
+			min-height: 0;
+			overflow-y: auto;
+			margin-inline: $grid-unit-20;
+			border-top:
+				$border-width solid
+				var(--wpds-color-stroke-surface-neutral);
+
+		}
+	}
+
+	// The pane already carries the inline gutter (see above), so the field
+	// stack inside it does not need its own.
 	.media-editor__panel {
-		padding: $grid-unit-20 $grid-unit-10;
+		padding: $grid-unit-20 $grid-unit-10 $grid-unit-30 $grid-unit-10;
 	}
 }
 

--- a/packages/media-editor/src/components/media-editor/style.scss
+++ b/packages/media-editor/src/components/media-editor/style.scss
@@ -187,6 +187,40 @@
 	.media-editor__panel {
 		padding: $grid-unit-20 $grid-unit-10 $grid-unit-30 $grid-unit-10;
 	}
+
+	// Collapsed (five-plus tabs): the select and the panels sit directly in
+	// the sidebar rather than inside a `[role="tabpanel"]`, so neither
+	// inherits the strip's inline gutter. Supplying it here rather than on
+	// `.media-editor__sidebar` keeps that rule's "no padding, the strip and
+	// panes own it" comment true for the tablist path.
+	.media-editor__sidebar-select {
+		flex-shrink: 0;
+		margin: $grid-unit-20;
+	}
+
+	// Only the active tab's panel renders here (see `MediaEditorSidebar`), so
+	// this always targets the one panel on screen.
+	.media-editor__sidebar-select ~ .media-editor__panel {
+		// Margin, not padding: the border below is drawn on this box, and
+		// padding sits inside it — the rule would still run the panel's full
+		// width. The margin pulls the box's edges in so the rule's ends land
+		// under the same edges the select and the fields do.
+		margin-inline: $grid-unit-20;
+
+		// The tablist path gets this from `[role="tabpanel"]`, which the
+		// collapsed path has no equivalent of — without it a long Details
+		// form runs past the sidebar instead of scrolling inside it.
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+
+		// Same divider the tablist draws above its pane, so the select reads
+		// as panel chrome the way the strip does — separated from the panel
+		// content rather than sitting flush above it.
+		border-top:
+			$border-width solid
+			var(--wpds-color-stroke-surface-neutral);
+	}
 }
 
 .media-editor__snackbar {


### PR DESCRIPTION
Stacked on #81840. 

Battle-tests the panel-layout work against a second panel, per the "Media Details Wireframes" tab addendum.

### Two tabs!

https://github.com/user-attachments/assets/c70e8dea-f51e-423e-bf75-710ddcb6c6d2



### More tabs!

https://github.com/user-attachments/assets/88abf919-8d3b-486b-a435-a626d2032b1a


### Even more!


https://github.com/user-attachments/assets/27cac004-485a-4d17-be2d-5e86c6cffe1e



## What this does

- Adds a tab strip inside the settings panel: Details, Crop, Filters, Enhance. Only Details has real content; Crop/Filters/Enhance are placeholders to prove the strip holds at its four-tab ceiling, not real features.
- Existing header toggle still opens/closes the panel. The strip only switches which tab shows inside it.
- Details is first and the default tab.
- Panes stay mounted so in-progress input (e.g. alt text) survives a tab switch.
- Strip carries the same bottom rule as `.components-panel__header`.

## Not done

- Real Crop tab contents (numeric size/position/scale) — separate work.
- Scrollbar visibility in the Details pane needs another look; flagged, not fixed here.
