### PR TITLE
UI: Add tooltips to Calendar and RangeCalendar navigation buttons

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Bug Fixes
 
+-   `Calendar`, `RangeCalendar`: Show tooltips for the previous and next month buttons. ([#81983](https://github.com/WordPress/gutenberg/pull/81983))
 -   `Calendar`, `RangeCalendar`: Make the navigation label translatable and use the same locale-derived default first day of the week for locale strings and date-fns locale objects. Existing object-based calendars may use a different default; pass `weekStartsOn` to preserve it. ([#81814](https://github.com/WordPress/gutenberg/pull/81814))
 -   `Autocomplete.Input`, `Combobox.Input`: Omit the `type` prop, since the combobox role is only valid on `input type="text"` ([#80636](https://github.com/WordPress/gutenberg/pull/80636)).
 -   `Card`: Use the normal neutral surface stroke for the default border. ([#81746](https://github.com/WordPress/gutenberg/pull/81746))

--- a/packages/ui/src/calendar/style.module.css
+++ b/packages/ui/src/calendar/style.module.css
@@ -108,19 +108,15 @@
 			text-transform: capitalize;
 		}
 
-		.chevron,
-		.nav-button svg {
+		.chevron {
 			display: inline-block;
 			fill: currentColor;
 			width: var(--wpds-dimension-size-2xs);
 			height: var(--wpds-dimension-size-2xs);
 		}
 
-		.nav-button svg {
-			margin: 0;
-		}
-
-		.root[dir="rtl"] .nav :is(.chevron, .nav-button svg) {
+		.root[dir="rtl"] .nav .chevron,
+		.root[dir="rtl"] .nav-button {
 			transform: rotate(180deg);
 			transform-origin: 50%;
 		}
@@ -413,15 +409,6 @@
 		.caption-after-exit,
 		.caption-before-exit {
 			animation-name: fade-out;
-		}
-	}
-
-	@layer compositions {
-		/*
-		 * Keep the month navigation buttons aligned to the calendar's cell size.
-		 */
-		.nav-button {
-			--wp-ui-button-height: var(--wp-ui-calendar-cell-size);
 		}
 	}
 }

--- a/packages/ui/src/calendar/style.module.css
+++ b/packages/ui/src/calendar/style.module.css
@@ -108,14 +108,6 @@
 			text-transform: capitalize;
 		}
 
-		.chevron {
-			display: inline-block;
-			fill: currentColor;
-			width: var(--wpds-dimension-size-2xs);
-			height: var(--wpds-dimension-size-2xs);
-		}
-
-		.root[dir="rtl"] .nav .chevron,
 		.root[dir="rtl"] .nav-button {
 			transform: rotate(180deg);
 			transform-origin: 50%;

--- a/packages/ui/src/calendar/style.module.css
+++ b/packages/ui/src/calendar/style.module.css
@@ -108,14 +108,19 @@
 			text-transform: capitalize;
 		}
 
-		.chevron {
+		.chevron,
+		.nav-button svg {
 			display: inline-block;
 			fill: currentColor;
 			width: var(--wpds-dimension-size-2xs);
 			height: var(--wpds-dimension-size-2xs);
 		}
 
-		.root[dir="rtl"] .nav .chevron {
+		.nav-button svg {
+			margin: 0;
+		}
+
+		.root[dir="rtl"] .nav :is(.chevron, .nav-button svg) {
 			transform: rotate(180deg);
 			transform-origin: 50%;
 		}
@@ -413,13 +418,9 @@
 
 	@layer compositions {
 		/*
-		 * The month navigation buttons render a `Button`. Square them off to the
-		 * calendar's cell size, the same way `IconButton` does.
+		 * Keep the month navigation buttons aligned to the calendar's cell size.
 		 */
 		.nav-button {
-			--wp-ui-button-aspect-ratio: 1;
-			--wp-ui-button-padding-inline: 0px;
-			--wp-ui-button-min-width: unset;
 			--wp-ui-button-height: var(--wp-ui-calendar-cell-size);
 		}
 	}

--- a/packages/ui/src/calendar/test/calendar.test.tsx
+++ b/packages/ui/src/calendar/test/calendar.test.tsx
@@ -105,6 +105,11 @@ describe( 'Calendar', () => {
 		jest.useRealTimers();
 	} );
 
+	afterEach( async () => {
+		// Let tooltip positioning updates caused by focus finish before cleanup.
+		await act( () => Promise.resolve() );
+	} );
+
 	describe( 'Semantics and basic behavior', () => {
 		it( 'should apply the correct roles, semantics and attributes', async () => {
 			render( <Calendar /> );

--- a/packages/ui/src/calendar/test/localization.test.tsx
+++ b/packages/ui/src/calendar/test/localization.test.tsx
@@ -34,7 +34,7 @@ function expectGregorianDate( localeCode: string ) {
 jest.mock( '@wordpress/i18n', () => {
 	const actual = jest.requireActual( '@wordpress/i18n' );
 	const translations: Record< string, string > = {
-		'Go to the Previous Month': 'Translated previous month',
+		'Previous month': 'Translated previous month',
 		'Navigation bar': 'Translated navigation bar',
 		'Today, %s, selected': 'Today and selected: %s',
 	};
@@ -94,6 +94,8 @@ describe.each( [
 	it.each( [
 		[ 'previous', 'Previous test month', 'labelPrevious' ],
 		[ 'next', 'Next test month', 'labelNext' ],
+		[ 'default previous', 'Translated previous month', undefined ],
+		[ 'default next', 'Next month', undefined ],
 	] as const )(
 		'shows the %s month button label in a tooltip',
 		async ( _direction, label, labelKey ) => {
@@ -101,7 +103,11 @@ describe.each( [
 
 			render(
 				<Tooltip.Provider delay={ 0 }>
-					<Component labels={ { [ labelKey ]: () => label } } />
+					<Component
+						labels={
+							labelKey ? { [ labelKey ]: () => label } : undefined
+						}
+					/>
 				</Tooltip.Provider>
 			);
 

--- a/packages/ui/src/calendar/test/localization.test.tsx
+++ b/packages/ui/src/calendar/test/localization.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { startOfDay } from 'date-fns';
 import { ckb, faIR, ug } from 'date-fns/locale';
 import { Calendar, RangeCalendar } from '..';
+import * as Tooltip from '../../tooltip';
 import {
 	dateNumberFormatter,
 	fullDateFormatter,
@@ -88,6 +90,28 @@ describe.each( [
 			} )
 		).toBeVisible();
 	} );
+
+	it.each( [
+		[ 'previous', 'Previous test month', 'labelPrevious' ],
+		[ 'next', 'Next test month', 'labelNext' ],
+	] as const )(
+		'shows the %s month button label in a tooltip',
+		async ( _direction, label, labelKey ) => {
+			const user = userEvent.setup();
+
+			render(
+				<Tooltip.Provider delay={ 0 }>
+					<Component labels={ { [ labelKey ]: () => label } } />
+				</Tooltip.Provider>
+			);
+
+			await user.hover( screen.getByRole( 'button', { name: label } ) );
+
+			await waitFor( () => {
+				expect( screen.getByText( label ) ).toBeVisible();
+			} );
+		}
+	);
 } );
 
 describe( 'Calendar locale inputs', () => {

--- a/packages/ui/src/calendar/test/range-calendar.test.tsx
+++ b/packages/ui/src/calendar/test/range-calendar.test.tsx
@@ -107,6 +107,11 @@ describe( 'RangeCalendar', () => {
 		jest.useRealTimers();
 	} );
 
+	afterEach( async () => {
+		// Let tooltip positioning updates caused by focus finish before cleanup.
+		await act( () => Promise.resolve() );
+	} );
+
 	describe( 'Semantics and basic behavior', () => {
 		it( 'should apply the correct roles, semantics and attributes', async () => {
 			render( <RangeCalendar /> );

--- a/packages/ui/src/calendar/types.ts
+++ b/packages/ui/src/calendar/types.ts
@@ -245,12 +245,12 @@ export interface BaseProps
 		labelGridcell?: ( date: Date, modifiers?: Modifiers ) => string;
 		/**
 		 * The label for the "next month" button.
-		 * @default "Go to the Next Month"
+		 * @default "Next month"
 		 */
 		labelNext?: ( month: Date | undefined ) => string;
 		/**
 		 * The label for the "previous month" button.
-		 * @default "Go to the Previous Month"
+		 * @default "Previous month"
 		 */
 		labelPrevious?: ( month: Date | undefined ) => string;
 		/**

--- a/packages/ui/src/calendar/utils/components.tsx
+++ b/packages/ui/src/calendar/utils/components.tsx
@@ -1,9 +1,8 @@
 import { useRender } from '@base-ui/react';
-import type { CalendarDay, RootProps, ChevronProps } from '@daypicker/react';
+import type { CalendarDay, RootProps } from '@daypicker/react';
 import { useContext } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { Icon } from '../../icon';
 import { IconButton } from '../../icon-button';
 import { RootContext } from './root-context';
 import type { Modifiers } from '../types';
@@ -155,24 +154,13 @@ export function Root( { rootRef, ...props }: RootProps ) {
 }
 
 /**
- * Render the chevron icon used in the navigation buttons.
- * @see https://daypicker.dev/guides/custom-components
- */
-export function Chevron( { orientation, className }: ChevronProps ) {
-	return (
-		<Icon
-			className={ className }
-			icon={ orientation === 'right' ? chevronRight : chevronLeft }
-		/>
-	);
-}
-
-/**
  * Render a month navigation button.
  *
  * `@daypicker/react` marks the button as `aria-disabled` (rather than
  * `disabled`) when there is no month to navigate to, so that it stays
  * discoverable. `IconButton`'s `focusableWhenDisabled` produces the same DOM.
+ * It also always provides the string returned by its navigation label formatter
+ * as `aria-label`; the native button prop type cannot express that requirement.
  * @see https://daypicker.dev/guides/custom-components
  */
 function NavButton( {
@@ -183,13 +171,13 @@ function NavButton( {
 	'aria-disabled': ariaDisabled,
 	...props
 }: React.ButtonHTMLAttributes< HTMLButtonElement > & {
-	icon: React.ComponentProps< typeof Icon >[ 'icon' ];
+	icon: React.ComponentProps< typeof IconButton >[ 'icon' ];
 } ) {
 	return (
 		<IconButton
 			{ ...props }
 			className={ className }
-			label={ label ?? '' }
+			label={ label as string }
 			icon={ icon }
 			variant="minimal"
 			tone="neutral"

--- a/packages/ui/src/calendar/utils/components.tsx
+++ b/packages/ui/src/calendar/utils/components.tsx
@@ -3,8 +3,8 @@ import type { CalendarDay, RootProps, ChevronProps } from '@daypicker/react';
 import { useContext } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { Button } from '../../button';
 import { Icon } from '../../icon';
+import { IconButton } from '../../icon-button';
 import { RootContext } from './root-context';
 import type { Modifiers } from '../types';
 
@@ -172,18 +172,25 @@ export function Chevron( { orientation, className }: ChevronProps ) {
  *
  * `@daypicker/react` marks the button as `aria-disabled` (rather than
  * `disabled`) when there is no month to navigate to, so that it stays
- * discoverable. `Button`'s `focusableWhenDisabled` produces the same DOM.
+ * discoverable. `IconButton`'s `focusableWhenDisabled` produces the same DOM.
  * @see https://daypicker.dev/guides/custom-components
  */
-export function NavButton( {
+function NavButton( {
+	icon,
 	className,
+	children: _children,
+	'aria-label': label,
 	'aria-disabled': ariaDisabled,
 	...props
-}: React.ButtonHTMLAttributes< HTMLButtonElement > ) {
+}: React.ButtonHTMLAttributes< HTMLButtonElement > & {
+	icon: React.ComponentProps< typeof Icon >[ 'icon' ];
+} ) {
 	return (
-		<Button
+		<IconButton
 			{ ...props }
 			className={ className }
+			label={ label ?? '' }
+			icon={ icon }
 			variant="minimal"
 			tone="neutral"
 			size="compact"
@@ -191,4 +198,16 @@ export function NavButton( {
 			focusableWhenDisabled
 		/>
 	);
+}
+
+export function PreviousMonthButton(
+	props: React.ButtonHTMLAttributes< HTMLButtonElement >
+) {
+	return <NavButton { ...props } icon={ chevronLeft } />;
+}
+
+export function NextMonthButton(
+	props: React.ButtonHTMLAttributes< HTMLButtonElement >
+) {
+	return <NavButton { ...props } icon={ chevronRight } />;
 }

--- a/packages/ui/src/calendar/utils/constants.ts
+++ b/packages/ui/src/calendar/utils/constants.ts
@@ -1,11 +1,5 @@
 import clsx from 'clsx';
-import {
-	Day,
-	Root,
-	Chevron,
-	PreviousMonthButton,
-	NextMonthButton,
-} from './components';
+import { Day, Root, PreviousMonthButton, NextMonthButton } from './components';
 import styles from '../style.module.css';
 import resetStyles from '../../utils/css/resets.module.css';
 import focusStyles from '../../utils/css/focus.module.scss';
@@ -23,7 +17,6 @@ const CLASSNAMES = {
 	caption_label: styles[ 'caption-label' ],
 	button_next: styles[ 'nav-button' ],
 	button_previous: styles[ 'nav-button' ],
-	chevron: styles.chevron,
 	nav: styles.nav,
 	month_caption: styles[ 'month-caption' ],
 	months: styles.months,
@@ -83,7 +76,6 @@ export const COMMON_PROPS = {
 	components: {
 		Day,
 		Root,
-		Chevron,
 		PreviousMonthButton,
 		NextMonthButton,
 	},

--- a/packages/ui/src/calendar/utils/constants.ts
+++ b/packages/ui/src/calendar/utils/constants.ts
@@ -1,5 +1,11 @@
 import clsx from 'clsx';
-import { Day, Root, Chevron, NavButton } from './components';
+import {
+	Day,
+	Root,
+	Chevron,
+	PreviousMonthButton,
+	NextMonthButton,
+} from './components';
 import styles from '../style.module.css';
 import resetStyles from '../../utils/css/resets.module.css';
 import focusStyles from '../../utils/css/focus.module.scss';
@@ -78,7 +84,7 @@ export const COMMON_PROPS = {
 		Day,
 		Root,
 		Chevron,
-		PreviousMonthButton: NavButton,
-		NextMonthButton: NavButton,
+		PreviousMonthButton,
+		NextMonthButton,
 	},
 } as const;

--- a/packages/ui/src/calendar/utils/use-localization-props.ts
+++ b/packages/ui/src/calendar/utils/use-localization-props.ts
@@ -165,9 +165,9 @@ export const useLocalizationProps = ( {
 					return label;
 				},
 				/** The label for the "next month" button. */
-				labelNext: () => __( 'Go to the Next Month' ),
+				labelNext: () => __( 'Next month' ),
 				/** The label for the "previous month" button. */
-				labelPrevious: () => __( 'Go to the Previous Month' ),
+				labelPrevious: () => __( 'Previous month' ),
 				/**
 				 * The label for the day button.
 				 * @param date


### PR DESCRIPTION
## What?

Add visible tooltips to the previous and next month buttons in the `Calendar` and `RangeCalendar` components.

## Why?

The icon-only navigation buttons have accessible labels, but sighted pointer and keyboard users cannot see those labels.

## How?

Render the navigation controls with `IconButton`, using the existing localized navigation labels for both the accessible name and tooltip text. Use the compact button size with IconButton's default 24px chevron, and rotate the complete button in RTL layouts while preserving disabled behavior.

## Testing Instructions

1. Open the `Design System/Components/Calendar/Calendar` Default story in Storybook.
2. Hover the previous and next month buttons. Confirm each button shows the matching tooltip and uses the default 24px chevron.
3. Repeat these steps in the `Design System/Components/Calendar/RangeCalendar` Default story.
4. Switch Storybook to an RTL locale. Confirm both chevrons point in the correct direction.

### Testing Instructions for Keyboard

1. In each story, press Tab until the previous month button receives focus. Confirm its tooltip appears.
2. Press Tab again. Confirm the next month button receives focus and its tooltip appears.
3. Press Enter on each button and confirm month navigation still works.

## Screenshots or screencast

<img width="682" height="902" alt="Screenshot 2026-08-24 at 16 05 01" src="https://github.com/user-attachments/assets/1aba3053-ed03-49b3-a3d0-804c9b18a341" />

## Use of AI Tools

Codex was used to implement and test this change.
