### PR TITLE
Media Modal Experiment: Allow filtering by attached to the post, or unattached

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Enhancements
 
+-   Media Library modal: Pass the current post to the modal so its "Attached to" filter can offer media uploaded to that post. Only a viewable post type is passed on: a template has no front end of its own, so media can't be uploaded to one ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 
 ### Bug Fixes
@@ -42,7 +43,6 @@
 
 ### Enhancements
 
--   Media Library modal: Pass the current post to the modal so its "Attached to" filter can offer media uploaded to that post.
 -   Commands: Add a command palette entry that opens the current post on the front end once it is published, labelled with the post type's `view_item` label ([#66720](https://github.com/WordPress/gutenberg/pull/66720)).
 -   Pre-publish panel: Remove the "Visibility" and "Publish" headings that repeated the title of the panel containing them. The publish date's reset action, which lived in the removed header, becomes a "Reset" button below the date picker, disabled but still focusable while the post is set to publish immediately ([#81806](https://github.com/WordPress/gutenberg/pull/81806)).
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Enhancements
 
+-   Media Library modal: Pass the current post to the modal so its "Attached to" filter can offer media uploaded to that post.
 -   Commands: Add a command palette entry that opens the current post on the front end once it is published, labelled with the post type's `view_item` label ([#66720](https://github.com/WordPress/gutenberg/pull/66720)).
 -   Pre-publish panel: Remove the "Visibility" and "Publish" headings that repeated the title of the panel containing them. The publish date's reset action, which lived in the removed header, becomes a "Reset" button below the date picker, disabled but still focusable while the post is set to publish immediately ([#81806](https://github.com/WordPress/gutenberg/pull/81806)).
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Enhancements
 
--   Media Library modal: Pass the current post to the modal so its "Attached to" filter can offer media uploaded to that post. Only a viewable post type is passed on: a template has no front end of its own, so media can't be uploaded to one ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
+-   Media Library modal: Pass the current post and its post type to the modal so its "Attached to" filter can offer media uploaded to that post, under the post type's own wording. Only a viewable post type is passed on: a template has no front end of its own, so media can't be uploaded to one ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 
 ### Bug Fixes

