### PR TITLE
Editor: Fix start page/template modal footer overflowing the modal width

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   Notes: Stop forcing capitalization of the user name in a note byline, so the name is shown as the user set it ([#81788](https://github.com/WordPress/gutenberg/pull/81788)).
 -   Device Preview: Center the editor canvas with the canvas container's own flex alignment rather than the canvas's auto margins, which were conditional on the resize handles being active. Switching from the mobile or tablet preview back to desktop no longer expands the canvas from the left edge ([#81484](https://github.com/WordPress/gutenberg/pull/81484)).
 -   `PostSchedule`: Announce the new publish date to screen readers when the date is changed ([#81629](https://github.com/WordPress/gutenberg/pull/81629)).
+-   Start page/template pattern modals: Align the footer actions with the modal content's padding, so the footer no longer overflows the modal width ([#82021](https://github.com/WordPress/gutenberg/pull/82021)).
 
 ### Internal
 

--- a/packages/editor/src/components/start-page-options/style.scss
+++ b/packages/editor/src/components/start-page-options/style.scss
@@ -11,10 +11,10 @@ $actions-height: 72px;
 		width: 100%;
 		height: $actions-height;
 		background-color: $white;
-		margin-left: - $grid-unit-40;
-		margin-right: - $grid-unit-40;
-		padding-left: $grid-unit-40;
-		padding-right: $grid-unit-40;
+		margin-left: - $grid-unit-30;
+		margin-right: - $grid-unit-30;
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
 		border-top: 1px solid $gray-300;
 		// Ensure modal footer actions appear above the modal's scrolling content.
 		z-index: 1;

--- a/packages/editor/src/components/start-template-options/style.scss
+++ b/packages/editor/src/components/start-template-options/style.scss
@@ -11,10 +11,10 @@ $actions-height: 92px;
 		width: 100%;
 		height: $actions-height;
 		background-color: $white;
-		margin-left: - $grid-unit-40;
-		margin-right: - $grid-unit-40;
-		padding-left: $grid-unit-40;
-		padding-right: $grid-unit-40;
+		margin-left: - $grid-unit-30;
+		margin-right: - $grid-unit-30;
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
 		border-top: 1px solid $gray-300;
 		// Ensure modal footer actions appear above the modal's scrolling content.
 		z-index: 1;


### PR DESCRIPTION
## What?

Related #73334

The footer actions of the "Start page" and "Start template" pattern modals overflow the modal content area horizontally. This PR aligns them with the modal's padding.

## Why?

#73334 changed the modal content padding from 32px to 24px. Both modals cancel that padding with negative margins to make their footer full width, but their values were not updated, so the footer now sticks out by 8px on each side.

## Testing Instructions

1. Create a new page or add a new template.
2. Confirm the footer holding the "Skip" button spans exactly the modal's inner width.

## Screenshots or screencast

| Modal | Before | After |
|--------|--------|--------|
| Page | <img width="977" height="572" alt="image" src="https://github.com/user-attachments/assets/ffdd62df-c725-4b43-8f59-324152c5bfc8" /> | <img width="972" height="573" alt="image" src="https://github.com/user-attachments/assets/5820222f-2b1e-4ace-b60f-47cd7ac2d90a" /> |
| Template | <img width="968" height="570" alt="image" src="https://github.com/user-attachments/assets/fd855911-c853-4914-869c-e88688ec95f1" /> | <img width="969" height="568" alt="image" src="https://github.com/user-attachments/assets/d28b84fc-aa31-4660-a92b-a321faa6fabe" />| 

## Use of AI Tools

Claude Code was used to locate the affected styles and to draft this change. All changes have been reviewed by me.
