### PR TITLE
PaletteEdit: Expose palette swatches as command buttons

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Bug Fixes
 
--   Cover: Use the new toggle-button presentation for the placeholder overlay color palette ([#81800](https://github.com/WordPress/gutenberg/issues/81800)).
+-   Cover: Use the new toggle-button presentation for the placeholder overlay color palette ([#82023](https://github.com/WordPress/gutenberg/pull/82023)).
 -   Columns: Preserve individual Column attributes supported by Group, including styles and layouts, when transforming to Row or Grid.
 -   Gallery: Don't offer the Image and Grid transforms while the block is in dynamic mode, where it has no inner blocks to convert ([#82009](https://github.com/WordPress/gutenberg/pull/82009)).
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Cover: Use the new toggle-button presentation for the placeholder overlay color palette ([#81800](https://github.com/WordPress/gutenberg/issues/81800)).
 -   Columns: Preserve individual Column attributes supported by Group, including styles and layouts, when transforming to Row or Grid.
 -   Gallery: Don't offer the Image and Grid transforms while the block is in dynamic mode, where it has no inner blocks to convert ([#82009](https://github.com/WordPress/gutenberg/pull/82009)).
 -   Icon: Apply only padding to the inner SVG in the editor, so margin is no longer applied twice compared to the front end ([#81292](https://github.com/WordPress/gutenberg/pull/81292)).

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -760,7 +760,7 @@ function CoverEdit( {
 								value={ overlayColor.color }
 								onChange={ onSetOverlayColor }
 								clearable={ false }
-								asButtons
+								presentation="toggle-buttons"
 								aria-label={ __( 'Overlay color' ) }
 							/>
 						</div>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Bug Fixes
 
--   `PaletteEdit`: Expose color, gradient, and duotone swatches as command buttons because activating them opens an editor instead of selecting a value. Add a `presentation` prop to `CircularOptionPicker`, `ColorPalette`, `GradientPicker`, and `DuotonePicker`, and deprecate `asButtons` in favor of `presentation="toggle-buttons"` ([#81800](https://github.com/WordPress/gutenberg/issues/81800)).
+-   `PaletteEdit`: Expose color, gradient, and duotone swatches as command buttons because activating them opens an editor instead of selecting a value. Add a `presentation` prop to `CircularOptionPicker`, `ColorPalette`, `GradientPicker`, and `DuotonePicker`, and deprecate `asButtons` in favor of `presentation="toggle-buttons"` ([#82023](https://github.com/WordPress/gutenberg/pull/82023)).
 -   `ConfirmDialog`: Preserve `title` as the dialog's accessible name when the header is hidden ([#81847](https://github.com/WordPress/gutenberg/pull/81847)).
 -   `DuotonePicker`: Do not render the custom controls wrapper when `disableCustomDuotone` is set, so a read-only picker no longer adds trailing padding below its swatches ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `DuotonePicker`: Stop the duotone bar offering to move its control points. It announced that arrow keys and dragging change the gradient position, but a duotone is two colors with no positions, so the move was discarded. `CustomGradientBar` gains a `disablePositioning` prop for this ([#81850](https://github.com/WordPress/gutenberg/pull/81850)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Bug Fixes
 
+-   `PaletteEdit`: Expose color, gradient, and duotone swatches as command buttons because activating them opens an editor instead of selecting a value. Add a `presentation` prop to `CircularOptionPicker`, `ColorPalette`, `GradientPicker`, and `DuotonePicker`, and deprecate `asButtons` in favor of `presentation="toggle-buttons"` ([#81800](https://github.com/WordPress/gutenberg/issues/81800)).
 -   `ConfirmDialog`: Preserve `title` as the dialog's accessible name when the header is hidden ([#81847](https://github.com/WordPress/gutenberg/pull/81847)).
 -   `DuotonePicker`: Do not render the custom controls wrapper when `disableCustomDuotone` is set, so a read-only picker no longer adds trailing padding below its swatches ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `DuotonePicker`: Stop the duotone bar offering to move its control points. It announced that arrow keys and dragging change the gradient position, but a duotone is two colors with no positions, so the move was discarded. `CustomGradientBar` gains a `disablePositioning` prop for this ([#81850](https://github.com/WordPress/gutenberg/pull/81850)).

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -77,16 +77,20 @@ The child elements.
 
 - Required: No
 
-### `asButtons`: `boolean`
+### `presentation`: `'listbox' | 'toggle-buttons' | 'command-buttons'`
 
-Whether the control should present as a set of buttons, each with its own tab stop.
+Controls the swatches' interaction and accessibility semantics.
+
+-   `listbox` uses one tab stop for the picker. Arrow keys move between options. Options expose selection with `aria-selected`.
+-   `toggle-buttons` uses a tab stop for each swatch. Swatches expose selection with `aria-pressed`.
+-   `command-buttons` uses a tab stop for each swatch. Swatches do not expose selection. Use this presentation when each swatch runs a command, such as opening an editor.
 
 - Required: No
-- Default: `false`
+- Default: `listbox`
 
 ### `loop`: `boolean`
 
-Prevents keyboard interaction from wrapping around. Only used when `asButtons` is not true.
+Prevents arrow-key navigation from wrapping around. Only used with the `listbox` presentation.
 
 - Required: No
 - Default: `true`

--- a/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
@@ -79,7 +79,9 @@ export function Option( {
 	tooltipText,
 	...additionalProps
 }: OptionProps ) {
-	const { baseId, setActiveId } = useContext( CircularOptionPickerContext );
+	const { baseId, presentation = 'listbox' } = useContext(
+		CircularOptionPickerContext
+	);
 	const id = useInstanceId(
 		Option,
 		baseId || 'components-circular-option-picker__option'
@@ -91,20 +93,24 @@ export function Option( {
 		...additionalProps,
 	};
 
-	const isListbox = setActiveId !== undefined;
-	const optionControl = isListbox ? (
-		<OptionAsOption
-			{ ...commonProps }
-			label={ tooltipText }
-			isSelected={ isSelected }
-		/>
-	) : (
-		<OptionAsButton
-			{ ...commonProps }
-			label={ tooltipText }
-			isPressed={ isSelected }
-		/>
-	);
+	const optionControl =
+		presentation === 'listbox' ? (
+			<OptionAsOption
+				{ ...commonProps }
+				label={ tooltipText }
+				isSelected={ isSelected }
+			/>
+		) : (
+			<OptionAsButton
+				{ ...commonProps }
+				label={ tooltipText }
+				isPressed={
+					presentation === 'toggle-buttons'
+						? !! isSelected
+						: undefined
+				}
+			/>
+		);
 
 	return (
 		<div
@@ -114,7 +120,9 @@ export function Option( {
 			) }
 		>
 			{ optionControl }
-			{ isSelected && <Icon icon={ check } { ...selectedIconProps } /> }
+			{ presentation !== 'command-buttons' && isSelected && (
+				<Icon icon={ check } { ...selectedIconProps } />
+			) }
 		</div>
 	);
 }

--- a/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker-option.tsx
@@ -79,7 +79,9 @@ export function Option( {
 	tooltipText,
 	...additionalProps
 }: OptionProps ) {
-	const { baseId, presentation = 'listbox' } = useContext(
+	// Preserve the historical toggle-button fallback when this public
+	// subcomponent is rendered without a parent picker.
+	const { baseId, presentation = 'toggle-buttons' } = useContext(
 		CircularOptionPickerContext
 	);
 	const id = useInstanceId(

--- a/packages/components/src/circular-option-picker/circular-option-picker.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker.tsx
@@ -15,6 +15,10 @@ import {
 	ButtonAction,
 	DropdownLinkAction,
 } from './circular-option-picker-actions';
+import {
+	resolveCircularOptionPickerPresentation,
+	warnIfCircularOptionPickerAsButtonsIsSet,
+} from './utils';
 
 /**
  *`CircularOptionPicker` is a component that displays a set of options as circular buttons.
@@ -83,6 +87,7 @@ function ListboxCircularOptionPicker(
 			baseId,
 			activeId,
 			setActiveId,
+			presentation: 'listbox' as const,
 		} ),
 		[ baseId, activeId, setActiveId ]
 	);
@@ -111,13 +116,21 @@ function ListboxCircularOptionPicker(
 function ButtonsCircularOptionPicker(
 	props: ButtonsCircularOptionPickerProps
 ) {
-	const { actions, options, children, baseId, ...additionalProps } = props;
+	const {
+		actions,
+		options,
+		children,
+		baseId,
+		presentation,
+		...additionalProps
+	} = props;
 
 	const contextValue = useMemo(
 		() => ( {
 			baseId,
+			presentation,
 		} ),
-		[ baseId ]
+		[ baseId, presentation ]
 	);
 
 	return (
@@ -134,22 +147,28 @@ function ButtonsCircularOptionPicker(
 function CircularOptionPicker( props: CircularOptionPickerProps ) {
 	const {
 		asButtons,
+		presentation,
+		loop,
 		actions: actionsProp,
 		options: optionsProp,
 		children,
 		className,
 		...additionalProps
 	} = props;
+	warnIfCircularOptionPickerAsButtonsIsSet(
+		'CircularOptionPicker',
+		asButtons
+	);
+	const resolvedPresentation = resolveCircularOptionPickerPresentation(
+		presentation,
+		asButtons
+	);
 
 	const baseId = useInstanceId(
 		CircularOptionPicker,
 		'components-circular-option-picker',
 		additionalProps.id
 	);
-
-	const OptionPickerImplementation = asButtons
-		? ButtonsCircularOptionPicker
-		: ListboxCircularOptionPicker;
 
 	const actions = actionsProp ? (
 		<div className="components-circular-option-picker__custom-clear-wrapper">
@@ -163,16 +182,30 @@ function CircularOptionPicker( props: CircularOptionPickerProps ) {
 		</div>
 	);
 
+	const sharedProps = {
+		baseId,
+		className: clsx( 'components-circular-option-picker', className ),
+		actions,
+		options,
+		children,
+	};
+
+	if ( resolvedPresentation === 'listbox' ) {
+		return (
+			<ListboxCircularOptionPicker
+				{ ...additionalProps }
+				{ ...sharedProps }
+				loop={ loop }
+			/>
+		);
+	}
+
 	return (
-		<OptionPickerImplementation
+		<ButtonsCircularOptionPicker
 			{ ...additionalProps }
-			baseId={ baseId }
-			className={ clsx( 'components-circular-option-picker', className ) }
-			actions={ actions }
-			options={ options }
-		>
-			{ children }
-		</OptionPickerImplementation>
+			{ ...sharedProps }
+			presentation={ resolvedPresentation }
+		/>
 	);
 }
 

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -6,6 +6,11 @@ export {
 	ButtonAction,
 	DropdownLinkAction,
 } from './circular-option-picker-actions';
-export { getComputeCircularOptionPickerCommonProps } from './utils';
+export {
+	getComputeCircularOptionPickerCommonProps,
+	resolveCircularOptionPickerPresentation,
+	warnIfCircularOptionPickerAsButtonsIsSet,
+} from './utils';
+export type { CircularOptionPickerPresentation } from './types';
 
 export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -11,6 +11,5 @@ export {
 	resolveCircularOptionPickerPresentation,
 	warnIfCircularOptionPickerAsButtonsIsSet,
 } from './utils';
-export type { CircularOptionPickerPresentation } from './types';
 
 export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/stories/index.story.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.story.tsx
@@ -107,10 +107,10 @@ Default.args = {
 	options: <DefaultOptions />,
 };
 
-export const AsButtons = Template.bind( {} );
-AsButtons.args = {
+export const AsToggleButtons = Template.bind( {} );
+AsToggleButtons.args = {
 	...Default.args,
-	asButtons: true,
+	presentation: 'toggle-buttons',
 };
 
 export const WithLoopingDisabled = Template.bind( {} );

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -26,6 +26,23 @@ describe( 'CircularOptionPicker', () => {
 		Object.keys( logged ).forEach( ( key ) => delete logged[ key ] );
 	} );
 
+	it( 'should preserve toggle-button semantics when an option is rendered without a picker', () => {
+		render(
+			<CircularOptionPicker.Option
+				isSelected
+				aria-label="Standalone option"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Standalone option',
+				pressed: true,
+			} )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'option' ) ).not.toBeInTheDocument();
+	} );
+
 	describe( 'when `asButtons` is not set', () => {
 		it( 'should render as a listbox', async () => {
 			render( <CircularOptionPicker { ...DEFAULT_PROPS } /> );

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -41,17 +41,142 @@ describe( 'CircularOptionPicker', () => {
 			expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option' ) ).toBeInTheDocument();
 			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+			expect( console ).toHaveWarnedWith(
+				'`asButtons` prop in wp.components.CircularOptionPicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
+			);
 		} );
 	} );
 
 	describe( 'when `asButtons` is true', () => {
-		it( 'should render as buttons', async () => {
-			render( <CircularOptionPicker { ...DEFAULT_PROPS } asButtons /> );
+		it( 'should render as toggle buttons with selected and unselected states', async () => {
+			render(
+				<CircularOptionPicker
+					{ ...DEFAULT_PROPS }
+					asButtons
+					options={ [
+						<CircularOptionPicker.Option
+							key="selected"
+							isSelected
+							aria-label="Selected"
+						/>,
+						<CircularOptionPicker.Option
+							key="unselected"
+							aria-label="Unselected"
+						/>,
+					] }
+				/>
+			);
 
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 			expect( screen.queryByRole( 'option' ) ).not.toBeInTheDocument();
 			expect( screen.getByRole( 'group' ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Selected',
+					pressed: true,
+				} )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Unselected',
+					pressed: false,
+				} )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'when `presentation` is set', () => {
+		it( 'should render a selected listbox option', () => {
+			render(
+				<CircularOptionPicker
+					{ ...DEFAULT_PROPS }
+					presentation="listbox"
+					options={ [
+						<CircularOptionPicker.Option
+							key="option"
+							isSelected
+							aria-label="Selected"
+						/>,
+					] }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'option', {
+					name: 'Selected',
+					selected: true,
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should render toggle buttons with selected and unselected states', () => {
+			render(
+				<CircularOptionPicker
+					{ ...DEFAULT_PROPS }
+					presentation="toggle-buttons"
+					options={ [
+						<CircularOptionPicker.Option
+							key="selected"
+							isSelected
+							aria-label="Selected"
+						/>,
+						<CircularOptionPicker.Option
+							key="unselected"
+							aria-label="Unselected"
+						/>,
+					] }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Selected',
+					pressed: true,
+				} )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Unselected',
+					pressed: false,
+				} )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should render command buttons without selection state or a selected check', () => {
+			render(
+				<CircularOptionPicker
+					{ ...DEFAULT_PROPS }
+					presentation="command-buttons"
+					options={ [
+						<CircularOptionPicker.Option
+							key="option"
+							isSelected
+							aria-label="Edit"
+						/>,
+					] }
+				/>
+			);
+
+			const button = screen.getByRole( 'button', { name: 'Edit' } );
+			expect( button ).not.toHaveAttribute( 'aria-pressed' );
+			expect( button ).not.toHaveAttribute( 'aria-selected' );
+			// The selected check is decorative and therefore has no semantic query.
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( button.nextElementSibling ).toBeNull();
+		} );
+
+		it( 'should prefer an explicit presentation over asButtons', () => {
+			render(
+				<CircularOptionPicker
+					{ ...DEFAULT_PROPS }
+					asButtons
+					presentation="command-buttons"
+				/>
+			);
+
+			expect( screen.getByRole( 'button' ) ).not.toHaveAttribute(
+				'aria-pressed'
+			);
 		} );
 	} );
 

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { press } from '@ariakit/test';
+import { logged } from '@wordpress/deprecated';
 import CircularOptionPicker from '..';
 
 const SINGLE_OPTION = [ <CircularOptionPicker.Option key="option" /> ];
@@ -13,12 +14,18 @@ const DEFAULT_PROPS = {
 	'aria-label': 'Circular Option Picker',
 	options: SINGLE_OPTION,
 };
+const AS_BUTTONS_DEPRECATION =
+	'`asButtons` prop in wp.components.CircularOptionPicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.';
 
 function getOption( name: string ) {
 	return screen.getByRole( 'option', { name } );
 }
 
 describe( 'CircularOptionPicker', () => {
+	beforeEach( () => {
+		Object.keys( logged ).forEach( ( key ) => delete logged[ key ] );
+	} );
+
 	describe( 'when `asButtons` is not set', () => {
 		it( 'should render as a listbox', async () => {
 			render( <CircularOptionPicker { ...DEFAULT_PROPS } /> );
@@ -41,9 +48,7 @@ describe( 'CircularOptionPicker', () => {
 			expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'option' ) ).toBeInTheDocument();
 			expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
-			expect( console ).toHaveWarnedWith(
-				'`asButtons` prop in wp.components.CircularOptionPicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
-			);
+			expect( console ).toHaveWarnedWith( AS_BUTTONS_DEPRECATION );
 		} );
 	} );
 
@@ -82,6 +87,7 @@ describe( 'CircularOptionPicker', () => {
 					pressed: false,
 				} )
 			).toBeInTheDocument();
+			expect( console ).toHaveWarnedWith( AS_BUTTONS_DEPRECATION );
 		} );
 	} );
 
@@ -177,6 +183,7 @@ describe( 'CircularOptionPicker', () => {
 			expect( screen.getByRole( 'button' ) ).not.toHaveAttribute(
 				'aria-pressed'
 			);
+			expect( console ).toHaveWarnedWith( AS_BUTTONS_DEPRECATION );
 		} );
 	} );
 

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -4,18 +4,6 @@ import type { ButtonAsButtonProps } from '../button/types';
 import type { DropdownProps } from '../dropdown/types';
 import type { WordPressComponentProps } from '../context';
 
-/**
- * How the swatches behave and are exposed to assistive technology.
- *
- * - `listbox`: a single-tab-stop selection control with listbox semantics.
- * - `toggle-buttons`: individual toggle buttons with pressed states.
- * - `command-buttons`: individual command buttons without selection state.
- */
-export type CircularOptionPickerPresentation =
-	| 'listbox'
-	| 'toggle-buttons'
-	| 'command-buttons';
-
 export type CircularOptionPickerProps = {
 	/**
 	 * An ID to apply to the component.
@@ -53,7 +41,7 @@ export type CircularOptionPickerProps = {
 	 *
 	 * @default 'listbox'
 	 */
-	presentation?: CircularOptionPickerPresentation;
+	presentation?: 'listbox' | 'toggle-buttons' | 'command-buttons';
 	/**
 	 * Whether the control should present as toggle buttons.
 	 *
@@ -91,7 +79,10 @@ export type ListboxCircularOptionPickerProps = WithBaseId &
 
 export type ButtonsCircularOptionPickerProps = WithBaseId &
 	Omit< CircularOptionPickerProps, 'asButtons' | 'presentation' | 'loop' > & {
-		presentation: Exclude< CircularOptionPickerPresentation, 'listbox' >;
+		presentation: Exclude<
+			NonNullable< CircularOptionPickerProps[ 'presentation' ] >,
+			'listbox'
+		>;
 	};
 
 export type DropdownLinkActionProps = {
@@ -130,5 +121,5 @@ export type CircularOptionPickerContextProps = {
 	baseId?: string;
 	activeId?: string | null | undefined;
 	setActiveId?: ( newId: string | null | undefined ) => void;
-	presentation?: CircularOptionPickerPresentation;
+	presentation?: CircularOptionPickerProps[ 'presentation' ];
 };

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -4,7 +4,19 @@ import type { ButtonAsButtonProps } from '../button/types';
 import type { DropdownProps } from '../dropdown/types';
 import type { WordPressComponentProps } from '../context';
 
-type CommonCircularOptionPickerProps = {
+/**
+ * How the swatches behave and are exposed to assistive technology.
+ *
+ * - `listbox`: a single-tab-stop selection control with listbox semantics.
+ * - `toggle-buttons`: individual toggle buttons with pressed states.
+ * - `command-buttons`: individual command buttons without selection state.
+ */
+export type CircularOptionPickerPresentation =
+	| 'listbox'
+	| 'toggle-buttons'
+	| 'command-buttons';
+
+export type CircularOptionPickerProps = {
 	/**
 	 * An ID to apply to the component.
 	 */
@@ -30,6 +42,35 @@ type CommonCircularOptionPickerProps = {
 	 */
 	children?: ReactNode;
 	/**
+	 * How the swatches behave and are exposed to assistive technology.
+	 *
+	 * - `listbox` uses one tab stop and arrow-key navigation, and exposes
+	 *   selection with `aria-selected`.
+	 * - `toggle-buttons` gives each swatch a tab stop and exposes selection with
+	 *   `aria-pressed`.
+	 * - `command-buttons` gives each swatch a tab stop and exposes no selection
+	 *   state. Use it when swatches run commands such as opening an editor.
+	 *
+	 * @default 'listbox'
+	 */
+	presentation?: CircularOptionPickerPresentation;
+	/**
+	 * Whether the control should present as toggle buttons.
+	 *
+	 * @deprecated Use `presentation="toggle-buttons"` instead. An explicit
+	 * `presentation` takes precedence.
+	 * @default false
+	 * @ignore
+	 */
+	asButtons?: boolean;
+	/**
+	 * Prevents keyboard interaction from wrapping around.
+	 * Only used with the `listbox` presentation.
+	 *
+	 * @default true
+	 */
+	loop?: boolean;
+	/**
 	 * The ID reference list of one or more elements that label the wrapper
 	 * element.
 	 */
@@ -45,40 +86,13 @@ type WithBaseId = {
 	baseId: string;
 };
 
-type FullListboxCircularOptionPickerProps = CommonCircularOptionPickerProps & {
-	/**
-	 * Whether the control should present as a set of buttons,
-	 * each with its own tab stop.
-	 */
-	asButtons?: false;
-	/**
-	 * Prevents keyboard interaction from wrapping around.
-	 * Only used when `asButtons` is not true.
-	 *
-	 * @default true
-	 */
-	loop?: boolean;
-};
-
 export type ListboxCircularOptionPickerProps = WithBaseId &
-	Omit< FullListboxCircularOptionPickerProps, 'asButtons' >;
-
-type FullButtonsCircularOptionPickerProps = CommonCircularOptionPickerProps & {
-	/**
-	 * Whether the control should present as a set of buttons,
-	 * each with its own tab stop.
-	 *
-	 * @default false
-	 */
-	asButtons: true;
-};
+	Omit< CircularOptionPickerProps, 'asButtons' | 'presentation' >;
 
 export type ButtonsCircularOptionPickerProps = WithBaseId &
-	Omit< FullButtonsCircularOptionPickerProps, 'asButtons' >;
-
-export type CircularOptionPickerProps =
-	| FullListboxCircularOptionPickerProps
-	| FullButtonsCircularOptionPickerProps;
+	Omit< CircularOptionPickerProps, 'asButtons' | 'presentation' | 'loop' > & {
+		presentation: Exclude< CircularOptionPickerPresentation, 'listbox' >;
+	};
 
 export type DropdownLinkActionProps = {
 	buttonProps?: Omit<
@@ -116,4 +130,5 @@ export type CircularOptionPickerContextProps = {
 	baseId?: string;
 	activeId?: string | null | undefined;
 	setActiveId?: ( newId: string | null | undefined ) => void;
+	presentation?: CircularOptionPickerPresentation;
 };

--- a/packages/components/src/circular-option-picker/utils.tsx
+++ b/packages/components/src/circular-option-picker/utils.tsx
@@ -1,4 +1,28 @@
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
+import type { CircularOptionPickerPresentation } from './types';
+
+export function warnIfCircularOptionPickerAsButtonsIsSet(
+	componentName: string,
+	asButtons?: boolean
+) {
+	if ( asButtons === undefined ) {
+		return;
+	}
+
+	deprecated( `\`asButtons\` prop in wp.components.${ componentName }`, {
+		since: '7.2',
+		alternative: '`presentation`',
+		hint: '`asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.',
+	} );
+}
+
+export function resolveCircularOptionPickerPresentation(
+	presentation?: CircularOptionPickerPresentation,
+	asButtons?: boolean
+): CircularOptionPickerPresentation {
+	return presentation ?? ( asButtons ? 'toggle-buttons' : 'listbox' );
+}
 
 /**
  * Computes the common props for the CircularOptionPicker.
@@ -7,11 +31,17 @@ export function getComputeCircularOptionPickerCommonProps(
 	asButtons?: boolean,
 	loop?: boolean,
 	ariaLabel?: string,
-	ariaLabelledby?: string
+	ariaLabelledby?: string,
+	presentation?: CircularOptionPickerPresentation
 ) {
-	const metaProps = asButtons
-		? { asButtons: true }
-		: { asButtons: false, loop };
+	const resolvedPresentation = resolveCircularOptionPickerPresentation(
+		presentation,
+		asButtons
+	);
+	const metaProps =
+		resolvedPresentation === 'listbox'
+			? { presentation: 'listbox' as const, loop }
+			: { presentation: resolvedPresentation };
 
 	const labelProps = {
 		'aria-labelledby': ariaLabelledby,
@@ -20,5 +50,5 @@ export function getComputeCircularOptionPickerCommonProps(
 			: ariaLabel || __( 'Custom color picker' ),
 	};
 
-	return { metaProps, labelProps };
+	return { metaProps, labelProps, resolvedPresentation };
 }

--- a/packages/components/src/circular-option-picker/utils.tsx
+++ b/packages/components/src/circular-option-picker/utils.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import deprecated from '@wordpress/deprecated';
-import type { CircularOptionPickerPresentation } from './types';
+import type { CircularOptionPickerProps } from './types';
 
 export function warnIfCircularOptionPickerAsButtonsIsSet(
 	componentName: string,
@@ -18,9 +18,9 @@ export function warnIfCircularOptionPickerAsButtonsIsSet(
 }
 
 export function resolveCircularOptionPickerPresentation(
-	presentation?: CircularOptionPickerPresentation,
+	presentation?: CircularOptionPickerProps[ 'presentation' ],
 	asButtons?: boolean
-): CircularOptionPickerPresentation {
+): NonNullable< CircularOptionPickerProps[ 'presentation' ] > {
 	return presentation ?? ( asButtons ? 'toggle-buttons' : 'listbox' );
 }
 
@@ -32,7 +32,7 @@ export function getComputeCircularOptionPickerCommonProps(
 	loop?: boolean,
 	ariaLabel?: string,
 	ariaLabelledby?: string,
-	presentation?: CircularOptionPickerPresentation
+	presentation?: CircularOptionPickerProps[ 'presentation' ]
 ) {
 	const resolvedPresentation = resolveCircularOptionPickerPresentation(
 		presentation,

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -85,16 +85,20 @@ Callback called when a color is selected.
 
 -   Required: Yes
 
-### `asButtons`: `boolean`
+### `presentation`: `'listbox' | 'toggle-buttons' | 'command-buttons'`
 
-Whether the control should present as a set of buttons, each with its own tab stop.
+Controls the predefined swatches' interaction and accessibility semantics.
 
-- Required: No
-- Default: `false`
+-   `listbox` uses one tab stop for the palette. Arrow keys move between options. Options expose selection with `aria-selected`.
+-   `toggle-buttons` uses a tab stop for each swatch. Swatches expose selection with `aria-pressed`.
+-   `command-buttons` uses a tab stop for each swatch. Swatches do not expose selection. The `value` and `selectedSlug` props do not mark predefined swatches as selected, and activating a swatch always calls `onChange` with that swatch. The `value` prop still controls the custom color picker.
+
+-   Required: No
+-   Default: `listbox`
 
 ### `loop`: `boolean`
 
-Prevents keyboard interaction from wrapping around. Only used when `asButtons` is not true.
+Prevents arrow-key navigation from wrapping around. Only used with the `listbox` presentation.
 
-- Required: No
-- Default: `true`
+-   Required: No
+-   Default: `true`

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -10,6 +10,7 @@ import Dropdown from '../dropdown';
 import { ColorPicker } from '../color-picker';
 import CircularOptionPicker, {
 	getComputeCircularOptionPickerCommonProps,
+	warnIfCircularOptionPickerAsButtonsIsSet,
 } from '../circular-option-picker';
 import { VStack } from '../v-stack';
 import { Truncate } from '../truncate';
@@ -41,6 +42,7 @@ function SinglePalette( {
 	onChange,
 	value,
 	selectedSlug,
+	presentation,
 	...additionalProps
 }: SinglePaletteProps ) {
 	const colorOptions = useMemo( () => {
@@ -52,9 +54,9 @@ function SinglePalette( {
 			// This correctly handles mixed palettes where some entries have slugs
 			// and others don't. Fall back to color value matching otherwise
 			// (including when selectedSlug is an empty string).
-			const isSelected = selectedSlug
-				? slug === selectedSlug
-				: value === color;
+			const isSelected =
+				presentation !== 'command-buttons' &&
+				( selectedSlug ? slug === selectedSlug : value === color );
 
 			return (
 				<CircularOptionPicker.Option
@@ -85,7 +87,7 @@ function SinglePalette( {
 				/>
 			);
 		} );
-	}, [ colors, value, selectedSlug, onChange, clearColor ] );
+	}, [ colors, value, selectedSlug, onChange, clearColor, presentation ] );
 
 	return (
 		<CircularOptionPicker.OptionGroup
@@ -104,6 +106,7 @@ function MultiplePalettes( {
 	value,
 	selectedSlug,
 	headingLevel,
+	presentation,
 }: MultiplePalettesProps ) {
 	const instanceId = useInstanceId( MultiplePalettes, 'color-palette' );
 
@@ -132,6 +135,7 @@ function MultiplePalettes( {
 							}
 							value={ value }
 							selectedSlug={ selectedSlug }
+							presentation={ presentation }
 							aria-labelledby={ id }
 						/>
 					</VStack>
@@ -185,6 +189,7 @@ function UnforwardedColorPalette(
 ) {
 	const {
 		asButtons,
+		presentation,
 		loop,
 		clearable = true,
 		colors = [],
@@ -199,6 +204,7 @@ function UnforwardedColorPalette(
 		'aria-labelledby': ariaLabelledby,
 		...additionalProps
 	} = props;
+	warnIfCircularOptionPickerAsButtonsIsSet( 'ColorPalette', asButtons );
 	const [ normalizedColorValue, setNormalizedColorValue ] = useState( value );
 
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
@@ -246,11 +252,21 @@ function UnforwardedColorPalette(
 		  )
 		: __( 'Custom color picker' );
 
+	const { metaProps, labelProps, resolvedPresentation } =
+		getComputeCircularOptionPickerCommonProps(
+			asButtons,
+			loop,
+			ariaLabel,
+			ariaLabelledby,
+			presentation
+		);
+
 	const paletteCommonProps = {
 		clearColor,
 		onChange,
 		value,
 		selectedSlug,
+		presentation: resolvedPresentation,
 	};
 
 	const actions = !! clearable && (
@@ -261,13 +277,6 @@ function UnforwardedColorPalette(
 		>
 			{ __( 'Clear' ) }
 		</CircularOptionPicker.ButtonAction>
-	);
-
-	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
-		asButtons,
-		loop,
-		ariaLabel,
-		ariaLabelledby
 	);
 
 	// If disableCustomColors is true and colors.length is 0, return null to avoid rendering an empty palette wrapper.

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -30,6 +30,51 @@ const ControlledColorPalette = ( {
 };
 
 describe( 'ColorPalette', () => {
+	it( 'should use matching values only for display in command button presentation', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render(
+			<ColorPalette
+				aria-label="Colors"
+				colors={ EXAMPLE_COLORS }
+				value={ INITIAL_COLOR }
+				onChange={ onChange }
+				presentation="command-buttons"
+				disableCustomColors
+				clearable={ false }
+			/>
+		);
+
+		const red = screen.getByRole( 'button', { name: 'red' } );
+		expect( screen.getByRole( 'group', { name: 'Colors' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		expect( red ).not.toHaveAttribute( 'aria-pressed' );
+
+		await user.click( red );
+		expect( onChange ).toHaveBeenCalledWith( '#f00', 0, undefined );
+	} );
+
+	it( 'should warn for asButtons and prefer an explicit presentation', () => {
+		render(
+			<ColorPalette
+				aria-label="Colors"
+				colors={ EXAMPLE_COLORS }
+				onChange={ jest.fn() }
+				asButtons={ false }
+				presentation="command-buttons"
+				disableCustomColors
+				clearable={ false }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'red' } )
+		).not.toHaveAttribute( 'aria-pressed' );
+		expect( console ).toHaveWarnedWith(
+			'`asButtons` prop in wp.components.ColorPalette is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
+		);
+	} );
+
 	it( 'should render three color button options', () => {
 		const onChange = jest.fn();
 

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -8,6 +8,10 @@ const EXAMPLE_COLORS = [
 	{ name: 'green', color: '#0f0' },
 	{ name: 'blue', color: '#00f' },
 ];
+const DUPLICATE_COLOR_PALETTE = [
+	{ name: 'Dark Background', slug: 'dark-background', color: '#000' },
+	{ name: 'Dark Text', slug: 'dark-text', color: '#000' },
+];
 const INITIAL_COLOR = EXAMPLE_COLORS[ 0 ].color;
 
 const ControlledColorPalette = ( {
@@ -36,8 +40,9 @@ describe( 'ColorPalette', () => {
 		render(
 			<ColorPalette
 				aria-label="Colors"
-				colors={ EXAMPLE_COLORS }
-				value={ INITIAL_COLOR }
+				colors={ DUPLICATE_COLOR_PALETTE }
+				value="#000"
+				selectedSlug="dark-background"
 				onChange={ onChange }
 				presentation="command-buttons"
 				disableCustomColors
@@ -45,13 +50,15 @@ describe( 'ColorPalette', () => {
 			/>
 		);
 
-		const red = screen.getByRole( 'button', { name: 'red' } );
+		const darkBackground = screen.getByRole( 'button', {
+			name: 'Dark Background',
+		} );
 		expect( screen.getByRole( 'group', { name: 'Colors' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
-		expect( red ).not.toHaveAttribute( 'aria-pressed' );
+		expect( darkBackground ).not.toHaveAttribute( 'aria-pressed' );
 
-		await user.click( red );
-		expect( onChange ).toHaveBeenCalledWith( '#f00', 0, undefined );
+		await user.click( darkBackground );
+		expect( onChange ).toHaveBeenCalledWith( '#000', 0, 'dark-background' );
 	} );
 
 	it( 'should warn for asButtons and prefer an explicit presentation', () => {
@@ -73,6 +80,34 @@ describe( 'ColorPalette', () => {
 		expect( console ).toHaveWarnedWith(
 			'`asButtons` prop in wp.components.ColorPalette is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
 		);
+	} );
+
+	it( 'should preserve asButtons as a toggle-button alias', () => {
+		render(
+			<ColorPalette
+				aria-label="Colors"
+				colors={ DUPLICATE_COLOR_PALETTE }
+				value="#000"
+				selectedSlug="dark-background"
+				onChange={ jest.fn() }
+				asButtons
+				disableCustomColors
+				clearable={ false }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Dark Background',
+				pressed: true,
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Dark Text',
+				pressed: false,
+			} )
+		).toBeVisible();
 	} );
 
 	it( 'should render three color button options', () => {
@@ -334,11 +369,6 @@ describe( 'ColorPalette', () => {
 	} );
 
 	describe( 'duplicate colors in palette', () => {
-		const DUPLICATE_COLOR_PALETTE = [
-			{ name: 'Dark Background', slug: 'dark-background', color: '#000' },
-			{ name: 'Dark Text', slug: 'dark-text', color: '#000' },
-		];
-
 		it( 'should render all swatches even when two entries share the same color value', () => {
 			render(
 				<ColorPalette

--- a/packages/components/src/color-palette/types.ts
+++ b/packages/components/src/color-palette/types.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import type { DropdownProps } from '../dropdown/types';
 import type { HeadingSize } from '../heading/types';
-import type { CircularOptionPickerPresentation } from '../circular-option-picker';
+import type { CircularOptionPickerProps } from '../circular-option-picker/types';
 
 export type ColorObject = {
 	name: string;
@@ -37,7 +37,7 @@ type PaletteProps = {
 	selectedSlug?: string;
 	actions?: ReactNode;
 	headingLevel?: HeadingSize;
-	presentation: CircularOptionPickerPresentation;
+	presentation: NonNullable< CircularOptionPickerProps[ 'presentation' ] >;
 };
 
 export type SinglePaletteProps = PaletteProps & {
@@ -109,7 +109,7 @@ export type ColorPaletteProps = Pick<
 	 *
 	 * @default 'listbox'
 	 */
-	presentation?: CircularOptionPickerPresentation;
+	presentation?: CircularOptionPickerProps[ 'presentation' ];
 	/**
 	 * Whether the control should present as toggle buttons.
 	 *

--- a/packages/components/src/color-palette/types.ts
+++ b/packages/components/src/color-palette/types.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import type { DropdownProps } from '../dropdown/types';
 import type { HeadingSize } from '../heading/types';
+import type { CircularOptionPickerPresentation } from '../circular-option-picker';
 
 export type ColorObject = {
 	name: string;
@@ -36,6 +37,7 @@ type PaletteProps = {
 	selectedSlug?: string;
 	actions?: ReactNode;
 	headingLevel?: HeadingSize;
+	presentation: CircularOptionPickerPresentation;
 };
 
 export type SinglePaletteProps = PaletteProps & {
@@ -93,15 +95,33 @@ export type ColorPaletteProps = Pick<
 	 */
 	value?: string;
 	/**
-	 * Whether the control should present as a set of buttons,
-	 * each with its own tab stop.
+	 * How predefined color swatches behave and are exposed to assistive
+	 * technology.
 	 *
+	 * - `listbox` uses one tab stop and arrow-key navigation, and exposes
+	 *   selection with `aria-selected`.
+	 * - `toggle-buttons` gives each swatch a tab stop and exposes selection with
+	 *   `aria-pressed`.
+	 * - `command-buttons` gives each swatch a tab stop and exposes no selection
+	 *   state. `value` and `selectedSlug` do not mark predefined swatches as
+	 *   selected, and activating a swatch always calls `onChange` with that
+	 *   swatch. `value` still controls the custom color picker.
+	 *
+	 * @default 'listbox'
+	 */
+	presentation?: CircularOptionPickerPresentation;
+	/**
+	 * Whether the control should present as toggle buttons.
+	 *
+	 * @deprecated Use `presentation="toggle-buttons"` instead. An explicit
+	 * `presentation` takes precedence.
 	 * @default false
+	 * @ignore
 	 */
 	asButtons?: boolean;
 	/**
 	 * Prevents keyboard interaction from wrapping around.
-	 * Only used when `asButtons` is not true.
+	 * Only used with the `listbox` presentation.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/duotone-picker/README.md
+++ b/packages/components/src/duotone-picker/README.md
@@ -75,16 +75,20 @@ The function called when the duotone colors change. It is passed the new `value`
 
 Both are omitted whenever no preset is being picked: the custom, unset and clear controls, and deselecting the currently selected preset, which reports `undefined` alone.
 
-### `asButtons`: `boolean`
+### `presentation`: `'listbox' | 'toggle-buttons' | 'command-buttons'`
 
-Whether the control should present as a set of buttons, each with its own tab stop.
+Controls the predefined swatches' interaction and accessibility semantics.
+
+-   `listbox` uses one tab stop for the picker. Arrow keys move between options. Options expose selection with `aria-selected`.
+-   `toggle-buttons` uses a tab stop for each swatch. Swatches expose selection with `aria-pressed`.
+-   `command-buttons` uses a tab stop for each swatch. Swatches do not expose selection. The `value` and `selectedSlug` props do not mark predefined swatches as selected, and activating a swatch always calls `onChange` with that swatch.
 
 - Required: No
-- Default: `false`
+- Default: `listbox`
 
 ### `loop`: `boolean`
 
-Prevents keyboard interaction from wrapping around. Only used when `asButtons` is not true.
+Prevents arrow-key navigation from wrapping around. Only used with the `listbox` presentation.
 
 - Required: No
 - Default: `true`

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -4,6 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import ColorListPicker from './color-list-picker';
 import CircularOptionPicker, {
 	getComputeCircularOptionPickerCommonProps,
+	warnIfCircularOptionPickerAsButtonsIsSet,
 } from '../circular-option-picker';
 import { VStack } from '../v-stack';
 import CustomDuotoneBar from './custom-duotone-bar';
@@ -46,6 +47,7 @@ import type { DuotonePickerProps } from './types';
  */
 function DuotonePicker( {
 	asButtons,
+	presentation,
 	loop,
 	clearable = true,
 	unsetable = true,
@@ -60,24 +62,35 @@ function DuotonePicker( {
 	'aria-labelledby': ariaLabelledby,
 	...otherProps
 }: DuotonePickerProps ) {
+	warnIfCircularOptionPickerAsButtonsIsSet( 'DuotonePicker', asButtons );
+	const { metaProps, labelProps, resolvedPresentation } =
+		getComputeCircularOptionPickerCommonProps(
+			asButtons,
+			loop,
+			ariaLabel,
+			ariaLabelledby,
+			presentation
+		);
 	const [ defaultDark, defaultLight ] = useMemo(
 		() => getDefaultColors( colorPalette ),
 		[ colorPalette ]
 	);
 
 	const isUnset = value === 'unset';
+	const isUnsetSelected =
+		resolvedPresentation !== 'command-buttons' && isUnset;
 	const unsetOptionLabel = __( 'Unset' );
 
 	const unsetOption = (
 		<CircularOptionPicker.Option
 			key="unset"
 			value="unset"
-			isSelected={ isUnset }
+			isSelected={ isUnsetSelected }
 			tooltipText={ unsetOptionLabel }
 			aria-label={ unsetOptionLabel }
 			className="components-duotone-picker__color-indicator"
 			onClick={ () => {
-				onChange( isUnset ? undefined : 'unset' );
+				onChange( isUnsetSelected ? undefined : 'unset' );
 			} }
 		/>
 	);
@@ -106,9 +119,11 @@ function DuotonePicker( {
 			// strictly by slug, which keeps two presets holding the same
 			// colors apart. Otherwise selection falls back to matching the
 			// colors themselves.
-			const isSelected = selectedSlug
-				? slug === selectedSlug
-				: fastDeepEqual( colors, value );
+			const isSelected =
+				resolvedPresentation !== 'command-buttons' &&
+				( selectedSlug
+					? slug === selectedSlug
+					: fastDeepEqual( colors, value ) );
 
 			return (
 				<CircularOptionPicker.Option
@@ -130,13 +145,6 @@ function DuotonePicker( {
 				/>
 			);
 		}
-	);
-
-	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
-		asButtons,
-		loop,
-		ariaLabel,
-		ariaLabelledby
 	);
 
 	const options = unsetable

--- a/packages/components/src/duotone-picker/test/index.tsx
+++ b/packages/components/src/duotone-picker/test/index.tsx
@@ -21,6 +21,59 @@ const COLOR_PALETTE = [
 ];
 
 describe( 'DuotonePicker', () => {
+	it( 'should use matching values only for display in command button presentation', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render(
+			<DuotonePicker
+				aria-label="Duotones"
+				duotonePalette={ DUPLICATE_DUOTONES }
+				colorPalette={ COLOR_PALETTE }
+				value={ COLORS_A }
+				onChange={ onChange }
+				presentation="command-buttons"
+				unsetable={ false }
+				clearable={ false }
+				disableCustomDuotone
+				disableCustomColors
+			/>
+		);
+
+		const duotone = screen.getByRole( 'button', {
+			name: 'Duotone: Dark Background',
+		} );
+		expect(
+			screen.getByRole( 'group', { name: 'Duotones' } )
+		).toBeVisible();
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		expect( duotone ).not.toHaveAttribute( 'aria-pressed' );
+
+		await user.click( duotone );
+		expect( onChange ).toHaveBeenCalledWith(
+			COLORS_A,
+			0,
+			'dark-background'
+		);
+	} );
+
+	it( 'should warn whenever asButtons is supplied', () => {
+		render(
+			<DuotonePicker
+				aria-label="Duotones"
+				duotonePalette={ DUPLICATE_DUOTONES }
+				colorPalette={ COLOR_PALETTE }
+				onChange={ jest.fn() }
+				asButtons={ false }
+				disableCustomDuotone
+				disableCustomColors
+			/>
+		);
+
+		expect( console ).toHaveWarnedWith(
+			'`asButtons` prop in wp.components.DuotonePicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
+		);
+	} );
+
 	describe( 'duplicate duotones in palette', () => {
 		it( 'should render all swatches even when two entries share the same colors', () => {
 			render(

--- a/packages/components/src/duotone-picker/test/index.tsx
+++ b/packages/components/src/duotone-picker/test/index.tsx
@@ -30,6 +30,7 @@ describe( 'DuotonePicker', () => {
 				duotonePalette={ DUPLICATE_DUOTONES }
 				colorPalette={ COLOR_PALETTE }
 				value={ COLORS_A }
+				selectedSlug="dark-background"
 				onChange={ onChange }
 				presentation="command-buttons"
 				unsetable={ false }
@@ -56,7 +57,7 @@ describe( 'DuotonePicker', () => {
 		);
 	} );
 
-	it( 'should warn whenever asButtons is supplied', () => {
+	it( 'should warn for asButtons and prefer an explicit presentation', () => {
 		render(
 			<DuotonePicker
 				aria-label="Duotones"
@@ -64,14 +65,51 @@ describe( 'DuotonePicker', () => {
 				colorPalette={ COLOR_PALETTE }
 				onChange={ jest.fn() }
 				asButtons={ false }
+				presentation="command-buttons"
 				disableCustomDuotone
 				disableCustomColors
 			/>
 		);
 
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Duotone: Dark Background',
+			} )
+		).not.toHaveAttribute( 'aria-pressed' );
 		expect( console ).toHaveWarnedWith(
 			'`asButtons` prop in wp.components.DuotonePicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
 		);
+	} );
+
+	it( 'should preserve asButtons as a toggle-button alias', () => {
+		render(
+			<DuotonePicker
+				aria-label="Duotones"
+				duotonePalette={ DUPLICATE_DUOTONES }
+				colorPalette={ COLOR_PALETTE }
+				value={ COLORS_A }
+				selectedSlug="dark-background"
+				onChange={ jest.fn() }
+				asButtons
+				unsetable={ false }
+				clearable={ false }
+				disableCustomDuotone
+				disableCustomColors
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Duotone: Dark Background',
+				pressed: true,
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Duotone: Dark Text',
+				pressed: false,
+			} )
+		).toBeVisible();
 	} );
 
 	describe( 'duplicate duotones in palette', () => {

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -1,3 +1,5 @@
+import type { CircularOptionPickerPresentation } from '../circular-option-picker';
+
 export type DuotonePickerProps = {
 	/**
 	 * Whether there should be a button to clear the duotone value.
@@ -64,15 +66,33 @@ export type DuotonePickerProps = {
 		slug?: string
 	) => void;
 	/**
-	 * Whether the control should present as a set of buttons,
-	 * each with its own tab stop.
+	 * How predefined duotone swatches behave and are exposed to assistive
+	 * technology.
 	 *
+	 * - `listbox` uses one tab stop and arrow-key navigation, and exposes
+	 *   selection with `aria-selected`.
+	 * - `toggle-buttons` gives each swatch a tab stop and exposes selection with
+	 *   `aria-pressed`.
+	 * - `command-buttons` gives each swatch a tab stop and exposes no selection
+	 *   state. `value` and `selectedSlug` do not mark predefined swatches as
+	 *   selected, and activating a swatch always calls `onChange` with that
+	 *   swatch.
+	 *
+	 * @default 'listbox'
+	 */
+	presentation?: CircularOptionPickerPresentation;
+	/**
+	 * Whether the control should present as toggle buttons.
+	 *
+	 * @deprecated Use `presentation="toggle-buttons"` instead. An explicit
+	 * `presentation` takes precedence.
 	 * @default false
+	 * @ignore
 	 */
 	asButtons?: boolean;
 	/**
 	 * Prevents keyboard interaction from wrapping around.
-	 * Only used when `asButtons` is not true.
+	 * Only used with the `listbox` presentation.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/duotone-picker/types.ts
+++ b/packages/components/src/duotone-picker/types.ts
@@ -1,4 +1,4 @@
-import type { CircularOptionPickerPresentation } from '../circular-option-picker';
+import type { CircularOptionPickerProps } from '../circular-option-picker/types';
 
 export type DuotonePickerProps = {
 	/**
@@ -80,7 +80,7 @@ export type DuotonePickerProps = {
 	 *
 	 * @default 'listbox'
 	 */
-	presentation?: CircularOptionPickerPresentation;
+	presentation?: CircularOptionPickerProps[ 'presentation' ];
 	/**
 	 * Whether the control should present as toggle buttons.
 	 *

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -54,15 +54,6 @@ const MyGradientPicker = () => {
 
 Whether this is rendered in the sidebar.
 
-### `asButtons`
-
- - Type: `boolean`
- - Required: No
- - Default: `false`
-
-Whether the control should present as a set of buttons,
-each with its own tab stop.
-
 ### `aria-label`
 
  - Type: `string`
@@ -137,7 +128,7 @@ contains two or more items).
  - Default: `true`
 
 Prevents keyboard interaction from wrapping around.
-Only used when `asButtons` is not true.
+Only used with the `listbox` presentation.
 
 ### `onChange`
 
@@ -148,6 +139,24 @@ The function called when a new gradient has been defined. It is passed
 the `currentGradient` as an argument. When a predefined gradient is
 selected, the second argument is its index (or, for multiple-origin
 gradients, the origin index) and the third argument is its slug.
+
+### `presentation`
+
+ - Type: `"listbox" | "toggle-buttons" | "command-buttons"`
+ - Required: No
+ - Default: `'listbox'`
+
+How predefined gradient swatches behave and are exposed to assistive
+technology.
+
+- `listbox` uses one tab stop and arrow-key navigation, and exposes
+  selection with `aria-selected`.
+- `toggle-buttons` gives each swatch a tab stop and exposes selection with
+  `aria-pressed`.
+- `command-buttons` gives each swatch a tab stop and exposes no selection
+  state. `value` and `selectedSlug` do not mark predefined swatches as
+  selected, and activating a swatch always calls `onChange` with that
+  swatch. `value` still controls the custom gradient picker.
 
 ### `selectedSlug`
 

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -3,6 +3,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { useCallback, useMemo } from '@wordpress/element';
 import CircularOptionPicker, {
 	getComputeCircularOptionPickerCommonProps,
+	warnIfCircularOptionPickerAsButtonsIsSet,
 } from '../circular-option-picker';
 import CustomGradientPicker from '../custom-gradient-picker';
 import { VStack } from '../v-stack';
@@ -36,6 +37,7 @@ function SingleOrigin( {
 	onChange,
 	value,
 	selectedSlug,
+	presentation,
 	...additionalProps
 }: PickerProps< GradientObject > ) {
 	const gradientOptions = useMemo( () => {
@@ -44,9 +46,9 @@ function SingleOrigin( {
 			// strictly by slug, which keeps two entries with the same gradient
 			// value apart. Otherwise selection falls back to matching the
 			// gradient value.
-			const isSelected = selectedSlug
-				? slug === selectedSlug
-				: value === gradient;
+			const isSelected =
+				presentation !== 'command-buttons' &&
+				( selectedSlug ? slug === selectedSlug : value === gradient );
 			return (
 				<CircularOptionPicker.Option
 					key={ slug }
@@ -76,7 +78,14 @@ function SingleOrigin( {
 				/>
 			);
 		} );
-	}, [ gradients, value, onChange, clearGradient, selectedSlug ] );
+	}, [
+		gradients,
+		value,
+		onChange,
+		clearGradient,
+		selectedSlug,
+		presentation,
+	] );
 	return (
 		<CircularOptionPicker.OptionGroup
 			className={ className }
@@ -94,6 +103,7 @@ function MultipleOrigin( {
 	value,
 	selectedSlug,
 	headingLevel,
+	presentation,
 }: PickerProps< OriginObject > ) {
 	const instanceId = useInstanceId( MultipleOrigin );
 
@@ -118,6 +128,7 @@ function MultipleOrigin( {
 							}
 							value={ value }
 							selectedSlug={ selectedSlug }
+							presentation={ presentation }
 							aria-labelledby={ id }
 						/>
 					</VStack>
@@ -130,6 +141,7 @@ function MultipleOrigin( {
 function Component( props: PickerProps< any > ) {
 	const {
 		asButtons,
+		presentation,
 		loop,
 		actions,
 		headingLevel,
@@ -137,17 +149,27 @@ function Component( props: PickerProps< any > ) {
 		'aria-labelledby': ariaLabelledby,
 		...additionalProps
 	} = props;
-	const options = isMultipleOriginArray( props.gradients ) ? (
-		<MultipleOrigin headingLevel={ headingLevel } { ...additionalProps } />
-	) : (
-		<SingleOrigin { ...additionalProps } />
-	);
+	warnIfCircularOptionPickerAsButtonsIsSet( 'GradientPicker', asButtons );
 
-	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
-		asButtons,
-		loop,
-		ariaLabel,
-		ariaLabelledby
+	const { metaProps, labelProps, resolvedPresentation } =
+		getComputeCircularOptionPickerCommonProps(
+			asButtons,
+			loop,
+			ariaLabel,
+			ariaLabelledby,
+			presentation
+		);
+	const options = isMultipleOriginArray( props.gradients ) ? (
+		<MultipleOrigin
+			headingLevel={ headingLevel }
+			{ ...additionalProps }
+			presentation={ resolvedPresentation }
+		/>
+	) : (
+		<SingleOrigin
+			{ ...additionalProps }
+			presentation={ resolvedPresentation }
+		/>
 	);
 
 	return (

--- a/packages/components/src/gradient-picker/test/index.tsx
+++ b/packages/components/src/gradient-picker/test/index.tsx
@@ -13,6 +13,55 @@ const DUPLICATE_GRADIENTS = [
 ];
 
 describe( 'GradientPicker', () => {
+	it( 'should use matching values only for display in command button presentation', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render(
+			<GradientPicker
+				aria-label="Gradients"
+				gradients={ DUPLICATE_GRADIENTS }
+				value={ GRADIENT_A }
+				onChange={ onChange }
+				presentation="command-buttons"
+				disableCustomGradients
+				clearable={ false }
+			/>
+		);
+
+		const gradient = screen.getByRole( 'button', {
+			name: 'Gradient: Dark Background',
+		} );
+		expect(
+			screen.getByRole( 'group', { name: 'Gradients' } )
+		).toBeVisible();
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		expect( gradient ).not.toHaveAttribute( 'aria-pressed' );
+
+		await user.click( gradient );
+		expect( onChange ).toHaveBeenCalledWith(
+			GRADIENT_A,
+			0,
+			'dark-background'
+		);
+	} );
+
+	it( 'should warn whenever asButtons is supplied', () => {
+		render(
+			<GradientPicker
+				aria-label="Gradients"
+				gradients={ DUPLICATE_GRADIENTS }
+				onChange={ jest.fn() }
+				asButtons={ false }
+				disableCustomGradients
+				clearable={ false }
+			/>
+		);
+
+		expect( console ).toHaveWarnedWith(
+			'`asButtons` prop in wp.components.GradientPicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
+		);
+	} );
+
 	describe( 'duplicate gradients in palette', () => {
 		it( 'should render all swatches even when two entries share the same gradient value', () => {
 			render(

--- a/packages/components/src/gradient-picker/test/index.tsx
+++ b/packages/components/src/gradient-picker/test/index.tsx
@@ -21,6 +21,7 @@ describe( 'GradientPicker', () => {
 				aria-label="Gradients"
 				gradients={ DUPLICATE_GRADIENTS }
 				value={ GRADIENT_A }
+				selectedSlug="dark-background"
 				onChange={ onChange }
 				presentation="command-buttons"
 				disableCustomGradients
@@ -45,21 +46,55 @@ describe( 'GradientPicker', () => {
 		);
 	} );
 
-	it( 'should warn whenever asButtons is supplied', () => {
+	it( 'should warn for asButtons and prefer an explicit presentation', () => {
 		render(
 			<GradientPicker
 				aria-label="Gradients"
 				gradients={ DUPLICATE_GRADIENTS }
 				onChange={ jest.fn() }
 				asButtons={ false }
+				presentation="command-buttons"
 				disableCustomGradients
 				clearable={ false }
 			/>
 		);
 
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Gradient: Dark Background',
+			} )
+		).not.toHaveAttribute( 'aria-pressed' );
 		expect( console ).toHaveWarnedWith(
 			'`asButtons` prop in wp.components.GradientPicker is deprecated since version 7.2. Please use `presentation` instead. Note: `asButtons={ true }` maps to `presentation="toggle-buttons"`. Explicit `presentation` takes precedence.'
 		);
+	} );
+
+	it( 'should preserve asButtons as a toggle-button alias', () => {
+		render(
+			<GradientPicker
+				aria-label="Gradients"
+				gradients={ DUPLICATE_GRADIENTS }
+				value={ GRADIENT_A }
+				selectedSlug="dark-background"
+				onChange={ jest.fn() }
+				asButtons
+				disableCustomGradients
+				clearable={ false }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Gradient: Dark Background',
+				pressed: true,
+			} )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Gradient: Dark Text',
+				pressed: false,
+			} )
+		).toBeVisible();
 	} );
 
 	describe( 'duplicate gradients in palette', () => {

--- a/packages/components/src/gradient-picker/types.ts
+++ b/packages/components/src/gradient-picker/types.ts
@@ -1,5 +1,5 @@
 import type { HeadingSize } from '../heading/types';
-import type { CircularOptionPickerPresentation } from '../circular-option-picker';
+import type { CircularOptionPickerProps } from '../circular-option-picker/types';
 
 export type GradientObject = {
 	gradient: string;
@@ -74,7 +74,7 @@ type GradientPickerBaseProps = {
 	 *
 	 * @default 'listbox'
 	 */
-	presentation?: CircularOptionPickerPresentation;
+	presentation?: CircularOptionPickerProps[ 'presentation' ];
 	/**
 	 * Whether the control should present as toggle buttons.
 	 *

--- a/packages/components/src/gradient-picker/types.ts
+++ b/packages/components/src/gradient-picker/types.ts
@@ -1,4 +1,5 @@
 import type { HeadingSize } from '../heading/types';
+import type { CircularOptionPickerPresentation } from '../circular-option-picker';
 
 export type GradientObject = {
 	gradient: string;
@@ -59,15 +60,33 @@ type GradientPickerBaseProps = {
 	 */
 	headingLevel?: HeadingSize;
 	/**
-	 * Whether the control should present as a set of buttons,
-	 * each with its own tab stop.
+	 * How predefined gradient swatches behave and are exposed to assistive
+	 * technology.
 	 *
+	 * - `listbox` uses one tab stop and arrow-key navigation, and exposes
+	 *   selection with `aria-selected`.
+	 * - `toggle-buttons` gives each swatch a tab stop and exposes selection with
+	 *   `aria-pressed`.
+	 * - `command-buttons` gives each swatch a tab stop and exposes no selection
+	 *   state. `value` and `selectedSlug` do not mark predefined swatches as
+	 *   selected, and activating a swatch always calls `onChange` with that
+	 *   swatch. `value` still controls the custom gradient picker.
+	 *
+	 * @default 'listbox'
+	 */
+	presentation?: CircularOptionPickerPresentation;
+	/**
+	 * Whether the control should present as toggle buttons.
+	 *
+	 * @deprecated Use `presentation="toggle-buttons"` instead. An explicit
+	 * `presentation` takes precedence.
 	 * @default false
+	 * @ignore
 	 */
 	asButtons?: boolean;
 	/**
 	 * Prevents keyboard interaction from wrapping around.
-	 * Only used when `asButtons` is not true.
+	 * Only used with the `listbox` presentation.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -872,6 +872,7 @@ export function PaletteEdit( {
 					) }
 					{ ! isEditing && variant === 'gradient' && (
 						<GradientPicker
+							presentation="command-buttons"
 							aria-labelledby={ paletteLabelId }
 							gradients={ gradients }
 							onChange={ onSelectPaletteItem }
@@ -881,6 +882,7 @@ export function PaletteEdit( {
 					) }
 					{ ! isEditing && variant === 'duotone' && (
 						<DuotonePicker
+							presentation="command-buttons"
 							aria-labelledby={ paletteLabelId }
 							duotonePalette={ duotones ?? [] }
 							colorPalette={ duotoneColorPalette }
@@ -893,6 +895,7 @@ export function PaletteEdit( {
 					) }
 					{ ! isEditing && variant === 'color' && (
 						<ColorPalette
+							presentation="command-buttons"
 							aria-labelledby={ paletteLabelId }
 							colors={ colors }
 							onChange={ onSelectPaletteItem }

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { click, type, press } from '@ariakit/test';
 import PaletteEdit, {
 	getNameAndSlugForPosition,
@@ -245,6 +245,52 @@ describe( 'PaletteEdit', () => {
 			} )
 		).toBeVisible();
 	} );
+
+	it.each( [
+		{
+			name: 'color',
+			props: { colors },
+			buttonName: 'Primary',
+			editorRole: 'textbox' as const,
+			editorName: 'Hex color',
+		},
+		{
+			name: 'gradient',
+			props: { gradients },
+			buttonName: 'Gradient: Pale ocean',
+			editorRole: 'combobox' as const,
+			editorName: 'Type',
+		},
+		{
+			name: 'duotone',
+			props: { duotones, colorPalette: colors },
+			buttonName: 'Duotone: Purple and yellow',
+			editorRole: 'button' as const,
+			editorName: /Shadows/,
+		},
+	] )(
+		'shows $name swatches as named command buttons that open the editor',
+		async ( { props, buttonName, editorRole, editorName } ) => {
+			render( <PaletteEdit { ...defaultProps } { ...props } /> );
+
+			const group = screen.getByRole( 'group', { name: 'Test label' } );
+			const swatch = within( group ).getByRole( 'button', {
+				name: buttonName,
+			} );
+			expect(
+				within( group ).queryByRole( 'listbox' )
+			).not.toBeInTheDocument();
+			expect(
+				within( group ).queryByRole( 'option' )
+			).not.toBeInTheDocument();
+			expect( swatch ).not.toHaveAttribute( 'aria-pressed' );
+
+			await click( swatch );
+			expect(
+				screen.getByRole( editorRole, { name: editorName } )
+			).toBeVisible();
+		}
+	);
 
 	it( 'shows empty message', () => {
 		render(

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -283,6 +283,7 @@ describe( 'PaletteEdit', () => {
 			expect(
 				within( group ).queryByRole( 'option' )
 			).not.toBeInTheDocument();
+			expect( swatch.tagName ).toBe( 'BUTTON' );
 			expect( swatch ).not.toHaveAttribute( 'aria-pressed' );
 
 			await click( swatch );
@@ -291,6 +292,33 @@ describe( 'PaletteEdit', () => {
 			).toBeVisible();
 		}
 	);
+
+	it( 'tabs between command swatches and opens one with Space', async () => {
+		render( <PaletteEdit { ...defaultProps } colors={ colors } /> );
+
+		const primary = screen.getByRole( 'button', { name: 'Primary' } );
+		const secondary = screen.getByRole( 'button', { name: 'Secondary' } );
+		primary.focus();
+
+		await press.Tab();
+		expect( secondary ).toHaveFocus();
+
+		await press.Space();
+		expect(
+			screen.getByRole( 'textbox', { name: 'Hex color' } )
+		).toBeVisible();
+	} );
+
+	it( 'opens a command swatch with Enter', async () => {
+		render( <PaletteEdit { ...defaultProps } colors={ colors } /> );
+
+		screen.getByRole( 'button', { name: 'Primary' } ).focus();
+		await press.Enter();
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Hex color' } )
+		).toBeVisible();
+	} );
 
 	it( 'shows empty message', () => {
 		render(

--- a/storybook/components-manifest.yml
+++ b/storybook/components-manifest.yml
@@ -336,7 +336,6 @@
       - aria-label
       - aria-labelledby
       - as
-      - asButtons
       - clearable
       - colors
       - disableCustomColors
@@ -344,6 +343,7 @@
       - headingLevel
       - loop
       - onChange
+      - presentation
       - selectedSlug
       - value
 - name: ColorPicker
@@ -695,7 +695,6 @@
       - __nextHasNoMargin
       - aria-label
       - aria-labelledby
-      - asButtons
       - className
       - clearable
       - disableCustomGradients
@@ -704,6 +703,7 @@
       - headingLevel
       - loop
       - onChange
+      - presentation
       - selectedSlug
       - value
 - name: Icon

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -84,7 +84,7 @@
 	"scripts": {
 		"manifest-snapshot": "node ./scripts/generate-manifest-snapshot.mjs ./build/manifests/components.json",
 		"postmanifest-snapshot": "prettier --write components-manifest.yml",
-		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c . -o ./build && node ./scripts/inject-legacy-docgen.mjs ./build/manifests/components.json",
+		"storybook:build": "NODE_OPTIONS=--max-old-space-size=8192 storybook build -c . -o ./build && node ./scripts/sanitize-components-manifest.mjs ./build/manifests/components.json && node ./scripts/inject-legacy-docgen.mjs ./build/manifests/components.json",
 		"storybook:dev": "storybook dev -c . -p 50240",
 		"test:smoke": "npm run test:smoke:build && vitest run --config vitest.config.ts",
 		"test:smoke:build": "node ./scripts/smoke-static-build.mjs",

--- a/storybook/scripts/inject-legacy-docgen.mjs
+++ b/storybook/scripts/inject-legacy-docgen.mjs
@@ -27,7 +27,17 @@ const manifestPath = process.argv[ 2 ];
 
 assert( manifestPath, 'Manifest path is required' );
 
+// `react-component-meta` removes JSDoc tags from prop descriptions before it
+// writes the manifest. Keep this list in sync with props that use `@ignore`
+// but whose tag is therefore unavailable to the manifest post-processors.
+const ignoredProps = new Set( [ 'asButtons' ] );
+
 function addLegacyShape( component ) {
+	for ( const propName of ignoredProps ) {
+		delete component.reactComponentMeta?.props?.[ propName ];
+		delete component.reactDocgen?.props?.[ propName ];
+	}
+
 	if ( component.reactComponentMeta && ! component.reactDocgen ) {
 		component.reactDocgen = {
 			...component.reactComponentMeta,

--- a/storybook/scripts/inject-legacy-docgen.mjs
+++ b/storybook/scripts/inject-legacy-docgen.mjs
@@ -27,17 +27,7 @@ const manifestPath = process.argv[ 2 ];
 
 assert( manifestPath, 'Manifest path is required' );
 
-// `react-component-meta` removes JSDoc tags from prop descriptions before it
-// writes the manifest. Keep this list in sync with props that use `@ignore`
-// but whose tag is therefore unavailable to the manifest post-processors.
-const ignoredProps = new Set( [ 'asButtons' ] );
-
 function addLegacyShape( component ) {
-	for ( const propName of ignoredProps ) {
-		delete component.reactComponentMeta?.props?.[ propName ];
-		delete component.reactDocgen?.props?.[ propName ];
-	}
-
 	if ( component.reactComponentMeta && ! component.reactDocgen ) {
 		component.reactDocgen = {
 			...component.reactComponentMeta,

--- a/storybook/scripts/sanitize-components-manifest.mjs
+++ b/storybook/scripts/sanitize-components-manifest.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Removes props that are intentionally hidden from the components manifest.
+ *
+ * `react-component-meta` removes JSDoc tags from prop descriptions before it
+ * writes the manifest, so post-processors cannot detect `@ignore` for these
+ * props. Keep this map scoped to the components that own each hidden prop.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import assert from 'node:assert';
+
+const manifestPath = process.argv[ 2 ];
+
+assert( manifestPath, 'Manifest path is required' );
+
+const ignoredPropsByComponent = new Map( [
+	[ 'CircularOptionPicker', new Set( [ 'asButtons' ] ) ],
+	[ 'ColorPalette', new Set( [ 'asButtons' ] ) ],
+	[ 'DuotonePicker', new Set( [ 'asButtons' ] ) ],
+	[ 'GradientPicker', new Set( [ 'asButtons' ] ) ],
+] );
+
+function sanitizeComponent( component ) {
+	const ignoredProps = ignoredPropsByComponent.get( component.name );
+
+	for ( const propName of ignoredProps ?? [] ) {
+		delete component.reactComponentMeta?.props?.[ propName ];
+		delete component.reactDocgen?.props?.[ propName ];
+		delete component.reactDocgenTypescript?.props?.[ propName ];
+	}
+
+	if ( component.subcomponents ) {
+		for ( const sub of Object.values( component.subcomponents ) ) {
+			sanitizeComponent( sub );
+		}
+	}
+}
+
+const raw = await readFile( manifestPath, 'utf8' );
+const manifest = JSON.parse( raw );
+for ( const component of Object.values( manifest.components ?? {} ) ) {
+	sanitizeComponent( component );
+}
+await writeFile( manifestPath, JSON.stringify( manifest, null, '\t' ) + '\n' );

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -8,5 +8,8 @@
 		"types": [ "jest" ]
 	},
 	"include": [ "**/*.tsx", "**/*.ts", "**/*.mjs" ],
-	"exclude": [ "scripts/inject-legacy-docgen.mjs" ]
+	"exclude": [
+		"scripts/inject-legacy-docgen.mjs",
+		"scripts/sanitize-components-manifest.mjs"
+	]
 }

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -152,15 +152,15 @@ test.describe( 'Global styles variations', () => {
 		await page.getByRole( 'button', { name: 'Edit palette' } ).click();
 
 		await expect(
-			page.locator( 'role=option[name="Foreground"i]' )
+			page.locator( 'role=button[name="Foreground"i]' )
 		).toHaveCSS( 'background-color', 'rgb(74, 7, 74)' );
 
 		await expect(
-			page.locator( 'role=option[name="Background"i]' )
+			page.locator( 'role=button[name="Background"i]' )
 		).toHaveCSS( 'background-color', 'rgb(202, 105, 211)' );
 
 		await expect(
-			page.locator( 'role=option[name="Awesome pink"i]' )
+			page.locator( 'role=button[name="Awesome pink"i]' )
 		).toHaveCSS( 'background-color', 'rgba(204, 0, 255, 0.77)' );
 	} );
 


### PR DESCRIPTION
## What?

Closes #81800.

Supersedes #81836.

**Virtual co-author:** [@dilipom13](https://github.com/dilipom13), who worked on #81836.

Expose the color, gradient, and duotone swatches in `PaletteEdit` as command buttons. Add a `presentation` prop to the picker components while keeping `asButtons` as a deprecated compatibility alias.

## Why?

These swatches open editors instead of selecting values. Listbox and toggle-button semantics therefore expose selection state that the controls do not have.

## How?

- Use `presentation="command-buttons"` for all three `PaletteEdit` variants.
- Keep listbox and toggle-button presentations for selection controls. An explicit `presentation` takes precedence over `asButtons`.
- Migrate Gutenberg consumers and update the documentation and tests.

## Testing Instructions

No visual changes.

1. Open the global Styles editor and go to **Colors > Palette > Edit**.
2. Check the color, gradient, and duotone palettes.
3. Confirm that each swatch is a button in a group named by its palette heading, has no selected or pressed state, and opens its editor when activated.
4. Open a Cover block placeholder and confirm that its overlay choices remain toggle buttons with pressed state.

### Testing Instructions for Keyboard

1. Use Tab to move through the palette swatches.
2. Activate each swatch with Enter and Space. Confirm that the matching editor opens each time.
3. Confirm that arrow keys are not required to move between the swatches.

## Screenshots or screencast

Not applicable. This changes accessibility semantics without changing the visual design.

## Use of AI Tools

OpenAI Codex was used to inspect the previous feedback, implement the change, and write tests and documentation. The generated work was reviewed during this task.

---

## ✍️ Dev note for WP 7.2

`ColorPalette`, `GradientPicker`, and `DuotonePicker` in `@wordpress/components` now accept a `presentation` prop with three modes:

- `listbox` (the default) uses one tab stop, arrow-key navigation, and `aria-selected`.
- `toggle-buttons` gives each swatch a tab stop and exposes selection with `aria-pressed`.
- `command-buttons` gives each swatch a tab stop without exposing selection state. Use this mode when swatches run actions, such as opening an editor.

The existing `asButtons` prop is deprecated. It remains supported as an alias for `presentation="toggle-buttons"` for backward compatibility. If both props are supplied, `presentation` takes precedence. Consumers should replace `asButtons` with `presentation="toggle-buttons"`.

The `loop` prop only affects the `listbox` presentation. In `command-buttons` mode, activating a predefined swatch always calls `onChange`, even when `value` or `selectedSlug` already identifies that swatch.
