### PR TITLE
Storybook: Add missing @types/jest devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54381,6 +54381,7 @@
 				"@storybook/icons": "^2.0.1",
 				"@storybook/react-vite": "^10.5.3",
 				"@types/babel__core": "^7.20.5",
+				"@types/jest": "^30.0.0",
 				"@types/js-yaml": "^3.12.10",
 				"@types/react": "^18.3.27",
 				"@vitejs/plugin-react": "^6.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54342,29 +54342,6 @@
 				"dequal": "^2.0.3"
 			}
 		},
-		"routes/theme-preview": {
-			"name": "@wordpress/theme-preview-route",
-			"version": "1.0.0",
-			"extraneous": true,
-			"dependencies": {
-				"@wordpress/admin-ui": "file:../../packages/admin-ui",
-				"@wordpress/api-fetch": "file:../../packages/api-fetch",
-				"@wordpress/components": "file:../../packages/components",
-				"@wordpress/compose": "file:../../packages/compose",
-				"@wordpress/core-data": "file:../../packages/core-data",
-				"@wordpress/data": "file:../../packages/data",
-				"@wordpress/editor": "file:../../packages/editor",
-				"@wordpress/element": "file:../../packages/element",
-				"@wordpress/html-entities": "file:../../packages/html-entities",
-				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/icons": "file:../../packages/icons",
-				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
-				"@wordpress/route": "file:../../packages/route",
-				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
-				"@wordpress/ui": "file:../../packages/ui",
-				"@wordpress/url": "file:../../packages/url"
-			}
-		},
 		"storybook": {
 			"name": "@wordpress/storybook",
 			"version": "0.0.0",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -35,6 +35,7 @@
 		"@storybook/icons": "^2.0.1",
 		"@storybook/react-vite": "^10.5.3",
 		"@types/babel__core": "^7.20.5",
+		"@types/jest": "^30.0.0",
 		"@types/js-yaml": "^3.12.10",
 		"@types/react": "^18.3.27",
 		"@vitejs/plugin-react": "^6.0.5",


### PR DESCRIPTION
## What?
Follow up to #81867 (see https://github.com/WordPress/gutenberg/pull/81867#discussion_r3831272880).

Adds the missing `@types/jest` devDependency to the `storybook` workspace.

## Why?
`storybook/tsconfig.json` sets `"types": [ "jest" ]`, but the package never declared `@types/jest`, so the typecheck only passed because the dependency was hoisted from elsewhere. Under an isolated install it fails, as seen in [this CI run](https://github.com/WordPress/gutenberg/actions/runs/32493673465/job/96806973274?pr=75814).

## How?
Declares `@types/jest` in [storybook/package.json](storybook/package.json#L38) and removes the extraneous lockfile entries left behind by the install.

## Testing Instructions
1. `npm install`
2. `npm run typecheck` passes.
3. Confirm `git status` shows a clean lockfile after the install.

## Use of AI Tools
The PR description was drafted with Claude Code and reviewed by the author.
