### PR TITLE
Cache the theme.json data merged from all origins

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -27,11 +27,22 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @var array
 	 */
 	protected static $blocks_cache = array(
-		'core'   => array(),
-		'blocks' => array(),
-		'theme'  => array(),
-		'user'   => array(),
+		'core'           => array(),
+		'blocks'         => array(),
+		'theme'          => array(),
+		'user'           => array(),
+		'merged_default' => array(),
+		'merged_blocks'  => array(),
+		'merged_theme'   => array(),
+		'merged_custom'  => array(),
 	);
+
+	/**
+	 * Container for the data merged from multiple origins, keyed by origin.
+	 *
+	 * @var array
+	 */
+	protected static $merged = array();
 
 	/**
 	 * Container for data coming from core.
@@ -602,24 +613,58 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
+		if ( ! in_array( $origin, array( 'default', 'blocks', 'theme', 'custom' ), true ) ) {
+			$origin = 'custom';
+		}
+
+		/*
+		 * The merged result is memoized per origin and refreshed when the set
+		 * of registered blocks changes, the same way each of the origins it
+		 * merges already is.
+		 */
+		if (
+			isset( static::$merged[ $origin ] ) &&
+			static::has_same_registered_blocks( 'merged_' . $origin )
+		) {
+			return clone static::$merged[ $origin ];
+		}
+
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( static::get_core_data() );
 		if ( 'default' === $origin ) {
-			return $result;
+			return static::cache_merged_data( $origin, $result );
 		}
 
 		$result->merge( static::get_block_data() );
 		if ( 'blocks' === $origin ) {
-			return $result;
+			return static::cache_merged_data( $origin, $result );
 		}
 
 		$result->merge( static::get_theme_data() );
 		if ( 'theme' === $origin ) {
-			return $result;
+			return static::cache_merged_data( $origin, $result );
 		}
 
 		$result->merge( static::get_user_data() );
-		return $result;
+		return static::cache_merged_data( $origin, $result );
+	}
+
+	/**
+	 * Stores the merged data for an origin and returns a copy of it.
+	 *
+	 * A copy is returned because callers are free to modify the result. In
+	 * particular {@see WP_Theme_JSON_Gutenberg::resolve_variables()} modifies
+	 * the object it is passed, and before this data was memoized every call
+	 * returned its own instance.
+	 *
+	 * @param string                 $origin     Origin the data was merged for.
+	 * @param WP_Theme_JSON_Gutenberg $theme_json Merged data.
+	 * @return WP_Theme_JSON_Gutenberg Copy of the merged data.
+	 */
+	protected static function cache_merged_data( $origin, $theme_json ) {
+		static::$merged[ $origin ] = $theme_json;
+
+		return clone $theme_json;
 	}
 
 	/**
@@ -693,11 +738,16 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		static::$core                     = null;
 		static::$blocks                   = null;
 		static::$blocks_cache             = array(
-			'core'   => array(),
-			'blocks' => array(),
-			'theme'  => array(),
-			'user'   => array(),
+			'core'           => array(),
+			'blocks'         => array(),
+			'theme'          => array(),
+			'user'           => array(),
+			'merged_default' => array(),
+			'merged_blocks'  => array(),
+			'merged_theme'   => array(),
+			'merged_custom'  => array(),
 		);
+		static::$merged                   = array();
 		static::$theme                    = null;
 		static::$user                     = null;
 		static::$user_custom_post_type_id = null;

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -621,10 +621,24 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * The merged result is memoized per origin and refreshed when the set
 		 * of registered blocks changes, the same way each of the origins it
 		 * merges already is.
+		 *
+		 * has_same_registered_blocks() runs before the isset() on purpose. It
+		 * records the registered blocks whenever it finds new ones, so running
+		 * it on the first call seeds that record while the data is built and
+		 * the second call hits. Checked the other way round, the record would
+		 * stay empty until the second call, and the first hit would be the
+		 * third.
+		 *
+		 * The guard tracks block registration only. get_theme_data() reads the
+		 * theme supports (palette, gradients, font sizes and the custom flags)
+		 * on every call, so a support added after the first call here stays
+		 * out of the merged data until the registered blocks change or
+		 * clean_cached_data() runs. gutenberg_get_global_settings() already
+		 * freezes them per request the same way.
 		 */
 		if (
-			isset( static::$merged[ $origin ] ) &&
-			static::has_same_registered_blocks( 'merged_' . $origin )
+			static::has_same_registered_blocks( 'merged_' . $origin ) &&
+			isset( static::$merged[ $origin ] )
 		) {
 			return clone static::$merged[ $origin ];
 		}

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -347,10 +347,6 @@ function _gutenberg_clean_theme_json_caches() {
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );
-	wp_cache_delete( 'gutenberg_get_global_styles_custom', 'theme_json' );
-	wp_cache_delete( 'gutenberg_get_global_styles_custom_resolved', 'theme_json' );
-	wp_cache_delete( 'gutenberg_get_global_styles_theme', 'theme_json' );
-	wp_cache_delete( 'gutenberg_get_global_styles_theme_resolved', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_custom_css', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_styles_base_custom_css', 'theme_json' );
 	WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
