### PR TITLE
Block Library: Allow themes to override the padding added via background color

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add a `$block-bg-padding` variable that resolves the default background padding through the `--wp--style--block-background-padding` custom property, keeping the existing values as its fallback ([#82024](https://github.com/WordPress/gutenberg/pull/82024)).
+
 ## 13.0.0 (2026-08-26)
 
 ### Breaking Changes

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -153,6 +153,8 @@ $default-font-size: $font-size-medium;
  */
 
 // Padding for blocks with a background color (e.g. paragraph or group).
+// Use $block-bg-padding; the --v and --h values below are only its fallback,
+// so referencing them directly skips the theme override.
 $block-bg-padding--v: 1.25em;
 $block-bg-padding--h: 2.375em;
 $block-bg-padding: var(--wp--style--block-background-padding, #{$block-bg-padding--v} #{$block-bg-padding--h});

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -155,6 +155,7 @@ $default-font-size: $font-size-medium;
 // Padding for blocks with a background color (e.g. paragraph or group).
 $block-bg-padding--v: 1.25em;
 $block-bg-padding--h: 2.375em;
+$block-bg-padding: var(--wp--style--block-background-padding, #{$block-bg-padding--v} #{$block-bg-padding--h});
 
 
 /**

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).
+-   Paragraph, List, Heading, Preformatted, Columns, Group, Template Part: Read the default padding these blocks add when they have a background color from the `--wp--style--block-background-padding` custom property, so themes can change or remove it ([#82024](https://github.com/WordPress/gutenberg/pull/82024)).
 -   Query: Show a snackbar notice instead of a blocking modal when "Reload full page" is turned on automatically because a block inside the Query block doesn't support client-side navigation ([#82246](https://github.com/WordPress/gutenberg/pull/82246)).
 
 ### Bug Fixes

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -84,7 +84,7 @@
 // Add low specificity default padding to columns blocks with backgrounds.
 :where(.wp-block-columns.has-background) {
 	// Matches paragraph block padding.
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: $block-bg-padding;
 }
 
 

--- a/packages/block-library/src/group/theme.scss
+++ b/packages/block-library/src/group/theme.scss
@@ -3,5 +3,5 @@
 // Add low specificity default padding to groups with backgrounds.
 :where(.wp-block-group.has-background) {
 	// Matches paragraph block padding.
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: $block-bg-padding;
 }

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -7,7 +7,7 @@ h4,
 h5,
 h6 {
 	&:where(.wp-block-heading).has-background {
-		padding: $block-bg-padding--v $block-bg-padding--h;
+		padding: $block-bg-padding;
 	}
 	&.has-text-align-right[style*="writing-mode"]:where([style*="vertical-rl"]),
 	&.has-text-align-left[style*="writing-mode"]:where([style*="vertical-lr"]) {

--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -6,5 +6,5 @@ ul {
 }
 
 :root :where(.wp-block-list.has-background) {
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: $block-bg-padding;
 }

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -42,7 +42,7 @@ p.has-drop-cap.has-background {
 
 // Specificity is reduced to 0-1-0 so global styles can override this.
 :root :where(p.has-background) {
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: $block-bg-padding;
 }
 
 // Use :where to contain the specificity of this rule

--- a/packages/block-library/src/preformatted/style.scss
+++ b/packages/block-library/src/preformatted/style.scss
@@ -8,5 +8,5 @@
 
 // Add low specificity default padding when a background is used.
 :where(.wp-block-preformatted.has-background) {
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: $block-bg-padding;
 }

--- a/packages/block-library/src/template-part/theme.scss
+++ b/packages/block-library/src/template-part/theme.scss
@@ -3,7 +3,7 @@
 // Same as the group block styles.
 :root :where(.wp-block-template-part.has-background) {
 	// Matches paragraph Block padding
-	padding: $block-bg-padding--v $block-bg-padding--h;
+	padding: $block-bg-padding;
 	margin-top: 0;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
See #36586.

## What?

Blocks that are given a background color also get a fixed amount of padding. This routes that padding through a new CSS custom property, `--wp--style--block-background-padding`, so themes can change it or remove it.

## Why?

The padding suits a lot of designs but not all of them, and there is currently no reliable way for a theme to override it. On Heading it cannot be overridden at all.

## How?

The seven blocks that add this padding (Paragraph, List, Heading, Preformatted, Columns, Group, and Template Part) now read the value from the custom property, keeping the current values as its fallback. A theme sets the property to change the padding, and everything renders exactly as before if it does not.

Reading the value from inside the rule also avoids the selector and specificity changes that overriding these rules would otherwise need, so existing sites are unaffected.

A follow up could a `theme.json` property that sets the same custom property, so themes will not need custom CSS. This PR does not depend on it.

## How to opt out

```json
{
      "version": 3,
      "styles": {
              "css": "body { --wp--style--block-background-padding: 0; }"
      }
}
```

Any value works, not only `0`. For a single block type, set it as block-level custom CSS instead, for example `styles.blocks.core/group.css`, and blocks nested inside will inherit it unless they set their own.

## Testing Instructions

Group and Template Part only load these styles when a theme calls `add_theme_support( 'wp-block-styles' )`, so test with Twenty Twenty-One as well as Twenty Twenty-Five.

1. Insert a Paragraph, List, Heading, Preformatted, Columns, Group, and Template Part block, and give each one a background color.
2. Confirm the padding on each looks the same as it does on the front end.
3. Confirm the Heading padding still scales with the heading level.
4. Confirm blocks without a background color are unchanged.
5. Add the snippet above to the theme's `theme.json` with a value of `0`. Confirm the padding is removed from all seven and nothing else moves.
6. Change the value to `1rem 2rem` and confirm all seven pick it up.
7. Replace it with a `core/group` value. Confirm Group changes, the other six keep the default, and a Paragraph with a background nested inside the Group inherits the Group's value.
8. Add a `core/paragraph` value as well and confirm it wins over the one inherited from the Group.

## Screenshots or screencast

N/A. No visual change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customization option for default background padding through the `--wp--style--block-background-padding` setting.
  * Applied the customizable padding to background-enabled Paragraph, List, Heading, Preformatted, Columns, Group, and Template Part blocks.
  * Existing padding values remain as fallbacks when no customization is provided.

* **Documentation**
  * Documented the new background-padding customization option in the relevant changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->