### PR TITLE
Theme: Update Terrazzo packages to 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14792,105 +14792,6 @@
 				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
-		"node_modules/@terrazzo/json-schema-tools": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@terrazzo/json-schema-tools/-/json-schema-tools-0.2.2.tgz",
-			"integrity": "sha512-4g+n4yG5XfqSJRMiH8wz+mTGibDavrGkxQ3s0gOrUsvYBHe9HU/j0ElW0PMYtR54+dcW8Tt9qpFSE7BfZcInmA==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"@humanwhocodes/momoa": "^3.0.0",
-				"yaml-to-momoa": "0.0.9"
-			},
-			"peerDependenciesMeta": {
-				"yaml-to-momoa": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@terrazzo/parser": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.5.0.tgz",
-			"integrity": "sha512-u8q7KDWJPXvcm3jOiTEBs1xCqNT8ZFu5QCN08YXeRhbekGe78JF+16c65p9y4t29Z6fN2fakc4bMCvGALlgIaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/json-schema-tools": "^0.2.2",
-				"@terrazzo/token-tools": "^2.4.0",
-				"@terrazzo/token-types": "^2.5.0",
-				"@types/babel__code-frame": "^7.27.0",
-				"colorjs.io": "^0.6.1",
-				"fast-deep-equal": "^3.1.3",
-				"merge-anything": "^5.1.7",
-				"picocolors": "^1.1.1",
-				"scule": "^1.3.0"
-			},
-			"peerDependencies": {
-				"yaml-to-momoa": "0.0.9"
-			},
-			"peerDependenciesMeta": {
-				"yaml-to-momoa": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@terrazzo/parser/node_modules/colorjs.io": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
-			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/color"
-			}
-		},
-		"node_modules/@terrazzo/plugin-css": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.5.0.tgz",
-			"integrity": "sha512-Bbrd7+kjyZp1TANzcXLWI/5/3j2eEBW0NBJFkhDoHdc7uh1vSXg+ev3VMFq/ycrS9AkqFZ9NvcjDFc/ypoNPeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@terrazzo/token-tools": "^2.4.0"
-			},
-			"peerDependencies": {
-				"@terrazzo/cli": "^2.5.0",
-				"@terrazzo/parser": "^2.5.0"
-			}
-		},
-		"node_modules/@terrazzo/token-tools": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.5.0.tgz",
-			"integrity": "sha512-CREnj4kmbskWugkNCA8SYFcjJmlNpXci2ft9U8GjLOdi5eNkWGjDSW5U3oxn+BQkm0mNjWrWBloyg/L6vzFnWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@humanwhocodes/momoa": "^3.3.10",
-				"@terrazzo/token-types": "^2.5.0",
-				"colorjs.io": "^0.6.1",
-				"wildcard-match": "^5.1.4"
-			}
-		},
-		"node_modules/@terrazzo/token-tools/node_modules/colorjs.io": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
-			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/color"
-			}
-		},
-		"node_modules/@terrazzo/token-types": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.5.0.tgz",
-			"integrity": "sha512-KJIG2a20UbG1+fCCuh9TvmyJ5NjHrZ8byFAEiNNJ8FZZ1Ut0DTo4V2vJY1i62bEYRm1kkLd+PkRM7KjsU1JgxQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@testing-library/dom": {
 			"version": "10.4.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -55182,9 +55083,9 @@
 			},
 			"devDependencies": {
 				"@storybook/react-vite": "^10.5.3",
-				"@terrazzo/parser": "^2.5.0",
-				"@terrazzo/plugin-css": "^2.5.0",
-				"@terrazzo/token-tools": "^2.5.0",
+				"@terrazzo/parser": "^2.7.1",
+				"@terrazzo/plugin-css": "^2.7.1",
+				"@terrazzo/token-tools": "^2.7.1",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
@@ -55228,6 +55129,82 @@
 					"optional": true
 				}
 			}
