### PR TITLE
TypeScript: Drop redundant undefined casts for keyless entity record IDs

### DIFF
--- a/routes/identity/stage.tsx
+++ b/routes/identity/stage.tsx
@@ -75,7 +75,7 @@ function Identity() {
 				'root',
 				'site',
 				// The site entity is a singleton and has no record key.
-				undefined as unknown as string
+				undefined
 			) as SiteSettings,
 		[]
 	);
@@ -83,12 +83,7 @@ function Identity() {
 
 	const onChange = ( edits: Record< string, any > ) => {
 		// The site entity is a singleton and has no record key.
-		editEntityRecord(
-			'root',
-			'site',
-			undefined as unknown as string,
-			edits
-		);
+		editEntityRecord( 'root', 'site', undefined, edits );
 	};
 
 	return (

--- a/routes/template-list/actions/set-active-template.tsx
+++ b/routes/template-list/actions/set-active-template.tsx
@@ -74,11 +74,10 @@ export function useSetActiveTemplateAction(): Action< Template > {
 					}
 				}
 				// The site entity is a singleton and has no record key.
-				const siteRecordKey = undefined as unknown as string;
-				await editEntityRecord( 'root', 'site', siteRecordKey, {
+				await editEntityRecord( 'root', 'site', undefined, {
 					active_templates: activeTemplates,
 				} );
-				await saveEditedEntityRecord( 'root', 'site', siteRecordKey );
+				await saveEditedEntityRecord( 'root', 'site' );
 			},
 		} ),
 		[


### PR DESCRIPTION
## What?

Follow up to #81847, addressing [this review comment](https://github.com/WordPress/gutenberg/pull/81847#discussion_r3840150777). Removes the `undefined as unknown as string` casts used when editing the keyless `root`/`site` entity.

## Why?

The casts were unnecessary: `editEntityRecord` already types `recordId` as `number | string | undefined`, and `saveEditedEntityRecord` types it as optional.

## How?

Passes `undefined` directly in [routes/identity/stage.tsx](https://github.com/WordPress/gutenberg/blob/trunk/routes/identity/stage.tsx) and drops the `siteRecordKey` local in [routes/template-list/actions/set-active-template.tsx](https://github.com/WordPress/gutenberg/blob/trunk/routes/template-list/actions/set-active-template.tsx), where the `saveEditedEntityRecord` call now omits the argument.

## Testing Instructions

1. `npm run typecheck` passes.
2. With the extensible site editor enabled, edit the site title in the Identity route and confirm it saves.
3. Set an active template from the Templates list and confirm it applies.

## Use of AI Tools

Written with the help of an AI assistant, reviewed and edited by the author.
