### PR TITLE
Lint: Prevent private API imports in all bundled packages

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### Internal
 
+-   Restrict `@wordpress/private-apis` imports via lint, with the `ThemeProvider` compatibility fallback as the only exemption. ([#82015](https://github.com/WordPress/gutenberg/pull/82015))
 -   Update `@base-ui/react` from `1.6.0` to `1.7.0`. ([#81390](https://github.com/WordPress/gutenberg/pull/81390))
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))

--- a/packages/ui/src/lock-unlock.ts
+++ b/packages/ui/src/lock-unlock.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- Exists solely for the ThemeProvider compatibility fallback in utils/theme-provider.ts. Remove in WordPress 7.3.
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 export const { lock, unlock } =

--- a/packages/ui/src/utils/theme-provider.ts
+++ b/packages/ui/src/utils/theme-provider.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports -- Temporary compatibility fallback for older @wordpress/theme runtimes. Remove in WordPress 7.3.
 import * as theme from '@wordpress/theme';
+// eslint-disable-next-line no-restricted-imports -- Temporary compatibility fallback for older @wordpress/theme runtimes. Remove in WordPress 7.3.
 import { unlock } from '../lock-unlock';
 
 type ThemeProviderComponent = typeof theme.ThemeProvider;

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -69,6 +69,16 @@ const typedFiles = glob( 'packages/*/package.json', { cwd: rootDir } )
 	.filter( ( fileName ) => require( join( rootDir, fileName ) ).types )
 	.map( ( fileName ) => fileName.replace( 'package.json', '**/*.js' ) );
 
+// All files from bundled packages: packages not registered as WordPress
+// scripts or script modules, which plugins therefore compile into their own
+// bundles when importing them via npm.
+const bundledPackageFiles = glob( 'packages/*/package.json', { cwd: rootDir } )
+	.filter( ( fileName ) => {
+		const pkg = require( join( rootDir, fileName ) );
+		return ! pkg.wpScript && ! pkg.wpScriptModuleExports;
+	} )
+	.map( ( fileName ) => fileName.replace( 'package.json', '**' ) );
+
 const restrictedImports = [
 	{
 		name: 'framer-motion',
@@ -127,6 +137,21 @@ const restrictedImports = [
 	},
 ];
 
+// Restrictions applied to every bundled package: a plugin bundling such a
+// package compiles a second copy of private-apis, which cannot unlock objects
+// locked by the WordPress copy and throws at runtime. Existing usage is
+// grandfathered in `tools/eslint/suppressions.json` and may only shrink.
+const privateApisRestrictedImport = {
+	name: '@wordpress/private-apis',
+	message:
+		'Bundled packages may be compiled into plugin bundles via npm, where a second copy of private-apis cannot unlock objects locked by the WordPress copy and throws at runtime.',
+};
+const lockUnlockRestrictedPattern = {
+	group: [ '**/lock-unlock' ],
+	message:
+		'This module wraps @wordpress/private-apis, which bundled packages must not depend on: a plugin bundling this package compiles a second copy of private-apis that cannot unlock objects locked by the WordPress copy and throws at runtime.',
+};
+
 const useIsomorphicLayoutEffectRestrictedImport = {
 	name: '@wordpress/element',
 	importNames: [ 'useLayoutEffect' ],
@@ -144,8 +169,12 @@ const UI_RESTRICTED_IMPORTS = {
 			( { name } ) => name !== '@base-ui/react'
 		),
 		useIsomorphicLayoutEffectRestrictedImport,
+		// `@wordpress/ui` is a bundled package, but its overrides below would
+		// replace the bundled-packages override, so the restriction is
+		// re-applied here.
+		privateApisRestrictedImport,
 	],
-	patterns: [],
+	patterns: [ lockUnlockRestrictedPattern ],
 };
 
 const restrictedSyntax = [
@@ -844,21 +873,30 @@ export default dedupePlugins( [
 		},
 	},
 
-	// Override: dataviews — restrict private-apis imports.
+	// Override: bundled packages — restrict private-apis imports, both direct
+	// and via each package's local `lock-unlock` wrapper module.
+	// `packages/ui` is excluded because this entry would replace its more
+	// specific overrides above; it gets the same restriction through
+	// `UI_RESTRICTED_IMPORTS`. `packages/e2e-test-utils-playwright` is
+	// excluded so its own `no-restricted-imports` override above (uuid) keeps
+	// applying; as Node-only test tooling it cannot hit this hazard.
 	{
-		files: [ 'packages/dataviews/**' ],
+		files: bundledPackageFiles.filter(
+			( files ) =>
+				! [
+					'packages/ui/**',
+					'packages/e2e-test-utils-playwright/**',
+				].includes( files )
+		),
 		rules: {
 			'no-restricted-imports': [
 				'error',
 				{
 					paths: [
 						...restrictedImports,
-						{
-							name: '@wordpress/private-apis',
-							message:
-								'dataviews is a bundled package that plugins may import via npm, where a second copy of private-apis cannot unlock objects locked by the WordPress copy and throws at runtime.',
-						},
+						privateApisRestrictedImport,
 					],
+					patterns: [ lockUnlockRestrictedPattern ],
 				},
 			],
 		},

--- a/tools/eslint/config.mjs
+++ b/tools/eslint/config.mjs
@@ -147,7 +147,7 @@ const privateApisRestrictedImport = {
 		'Bundled packages may be compiled into plugin bundles via npm, where a second copy of private-apis cannot unlock objects locked by the WordPress copy and throws at runtime.',
 };
 const lockUnlockRestrictedPattern = {
-	group: [ '**/lock-unlock' ],
+	group: [ '**/lock-unlock', '**/lock-unlock.*' ],
 	message:
 		'This module wraps @wordpress/private-apis, which bundled packages must not depend on: a plugin bundling this package compiles a second copy of private-apis that cannot unlock objects locked by the WordPress copy and throws at runtime.',
 };

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -2031,19 +2031,9 @@
 			"count": 2
 		}
 	},
-	"packages/ui/src/lock-unlock.ts": {
-		"no-restricted-imports": {
-			"count": 1
-		}
-	},
 	"packages/ui/src/utils/test/use-deprioritized-initial-focus.test.tsx": {
 		"react-hooks/refs": {
 			"count": 2
-		}
-	},
-	"packages/ui/src/utils/theme-provider.ts": {
-		"no-restricted-imports": {
-			"count": 1
 		}
 	},
 	"packages/ui/src/utils/use-schedule-validation.ts": {

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -1,4 +1,14 @@
 {
+	"packages/admin-ui/src/lock-unlock.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/admin-ui/src/stories/with-router.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/block-directory/src/components/downloadable-blocks-panel/no-results.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1397,6 +1407,14 @@
 	"packages/fields/src/actions/delete-post.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
+		},
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/fields/src/actions/duplicate-pattern.tsx": {
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/fields/src/actions/duplicate-post.tsx": {
@@ -1412,6 +1430,9 @@
 	"packages/fields/src/actions/rename-post.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
+		},
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/fields/src/actions/reorder-page.tsx": {
@@ -1438,6 +1459,9 @@
 		"@wordpress/use-recommended-components": {
 			"count": 3
 		},
+		"no-restricted-imports": {
+			"count": 1
+		},
 		"react-hooks/refs": {
 			"count": 7
 		}
@@ -1457,6 +1481,11 @@
 			"count": 2
 		}
 	},
