### PR TITLE
List: outdent an empty middle item without adding an item

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -5,12 +5,8 @@ import { cloneBlock } from '@wordpress/blocks';
 
 export default function useOutdentListItem() {
 	const registry = useRegistry();
-	const {
-		moveBlocksToPosition,
-		removeBlock,
-		insertBlock,
-		updateBlockListSettings,
-	} = useDispatch( blockEditorStore );
+	const { moveBlocksToPosition, removeBlock, removeBlocks, insertBlock } =
+		useDispatch( blockEditorStore );
 	const {
 		getBlockRootClientId,
 		getBlockName,
@@ -18,7 +14,6 @@ export default function useOutdentListItem() {
 		getBlockIndex,
 		getSelectedBlockClientIds,
 		getBlock,
-		getBlockListSettings,
 	} = useSelect( blockEditorStore );
 
 	function getParentListItemId( id ) {
@@ -65,29 +60,28 @@ export default function useOutdentListItem() {
 
 		registry.batch( () => {
 			if ( followingListItems.length ) {
-				let nestedListId = getBlockOrder( firstClientId )[ 0 ];
+				const nestedListId = getBlockOrder( firstClientId )[ 0 ];
 
-				if ( ! nestedListId ) {
+				if ( nestedListId ) {
+					moveBlocksToPosition(
+						followingListItems,
+						parentListId,
+						nestedListId
+					);
+				} else {
+					// Insert the list with the items already inside: an
+					// empty list would be scaffolded with the list block
+					// type's template at insertion.
 					const nestedListBlock = cloneBlock(
 						getBlock( parentListId ),
 						{},
-						[]
+						followingListItems.map( ( id ) =>
+							cloneBlock( getBlock( id ) )
+						)
 					);
-					nestedListId = nestedListBlock.clientId;
+					removeBlocks( followingListItems, false );
 					insertBlock( nestedListBlock, 0, firstClientId, false );
-					// Immediately update the block list settings, otherwise
-					// blocks can't be moved here due to canInsert checks.
-					updateBlockListSettings(
-						nestedListId,
-						getBlockListSettings( parentListId )
-					);
 				}
-
-				moveBlocksToPosition(
-					followingListItems,
-					parentListId,
-					nestedListId
-				);
 			}
 			moveBlocksToPosition(
 				clientIds,

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -71,13 +71,13 @@ export default function useOutdentListItem() {
 				} else {
 					// Insert the list with the items already inside: an
 					// empty list would be scaffolded with the list block
-					// type's template at insertion.
+					// type's template at insertion. Removing the items
+					// first frees them to be reinserted with their client
+					// IDs kept.
 					const nestedListBlock = cloneBlock(
 						getBlock( parentListId ),
 						{},
-						followingListItems.map( ( id ) =>
-							cloneBlock( getBlock( id ) )
-						)
+						followingListItems.map( ( id ) => getBlock( id ) )
 					);
 					removeBlocks( followingListItems, false );
 					insertBlock( nestedListBlock, 0, firstClientId, false );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1099,6 +1099,68 @@ test.describe( 'List (@firefox)', () => {
 		// the list. ;)
 	} );
 
+	test( 'should outdent an empty middle item without adding an item', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=document[name="Add default block"i]' )
+			.click();
+
+		await page.keyboard.type( '* a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' b' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'c' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>c</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
+		await page.keyboard.press( 'Backspace' );
+		// Type to also verify the caret stays in the outdented item.
+		await page.keyboard.type( 'x' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>x<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>c</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+	} );
+
 	test( 'should place the caret in the right place with nested list', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Fixes Backspace in an empty nested list item leaving an extra empty item behind.

## Why?

Outdenting an item with following siblings inserted an empty list into the item and moved the siblings in afterwards. Since #80027, inserting an empty list scaffolds it with the list block type's template, so the item gained a fresh empty child item before the siblings arrived.

## How?

`useOutdentListItem` builds the helper list with the items already inside and inserts it populated, the way indenting already does. The `updateBlockListSettings` workaround for the two-step insert falls away.

## Testing Instructions

1. Create a nested list: `a` with children `b`, an empty item, and `c`.
2. Place the caret in the empty item and press Backspace.
3. The empty item is outdented with `c` nested under it, and no extra empty item appears.

Covered by a new e2e test.

### Testing Instructions for Keyboard

Same as above.

## Screenshots or screencast

## Use of AI Tools

Written with Claude Code, reviewed and tested by me.
