### PR TITLE
Element: Serialize memo-wrapped components instead of an empty string

### DIFF
--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `serialize`/`renderToString`: Render `memo`-wrapped components instead of serializing them to an empty string ([#81986](https://github.com/WordPress/gutenberg/pull/81986)).
+
 ### Internal
 
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81514](https://github.com/WordPress/gutenberg/pull/81514))

--- a/packages/element/src/serialize.ts
+++ b/packages/element/src/serialize.ts
@@ -31,7 +31,14 @@ import {
 	escapeAttribute,
 	isValidAttributeName,
 } from '@wordpress/escape-html';
-import { createContext, Fragment, StrictMode, forwardRef } from './react';
+import {
+	createContext,
+	createElement,
+	Fragment,
+	StrictMode,
+	forwardRef,
+	memo,
+} from './react';
 import RawHTML from './raw-html';
 
 /** @typedef {React.ReactElement} ReactElement */
@@ -68,6 +75,10 @@ interface HTMLProps {
 const { Provider, Consumer } = Context;
 
 const ForwardRef = forwardRef( () => {
+	return null;
+} );
+
+const Memo = memo( () => {
 	return null;
 } );
 
@@ -622,6 +633,15 @@ export function renderElement(
 		case ForwardRef.$$typeof:
 			return renderElement(
 				type.render( props ),
+				context,
+				legacyContext
+			);
+
+		case Memo.$$typeof:
+			// Memoization is meaningless for a static, one-off serialization,
+			// so the wrapped type is rendered directly.
+			return renderElement(
+				createElement( type.type, props ),
 				context,
 				legacyContext
 			);

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -6,6 +6,7 @@ import {
 	Fragment,
 	StrictMode,
 	forwardRef,
+	memo,
 } from '../react';
 import RawHTML from '../raw-html';
 import serialize, {
@@ -82,6 +83,28 @@ describe( 'serialize()', () => {
 		} );
 
 		const result = serialize( <ForwardedComponent /> );
+
+		expect( result ).toBe( '<div>test</div>' );
+	} );
+
+	it( 'should render with memo', () => {
+		const MemoizedComponent = memo( ( { value } ) => {
+			return <div>{ value }</div>;
+		} );
+
+		const result = serialize( <MemoizedComponent value="test" /> );
+
+		expect( result ).toBe( '<div>test</div>' );
+	} );
+
+	it( 'should render with memo wrapping forwardRef', () => {
+		const MemoizedComponent = memo(
+			forwardRef( () => {
+				return <div>test</div>;
+			} )
+		);
+
+		const result = serialize( <MemoizedComponent /> );
 
 		expect( result ).toBe( '<div>test</div>' );
 	} );


### PR DESCRIPTION
## What?

Fixes `renderToString`/`serialize` from `@wordpress/element` silently rendering `React.memo`-wrapped components as an empty string.

Closes #81956.

## Why?

`renderElement` in `packages/element/src/serialize.ts` handles `Fragment`, context `Provider`/`Consumer`, `StrictMode`, and `forwardRef`, but has no case for `memo`. A `memo()` type is an object (`{ $$typeof: Symbol(react.memo), type, compare }`), so it skips the `typeof type === 'function'` branch, matches no case in the `type.$$typeof` switch, and falls through to the final `return ''` — with no warning.

Because `@wordpress/blocks`' `getSaveContent` uses `renderToString`, any block whose `save()` output contains a memo-wrapped component loses that subtree from its stored markup, and block validation then compares against the truncated HTML. This shows up with third-party design-system packages whose components are memoized internally.

## How?

Adds a `Memo.$$typeof` case to the existing switch, alongside `ForwardRef`, that unwraps to `type.type` — memoization has no meaning during a static, one-off serialization.

The case recurses through `renderElement` with `createElement( type.type, props )` rather than invoking the inner type directly (as the `ForwardRef` case does with `type.render`). That way each unwrapped layer falls back through the same switch, so `memo( forwardRef( … ) )`, `memo( ClassComponent )`, and nested memos are all handled without extra branches.
