### PR TITLE
Bundled packages: Add a check for transitive private API usage

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -144,3 +144,33 @@ jobs:
 
             - name: License compatibility
               run: npm run other:check-licenses
+
+    # Fails when a checked bundled package pulls @wordpress/private-apis into
+    # its module graph, including transitively through another package.
+    check-private-apis:
+        name: Check DataViews private APIs
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        timeout-minutes: 10
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Use desired version of Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version-file: '.nvmrc'
+                  # No cache restoration: this workflow also runs on push,
+                  # and the job doesn't need the install speed.
+                  package-manager-cache: false
+
+            - name: npm install
+              run: npm install
+
+            - name: Check private API usage in DataViews
+              run: node bin/check-private-apis.mjs

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -145,10 +145,10 @@ jobs:
             - name: License compatibility
               run: npm run other:check-licenses
 
-    # Fails when a checked bundled package pulls @wordpress/private-apis into
-    # its module graph, including transitively through another package.
+    # Fails when a bundled package pulls @wordpress/private-apis into its
+    # module graph, including transitively through another package.
     check-private-apis:
-        name: Check DataViews private APIs
+        name: Check private API usage in bundled packages
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -172,5 +172,5 @@ jobs:
             - name: npm install
               run: npm install
 
-            - name: Check private API usage in DataViews
-              run: node tools/validation/check-private-apis.mjs
+            - name: Check private API usage in bundled packages
+              run: npm run --workspace @wordpress/validation-tools check-private-apis

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -170,6 +170,9 @@ jobs:
                   package-manager-cache: false
 
             - name: npm install
+              # Not the setup-node composite action: its cached node_modules
+              # path skips `prepare` scripts, and bundling from source needs
+              # what they generate (e.g. the icons `src/library`).
               run: npm install
 
             - name: Check private API usage in bundled packages

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -173,4 +173,4 @@ jobs:
               run: npm install
 
             - name: Check private API usage in DataViews
-              run: node bin/check-private-apis.mjs
+              run: node tools/validation/check-private-apis.mjs