+	"packages/fields/src/fields/page-title/view.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/fields/src/fields/parent/parent-edit.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
@@ -1465,6 +1494,16 @@
 	"packages/fields/src/fields/password/edit.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
+		}
+	},
+	"packages/fields/src/fields/pattern-sync-status/index.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/fields/src/fields/pattern-title/view.tsx": {
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/fields/src/fields/ping-status/index.tsx": {
@@ -1495,8 +1534,23 @@
 			"count": 1
 		}
 	},
+	"packages/fields/src/fields/template/hooks.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/fields/src/fields/template/template-edit.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/fields/src/fields/title/view.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		}
+	},
+	"packages/fields/src/lock-unlock.ts": {
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -1536,8 +1590,26 @@
 			"count": 2
 		}
 	},
+	"packages/global-styles-engine/src/lock-unlock.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-engine/src/private-apis.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/background-panel.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/global-styles-ui/src/block-preview-panel.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		},
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -1553,6 +1625,11 @@
 	},
 	"packages/global-styles-ui/src/color-preview.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/dimensions-panel.tsx": {
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -1604,6 +1681,9 @@
 	"packages/global-styles-ui/src/font-library/modal.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
+		},
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/font-library/upload-fonts.tsx": {
@@ -1631,6 +1711,11 @@
 			"count": 1
 		}
 	},
