### PR TITLE
RadioControl: allow individual options to be disabled

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Enhancements
 
+-   `RadioControl`: Allow individual options to be disabled while the rest of the group remains available ([#82026](https://github.com/WordPress/gutenberg/pull/82026)).
 -   `PaletteEdit`: Add a duotone variant. Passing `duotones` (with an optional `colorPalette` for the shadows and highlights pickers) edits duotone presets with the same UI as colors and gradients. Palette colors that do not resolve to a concrete value, such as `color-mix()`, are left out of the duotone pickers, since a duotone built from one cannot be rendered, and the rest are normalized to hex, since the front end's duotone parser does not accept CSS named colors ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `DuotonePicker`: Add `selectedSlug` prop for slug-based selection and pass the picked preset's index and slug to `onChange`, so two presets sharing a pair of colors keep their identity ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `PaletteEdit`: Name the swatch picker after the palette's heading, so it is announced as Theme, Default or Custom rather than an unlabelled list ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -100,12 +100,14 @@ A function that receives the value of the new option that is being selected as i
 
 -   Required: Yes
 
-#### `options`: `{ label: string, value: string }[]`
+#### `options`: `{ label: string, value: string, description?: string, disabled?: boolean }[]`
 
 An array of objects containing the value and label of the options.
 
 -   `label`: `string` The label to be shown to the user.
 -   `value`: `string` The internal value compared against select and passed to onChange.
+-   `description`: `string` Optional help text shown below the label.
+-   `disabled`: `boolean` Whether the option is disabled.
 
 *   Required: No
 

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -107,6 +107,7 @@ export function RadioControl(
 							type="radio"
 							name={ id }
 							value={ option.value }
+							disabled={ option.disabled }
 							onChange={ onChangeValue }
 							checked={ option.value === selected }
 							aria-describedby={

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -87,3 +87,15 @@ WithOptionDescriptions.args = {
 		},
 	],
 };
+
+export const WithDisabledOption: StoryFn< typeof RadioControl > = Template.bind(
+	{}
+);
+WithDisabledOption.args = {
+	...Default.args,
+	options: [
+		{ label: 'Public', value: 'public' },
+		{ label: 'Private', value: 'private', disabled: true },
+		{ label: 'Password Protected', value: 'password' },
+	],
+};

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -69,16 +69,14 @@
 	grid-column: 2;
 	grid-row: 1;
 
+	.components-radio-control__input:not(:disabled) + & {
+		cursor: var(--wpds-cursor-control);
+	}
+
 	line-height: $radio-input-size-sm;
 
 	@include break-small() {
 		line-height: $radio-input-size;
-	}
-}
-
-.components-radio-control__input:not(:disabled) {
-	& + .components-radio-control__label {
-		cursor: var(--wpds-cursor-control);
 	}
 }
 

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -10,7 +10,6 @@
 
 	font-family: $default-font;
 	font-size: $default-font-size;
-
 }
 
 .components-radio-control__group-wrapper.has-help {
@@ -62,7 +61,6 @@
 		&:checked::before {
 			border-color: $components-color-gray-400;
 			opacity: 1; // Override style from wp-admin forms.css.
-
 		}
 	}
 }
@@ -71,14 +69,16 @@
 	grid-column: 2;
 	grid-row: 1;
 
-	.components-radio-control:not(:disabled) & {
-		cursor: var(--wpds-cursor-control);
-	}
-
 	line-height: $radio-input-size-sm;
 
 	@include break-small() {
 		line-height: $radio-input-size;
+	}
+}
+
+.components-radio-control__input:not(:disabled) {
+	& + .components-radio-control__label {
+		cursor: var(--wpds-cursor-control);
 	}
 }
 

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -37,6 +37,14 @@ const defaultPropsWithDescriptions = {
 	} ) ),
 };
 
