### PR TITLE
Dynamic Gallery block: Skip transforms that expect inner blocks, e.g. Image and Grid transforms

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Bug Fixes
 
 -   Columns: Preserve individual Column attributes supported by Group, including styles and layouts, when transforming to Row or Grid.
+-   Gallery: Don't offer the Image and Grid transforms while the block is in dynamic mode, where it has no inner blocks to convert.
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 -   Playlist: Attach the inner block drop zone to the track list, so Playlist Track blocks show insertion markers while being reordered.
 -   Playlist Track: Hide the Title and Replace audio controls when multiple tracks are selected.

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Bug Fixes
 
 -   Columns: Preserve individual Column attributes supported by Group, including styles and layouts, when transforming to Row or Grid.
--   Gallery: Don't offer the Image and Grid transforms while the block is in dynamic mode, where it has no inner blocks to convert.
+-   Gallery: Don't offer the Image and Grid transforms while the block is in dynamic mode, where it has no inner blocks to convert ([#82009](https://github.com/WordPress/gutenberg/pull/82009)).
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).
 -   Playlist: Attach the inner block drop zone to the track list, so Playlist Track blocks show insertion markers while being reordered.
 -   Playlist Track: Hide the Title and Replace audio controls when multiple tracks are selected.

--- a/packages/block-library/src/gallery/test/transforms.js
+++ b/packages/block-library/src/gallery/test/transforms.js
@@ -1,6 +1,7 @@
 import {
 	createBlock,
 	getBlockTypes,
+	getPossibleBlockTransformations,
 	registerBlockType,
 	switchToBlockType,
 	unregisterBlockType,
@@ -13,6 +14,7 @@ import {
 	metadata as groupMetadata,
 	settings as groupSettings,
 } from '../../group';
+import { ATTACHED_MEDIA } from '../dynamic-source';
 
 describe( 'transforms', () => {
 	beforeAll( () => {
@@ -143,6 +145,61 @@ describe( 'transforms', () => {
 			attributes: {
 				layout: { type: 'grid', columnCount: 2 },
 			},
+		} );
+	} );
+	it( 'transforms an empty static Gallery to the Grid variation of Group', () => {
+		const block = createBlock( 'core/gallery', {}, [] );
+
+		const transformedBlocks = switchToBlockType(
+			block,
+			'core/group',
+			'group-grid'
+		);
+
+		expect( transformedBlocks[ 0 ] ).toMatchObject( {
+			name: 'core/group',
+			attributes: { layout: { type: 'grid' } },
+		} );
+	} );
+
+	describe( 'dynamic mode', () => {
+		const createDynamicGallery = () =>
+			createBlock(
+				'core/gallery',
+				{ dynamicContent: { source: ATTACHED_MEDIA } },
+				[]
+			);
+
+		it( 'does not transform a dynamic Gallery to the Grid variation of Group', () => {
+			expect(
+				switchToBlockType(
+					createDynamicGallery(),
+					'core/group',
+					'group-grid'
+				)
+			).toBeNull();
+		} );
+
+		it( 'does not transform a dynamic Gallery to Image', () => {
+			expect(
+				switchToBlockType( createDynamicGallery(), 'core/image' )
+			).toBeNull();
+		} );
+
+		it( 'does not offer the Image or Grid transforms for a dynamic Gallery', () => {
+			const transformations = getPossibleBlockTransformations( [
+				createDynamicGallery(),
+			] );
+
+			expect(
+				transformations.find( ( { name } ) => name === 'core/image' )
+			).toBeUndefined();
+			expect(
+				transformations.find(
+					( { name, variationName } ) =>
+						name === 'core/group' && variationName === 'group-grid'
+				)
+			).toBeUndefined();
 		} );
 	} );
 } );

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -225,8 +225,7 @@ const transforms = {
 			blocks: [ 'core/image' ],
 			// A dynamic gallery has no inner blocks — its images are resolved
 			// from a source at render time — so this transform would produce a
-			// single empty image and drop the source. Detaching the gallery
-			// first materializes the images, after which it applies as usual.
+			// single empty image and drop the source.
 			isMatch: ( { dynamicContent } ) => ! dynamicContent,
 			transform: ( { align }, innerBlocks ) => {
 				if ( innerBlocks.length > 0 ) {

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -223,6 +223,11 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
+			// A dynamic gallery has no inner blocks — its images are resolved
+			// from a source at render time — so this transform would produce a
+			// single empty image and drop the source. Detaching the gallery
+			// first materializes the images, after which it applies as usual.
+			isMatch: ( { dynamicContent } ) => ! dynamicContent,
 			transform: ( { align }, innerBlocks ) => {
 				if ( innerBlocks.length > 0 ) {
 					return innerBlocks.map(
@@ -268,12 +273,16 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/group' ],
 			variationName: 'group-grid',
+			// As above: with no inner blocks to clone, a dynamic gallery would
+			// transform into an empty grid.
+			isMatch: ( { dynamicContent } ) => ! dynamicContent,
 			transform: ( attributes, innerBlocks ) => {
 				const {
 					allowResize,
 					aspectRatio,
 					caption,
 					columns,
+					dynamicContent,
 					fixedHeight,
 					ids,
 					imageCrop,


### PR DESCRIPTION
## What?

For the Dynamic Gallery block variation, skip the block transforms that aren't applicable to this mode, that is, those that expect inner blocks.

## Why?

Some of the transforms (e.g. Group, Columns) simply wrap the Gallery block, so those work pretty well for the Dynamic Gallery block variation. However, for the Image and Grid transforms, they expect to replace the inner blocks (individual image blocks) and so depend on inner blocks.

For these cases, the user can achieve the transform by first detaching the dynamic gallery block. Rather than attempt to automate that in these transforms, I'm proposing we just hide/skip these transforms when the gallery block is in dynamic mode. The "Detach" button is already available, and this keeps the logic simple.

## How?

* Add `isMatch` checks for the image and grid transforms for the Gallery block, to check that the Gallery block isn't in its dynamic mode

## Testing Instructions

* Upload a few images to a post
* Add a Gallery block and select the "Use attached images" option to switch to the Dynamic Gallery block variation
* With the Dynamic Gallery selected, take a look at the available transforms, you should see Group, Columns, and Details available
* Now, detach the Dynamic Gallery by using the Detach button in the block toolbar
* With that done, and the gallery now being a static set of images, click the block transform button again, and you should see "Image" and "Grid" transforms available in the list, too

## Screenshots or screencast <!-- if applicable -->

### Dynamic Gallery block transforms

<img width="1364" height="862" alt="image" src="https://github.com/user-attachments/assets/62f7b3b2-692a-48cb-b1ba-e4733ccdfad4" />

### Static Gallery block transforms

<img width="1446" height="834" alt="image" src="https://github.com/user-attachments/assets/cb987c04-f689-49c5-affe-fa6e4e5163bb" />

## Use of AI Tools

Claude Code (Opus 5)