### PR TITLE
Add color supports for individual track customization in Playlist Track block

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -645,7 +645,7 @@ Playlist track.
 -	**Name:** [core/playlist-track](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/core-block-playlist-track/)
 -	**Category:** [media](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-media/)
 -	**Parent:** core/playlist
--	**Supports:** interactivity (clientNavigation), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, text), interactivity (clientNavigation), ~~html~~, ~~reusable~~
 -	**Attributes:** album, artist, blob, id, image, imageAlt, length, src, title, type
 
 ## Author (deprecated)

--- a/packages/block-library/src/playlist-track/README.md
+++ b/packages/block-library/src/playlist-track/README.md
@@ -39,6 +39,10 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 - [`reusable`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#reusable): `false`
+- [`color`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color):
+  - [`text`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-text): `true`
+  - [`background`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-background): `true`
+  - [`gradients`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color-gradients): `true`
 
 ## Context
 

--- a/packages/block-library/src/playlist-track/block.json
+++ b/packages/block-library/src/playlist-track/block.json
@@ -48,7 +48,12 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"reusable": false
+		"reusable": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"gradients": true
+		}
 	},
 	"style": "wp-block-playlist-track"
 }

--- a/packages/block-library/src/playlist-track/style.scss
+++ b/packages/block-library/src/playlist-track/style.scss
@@ -1,11 +1,4 @@
 .wp-block-playlist-track {
-	&:has([aria-current="true"]) {
-		background-color: color-mix(in srgb, currentColor 10%, transparent);
-	}
-
-	&:hover {
-		background-color: color-mix(in srgb, currentColor 15%, transparent);
-	}
 
 	.wp-block-playlist__tracklist-show-numbers & {
 		counter-increment: playlist-track;
@@ -24,6 +17,14 @@
 		border: 0;
 		outline-offset: 2px;
 		cursor: pointer;
+
+		&[aria-current="true"] {
+			background-color: color-mix(in srgb, currentColor 10%, transparent);
+		}
+
+		&:hover {
+			background-color: color-mix(in srgb, currentColor 15%, transparent);
+		}
 
 		.wp-block-playlist__tracklist-show-numbers &::before {
 			content: counter(playlist-track);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #81424

This PR adds color supports (text, background and gradients) to the `core/playlist-track` block.

## Why?
Previously, color settings were only available at the parent `core/playlist` level, applying a uniform style to the entire block. This enhancement allows users to customize colors on an individual track basis. This satisfies use cases requested by the community, such as:
* Creating mixtape style theming with varying colors.
* Grouping tracks by artist using background colors.
* Visually highlighting a specific "featured" track within a larger list.

## How?
Opted the `core/playlist-track` block into color supports by updating its `block.json`.

## Testing Instructions
1. Open a post or page in the editor.
2. Insert a **Playlist** block and upload or select at least two audio tracks to populate the list.
3. Using the List View or by clicking directly on the canvas, select an individual **Playlist track** block.
4. Open the Block Inspector settings sidebar.
5. Verify that the **Color** panel (Text, Background) is now available.
6. Apply a background color and text color to a single track.
7. Verify the color applies correctly in the editor canvas.
8. Save the post and verify the individual track colors render correctly on the frontend.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1358" height="722" alt="image" src="https://github.com/user-attachments/assets/e858966d-749c-4140-94f1-1d54e5a82660" />|<img width="1392" height="820" alt="image" src="https://github.com/user-attachments/assets/f0da2aac-09a5-4913-9232-74d8db97d0f3" />|

## Use of AI Tools
None.