+const defaultPropsWithDisabledOption = {
+	...defaultProps,
+	options: defaultProps.options.map( ( option, index ) => ( {
+		...option,
+		disabled: index === 1,
+	} ) ),
+};
+
 describe.each( [
 	// TODO: `RadioControl` doesn't currently support uncontrolled mode.
 	// [ 'uncontrolled', RadioControl ],
@@ -78,6 +86,29 @@ describe.each( [
 
 			expect(
 				screen.getByRole( 'radiogroup', { name: defaultProps.label } )
+			).toBeDisabled();
+		} );
+
+		it( 'should disable an individual option without disabling the radio group', () => {
+			render(
+				<Component
+					{ ...defaultPropsWithDisabledOption }
+					onChange={ () => {} }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'radiogroup', { name: defaultProps.label } )
+			).toBeEnabled();
+			expect(
+				screen.getByRole( 'radio', {
+					name: defaultProps.options[ 0 ].label,
+				} )
+			).toBeEnabled();
+			expect(
+				screen.getByRole( 'radio', {
+					name: defaultProps.options[ 1 ].label,
+				} )
 			).toBeDisabled();
 		} );
 
@@ -166,6 +197,34 @@ describe.each( [
 	} );
 
 	describe( 'interaction', () => {
+		it( 'should keep enabled options interactive when another option is disabled', async () => {
+			const user = userEvent.setup();
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultPropsWithDisabledOption }
+					onChange={ onChangeSpy }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'radio', {
+					name: defaultProps.options[ 1 ].label,
+				} )
+			);
+			expect( onChangeSpy ).not.toHaveBeenCalled();
+
+			await user.click(
+				screen.getByRole( 'radio', {
+					name: defaultProps.options[ 2 ].label,
+				} )
+			);
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				defaultProps.options[ 2 ].value
+			);
+		} );
+
 		it( 'should select a new value when clicking on the radio input', async () => {
 			const user = userEvent.setup();
 			const onChangeSpy = jest.fn();

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -31,6 +31,12 @@ export type RadioControlProps = Pick<
 		 * Optional help text to be shown in addition the label.
 		 */
 		description?: string;
+		/**
+		 * Whether the option should be disabled.
+		 *
+		 * @default false
+		 */
+		disabled?: boolean;
 	}[];
 	/**
 	 * The value property of the currently selected option.


### PR DESCRIPTION
Closes #81939

## What?

Adds an optional `disabled` field to individual `RadioControl` options. Unavailable choices can remain visible without disabling the whole radio group.

## Why?

Consumers currently have to hide the option, disable every choice, or recreate `RadioControl` markup and depend on its internal class names.

## How?

The option's `disabled` value is passed to its native radio input. This reuses the existing disabled indicator styles while keeping the label at its normal color and opacity, as shown in [the design feedback](https://github.com/WordPress/gutenberg/issues/81939#issuecomment-5410318468).

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Open **Components > Selection & Input > Common > RadioControl > With Disabled Option**.
3. Confirm that **Private** has a disabled gray radio indicator, while its label keeps the same text color and opacity as the other labels.
4. Confirm that clicking **Private** does not select it.
5. Confirm that **Public** and **Password Protected** remain selectable.

### Testing Instructions for Keyboard

1. Press Tab until focus enters the radio group.
2. Use the arrow keys to move through the available options.
3. Confirm that the disabled **Private** option is not selected and the enabled options remain reachable.

## Screenshots

All options disabled (same as on trunk)

<img width="468" height="288" alt="Screenshot 2026-08-25 at 14 51 22" src="https://github.com/user-attachments/assets/ff743aca-9906-4b0b-a087-b3975f799d39" />

One option disabled, unselected

<img width="488" height="306" alt="Screenshot 2026-08-25 at 14 51 17" src="https://github.com/user-attachments/assets/fff909b1-4045-4a30-8c50-2494c9448db0" />

One option disabled, selected

<img width="576" height="318" alt="Screenshot 2026-08-25 at 14 51 07" src="https://github.com/user-attachments/assets/236e3a43-33ed-4234-b87f-805ddd46945e" />



## Use of AI Tools

Codex was used to implement the change, run verification, and draft this description.