+		},
+		"packages/theme/node_modules/@terrazzo/json-schema-tools": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@terrazzo/json-schema-tools/-/json-schema-tools-0.3.0.tgz",
+			"integrity": "sha512-uF6tpAi+slKtvycLvwZGN1siLUTTqVri1iF2b05Dx1hvYM0WWzUdLC9RD7tAwQ39tTPf9rmI6czA8W0rGB5wUQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@humanwhocodes/momoa": "^3.0.0",
+				"yaml-to-momoa": "0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"yaml-to-momoa": {
+					"optional": true
+				}
+			}
+		},
+		"packages/theme/node_modules/@terrazzo/parser": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@terrazzo/parser/-/parser-2.7.1.tgz",
+			"integrity": "sha512-dZPVp1mndx81PEbXe9NM8lZRh50TfwzyV0mOIaAcq1r3MiWGkr/K2WLObJjcDivP/5VbScxtGXbTbAW0oB1WIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@humanwhocodes/momoa": "^3.3.10",
+				"@terrazzo/json-schema-tools": "^0.3.0",
+				"@terrazzo/token-tools": "^2.7.1",
+				"@terrazzo/token-types": "^2.7.1",
+				"@types/babel__code-frame": "^7.27.0",
+				"colorjs.io": "^0.7.1",
+				"merge-anything": "^5.1.7",
+				"picocolors": "^1.1.1",
+				"scule": "^1.3.0"
+			},
+			"peerDependencies": {
+				"yaml-to-momoa": "0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"yaml-to-momoa": {
+					"optional": true
+				}
+			}
+		},
+		"packages/theme/node_modules/@terrazzo/plugin-css": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@terrazzo/plugin-css/-/plugin-css-2.7.1.tgz",
+			"integrity": "sha512-aT83ChKpeRd1D/HbeWABiRksTN/pBXSjYHuaBzHj+9xj5Ouyd47Z8OEjRfx5yvJlJnNyjk2+ztDbF1IcBMrE3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@terrazzo/token-tools": "^2.7.1"
+			},
+			"peerDependencies": {
+				"@terrazzo/cli": "^2.7.1",
+				"@terrazzo/parser": "^2.7.1"
+			}
+		},
+		"packages/theme/node_modules/@terrazzo/token-tools": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-tools/-/token-tools-2.7.1.tgz",
+			"integrity": "sha512-ylPpuUi5se/uzvpTiiTnOZqXMqVEpfhYBt8UY4D10NijZV76tjN55KNyRlSMPA1zg+loO06BktL1CR1/EhBtvQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@humanwhocodes/momoa": "^3.3.10",
+				"@terrazzo/token-types": "^2.7.1",
+				"colorjs.io": "^0.7.1",
+				"wildcard-match": "^5.1.4"
+			}
+		},
+		"packages/theme/node_modules/@terrazzo/token-types": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@terrazzo/token-types/-/token-types-2.7.1.tgz",
+			"integrity": "sha512-ahMSS4i4yXbtVyXRupbdMP2gkotSIh2sXHEyM2fBVRcmcydggxeVs9qJ+x7e6M4hacqFDiaDigcbpRRS2lrvdQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"packages/theme/node_modules/colorjs.io": {
 			"version": "0.7.1",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 