--- a/packages/editor/src/hooks/media-upload.jsx
+++ b/packages/editor/src/hooks/media-upload.jsx
@@ -16,8 +16,9 @@ const { MediaUploadModal: MediaUploadModalComponent } = unlock(
 
 /**
  * Supplies the modal with the post it was opened from, so that its "Attached to"
- * filter can offer media uploaded to that post. `media-utils` has no editor
- * dependency, so the post is injected here.
+ * filter can offer media uploaded to that post, labelled with the post type's
+ * own wording. `media-utils` has no editor dependency, so the post is injected
+ * here.
  *
  * The post is only passed on when media can actually belong to it. Templates and
  * the like have no front end of their own, so an image can't be uploaded to one —
@@ -28,7 +29,7 @@ const { MediaUploadModal: MediaUploadModalComponent } = unlock(
  * @param {Object} props Props passed through to the modal.
  */
 function MediaUploadModalWithPostContext( props ) {
-	const postId = useSelect( ( select ) => {
+	const { postId, postType } = useSelect( ( select ) => {
 		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
 		const currentPostId = getCurrentPostId();
 		const currentPostType = getCurrentPostType();
@@ -37,13 +38,19 @@ function MediaUploadModalWithPostContext( props ) {
 			: undefined;
 
 		if ( typeof currentPostId !== 'number' || ! postTypeObject?.viewable ) {
-			return undefined;
+			return {};
 		}
 
-		return currentPostId;
+		return { postId: currentPostId, postType: currentPostType };
 	}, [] );
 
-	return <MediaUploadModalComponent { ...props } postId={ postId } />;
+	return (
+		<MediaUploadModalComponent
+			{ ...props }
+			postId={ postId }
+			postType={ postType }
+		/>
+	);
 }
 
 /**

--- a/packages/editor/src/hooks/media-upload.jsx
+++ b/packages/editor/src/hooks/media-upload.jsx
@@ -2,6 +2,7 @@ import { Component } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import deprecated from '@wordpress/deprecated';
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import {
 	MediaUpload,
 	privateApis as mediaUtilsPrivateApis,
@@ -18,13 +19,30 @@ const { MediaUploadModal: MediaUploadModalComponent } = unlock(
  * filter can offer media uploaded to that post. `media-utils` has no editor
  * dependency, so the post is injected here.
  *
+ * The post is only passed on when media can actually belong to it. Templates and
+ * the like have no front end of their own, so an image can't be uploaded to one —
+ * the same reasoning, and the same `viewable` check, as attaching media on save.
+ * Their entity ID is a slug rather than a number besides, which the media query
+ * has no use for.
+ *
  * @param {Object} props Props passed through to the modal.
  */
 function MediaUploadModalWithPostContext( props ) {
-	const postId = useSelect(
-		( select ) => select( editorStore ).getCurrentPostId(),
-		[]
-	);
+	const postId = useSelect( ( select ) => {
+		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
+		const currentPostId = getCurrentPostId();
+		const currentPostType = getCurrentPostType();
+		const postTypeObject = currentPostType
+			? select( coreStore ).getPostType( currentPostType )
+			: undefined;
+
+		if ( typeof currentPostId !== 'number' || ! postTypeObject?.viewable ) {
+			return undefined;
+		}
+
+		return currentPostId;
+	}, [] );
+
 	return <MediaUploadModalComponent { ...props } postId={ postId } />;
 }
 

--- a/packages/editor/src/hooks/media-upload.jsx
+++ b/packages/editor/src/hooks/media-upload.jsx
@@ -1,15 +1,32 @@
 import { Component } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import deprecated from '@wordpress/deprecated';
+import { useSelect } from '@wordpress/data';
 import {
 	MediaUpload,
 	privateApis as mediaUtilsPrivateApis,
 } from '@wordpress/media-utils';
 import { unlock } from '../lock-unlock';
+import { store as editorStore } from '../store';
 
 const { MediaUploadModal: MediaUploadModalComponent } = unlock(
 	mediaUtilsPrivateApis
 );
+
+/**
+ * Supplies the modal with the post it was opened from, so that its "Attached to"
+ * filter can offer media uploaded to that post. `media-utils` has no editor
+ * dependency, so the post is injected here.
+ *
+ * @param {Object} props Props passed through to the modal.
+ */
+function MediaUploadModalWithPostContext( props ) {
+	const postId = useSelect(
+		( select ) => select( editorStore ).getCurrentPostId(),
+		[]
+	);
+	return <MediaUploadModalComponent { ...props } postId={ postId } />;
+}
 
 /**
  * Class component wrapper for MediaUploadModal to maintain compatibility
@@ -49,7 +66,7 @@ class MediaUploadModalWrapper extends Component {
 		return (
 			<>
 				{ render( { open: this.openModal } ) }
-				<MediaUploadModalComponent
+				<MediaUploadModalWithPostContext
 					allowedTypes={ allowedTypes }
 					multiple={ multiple }
 					value={ value }

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Media Library modal: Add an "Attached to" filter offering "Uploaded to this post" and "Unattached", along with a `postId` prop supplying the post the modal was opened from.
+
 ### Bug Fixes
 
 -   Preserve array-valued fields in multipart form data so grouped image-size sideload requests reach the REST API as arrays ([#82353](https://github.com/WordPress/gutenberg/pull/82353)).

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Media Library modal: Add an "Attached to" filter offering "Uploaded to this post" and "Unattached", along with a `postId` prop supplying the post the modal was opened from ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
+-   Media Library modal: Add an "Attached to" filter offering "Uploaded to this post" and "Unattached", along with a `postId` prop supplying the post the modal was opened from. The filter is not persisted with the rest of the view: it describes the task at hand rather than a standing preference ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 
 ### Bug Fixes
 

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Media Library modal: Add an "Attached to" filter offering "Uploaded to this post" and "Unattached", along with a `postId` prop supplying the post the modal was opened from. The filter is not persisted with the rest of the view: it describes the task at hand rather than a standing preference ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
+-   Media Library modal: Add an "Attached to" filter offering "Unattached" and an option for the post the modal was opened from, labelled with that post type's `uploaded_to_this_item` label as the classic media frame does. Adds `postId` and `postType` props supplying the post. The filter is not persisted with the rest of the view: it describes the task at hand rather than a standing preference ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 
 ### Bug Fixes
 

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Media Library modal: Add an "Attached to" filter offering "Uploaded to this post" and "Unattached", along with a `postId` prop supplying the post the modal was opened from.
+-   Media Library modal: Add an "Attached to" filter offering "Uploaded to this post" and "Unattached", along with a `postId` prop supplying the post the modal was opened from ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 
 ### Bug Fixes
 

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -204,6 +204,13 @@ interface MediaUploadModalProps {
 	 * Label for the search input.
 	 */
 	searchLabel?: string;
+
+	/**
+	 * ID of the post the modal was opened from. When set, the "Attached to"
+	 * filter offers an option for media uploaded to that post. Omit outside of
+	 * a post context.
+	 */
+	postId?: number;
 }
 
 /**
@@ -225,6 +232,7 @@ interface MediaUploadModalProps {
  * @param props.modalClass    Additional CSS class for modal
  * @param props.search        Whether to show search input
  * @param props.searchLabel   Label for search input
+ * @param props.postId        ID of the post the modal was opened from
  * @return JSX element or null
  */
 export function MediaUploadModal( {
@@ -240,6 +248,7 @@ export function MediaUploadModal( {
 	modalClass,
 	search = true,
 	searchLabel = __( 'Search media' ),
+	postId,
 }: MediaUploadModalProps ) {
 	const [ selection, setSelection ] = useState< string[] >( () =>
 		getSelectionFromValue( value )
@@ -304,6 +313,31 @@ export function MediaUploadModal( {
 			if ( filter.field === 'mime_type' ) {
 				filters.mime_type = filter.value;
 			}
+			// Handle attachment parent filters. The filter stores context-free
+			// sentinels rather than post IDs, because the view — filters included —
+			// is persisted across sessions and would otherwise carry a stale post
+			// ID into the modal opened from a different post.
+			if (
+				filter.field === 'attached_to' &&
+				filter.operator === 'isAny'
+			) {
+				const parents = (
+					Array.isArray( filter.value ) ? filter.value : []
+				)
+					.map( ( sentinel ) => {
+						if ( sentinel === 'unattached' ) {
+							return 0;
+						}
+						return sentinel === 'current' ? postId : undefined;
+					} )
+					.filter( ( parent ) => parent !== undefined );
+
+				// A newly added filter has no value yet, and deselecting every
+				// option leaves an empty one: both mean "no constraint".
+				if ( parents.length ) {
+					filters.parent = parents;
+				}
+			}
 		} );
 
 		// Base media and mime type on allowedTypes if no filter is set
@@ -346,7 +380,7 @@ export function MediaUploadModal( {
 			_embed: 'author,wp:attached-to',
 			...filters,
 		};
-	}, [ view, allowedTypes ] );
+	}, [ view, allowedTypes, postId ] );
 
 	// Per-batch completion handler: auto-select uploaded items and refresh the grid.
 	const handleBatchComplete = useCallback(
@@ -428,9 +462,26 @@ export function MediaUploadModal( {
 			filesizeField as Field< RestAttachment >,
 			mediaDimensionsField as Field< RestAttachment >,
 			mimeTypeField as Field< RestAttachment >,
-			attachedToField as Field< RestAttachment >,
+			{
+				...( attachedToField as Field< RestAttachment > ),
+				// The shared field definition is not filterable, because the
+				// "Uploaded to this post" option only makes sense with the modal's
+				// post context. Values are sentinels resolved in `queryArgs` above.
+				elements: [
+					...( postId
+						? [
+								{
+									value: 'current',
+									label: __( 'Uploaded to this post' ),
+								},
+						  ]
+						: [] ),
+					{ value: 'unattached', label: __( 'Unattached' ) },
+				],
+				filterBy: { operators: [ 'isAny' ] },
+			},
 		],
-		[]
+		[ postId ]
 	);
 
 	const actions: ActionButton< RestAttachment >[] = useMemo(

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -208,7 +208,7 @@ interface MediaUploadModalProps {
 	/**
 	 * ID of the post the modal was opened from. When set, the "Attached to"
 	 * filter offers an option for media uploaded to that post. Omit outside of
-	 * a post context.
+	 * a post context, and for a post media can't be uploaded to.
 	 */
 	postId?: number;
 }
@@ -250,6 +250,10 @@ export function MediaUploadModal( {
 	searchLabel = __( 'Search media' ),
 	postId,
 }: MediaUploadModalProps ) {
+	// The filter resolves its sentinel to this ID, and the media query has no use
+	// for anything else — a template's entity ID, for instance, is a slug.
+	const attachedToPostId = Number.isInteger( postId ) ? postId : undefined;
+
 	const [ selection, setSelection ] = useState< string[] >( () =>
 		getSelectionFromValue( value )
 	);
@@ -328,7 +332,9 @@ export function MediaUploadModal( {
 						if ( sentinel === 'unattached' ) {
 							return 0;
 						}
-						return sentinel === 'current' ? postId : undefined;
+						return sentinel === 'current'
+							? attachedToPostId
+							: undefined;
 					} )
 					.filter( ( parent ) => parent !== undefined );
 
@@ -380,7 +386,7 @@ export function MediaUploadModal( {
 			_embed: 'author,wp:attached-to',
 			...filters,
 		};
-	}, [ view, allowedTypes, postId ] );
+	}, [ view, allowedTypes, attachedToPostId ] );
 
 	// Per-batch completion handler: auto-select uploaded items and refresh the grid.
 	const handleBatchComplete = useCallback(
@@ -468,7 +474,7 @@ export function MediaUploadModal( {
 				// "Uploaded to this post" option only makes sense with the modal's
 				// post context. Values are sentinels resolved in `queryArgs` above.
 				elements: [
-					...( postId
+					...( attachedToPostId
 						? [
 								{
 									value: 'current',
@@ -481,7 +487,7 @@ export function MediaUploadModal( {
 				filterBy: { operators: [ 'isAny' ] },
 			},
 		],
-		[ postId ]
+		[ attachedToPostId ]
 	);
 
 	const actions: ActionButton< RestAttachment >[] = useMemo(

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -254,8 +254,9 @@ export function MediaUploadModal( {
 	searchLabel = __( 'Search media' ),
 	postId,
 }: MediaUploadModalProps ) {
-	// The filter resolves its sentinel to this ID, and the media query has no use
-	// for anything else — a template's entity ID, for instance, is a slug.
+	// The "uploaded to this post" option resolves to this ID, and the media query
+	// has no use for anything else — a template's entity ID, for instance, is a
+	// slug.
 	const attachedToPostId = Number.isInteger( postId ) ? postId : undefined;
 
 	const [ selection, setSelection ] = useState< string[] >( () =>
@@ -362,9 +363,9 @@ export function MediaUploadModal( {
 			if ( filter.field === 'mime_type' ) {
 				filters.mime_type = filter.value;
 			}
-			// Handle attachment parent filters. The filter stores context-free
-			// sentinels rather than post IDs, so that an option is never tied to
-			// a post the modal is no longer looking at.
+			// Handle attachment parent filters. The filter's values name the
+			// option the user picked rather than a post ID, so a stored choice
+			// can't end up pointing at a post the modal is no longer looking at.
 			if (
 				filter.field === ATTACHED_TO_FIELD &&
 				filter.operator === 'isAny'
@@ -372,11 +373,11 @@ export function MediaUploadModal( {
 				const parents = (
 					Array.isArray( filter.value ) ? filter.value : []
 				)
-					.map( ( sentinel ) => {
-						if ( sentinel === 'unattached' ) {
+					.map( ( optionValue ) => {
+						if ( optionValue === 'unattached' ) {
 							return 0;
 						}
-						return sentinel === 'current'
+						return optionValue === 'current'
 							? attachedToPostId
 							: undefined;
 					} )
@@ -516,7 +517,8 @@ export function MediaUploadModal( {
 				...( attachedToField as Field< RestAttachment > ),
 				// The shared field definition is not filterable, because the
 				// "Uploaded to this post" option only makes sense with the modal's
-				// post context. Values are sentinels resolved in `queryArgs` above.
+				// post context. Values name options, and `queryArgs` above
+				// translates them to `parent`.
 				elements: [
 					...( attachedToPostId
 						? [

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -289,8 +289,7 @@ export function MediaUploadModal( {
 	// preference like author or mime type is worth carrying between posts, but
 	// scoping the library to the post being edited, or to unattached media, is a
 	// choice about the task at hand — one that is easy to set, easy to forget,
-	// and hides most of the library once it follows the user somewhere else. It
-	// lives here instead, for as long as the picker is on screen.
+	// and hides most of the library once it follows the user somewhere else.
 	const [ attachedToFilter, setAttachedToFilter ] = useState<
 		Filter | undefined
 	>();

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -7,12 +7,12 @@ import {
 	useRef,
 	useEffect,
 } from '@wordpress/element';
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __, _x, sprintf, _n } from '@wordpress/i18n';
 import {
 	privateApis as coreDataPrivateApis,
 	store as coreStore,
 } from '@wordpress/core-data';
-import { resolveSelect, useDispatch } from '@wordpress/data';
+import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { Modal, DropZone, FormFileUpload, Button } from '@wordpress/components';
 import { upload as uploadIcon } from '@wordpress/icons';
 import { DataViewsPicker } from '@wordpress/dataviews';
@@ -215,6 +215,13 @@ interface MediaUploadModalProps {
 	 * a post context, and for a post media can't be uploaded to.
 	 */
 	postId?: number;
+
+	/**
+	 * Slug of the post type `postId` belongs to. Labels that option with the
+	 * post type's own wording — "Uploaded to this page", "Uploaded to this
+	 * template" — falling back to a generic label when it is absent.
+	 */
+	postType?: string;
 }
 
 /**
@@ -237,6 +244,7 @@ interface MediaUploadModalProps {
  * @param props.search        Whether to show search input
  * @param props.searchLabel   Label for search input
  * @param props.postId        ID of the post the modal was opened from
+ * @param props.postType      Slug of that post's type
  * @return JSX element or null
  */
 export function MediaUploadModal( {
@@ -253,11 +261,25 @@ export function MediaUploadModal( {
 	search = true,
 	searchLabel = __( 'Search media' ),
 	postId,
+	postType,
 }: MediaUploadModalProps ) {
 	// The "uploaded to this post" option resolves to this ID, and the media query
 	// has no use for anything else — a template's entity ID, for instance, is a
 	// slug.
 	const attachedToPostId = Number.isInteger( postId ) ? postId : undefined;
+
+	// Every post type carries its own wording for this — "Uploaded to this
+	// page", "Uploaded to this template" — and core's own media frame labels the
+	// same filter with it. Only looked up when the option is on offer, so that a
+	// caller passing no post type never triggers the resolver.
+	const uploadedToLabel = useSelect(
+		( select ) =>
+			attachedToPostId && postType
+				? select( coreStore ).getPostType( postType )?.labels
+						?.uploaded_to_this_item
+				: undefined,
+		[ attachedToPostId, postType ]
+	);
 
 	const [ selection, setSelection ] = useState< string[] >( () =>
 		getSelectionFromValue( value )
@@ -524,16 +546,21 @@ export function MediaUploadModal( {
 						? [
 								{
 									value: 'current',
-									label: __( 'Uploaded to this post' ),
+									label:
+										uploadedToLabel ??
+										__( 'Uploaded to this item' ),
 								},
 						  ]
 						: [] ),
-					{ value: 'unattached', label: __( 'Unattached' ) },
+					{
+						value: 'unattached',
+						label: _x( 'Unattached', 'media items' ),
+					},
 				],
 				filterBy: { operators: [ 'isAny' ] },
 			},
 		],
-		[ attachedToPostId ]
+		[ attachedToPostId, uploadedToLabel ]
 	);
 
 	const actions: ActionButton< RestAttachment >[] = useMemo(

--- a/packages/media-utils/src/components/media-upload-modal/index.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/index.tsx
@@ -19,6 +19,7 @@ import { DataViewsPicker } from '@wordpress/dataviews';
 import type {
 	Field,
 	ActionButton,
+	Filter,
 	SupportedLayouts,
 	View,
 } from '@wordpress/dataviews';
@@ -58,6 +59,9 @@ const NOTICES_CONTEXT = 'media-modal';
 
 // Notice ID - reused for all upload-related notices to prevent flooding
 const NOTICE_ID_UPLOAD_PROGRESS = 'media-modal-upload-progress';
+
+// The one filter the modal keeps out of the persisted view.
+const ATTACHED_TO_FIELD = 'attached_to';
 
 type ViewQueryParams = Pick< View, 'page' | 'search' >;
 
@@ -267,7 +271,12 @@ export function MediaUploadModal( {
 	);
 
 	// Persist view configuration across sessions via the preferences store.
-	const { view, updateView, isModified, resetToDefault } = useView( {
+	const {
+		view: persistedView,
+		updateView,
+		isModified,
+		resetToDefault,
+	} = useView( {
 		kind: 'postType',
 		name: 'attachment',
 		slug: 'media-modal',
@@ -276,6 +285,28 @@ export function MediaUploadModal( {
 		onChangeQueryParams: setQueryParams,
 	} );
 
+	// The "Attached to" filter is deliberately not persisted. A standing
+	// preference like author or mime type is worth carrying between posts, but
+	// scoping the library to the post being edited, or to unattached media, is a
+	// choice about the task at hand — one that is easy to set, easy to forget,
+	// and hides most of the library once it follows the user somewhere else. It
+	// lives here instead, for as long as the picker is on screen.
+	const [ attachedToFilter, setAttachedToFilter ] = useState<
+		Filter | undefined
+	>();
+
+	const view = useMemo( () => {
+		const filters = ( persistedView.filters ?? [] ).filter(
+			( { field } ) => field !== ATTACHED_TO_FIELD
+		);
+		return {
+			...persistedView,
+			filters: attachedToFilter
+				? [ ...filters, attachedToFilter ]
+				: filters,
+		};
+	}, [ persistedView, attachedToFilter ] );
+
 	// Normalize undefined transient DataViews values so they do not persist as modified modal preferences.
 	const handleChangeView = useCallback(
 		( nextView: View ) => {
@@ -283,10 +314,25 @@ export function MediaUploadModal( {
 			if ( normalizedView.startPosition === undefined ) {
 				delete normalizedView.startPosition;
 			}
-			updateView( normalizedView );
+			setAttachedToFilter(
+				normalizedView.filters?.find(
+					( { field } ) => field === ATTACHED_TO_FIELD
+				)
+			);
+			updateView( {
+				...normalizedView,
+				filters: normalizedView.filters?.filter(
+					( { field } ) => field !== ATTACHED_TO_FIELD
+				),
+			} );
 		},
 		[ updateView ]
 	);
+
+	const handleReset = useCallback( () => {
+		setAttachedToFilter( undefined );
+		resetToDefault();
+	}, [ resetToDefault ] );
 
 	// Build query args based on view properties, similar to PostList
 	const queryArgs = useMemo( () => {
@@ -318,11 +364,10 @@ export function MediaUploadModal( {
 				filters.mime_type = filter.value;
 			}
 			// Handle attachment parent filters. The filter stores context-free
-			// sentinels rather than post IDs, because the view — filters included —
-			// is persisted across sessions and would otherwise carry a stale post
-			// ID into the modal opened from a different post.
+			// sentinels rather than post IDs, so that an option is never tied to
+			// a post the modal is no longer looking at.
 			if (
-				filter.field === 'attached_to' &&
+				filter.field === ATTACHED_TO_FIELD &&
 				filter.operator === 'isAny'
 			) {
 				const parents = (
@@ -705,7 +750,7 @@ export function MediaUploadModal( {
 				config={ dataViewsConfig }
 				getItemId={ ( item: RestAttachment ) => String( item.id ) }
 				itemListLabel={ __( 'Media items' ) }
-				onReset={ isModified ? resetToDefault : false }
+				onReset={ isModified || attachedToFilter ? handleReset : false }
 			>
 				<Stack
 					direction="row"

--- a/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
@@ -393,43 +393,20 @@ describe( 'MediaUploadModal', () => {
 			} );
 		} );
 
-		it( 'queries unattached media as `parent: [ 0 ]`', async () => {
-			renderModal(
-				{ postId: 42 },
-				{
-					filters: [
-						{
-							field: 'attached_to',
-							operator: 'isAny',
-							value: [ 'unattached' ],
-						},
-					],
-				}
+		it( 'queries media uploaded to the post as its `parent`', async () => {
+			const user = userEvent.setup();
+			renderModal( { postId: 42 } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
 			);
-
-			await waitFor( () => {
-				expect(
-					mockUseEntityRecordsWithPermissions
-				).toHaveBeenLastCalledWith(
-					'postType',
-					'attachment',
-					expect.objectContaining( { parent: [ 0 ] } )
-				);
-			} );
-		} );
-
-		it( 'resolves the persisted `current` sentinel against the post it is opened from', async () => {
-			renderModal(
-				{ postId: 42 },
-				{
-					filters: [
-						{
-							field: 'attached_to',
-							operator: 'isAny',
-							value: [ 'current' ],
-						},
-					],
-				}
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+			await user.click(
+				await screen.findByRole( 'option', {
+					name: 'Uploaded to this post',
+				} )
 			);
 
 			await waitFor( () => {
@@ -443,9 +420,72 @@ describe( 'MediaUploadModal', () => {
 			} );
 		} );
 
-		it( 'ignores a persisted `current` sentinel when there is no post context', async () => {
+		it( 'does not persist the filter', async () => {
+			// Unlike author or mime type, scoping the library to a post — or to
+			// unattached media — is about the task at hand, not a standing
+			// preference. Carrying it into the next post would quietly hide most
+			// of the library.
+			const user = userEvent.setup();
+			const { registry } = renderModal( { postId: 42 } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+			await user.click(
+				await screen.findByRole( 'option', { name: 'Unattached' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.objectContaining( { parent: [ 0 ] } )
+				);
+			} );
+			expect(
+				registry
+					.select( preferencesStore )
+					.get( 'core/views', preferenceKey )
+			).toBeUndefined();
+		} );
+
+		it( 'keeps the filter while the picker stays on screen', async () => {
+			const user = userEvent.setup();
+			const { rerender } = renderModal( { postId: 42 } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+			await user.click(
+				await screen.findByRole( 'option', { name: 'Unattached' } )
+			);
+
+			// Closing and reopening is the same instance: the choice stands.
+			rerender( { isOpen: false, postId: 42 } );
+			rerender( { isOpen: true, postId: 42 } );
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.objectContaining( { parent: [ 0 ] } )
+				);
+			} );
+		} );
+
+		it( 'ignores an `attached_to` filter left in the persisted view', async () => {
 			renderModal(
-				{},
+				{ postId: 42 },
 				{
 					filters: [
 						{
@@ -469,6 +509,9 @@ describe( 'MediaUploadModal', () => {
 				'attachment',
 				expect.not.objectContaining( { parent: expect.anything() } )
 			);
+			expect(
+				screen.queryByRole( 'button', { name: /Attached to/ } )
+			).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
@@ -9,6 +9,15 @@ import { unlock } from '../../../lock-unlock';
 
 const preferenceKey = 'dataviews-postType-attachment-media-modal';
 
+// Only the labels the modal reads. `getPostType` is resolved through core-data
+// in the real editor; here a minimal store named `core` stands in for it.
+const POST_TYPES: Record< string, unknown > = {
+	post: { labels: { uploaded_to_this_item: 'Uploaded to this post' } },
+	page: { labels: { uploaded_to_this_item: 'Uploaded to this page' } },
+	// A post type that never set the label.
+	cpt: { labels: {} },
+};
+
 jest.mock( '@wordpress/core-data', () => {
 	const { __dangerousOptInToUnstableAPIsOnlyForCoreModules } =
 		jest.requireActual( '@wordpress/private-apis' );
@@ -65,15 +74,22 @@ type ModalProps = {
 	isOpen?: boolean;
 	value?: number | number[];
 	postId?: number;
+	postType?: string;
 };
 
 function renderModal(
-	{ isOpen = true, value, postId }: ModalProps = {},
+	{ isOpen = true, value, postId, postType }: ModalProps = {},
 	persistedView?: Record< string, unknown >
 ) {
 	const registry = createRegistry();
 	registry.register( noticesStore );
 	registry.register( preferencesStore );
+	registry.registerStore( 'core', {
+		reducer: ( state = {} ) => state,
+		selectors: {
+			getPostType: ( state: unknown, slug: string ) => POST_TYPES[ slug ],
+		},
+	} );
 
 	if ( persistedView ) {
 		registry
@@ -90,6 +106,7 @@ function renderModal(
 				isOpen={ isOpen }
 				value={ value }
 				postId={ postId }
+				postType={ postType }
 				onSelect={ onSelect }
 				onClose={ onClose }
 			/>
@@ -263,7 +280,10 @@ describe( 'MediaUploadModal', () => {
 	describe( 'the "Attached to" filter', () => {
 		it( 'offers the current post only when the modal knows one', async () => {
 			const user = userEvent.setup();
-			const { rerender } = renderModal( { postId: 42 } );
+			const { rerender } = renderModal( {
+				postId: 42,
+				postType: 'post',
+			} );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Add filter' } )
@@ -296,12 +316,49 @@ describe( 'MediaUploadModal', () => {
 			).toBeVisible();
 		} );
 
+		it( "labels the option with the post type's own wording", async () => {
+			const user = userEvent.setup();
+			renderModal( { postId: 42, postType: 'page' } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+
+			expect(
+				await screen.findByRole( 'option', {
+					name: 'Uploaded to this page',
+				} )
+			).toBeVisible();
+		} );
+
+		it( 'falls back to a generic label when the post type has none', async () => {
+			const user = userEvent.setup();
+			renderModal( { postId: 42, postType: 'cpt' } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+
+			expect(
+				await screen.findByRole( 'option', {
+					name: 'Uploaded to this item',
+				} )
+			).toBeVisible();
+		} );
+
 		it( 'ignores a post ID that is not a number', async () => {
 			const user = userEvent.setup();
 			// A template's entity ID is a slug rather than a post ID, and media
 			// can't be uploaded to one.
 			renderModal( {
 				postId: 'twentytwentyfive//index' as unknown as number,
+				postType: 'wp_template',
 			} );
 
 			await user.click(
@@ -323,7 +380,7 @@ describe( 'MediaUploadModal', () => {
 
 		it( 'stops constraining the query when the chosen option is clicked again', async () => {
 			const user = userEvent.setup();
-			renderModal( { postId: 42 } );
+			renderModal( { postId: 42, postType: 'post' } );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Add filter' } )
@@ -365,7 +422,7 @@ describe( 'MediaUploadModal', () => {
 
 		it( 'queries both options together as a single `parent` list', async () => {
 			const user = userEvent.setup();
-			renderModal( { postId: 42 } );
+			renderModal( { postId: 42, postType: 'post' } );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Add filter' } )
@@ -395,7 +452,7 @@ describe( 'MediaUploadModal', () => {
 
 		it( 'queries media uploaded to the post as its `parent`', async () => {
 			const user = userEvent.setup();
-			renderModal( { postId: 42 } );
+			renderModal( { postId: 42, postType: 'post' } );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Add filter' } )
@@ -426,7 +483,10 @@ describe( 'MediaUploadModal', () => {
 			// preference. Carrying it into the next post would quietly hide most
 			// of the library.
 			const user = userEvent.setup();
-			const { registry } = renderModal( { postId: 42 } );
+			const { registry } = renderModal( {
+				postId: 42,
+				postType: 'post',
+			} );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Add filter' } )
@@ -456,7 +516,10 @@ describe( 'MediaUploadModal', () => {
 
 		it( 'keeps the filter while the picker stays on screen', async () => {
 			const user = userEvent.setup();
-			const { rerender } = renderModal( { postId: 42 } );
+			const { rerender } = renderModal( {
+				postId: 42,
+				postType: 'post',
+			} );
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Add filter' } )
@@ -469,8 +532,8 @@ describe( 'MediaUploadModal', () => {
 			);
 
 			// Closing and reopening is the same instance: the choice stands.
-			rerender( { isOpen: false, postId: 42 } );
-			rerender( { isOpen: true, postId: 42 } );
+			rerender( { isOpen: false, postId: 42, postType: 'post' } );
+			rerender( { isOpen: true, postId: 42, postType: 'post' } );
 
 			await waitFor( () => {
 				expect(
@@ -485,7 +548,7 @@ describe( 'MediaUploadModal', () => {
 
 		it( 'ignores an `attached_to` filter left in the persisted view', async () => {
 			renderModal(
-				{ postId: 42 },
+				{ postId: 42, postType: 'post' },
 				{
 					filters: [
 						{

--- a/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
@@ -61,12 +61,25 @@ function mockRecords( records: unknown[] ) {
 	} );
 }
 
-type ModalProps = { isOpen?: boolean; value?: number | number[] };
+type ModalProps = {
+	isOpen?: boolean;
+	value?: number | number[];
+	postId?: number;
+};
 
-function renderModal( { isOpen = true, value }: ModalProps = {} ) {
+function renderModal(
+	{ isOpen = true, value, postId }: ModalProps = {},
+	persistedView?: Record< string, unknown >
+) {
 	const registry = createRegistry();
 	registry.register( noticesStore );
 	registry.register( preferencesStore );
+
+	if ( persistedView ) {
+		registry
+			.dispatch( preferencesStore )
+			.set( 'core/views', preferenceKey, persistedView );
+	}
 
 	const onSelect = jest.fn();
 	const onClose = jest.fn();
@@ -76,6 +89,7 @@ function renderModal( { isOpen = true, value }: ModalProps = {} ) {
 			<MediaUploadModal
 				isOpen={ isOpen }
 				value={ value }
+				postId={ postId }
 				onSelect={ onSelect }
 				onClose={ onClose }
 			/>
@@ -109,6 +123,17 @@ describe( 'MediaUploadModal', () => {
 
 	afterEach( () => {
 		jest.clearAllMocks();
+		// The popover fallback container is appended to `document.body`, outside
+		// the tree Testing Library cleans up. Left in place, the next modal to
+		// open marks it `aria-hidden` — hiding the popovers that later tests
+		// render into it — so it is removed and recreated per test. This is DOM
+		// teardown outside the rendered tree, not a query for an element under
+		// test, so Testing Library has nothing to offer here.
+		/* eslint-disable testing-library/no-node-access */
+		document
+			.querySelectorAll( '.components-popover__fallback-container' )
+			.forEach( ( node ) => node.remove() );
+		/* eslint-enable testing-library/no-node-access */
 	} );
 
 	it( 'resets page and search when the modal is closed and reopened', async () => {
@@ -233,6 +258,193 @@ describe( 'MediaUploadModal', () => {
 				.select( preferencesStore )
 				.get( 'core/views', preferenceKey )
 		).toBeUndefined();
+	} );
+
+	describe( 'the "Attached to" filter', () => {
+		it( 'offers the current post only when the modal knows one', async () => {
+			const user = userEvent.setup();
+			const { rerender } = renderModal( { postId: 42 } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+
+			expect(
+				await screen.findByRole( 'option', {
+					name: 'Uploaded to this post',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'option', { name: 'Unattached' } )
+			).toBeVisible();
+
+			// Outside a post context, only "Unattached" is meaningful.
+			rerender( { isOpen: true } );
+
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'option', {
+						name: 'Uploaded to this post',
+					} )
+				).not.toBeInTheDocument();
+			} );
+			expect(
+				screen.getByRole( 'option', { name: 'Unattached' } )
+			).toBeVisible();
+		} );
+
+		it( 'stops constraining the query when the chosen option is clicked again', async () => {
+			const user = userEvent.setup();
+			renderModal( { postId: 42 } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+
+			const unattached = await screen.findByRole( 'option', {
+				name: 'Unattached',
+			} );
+			await user.click( unattached );
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.objectContaining( { parent: [ 0 ] } )
+				);
+			} );
+
+			// Clicking the selected option again deselects it. The filter stays
+			// in the view with an empty value, which must read as "no constraint"
+			// rather than as "attached to nothing".
+			await user.click( unattached );
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.not.objectContaining( { parent: expect.anything() } )
+				);
+			} );
+		} );
+
+		it( 'queries both options together as a single `parent` list', async () => {
+			const user = userEvent.setup();
+			renderModal( { postId: 42 } );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+			await user.click(
+				await screen.findByRole( 'option', {
+					name: 'Uploaded to this post',
+				} )
+			);
+			await user.click(
+				screen.getByRole( 'option', { name: 'Unattached' } )
+			);
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.objectContaining( { parent: [ 42, 0 ] } )
+				);
+			} );
+		} );
+
+		it( 'queries unattached media as `parent: [ 0 ]`', async () => {
+			renderModal(
+				{ postId: 42 },
+				{
+					filters: [
+						{
+							field: 'attached_to',
+							operator: 'isAny',
+							value: [ 'unattached' ],
+						},
+					],
+				}
+			);
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.objectContaining( { parent: [ 0 ] } )
+				);
+			} );
+		} );
+
+		it( 'resolves the persisted `current` sentinel against the post it is opened from', async () => {
+			renderModal(
+				{ postId: 42 },
+				{
+					filters: [
+						{
+							field: 'attached_to',
+							operator: 'isAny',
+							value: [ 'current' ],
+						},
+					],
+				}
+			);
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenLastCalledWith(
+					'postType',
+					'attachment',
+					expect.objectContaining( { parent: [ 42 ] } )
+				);
+			} );
+		} );
+
+		it( 'ignores a persisted `current` sentinel when there is no post context', async () => {
+			renderModal(
+				{},
+				{
+					filters: [
+						{
+							field: 'attached_to',
+							operator: 'isAny',
+							value: [ 'current' ],
+						},
+					],
+				}
+			);
+
+			await waitFor( () => {
+				expect(
+					mockUseEntityRecordsWithPermissions
+				).toHaveBeenCalled();
+			} );
+			expect(
+				mockUseEntityRecordsWithPermissions
+			).toHaveBeenLastCalledWith(
+				'postType',
+				'attachment',
+				expect.not.objectContaining( { parent: expect.anything() } )
+			);
+		} );
 	} );
 
 	it( 'updates the media query when the picker changes search', async () => {

--- a/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
+++ b/packages/media-utils/src/components/media-upload-modal/test/index.jsdom.test.tsx
@@ -296,6 +296,31 @@ describe( 'MediaUploadModal', () => {
 			).toBeVisible();
 		} );
 
+		it( 'ignores a post ID that is not a number', async () => {
+			const user = userEvent.setup();
+			// A template's entity ID is a slug rather than a post ID, and media
+			// can't be uploaded to one.
+			renderModal( {
+				postId: 'twentytwentyfive//index' as unknown as number,
+			} );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Add filter' } )
+			);
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Attached to' } )
+			);
+
+			expect(
+				await screen.findByRole( 'option', { name: 'Unattached' } )
+			).toBeVisible();
+			expect(
+				screen.queryByRole( 'option', {
+					name: 'Uploaded to this post',
+				} )
+			).not.toBeInTheDocument();
+		} );
+
 		it( 'stops constraining the query when the chosen option is clicked again', async () => {
 			const user = userEvent.setup();
 			renderModal( { postId: 42 } );


### PR DESCRIPTION
## What?

Part of:

* #73085

Add missing functionality to the experimental media upload modal (the one powered by DataViews): allow the library to be filtered by items attached to the current post, or unattached items.

## Why?

This is a feature of the classic media library and modal, and it's key to some folks' workflows. This feature also becomes a bit more apparent now that we have an attached images media category in the media inserter and the dynamic gallery block, that displays attached images. So, for the media upload/media selection modal, we should ensure the filter is available.

## Questions for the reviewer

Is this the right way to expose this filter? Is the right level of prominence for the control, the right wording?

## How?

* Just added to the modal for now, kind of hacked in there rather than added directly to the attached_to field. This is because we need to have access to the current postId and I was a bit cautious that we might not always want this particular UI for all cases where this field is used, as it's really more about this particular modal.
* So, (for now) just include this feature in this modal, and we can always generalise it further down the track if we need to

## To-do

* [x] Figure out what we want to do when there isn't a current post id or if we're editing a template
* Should we also display the name of the post type, or is the word "post" sufficient?

## Testing Instructions

Enable the experiment:

<img width="622" height="93" alt="image" src="https://github.com/user-attachments/assets/916d8d80-f2b3-43dd-82e7-9bd58b9e32a9" />

* Upload some images to the media library in wp-admin
* Create a post or page
* Upload some images to the post or page
* Go to replace the image and open the new media library modal experiment
* Under filters, you should be able to filter by those images already attached to the post (the ones you uploaded to the post) and you should be be able to filter by the unattached ones (that you uploaded directly to the media library)
* With both filters off, you should see your entire media library

## Screenshots or screencast <!-- if applicable -->

### How the filter looks in the class media library modal

<img width="1368" height="654" alt="image" src="https://github.com/user-attachments/assets/dbb2c41e-020f-4cd5-b9d0-c54e723b4125" />

### How this PR looks (just one of the filters a user can apply)

<img width="534" height="359" alt="image" src="https://github.com/user-attachments/assets/b85de0fb-645a-4925-b034-e55128349784" />

<img width="1266" height="422" alt="image" src="https://github.com/user-attachments/assets/2fac7fed-43a4-417d-933b-fced46c9bb86" />

### Video demo

https://github.com/user-attachments/assets/5619aca2-c991-46b6-95b5-6d7406a5e03b

## Use of AI Tools

Claude Code Opus 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The Media Library modal’s “Attached to” filter now uses the current post type’s localized wording.
  - The filter offers options for media attached to the current post or unattached media, with a generic fallback when needed.
- **Bug Fixes**
  - Attachment filtering continues to exclude invalid or non-viewable post contexts.
  - Filter selections are no longer retained when reopening the modal or saving view settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->