--- a/bin/check-private-apis.mjs
+++ b/bin/check-private-apis.mjs
@@ -1,0 +1,289 @@
+/**
+ * Checks that a bundled package never pulls `@wordpress/private-apis` into its
+ * module graph, including transitively (e.g. by importing a component from
+ * `@wordpress/components` whose implementation uses private APIs internally).
+ *
+ * It bundles the package from `src/index` with esbuild, resolving all
+ * `@wordpress/*` imports to their `src/` (so it checks current source, not
+ * build output), then fails if any file from `packages/private-apis/` ends up
+ * in the graph. Tree shaking keeps this precise: only code that is actually
+ * used is followed.
+ *
+ * Singleton packages (data, hooks, i18n, date) stay external, mirroring the
+ * dataviews `/wp` bundle: they are shared with the platform and never inlined
+ * into a consumer bundle.
+ *
+ * Usage:
+ *   node bin/check-private-apis.mjs [package-name ...]  # default: dataviews
+ *   node bin/check-private-apis.mjs --all               # every bundled package
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// eslint-disable-next-line import/no-extraneous-dependencies -- Hoisted from the packages that depend on it. A production version of this check would live in a workspace declaring it.
+import esbuild from 'esbuild';
+
+const ROOT = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'..'
+);
+const PACKAGES_DIR = path.join( ROOT, 'packages' );
+const SINGLETONS = new Set( [ 'data', 'hooks', 'i18n', 'date' ] );
+
+function readPackageJson( name ) {
+	try {
+		return JSON.parse(
+			fs.readFileSync(
+				path.join( PACKAGES_DIR, name, 'package.json' ),
+				'utf8'
+			)
+		);
+	} catch {
+		return null;
+	}
+}
+
+function isBundled( pkgJson ) {
+	return (
+		pkgJson &&
+		! pkgJson.private &&
+		! pkgJson.wpScript &&
+		! pkgJson.wpScriptModuleExports
+	);
+}
+
+function findEntry( name ) {
+	for ( const candidate of [ 'index.ts', 'index.tsx', 'index.js' ] ) {
+		const entry = path.join( PACKAGES_DIR, name, 'src', candidate );
+		if ( fs.existsSync( entry ) ) {
+			return entry;
+		}
+	}
+	return null;
+}
+
+function resolveSource( base ) {
+	for ( const candidate of [
+		base,
+		`${ base }.ts`,
+		`${ base }.tsx`,
+		`${ base }.js`,
+		`${ base }.jsx`,
+		path.join( base, 'index.ts' ),
+		path.join( base, 'index.tsx' ),
+		path.join( base, 'index.js' ),
+	] ) {
+		if ( fs.existsSync( candidate ) && fs.statSync( candidate ).isFile() ) {
+			return candidate;
+		}
+	}
+	return null;
+}
+
+// Resolves @wordpress/* to package sources, keeps everything else external.
+function wordpressSources( onUnresolved ) {
+	return {
+		name: 'wordpress-sources',
+		setup( build ) {
+			build.onResolve(
+				{ filter: /\.(scss|css|svg|png)$/ },
+				( args ) => ( {
+					path: args.path,
+					external: true,
+				} )
+			);
+			build.onResolve( { filter: /^@wordpress\// }, ( args ) => {
+				const match = args.path.match( /^@wordpress\/([^/]+)(\/.*)?$/ );
+				const name = match[ 1 ];
+				if ( SINGLETONS.has( name ) ) {
+					return { path: args.path, external: true };
+				}
+				const subpath = match[ 2 ];
+				const resolved = resolveSource(
+					path.join(
+						PACKAGES_DIR,
+						name,
+						'src',
+						subpath ? `.${ subpath }` : '.'
+					)
+				);
+				if ( ! resolved ) {
+					onUnresolved( args.path, args.importer );
+					return { path: args.path, external: true };
+				}
+				// esbuild does not read package.json for plugin-resolved paths,
+				// so declare what the packages themselves declare: their JS is
+				// side-effect free (only style files are not, and those stay
+				// external here). Without this, module-level lock() calls in
+				// unused private-apis registries defeat tree shaking.
+				return { path: resolved, sideEffects: false };
+			} );
+			build.onResolve( { filter: /^[^./]/ }, ( args ) => ( {
+				path: args.path,
+				external: true,
+			} ) );
+			// esbuild only honors package.json `sideEffects` for files inside
+			// node_modules, so relative imports between source files must be
+			// marked side-effect free here too. Matches what the packages
+			// declare for their published builds.
+			build.onResolve( { filter: /^\./ }, ( args ) => {
+				const resolved = resolveSource(
+					path.resolve( path.dirname( args.importer ), args.path )
+				);
+				return resolved
+					? { path: resolved, sideEffects: false }
+					: undefined;
+			} );
+		},
+	};
+}
+
+// Shortest import chain from the entry to a target file. Import edges come
+// from `metafile.inputs` (the visited set); when `kept` is given the chain is
+// restricted to files that survived tree shaking.
+function findChain( metafile, entry, target, kept ) {
+	const previous = new Map( [ [ entry, null ] ] );
+	const queue = [ entry ];
+	while ( queue.length ) {
+		const file = queue.shift();
+		if ( file === target ) {
+			const chain = [];
+			for (
+				let current = file;
+				current;
+				current = previous.get( current )
+			) {
+				chain.unshift( current );
+			}
+			return chain;
+		}
+		for ( const dep of metafile.inputs[ file ]?.imports ?? [] ) {
+			if (
+				! dep.external &&
+				! previous.has( dep.path ) &&
+				( ! kept || kept.has( dep.path ) )
+			) {
+				previous.set( dep.path, file );
+				queue.push( dep.path );
+			}
+		}
+	}
+	return null;
+}
+
+async function checkPackage( name ) {
+	const entry = findEntry( name );
+	if ( ! entry ) {
+		return { name, status: 'skipped', reason: 'no src/index entry' };
+	}
+	const unresolved = [];
+	let result;
+	try {
+		result = await esbuild.build( {
+			entryPoints: [ entry ],
+			bundle: true,
+			write: false,
+			metafile: true,
+			plugins: [
+				wordpressSources( ( specifier, importer ) =>
+					unresolved.push( { specifier, importer } )
+				),
+			],
+			jsx: 'automatic',
+			loader: { '.js': 'jsx' },
+			format: 'esm',
+			logLevel: 'silent',
+		} );
+	} catch ( error ) {
+		return {
+			name,
+			status: 'skipped',
+			reason: `build error: ${ error.message.split( '\n' )[ 0 ] }`,
+		};
+	}
+
+	const entryKey = path.relative( ROOT, entry );
+	// Only files that survived tree shaking count: an unused private-apis
+	// registry re-exported from a package entry is dropped from real builds.
+	// Fully shaken modules are absent from the output's inputs, while used
+	// barrel files stay listed at 0 bytes, so presence is the right signal.
+	const kept = new Set();
+	for ( const output of Object.values( result.metafile.outputs ) ) {
+		for ( const file of Object.keys( output.inputs ) ) {
+			kept.add( file );
+		}
+	}
+	const offenders = [ ...kept ].filter( ( file ) =>
+		file.startsWith( 'packages/private-apis/' )
+	);
+	// The files that actually consume private-apis (the lock-unlock modules),
+	// each with an import chain from the entry showing how they got pulled in.
+	const culprits = offenders.length
+		? [ ...kept ].filter(
+				( file ) =>
+					! file.startsWith( 'packages/private-apis/' ) &&
+					( result.metafile.inputs[ file ]?.imports ?? [] ).some(
+						( dep ) =>
+							! dep.external &&
+							dep.path.startsWith( 'packages/private-apis/' )
+					)
+		  )
+		: [];
+	const chains = culprits.map( ( culprit ) => [
+		...( findChain( result.metafile, entryKey, culprit, kept ) ?? [
+			culprit,
+		] ),
+		'@wordpress/private-apis',
+	] );
+	return {
+		name,
+		status: offenders.length ? 'fail' : 'pass',
+		chains,
+		unresolved,
+	};
+}
+
+async function main() {
+	const args = process.argv.slice( 2 );
+	const names = args.includes( '--all' )
+		? fs
+				.readdirSync( PACKAGES_DIR )
+				.filter( ( name ) => isBundled( readPackageJson( name ) ) )
+		: args.filter( ( arg ) => ! arg.startsWith( '--' ) );
+	if ( ! names.length ) {
+		names.push( 'dataviews' );
+	}
+
+	let failed = false;
+	for ( const name of names ) {
+		const { status, reason, chains, unresolved } =
+			await checkPackage( name );
+		if ( status === 'skipped' ) {
+			console.log( `SKIP @wordpress/${ name } (${ reason })` );
+			continue;
+		}
+		if ( status === 'pass' ) {
+			console.log( `PASS @wordpress/${ name }` );
+		} else {
+			failed = true;
+			console.log(
+				`FAIL @wordpress/${ name } — private-apis is in the module graph:`
+			);
+			for ( const chain of chains ) {
+				console.log( `  ${ chain.join( '\n    -> ' ) }` );
+			}
+		}
+		for ( const { specifier, importer } of unresolved ) {
+			console.log(
+				`  note: could not resolve ${ specifier } to source (from ${ path.relative(
+					ROOT,
+					importer
+				) }), kept external`
+			);
+		}
+	}
+	process.exit( failed ? 1 : 0 );
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -54993,6 +54993,7 @@
 				"@wordpress/create-block": "file:../../packages/create-block",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"chalk": "^4.1.1",
+				"esbuild": "^0.27.2",
 				"glob": "^7.1.2",
 				"jsonc-parser": "^3.3.1",
 				"simple-git": "^3.32.3"

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
+-   Note in the `/wp` bundle build script that its singleton externals list must stay in sync with the transitive private API usage check ([#82027](https://github.com/WordPress/gutenberg/pull/82027)).
 
 ## 18.1.0 (2026-08-26)
 

--- a/packages/dataviews/build.cjs
+++ b/packages/dataviews/build.cjs
@@ -6,7 +6,9 @@ const wpExternals = {
 		build.onResolve(
 			{ filter: /^@wordpress\/(data|hooks|i18n|date)(\/|$)/ },
 			( args ) => {
-				// Don't bundle WordPress signleton packages
+				// Don't bundle WordPress singleton packages. Keep the list in
+				// sync with `SINGLETONS` in
+				// `tools/validation/check-private-apis.mjs`.
 				return { path: args.path, external: true };
 			}
 		);

--- a/tools/validation/check-private-apis.config.json
+++ b/tools/validation/check-private-apis.config.json
@@ -1,0 +1,164 @@
+{
+	"exceptions": [
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "dataviews",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "fields",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/core-data, whose internals unlock private APIs across api-fetch, sync, blocks, block-editor, and global-styles-engine. Remove when the core-data dependency is dropped or those internals stop using private APIs.",
+			"package": "fields",
+			"via": "packages/core-data/src/index.js"
+		},
+		{
+			"comment": "Depends on @wordpress/blocks, whose store unlocks private APIs internally (and pulls rich-text, reviving the components/compose private registries). Remove when those internals stop using private APIs.",
+			"package": "fields",
+			"via": "packages/blocks/src/index.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/patterns (see the pattern-sync-status field), whose store pulls block-editor and its private-API cascade (rich-text, global-styles-engine, upload-media, commands). Remove when the patterns dependency is dropped or its store no longer pulls block-editor.",
+			"package": "fields",
+			"via": "packages/patterns/src/index.js"
+		},
+		{
+			"comment": "Unlocks private APIs of @wordpress/components. Remove when the unlocked surface goes public.",
+			"package": "fields",
+			"via": "packages/components/src/private-apis.ts"
+		},
+		{
+			"comment": "The package's own private cross-package API usage, tracked file-by-file by the private-apis lint suppressions. Remove when the package stops using private APIs.",
+			"package": "fields",
+			"via": "packages/fields/src/lock-unlock.ts"
+		},
+		{
+			"comment": "Unlocks private APIs of @wordpress/media-utils (see its media-edit component). Remove when the unlocked surface goes public.",
+			"package": "fields",
+			"via": "packages/media-utils/src/private-apis.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/api-fetch, whose internals unlock private APIs. Remove when api-fetch no longer does.",
+			"package": "fields",
+			"via": "packages/api-fetch/src/index.ts"
+		},
+		{
+			"comment": "The package's own private cross-package API usage, tracked file-by-file by the private-apis lint suppressions. Remove when the package stops using private APIs.",
+			"package": "global-styles-engine",
+			"via": "packages/global-styles-engine/src/lock-unlock.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/blocks, whose store unlocks private APIs internally. Remove when blocks' store no longer does.",
+			"package": "global-styles-engine",
+			"via": "packages/blocks/src/index.ts"
+		},
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "global-styles-ui",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/blocks, whose store unlocks private APIs internally (and pulls rich-text, reviving the components/compose private registries). Remove when those internals stop using private APIs.",
+			"package": "global-styles-ui",
+			"via": "packages/blocks/src/index.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/block-editor, which unlocks private APIs throughout its store and components. Remove when the block-editor dependency is dropped or that stops.",
+			"package": "global-styles-ui",
+			"via": "packages/block-editor/src/index.js"
+		},
+		{
+			"comment": "Depends on @wordpress/global-styles-engine, which has its own private API surface. Remove when that surface goes public.",
+			"package": "global-styles-ui",
+			"via": "packages/global-styles-engine/src/index.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/core-data, whose internals unlock private APIs across api-fetch, sync, blocks, block-editor, and global-styles-engine. Remove when the core-data dependency is dropped or those internals stop using private APIs.",
+			"package": "global-styles-ui",
+			"via": "packages/core-data/src/index.js"
+		},
+		{
+			"comment": "Depends on @wordpress/api-fetch, whose internals unlock private APIs. Remove when api-fetch no longer does.",
+			"package": "global-styles-ui",
+			"via": "packages/api-fetch/src/index.ts"
+		},
+		{
+			"comment": "Unlocks private APIs of @wordpress/components. Remove when the unlocked surface goes public.",
+			"package": "global-styles-ui",
+			"via": "packages/components/src/private-apis.ts"
+		},
+		{
+			"comment": "The package's own private cross-package API usage, tracked file-by-file by the private-apis lint suppressions. Remove when the package stops using private APIs.",
+			"package": "global-styles-ui",
+			"via": "packages/global-styles-ui/src/lock-unlock.ts"
+		},
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "media-editor",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/core-data, whose internals unlock private APIs across api-fetch, sync, blocks, block-editor, and global-styles-engine. Remove when the core-data dependency is dropped or those internals stop using private APIs.",
+			"package": "media-editor",
+			"via": "packages/core-data/src/index.js"
+		},
+		{
+			"comment": "Depends on @wordpress/api-fetch, whose internals unlock private APIs. Remove when api-fetch no longer does.",
+			"package": "media-editor",
+			"via": "packages/api-fetch/src/index.ts"
+		},
+		{
+			"comment": "The package's own private cross-package API usage, tracked file-by-file by the private-apis lint suppressions. Remove when the package stops using private APIs.",
+			"package": "media-editor",
+			"via": "packages/media-editor/src/lock-unlock.ts"
+		},
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "media-fields",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/core-data, whose internals unlock private APIs across api-fetch, sync, blocks, block-editor, and global-styles-engine. Remove when the core-data dependency is dropped or those internals stop using private APIs.",
+			"package": "media-fields",
+			"via": "packages/core-data/src/index.js"
+		},
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "ui",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/core-data, whose internals unlock private APIs across api-fetch, sync, blocks, block-editor, and global-styles-engine. Remove when the core-data dependency is dropped or those internals stop using private APIs.",
+			"package": "views",
+			"via": "packages/core-data/src/index.js"
+		},
+		{
+			"comment": "The package's own private cross-package API usage, tracked file-by-file by the private-apis lint suppressions. Remove when the package stops using private APIs.",
+			"package": "views",
+			"via": "packages/views/src/lock-unlock.ts"
+		},
+		{
+			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",
+			"package": "widget-dashboard",
+			"via": "packages/ui/src/utils/theme-provider.ts"
+		},
+		{
+			"comment": "Unlocks private APIs of @wordpress/components (see its actions-menu component). Remove when the unlocked components go public.",
+			"package": "widget-dashboard",
+			"via": "packages/components/src/private-apis.ts"
+		},
+		{
+			"comment": "Depends on @wordpress/commands, whose store and private surface use private APIs. Remove when commands no longer does or the dependency is dropped.",
+			"package": "widget-dashboard",
+			"via": "packages/commands/src/index.js"
+		},
+		{
+			"comment": "The package's own private cross-package API usage, tracked file-by-file by the private-apis lint suppressions. Remove when the package stops using private APIs.",
+			"package": "widget-dashboard",
+			"via": "packages/widget-dashboard/src/lock-unlock.ts"
+		}
+	]
+}

--- a/tools/validation/check-private-apis.config.json
+++ b/tools/validation/check-private-apis.config.json
@@ -1,4 +1,5 @@
 {
+	"comment": "The direct-import counterpart of the lock-unlock entries lives in tools/eslint/suppressions.json (no-restricted-imports). The two lists are enforced independently — a stale entry fails CI in each — but a package dropping private APIs needs an edit in both.",
 	"exceptions": [
 		{
 			"comment": "ThemeProvider falls back to the WP 7.2 theme/ui private APIs when the public API is unavailable. Remove when the fallback is deleted (scheduled for WP 7.3; see the TODO in the file).",

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -14,8 +14,8 @@
  * into a consumer bundle.
  *
  * Usage:
- *   node tools/validation/check-private-apis.mjs [package-name ...]  # default: dataviews
- *   node tools/validation/check-private-apis.mjs --all               # every bundled package
+ *   node tools/validation/check-private-apis.mjs                     # every bundled package
+ *   node tools/validation/check-private-apis.mjs [package-name ...]  # specific packages
  */
 
 import fs from 'node:fs';
