### PR TITLE
Theme: Rename ThemeProvider wrapper CSS class from root to wrapper

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Internal
 
--   Rename `ThemeProvider` wrapper CSS module class from `root` to `wrapper` for clearer DevTools inspection.
+-   Rename `ThemeProvider` wrapper CSS module class from `root` to `wrapper` for clearer DevTools inspection ([#81996](https://github.com/WordPress/gutenberg/pull/81996)).
 -   Update Terrazzo packages to 2.7.1 ([#81978](https://github.com/WordPress/gutenberg/pull/81978)).
 -   Point tsconfig references at split dependencies' build projects. ([#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Collapse the `tsconfig.src.json`/`tsconfig.bin.json`/`tsconfig.test.json` projects into the repository-standard split of `tsconfig.build.json` and a default dev `tsconfig.json`. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Internal
 
+-   Rename `ThemeProvider` wrapper CSS module class from `root` to `wrapper` for clearer DevTools inspection.
 -   Update Terrazzo packages to 2.7.1 ([#81978](https://github.com/WordPress/gutenberg/pull/81978)).
 -   Point tsconfig references at split dependencies' build projects. ([#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Collapse the `tsconfig.src.json`/`tsconfig.bin.json`/`tsconfig.test.json` projects into the repository-standard split of `tsconfig.build.json` and a default dev `tsconfig.json`. ([#81509](https://github.com/WordPress/gutenberg/pull/81509))

--- a/packages/theme/src/style.module.css
+++ b/packages/theme/src/style.module.css
@@ -1,3 +1,3 @@
-.root {
+.wrapper {
 	display: contents;
 }

--- a/packages/theme/src/test/theme-provider.test.tsx
+++ b/packages/theme/src/test/theme-provider.test.tsx
@@ -13,7 +13,7 @@ import type { ThemeProviderColorWarning } from '../theme-provider-color-warnings
 // Give the wrapper a stable class so tests can locate it and read its
 // computed custom properties.
 jest.mock( '../style.module.css', () => ( {
-	root: 'theme-provider-root',
+	wrapper: 'theme-provider-wrapper',
 } ) );
 
 // The "strong" brand background resolves to the `color.primary` seed itself, and
@@ -39,7 +39,7 @@ function readProp( element: Element, property: string ) {
 
 // The `ThemeProvider` wrapper element that scopes the given descendant.
 function getScopingProvider( element: Element ) {
-	return element.closest< HTMLElement >( '.theme-provider-root' )!;
+	return element.closest< HTMLElement >( '.theme-provider-wrapper' )!;
 }
 
 async function withInjectedThemeProviderStyles(
@@ -49,7 +49,7 @@ async function withInjectedThemeProviderStyles(
 	style.textContent = readFileSync(
 		join( import.meta.dirname, '../style.module.css' ),
 		'utf8'
-	).replaceAll( '.root', '.theme-provider-root' );
+	).replaceAll( '.wrapper', '.theme-provider-wrapper' );
 	document.head.appendChild( style );
 
 	try {

--- a/packages/theme/src/theme-provider.tsx
+++ b/packages/theme/src/theme-provider.tsx
@@ -145,7 +145,7 @@ export const ThemeProvider = ( {
 			ref={ wrapperRef }
 			data-wpds-root-provider={ isRoot || undefined }
 			data-wpds-corner-radius={ cornerRadiusPreset }
-			className={ styles.root }
+			className={ styles.wrapper }
 			style={ themeProviderStyles }
 		>
 			<ThemeContext.Provider value={ contextValue }>


### PR DESCRIPTION
## What?

Renames the CSS module class on `ThemeProvider`'s scoping wrapper from `root` to `wrapper`.

## Why?

In DevTools, the generated class name looked like it was applying root-level styles to every `ThemeProvider`, when it is only a layout wrapper (`display: contents`) around the provider subtree. That was easy to misread alongside the separate `isRoot` behavior that forwards tokens to the document element.

## How?

- Renamed `.root` to `.wrapper` in `packages/theme/src/style.module.css`.
- Updated the class reference in `ThemeProvider` and the test mock/helpers that locate the scoping element.

## Testing Instructions

1. Open any screen that uses `ThemeProvider` (for example, the site editor or a Storybook story that wraps content in the provider).
2. Inspect the provider element in DevTools and confirm the CSS module class is now named `wrapper` rather than `root`.
3. Confirm nested providers and root providers (`isRoot`) still apply theme tokens as before.