### PR TITLE
E2E Tests: Use str_starts_with()/str_contains() in hide-user-rest-routes plugin

### DIFF
--- a/packages/e2e-tests/plugins/hide-user-rest-routes.php
+++ b/packages/e2e-tests/plugins/hide-user-rest-routes.php
@@ -26,8 +26,8 @@ function gutenberg_test_hide_user_rest_routes( $endpoints ) {
 
 	foreach ( array_keys( $endpoints ) as $route ) {
 		if (
-			0 === strpos( $route, '/wp/v2/users' ) &&
-			false === strpos( $route, '/application-passwords' )
+			str_starts_with( $route, '/wp/v2/users' ) &&
+			! str_contains( $route, '/application-passwords' )
 		) {
 			unset( $endpoints[ $route ] );
 		}


### PR DESCRIPTION
## What & Why?

Replaces the legacy `strpos()` idioms in the `hide-user-rest-routes` E2E test plugin with `str_starts_with()` and `str_contains()`, which state the intent directly. Both functions are polyfilled by WordPress core, so they are safe on Gutenberg's minimum PHP version (7.4), and are already used throughout `lib/`.

No behaviour change.