+-   Update Terrazzo packages to 2.7.1 ([#81978](https://github.com/WordPress/gutenberg/pull/81978)).
 -   Point tsconfig references at split dependencies' build projects. ([#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Collapse the `tsconfig.src.json`/`tsconfig.bin.json`/`tsconfig.test.json` projects into the repository-standard split of `tsconfig.build.json` and a default dev `tsconfig.json`. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))
 -   Update Terrazzo packages to 2.5.0, use its resolver for mode overrides, and restore token linting with semantic WCAG AA contrast checks ([#81082](https://github.com/WordPress/gutenberg/pull/81082)).

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -88,9 +88,9 @@
 	},
 	"devDependencies": {
 		"@storybook/react-vite": "^10.5.3",
-		"@terrazzo/parser": "^2.5.0",
-		"@terrazzo/plugin-css": "^2.5.0",
-		"@terrazzo/token-tools": "^2.5.0",
+		"@terrazzo/parser": "^2.7.1",
+		"@terrazzo/plugin-css": "^2.7.1",
+		"@terrazzo/token-tools": "^2.7.1",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## What?

Updates the aligned Terrazzo build dependencies in `@wordpress/theme` from declared and resolved version 2.5.0 to 2.7.1:

- `@terrazzo/parser`
- `@terrazzo/plugin-css`
- `@terrazzo/token-tools`

The root lockfile also moves `@terrazzo/token-types` from 2.5.0 to 2.7.1 and `@terrazzo/json-schema-tools` from 0.2.2 to 0.3.0. It removes Terrazzo's unused `fast-deep-equal` dependency and deduplicates Terrazzo onto the `colorjs.io` 0.7.1 version already used directly by Theme.

Upstream did not publish GitHub releases or tags for these versions. Each published npm package contains its generated changelog.

**Complete release span**

- `@terrazzo/parser`: [2.6.0](https://www.npmjs.com/package/@terrazzo/parser/v/2.6.0), [2.7.0](https://www.npmjs.com/package/@terrazzo/parser/v/2.7.0), [2.7.1](https://www.npmjs.com/package/@terrazzo/parser/v/2.7.1)
- `@terrazzo/plugin-css`: [2.6.0](https://www.npmjs.com/package/@terrazzo/plugin-css/v/2.6.0), [2.7.0](https://www.npmjs.com/package/@terrazzo/plugin-css/v/2.7.0), [2.7.1](https://www.npmjs.com/package/@terrazzo/plugin-css/v/2.7.1)
- `@terrazzo/token-tools`: [2.6.0](https://www.npmjs.com/package/@terrazzo/token-tools/v/2.6.0), [2.7.0](https://www.npmjs.com/package/@terrazzo/token-tools/v/2.7.0), [2.7.1](https://www.npmjs.com/package/@terrazzo/token-tools/v/2.7.1)

### Notable upstream changes

- **2.6.0:** contains dependency-alignment releases only for these three packages. Theme's token generation remains byte-for-byte unchanged.
- **Partial resolver support:** [Terrazzo #815](https://github.com/terrazzoapp/terrazzo/pull/815) adds opt-in partial CSS output. Theme does not enable the new plugin-css option. Its separate mode-overrides plugin already uses `resolver.apply()` with selected modifiers and unresolved aliases; the focused mode tests and generated mode files remain unchanged.
- **Alias handling:** [Terrazzo #816](https://github.com/terrazzoapp/terrazzo/pull/816) fixes custom token-type and nested `$root` aliases. Theme's current token sources do not use those forms. [Terrazzo #817](https://github.com/terrazzoapp/terrazzo/pull/817) fixes raw values following aliases in resolver permutations. Theme exercises that resolver path, and all generated token files remain unchanged after the update.
- **Color and dependency cleanup:** 2.7.0 moves Terrazzo to `colorjs.io` 0.7 and removes an unused `fast-deep-equal` dependency. This deduplicates Terrazzo onto Theme's existing `colorjs.io` 0.7.1 installation. No Theme color output changes.
- **Transitive schema tooling:** `@terrazzo/json-schema-tools` 0.3.0 only aligns its optional `yaml-to-momoa` peer to 0.1.0. Theme supplies JSON token files and does not use the optional YAML parser.

## Why?

This keeps Theme's token-generation toolchain on the current aligned Terrazzo release and includes the latest resolver correctness fixes without changing the published token contract.

## How?

The Theme manifest now declares all three Terrazzo packages at `^2.7.1`, the root lockfile records the aligned dependency tree, and the Theme changelog records the internal update. No Theme source, token source, generated artifact, or public API changes.

## Testing Instructions

This is an internal build-tool update with no intended UI change.

1. Open Gutenberg Storybook and navigate to **Design System / Theme / Theme Provider / Example Application**.
2. Change the available theme controls and confirm the example still updates its colors and tokens normally.
3. Navigate to **Design System / Theme / Theme Provider / Color Scales** and confirm the generated ramps render without missing values.

### Testing Instructions for Keyboard

No keyboard behavior changes. As a smoke test, use Tab to move through the Example Application controls and confirm focus remains visible and each control still works.

<details>
<summary>Automated verification</summary>

- Theme token and default-ramp generation produces no tracked artifact changes.
- All 15 Theme suites pass: 151 tests and 8 snapshots.
- Repository dependency, lockfile, type, build, and published-dependency validation pass after a clean install and full build.
- The workspace-scoped npm audit reports no advisory in the changed Terrazzo, Color.js, or Momoa dependency chain. Unrelated repository findings remain.

The `@terrazzo/plugin-css` package continues to declare `@terrazzo/cli` as a peer even though Gutenberg imports the plugin programmatically and does not install the CLI. This pre-existing peer warning is unchanged from Terrazzo 2.5.0; token generation and the full repository build pass without it.

Manual browser, screen-reader, and assistive-technology verification was not run.

</details>

## Screenshots or screencast

Not applicable; generated artifacts and expected UI behavior are unchanged.

## Use of AI Tools

Codex selected and audited the dependency update, inspected the complete upstream release span and Gutenberg consumers, regenerated the lockfile, ran verification, and drafted this pull request. A human has not reviewed the result.