@@ -234,14 +234,13 @@ async function checkPackage( name ) {
 }
 
 async function main() {
-	const args = process.argv.slice( 2 );
-	const names = args.includes( '--all' )
-		? fs
+	const names = process.argv.slice( 2 );
+	if ( ! names.length ) {
+		names.push(
+			...fs
 				.readdirSync( PACKAGES_DIR )
 				.filter( ( name ) => isBundled( readPackageJson( name ) ) )
-		: args.filter( ( arg ) => ! arg.startsWith( '--' ) );
-	if ( ! names.length ) {
-		names.push( 'dataviews' );
+		);
 	}
 
 	let failed = false;

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -71,7 +71,10 @@ function readPackageJson( name ) {
 
 // `module` limits the sweep to packages shipping a browser ESM build — the
 // ones that can end up inlined in a consumer bundle. Node tooling packages
-// (env, scripts, docgen, …) deliberately fall outside the gate.
+// (env, scripts, docgen, …) deliberately fall outside the gate. This is
+// intentionally narrower than the bundled-package predicate in
+// `tools/eslint/config.mjs`, which restricts direct private-apis imports in
+// every bundled package, browser build or not.
 function isBundled( pkgJson ) {
 	return (
 		pkgJson &&

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -52,16 +52,6 @@ function isBundled( pkgJson ) {
 	);
 }
 
-function findEntry( name ) {
-	for ( const candidate of [ 'index.ts', 'index.tsx', 'index.js' ] ) {
-		const entry = path.join( PACKAGES_DIR, name, 'src', candidate );
-		if ( fs.existsSync( entry ) ) {
-			return entry;
-		}
-	}
-	return null;
-}
-
 function resolveSource( base ) {
 	for ( const candidate of [
 		base,
@@ -139,8 +129,8 @@ function wordpressSources( onUnresolved ) {
 }
 
 // Shortest import chain from the entry to a target file. Import edges come
-// from `metafile.inputs` (the visited set); when `kept` is given the chain is
-// restricted to files that survived tree shaking.
+// from `metafile.inputs` (the visited set); the chain is restricted to files
+// that survived tree shaking.
 function findChain( metafile, entry, target, kept ) {
 	const previous = new Map( [ [ entry, null ] ] );
 	const queue = [ entry ];
@@ -161,7 +151,7 @@ function findChain( metafile, entry, target, kept ) {
 			if (
 				! dep.external &&
 				! previous.has( dep.path ) &&
-				( ! kept || kept.has( dep.path ) )
+				kept.has( dep.path )
 			) {
 				previous.set( dep.path, file );
 				queue.push( dep.path );
@@ -172,7 +162,7 @@ function findChain( metafile, entry, target, kept ) {
 }
 
 async function checkPackage( name ) {
-	const entry = findEntry( name );
+	const entry = resolveSource( path.join( PACKAGES_DIR, name, 'src' ) );
 	if ( ! entry ) {
 		return { name, status: 'skipped', reason: 'no src/index entry' };
 	}

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -227,10 +227,20 @@ async function checkPackage( name, exclude = new Set() ) {
 			logLevel: 'silent',
 		} );
 	} catch ( error ) {
+		// Unlike a missing entry, a build error means a checkable package
+		// could not be checked — fail rather than skip, so a genuine
+		// breakage cannot pass CI silently.
+		const [ first ] = error.errors ?? [];
 		return {
 			name,
-			status: 'skipped',
-			reason: `build error: ${ error.message.split( '\n' )[ 0 ] }`,
+			status: 'error',
+			reason: first
+				? `${ first.text }${
+						first.location
+							? ` (${ first.location.file }:${ first.location.line })`
+							: ''
+				  }`
+				: error.message.split( '\n' )[ 0 ],
 		};
 	}
 
@@ -308,6 +318,13 @@ async function main() {
 		const result = await checkPackage( name );
 		if ( result.status === 'skipped' ) {
 			console.log( `SKIP @wordpress/${ name } (${ result.reason })` );
+			continue;
+		}
+		if ( result.status === 'error' ) {
+			failed = true;
+			console.log(
+				`FAIL @wordpress/${ name } — build error: ${ result.reason }`
+			);
 			continue;
 		}
 		const vias = exceptions.get( name ) ?? [];

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -13,6 +13,13 @@
  * dataviews `/wp` bundle: they are shared with the platform and never inlined
  * into a consumer bundle.
  *
+ * Known, temporary violations live in `check-private-apis.config.json`, each
+ * keyed on the module the pull passes through. A failing package is rebuilt
+ * with its excepted modules externalized and passes only if that removes
+ * private-apis from the graph entirely, so an exception never hides a new
+ * route. An entry the package no longer needs fails the run as stale, so the
+ * list can only shrink.
+ *
  * Usage:
  *   node tools/validation/check-private-apis.mjs                     # every bundled package
  *   node tools/validation/check-private-apis.mjs [package-name ...]  # specific packages
@@ -30,6 +37,18 @@ const ROOT = path.resolve(
 );
 const PACKAGES_DIR = path.join( ROOT, 'packages' );
 const SINGLETONS = new Set( [ 'data', 'hooks', 'i18n', 'date' ] );
+const CONFIG = 'check-private-apis.config.json';
+
+function readExceptions() {
+	const { exceptions = [] } = JSON.parse(
+		fs.readFileSync( new URL( CONFIG, import.meta.url ), 'utf8' )
+	);
+	const byPackage = new Map();
+	for ( const { package: name, via } of exceptions ) {
+		byPackage.set( name, [ ...( byPackage.get( name ) ?? [] ), via ] );
+	}
+	return byPackage;
+}
 
 function readPackageJson( name ) {
 	try {
@@ -44,12 +63,16 @@ function readPackageJson( name ) {
 	}
 }
 
+// `module` limits the sweep to packages shipping a browser ESM build — the
+// ones that can end up inlined in a consumer bundle. Node tooling packages
+// (env, scripts, docgen, …) deliberately fall outside the gate.
 function isBundled( pkgJson ) {
 	return (
 		pkgJson &&
 		! pkgJson.private &&
 		! pkgJson.wpScript &&
-		! pkgJson.wpScriptModuleExports
+		! pkgJson.wpScriptModuleExports &&
+		pkgJson.module
 	);
 }
 
@@ -72,7 +95,12 @@ function resolveSource( base ) {
 }
 
 // Resolves @wordpress/* to package sources, keeps everything else external.
-function wordpressSources( onUnresolved ) {
+// Files in `exclude` (ROOT-relative) are forced external wherever they are
+// imported from, so a build can answer "would private-apis still be pulled in
+// without this module?".
+function wordpressSources( onUnresolved, exclude ) {
+	const excluded = ( resolved ) =>
+		exclude.has( path.relative( ROOT, resolved ) );
 	return {
 		name: 'wordpress-sources',
 		setup( build ) {
@@ -102,6 +130,9 @@ function wordpressSources( onUnresolved ) {
 					onUnresolved( args.path, args.importer );
 					return { path: args.path, external: true };
 				}
+				if ( excluded( resolved ) ) {
+					return { path: args.path, external: true };
+				}
 				// esbuild does not read package.json for plugin-resolved paths,
 				// so declare what the packages themselves declare: their JS is
 				// side-effect free (only style files are not, and those stay
@@ -121,9 +152,13 @@ function wordpressSources( onUnresolved ) {
 				const resolved = resolveSource(
 					path.resolve( path.dirname( args.importer ), args.path )
 				);
-				return resolved
-					? { path: resolved, sideEffects: false }
-					: undefined;
+				if ( ! resolved ) {
+					return undefined;
+				}
+				if ( excluded( resolved ) ) {
+					return { path: args.path, external: true };
+				}
+				return { path: resolved, sideEffects: false };
 			} );
 		},
 	};
@@ -162,7 +197,7 @@ function findChain( metafile, entry, target, kept ) {
 	return null;
 }
 
-async function checkPackage( name ) {
+async function checkPackage( name, exclude = new Set() ) {
 	const entry = resolveSource( path.join( PACKAGES_DIR, name, 'src' ) );
 	if ( ! entry ) {
 		return { name, status: 'skipped', reason: 'no src/index entry' };
@@ -172,12 +207,18 @@ async function checkPackage( name ) {
 	try {
 		result = await esbuild.build( {
 			entryPoints: [ entry ],
+			// Metafile keys are relative to the working directory; pin it so
+			// the `packages/...` path checks hold regardless of where the
+			// script is invoked from (npm workspace scripts run in tools/).
+			absWorkingDir: ROOT,
 			bundle: true,
 			write: false,
 			metafile: true,
 			plugins: [
-				wordpressSources( ( specifier, importer ) =>
-					unresolved.push( { specifier, importer } )
+				wordpressSources(
+					( specifier, importer ) =>
+						unresolved.push( { specifier, importer } ),
+					exclude
 				),
 			],
 			jsx: 'automatic',
@@ -220,12 +261,22 @@ async function checkPackage( name ) {
 					)
 		  )
 		: [];
-	const chains = culprits.map( ( culprit ) => [
-		...( findChain( result.metafile, entryKey, culprit, kept ) ?? [
-			culprit,
-		] ),
-		'@wordpress/private-apis',
-	] );
+	// A culprit can survive with no live import edge among kept files: its
+	// importer was shaken but its module-level side effects kept it. Fall back
+	// to the unrestricted visited graph so the route that pulled it in is
+	// still shown, labelled as such.
+	const visited = new Set( Object.keys( result.metafile.inputs ) );
+	const chains = culprits.map( ( culprit ) => {
+		const keptChain = findChain( result.metafile, entryKey, culprit, kept );
+		const chain = keptChain ??
+			findChain( result.metafile, entryKey, culprit, visited ) ?? [
+				culprit,
+			];
+		return {
+			revived: ! keptChain,
+			chain: [ ...chain, '@wordpress/private-apis' ],
+		};
+	} );
 	return {
 		name,
 		status: offenders.length ? 'fail' : 'pass',
@@ -251,26 +302,75 @@ async function main() {
 				.readdirSync( PACKAGES_DIR )
 				.filter( ( name ) => isBundled( readPackageJson( name ) ) );
 
+	const exceptions = readExceptions();
 	let failed = false;
 	for ( const name of names ) {
-		const { status, reason, chains, unresolved } =
-			await checkPackage( name );
-		if ( status === 'skipped' ) {
-			console.log( `SKIP @wordpress/${ name } (${ reason })` );
+		const result = await checkPackage( name );
+		if ( result.status === 'skipped' ) {
+			console.log( `SKIP @wordpress/${ name } (${ result.reason })` );
 			continue;
 		}
+		const vias = exceptions.get( name ) ?? [];
+		let { status, chains } = result;
+		const stale = [];
 		if ( status === 'pass' ) {
+			stale.push( ...vias );
+		} else if ( vias.length ) {
+			const retry = await checkPackage( name, new Set( vias ) );
+			if ( retry.status === 'pass' ) {
+				status = 'excepted';
+				// Every entry must still be load-bearing: without it (the
+				// others kept), the package must fail again.
+				for ( const via of vias ) {
+					const others = vias.filter( ( other ) => other !== via );
+					if (
+						others.length &&
+						( await checkPackage( name, new Set( others ) ) )
+							.status === 'pass'
+					) {
+						stale.push( via );
+					}
+				}
+			} else if ( retry.status === 'fail' ) {
+				// Report only the routes the exceptions do not explain.
+				chains = retry.chains;
+			}
+		}
+		if ( stale.length ) {
+			failed = true;
+			console.log(
+				`FAIL @wordpress/${ name } — stale exception${
+					stale.length > 1 ? 's' : ''
+				}, no longer needed, remove from ${ CONFIG }:`
+			);
+			for ( const via of stale ) {
+				console.log( `  ${ via }` );
+			}
+		} else if ( status === 'pass' ) {
 			console.log( `PASS @wordpress/${ name }` );
+		} else if ( status === 'excepted' ) {
+			console.log(
+				`PASS @wordpress/${ name } (excepted via: ${ vias.join(
+					', '
+				) })`
+			);
 		} else {
 			failed = true;
 			console.log(
-				`FAIL @wordpress/${ name } — private-apis is in the module graph:`
+				`FAIL @wordpress/${ name } — private-apis is in the module graph${
+					vias.length ? ' beyond the configured exceptions' : ''
+				}:`
 			);
-			for ( const chain of chains ) {
+			for ( const { revived, chain } of chains ) {
+				if ( revived ) {
+					console.log(
+						'  (kept by module-level side effects — no live import edge; the shaken route that pulled it in:)'
+					);
+				}
 				console.log( `  ${ chain.join( '\n    -> ' ) }` );
 			}
 		}
-		for ( const { specifier, importer } of unresolved ) {
+		for ( const { specifier, importer } of result.unresolved ) {
 			console.log(
 				`  note: could not resolve ${ specifier } to source (from ${ path.relative(
 					ROOT,

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -14,19 +14,18 @@
  * into a consumer bundle.
  *
  * Usage:
- *   node bin/check-private-apis.mjs [package-name ...]  # default: dataviews
- *   node bin/check-private-apis.mjs --all               # every bundled package
+ *   node tools/validation/check-private-apis.mjs [package-name ...]  # default: dataviews
+ *   node tools/validation/check-private-apis.mjs --all               # every bundled package
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-// eslint-disable-next-line import/no-extraneous-dependencies -- Hoisted from the packages that depend on it. A production version of this check would live in a workspace declaring it.
 import esbuild from 'esbuild';
 
 const ROOT = path.resolve(
 	path.dirname( fileURLToPath( import.meta.url ) ),
-	'..'
+	'../..'
 );
 const PACKAGES_DIR = path.join( ROOT, 'packages' );
 const SINGLETONS = new Set( [ 'data', 'hooks', 'i18n', 'date' ] );

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -36,7 +36,13 @@ const ROOT = path.resolve(
 	'../..'
 );
 const PACKAGES_DIR = path.join( ROOT, 'packages' );
+// The platform singletons that must never be inlined into a consumer bundle:
+// stateful registries where a second copy forks state. Not derivable from
+// package.json (`wpScript` covers many safely inlined packages too). Keep in
+// sync with the externals regex in `packages/dataviews/build.cjs`.
 const SINGLETONS = new Set( [ 'data', 'hooks', 'i18n', 'date' ] );
+// ROOT-relative like the metafile keys it is matched against.
+const PRIVATE_APIS_DIR = 'packages/private-apis/';
 const CONFIG = 'check-private-apis.config.json';
 
 function readExceptions() {
@@ -101,6 +107,17 @@ function resolveSource( base ) {
 function wordpressSources( onUnresolved, exclude ) {
 	const excluded = ( resolved ) =>
 		exclude.has( path.relative( ROOT, resolved ) );
+	// A resolved file enters the graph marked side-effect free, unless it is
+	// excluded (then it goes external under its import specifier). esbuild
+	// only honors package.json `sideEffects` for files inside node_modules,
+	// so plugin-resolved paths must declare here what the packages declare
+	// for their published builds: their JS is side-effect free (only style
+	// files are not, and those stay external). Without this, module-level
+	// lock() calls in unused private-apis registries defeat tree shaking.
+	const keep = ( resolved, specifier ) =>
+		excluded( resolved )
+			? { path: specifier, external: true }
+			: { path: resolved, sideEffects: false };
 	return {
 		name: 'wordpress-sources',
 		setup( build ) {
@@ -130,24 +147,14 @@ function wordpressSources( onUnresolved, exclude ) {
 					onUnresolved( args.path, args.importer );
 					return { path: args.path, external: true };
 				}
-				if ( excluded( resolved ) ) {
-					return { path: args.path, external: true };
-				}
-				// esbuild does not read package.json for plugin-resolved paths,
-				// so declare what the packages themselves declare: their JS is
-				// side-effect free (only style files are not, and those stay
-				// external here). Without this, module-level lock() calls in
-				// unused private-apis registries defeat tree shaking.
-				return { path: resolved, sideEffects: false };
+				return keep( resolved, args.path );
 			} );
 			build.onResolve( { filter: /^[^./]/ }, ( args ) => ( {
 				path: args.path,
 				external: true,
 			} ) );
-			// esbuild only honors package.json `sideEffects` for files inside
-			// node_modules, so relative imports between source files must be
-			// marked side-effect free here too. Matches what the packages
-			// declare for their published builds.
+			// Relative imports would resolve without a plugin; intercepting
+			// them only serves the `keep` contract above.
 			build.onResolve( { filter: /^\./ }, ( args ) => {
 				const resolved = resolveSource(
 					path.resolve( path.dirname( args.importer ), args.path )
@@ -155,10 +162,7 @@ function wordpressSources( onUnresolved, exclude ) {
 				if ( ! resolved ) {
 					return undefined;
 				}
-				if ( excluded( resolved ) ) {
-					return { path: args.path, external: true };
-				}
-				return { path: resolved, sideEffects: false };
+				return keep( resolved, args.path );
 			} );
 		},
 	};
@@ -256,18 +260,18 @@ async function checkPackage( name, exclude = new Set() ) {
 		}
 	}
 	const offenders = [ ...kept ].filter( ( file ) =>
-		file.startsWith( 'packages/private-apis/' )
+		file.startsWith( PRIVATE_APIS_DIR )
 	);
 	// The files that actually consume private-apis (the lock-unlock modules),
 	// each with an import chain from the entry showing how they got pulled in.
 	const culprits = offenders.length
 		? [ ...kept ].filter(
 				( file ) =>
-					! file.startsWith( 'packages/private-apis/' ) &&
+					! file.startsWith( PRIVATE_APIS_DIR ) &&
 					( result.metafile.inputs[ file ]?.imports ?? [] ).some(
 						( dep ) =>
 							! dep.external &&
-							dep.path.startsWith( 'packages/private-apis/' )
+							dep.path.startsWith( PRIVATE_APIS_DIR )
 					)
 		  )
 		: [];

--- a/tools/validation/check-private-apis.mjs
+++ b/tools/validation/check-private-apis.mjs
@@ -21,6 +21,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
 import esbuild from 'esbuild';
 
 const ROOT = path.resolve(
@@ -234,14 +235,21 @@ async function checkPackage( name ) {
 }
 
 async function main() {
-	const names = process.argv.slice( 2 );
-	if ( ! names.length ) {
-		names.push(
-			...fs
-				.readdirSync( PACKAGES_DIR )
-				.filter( ( name ) => isBundled( readPackageJson( name ) ) )
+	let positionals;
+	try {
+		( { positionals } = parseArgs( { allowPositionals: true } ) );
+	} catch ( error ) {
+		console.error( error.message );
+		console.error(
+			'Usage: check-private-apis.mjs [package-name ...]   # default: every bundled package'
 		);
+		process.exit( 2 );
 	}
+	const names = positionals.length
+		? positionals
+		: fs
+				.readdirSync( PACKAGES_DIR )
+				.filter( ( name ) => isBundled( readPackageJson( name ) ) );
 
 	let failed = false;
 	for ( const name of names ) {

--- a/tools/validation/package.json
+++ b/tools/validation/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/create-block": "file:../../packages/create-block",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"chalk": "^4.1.1",
+		"esbuild": "^0.27.2",
 		"glob": "^7.1.2",
 		"jsonc-parser": "^3.3.1",
 		"simple-git": "^3.32.3"
@@ -38,6 +39,7 @@
 	"scripts": {
 		"check-installed-deps": "node ./check-installed-deps.mjs",
 		"check-licenses": "node ./check-licenses.mjs",
+		"check-private-apis": "node ./check-private-apis.mjs",
 		"dependency-audit": "dependency-audit --collapse-root-cause \"../../packages/*\"",
 		"check-local-changes": "node ./check-local-changes.cjs",
 		"check-root-dependencies": "node ./check-root-dependencies.mjs",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->




## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/81478#issuecomment-5409016979

This PR adds a script that checks bundled packages don't use private APIs transitively, for example by importing a component from `components` that uses private APIs internally.

The script bundles each package from its entry with esbuild, resolving all `@wordpress/*` imports to their sources, and fails if `@wordpress/private-apis` ends up in the module graph. It only follows the code that is actually used, so unused private exports in dependencies don't fail it. A new `check-private-apis` job runs it in the static checks workflow.

Known violations live in an exception list (`check-private-apis.config.json`), keyed on the module the private APIs come through. A failing package is rebuilt without its excepted modules and passes only if that removes private apis entirely, so an exception can't hide a new route. Entries that are no longer needed fail the run as stale, so the list can only shrink.

## Testing Instructions
1. Run `npm run --workspace @wordpress/validation-tools check-private-apis`.
2. All bundled packages should pass, some through the exception list.
3. Remove an entry from `check-private-apis.config.json` and run again. You should see a failure with the import chains.
4. Add an entry for a passing package (e.g. `icons`) and run again. You should see a stale exception failure. For example:
```
{
      "comment": "Testing stale detection.",
      "package": "icons",
      "via": "packages/theme/src/lock-unlock.ts"
}
```
5. Add a temporary usage in a `dataviews` file and run again the script. For example (note that the console.log matters because a plain import would be dropped by tree shaking):
```
import { Autocomplete } from '@wordpress/components';
console.log( Autocomplete );
```

## Use of AI Tools
Generated with Fable 5 and adjusted/reviewed manually.







