### PR TITLE
Editor: Offer the theme export from both site editors

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Offer the Export tool only while editing a template or a template part, the entities the exported theme is made of. The menu item now lives in the editor package ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 ### Bug Fixes
 
 -   Seed the root `ThemeProvider` with the admin color scheme primary color so portaled popovers and modals receive the scheme's accent colors ([#81653](https://github.com/WordPress/gutenberg/pull/81653)).

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Offer the Export tool only while editing a template or a template part, the entities the exported theme is made of. The menu item now lives in the editor package ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Offer the Export tool only while editing a template or a template part, the entities the exported theme is made of. The menu item now lives in the editor package ([#81992](https://github.com/WordPress/gutenberg/pull/81992)).
 
 ### Bug Fixes
 

--- a/packages/edit-site/src/components/more-menu/index.js
+++ b/packages/edit-site/src/components/more-menu/index.js
@@ -1,9 +1,9 @@
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
-import SiteExport from './site-export';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 import { unlock } from '../../lock-unlock';
 
-const { ToolsMoreMenuGroup, PreferencesModal } = unlock( editorPrivateApis );
+const { ToolsMoreMenuGroup, PreferencesModal, SiteExport } =
+	unlock( editorPrivateApis );
 
 export default function MoreMenu() {
 	return (

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Add a private `SiteExport` menu item, moved from `edit-site`. It offers downloading the theme with the user's changes, only while editing a template or a template part — the entities the exported theme is made of ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Add a private `SiteExport` menu item, moved from `edit-site`. It offers downloading the theme with the user's changes, only while editing a template or a template part — the entities the exported theme is made of ([#81992](https://github.com/WordPress/gutenberg/pull/81992)).
 
 ### Enhancements
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add a private `SiteExport` menu item, moved from `edit-site`. It offers downloading the theme with the user's changes, only while editing a template or a template part — the entities the exported theme is made of ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 ### Enhancements
 
 -   Commands: Add a command palette entry that opens the current post on the front end once it is published, labelled with the post type's `view_item` label ([#66720](https://github.com/WordPress/gutenberg/pull/66720)).

--- a/packages/editor/src/components/site-export/index.js
+++ b/packages/editor/src/components/site-export/index.js
@@ -6,9 +6,33 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { downloadBlob } from '@wordpress/blob';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as editorStore } from '../../store';
+import {
+	TEMPLATE_POST_TYPE,
+	TEMPLATE_PART_POST_TYPE,
+} from '../../store/constants';
 
+/**
+ * Menu item offering to download the active theme, with the user's template
+ * and style changes, as a zip.
+ *
+ * Offered only while editing one of the entities the exported theme is made
+ * of — a template or a template part — and only to users the export endpoint
+ * accepts. The host places it in a menu group.
+ *
+ * @return {React.ReactNode} The menu item, or nothing where export does not
+ *                           apply.
+ */
 export default function SiteExport() {
 	const canExport = useSelect( ( select ) => {
+		const postType = select( editorStore ).getCurrentPostType();
+		if (
+			postType !== TEMPLATE_POST_TYPE &&
+			postType !== TEMPLATE_PART_POST_TYPE
+		) {
+			return false;
+		}
+
 		const targetHints =
 			select( coreStore ).getCurrentTheme()?._links?.[
 				'wp:export-theme'

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -13,6 +13,7 @@ import PreferencesModal from './components/preferences-modal';
 import { usePostActions } from './components/post-actions/actions';
 import usePostFields from './components/post-fields';
 import ToolsMoreMenuGroup from './components/more-menu/tools-more-menu-group';
+import SiteExport from './components/site-export';
 import ViewMoreMenuGroup from './components/more-menu/view-more-menu-group';
 import ResizableEditor from './components/resizable-editor';
 import { registerCoreBlockBindingsSources } from './bindings/api';
@@ -37,6 +38,7 @@ lock( privateApis, {
 	usePostActions,
 	usePostFields,
 	ToolsMoreMenuGroup,
+	SiteExport,
 	ViewMoreMenuGroup,
 	ResizableEditor,
 	UploadProgressSnackbar,

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Render the editor's Export tool, so a theme can be downloaded with the user's changes while editing a template or a template part ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+
 ### Bug Fixes
 
 -   Add the styles a host passes to the theme's and the user's instead of replacing them, so an editor canvas keeps the CSS a theme registers with `add_editor_style` ([#81747](https://github.com/WordPress/gutenberg/pull/81747)).

--- a/packages/lazy-editor/CHANGELOG.md
+++ b/packages/lazy-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Render the editor's Export tool, so a theme can be downloaded with the user's changes while editing a template or a template part ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Render the editor's Export tool, so a theme can be downloaded with the user's changes while editing a template or a template part ([#81992](https://github.com/WordPress/gutenberg/pull/81992)).
 
 ### Bug Fixes
 

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -13,6 +13,8 @@ const {
 	Editor: PrivateEditor,
 	BackButton,
 	PreferencesModal,
+	ToolsMoreMenuGroup,
+	SiteExport,
 } = unlock( editorPrivateApis );
 
 interface EditorProps {
@@ -139,6 +141,13 @@ export function Editor( {
 			   nothing until one of them opens it.
 			 */ }
 			<PreferencesModal />
+			{ /*
+			   Self-gated: renders only while editing a template or template
+			   part, the entities the exported theme is made of.
+			 */ }
+			<ToolsMoreMenuGroup>
+				<SiteExport />
+			</ToolsMoreMenuGroup>
 		</PrivateEditor>
 	);
 }


### PR DESCRIPTION
## What?

Brings the theme Export tool to the extensible site editor, and narrows where it appears in both site editors: the menu item now renders only while editing a **template or template part** — the entities the exported theme is made of.

Supersedes the placement half of #79228.

## Why?

The Export tool downloads the active theme with the user's template and style changes. It was an `edit-site`-local component mounted unconditionally, which produced both halves of the problem:

- The classic site editor offered it while editing *anything* — a page, a pattern, a navigation menu — although none of those ship with the exported theme.
- The extensible site editor didn't offer it at all.

#79228 addressed the second half by duplicating the ~90 lines boot-locally and mounting them in a site-hub options menu — but that site hub doesn't exist on trunk (the PR is stacked on unmerged work and conflicting), and duplication is how the two site editors drift.

## How?

The component moves to `@wordpress/editor` as a private export — the same migration path the `Plugin*` components, `PreferencesModal`, and `GlobalStylesActionMenu` already took — and **self-gates** on the editor store: it renders only when `getCurrentPostType()` is `wp_template` or `wp_template_part`, and only when the theme's `wp:export-theme` target hint allows `GET` (which also excludes classic themes and under-capability users).

Both hosts then render the one component:

- `edit-site`'s more menu swaps its local import for the private API; the local file is deleted. Because the gate is inside the component, v1's behavior narrows with no other change.
- `lazy-editor` renders it in a `ToolsMoreMenuGroup` fill next to the `PreferencesModal` it already hosts. The fill follows the editor, so it appears exactly where the v2 site editor edits — verified: every canvas route belongs solely to the `site-editor-v2` page today, and the `theme-preview` page consumes lazy-editor's hooks but not its `Editor`, so nothing leaks there.

The fetch/blob/filename/error handling is byte-for-byte v1's; no strings changed.

## Testing Instructions

1. On a block theme, open a **template** in the extensible site editor (Appearance → Design → Templates), open the editor ⋮ menu, and confirm **Export** appears under Tools and downloads the theme zip.
2. Open a **template part** and confirm the same.
3. Open a **page** and confirm Export is absent — in both the extensible and the classic site editor (`site-editor.php`). The classic editor previously showed it here; that narrowing is this PR's deliberate behavior change.
4. Confirm the classic site editor still shows Export on templates and template parts.
5. Activate a classic theme and confirm Export appears nowhere.
6. Break the export path (e.g. as a user without the capability) and confirm the error snackbar wording is unchanged.

### Testing Instructions for Keyboard

Open the ⋮ menu with the keyboard while editing a template, navigate to Export with arrow keys, and activate with <kbd>Enter</kbd>; confirm the download starts and focus stays in the menu flow.

## Use of AI Tools

Authored with Claude Code (Claude Fable 5), including this description; reviewed by the PR author. The component body is @scruffian's concern in #79228 resolved differently; the implementation reuses the existing `edit-site` code rather than either copy.

Verified: lint clean; `tsc --build` exits 0 for both `packages/editor` and `packages/lazy-editor`; git records the move as a rename (72% similarity), so review shows the delta rather than a fresh file. Not verified: no browser pass — the steps above are unrun.