+	"packages/global-styles-ui/src/lock-unlock.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/global-styles-ui/src/navigation-button.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
@@ -1654,10 +1739,16 @@
 	"packages/global-styles-ui/src/presets/preset-edit-header.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 2
+		},
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/presets/preset-group.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		},
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -1676,18 +1767,32 @@
 			"count": 1
 		}
 	},
+	"packages/global-styles-ui/src/root-menu.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/global-styles-ui/src/screen-background.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		},
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/screen-block-list.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
+		},
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/screen-block.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		},
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
@@ -1699,16 +1804,35 @@
 	"packages/global-styles-ui/src/screen-colors.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
+		},
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/screen-css.tsx": {
 		"@wordpress/use-recommended-components": {
+			"count": 1
+		},
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/screen-header.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 6
+		},
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/screen-layout.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/screen-revisions/revisions-buttons.tsx": {
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/screen-root.tsx": {
@@ -1759,6 +1883,16 @@
 	"packages/global-styles-ui/src/typography-elements.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 3
+		}
+	},
+	"packages/global-styles-ui/src/typography-panel.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/global-styles-ui/src/utils.ts": {
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/global-styles-ui/src/variations/variations-color.tsx": {
@@ -1815,6 +1949,16 @@
 		},
 		"@wordpress/use-recommended-components": {
 			"count": 2
+		}
+	},
+	"packages/media-editor/src/lock-unlock.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/media-editor/src/private-apis.ts": {
+		"no-restricted-imports": {
+			"count": 1
 		}
 	},
 	"packages/media-fields/src/alt_text/index.tsx": {
@@ -1887,13 +2031,58 @@
 			"count": 2
 		}
 	},
+	"packages/ui/src/lock-unlock.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/ui/src/utils/test/use-deprioritized-initial-focus.test.tsx": {
 		"react-hooks/refs": {
 			"count": 2
 		}
 	},
+	"packages/ui/src/utils/theme-provider.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
 	"packages/ui/src/utils/use-schedule-validation.ts": {
 		"react-hooks/refs": {
+			"count": 1
+		}
+	},
+	"packages/views/src/lock-unlock.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/views/src/use-view-config.ts": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/widget-dashboard/src/components/actions-menu/actions-menu.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/widget-dashboard/src/components/commands/commands.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/widget-dashboard/src/components/widget-actions/widget-actions.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/widget-dashboard/src/components/widget-layout-controls/widget-layout-controls.tsx": {
+		"no-restricted-imports": {
+			"count": 1
+		}
+	},
+	"packages/widget-dashboard/src/lock-unlock.ts": {
+		"no-restricted-imports": {
 			"count": 1
 		}
 	},


### PR DESCRIPTION
## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/81478#issuecomment-5374142785

This PR extends the restriction from #81478 to every bundled package (packages with neither `wpScript` nor `wpScriptModuleExports`), so private API usage can't creep into any package that plugins may bundle via npm. Besides the direct `@wordpress/private-apis` imports, the rule also restricts the relative `lock-unlock` imports, so new usages inside packages that already use private APIs are blocked too.

The existing usages (43 across 8 packages) are suppressed in `tools/eslint/suppressions.json`, so they can only go down. `ui` and `e2e-test-utils-playwright` are excluded from the shared override because they have their own `no-restricted-imports` overrides, `ui` gets the same restriction through `UI_RESTRICTED_IMPORTS`.

## Testing Instructions
1. Add `import { unlock } from './lock-unlock';` to a file in `packages/fields/src` that doesn't already import it and run `npm run lint:js -- <the file>`. It should error.
2. Do the same in a file in `packages/ui/src` with `import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';`. It should error.
3. Without changes, `npm run lint:js` should be 🟢.


## Use of AI Tools
Generated with Fable 5 and adjusted/reviewed manually.