### PR TITLE
Quick draft: replace Button+Link with LinkButton

### DIFF
--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -2101,7 +2101,7 @@
 	},
 	"widgets/quick-draft/components/saved-post/saved-post.tsx": {
 		"@wordpress/use-recommended-components": {
-			"count": 1
+			"count": 2
 		}
 	},
 	"widgets/quick-draft/fields/quick-draft-content-field/quick-draft-content-field.tsx": {

--- a/tools/stylelint/stylelint-suppressions.json
+++ b/tools/stylelint/stylelint-suppressions.json
@@ -39,11 +39,6 @@
 			"count": 5
 		}
 	},
-	"widgets/quick-draft/components/saved-post/saved-post.module.css": {
-		"selector-class-pattern": {
-			"count": 1
-		}
-	},
 	"widgets/welcome/components/banner/banner.module.css": {
 		"selector-class-pattern": {
 			"count": 2

--- a/widgets/quick-draft/components/saved-post/saved-post.module.css
+++ b/widgets/quick-draft/components/saved-post/saved-post.module.css
@@ -7,17 +7,3 @@
 	border-color: var(--wpds-color-stroke-surface-success);
 	background-color: var(--wpds-color-background-surface-success-weak);
 }
-
-/*
- * API gap workaround.
- *
- * The "Continue editing" action is a `Button` rendered as a `Link`
- * (polymorphic `render`). `@wordpress/ui` Button exposes no color/tone prop
- * that reaches the rendered anchor, so the brand-strong link color is set
- * here; the unlayered module class wins over `@layer wp-ui`. Drop
- * once Button exposes a color API for the rendered element, or once a
- * dedicated link component lands (https://github.com/WordPress/gutenberg/issues/77098).
- */
-.continueLink {
-	color: var(--wpds-color-foreground-interactive-brand-strong);
-}

--- a/widgets/quick-draft/components/saved-post/saved-post.tsx
+++ b/widgets/quick-draft/components/saved-post/saved-post.tsx
@@ -2,7 +2,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Button, EmptyState, Link, Stack } from '@wordpress/ui';
+import { Button, EmptyState, LinkButton, Stack } from '@wordpress/ui';
 import styles from './saved-post.module.css';
 
 type SavedPostProps = {
@@ -46,20 +46,14 @@ export function SavedPost( {
 					) }
 				</EmptyState.Description>
 				<EmptyState.Actions>
-					<Button
+					<LinkButton
 						variant="solid"
 						size="compact"
-						nativeButton={ false }
-						render={
-							<Link
-								href={ editUrl }
-								openInNewTab
-								className={ styles.continueLink }
-							/>
-						}
+						href={ editUrl }
+						openInNewTab
 					>
 						{ __( 'Continue editing' ) }
-					</Button>
+					</LinkButton>
 					<Button
 						variant="minimal"
 						size="compact"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to  https://github.com/WordPress/gutenberg/pull/78601#discussion_r3297061018

<!-- In a few words, what is the PR actually doing? -->

Replace usage of Button+Link+styles workaround with appropriate LinkButton component in the experimental dashboard's Quick draft widget.

Styles remain the same, no visual changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Proper usage of design system components.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the new `LinkButton` component instead of Button+Link+styles workaround.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Enable experimental dashboard via Gutenberg experiments.
- Try Quick Draft widget; no visual change

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->yes
