### PR TITLE
Navigation: Support customizable overlay toggle button label for menu differentiation

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -549,7 +549,7 @@ A collection of blocks that allow visitors to get around your site.
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayButtonLabel, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/README.md
+++ b/packages/block-library/src/navigation/README.md
@@ -57,6 +57,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `overlay` | `string` | — | — |
 | `icon` | `string` | `"handle"` | — |
 | `hasIcon` | `boolean` | `true` | — |
+| `overlayButtonLabel` | `string` | — | — |
 | `__unstableLocation` | `string` | — | — |
 | `overlayBackgroundColor` | `string` | — | — |
 | `customOverlayBackgroundColor` | `string` | — | — |

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -67,6 +67,9 @@
 			"type": "boolean",
 			"default": true
 		},
+		"overlayButtonLabel": {
+			"type": "string"
+		},
 		"__unstableLocation": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -267,6 +267,7 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		overlayButtonLabel,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -919,6 +920,7 @@ function Navigation( {
 						setOverlayMenuPreview={ setOverlayMenuPreview }
 						hasIcon={ hasIcon }
 						icon={ icon }
+						overlayButtonLabel={ overlayButtonLabel }
 						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
 						overlayMenuPreviewId={ overlayMenuPreviewId }
 						isResponsive={ isResponsive }
@@ -991,6 +993,7 @@ function Navigation( {
 						isOpen={ isResponsiveMenuOpen }
 						hasIcon={ hasIcon }
 						icon={ icon }
+						overlayButtonLabel={ overlayButtonLabel }
 						isResponsive={ isResponsive }
 						isHiddenByDefault={ isHiddenByDefault }
 						overlayBackgroundColor={ overlayBackgroundColor }
@@ -1155,6 +1158,7 @@ function Navigation( {
 									onToggle={ setResponsiveMenuVisibility }
 									hasIcon={ hasIcon }
 									icon={ icon }
+									overlayButtonLabel={ overlayButtonLabel }
 									isOpen={ isResponsiveMenuOpen }
 									isResponsive={ isResponsive }
 									isHiddenByDefault={ isHiddenByDefault }

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-button.js
@@ -13,6 +13,7 @@ import OverlayMenuPreviewControls from './overlay-menu-preview-controls';
  * @param {Function} props.setOverlayMenuPreview     Function to toggle overlay menu preview.
  * @param {boolean}  props.hasIcon                   Whether the overlay menu has an icon.
  * @param {string}   props.icon                      Icon type for overlay menu.
+ * @param {string}   props.overlayButtonLabel        Text label for overlay menu button.
  * @param {Function} props.setAttributes             Function to update block attributes.
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
  * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
@@ -25,6 +26,7 @@ export default function OverlayMenuPreviewButton( {
 	setOverlayMenuPreview,
 	hasIcon,
 	icon,
+	overlayButtonLabel,
 	setAttributes,
 	overlayMenuPreviewClasses,
 	overlayMenuPreviewId,
@@ -52,7 +54,7 @@ export default function OverlayMenuPreviewButton( {
 				) }
 				{ ! hasIcon && (
 					<>
-						<span>{ __( 'Menu' ) }</span>
+						<span>{ overlayButtonLabel || __( 'Menu' ) }</span>
 						<span>{ __( 'Close' ) }</span>
 					</>
 				) }
@@ -66,6 +68,7 @@ export default function OverlayMenuPreviewButton( {
 					<OverlayMenuPreviewControls
 						hasIcon={ hasIcon }
 						icon={ icon }
+						overlayButtonLabel={ overlayButtonLabel }
 						setAttributes={ setAttributes }
 					/>
 				</VStack>

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js
@@ -1,9 +1,9 @@
 import {
-	__experimentalVStack as VStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToggleControl,
 } from '@wordpress/components';
+import { InputControl, Stack } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import OverlayMenuIcon from './overlay-menu-icon';
 
@@ -11,19 +11,21 @@ import OverlayMenuIcon from './overlay-menu-icon';
  * Overlay Menu Preview Controls component.
  * Used within PanelBody context (not ToolsPanel).
  *
- * @param {Object}   props               Component props.
- * @param {boolean}  props.hasIcon       Whether the overlay menu has an icon.
- * @param {string}   props.icon          Icon type for overlay menu.
- * @param {Function} props.setAttributes Function to update block attributes.
+ * @param {Object}   props                    Component props.
+ * @param {boolean}  props.hasIcon            Whether the overlay menu has an icon.
+ * @param {string}   props.icon               Icon type for overlay menu.
+ * @param {string}   props.overlayButtonLabel Text label for overlay menu button.
+ * @param {Function} props.setAttributes      Function to update block attributes.
  * @return {React.JSX.Element}                The overlay menu preview controls.
  */
 export default function OverlayMenuPreviewControls( {
 	hasIcon,
 	icon,
+	overlayButtonLabel,
 	setAttributes,
 } ) {
 	return (
-		<VStack spacing={ 4 }>
+		<Stack direction="column" gap={ 4 }>
 			<ToggleControl
 				label={ __( 'Show icon button' ) }
 				help={ __(
@@ -32,24 +34,39 @@ export default function OverlayMenuPreviewControls( {
 				onChange={ ( value ) => setAttributes( { hasIcon: value } ) }
 				checked={ hasIcon }
 			/>
-			<ToggleGroupControl
-				className="wp-block-navigation__overlay-menu-icon-toggle-group"
-				label={ __( 'Icon' ) }
-				value={ icon }
-				onChange={ ( value ) => setAttributes( { icon: value } ) }
-				isBlock
-			>
-				<ToggleGroupControlOption
-					value="handle"
-					aria-label={ __( 'handle' ) }
-					label={ <OverlayMenuIcon icon="handle" /> }
+			{ ! hasIcon && (
+				<InputControl
+					label={ __( 'Button label' ) }
+					value={ overlayButtonLabel || '' }
+					placeholder={ __( 'Menu' ) }
+					onValueChange={ ( value ) =>
+						setAttributes( { overlayButtonLabel: value } )
+					}
+					help={ __(
+						'Text label for the button that opens the overlay menu.'
+					) }
 				/>
-				<ToggleGroupControlOption
-					value="menu"
-					aria-label={ __( 'menu' ) }
-					label={ <OverlayMenuIcon icon="menu" /> }
-				/>
-			</ToggleGroupControl>
-		</VStack>
+			) }
+			{ hasIcon && (
+				<ToggleGroupControl
+					className="wp-block-navigation__overlay-menu-icon-toggle-group"
+					label={ __( 'Icon' ) }
+					value={ icon }
+					onChange={ ( value ) => setAttributes( { icon: value } ) }
+					isBlock
+				>
+					<ToggleGroupControlOption
+						value="handle"
+						aria-label={ __( 'handle' ) }
+						label={ <OverlayMenuIcon icon="handle" /> }
+					/>
+					<ToggleGroupControlOption
+						value="menu"
+						aria-label={ __( 'menu' ) }
+						label={ <OverlayMenuIcon icon="menu" /> }
+					/>
+				</ToggleGroupControl>
+			) }
+		</Stack>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -21,6 +21,7 @@ import OverlayPreview from './overlay-preview';
  * @param {Function} props.setOverlayMenuPreview     Function to toggle overlay menu preview.
  * @param {boolean}  props.hasIcon                   Whether the overlay menu has an icon.
  * @param {string}   props.icon                      Icon type for overlay menu.
+ * @param {string}   props.overlayButtonLabel        Text label for overlay menu button.
  * @param {string}   props.overlayMenuPreviewClasses CSS classes for overlay menu preview button.
  * @param {string}   props.overlayMenuPreviewId      ID for overlay menu preview.
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
@@ -37,6 +38,7 @@ export default function OverlayPanel( {
 	setOverlayMenuPreview,
 	hasIcon,
 	icon,
+	overlayButtonLabel,
 	overlayMenuPreviewClasses,
 	overlayMenuPreviewId,
 	isResponsive,
@@ -60,6 +62,7 @@ export default function OverlayPanel( {
 						setOverlayMenuPreview={ setOverlayMenuPreview }
 						hasIcon={ hasIcon }
 						icon={ icon }
+						overlayButtonLabel={ overlayButtonLabel }
 						setAttributes={ setAttributes }
 						overlayMenuPreviewClasses={ overlayMenuPreviewClasses }
 						overlayMenuPreviewId={ overlayMenuPreviewId }

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { close, Icon } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getColorClassName } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -19,6 +19,7 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
+	overlayButtonLabel,
 	overlay,
 	onNavigateToEntityRecord,
 } ) {
@@ -77,7 +78,7 @@ export default function ResponsiveWrapper( {
 		...( isOpen && {
 			role: 'dialog',
 			'aria-modal': true,
-			'aria-label': __( 'Menu' ),
+			'aria-label': overlayButtonLabel || __( 'Menu' ),
 		} ),
 	};
 
@@ -99,18 +100,29 @@ export default function ResponsiveWrapper( {
 		onToggle( true );
 	};
 
+	let openButtonAriaLabel;
+	if ( hasIcon ) {
+		openButtonAriaLabel = overlayButtonLabel
+			? sprintf(
+					/* translators: %s: Menu name */
+					__( 'Open %s' ),
+					overlayButtonLabel
+			  )
+			: __( 'Open menu' );
+	}
+
 	return (
 		<>
 			{ ! isOpen && (
 				<Button
 					__next40pxDefaultSize
 					aria-haspopup="true"
-					aria-label={ hasIcon && __( 'Open menu' ) }
+					aria-label={ openButtonAriaLabel }
 					className={ openButtonClasses }
 					onClick={ handleToggleClick }
 				>
 					{ hasIcon && <OverlayMenuIcon icon={ icon } /> }
-					{ ! hasIcon && __( 'Menu' ) }
+					{ ! hasIcon && ( overlayButtonLabel || __( 'Menu' ) ) }
 				</Button>
 			) }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -797,10 +797,13 @@ class WP_Navigation_Block_Renderer {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5z"></path><path d="M5 12.8h14v-1.5H5v1.5z"></path><path d="M5 19h14v-1.5H5V19z"></path></svg>';
 			}
 		}
-		$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : __( 'Menu' );
+		$overlay_button_label        = ! empty( $attributes['overlayButtonLabel'] ) ? $attributes['overlayButtonLabel'] : __( 'Menu' );
+		$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : esc_html( $overlay_button_label );
 		$toggle_close_button_icon    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
 		$toggle_close_button_content = $should_display_icon_label ? $toggle_close_button_icon : __( 'Close' );
-		$toggle_aria_label_open      = $should_display_icon_label ? 'aria-label="' . __( 'Open menu' ) . '"' : ''; // Open button label.
+		$toggle_aria_label_open      = $should_display_icon_label
+			? 'aria-label="' . esc_attr( ! empty( $attributes['overlayButtonLabel'] ) ? sprintf( /* translators: %s: Menu name */ __( 'Open %s' ), $attributes['overlayButtonLabel'] ) : __( 'Open menu' ) ) . '"'
+			: ''; // Open button label.
 		$toggle_aria_label_close     = $should_display_icon_label ? 'aria-label="' . __( 'Close menu' ) . '"' : ''; // Close button label.
 
 		// Add Interactivity API directives to the markup if needed.
@@ -920,7 +923,7 @@ class WP_Navigation_Block_Renderer {
 		$wrapper_attributes = get_block_wrapper_attributes( $extra_attributes );
 
 		if ( $is_responsive_menu ) {
-			$nav_element_directives = static::get_nav_element_directives( $is_interactive );
+			$nav_element_directives = static::get_nav_element_directives( $is_interactive, $attributes );
 			$wrapper_attributes    .= ' ' . $nav_element_directives;
 		}
 
@@ -932,13 +935,15 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param bool $is_interactive Whether the block is interactive.
+	 * @param bool  $is_interactive Whether the block is interactive.
+	 * @param array $attributes     The block attributes.
 	 * @return string the directives for the navigation element.
 	 */
-	private static function get_nav_element_directives( $is_interactive ) {
+	private static function get_nav_element_directives( $is_interactive, $attributes = array() ) {
 		if ( ! $is_interactive ) {
 			return '';
 		}
+		$overlay_button_label = ! empty( $attributes['overlayButtonLabel'] ) ? $attributes['overlayButtonLabel'] : __( 'Menu' );
 		// When adding to this array be mindful of security concerns.
 		$nav_element_context    = wp_interactivity_data_wp_context(
 			array(
@@ -949,7 +954,7 @@ class WP_Navigation_Block_Renderer {
 				),
 				'type'            => 'overlay',
 				'roleAttribute'   => '',
-				'ariaLabel'       => __( 'Menu' ),
+				'ariaLabel'       => $overlay_button_label,
 			)
 		);
 		$nav_element_directives = '

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -500,11 +500,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-library/src/navigation/edit/overlay-menu-preview-controls.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/navigation/edit/overlay-panel.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION

## What?

Closes #81935

Adds an optional `overlayButtonLabel` attribute and a settings field to the Navigation block so editors can customize the text and accessible label of the mobile overlay toggle button.

## Why?

When a page contains more than one Navigation block that collapses on mobile (such as a header menu and a footer/utility menu), all overlay buttons display the default text "Menu" and announce `aria-label="Open menu"`. 

Visitors and screen-reader users have no way to tell which button opens which menu. Allowing a custom label lets editors distinguish between multiple menus (e.g., "Primary Menu" vs. "Footer Menu").

## How?

- Added `overlayButtonLabel` (string) to `block.json`. It defaults to an empty string and falls back to `"Menu"` for 100% backward compatibility.
- Added a "Button label" input field in the Overlay settings panel (`overlay-menu-preview-controls.js`) when "Show icon button" is disabled.
- Updated `overlay-menu-preview-button.js` and `responsive-wrapper.js` to reflect the custom label in the inspector preview, the canvas toggle button, and the modal dialog landmark.
- Updated `index.php` so the server renders the custom label for text buttons, generates `aria-label="Open <Label>"` for icon buttons, and binds the custom label.

## Testing Instructions

1. Open a post or page in the editor.
2. Add two **Navigation** blocks with different links (e.g., one with main site links and one with footer links).
3. Select each Navigation block and open the **Overlay** panel in the inspector sidebar.
4. Set **Overlay Visibility** to **Mobile** (or **Always**), click the preview box to expand the controls, and turn off **Show icon button**.
5. In the **Button label** field, give each menu a unique name (e.g., "Main Menu" and "Footer Menu").
6. Verify that the inspector preview, editor canvas, and frontend mobile view show the respective custom labels instead of the default "Menu".
7. Verify that leaving the field blank continues to display and announce "Menu".


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/219cfca6-a956-47ab-b028-92347a163f7b

## Use of AI Tools

Used Gemini Flash 3.5 for drafting and review