### PR TITLE
Core Data: Discard entity record edits once the document stops referencing them

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#81809](https://github.com/WordPress/gutenberg/pull/81809)).
 -   Allow keyless entities to be addressed without a record ID in the entity record selectors and actions ([#81857](https://github.com/WordPress/gutenberg/pull/81857)).
+-   Discard the edits of an entity record once the document stops referencing it, so removing a navigation, pattern, or template part block no longer leaves the record it referenced listed as an unsaved change. Undoing the removal restores the edits along with the block ([#58892](https://github.com/WordPress/gutenberg/issues/58892)).
+-   Drop the edits of an entity record when the record is removed from the state, so a deleted record's edits are no longer kept for the rest of the session ([#58892](https://github.com/WordPress/gutenberg/issues/58892)).
 
 ### Internal
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -19,6 +19,12 @@ import {
 	getRawValue,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from './utils/crdt';
+import {
+	findReferencedEntityRecords,
+	getEntityReferenceKey,
+	isBlockReferencedEntity,
+} from './entity-block-references';
+import { getCachedBlocks } from './parsed-blocks-cache';
 
 function addTitleToAutoDraft( record ) {
 	return record.status === 'auto-draft' ? { ...record, title: '' } : record;
@@ -425,6 +431,111 @@ export const deleteEntityRecord =
 	};
 
 /**
+ * Discards the edits of every entity record that the given document stopped
+ * referencing.
+ *
+ * The discarded edits are staged onto the undo level the removal itself
+ * creates, so undoing the removal brings them back with the block.
+ *
+ * @param {Array} previousBlocks The document's block tree before the edit.
+ * @param {Array} nextBlocks     The document's block tree after the edit.
+ */
+const discardEditsForRemovedEntityReferences =
+	( previousBlocks, nextBlocks ) =>
+	( { select, dispatch } ) => {
+		const candidates = select
+			.__experimentalGetDirtyEntityRecords()
+			.filter( ( { kind, name } ) =>
+				isBlockReferencedEntity( kind, name )
+			);
+
+		if ( ! candidates.length ) {
+			return;
+		}
+
+		const context = { theme: select.getCurrentTheme()?.stylesheet };
+		const candidatesByKey = new Map(
+			candidates.map( ( candidate ) => [
+				getEntityReferenceKey(
+					candidate.kind,
+					candidate.name,
+					candidate.key
+				),
+				candidate,
+			] )
+		);
+		const keys = new Set( candidatesByKey.keys() );
+
+		const stillReferenced = findReferencedEntityRecords(
+			nextBlocks,
+			keys,
+			context
+		);
+		const unreferenced = new Set(
+			[ ...keys ].filter( ( key ) => ! stillReferenced.has( key ) )
+		);
+
+		if ( ! unreferenced.size ) {
+			return;
+		}
+
+		const wasReferenced = findReferencedEntityRecords(
+			previousBlocks,
+			unreferenced,
+			context
+		);
+
+		for ( const referenceKey of wasReferenced ) {
+			const {
+				kind,
+				name,
+				key: recordId,
+			} = candidatesByKey.get( referenceKey );
+			const edits = select.getEntityRecordEdits( kind, name, recordId );
+
+			if ( ! edits ) {
+				continue;
+			}
+
+			const editedRecord = select.getEditedEntityRecord(
+				kind,
+				name,
+				recordId
+			);
+			const editedKeys = Object.keys( edits );
+
+			// Staged, so the undo manager merges it into the undo level the
+			// block removal just created instead of adding one of its own.
+			select.getUndoManager().addRecord(
+				[
+					{
+						id: { kind, name, recordId },
+						changes: Object.fromEntries(
+							editedKeys.map( ( key ) => [
+								key,
+								{ from: editedRecord[ key ], to: undefined },
+							] )
+						),
+					},
+				],
+				true
+			);
+
+			// Dispatched directly rather than through `editEntityRecord` so
+			// that discarding an edit is not itself synchronized as one.
+			dispatch( {
+				type: 'EDIT_ENTITY_RECORD',
+				kind,
+				name,
+				recordId,
+				edits: Object.fromEntries(
+					editedKeys.map( ( key ) => [ key, undefined ] )
+				),
+			} );
+		}
+	};
+
+/**
  * Returns an action object that triggers an
  * edit to an entity record.
  *
@@ -532,6 +643,24 @@ export const editEntityRecord =
 			type: 'EDIT_ENTITY_RECORD',
 			...edit,
 		} );
+
+		if ( Array.isArray( edits.blocks ) ) {
+			// `blocks` only lives in the edits, so before the first block edit
+			// the previous tree is the one the entity hook parsed from the
+			// content and shared through the cache.
+			const previousBlocks = Array.isArray( editedRecord.blocks )
+				? editedRecord.blocks
+				: getCachedBlocks( kind, name, recordId, record?.content );
+
+			if ( previousBlocks ) {
+				dispatch(
+					discardEditsForRemovedEntityReferences(
+						previousBlocks,
+						edits.blocks
+					)
+				);
+			}
+		}
 	};
 
 /**

--- a/packages/core-data/src/entity-block-references.js
+++ b/packages/core-data/src/entity-block-references.js
@@ -1,0 +1,123 @@
+/**
+ * Blocks that do not carry their content in the document. They store a
+ * reference to an entity record and read the content from it, so the edits a
+ * user makes "inside" one of these blocks belong to the referenced record
+ * rather than to the document being edited.
+ *
+ * `getRecordId` receives the block attributes and a context object holding the
+ * pieces of state a reference may need to resolve — currently only the active
+ * theme's stylesheet, which template parts combine with their slug.
+ *
+ * @type {Record<string, {kind: string, name: string, getRecordId: Function}>}
+ */
+const ENTITY_BLOCK_REFERENCES = {
+	'core/block': {
+		kind: 'postType',
+		name: 'wp_block',
+		getRecordId: ( attributes ) => attributes?.ref,
+	},
+	'core/navigation': {
+		kind: 'postType',
+		name: 'wp_navigation',
+		getRecordId: ( attributes ) => attributes?.ref,
+	},
+	'core/template-part': {
+		kind: 'postType',
+		name: 'wp_template_part',
+		getRecordId: ( attributes, { theme } ) => {
+			const stylesheet = attributes?.theme ?? theme;
+			return attributes?.slug && stylesheet
+				? `${ stylesheet }//${ attributes.slug }`
+				: undefined;
+		},
+	},
+};
+
+/**
+ * Whether any registered block references records of the given entity.
+ *
+ * @param {string} kind Entity kind.
+ * @param {string} name Entity name.
+ *
+ * @return {boolean} Whether the entity is referenced by a block.
+ */
+export function isBlockReferencedEntity( kind, name ) {
+	return Object.values( ENTITY_BLOCK_REFERENCES ).some(
+		( reference ) => reference.kind === kind && reference.name === name
+	);
+}
+
+/**
+ * Builds the key an entity record is tracked under while diffing references.
+ * Record IDs are numbers for some entities and strings for others, and the
+ * edits state keys them as strings, so the key normalises them the same way.
+ *
+ * @param {string}        kind     Entity kind.
+ * @param {string}        name     Entity name.
+ * @param {string|number} recordId Record ID.
+ *
+ * @return {string} The reference key.
+ */
+export function getEntityReferenceKey( kind, name, recordId ) {
+	return `${ kind }|${ name }|${ recordId }`;
+}
+
+/**
+ * Walks a block tree looking for references to the given entity records.
+ *
+ * The walk stops as soon as every key has been found, so passing the smallest
+ * set of keys that matters keeps the common case cheap.
+ *
+ * @param {Array}       blocks          The block tree to walk.
+ * @param {Set<string>} keys            Reference keys to look for, as built by
+ *                                      `getEntityReferenceKey`.
+ * @param {Object}      context         Context for resolving a reference.
+ * @param {string}      [context.theme] The active theme's stylesheet.
+ *
+ * @return {Set<string>} The subset of `keys` the tree references.
+ */
+export function findReferencedEntityRecords( blocks, keys, context ) {
+	const found = new Set();
+
+	if ( ! keys.size || ! Array.isArray( blocks ) ) {
+		return found;
+	}
+
+	const stack = [ ...blocks ];
+
+	while ( stack.length ) {
+		const block = stack.pop();
+
+		if ( ! block ) {
+			continue;
+		}
+
+		const reference = ENTITY_BLOCK_REFERENCES[ block.name ];
+
+		if ( reference ) {
+			const recordId = reference.getRecordId( block.attributes, context );
+
+			if ( recordId !== undefined && recordId !== null ) {
+				const key = getEntityReferenceKey(
+					reference.kind,
+					reference.name,
+					recordId
+				);
+
+				if ( keys.has( key ) ) {
+					found.add( key );
+
+					if ( found.size === keys.size ) {
+						return found;
+					}
+				}
+			}
+		}
+
+		if ( block.innerBlocks?.length ) {
+			stack.push( ...block.innerBlocks );
+		}
+	}
+
+	return found;
+}

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -255,6 +255,22 @@ function entity( entityConfig ) {
 
 						return nextState;
 
+					case 'REMOVE_ITEMS':
+						// Edits of a record that no longer exists can never be
+						// saved, and would otherwise be reported as unsaved
+						// changes for the rest of the session.
+						const remainingEdits = { ...state };
+						let hasRemovedEdits = false;
+
+						for ( const itemId of action.itemIds ?? [] ) {
+							if ( remainingEdits[ itemId ] !== undefined ) {
+								delete remainingEdits[ itemId ];
+								hasRemovedEdits = true;
+							}
+						}
+
+						return hasRemovedEdits ? remainingEdits : state;
+
 					case 'EDIT_ENTITY_RECORD':
 						const nextEdits = {
 							...state[ action.recordId ],

--- a/packages/core-data/src/test/entity-block-references.js
+++ b/packages/core-data/src/test/entity-block-references.js
@@ -1,0 +1,256 @@
+import { createRegistry } from '@wordpress/data';
+import { store as coreDataStore } from '../index';
+import {
+	findReferencedEntityRecords,
+	getEntityReferenceKey,
+	isBlockReferencedEntity,
+} from '../entity-block-references';
+
+const NAV_KEY = getEntityReferenceKey( 'postType', 'wp_navigation', 42 );
+
+function block( name, attributes = {}, innerBlocks = [] ) {
+	return {
+		clientId: name + JSON.stringify( attributes ),
+		name,
+		attributes,
+		innerBlocks,
+	};
+}
+
+describe( 'isBlockReferencedEntity', () => {
+	it( 'recognises the entities blocks reference', () => {
+		expect( isBlockReferencedEntity( 'postType', 'wp_navigation' ) ).toBe(
+			true
+		);
+		expect( isBlockReferencedEntity( 'postType', 'wp_block' ) ).toBe(
+			true
+		);
+		expect(
+			isBlockReferencedEntity( 'postType', 'wp_template_part' )
+		).toBe( true );
+	} );
+
+	it( 'does not recognise other entities', () => {
+		expect( isBlockReferencedEntity( 'postType', 'post' ) ).toBe( false );
+		expect( isBlockReferencedEntity( 'root', 'site' ) ).toBe( false );
+	} );
+} );
+
+describe( 'findReferencedEntityRecords', () => {
+	const keys = new Set( [ NAV_KEY ] );
+
+	it( 'finds a reference at the root of the tree', () => {
+		const blocks = [ block( 'core/navigation', { ref: 42 } ) ];
+
+		expect( findReferencedEntityRecords( blocks, keys, {} ) ).toEqual(
+			new Set( [ NAV_KEY ] )
+		);
+	} );
+
+	it( 'finds a reference nested in inner blocks', () => {
+		const blocks = [
+			block( 'core/group', {}, [
+				block( 'core/columns', {}, [
+					block( 'core/navigation', { ref: 42 } ),
+				] ),
+			] ),
+		];
+
+		expect( findReferencedEntityRecords( blocks, keys, {} ) ).toEqual(
+			new Set( [ NAV_KEY ] )
+		);
+	} );
+
+	it( 'ignores references to other records of the same entity', () => {
+		const blocks = [ block( 'core/navigation', { ref: 7 } ) ];
+
+		expect( findReferencedEntityRecords( blocks, keys, {} ) ).toEqual(
+			new Set()
+		);
+	} );
+
+	it( 'ignores a reference with no record ID', () => {
+		const blocks = [ block( 'core/navigation', {} ) ];
+
+		expect( findReferencedEntityRecords( blocks, keys, {} ) ).toEqual(
+			new Set()
+		);
+	} );
+
+	it( 'builds a template part reference from its slug and the active theme', () => {
+		const key = getEntityReferenceKey(
+			'postType',
+			'wp_template_part',
+			'twentytwentyfive//header'
+		);
+		const blocks = [ block( 'core/template-part', { slug: 'header' } ) ];
+
+		expect(
+			findReferencedEntityRecords( blocks, new Set( [ key ] ), {
+				theme: 'twentytwentyfive',
+			} )
+		).toEqual( new Set( [ key ] ) );
+	} );
+
+	it( "prefers the block's own theme attribute over the active theme", () => {
+		const key = getEntityReferenceKey(
+			'postType',
+			'wp_template_part',
+			'othertheme//header'
+		);
+		const blocks = [
+			block( 'core/template-part', {
+				slug: 'header',
+				theme: 'othertheme',
+			} ),
+		];
+
+		expect(
+			findReferencedEntityRecords( blocks, new Set( [ key ] ), {
+				theme: 'twentytwentyfive',
+			} )
+		).toEqual( new Set( [ key ] ) );
+	} );
+
+	it( 'returns nothing when there is nothing to look for', () => {
+		const blocks = [ block( 'core/navigation', { ref: 42 } ) ];
+
+		expect( findReferencedEntityRecords( blocks, new Set(), {} ) ).toEqual(
+			new Set()
+		);
+	} );
+} );
+
+describe( 'edits of entities removed from the document', () => {
+	let registry;
+
+	const postEntityConfig = {
+		kind: 'postType',
+		baseURL: '/wp/v2/posts',
+		name: 'post',
+		label: 'Posts',
+		transientEdits: { blocks: true, selection: true },
+		rawAttributes: [ 'title', 'excerpt', 'content' ],
+	};
+
+	const navigationEntityConfig = {
+		kind: 'postType',
+		baseURL: '/wp/v2/navigation',
+		name: 'wp_navigation',
+		label: 'Navigation Menus',
+		transientEdits: { blocks: true, selection: true },
+		rawAttributes: [ 'title', 'excerpt', 'content' ],
+	};
+
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.register( coreDataStore );
+		registry
+			.dispatch( coreDataStore )
+			.addEntities( [ postEntityConfig, navigationEntityConfig ] );
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'postType', 'post', [
+				{ id: 1, title: { raw: 'A post' }, content: { raw: '' } },
+			] );
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'postType', 'wp_navigation', [
+				{ id: 42, title: { raw: 'Main' }, content: { raw: '' } },
+			] );
+	} );
+
+	const navBlock = () => block( 'core/navigation', { ref: 42 } );
+	const paragraph = () => block( 'core/paragraph', { content: 'Hi' } );
+
+	function editNavigation() {
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord( 'postType', 'wp_navigation', 42, {
+				title: 'Main menu',
+			} );
+	}
+
+	function editPostBlocks( blocks ) {
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord( 'postType', 'post', 1, { blocks } );
+	}
+
+	const getNavigationEdits = () =>
+		registry
+			.select( coreDataStore )
+			.getEntityRecordEdits( 'postType', 'wp_navigation', 42 );
+
+	it( 'discards them when the referencing block is removed', () => {
+		editPostBlocks( [ navBlock(), paragraph() ] );
+		editNavigation();
+
+		expect( getNavigationEdits() ).toEqual( { title: 'Main menu' } );
+
+		editPostBlocks( [ paragraph() ] );
+
+		expect( getNavigationEdits() ).toEqual( {} );
+		// The navigation menu is no longer listed as an unsaved change.
+		expect(
+			registry
+				.select( coreDataStore )
+				.__experimentalGetDirtyEntityRecords()
+		).toEqual( [] );
+	} );
+
+	it( 'keeps them while another block still references the record', () => {
+		editPostBlocks( [ navBlock(), navBlock(), paragraph() ] );
+		editNavigation();
+
+		editPostBlocks( [ navBlock(), paragraph() ] );
+
+		expect( getNavigationEdits() ).toEqual( { title: 'Main menu' } );
+	} );
+
+	it( 'keeps them when the document never referenced the record', () => {
+		editPostBlocks( [ paragraph(), paragraph() ] );
+		editNavigation();
+
+		editPostBlocks( [ paragraph() ] );
+
+		expect( getNavigationEdits() ).toEqual( { title: 'Main menu' } );
+	} );
+
+	it( 'finds the reference in nested inner blocks', () => {
+		editPostBlocks( [ block( 'core/group', {}, [ navBlock() ] ) ] );
+		editNavigation();
+
+		editPostBlocks( [ block( 'core/group', {}, [] ) ] );
+
+		expect( getNavigationEdits() ).toEqual( {} );
+	} );
+
+	it( 'restores them when the removal is undone', () => {
+		editPostBlocks( [ navBlock(), paragraph() ] );
+		editNavigation();
+
+		editPostBlocks( [ paragraph() ] );
+		expect( getNavigationEdits() ).toEqual( {} );
+
+		registry.dispatch( coreDataStore ).undo();
+
+		expect( getNavigationEdits() ).toEqual( { title: 'Main menu' } );
+		expect(
+			registry
+				.select( coreDataStore )
+				.getEditedEntityRecord( 'postType', 'post', 1 ).blocks
+		).toHaveLength( 2 );
+	} );
+
+	it( 'discards them again when the removal is redone', () => {
+		editPostBlocks( [ navBlock(), paragraph() ] );
+		editNavigation();
+		editPostBlocks( [ paragraph() ] );
+
+		registry.dispatch( coreDataStore ).undo();
+		registry.dispatch( coreDataStore ).redo();
+
+		expect( getNavigationEdits() ).toEqual( {} );
+	} );
+} );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -24,6 +24,31 @@ describe( 'entities', () => {
 		} );
 	} );
 
+	it( 'drops the edits of a record that was removed', () => {
+		const originalState = deepFreeze( {
+			records: {
+				root: {
+					postType: {
+						edits: {
+							b: { title: 'beach' },
+							s: { title: 'sun' },
+						},
+					},
+				},
+			},
+		} );
+		const state = entities( originalState, {
+			type: 'REMOVE_ITEMS',
+			itemIds: [ 'b' ],
+			kind: 'root',
+			name: 'postType',
+		} );
+
+		expect( state.records.root.postType.edits ).toEqual( {
+			s: { title: 'sun' },
+		} );
+	} );
+
 	it( 'returns with received post types by slug', () => {
 		const originalState = deepFreeze( {} );
 		const state = entities( originalState, {


### PR DESCRIPTION
## What?
Closes #58892

Some blocks carry no content of their own, Navigation, Pattern (`core/block`), and Template Part store a reference to another entity record and read their content from it. The edits a user makes "inside" one of those blocks are therefore stored as edits of the *referenced* record, not of the document.

Nothing dropped those edits when the referencing block left the document. This PR handles that in `core-data`: when an edit replaces a document's block tree, any block-referenced record that the previous tree referenced and the next one no longer does has its edits discarded.

It also fixes a second, related leak in the same reducer: the `edits` sub-reducer never handled `REMOVE_ITEMS`, so a record's edits survived the record itself being deleted

## Testing Instructions
1. Open a new post.
2. Insert a Navigation block and pick or create a menu.
3. Customise the menu, add a link, or rename it from the block inspector.
4. Select the Navigation block and delete it.
5. Type something into a paragraph.
6. Click **Save**.
7. **Expected:** the changes panel lists only the post. On `trunk` it also lists the navigation menu you deleted.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/7352d8ba-bd52-4fe8-b946-1eda33dd5432

## Use of AI Tools
This PR was helped with Claude Opus.