@@ -397,21 +393,11 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 	&& is_array( $context['transforms'] )
 	&& in_array( 'resolve-variables', $context['transforms'], true );
 
-	$cache_group = 'theme_json';
-	$cache_key   = 'gutenberg_get_global_styles_' . $origin;
+	$merged_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin );
 	if ( $resolve_variables ) {
-		$cache_key .= '_resolved';
+		$merged_data = WP_Theme_JSON_Gutenberg::resolve_variables( $merged_data );
 	}
-	$styles = wp_cache_get( $cache_key, $cache_group );
-
-	if ( false === $styles || WP_DEBUG ) {
-		$merged_data = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin );
-		if ( $resolve_variables ) {
-			$merged_data = WP_Theme_JSON_Gutenberg::resolve_variables( $merged_data );
-		}
-		$styles = $merged_data->get_raw_data()['styles'];
-		wp_cache_set( $cache_key, $styles, $cache_group );
-	}
+	$styles = $merged_data->get_raw_data()['styles'];
 
 	return _wp_array_get( $styles, $path, $styles );
 }

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
 -   Image: Keep the selected image size, and re-point a media file or attachment page link, when an edit in the media editor saves to a new attachment. Cropping, rotating or flipping left the block rendering the full-size file while the size control still reported the size the user had chosen, and left the link pointing at the pre-edit image ([#82316](https://github.com/WordPress/gutenberg/pull/82316)).
+-   Gallery: Read the global gap from the plugin's theme.json data when the plugin is active, and read it on every render instead of once per request, so a gap set after the first gallery renders applies to the next ([#81979](https://github.com/WordPress/gutenberg/pull/81979)).
 
 ### Internal
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -392,8 +392,6 @@ function block_core_gallery_render_dynamic_image( $attachment_id, $attributes, $
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content, $block ) {
-	static $global_styles = null;
-
 	// Gallery blocks created before layout variations existed do not have an
 	// explicit layout attribute. Missing and malformed layout data therefore
 	// falls back to Flex so existing galleries retain their current appearance.
@@ -496,8 +494,12 @@ function block_core_gallery_render( $attributes, $content, $block ) {
 		// gap on the gallery.
 		$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
 
-		if ( null === $global_styles ) {
-			$global_styles = function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles() : array();
+		if ( function_exists( 'gutenberg_get_global_styles' ) ) {
+			$global_styles = gutenberg_get_global_styles();
+		} elseif ( function_exists( 'wp_get_global_styles' ) ) {
+			$global_styles = wp_get_global_styles();
+		} else {
+			$global_styles = array();
 		}
 
 		$global_gallery_styles = $global_styles['blocks']['core/gallery'] ?? array();

--- a/phpunit/blocks/render-block-gallery-test.php
+++ b/phpunit/blocks/render-block-gallery-test.php
@@ -373,4 +373,49 @@ class Tests_Blocks_Render_Gallery extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'object-fit:fill', $stylesheet );
 		$this->assertStringContainsString( 'display:block', $stylesheet );
 	}
+
+	/**
+	 * The gap read from global styles must follow the theme.json data for the
+	 * rest of the request, so a change made after one render shows in the next.
+	 */
+	public function test_static_gallery_reads_the_current_global_gap_on_every_render() {
+		$markup  = '<!-- wp:gallery --><figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image --><figure class="wp-block-image"><img alt=""/></figure><!-- /wp:image --></figure><!-- /wp:gallery -->';
+		$gap_var = '--wp--style--unstable-gallery-gap:37px';
+
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+		do_blocks( $markup );
+		$this->assertStringNotContainsString(
+			$gap_var,
+			gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) ),
+			'The gap should not be set before global styles define it, otherwise this test asserts nothing.'
+		);
+
+		$filter = static function ( $theme_json ) {
+			return $theme_json->update_with(
+				array(
+					'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+					'styles'  => array(
+						'blocks' => array(
+							'core/gallery' => array(
+								'spacing' => array( 'blockGap' => '37px' ),
+							),
+						),
+					),
+				)
+			);
+		};
+		add_filter( 'wp_theme_json_data_theme', $filter );
+		_gutenberg_clean_theme_json_caches();
+
+		try {
+			WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+			do_blocks( $markup );
+			$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+		} finally {
+			remove_filter( 'wp_theme_json_data_theme', $filter );
+			_gutenberg_clean_theme_json_caches();
+		}
+
+		$this->assertStringContainsString( $gap_var, $stylesheet, 'A gap set in global styles after a previous render should be used.' );
+	}
 }

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -46,6 +46,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	private static $property_core_orig_value;
 
 	/**
+	 * WP_Theme_JSON_Resolver_Gutenberg::$merged property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_merged;
+
+	/**
 	 * Theme root directory.
 	 *
 	 * @var string|null
@@ -85,6 +92,11 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 			static::$property_core->setAccessible( true );
 		}
 		static::$property_core_orig_value = static::$property_core->getValue();
+
+		static::$property_merged = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'merged' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			static::$property_merged->setAccessible( true );
+		}
 	}
 
 	public static function tear_down_after_class() {
@@ -1465,6 +1477,23 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_returns_the_memoized_data() {
+		WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+
+		$sentinel = $this->replace_merged_data_with_sentinel( 'custom' );
+		$result   = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+
+		$this->assertSame(
+			'sentinel',
+			$result->get_raw_data()['styles']['color']['text'] ?? null,
+			'The second call should return the data memoized by the first.'
+		);
+		$this->assertNotSame( $sentinel, $result, 'A copy of the memoized data should be returned, not the memoized instance.' );
+	}
+
+	/**
 	 * Callers are free to modify the returned data. WP_Theme_JSON_Gutenberg::resolve_variables()
 	 * does exactly that, so a modification must not be observable by the next caller.
 	 *
@@ -1498,6 +1527,8 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
 	 */
 	public function test_get_merged_data_reflects_blocks_registered_after_a_previous_call() {
+		// The first call records the registered blocks and stores the data; the second returns it.
+		WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 		WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 
 		register_block_type(
@@ -1533,5 +1564,27 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$after = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
 
 		$this->assertNotEquals( $before, $after, 'Switching themes should refresh the merged data.' );
+	}
+
+	/**
+	 * Replaces the memoized merged data for an origin with a recognizable instance.
+	 *
+	 * @param string $origin Origin to replace the data for.
+	 * @return WP_Theme_JSON_Gutenberg The instance now memoized for the origin.
+	 */
+	private function replace_merged_data_with_sentinel( $origin ) {
+		$sentinel = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array( 'color' => array( 'text' => 'sentinel' ) ),
+			)
+		);
+
+		$merged = static::$property_merged->getValue();
+		$this->assertArrayHasKey( $origin, $merged, 'The merged data should be stored for the origin before it is replaced.' );
+		$merged[ $origin ] = $sentinel;
+		static::$property_merged->setValue( null, $merged );
+
+		return $sentinel;
 	}
 }

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1501,24 +1501,29 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_merged_data_is_not_affected_by_modifying_the_result() {
 		/*
-		 * A theme with presets is required: resolving variables is a no-op when
-		 * the active theme's styles contain no variable references, which would
-		 * leave this test asserting nothing.
+		 * A theme whose styles reference a preset is required: resolving
+		 * variables changes nothing otherwise, which would leave this test
+		 * asserting nothing. The fonts-block-theme fixture sets the root font
+		 * family to one of its font family presets.
 		 */
-		switch_theme( 'twentytwentyfour' );
+		switch_theme( 'fonts-block-theme' );
+		$path = array( 'typography', 'fontFamily' );
 
-		$before   = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
-		$resolved = WP_Theme_JSON_Gutenberg::resolve_variables( WP_Theme_JSON_Resolver_Gutenberg::get_merged_data() )->get_raw_data();
-
-		$this->assertNotEquals(
-			$before['styles'],
-			$resolved['styles'],
-			'Resolving variables should change the styles, otherwise this test asserts nothing.'
+		$before   = _wp_array_get( WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data()['styles'], $path );
+		$resolved = _wp_array_get(
+			WP_Theme_JSON_Gutenberg::resolve_variables( WP_Theme_JSON_Resolver_Gutenberg::get_merged_data() )->get_raw_data()['styles'],
+			$path
 		);
 
-		$this->assertSameSetsWithIndex(
+		$this->assertSame( 'var(--wp--preset--font-family--system-font)', $before, 'The fixture should reference a preset.' );
+		$this->assertNotSame(
 			$before,
-			WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data(),
+			$resolved,
+			'Resolving variables should change the value, otherwise this test asserts nothing.'
+		);
+		$this->assertSame(
+			$before,
+			_wp_array_get( WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data()['styles'], $path ),
 			'Resolving variables should not affect subsequent calls.'
 		);
 	}
@@ -1557,6 +1562,22 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	 * @covers WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data
 	 */
 	public function test_clean_cached_data_refreshes_merged_data() {
+		WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$this->replace_merged_data_with_sentinel( 'custom' );
+
+		WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+
+		$this->assertNotSame(
+			'sentinel',
+			WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data()['styles']['color']['text'] ?? null,
+			'Cleaning the cached data should discard the memoized merged data.'
+		);
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_switching_theme_refreshes_merged_data() {
 		switch_theme( 'block-theme' );
 		$before = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
 

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1448,4 +1448,90 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $actual, 'Merged variation styles do not match.' );
 	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_returns_a_separate_instance_per_call() {
+		$first  = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$second = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+
+		$this->assertNotSame( $first, $second, 'Each call should return its own instance.' );
+		$this->assertSameSetsWithIndex(
+			$first->get_raw_data(),
+			$second->get_raw_data(),
+			'Repeated calls should return equivalent data.'
+		);
+	}
+
+	/**
+	 * Callers are free to modify the returned data. WP_Theme_JSON_Gutenberg::resolve_variables()
+	 * does exactly that, so a modification must not be observable by the next caller.
+	 *
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_is_not_affected_by_modifying_the_result() {
+		/*
+		 * A theme with presets is required: resolving variables is a no-op when
+		 * the active theme's styles contain no variable references, which would
+		 * leave this test asserting nothing.
+		 */
+		switch_theme( 'twentytwentyfour' );
+
+		$before   = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+		$resolved = WP_Theme_JSON_Gutenberg::resolve_variables( WP_Theme_JSON_Resolver_Gutenberg::get_merged_data() )->get_raw_data();
+
+		$this->assertNotEquals(
+			$before['styles'],
+			$resolved['styles'],
+			'Resolving variables should change the styles, otherwise this test asserts nothing.'
+		);
+
+		$this->assertSameSetsWithIndex(
+			$before,
+			WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data(),
+			'Resolving variables should not affect subsequent calls.'
+		);
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_merged_data
+	 */
+	public function test_get_merged_data_reflects_blocks_registered_after_a_previous_call() {
+		WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+
+		register_block_type(
+			'test/block-gap',
+			array(
+				'supports' => array(
+					'__experimentalStyle' => array(
+						'spacing' => array( 'blockGap' => '77px' ),
+					),
+				),
+			)
+		);
+
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data()['styles'];
+
+		unregister_block_type( 'test/block-gap' );
+
+		$this->assertSame(
+			'77px',
+			$styles['blocks']['test/block-gap']['spacing']['blockGap'] ?? null,
+			'Data for a block registered after a previous call should be present.'
+		);
+	}
+
+	/**
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data
+	 */
+	public function test_clean_cached_data_refreshes_merged_data() {
+		switch_theme( 'block-theme' );
+		$before = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+
+		switch_theme( 'default' );
+		$after = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_raw_data();
+
+		$this->assertNotEquals( $before, $after, 'Switching themes should refresh the merged data.' );
+	}
 }

--- a/phpunit/wp-theme-json-test.php
+++ b/phpunit/wp-theme-json-test.php
@@ -134,16 +134,41 @@ class WP_Theme_Json_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The theme.json data for a block is available once the block is registered,
-	 * so styles read before that must not hide it from the styles read after.
+	 * gutenberg_get_global_styles() must read the merged data through
+	 * WP_Theme_JSON_Resolver_Gutenberg::get_merged_data() on every call instead of
+	 * keeping a copy of its own. The resolver rebuilds its data when the registered
+	 * blocks change; a cache in front of it does not, so a block registered after
+	 * the first call would stay invisible to this accessor for the rest of the
+	 * request while every other consumer of the merged data sees it.
 	 *
-	 * The test suite runs with WP_DEBUG on. A cache that skips itself under
-	 * WP_DEBUG would pass this test and still hide late registrations elsewhere.
+	 * The suite runs with WP_DEBUG on, and the object cache this replaced
+	 * (WordPress/gutenberg#81889) recomputed under WP_DEBUG, so the late
+	 * registration on its own cannot see that cache. The cache was written on every
+	 * call whatever WP_DEBUG said, so the assertions on its four keys can.
 	 *
 	 * @covers gutenberg_get_global_styles
 	 */
-	public function test_gutenberg_get_global_styles_reflects_blocks_registered_after_a_previous_call() {
-		gutenberg_get_global_styles();
+	public function test_gutenberg_get_global_styles_reads_through_to_the_resolver() {
+		$contexts = array(
+			'gutenberg_get_global_styles_custom'          => array(),
+			'gutenberg_get_global_styles_custom_resolved' => array( 'transforms' => array( 'resolve-variables' ) ),
+			'gutenberg_get_global_styles_theme'           => array( 'origin' => 'base' ),
+			'gutenberg_get_global_styles_theme_resolved'  => array(
+				'origin'     => 'base',
+				'transforms' => array( 'resolve-variables' ),
+			),
+		);
+
+		foreach ( $contexts as $context ) {
+			gutenberg_get_global_styles( array(), $context );
+		}
+
+		foreach ( array_keys( $contexts ) as $cache_key ) {
+			$this->assertFalse(
+				wp_cache_get( $cache_key, 'theme_json' ),
+				"The merged styles should not be cached under $cache_key."
+			);
+		}
 
 		register_block_type(
 			'test/block-gap',

--- a/phpunit/wp-theme-json-test.php
+++ b/phpunit/wp-theme-json-test.php
@@ -43,6 +43,7 @@ class WP_Theme_Json_Test extends WP_UnitTestCase {
 		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
+		_gutenberg_clean_theme_json_caches();
 		parent::tear_down();
 	}
 
@@ -130,5 +131,39 @@ class WP_Theme_Json_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $default );
 		$this->assertTrue( $block_theme );
+	}
+
+	/**
+	 * The theme.json data for a block is available once the block is registered,
+	 * so styles read before that must not hide it from the styles read after.
+	 *
+	 * The test suite runs with WP_DEBUG on. A cache that skips itself under
+	 * WP_DEBUG would pass this test and still hide late registrations elsewhere.
+	 *
+	 * @covers gutenberg_get_global_styles
+	 */
+	public function test_gutenberg_get_global_styles_reflects_blocks_registered_after_a_previous_call() {
+		gutenberg_get_global_styles();
+
+		register_block_type(
+			'test/block-gap',
+			array(
+				'supports' => array(
+					'__experimentalStyle' => array(
+						'spacing' => array( 'blockGap' => '77px' ),
+					),
+				),
+			)
+		);
+
+		$styles = gutenberg_get_global_styles();
+
+		unregister_block_type( 'test/block-gap' );
+
+		$this->assertSame(
+			'77px',
+			$styles['blocks']['test/block-gap']['spacing']['blockGap'] ?? null,
+			'Styles for a block registered after a previous call should be present.'
+		);
 	}
 }


### PR DESCRIPTION
> [!WARNING]
> **AI generated from human direction. It has not yet been human reviewed.** The first round was written by Claude under @sirreal's direction. The 2026-09-03 round (rebase, review fixes, tests, this description) was done by Claude Fable 5.1 under @sirreal's direction.
> **Draft.** Opened for discussion of the approach, not for merge. See [Status](#status) for what has and has not been validated.

## What

`WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()` builds a new `WP_Theme_JSON_Gutenberg` and merges up to four origins on every call, about 0.3ms each. This PR memoizes the merged result per origin behind the `has_same_registered_blocks()` guard the origins already use, resets it in `clean_cached_data()`, and returns a copy on each call. Every consumer of the merged data gets the saving without a cache of its own.

## Relation to #81889

#81889 by @tellthemachines landed on 2026-08-21 with an object cache in `gutenberg_get_global_styles()` and without the function static in `gutenberg_render_layout_support_flag()`. It is in this PR's base; [WordPress/wordpress-develop#13214](https://github.com/WordPress/wordpress-develop/pull/13214) is its core side. This PR keeps the layout change and removes the accessor cache, for four reasons:

- Nothing reads its `_resolved` keys. No caller in Gutenberg or core passes the `resolve-variables` transform; the accessor's own docblock is the only mention.
- A plain-key hit saves one `clone` and one array read over the memoized resolver. Measured below: a third of a microsecond per call.
- It sits in front of `has_same_registered_blocks()`, so a block registered after the first call stays invisible to `gutenberg_get_global_styles()` for the rest of the request while every other consumer sees it. A test covers this now.
- `WP_DEBUG` bypasses it, so under `WP_DEBUG` every layout block paid the full merge. The resolver memoization has no such bypass.

## Why the resolver

Several callers read `get_merged_data()` directly and get nothing from an accessor cache: `gutenberg_render_block_style_variation_support_styles()`, which runs on `render_block_data` for every block with an `is-style-*` class; `gutenberg_get_global_stylesheet()` and `gutenberg_get_global_settings()` on their cache misses; `WP_Duotone_Gutenberg`; and the REST global styles controller.

## Gallery

`block_core_gallery_render()` kept the global styles in a function static and read them through core's `wp_get_global_styles()`, which uses core's resolver, not the plugin's. #80030 added the static as a workaround for the uncached merge. It goes: the gallery now prefers `gutenberg_get_global_styles()` when it exists, the way the same file already prefers `gutenberg_resolve_style_state_aliases()`. In the plugin that is the memoized plugin resolver, the one the layout support already reads. In core the first branch is dead and `wp_get_global_styles()` runs, which becomes cheap once the resolver change syncs. One observable change: with the plugin active the gallery reads the plugin's theme.json data instead of core's, as the layout support already does.

## Why a copy is returned

Callers are free to modify the result, and `WP_Theme_JSON_Gutenberg::resolve_variables()` modifies the object it is passed. Before memoization every call received its own instance, so returning the shared one would be a behaviour change. `WP_Theme_JSON_Gutenberg` holds a single array property, so the copy is shallow and copy-on-write makes it effectively free. A test covers this, and it fails if the `clone` is removed.

## Known change

The guard tracks block registration only. `get_theme_data()` memoizes theme.json but rebuilds the theme-supports overlay (palette, gradients, font sizes and the custom flags from `add_theme_support()`) on every call. With the merged data memoized, a support added after the first `get_merged_data()` of a request stays out of it until the registered blocks change or `clean_cached_data()` runs. Supports register on `after_setup_theme`, before any of this runs, and `gutenberg_get_global_settings()` already freezes them per request the same way. The resolver comment says so.

## Numbers

Measured in this repo, 1,000 iterations, median of five runs, twentytwentyfour, `WP_DEBUG` off. Trunk includes #81889's accessor cache.

| | trunk | this PR |
| --- | --- | --- |
| `get_merged_data()` | 294.65ms | 0.41ms |
| `gutenberg_get_global_styles()` | 0.15ms | 0.49ms |
| `gutenberg_get_global_settings()` | 0.15ms | 0.15ms |
| `gutenberg_render_layout_support_flag()` | 22.62ms | 22.62ms |
| `render_block_data` variation path | 295.79ms | 0.62ms |

The accessor row is what #81889's cache bought: 0.34µs per call. The layout row does not move because the accessor is cheap either way. The equivalent core change measured the same shape (`get_merged_data()` 286.78ms to 0.36ms).

## Status

Run in this repo on this branch, rebased on trunk at 5903a6e3f6e:

- `WP_Theme_JSON_Resolver_Gutenberg_Test`: 46 tests, 171 assertions, green. The memoization test fails when the `merged_*` keys are removed from the block record; the isolation test fails when both `clone` sites are removed.
- `WP_Theme_Json_Test`: 7 tests, 12 assertions, green. The new accessor test fails against #81889's cache under the settings CI runs with. The suite defines `WP_DEBUG` true, and that cache recomputed under `WP_DEBUG`, so reading a block registered after a previous call cannot see it; the cache was written on every call either way, so the test also asserts its four keys stay empty. Putting the cache back fails the first of those assertions.
- `Tests_Blocks_Render_Gallery`: 13 tests, 42 assertions, green. The new test fails against trunk's static.
- Full single-site suite: 2,301 tests, 4,752 assertions, no failures; 7 skipped and 1 risky, all in unrelated files.
- phpcs is clean on the changed files.

Not done: the core PR, so the "Check for a Core backport changelog entry" check stays red until one exists. The multisite suite, e2e and performance jobs run in CI only.

## Open questions

- `has_same_registered_blocks()` detects block additions only, not removals. This inherits that; it does not make it worse.
- The same change is needed in `wordpress-develop`, with a Trac ticket. [WordPress/wordpress-develop#13192](https://github.com/WordPress/wordpress-develop/pull/13192) and [#13214](https://github.com/WordPress/wordpress-develop/pull/13214) overlap with each other and with this PR.

Supersedes #81883.
