### PR TITLE
Font Library: Keep CSS custom properties unquoted in font previews

### DIFF
--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Font Library: Leave a `var()` custom property unquoted in the font previews, so a theme that sets `fontFamily` to a custom property previews in the right font ([#82010](https://github.com/WordPress/gutenberg/pull/82010)).
 -   Revisions: close the screen on the first click of the back arrow after a revision has been selected, instead of requiring a second click ([#81897](https://github.com/WordPress/gutenberg/pull/81897)).
 -   Revisions: close the screen after applying a revision, which stopped happening when the screen moved into this package ([#81897](https://github.com/WordPress/gutenberg/pull/81897)).
 -   Color palette panel: do not render the theme colors wrapper when the theme provides no colors, which left an empty gap above the Custom section ([#81894](https://github.com/WordPress/gutenberg/pull/81894)).

--- a/packages/global-styles-ui/src/font-library/utils/preview-styles.ts
+++ b/packages/global-styles-ui/src/font-library/utils/preview-styles.ts
@@ -75,6 +75,7 @@ export function formatFontFamily( input: string ) {
 	// custom property such as `var(--wp--preset--font-family--body)`. The last
 	// two are CSS function calls rather than names, so quoting either one
 	// would stop it resolving.
+	// TODO: The regex was scoped to `var(--name )` and not things like `var(--name, fallback)`. That'll require more string parsing.
 	const regex =
 		/^(?!generic\([ a-zA-Z\-]+\)$)(?!var\(\s*--[\w-]+\s*\)$)(?!^[a-zA-Z\-]+$).+/;
 	const output = input.trim();

--- a/packages/global-styles-ui/src/font-library/utils/preview-styles.ts
+++ b/packages/global-styles-ui/src/font-library/utils/preview-styles.ts
@@ -63,13 +63,20 @@ function resolveFontWeight( fontWeight: FontFace[ 'fontWeight' ] ): string {
  *
  * Example:
  * formatFontFamily( "Open Sans, Font+Name, sans-serif" ) => '"Open Sans", "Font+Name", sans-serif'
- * formatFontFamily( "'Open Sans', generic(kai), sans-serif" ) => '"Open Sans", sans-serif'
- * formatFontFamily( "DotGothic16, Slabo 27px, serif" ) => '"DotGothic16","Slabo 27px",serif'
- * formatFontFamily( "Mine's, Moe's Typography" ) => `"mine's","Moe's Typography"`
+ * formatFontFamily( "'Open Sans', generic(kai), sans-serif" ) => '"Open Sans", generic(kai), sans-serif'
+ * formatFontFamily( "DotGothic16, Slabo 27px, serif" ) => '"DotGothic16", "Slabo 27px", serif'
+ * formatFontFamily( "Mine's, Moe's Typography" ) => `"Mine's", "Moe's Typography"`
+ * formatFontFamily( "var(--my-font), sans-serif" ) => 'var(--my-font), sans-serif'
  */
 export function formatFontFamily( input: string ) {
-	// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
-	const regex = /^(?!generic\([ a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/;
+	// Matches anything that has to be quoted to be a valid font family name.
+	// Left alone: a bare run of letters and hyphens, which covers the generic
+	// keywords such as `sans-serif`; `generic(kai)`; and a reference to a
+	// custom property such as `var(--wp--preset--font-family--body)`. The last
+	// two are CSS function calls rather than names, so quoting either one
+	// would stop it resolving.
+	const regex =
+		/^(?!generic\([ a-zA-Z\-]+\)$)(?!var\(\s*--[\w-]+\s*\)$)(?!^[a-zA-Z\-]+$).+/;
 	const output = input.trim();
 
 	const formatItem = ( item: string ) => {

--- a/packages/global-styles-ui/src/font-library/utils/test/preview-styles.js
+++ b/packages/global-styles-ui/src/font-library/utils/test/preview-styles.js
@@ -1,4 +1,8 @@
-import { getFacePreviewStyle, getFamilyPreviewStyle } from '../preview-styles';
+import {
+	formatFontFamily,
+	getFacePreviewStyle,
+	getFamilyPreviewStyle,
+} from '../preview-styles';
 
 describe( 'getFacePreviewStyle', () => {
 	it.each( [
@@ -51,5 +55,40 @@ describe( 'getFamilyPreviewStyle', () => {
 				fontWeight: '400',
 			} )
 		);
+	} );
+} );
+
+describe( 'formatFontFamily', () => {
+	it.each( [
+		// A reference to a custom property is a CSS function call, so it is
+		// left as it is rather than quoted like a font name.
+		[
+			'var(--wp--preset--font-family--body)',
+			'var(--wp--preset--font-family--body)',
+		],
+		[ 'var(--my-font), sans-serif', 'var(--my-font), sans-serif' ],
+		[ 'Open Sans, var(--my-font)', '"Open Sans", var(--my-font)' ],
+		// CSS allows whitespace inside the parentheses.
+		[ 'var( --my-font )', 'var( --my-font )' ],
+		// Not a custom property: a `var()` reference has to start with `--`.
+		[ 'var(myfont)', '"var(myfont)"' ],
+		// Names and keywords are unaffected.
+		[
+			'Open Sans, Font+Name, sans-serif',
+			'"Open Sans", "Font+Name", sans-serif',
+		],
+		[ 'sans-serif', 'sans-serif' ],
+		[ 'generic(kai), sans-serif', 'generic(kai), sans-serif' ],
+		[
+			"'Open Sans', generic(kai), sans-serif",
+			'"Open Sans", generic(kai), sans-serif',
+		],
+		[
+			'DotGothic16, Slabo 27px, serif',
+			'"DotGothic16", "Slabo 27px", serif',
+		],
+		[ "Mine's, Moe's Typography", '"Mine\'s", "Moe\'s Typography"' ],
+	] )( 'formats %p as %p', ( input, expected ) => {
+		expect( formatFontFamily( input ) ).toBe( expected );
 	} );
 } );


### PR DESCRIPTION
## What?

`formatFontFamily` quoted a `var()` value, turning a CSS function call into a font name, so a theme that sets a font family to a custom property previewed in the fallback font. Maybe supersedes #69926.

Props to @nextend for getting it started.

## Testing Instructions

1. In a block theme, point a font family at a custom property in `theme.json`:

```json
{
	"settings": {
		"typography": {
			"fontFamilies": [
				{
					"name": "Body font",
					"slug": "body-font",
					"fontFamily": "var(--wp--preset--font-family--body)"
				}
			]
		}
	}
}
```

2. Open the Site Editor and go to Styles → Typography → Fonts.
3. Inspect the preview for that font.
4. Expected: `font-family: var(--wp--preset--font-family--body)`, unquoted, and the preview renders in the themed font.
5. Before this change: `font-family: "var(--wp--preset--font-family--body)"`, and the preview renders in the fallback font.
6. Check the other font previews (Styles → Typography, the font family list, and the Font Library modal) are unchanged.

| Before | After |
|--------|--------|
| <img width="830" height="603" alt="Screenshot 2026-08-25 at 4 05 16 pm" src="https://github.com/user-attachments/assets/063b23ed-938d-4579-872e-aedf27b5e225" /> | <img width="843" height="668" alt="Screenshot 2026-08-25 at 4 05 01 pm" src="https://github.com/user-attachments/assets/190bb59c-6dbd-49f6-a4e6-7c7d2157266d" /> | 




