### PR TITLE
Theme: Add perceptual foreground scale pilot

### DIFF
--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -28,6 +28,7 @@ export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'state-skewed',
 	'state-skewed-relative-chroma',
 	'state-skewed-okhsl',
+	'anchored-state-skewed-relative-chroma',
 ] as const;
 
 export type ExperimentalForegroundMethod =
@@ -679,7 +680,10 @@ export function buildPerceptualForegroundScale( {
 	let getColorAtLightness = getChromaPreservingColorForLightness;
 	if ( scaleType === 'neutral' ) {
 		getColorAtLightness = getNeutralColorForLightness;
-	} else if ( method === 'state-skewed-relative-chroma' ) {
+	} else if (
+		method === 'state-skewed-relative-chroma' ||
+		method === 'anchored-state-skewed-relative-chroma'
+	) {
 		getColorAtLightness = createGamutRelativeColorForLightness( seed );
 	} else if ( method === 'state-skewed-okhsl' ) {
 		getColorAtLightness = createOkhslColorForLightness( seed );
@@ -784,6 +788,99 @@ export function buildPerceptualForegroundScale( {
 			  } );
 
 		experimentalColors = [ ...constrainedAnchors, restColor, strongColor ];
+	} else if ( method === 'anchored-state-skewed-relative-chroma' ) {
+		const constrainedAnchors = [
+			currentWeakColor,
+			clampToGamut( ramp.ramp.fgSurface2 ),
+		].map( ( currentAnchor, stepIndex ) => {
+			if (
+				colorMeetsContrastTarget(
+					currentAnchor,
+					stepIndex,
+					ramp,
+					backgroundRamp
+				)
+			) {
+				return currentAnchor;
+			}
+
+			return getFloorColor( {
+				getColorAtLightness: ( _, lightness ) =>
+					getChromaPreservingColorForLightness(
+						currentAnchor,
+						lightness
+					),
+				stepIndex,
+				seed: currentAnchor,
+				weakColor: currentAnchor,
+				strongColor,
+				ramp,
+				backgroundRamp,
+			} );
+		} ) as [ PlainColorObject, PlainColorObject ];
+
+		const weakContrast = getPerceptualContrastMagnitude(
+			displayBackground,
+			constrainedAnchors[ 0 ]
+		);
+		const strongContrast = getPerceptualContrastMagnitude(
+			displayBackground,
+			strongColor
+		);
+		const colors = [ ...constrainedAnchors ];
+
+		for ( const stepIndex of [ 2, 3 ] ) {
+			const previousColor = colors.at( -1 )!;
+			const target =
+				weakContrast +
+				( strongContrast - weakContrast ) *
+					STATE_SKEWED_PROGRESS[ stepIndex ];
+			const previousContrast = getPerceptualContrastMagnitude(
+				displayBackground,
+				previousColor
+			);
+			const candidate =
+				target <= previousContrast
+					? previousColor
+					: findColorAtPerceptualContrast( {
+							displayBackground,
+							getColorAtLightness,
+							seed,
+							weakColor: getColorAtLightness(
+								seed,
+								get( previousColor, [ OKLCH, 'l' ] )
+							),
+							strongColor,
+							target,
+					  } );
+
+			colors.push(
+				colorMeetsContrastTarget(
+					candidate,
+					stepIndex,
+					ramp,
+					backgroundRamp
+				)
+					? candidate
+					: getFloorColor( {
+							getColorAtLightness,
+							stepIndex,
+							seed,
+							weakColor: candidate,
+							strongColor,
+							ramp,
+							backgroundRamp,
+					  } )
+			);
+		}
+
+		experimentalColors = [
+			colors[ 0 ],
+			colors[ 1 ],
+			colors[ 2 ],
+			colors[ 3 ],
+			strongColor,
+		];
 	} else {
 		const initialWeakContrast = getPerceptualContrastMagnitude(
 			displayBackground,

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -1,19 +1,25 @@
 import {
 	ColorSpace,
+	deltaEOK,
 	get,
+	OKLab,
 	OKLCH,
+	parse,
 	sRGB,
 	contrastAPCA,
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 import { clampToGamut, getColorString, getContrast } from '../lib/color-utils';
 import { UNIVERSAL_CONTRAST_TOPUP } from '../lib/constants';
+import { BG_RAMP_CONFIG } from '../lib/ramp-configs';
+import { taperChroma } from '../lib/taper-chroma';
 import type { RampResult } from '../lib/types';
 import { solveWithBisect } from '../lib/utils';
 
 export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'current',
 	'uniform',
+	'state-skewed',
 	'uniform-free-endpoint',
 	'semantic-anchors',
 	'eased',
@@ -21,6 +27,8 @@ export const EXPERIMENTAL_FOREGROUND_METHODS = [
 
 export type ExperimentalForegroundMethod =
 	( typeof EXPERIMENTAL_FOREGROUND_METHODS )[ number ];
+
+export type ExperimentalForegroundScaleType = 'neutral' | 'accent';
 
 export type ExperimentalForegroundScale = {
 	colors: readonly [ string, string, string, string, string ];
@@ -31,8 +39,10 @@ export type ExperimentalForegroundScale = {
 const FOREGROUND_WCAG_FLOORS = [ 2, 3, 4.5, 4.5, 4.5 ] as const;
 const EASED_SPACING_POWER = 1.35;
 const FREE_ENDPOINT_MINIMUM_APCA_INTERVAL = 7;
+const STATE_SKEWED_PROGRESS = [ 0, 0.2, 0.4, 0.6, 1 ] as const;
 
 ColorSpace.register( sRGB );
+ColorSpace.register( OKLab );
 ColorSpace.register( OKLCH );
 
 /**
@@ -44,6 +54,12 @@ export function getPerceptualContrast(
 	foreground: string | PlainColorObject
 ) {
 	return Math.abs( contrastAPCA( background, foreground ) );
+}
+
+export function getStateColorDifference(
+	colors: ExperimentalForegroundScale[ 'colors' ]
+) {
+	return deltaEOK( parse( colors[ 3 ] ), parse( colors[ 4 ] ) );
 }
 
 function getChromaPreservingColorForLightness(
@@ -59,6 +75,27 @@ function getChromaPreservingColorForLightness(
 		],
 		alpha: seed.alpha,
 	} );
+}
+
+function getNeutralColorForLightness(
+	seed: PlainColorObject,
+	lightness: number
+) {
+	const taperOptions = BG_RAMP_CONFIG.fgSurface1.taperChromaOptions;
+	if ( ! taperOptions ) {
+		return getChromaPreservingColorForLightness( seed, lightness );
+	}
+
+	const tapered = taperChroma( seed, lightness, taperOptions );
+	if ( 'l' in tapered && 'c' in tapered ) {
+		return clampToGamut( {
+			space: OKLCH,
+			coords: [ tapered.l, tapered.c, get( seed, [ OKLCH, 'h' ] ) ],
+			alpha: seed.alpha,
+		} );
+	}
+
+	return clampToGamut( tapered );
 }
 
 type GetColorForLightness = (
@@ -109,14 +146,14 @@ function getWcagFloorMargin(
 
 function findColorAtPerceptualContrast( {
 	displayBackground,
-	getColorAtLightness = getChromaPreservingColorForLightness,
+	getColorAtLightness,
 	seed,
 	weakColor,
 	strongColor,
 	target,
 }: {
 	displayBackground: string;
-	getColorAtLightness?: GetColorForLightness;
+	getColorAtLightness: GetColorForLightness;
 	seed: PlainColorObject;
 	weakColor: PlainColorObject;
 	strongColor: PlainColorObject;
@@ -181,14 +218,14 @@ function findColorAtPerceptualContrast( {
 }
 
 function findColorAtWcagFloor( {
-	getColorAtLightness = getChromaPreservingColorForLightness,
+	getColorAtLightness,
 	seed,
 	weakColor,
 	strongColor,
 	references,
 	target,
 }: {
-	getColorAtLightness?: GetColorForLightness;
+	getColorAtLightness: GetColorForLightness;
 	seed: PlainColorObject;
 	weakColor: PlainColorObject;
 	strongColor: PlainColorObject;
@@ -235,11 +272,13 @@ function colorMeetsWcagFloor(
 }
 
 function findStrongBoundary( {
+	getColorAtLightness,
 	seed,
 	ramp,
 	backgroundRamp,
 	currentStrongColor,
 }: {
+	getColorAtLightness: GetColorForLightness;
 	seed: PlainColorObject;
 	ramp: RampResult;
 	backgroundRamp: RampResult;
@@ -260,11 +299,12 @@ function findStrongBoundary( {
 		return currentStrongColor;
 	}
 
-	const endpoint = getChromaPreservingColorForLightness(
+	const endpoint = getColorAtLightness(
 		seed,
 		ramp.direction === 'lighter' ? 1 : 0
 	);
 	return findColorAtWcagFloor( {
+		getColorAtLightness,
 		seed,
 		weakColor: currentStrongColor,
 		strongColor: endpoint,
@@ -282,7 +322,7 @@ function getFloorColor( {
 	ramp,
 	backgroundRamp,
 }: {
-	getColorAtLightness?: GetColorForLightness;
+	getColorAtLightness: GetColorForLightness;
 	stepIndex: number;
 	seed: PlainColorObject;
 	weakColor: PlainColorObject;
@@ -395,12 +435,14 @@ function getUniformFreeEndpointTargets(
 
 function strengthenColorsForSerialization( {
 	colors,
+	getColorAtLightness,
 	seed,
 	strongColor,
 	ramp,
 	backgroundRamp,
 }: {
 	colors: readonly PlainColorObject[];
+	getColorAtLightness: GetColorForLightness;
 	seed: PlainColorObject;
 	strongColor: PlainColorObject;
 	ramp: RampResult;
@@ -431,7 +473,7 @@ function strengthenColorsForSerialization( {
 			offset < maximumOffset;
 			offset += 0.00025
 		) {
-			const strengthened = getChromaPreservingColorForLightness(
+			const strengthened = getColorAtLightness(
 				seed,
 				candidateLightness + direction * offset
 			);
@@ -459,27 +501,29 @@ function strengthenColorsForSerialization( {
 }
 
 function buildUniformFreeEndpointColors( {
+	getColorAtLightness,
 	seed,
 	ramp,
 	backgroundRamp,
 }: {
+	getColorAtLightness: GetColorForLightness;
 	seed: PlainColorObject;
 	ramp: RampResult;
 	backgroundRamp: RampResult;
 } ) {
 	const displayBackground = backgroundRamp.ramp.surface2;
 	const displayBackgroundColor = clampToGamut( displayBackground );
-	const weakColor = getChromaPreservingColorForLightness(
+	const weakColor = getColorAtLightness(
 		seed,
 		get( displayBackgroundColor, [ OKLCH, 'l' ] )
 	);
-	const strongColor = getChromaPreservingColorForLightness(
+	const strongColor = getColorAtLightness(
 		seed,
 		ramp.direction === 'lighter' ? 1 : 0
 	);
 	const floorColors = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) =>
 		getFloorColor( {
-			getColorAtLightness: getChromaPreservingColorForLightness,
+			getColorAtLightness,
 			stepIndex,
 			seed,
 			weakColor,
@@ -499,7 +543,7 @@ function buildUniformFreeEndpointColors( {
 	const colors = targets.map( ( target ) =>
 		findColorAtPerceptualContrast( {
 			displayBackground,
-			getColorAtLightness: getChromaPreservingColorForLightness,
+			getColorAtLightness,
 			seed,
 			weakColor,
 			strongColor,
@@ -509,6 +553,7 @@ function buildUniformFreeEndpointColors( {
 
 	return strengthenColorsForSerialization( {
 		colors,
+		getColorAtLightness,
 		seed,
 		strongColor,
 		ramp,
@@ -521,11 +566,13 @@ export function buildPerceptualForegroundScale( {
 	ramp,
 	backgroundRamp,
 	seed: seedArg,
+	scaleType,
 }: {
 	method: ExperimentalForegroundMethod;
 	ramp: RampResult;
 	backgroundRamp: RampResult;
 	seed: string;
+	scaleType: ExperimentalForegroundScaleType;
 } ): ExperimentalForegroundScale {
 	const currentColors = [
 		ramp.ramp.fgSurface1,
@@ -540,9 +587,18 @@ export function buildPerceptualForegroundScale( {
 	}
 
 	const seed = clampToGamut( seedArg );
+	const getColorAtLightness =
+		scaleType === 'neutral'
+			? getNeutralColorForLightness
+			: getChromaPreservingColorForLightness;
 	if ( method === 'uniform-free-endpoint' ) {
 		const colors = serializeScale(
-			buildUniformFreeEndpointColors( { seed, ramp, backgroundRamp } )
+			buildUniformFreeEndpointColors( {
+				getColorAtLightness,
+				seed,
+				ramp,
+				backgroundRamp,
+			} )
 		);
 		return createScaleResult( colors, ramp, backgroundRamp );
 	}
@@ -551,6 +607,7 @@ export function buildPerceptualForegroundScale( {
 	const currentWeakColor = clampToGamut( ramp.ramp.fgSurface1 );
 	const currentStrongColor = clampToGamut( ramp.ramp.fgSurface4 );
 	const strongColor = findStrongBoundary( {
+		getColorAtLightness,
 		seed,
 		ramp,
 		backgroundRamp,
@@ -564,6 +621,7 @@ export function buildPerceptualForegroundScale( {
 	)
 		? currentWeakColor
 		: getFloorColor( {
+				getColorAtLightness,
 				stepIndex: 0,
 				seed,
 				weakColor: currentWeakColor,
@@ -590,6 +648,7 @@ export function buildPerceptualForegroundScale( {
 			colorMeetsWcagFloor( anchor, stepIndex, ramp, backgroundRamp )
 				? anchor
 				: getFloorColor( {
+						getColorAtLightness,
 						stepIndex,
 						seed,
 						weakColor,
@@ -608,6 +667,7 @@ export function buildPerceptualForegroundScale( {
 		);
 		const restCandidate = findColorAtPerceptualContrast( {
 			displayBackground,
+			getColorAtLightness,
 			seed,
 			weakColor: constrainedAnchors[ 2 ],
 			strongColor,
@@ -621,6 +681,7 @@ export function buildPerceptualForegroundScale( {
 		)
 			? restCandidate
 			: getFloorColor( {
+					getColorAtLightness,
 					stepIndex: 3,
 					seed,
 					weakColor: constrainedAnchors[ 2 ],
@@ -641,6 +702,9 @@ export function buildPerceptualForegroundScale( {
 		);
 		const progressValues = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) => {
 			const progress = stepIndex / ( FOREGROUND_WCAG_FLOORS.length - 1 );
+			if ( method === 'state-skewed' ) {
+				return STATE_SKEWED_PROGRESS[ stepIndex ];
+			}
 			return method === 'eased'
 				? Math.pow( progress, EASED_SPACING_POWER )
 				: progress;
@@ -649,6 +713,7 @@ export function buildPerceptualForegroundScale( {
 			getPerceptualContrast(
 				displayBackground,
 				getFloorColor( {
+					getColorAtLightness,
 					stepIndex,
 					seed,
 					weakColor,
@@ -669,6 +734,7 @@ export function buildPerceptualForegroundScale( {
 			}, initialWeakContrast );
 		const adjustedWeakColor = findColorAtPerceptualContrast( {
 			displayBackground,
+			getColorAtLightness,
 			seed,
 			weakColor,
 			strongColor,
@@ -682,6 +748,7 @@ export function buildPerceptualForegroundScale( {
 			const perceptualProgress = progressValues[ stepIndex ];
 			const candidate = findColorAtPerceptualContrast( {
 				displayBackground,
+				getColorAtLightness,
 				seed,
 				weakColor: adjustedWeakColor,
 				strongColor,
@@ -702,6 +769,7 @@ export function buildPerceptualForegroundScale( {
 			}
 
 			return getFloorColor( {
+				getColorAtLightness,
 				stepIndex,
 				seed,
 				weakColor: adjustedWeakColor,
@@ -723,6 +791,7 @@ export function buildPerceptualForegroundScale( {
 	const colors = serializeScale(
 		strengthenColorsForSerialization( {
 			colors: experimentalColors,
+			getColorAtLightness,
 			seed,
 			strongColor,
 			ramp,

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -1,12 +1,14 @@
 import {
 	ColorSpace,
-	deltaEOK,
+	deltaEOK2,
 	get,
 	OKLab,
 	OKLCH,
+	OKLCH_sRGB as OklchSrgb,
 	parse,
 	sRGB,
 	contrastAPCA,
+	to,
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 import { clampToGamut, getColorString, getContrast } from '../lib/color-utils';
@@ -20,6 +22,7 @@ export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'current',
 	'uniform',
 	'state-skewed',
+	'state-skewed-relative-chroma',
 	'uniform-free-endpoint',
 	'semantic-anchors',
 	'eased',
@@ -32,11 +35,12 @@ export type ExperimentalForegroundScaleType = 'neutral' | 'accent';
 
 export type ExperimentalForegroundScale = {
 	colors: readonly [ string, string, string, string, string ];
-	minimumWcagContrasts: readonly [ number, number, number, number, number ];
-	meetsWcagFloors: boolean;
+	minimumContrasts: readonly [ number, number, number, number, number ];
+	contrastTargets: readonly [ number, number, number, number, number ];
+	meetsContrastTargets: boolean;
 };
 
-const FOREGROUND_WCAG_FLOORS = [ 2, 3, 4.5, 4.5, 4.5 ] as const;
+const FOREGROUND_CONTRAST_TARGETS = [ 2, 3, 4.5, 4.5, 4.5 ] as const;
 const EASED_SPACING_POWER = 1.35;
 const FREE_ENDPOINT_MINIMUM_APCA_INTERVAL = 7;
 const STATE_SKEWED_PROGRESS = [ 0, 0.2, 0.4, 0.6, 1 ] as const;
@@ -44,22 +48,35 @@ const STATE_SKEWED_PROGRESS = [ 0, 0.2, 0.4, 0.6, 1 ] as const;
 ColorSpace.register( sRGB );
 ColorSpace.register( OKLab );
 ColorSpace.register( OKLCH );
+ColorSpace.register( OklchSrgb );
 
 /**
- * APCA is used only as an experimental perceptual coordinate. WCAG contrast
- * remains the pass/fail accessibility constraint.
+ * APCA is used only as an experimental perceptual coordinate. WCAG 2.1
+ * contrast ratios measure the hard per-step role targets. The lower role
+ * targets are not general WCAG text-conformance thresholds.
  */
-export function getPerceptualContrast(
+export function getSignedPerceptualContrast(
 	background: string | PlainColorObject,
 	foreground: string | PlainColorObject
 ) {
-	return Math.abs( contrastAPCA( background, foreground ) );
+	return contrastAPCA( background, foreground );
+}
+
+export function getPerceptualContrastMagnitude(
+	background: string | PlainColorObject,
+	foreground: string | PlainColorObject
+) {
+	return Math.abs( getSignedPerceptualContrast( background, foreground ) );
+}
+
+export function getGamutRelativeChroma( color: string | PlainColorObject ) {
+	return get( color, [ OklchSrgb, 'c' ] );
 }
 
 export function getStateColorDifference(
 	colors: ExperimentalForegroundScale[ 'colors' ]
 ) {
-	return deltaEOK( parse( colors[ 3 ] ), parse( colors[ 4 ] ) );
+	return deltaEOK2( parse( colors[ 3 ] ), parse( colors[ 4 ] ) );
 }
 
 function getChromaPreservingColorForLightness(
@@ -75,6 +92,33 @@ function getChromaPreservingColorForLightness(
 		],
 		alpha: seed.alpha,
 	} );
+}
+
+function createGamutRelativeColorForLightness(
+	seed: PlainColorObject
+): GetColorForLightness {
+	const relativeSeed = to( seed, OklchSrgb );
+	const relativeChroma = get( relativeSeed, [ OklchSrgb, 'c' ] );
+	const hue = get( relativeSeed, [ OklchSrgb, 'h' ] );
+	const colorCache = new Map< number, PlainColorObject >();
+
+	return ( _, lightness ) => {
+		const cachedColor = colorCache.get( lightness );
+		if ( cachedColor ) {
+			return cachedColor;
+		}
+
+		const color = to(
+			{
+				space: OklchSrgb,
+				coords: [ lightness, relativeChroma, hue ],
+				alpha: seed.alpha,
+			},
+			OKLCH
+		);
+		colorCache.set( lightness, color );
+		return color;
+	};
 }
 
 function getNeutralColorForLightness(
@@ -131,7 +175,7 @@ function getForegroundConstraintReferences(
 	);
 }
 
-function getWcagFloorMargin(
+function getContrastTargetMargin(
 	color: PlainColorObject,
 	references: readonly string[],
 	target: number
@@ -159,12 +203,15 @@ function findColorAtPerceptualContrast( {
 	strongColor: PlainColorObject;
 	target: number;
 } ) {
-	const weakContrast = getPerceptualContrast( displayBackground, weakColor );
+	const weakContrast = getPerceptualContrastMagnitude(
+		displayBackground,
+		weakColor
+	);
 	if ( target <= weakContrast ) {
 		return weakColor;
 	}
 
-	const strongContrast = getPerceptualContrast(
+	const strongContrast = getPerceptualContrastMagnitude(
 		displayBackground,
 		strongColor
 	);
@@ -174,7 +221,8 @@ function findColorAtPerceptualContrast( {
 
 	const solvedColor = solveWithBisect(
 		( lightness ) => getColorAtLightness( seed, lightness ),
-		( color ) => getPerceptualContrast( displayBackground, color ) - target,
+		( color ) =>
+			getPerceptualContrastMagnitude( displayBackground, color ) - target,
 		get( weakColor, [ OKLCH, 'l' ] ),
 		weakContrast - target,
 		get( strongColor, [ OKLCH, 'l' ] ),
@@ -190,7 +238,7 @@ function findColorAtPerceptualContrast( {
 	const maximumLightness = Math.max( weakLightness, strongLightness );
 	let bestColor = solvedColor;
 	let bestDifference = Math.abs(
-		getPerceptualContrast(
+		getPerceptualContrastMagnitude(
 			displayBackground,
 			getColorString( solvedColor )
 		) - target
@@ -203,7 +251,7 @@ function findColorAtPerceptualContrast( {
 		);
 		const candidate = getColorAtLightness( seed, lightness );
 		const difference = Math.abs(
-			getPerceptualContrast(
+			getPerceptualContrastMagnitude(
 				displayBackground,
 				getColorString( candidate )
 			) - target
@@ -217,7 +265,7 @@ function findColorAtPerceptualContrast( {
 	return bestColor;
 }
 
-function findColorAtWcagFloor( {
+function findColorAtContrastTarget( {
 	getColorAtLightness,
 	seed,
 	weakColor,
@@ -232,19 +280,23 @@ function findColorAtWcagFloor( {
 	references: readonly string[];
 	target: number;
 } ) {
-	const weakMargin = getWcagFloorMargin( weakColor, references, target );
+	const weakMargin = getContrastTargetMargin( weakColor, references, target );
 	if ( weakMargin >= 0 ) {
 		return weakColor;
 	}
 
-	const strongMargin = getWcagFloorMargin( strongColor, references, target );
+	const strongMargin = getContrastTargetMargin(
+		strongColor,
+		references,
+		target
+	);
 	if ( strongMargin < 0 ) {
 		return strongColor;
 	}
 
 	return solveWithBisect(
 		( lightness ) => getColorAtLightness( seed, lightness ),
-		( color ) => getWcagFloorMargin( color, references, target ),
+		( color ) => getContrastTargetMargin( color, references, target ),
 		get( weakColor, [ OKLCH, 'l' ] ),
 		weakMargin,
 		get( strongColor, [ OKLCH, 'l' ] ),
@@ -252,21 +304,21 @@ function findColorAtWcagFloor( {
 	);
 }
 
-function colorMeetsWcagFloor(
+function colorMeetsContrastTarget(
 	color: PlainColorObject,
 	stepIndex: number,
 	ramp: RampResult,
 	backgroundRamp: RampResult
 ) {
 	return (
-		getWcagFloorMargin(
+		getContrastTargetMargin(
 			color,
 			getForegroundConstraintReferences(
 				stepIndex,
 				ramp,
 				backgroundRamp
 			),
-			FOREGROUND_WCAG_FLOORS[ stepIndex ]
+			FOREGROUND_CONTRAST_TARGETS[ stepIndex ]
 		) >= 0
 	);
 }
@@ -290,10 +342,10 @@ function findStrongBoundary( {
 		backgroundRamp
 	);
 	if (
-		getWcagFloorMargin(
+		getContrastTargetMargin(
 			currentStrongColor,
 			references,
-			FOREGROUND_WCAG_FLOORS[ 4 ]
+			FOREGROUND_CONTRAST_TARGETS[ 4 ]
 		) >= 0
 	) {
 		return currentStrongColor;
@@ -303,13 +355,13 @@ function findStrongBoundary( {
 		seed,
 		ramp.direction === 'lighter' ? 1 : 0
 	);
-	return findColorAtWcagFloor( {
+	return findColorAtContrastTarget( {
 		getColorAtLightness,
 		seed,
 		weakColor: currentStrongColor,
 		strongColor: endpoint,
 		references,
-		target: FOREGROUND_WCAG_FLOORS[ 4 ],
+		target: FOREGROUND_CONTRAST_TARGETS[ 4 ],
 	} );
 }
 
@@ -330,7 +382,7 @@ function getFloorColor( {
 	ramp: RampResult;
 	backgroundRamp: RampResult;
 } ) {
-	return findColorAtWcagFloor( {
+	return findColorAtContrastTarget( {
 		getColorAtLightness,
 		seed,
 		weakColor,
@@ -340,7 +392,7 @@ function getFloorColor( {
 			ramp,
 			backgroundRamp
 		),
-		target: FOREGROUND_WCAG_FLOORS[ stepIndex ],
+		target: FOREGROUND_CONTRAST_TARGETS[ stepIndex ],
 	} );
 }
 
@@ -362,7 +414,7 @@ function serializeScale(
 	];
 }
 
-function getMinimumWcagContrasts(
+function getMinimumContrasts(
 	colors: ExperimentalForegroundScale[ 'colors' ],
 	ramp: RampResult,
 	backgroundRamp: RampResult
@@ -383,17 +435,18 @@ function createScaleResult(
 	ramp: RampResult,
 	backgroundRamp: RampResult
 ): ExperimentalForegroundScale {
-	const minimumWcagContrasts = getMinimumWcagContrasts(
+	const minimumContrasts = getMinimumContrasts(
 		colors,
 		ramp,
 		backgroundRamp
 	);
 	return {
 		colors,
-		minimumWcagContrasts,
-		meetsWcagFloors: minimumWcagContrasts.every(
+		minimumContrasts,
+		contrastTargets: FOREGROUND_CONTRAST_TARGETS,
+		meetsContrastTargets: minimumContrasts.every(
 			( contrast, stepIndex ) =>
-				contrast >= FOREGROUND_WCAG_FLOORS[ stepIndex ]
+				contrast >= FOREGROUND_CONTRAST_TARGETS[ stepIndex ]
 		),
 	};
 }
@@ -458,7 +511,7 @@ function strengthenColorsForSerialization( {
 			references.every(
 				( reference ) =>
 					getContrast( reference, getColorString( candidate ) ) >=
-					FOREGROUND_WCAG_FLOORS[ stepIndex ]
+					FOREGROUND_CONTRAST_TARGETS[ stepIndex ]
 			)
 		) {
 			return candidate;
@@ -483,7 +536,7 @@ function strengthenColorsForSerialization( {
 						getContrast(
 							reference,
 							getColorString( strengthened )
-						) >= FOREGROUND_WCAG_FLOORS[ stepIndex ]
+						) >= FOREGROUND_CONTRAST_TARGETS[ stepIndex ]
 				)
 			) {
 				return strengthened;
@@ -521,7 +574,7 @@ function buildUniformFreeEndpointColors( {
 		seed,
 		ramp.direction === 'lighter' ? 1 : 0
 	);
-	const floorColors = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) =>
+	const floorColors = FOREGROUND_CONTRAST_TARGETS.map( ( _, stepIndex ) =>
 		getFloorColor( {
 			getColorAtLightness,
 			stepIndex,
@@ -533,11 +586,11 @@ function buildUniformFreeEndpointColors( {
 		} )
 	);
 	const floorContrasts = floorColors.map( ( color ) =>
-		getPerceptualContrast( displayBackground, color )
+		getPerceptualContrastMagnitude( displayBackground, color )
 	);
 	const targets = getUniformFreeEndpointTargets(
 		floorContrasts,
-		getPerceptualContrast( displayBackground, strongColor )
+		getPerceptualContrastMagnitude( displayBackground, strongColor )
 	);
 
 	const colors = targets.map( ( target ) =>
@@ -587,10 +640,12 @@ export function buildPerceptualForegroundScale( {
 	}
 
 	const seed = clampToGamut( seedArg );
-	const getColorAtLightness =
-		scaleType === 'neutral'
-			? getNeutralColorForLightness
-			: getChromaPreservingColorForLightness;
+	let getColorAtLightness = getChromaPreservingColorForLightness;
+	if ( scaleType === 'neutral' ) {
+		getColorAtLightness = getNeutralColorForLightness;
+	} else if ( method === 'state-skewed-relative-chroma' ) {
+		getColorAtLightness = createGamutRelativeColorForLightness( seed );
+	}
 	if ( method === 'uniform-free-endpoint' ) {
 		const colors = serializeScale(
 			buildUniformFreeEndpointColors( {
@@ -613,7 +668,7 @@ export function buildPerceptualForegroundScale( {
 		backgroundRamp,
 		currentStrongColor,
 	} );
-	const weakColor = colorMeetsWcagFloor(
+	const weakColor = colorMeetsContrastTarget(
 		currentWeakColor,
 		0,
 		ramp,
@@ -645,7 +700,7 @@ export function buildPerceptualForegroundScale( {
 			clampToGamut( ramp.ramp.fgSurface3 ),
 		] as const;
 		const constrainedAnchors = lowerAnchors.map( ( anchor, stepIndex ) =>
-			colorMeetsWcagFloor( anchor, stepIndex, ramp, backgroundRamp )
+			colorMeetsContrastTarget( anchor, stepIndex, ramp, backgroundRamp )
 				? anchor
 				: getFloorColor( {
 						getColorAtLightness,
@@ -657,11 +712,11 @@ export function buildPerceptualForegroundScale( {
 						backgroundRamp,
 				  } )
 		) as [ PlainColorObject, PlainColorObject, PlainColorObject ];
-		const normalContrast = getPerceptualContrast(
+		const normalContrast = getPerceptualContrastMagnitude(
 			displayBackground,
 			constrainedAnchors[ 2 ]
 		);
-		const strongContrast = getPerceptualContrast(
+		const strongContrast = getPerceptualContrastMagnitude(
 			displayBackground,
 			strongColor
 		);
@@ -673,7 +728,7 @@ export function buildPerceptualForegroundScale( {
 			strongColor,
 			target: normalContrast + ( strongContrast - normalContrast ) / 2,
 		} );
-		const restColor = colorMeetsWcagFloor(
+		const restColor = colorMeetsContrastTarget(
 			restCandidate,
 			3,
 			ramp,
@@ -692,36 +747,43 @@ export function buildPerceptualForegroundScale( {
 
 		experimentalColors = [ ...constrainedAnchors, restColor, strongColor ];
 	} else {
-		const initialWeakContrast = getPerceptualContrast(
+		const initialWeakContrast = getPerceptualContrastMagnitude(
 			displayBackground,
 			weakColor
 		);
-		const strongContrast = getPerceptualContrast(
+		const strongContrast = getPerceptualContrastMagnitude(
 			displayBackground,
 			strongColor
 		);
-		const progressValues = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) => {
-			const progress = stepIndex / ( FOREGROUND_WCAG_FLOORS.length - 1 );
-			if ( method === 'state-skewed' ) {
-				return STATE_SKEWED_PROGRESS[ stepIndex ];
+		const progressValues = FOREGROUND_CONTRAST_TARGETS.map(
+			( _, stepIndex ) => {
+				const progress =
+					stepIndex / ( FOREGROUND_CONTRAST_TARGETS.length - 1 );
+				if (
+					method === 'state-skewed' ||
+					method === 'state-skewed-relative-chroma'
+				) {
+					return STATE_SKEWED_PROGRESS[ stepIndex ];
+				}
+				return method === 'eased'
+					? Math.pow( progress, EASED_SPACING_POWER )
+					: progress;
 			}
-			return method === 'eased'
-				? Math.pow( progress, EASED_SPACING_POWER )
-				: progress;
-		} );
-		const floorContrasts = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) =>
-			getPerceptualContrast(
-				displayBackground,
-				getFloorColor( {
-					getColorAtLightness,
-					stepIndex,
-					seed,
-					weakColor,
-					strongColor,
-					ramp,
-					backgroundRamp,
-				} )
-			)
+		);
+		const floorContrasts = FOREGROUND_CONTRAST_TARGETS.map(
+			( _, stepIndex ) =>
+				getPerceptualContrastMagnitude(
+					displayBackground,
+					getFloorColor( {
+						getColorAtLightness,
+						stepIndex,
+						seed,
+						weakColor,
+						strongColor,
+						ramp,
+						backgroundRamp,
+					} )
+				)
 		);
 		const requiredWeakContrast = progressValues
 			.slice( 0, -1 )
@@ -740,11 +802,18 @@ export function buildPerceptualForegroundScale( {
 			strongColor,
 			target: requiredWeakContrast,
 		} );
-		const weakContrast = getPerceptualContrast(
+		const weakContrast = getPerceptualContrastMagnitude(
 			displayBackground,
 			adjustedWeakColor
 		);
-		const colors = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) => {
+		const colors = FOREGROUND_CONTRAST_TARGETS.map( ( _, stepIndex ) => {
+			if ( stepIndex === 0 ) {
+				return adjustedWeakColor;
+			}
+			if ( stepIndex === FOREGROUND_CONTRAST_TARGETS.length - 1 ) {
+				return strongColor;
+			}
+
 			const perceptualProgress = progressValues[ stepIndex ];
 			const candidate = findColorAtPerceptualContrast( {
 				displayBackground,
@@ -758,7 +827,7 @@ export function buildPerceptualForegroundScale( {
 			} );
 
 			if (
-				colorMeetsWcagFloor(
+				colorMeetsContrastTarget(
 					candidate,
 					stepIndex,
 					ramp,

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -1,0 +1,546 @@
+import {
+	ColorSpace,
+	get,
+	OKLCH,
+	sRGB,
+	contrastAPCA,
+	type PlainColorObject,
+} from 'colorjs.io/fn';
+import { clampToGamut, getColorString, getContrast } from '../lib/color-utils';
+import { UNIVERSAL_CONTRAST_TOPUP } from '../lib/constants';
+import { taperChroma } from '../lib/taper-chroma';
+import type { RampResult } from '../lib/types';
+import { solveWithBisect } from '../lib/utils';
+
+export const EXPERIMENTAL_FOREGROUND_METHODS = [
+	'current',
+	'uniform',
+	'semantic-anchors',
+	'eased',
+] as const;
+
+export type ExperimentalForegroundMethod =
+	( typeof EXPERIMENTAL_FOREGROUND_METHODS )[ number ];
+
+export type ExperimentalForegroundScale = {
+	colors: readonly [ string, string, string, string, string ];
+	meetsWcagFloors: boolean;
+};
+
+const FOREGROUND_WCAG_FLOORS = [ 2, 3, 4.5, 4.5, 4.5 ] as const;
+const EASED_SPACING_POWER = 1.35;
+const FOREGROUND_TAPER_CHROMA_OPTIONS = {
+	alpha: 0.6,
+	kLight: 0.2,
+	kDark: 0.2,
+} as const;
+
+ColorSpace.register( sRGB );
+ColorSpace.register( OKLCH );
+
+/**
+ * APCA is used only as an experimental perceptual coordinate. WCAG contrast
+ * remains the pass/fail accessibility constraint.
+ */
+export function getPerceptualContrast(
+	background: string | PlainColorObject,
+	foreground: string | PlainColorObject
+) {
+	return Math.abs( contrastAPCA( background, foreground ) );
+}
+
+function getColorForLightness( seed: PlainColorObject, lightness: number ) {
+	const tapered = taperChroma(
+		seed,
+		lightness,
+		FOREGROUND_TAPER_CHROMA_OPTIONS
+	);
+
+	if ( 'space' in tapered ) {
+		return clampToGamut( tapered );
+	}
+
+	return clampToGamut( {
+		space: OKLCH,
+		coords: [ tapered.l, tapered.c, get( seed, [ OKLCH, 'h' ] ) ],
+		alpha: seed.alpha,
+	} );
+}
+
+function getForegroundConstraintReferences(
+	stepIndex: number,
+	ramp: RampResult,
+	backgroundRamp: RampResult
+) {
+	let surfaceNames: readonly ( keyof RampResult[ 'ramp' ] )[];
+	if ( stepIndex < 2 ) {
+		surfaceNames = [ 'surface3' ];
+	} else if ( stepIndex < 4 ) {
+		surfaceNames = [ 'surface1', 'surface2', 'surface3' ];
+	} else {
+		surfaceNames = [
+			'surface1',
+			'surface2',
+			'surface3',
+			'surface4',
+			'surface5',
+		];
+	}
+
+	return Array.from(
+		new Set( [
+			...surfaceNames.map( ( name ) => ramp.ramp[ name ] ),
+			...surfaceNames.map( ( name ) => backgroundRamp.ramp[ name ] ),
+		] )
+	);
+}
+
+function getWcagFloorMargin(
+	color: PlainColorObject,
+	references: readonly string[],
+	target: number
+) {
+	const adjustedTarget = target + UNIVERSAL_CONTRAST_TOPUP;
+	return Math.min(
+		...references.map( ( reference ) =>
+			Math.log( getContrast( reference, color ) / adjustedTarget )
+		)
+	);
+}
+
+function findColorAtPerceptualContrast( {
+	displayBackground,
+	seed,
+	weakColor,
+	strongColor,
+	target,
+}: {
+	displayBackground: string;
+	seed: PlainColorObject;
+	weakColor: PlainColorObject;
+	strongColor: PlainColorObject;
+	target: number;
+} ) {
+	const weakContrast = getPerceptualContrast( displayBackground, weakColor );
+	if ( target <= weakContrast ) {
+		return weakColor;
+	}
+
+	const strongContrast = getPerceptualContrast(
+		displayBackground,
+		strongColor
+	);
+	if ( target >= strongContrast ) {
+		return strongColor;
+	}
+
+	const solvedColor = solveWithBisect(
+		( lightness ) => getColorForLightness( seed, lightness ),
+		( color ) => getPerceptualContrast( displayBackground, color ) - target,
+		get( weakColor, [ OKLCH, 'l' ] ),
+		weakContrast - target,
+		get( strongColor, [ OKLCH, 'l' ] ),
+		strongContrast - target
+	);
+
+	// The theme ultimately emits 8-bit hex values. Search the immediate
+	// lightness neighborhood so serialization does not undo the APCA spacing.
+	const solvedLightness = get( solvedColor, [ OKLCH, 'l' ] );
+	const weakLightness = get( weakColor, [ OKLCH, 'l' ] );
+	const strongLightness = get( strongColor, [ OKLCH, 'l' ] );
+	const minimumLightness = Math.min( weakLightness, strongLightness );
+	const maximumLightness = Math.max( weakLightness, strongLightness );
+	let bestColor = solvedColor;
+	let bestDifference = Math.abs(
+		getPerceptualContrast(
+			displayBackground,
+			getColorString( solvedColor )
+		) - target
+	);
+
+	for ( let offset = -0.004; offset <= 0.004; offset += 0.00025 ) {
+		const lightness = Math.max(
+			minimumLightness,
+			Math.min( maximumLightness, solvedLightness + offset )
+		);
+		const candidate = getColorForLightness( seed, lightness );
+		const difference = Math.abs(
+			getPerceptualContrast(
+				displayBackground,
+				getColorString( candidate )
+			) - target
+		);
+		if ( difference < bestDifference ) {
+			bestColor = candidate;
+			bestDifference = difference;
+		}
+	}
+
+	return bestColor;
+}
+
+function findColorAtWcagFloor( {
+	seed,
+	weakColor,
+	strongColor,
+	references,
+	target,
+}: {
+	seed: PlainColorObject;
+	weakColor: PlainColorObject;
+	strongColor: PlainColorObject;
+	references: readonly string[];
+	target: number;
+} ) {
+	const weakMargin = getWcagFloorMargin( weakColor, references, target );
+	if ( weakMargin >= 0 ) {
+		return weakColor;
+	}
+
+	const strongMargin = getWcagFloorMargin( strongColor, references, target );
+	if ( strongMargin < 0 ) {
+		return strongColor;
+	}
+
+	return solveWithBisect(
+		( lightness ) => getColorForLightness( seed, lightness ),
+		( color ) => getWcagFloorMargin( color, references, target ),
+		get( weakColor, [ OKLCH, 'l' ] ),
+		weakMargin,
+		get( strongColor, [ OKLCH, 'l' ] ),
+		strongMargin
+	);
+}
+
+function colorMeetsWcagFloor(
+	color: PlainColorObject,
+	stepIndex: number,
+	ramp: RampResult,
+	backgroundRamp: RampResult
+) {
+	return (
+		getWcagFloorMargin(
+			color,
+			getForegroundConstraintReferences(
+				stepIndex,
+				ramp,
+				backgroundRamp
+			),
+			FOREGROUND_WCAG_FLOORS[ stepIndex ]
+		) >= 0
+	);
+}
+
+function findStrongBoundary( {
+	seed,
+	ramp,
+	backgroundRamp,
+	currentStrongColor,
+}: {
+	seed: PlainColorObject;
+	ramp: RampResult;
+	backgroundRamp: RampResult;
+	currentStrongColor: PlainColorObject;
+} ) {
+	const references = getForegroundConstraintReferences(
+		4,
+		ramp,
+		backgroundRamp
+	);
+	if (
+		getWcagFloorMargin(
+			currentStrongColor,
+			references,
+			FOREGROUND_WCAG_FLOORS[ 4 ]
+		) >= 0
+	) {
+		return currentStrongColor;
+	}
+
+	const endpoint = getColorForLightness(
+		seed,
+		ramp.direction === 'lighter' ? 1 : 0
+	);
+	return findColorAtWcagFloor( {
+		seed,
+		weakColor: currentStrongColor,
+		strongColor: endpoint,
+		references,
+		target: FOREGROUND_WCAG_FLOORS[ 4 ],
+	} );
+}
+
+function getFloorColor( {
+	stepIndex,
+	seed,
+	weakColor,
+	strongColor,
+	ramp,
+	backgroundRamp,
+}: {
+	stepIndex: number;
+	seed: PlainColorObject;
+	weakColor: PlainColorObject;
+	strongColor: PlainColorObject;
+	ramp: RampResult;
+	backgroundRamp: RampResult;
+} ) {
+	return findColorAtWcagFloor( {
+		seed,
+		weakColor,
+		strongColor,
+		references: getForegroundConstraintReferences(
+			stepIndex,
+			ramp,
+			backgroundRamp
+		),
+		target: FOREGROUND_WCAG_FLOORS[ stepIndex ],
+	} );
+}
+
+function serializeScale(
+	colors: readonly [
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+	]
+): ExperimentalForegroundScale[ 'colors' ] {
+	return [
+		getColorString( colors[ 0 ] ),
+		getColorString( colors[ 1 ] ),
+		getColorString( colors[ 2 ] ),
+		getColorString( colors[ 3 ] ),
+		getColorString( colors[ 4 ] ),
+	];
+}
+
+function scaleMeetsWcagFloors(
+	colors: ExperimentalForegroundScale[ 'colors' ],
+	ramp: RampResult,
+	backgroundRamp: RampResult
+) {
+	return colors.every( ( color, stepIndex ) =>
+		getForegroundConstraintReferences(
+			stepIndex,
+			ramp,
+			backgroundRamp
+		).every(
+			( reference ) =>
+				getContrast( reference, color ) >=
+				FOREGROUND_WCAG_FLOORS[ stepIndex ]
+		)
+	);
+}
+
+export function buildPerceptualForegroundScale( {
+	method,
+	ramp,
+	backgroundRamp,
+	seed: seedArg,
+}: {
+	method: ExperimentalForegroundMethod;
+	ramp: RampResult;
+	backgroundRamp: RampResult;
+	seed: string;
+} ): ExperimentalForegroundScale {
+	const currentColors = [
+		ramp.ramp.fgSurface1,
+		ramp.ramp.fgSurface2,
+		ramp.ramp.fgSurface3,
+		ramp.ramp.fgSurface4,
+		ramp.ramp.fgSurface4,
+	] as const;
+
+	if ( method === 'current' ) {
+		return {
+			colors: currentColors,
+			meetsWcagFloors: scaleMeetsWcagFloors(
+				currentColors,
+				ramp,
+				backgroundRamp
+			),
+		};
+	}
+
+	const seed = clampToGamut( seedArg );
+	const displayBackground = backgroundRamp.ramp.surface2;
+	const currentWeakColor = clampToGamut( ramp.ramp.fgSurface1 );
+	const currentStrongColor = clampToGamut( ramp.ramp.fgSurface4 );
+	const strongColor = findStrongBoundary( {
+		seed,
+		ramp,
+		backgroundRamp,
+		currentStrongColor,
+	} );
+	const weakColor = colorMeetsWcagFloor(
+		currentWeakColor,
+		0,
+		ramp,
+		backgroundRamp
+	)
+		? currentWeakColor
+		: getFloorColor( {
+				stepIndex: 0,
+				seed,
+				weakColor: currentWeakColor,
+				strongColor,
+				ramp,
+				backgroundRamp,
+		  } );
+
+	let experimentalColors: readonly [
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+	];
+
+	if ( method === 'semantic-anchors' ) {
+		const lowerAnchors = [
+			weakColor,
+			clampToGamut( ramp.ramp.fgSurface2 ),
+			clampToGamut( ramp.ramp.fgSurface3 ),
+		] as const;
+		const constrainedAnchors = lowerAnchors.map( ( anchor, stepIndex ) =>
+			colorMeetsWcagFloor( anchor, stepIndex, ramp, backgroundRamp )
+				? anchor
+				: getFloorColor( {
+						stepIndex,
+						seed,
+						weakColor,
+						strongColor,
+						ramp,
+						backgroundRamp,
+				  } )
+		) as [ PlainColorObject, PlainColorObject, PlainColorObject ];
+		const normalContrast = getPerceptualContrast(
+			displayBackground,
+			constrainedAnchors[ 2 ]
+		);
+		const strongContrast = getPerceptualContrast(
+			displayBackground,
+			strongColor
+		);
+		const restCandidate = findColorAtPerceptualContrast( {
+			displayBackground,
+			seed,
+			weakColor: constrainedAnchors[ 2 ],
+			strongColor,
+			target: normalContrast + ( strongContrast - normalContrast ) / 2,
+		} );
+		const restColor = colorMeetsWcagFloor(
+			restCandidate,
+			3,
+			ramp,
+			backgroundRamp
+		)
+			? restCandidate
+			: getFloorColor( {
+					stepIndex: 3,
+					seed,
+					weakColor: constrainedAnchors[ 2 ],
+					strongColor,
+					ramp,
+					backgroundRamp,
+			  } );
+
+		experimentalColors = [ ...constrainedAnchors, restColor, strongColor ];
+	} else {
+		const initialWeakContrast = getPerceptualContrast(
+			displayBackground,
+			weakColor
+		);
+		const strongContrast = getPerceptualContrast(
+			displayBackground,
+			strongColor
+		);
+		const progressValues = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) => {
+			const progress = stepIndex / ( FOREGROUND_WCAG_FLOORS.length - 1 );
+			return method === 'eased'
+				? Math.pow( progress, EASED_SPACING_POWER )
+				: progress;
+		} );
+		const floorContrasts = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) =>
+			getPerceptualContrast(
+				displayBackground,
+				getFloorColor( {
+					stepIndex,
+					seed,
+					weakColor,
+					strongColor,
+					ramp,
+					backgroundRamp,
+				} )
+			)
+		);
+		const requiredWeakContrast = progressValues
+			.slice( 0, -1 )
+			.reduce( ( requiredContrast, progress, stepIndex ) => {
+				const minimumStartContrast =
+					( floorContrasts[ stepIndex ] -
+						progress * strongContrast ) /
+					( 1 - progress );
+				return Math.max( requiredContrast, minimumStartContrast );
+			}, initialWeakContrast );
+		const adjustedWeakColor = findColorAtPerceptualContrast( {
+			displayBackground,
+			seed,
+			weakColor,
+			strongColor,
+			target: requiredWeakContrast,
+		} );
+		const weakContrast = getPerceptualContrast(
+			displayBackground,
+			adjustedWeakColor
+		);
+		const colors = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) => {
+			const perceptualProgress = progressValues[ stepIndex ];
+			const candidate = findColorAtPerceptualContrast( {
+				displayBackground,
+				seed,
+				weakColor: adjustedWeakColor,
+				strongColor,
+				target:
+					weakContrast +
+					( strongContrast - weakContrast ) * perceptualProgress,
+			} );
+
+			if (
+				colorMeetsWcagFloor(
+					candidate,
+					stepIndex,
+					ramp,
+					backgroundRamp
+				)
+			) {
+				return candidate;
+			}
+
+			return getFloorColor( {
+				stepIndex,
+				seed,
+				weakColor: adjustedWeakColor,
+				strongColor,
+				ramp,
+				backgroundRamp,
+			} );
+		} );
+
+		experimentalColors = colors as [
+			PlainColorObject,
+			PlainColorObject,
+			PlainColorObject,
+			PlainColorObject,
+			PlainColorObject,
+		];
+	}
+
+	const colors = serializeScale( experimentalColors );
+	return {
+		colors,
+		meetsWcagFloors: scaleMeetsWcagFloors( colors, ramp, backgroundRamp ),
+	};
+}

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -5,6 +5,7 @@ import {
 	OKLab,
 	OKLCH,
 	OKLCH_sRGB as OklchSrgb,
+	Okhsl,
 	parse,
 	sRGB,
 	contrastAPCA,
@@ -26,6 +27,7 @@ export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'uniform-free-endpoint',
 	'state-skewed',
 	'state-skewed-relative-chroma',
+	'state-skewed-okhsl',
 ] as const;
 
 export type ExperimentalForegroundMethod =
@@ -49,6 +51,7 @@ ColorSpace.register( sRGB );
 ColorSpace.register( OKLab );
 ColorSpace.register( OKLCH );
 ColorSpace.register( OklchSrgb );
+ColorSpace.register( Okhsl );
 
 /**
  * APCA is used only as an experimental perceptual coordinate. WCAG 2.1
@@ -71,6 +74,10 @@ export function getPerceptualContrastMagnitude(
 
 export function getGamutRelativeChroma( color: string | PlainColorObject ) {
 	return get( color, [ OklchSrgb, 'c' ] );
+}
+
+export function getOkhslSaturation( color: string | PlainColorObject ) {
+	return get( color, [ Okhsl, 's' ] );
 }
 
 export function getStateColorDifference(
@@ -116,6 +123,35 @@ function createGamutRelativeColorForLightness(
 			},
 			OKLCH
 		);
+		colorCache.set( lightness, color );
+		return color;
+	};
+}
+
+function createOkhslColorForLightness(
+	seed: PlainColorObject
+): GetColorForLightness {
+	const okhslSeed = to( seed, Okhsl );
+	const saturation = get( okhslSeed, [ Okhsl, 's' ] );
+	const hue = get( okhslSeed, [ Okhsl, 'h' ] );
+	const colorCache = new Map< number, PlainColorObject >();
+
+	return ( _, lightness ) => {
+		const cachedColor = colorCache.get( lightness );
+		if ( cachedColor ) {
+			return cachedColor;
+		}
+
+		// The solver works in OKLCH lightness. Convert the same neutral
+		// lightness to OKHSL's toe-adjusted lightness before restoring the
+		// seed saturation and hue. These direct base-space conversions avoid
+		// repeating Color.js's full conversion-path lookup in the solver loop.
+		const okhslLightness = Okhsl.fromBase!( [ lightness, 0, 0 ] )[ 2 ];
+		const color = {
+			space: OKLab,
+			coords: Okhsl.toBase!( [ hue, saturation, okhslLightness ] ),
+			alpha: seed.alpha,
+		};
 		colorCache.set( lightness, color );
 		return color;
 	};
@@ -645,6 +681,8 @@ export function buildPerceptualForegroundScale( {
 		getColorAtLightness = getNeutralColorForLightness;
 	} else if ( method === 'state-skewed-relative-chroma' ) {
 		getColorAtLightness = createGamutRelativeColorForLightness( seed );
+	} else if ( method === 'state-skewed-okhsl' ) {
+		getColorAtLightness = createOkhslColorForLightness( seed );
 	}
 	if ( method === 'uniform-free-endpoint' ) {
 		const colors = serializeScale(
@@ -761,7 +799,8 @@ export function buildPerceptualForegroundScale( {
 					stepIndex / ( FOREGROUND_CONTRAST_TARGETS.length - 1 );
 				if (
 					method === 'state-skewed' ||
-					method === 'state-skewed-relative-chroma'
+					method === 'state-skewed-relative-chroma' ||
+					method === 'state-skewed-okhsl'
 				) {
 					return STATE_SKEWED_PROGRESS[ stepIndex ];
 				}

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -21,11 +21,11 @@ import { solveWithBisect } from '../lib/utils';
 export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'current',
 	'uniform',
-	'state-skewed',
-	'state-skewed-relative-chroma',
-	'uniform-free-endpoint',
 	'semantic-anchors',
 	'eased',
+	'uniform-free-endpoint',
+	'state-skewed',
+	'state-skewed-relative-chroma',
 ] as const;
 
 export type ExperimentalForegroundMethod =

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -8,14 +8,13 @@ import {
 } from 'colorjs.io/fn';
 import { clampToGamut, getColorString, getContrast } from '../lib/color-utils';
 import { UNIVERSAL_CONTRAST_TOPUP } from '../lib/constants';
-import { taperChroma } from '../lib/taper-chroma';
 import type { RampResult } from '../lib/types';
 import { solveWithBisect } from '../lib/utils';
 
 export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'current',
-	'chroma-first',
 	'uniform',
+	'uniform-free-endpoint',
 	'semantic-anchors',
 	'eased',
 ] as const;
@@ -31,12 +30,7 @@ export type ExperimentalForegroundScale = {
 
 const FOREGROUND_WCAG_FLOORS = [ 2, 3, 4.5, 4.5, 4.5 ] as const;
 const EASED_SPACING_POWER = 1.35;
-const CHROMA_FIRST_MINIMUM_APCA_INTERVAL = 7;
-const FOREGROUND_TAPER_CHROMA_OPTIONS = {
-	alpha: 0.6,
-	kLight: 0.2,
-	kDark: 0.2,
-} as const;
+const FREE_ENDPOINT_MINIMUM_APCA_INTERVAL = 7;
 
 ColorSpace.register( sRGB );
 ColorSpace.register( OKLCH );
@@ -50,24 +44,6 @@ export function getPerceptualContrast(
 	foreground: string | PlainColorObject
 ) {
 	return Math.abs( contrastAPCA( background, foreground ) );
-}
-
-function getColorForLightness( seed: PlainColorObject, lightness: number ) {
-	const tapered = taperChroma(
-		seed,
-		lightness,
-		FOREGROUND_TAPER_CHROMA_OPTIONS
-	);
-
-	if ( 'space' in tapered ) {
-		return clampToGamut( tapered );
-	}
-
-	return clampToGamut( {
-		space: OKLCH,
-		coords: [ tapered.l, tapered.c, get( seed, [ OKLCH, 'h' ] ) ],
-		alpha: seed.alpha,
-	} );
 }
 
 function getChromaPreservingColorForLightness(
@@ -133,7 +109,7 @@ function getWcagFloorMargin(
 
 function findColorAtPerceptualContrast( {
 	displayBackground,
-	getColorAtLightness = getColorForLightness,
+	getColorAtLightness = getChromaPreservingColorForLightness,
 	seed,
 	weakColor,
 	strongColor,
@@ -205,7 +181,7 @@ function findColorAtPerceptualContrast( {
 }
 
 function findColorAtWcagFloor( {
-	getColorAtLightness = getColorForLightness,
+	getColorAtLightness = getChromaPreservingColorForLightness,
 	seed,
 	weakColor,
 	strongColor,
@@ -284,7 +260,7 @@ function findStrongBoundary( {
 		return currentStrongColor;
 	}
 
-	const endpoint = getColorForLightness(
+	const endpoint = getChromaPreservingColorForLightness(
 		seed,
 		ramp.direction === 'lighter' ? 1 : 0
 	);
@@ -382,25 +358,25 @@ function createScaleResult(
 	};
 }
 
-function getChromaFirstTargets(
+function getUniformFreeEndpointTargets(
 	floorContrasts: readonly number[],
 	maximumContrast: number
 ) {
-	const buildTargets = ( minimumInterval: number ) =>
-		floorContrasts.reduce< number[] >( ( targets, floorContrast ) => {
-			const previousTarget = targets.at( -1 );
-			targets.push(
-				Math.max(
-					floorContrast,
-					previousTarget === undefined
-						? floorContrast
-						: previousTarget + minimumInterval
-				)
-			);
-			return targets;
-		}, [] );
+	const buildTargets = ( interval: number ) => {
+		const start = Math.max(
+			...floorContrasts.map(
+				( floorContrast, stepIndex ) =>
+					floorContrast - stepIndex * interval
+			)
+		);
+		return floorContrasts.map(
+			( _, stepIndex ) => start + stepIndex * interval
+		);
+	};
 
-	const preferredTargets = buildTargets( CHROMA_FIRST_MINIMUM_APCA_INTERVAL );
+	const preferredTargets = buildTargets(
+		FREE_ENDPOINT_MINIMUM_APCA_INTERVAL
+	);
 	if ( preferredTargets.at( -1 )! <= maximumContrast ) {
 		return preferredTargets;
 	}
@@ -417,7 +393,72 @@ function getChromaFirstTargets(
 	return buildTargets( Math.max( 0, availableInterval ) );
 }
 
-function buildChromaFirstColors( {
+function strengthenColorsForSerialization( {
+	colors,
+	seed,
+	strongColor,
+	ramp,
+	backgroundRamp,
+}: {
+	colors: readonly PlainColorObject[];
+	seed: PlainColorObject;
+	strongColor: PlainColorObject;
+	ramp: RampResult;
+	backgroundRamp: RampResult;
+} ) {
+	return colors.map( ( candidate, stepIndex ) => {
+		const references = getForegroundConstraintReferences(
+			stepIndex,
+			ramp,
+			backgroundRamp
+		);
+		if (
+			references.every(
+				( reference ) =>
+					getContrast( reference, getColorString( candidate ) ) >=
+					FOREGROUND_WCAG_FLOORS[ stepIndex ]
+			)
+		) {
+			return candidate;
+		}
+
+		const candidateLightness = get( candidate, [ OKLCH, 'l' ] );
+		const strongLightness = get( strongColor, [ OKLCH, 'l' ] );
+		const direction = Math.sign( strongLightness - candidateLightness );
+		const maximumOffset = Math.abs( strongLightness - candidateLightness );
+		for (
+			let offset = 0.00025;
+			offset < maximumOffset;
+			offset += 0.00025
+		) {
+			const strengthened = getChromaPreservingColorForLightness(
+				seed,
+				candidateLightness + direction * offset
+			);
+			if (
+				references.every(
+					( reference ) =>
+						getContrast(
+							reference,
+							getColorString( strengthened )
+						) >= FOREGROUND_WCAG_FLOORS[ stepIndex ]
+				)
+			) {
+				return strengthened;
+			}
+		}
+
+		return strongColor;
+	} ) as [
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+	];
+}
+
+function buildUniformFreeEndpointColors( {
 	seed,
 	ramp,
 	backgroundRamp,
@@ -450,54 +491,29 @@ function buildChromaFirstColors( {
 	const floorContrasts = floorColors.map( ( color ) =>
 		getPerceptualContrast( displayBackground, color )
 	);
-	const targets = getChromaFirstTargets(
+	const targets = getUniformFreeEndpointTargets(
 		floorContrasts,
 		getPerceptualContrast( displayBackground, strongColor )
 	);
 
-	return targets.map( ( target, stepIndex ) => {
-		const candidate = findColorAtPerceptualContrast( {
+	const colors = targets.map( ( target ) =>
+		findColorAtPerceptualContrast( {
 			displayBackground,
 			getColorAtLightness: getChromaPreservingColorForLightness,
 			seed,
 			weakColor,
 			strongColor,
 			target,
-		} );
-		const references = getForegroundConstraintReferences(
-			stepIndex,
-			ramp,
-			backgroundRamp
-		);
-		const candidateLightness = get( candidate, [ OKLCH, 'l' ] );
-		const strongLightness = get( strongColor, [ OKLCH, 'l' ] );
-		const direction = Math.sign( strongLightness - candidateLightness );
-		const maximumOffset = Math.abs( strongLightness - candidateLightness );
-		for ( let offset = 0; offset < maximumOffset; offset += 0.00025 ) {
-			const strengthened = getChromaPreservingColorForLightness(
-				seed,
-				candidateLightness + direction * offset
-			);
-			if (
-				references.every(
-					( reference ) =>
-						getContrast(
-							reference,
-							getColorString( strengthened )
-						) >= FOREGROUND_WCAG_FLOORS[ stepIndex ]
-				)
-			) {
-				return strengthened;
-			}
-		}
-		return strongColor;
-	} ) as [
-		PlainColorObject,
-		PlainColorObject,
-		PlainColorObject,
-		PlainColorObject,
-		PlainColorObject,
-	];
+		} )
+	);
+
+	return strengthenColorsForSerialization( {
+		colors,
+		seed,
+		strongColor,
+		ramp,
+		backgroundRamp,
+	} );
 }
 
 export function buildPerceptualForegroundScale( {
@@ -524,9 +540,9 @@ export function buildPerceptualForegroundScale( {
 	}
 
 	const seed = clampToGamut( seedArg );
-	if ( method === 'chroma-first' ) {
+	if ( method === 'uniform-free-endpoint' ) {
 		const colors = serializeScale(
-			buildChromaFirstColors( { seed, ramp, backgroundRamp } )
+			buildUniformFreeEndpointColors( { seed, ramp, backgroundRamp } )
 		);
 		return createScaleResult( colors, ramp, backgroundRamp );
 	}
@@ -704,6 +720,14 @@ export function buildPerceptualForegroundScale( {
 		];
 	}
 
-	const colors = serializeScale( experimentalColors );
+	const colors = serializeScale(
+		strengthenColorsForSerialization( {
+			colors: experimentalColors,
+			seed,
+			strongColor,
+			ramp,
+			backgroundRamp,
+		} )
+	);
 	return createScaleResult( colors, ramp, backgroundRamp );
 }

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-experiment.ts
@@ -14,6 +14,7 @@ import { solveWithBisect } from '../lib/utils';
 
 export const EXPERIMENTAL_FOREGROUND_METHODS = [
 	'current',
+	'chroma-first',
 	'uniform',
 	'semantic-anchors',
 	'eased',
@@ -24,11 +25,13 @@ export type ExperimentalForegroundMethod =
 
 export type ExperimentalForegroundScale = {
 	colors: readonly [ string, string, string, string, string ];
+	minimumWcagContrasts: readonly [ number, number, number, number, number ];
 	meetsWcagFloors: boolean;
 };
 
 const FOREGROUND_WCAG_FLOORS = [ 2, 3, 4.5, 4.5, 4.5 ] as const;
 const EASED_SPACING_POWER = 1.35;
+const CHROMA_FIRST_MINIMUM_APCA_INTERVAL = 7;
 const FOREGROUND_TAPER_CHROMA_OPTIONS = {
 	alpha: 0.6,
 	kLight: 0.2,
@@ -66,6 +69,26 @@ function getColorForLightness( seed: PlainColorObject, lightness: number ) {
 		alpha: seed.alpha,
 	} );
 }
+
+function getChromaPreservingColorForLightness(
+	seed: PlainColorObject,
+	lightness: number
+) {
+	return clampToGamut( {
+		space: OKLCH,
+		coords: [
+			lightness,
+			get( seed, [ OKLCH, 'c' ] ),
+			get( seed, [ OKLCH, 'h' ] ),
+		],
+		alpha: seed.alpha,
+	} );
+}
+
+type GetColorForLightness = (
+	seed: PlainColorObject,
+	lightness: number
+) => PlainColorObject;
 
 function getForegroundConstraintReferences(
 	stepIndex: number,
@@ -110,12 +133,14 @@ function getWcagFloorMargin(
 
 function findColorAtPerceptualContrast( {
 	displayBackground,
+	getColorAtLightness = getColorForLightness,
 	seed,
 	weakColor,
 	strongColor,
 	target,
 }: {
 	displayBackground: string;
+	getColorAtLightness?: GetColorForLightness;
 	seed: PlainColorObject;
 	weakColor: PlainColorObject;
 	strongColor: PlainColorObject;
@@ -135,7 +160,7 @@ function findColorAtPerceptualContrast( {
 	}
 
 	const solvedColor = solveWithBisect(
-		( lightness ) => getColorForLightness( seed, lightness ),
+		( lightness ) => getColorAtLightness( seed, lightness ),
 		( color ) => getPerceptualContrast( displayBackground, color ) - target,
 		get( weakColor, [ OKLCH, 'l' ] ),
 		weakContrast - target,
@@ -163,7 +188,7 @@ function findColorAtPerceptualContrast( {
 			minimumLightness,
 			Math.min( maximumLightness, solvedLightness + offset )
 		);
-		const candidate = getColorForLightness( seed, lightness );
+		const candidate = getColorAtLightness( seed, lightness );
 		const difference = Math.abs(
 			getPerceptualContrast(
 				displayBackground,
@@ -180,12 +205,14 @@ function findColorAtPerceptualContrast( {
 }
 
 function findColorAtWcagFloor( {
+	getColorAtLightness = getColorForLightness,
 	seed,
 	weakColor,
 	strongColor,
 	references,
 	target,
 }: {
+	getColorAtLightness?: GetColorForLightness;
 	seed: PlainColorObject;
 	weakColor: PlainColorObject;
 	strongColor: PlainColorObject;
@@ -203,7 +230,7 @@ function findColorAtWcagFloor( {
 	}
 
 	return solveWithBisect(
-		( lightness ) => getColorForLightness( seed, lightness ),
+		( lightness ) => getColorAtLightness( seed, lightness ),
 		( color ) => getWcagFloorMargin( color, references, target ),
 		get( weakColor, [ OKLCH, 'l' ] ),
 		weakMargin,
@@ -271,6 +298,7 @@ function findStrongBoundary( {
 }
 
 function getFloorColor( {
+	getColorAtLightness,
 	stepIndex,
 	seed,
 	weakColor,
@@ -278,6 +306,7 @@ function getFloorColor( {
 	ramp,
 	backgroundRamp,
 }: {
+	getColorAtLightness?: GetColorForLightness;
 	stepIndex: number;
 	seed: PlainColorObject;
 	weakColor: PlainColorObject;
@@ -286,6 +315,7 @@ function getFloorColor( {
 	backgroundRamp: RampResult;
 } ) {
 	return findColorAtWcagFloor( {
+		getColorAtLightness,
 		seed,
 		weakColor,
 		strongColor,
@@ -316,22 +346,158 @@ function serializeScale(
 	];
 }
 
-function scaleMeetsWcagFloors(
+function getMinimumWcagContrasts(
 	colors: ExperimentalForegroundScale[ 'colors' ],
 	ramp: RampResult,
 	backgroundRamp: RampResult
 ) {
-	return colors.every( ( color, stepIndex ) =>
-		getForegroundConstraintReferences(
+	return colors.map( ( color, stepIndex ) =>
+		Math.min(
+			...getForegroundConstraintReferences(
+				stepIndex,
+				ramp,
+				backgroundRamp
+			).map( ( reference ) => getContrast( reference, color ) )
+		)
+	) as [ number, number, number, number, number ];
+}
+
+function createScaleResult(
+	colors: ExperimentalForegroundScale[ 'colors' ],
+	ramp: RampResult,
+	backgroundRamp: RampResult
+): ExperimentalForegroundScale {
+	const minimumWcagContrasts = getMinimumWcagContrasts(
+		colors,
+		ramp,
+		backgroundRamp
+	);
+	return {
+		colors,
+		minimumWcagContrasts,
+		meetsWcagFloors: minimumWcagContrasts.every(
+			( contrast, stepIndex ) =>
+				contrast >= FOREGROUND_WCAG_FLOORS[ stepIndex ]
+		),
+	};
+}
+
+function getChromaFirstTargets(
+	floorContrasts: readonly number[],
+	maximumContrast: number
+) {
+	const buildTargets = ( minimumInterval: number ) =>
+		floorContrasts.reduce< number[] >( ( targets, floorContrast ) => {
+			const previousTarget = targets.at( -1 );
+			targets.push(
+				Math.max(
+					floorContrast,
+					previousTarget === undefined
+						? floorContrast
+						: previousTarget + minimumInterval
+				)
+			);
+			return targets;
+		}, [] );
+
+	const preferredTargets = buildTargets( CHROMA_FIRST_MINIMUM_APCA_INTERVAL );
+	if ( preferredTargets.at( -1 )! <= maximumContrast ) {
+		return preferredTargets;
+	}
+
+	const availableInterval = Math.min(
+		...floorContrasts
+			.slice( 0, -1 )
+			.map(
+				( floorContrast, stepIndex ) =>
+					( maximumContrast - floorContrast ) /
+					( floorContrasts.length - stepIndex - 1 )
+			)
+	);
+	return buildTargets( Math.max( 0, availableInterval ) );
+}
+
+function buildChromaFirstColors( {
+	seed,
+	ramp,
+	backgroundRamp,
+}: {
+	seed: PlainColorObject;
+	ramp: RampResult;
+	backgroundRamp: RampResult;
+} ) {
+	const displayBackground = backgroundRamp.ramp.surface2;
+	const displayBackgroundColor = clampToGamut( displayBackground );
+	const weakColor = getChromaPreservingColorForLightness(
+		seed,
+		get( displayBackgroundColor, [ OKLCH, 'l' ] )
+	);
+	const strongColor = getChromaPreservingColorForLightness(
+		seed,
+		ramp.direction === 'lighter' ? 1 : 0
+	);
+	const floorColors = FOREGROUND_WCAG_FLOORS.map( ( _, stepIndex ) =>
+		getFloorColor( {
+			getColorAtLightness: getChromaPreservingColorForLightness,
+			stepIndex,
+			seed,
+			weakColor,
+			strongColor,
+			ramp,
+			backgroundRamp,
+		} )
+	);
+	const floorContrasts = floorColors.map( ( color ) =>
+		getPerceptualContrast( displayBackground, color )
+	);
+	const targets = getChromaFirstTargets(
+		floorContrasts,
+		getPerceptualContrast( displayBackground, strongColor )
+	);
+
+	return targets.map( ( target, stepIndex ) => {
+		const candidate = findColorAtPerceptualContrast( {
+			displayBackground,
+			getColorAtLightness: getChromaPreservingColorForLightness,
+			seed,
+			weakColor,
+			strongColor,
+			target,
+		} );
+		const references = getForegroundConstraintReferences(
 			stepIndex,
 			ramp,
 			backgroundRamp
-		).every(
-			( reference ) =>
-				getContrast( reference, color ) >=
-				FOREGROUND_WCAG_FLOORS[ stepIndex ]
-		)
-	);
+		);
+		const candidateLightness = get( candidate, [ OKLCH, 'l' ] );
+		const strongLightness = get( strongColor, [ OKLCH, 'l' ] );
+		const direction = Math.sign( strongLightness - candidateLightness );
+		const maximumOffset = Math.abs( strongLightness - candidateLightness );
+		for ( let offset = 0; offset < maximumOffset; offset += 0.00025 ) {
+			const strengthened = getChromaPreservingColorForLightness(
+				seed,
+				candidateLightness + direction * offset
+			);
+			if (
+				references.every(
+					( reference ) =>
+						getContrast(
+							reference,
+							getColorString( strengthened )
+						) >= FOREGROUND_WCAG_FLOORS[ stepIndex ]
+				)
+			) {
+				return strengthened;
+			}
+		}
+		return strongColor;
+	} ) as [
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+		PlainColorObject,
+	];
 }
 
 export function buildPerceptualForegroundScale( {
@@ -354,17 +520,17 @@ export function buildPerceptualForegroundScale( {
 	] as const;
 
 	if ( method === 'current' ) {
-		return {
-			colors: currentColors,
-			meetsWcagFloors: scaleMeetsWcagFloors(
-				currentColors,
-				ramp,
-				backgroundRamp
-			),
-		};
+		return createScaleResult( currentColors, ramp, backgroundRamp );
 	}
 
 	const seed = clampToGamut( seedArg );
+	if ( method === 'chroma-first' ) {
+		const colors = serializeScale(
+			buildChromaFirstColors( { seed, ramp, backgroundRamp } )
+		);
+		return createScaleResult( colors, ramp, backgroundRamp );
+	}
+
 	const displayBackground = backgroundRamp.ramp.surface2;
 	const currentWeakColor = clampToGamut( ramp.ramp.fgSurface1 );
 	const currentStrongColor = clampToGamut( ramp.ramp.fgSurface4 );
@@ -539,8 +705,5 @@ export function buildPerceptualForegroundScale( {
 	}
 
 	const colors = serializeScale( experimentalColors );
-	return {
-		colors,
-		meetsWcagFloors: scaleMeetsWcagFloors( colors, ramp, backgroundRamp ),
-	};
+	return createScaleResult( colors, ramp, backgroundRamp );
 }

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
@@ -14,41 +14,59 @@
 .introduction p,
 .seed-section h2,
 .seed-section p,
-.variant-card h3,
-.variant-card h4 {
+.scale-comparison h3,
+.approach-card h4 {
 	margin: 0;
 }
 
 .seed-section {
 	display: grid;
-	gap: 12px;
+	gap: 24px;
 }
 
-.variants {
+.scale-comparison {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-	gap: 12px;
-	align-items: start;
-}
-
-.variant-card {
-	display: grid;
-	gap: 16px;
+	gap: 8px;
 	min-width: 0;
-	padding: 16px;
+}
+
+.scale-comparison h3 {
+	font-size: 16px;
+}
+
+.approaches {
+	display: grid;
+	grid-auto-columns: minmax(320px, 1fr);
+	grid-auto-flow: column;
+	gap: 12px;
+	padding-block-end: 8px;
+	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+}
+
+.approaches:focus-visible {
+	outline: 2px solid currentColor;
+	outline-offset: 2px;
+}
+
+.approach-card {
+	display: grid;
+	gap: 8px;
+	min-width: 0;
+	padding: 12px;
 	border: 1px solid #dcdcde;
 	border-radius: 8px;
 }
 
-.variant-card > header {
+.approach-card > header {
 	display: grid;
-	gap: 4px;
+	min-height: 2.6em;
+	align-content: start;
 }
 
-.variant-card > header p {
-	min-height: 3em;
-	font-size: 12px;
-	line-height: 1.5;
+.approach-card h4 {
+	font-size: 13px;
+	line-height: 1.3;
 }
 
 .scale {
@@ -71,7 +89,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
-	justify-content: flex-end;
+	justify-content: flex-start;
 }
 
 .state-difference {
@@ -120,6 +138,47 @@
 .swatch code {
 	font-family: monospace;
 	font-size: 9px;
+}
+
+.approach-descriptions {
+	display: grid;
+	gap: 12px;
+	padding: 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+}
+
+.approach-descriptions summary {
+	cursor: var(--wpds-cursor-control);
+	font-weight: 600;
+}
+
+.approach-descriptions dl,
+.approach-descriptions dl > div {
+	display: grid;
+	gap: 8px;
+}
+
+.approach-descriptions dl {
+	margin: 0;
+}
+
+.approach-descriptions dl > div {
+	grid-template-columns: minmax(180px, 1fr) 3fr;
+}
+
+.approach-descriptions dt {
+	font-weight: 600;
+}
+
+.approach-descriptions dd {
+	margin: 0;
+}
+
+.empty-state {
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
 }
 
 .component-panel {

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
@@ -34,6 +34,34 @@
 	font-size: 16px;
 }
 
+.scale-comparison-heading {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.scale-seed {
+	display: inline-flex;
+	gap: 6px;
+	align-items: center;
+	font-size: 12px;
+}
+
+.scale-seed-swatch {
+	box-sizing: border-box;
+	width: 20px;
+	height: 20px;
+	border: 1px solid #949494;
+	border-radius: 4px;
+}
+
+.scale-seed code {
+	font-family: monospace;
+	font-size: 11px;
+}
+
 .approaches {
 	display: grid;
 	grid-auto-columns: minmax(320px, 1fr);

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
@@ -44,9 +44,59 @@
 	overscroll-behavior-inline: contain;
 }
 
-.approaches:focus-visible {
+.approaches:focus-visible,
+.scale-table-scroll:focus-visible {
 	outline: 2px solid currentColor;
 	outline-offset: 2px;
+}
+
+.scale-table-scroll {
+	padding-block-end: 8px;
+	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+}
+
+.scale-table {
+	width: 100%;
+	min-width: 860px;
+	table-layout: fixed;
+	border-collapse: separate;
+	border-spacing: 2px;
+}
+
+.scale-table th,
+.scale-table td {
+	text-align: start;
+	vertical-align: top;
+}
+
+.scale-table thead th {
+	padding: 6px 8px;
+	background: #f6f7f7;
+	font-size: 11px;
+}
+
+.scale-table thead th:first-child {
+	width: 220px;
+}
+
+.method-cell {
+	padding: 8px;
+	border: 1px solid #dcdcde;
+	background: #fff;
+}
+
+.method-cell > strong {
+	display: block;
+	font-size: 13px;
+	line-height: 1.3;
+}
+
+.method-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin-block-start: 8px;
 }
 
 .approach-card {
@@ -69,29 +119,6 @@
 	line-height: 1.3;
 }
 
-.scale {
-	display: grid;
-	gap: 6px;
-}
-
-.scale-heading {
-	display: flex;
-	gap: 8px;
-	align-items: start;
-	justify-content: space-between;
-}
-
-.scale-heading h4 {
-	font-size: 13px;
-}
-
-.scale-meta {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px;
-	justify-content: flex-start;
-}
-
 .state-difference {
 	font-size: 10px;
 	font-variant-numeric: tabular-nums;
@@ -112,32 +139,22 @@
 	color: #8a2424;
 }
 
-.swatches {
-	display: grid;
-	grid-template-columns: repeat(5, minmax(50px, 1fr));
-	gap: 2px;
-	overflow-x: auto;
-}
-
-.swatch {
+.scale-cell {
 	box-sizing: border-box;
-	display: grid;
-	gap: 1px;
-	min-width: 50px;
-	min-height: 88px;
-	padding: 6px;
-	align-content: end;
+	height: 112px;
+	padding: 8px;
 	font-size: 9px;
 	line-height: 1.25;
 }
 
-.swatch strong {
-	font-size: 11px;
+.scale-cell > * {
+	display: block;
 }
 
-.swatch code {
+.scale-cell code {
 	font-family: monospace;
-	font-size: 9px;
+	font-size: 10px;
+	font-weight: 600;
 }
 
 .approach-descriptions {

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
@@ -59,12 +59,25 @@
 .scale-heading {
 	display: flex;
 	gap: 8px;
-	align-items: center;
+	align-items: start;
 	justify-content: space-between;
 }
 
 .scale-heading h4 {
 	font-size: 13px;
+}
+
+.scale-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	justify-content: flex-end;
+}
+
+.state-difference {
+	font-size: 10px;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
 }
 
 .status {

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.module.css
@@ -1,0 +1,252 @@
+.page {
+	display: grid;
+	gap: 32px;
+	font-family: var(--wpds-typography-font-family-body);
+}
+
+.introduction,
+.seed-section > header {
+	display: grid;
+	gap: 4px;
+}
+
+.introduction h1,
+.introduction p,
+.seed-section h2,
+.seed-section p,
+.variant-card h3,
+.variant-card h4 {
+	margin: 0;
+}
+
+.seed-section {
+	display: grid;
+	gap: 12px;
+}
+
+.variants {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: 12px;
+	align-items: start;
+}
+
+.variant-card {
+	display: grid;
+	gap: 16px;
+	min-width: 0;
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+}
+
+.variant-card > header {
+	display: grid;
+	gap: 4px;
+}
+
+.variant-card > header p {
+	min-height: 3em;
+	font-size: 12px;
+	line-height: 1.5;
+}
+
+.scale {
+	display: grid;
+	gap: 6px;
+}
+
+.scale-heading {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.scale-heading h4 {
+	font-size: 13px;
+}
+
+.status {
+	padding: 2px 6px;
+	border-radius: 999px;
+	background: #f0f6fc;
+	color: #043959;
+	font-size: 10px;
+	font-weight: 600;
+}
+
+.status[data-pass="false"] {
+	background: #fcf0f1;
+	color: #8a2424;
+}
+
+.swatches {
+	display: grid;
+	grid-template-columns: repeat(5, minmax(50px, 1fr));
+	gap: 2px;
+	overflow-x: auto;
+}
+
+.swatch {
+	box-sizing: border-box;
+	display: grid;
+	gap: 1px;
+	min-width: 50px;
+	min-height: 88px;
+	padding: 6px;
+	align-content: end;
+	font-size: 9px;
+	line-height: 1.25;
+}
+
+.swatch strong {
+	font-size: 11px;
+}
+
+.swatch code {
+	font-family: monospace;
+	font-size: 9px;
+}
+
+.component-panel {
+	display: grid;
+	gap: 14px;
+	padding: 14px;
+	border: 1px solid var(--pilot-border);
+	border-radius: 6px;
+	background: var(--pilot-surface);
+	color: var(--pilot-content);
+	font-size: 13px;
+	line-height: 1.4;
+}
+
+.component-panel p,
+.component-panel ul {
+	margin: 0;
+}
+
+.component-panel button,
+.component-panel a {
+	font: inherit;
+}
+
+.component-panel button:focus-visible,
+.component-panel a:focus-visible {
+	outline: 2px solid var(--pilot-focus);
+	outline-offset: 2px;
+}
+
+.text-hierarchy {
+	display: grid;
+	gap: 4px;
+}
+
+.weak-text,
+.menu-label {
+	color: var(--pilot-content-weak);
+}
+
+.component-panel button:disabled {
+	border: 0;
+	background: transparent;
+	color: var(--pilot-content-disabled);
+	text-align: start;
+}
+
+.control-group,
+.links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.text-button {
+	min-height: 32px;
+	padding: 4px 8px;
+	border: 0;
+	border-radius: 4px;
+	background: transparent;
+	cursor: var(--wpds-cursor-control);
+}
+
+.neutral-interactive {
+	color: var(--pilot-neutral-rest);
+}
+
+.brand-interactive {
+	color: var(--pilot-brand-rest);
+}
+
+.error-interactive {
+	color: var(--pilot-error-rest);
+}
+
+.neutral-interactive:is(:hover, :active, :focus-visible),
+.neutral-interactive.forced-active {
+	color: var(--pilot-neutral-active);
+}
+
+.brand-interactive:is(:hover, :active, :focus-visible),
+.brand-interactive.forced-active {
+	color: var(--pilot-brand-active);
+}
+
+.error-interactive:is(:hover, :active, :focus-visible),
+.error-interactive.forced-active {
+	color: var(--pilot-error-active);
+}
+
+.links a {
+	text-decoration: underline;
+	text-underline-offset: 0.2em;
+}
+
+.view-switcher,
+.menu ul {
+	display: flex;
+	gap: 4px;
+	padding: 0;
+	list-style: none;
+}
+
+.view-switcher a,
+.menu a,
+.menu button {
+	display: block;
+	padding: 5px 8px;
+	border-radius: 4px;
+	text-decoration: none;
+}
+
+.view-switcher a[aria-current="page"] {
+	box-shadow: inset 0 -2px currentColor;
+}
+
+.menu {
+	display: grid;
+	gap: 4px;
+}
+
+.menu-label {
+	font-size: 11px;
+	text-transform: uppercase;
+}
+
+.menu ul {
+	display: grid;
+}
+
+.menu a[aria-current="page"] {
+	box-shadow: inset 2px 0 currentColor;
+}
+
+@media (forced-colors: active) {
+	.component-panel {
+		border-color: CanvasText;
+	}
+
+	.forced-active {
+		outline: 1px solid Highlight;
+	}
+}

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -75,21 +75,6 @@ const METHOD_DETAILS: Record<
 		description:
 			'Uses five equal intervals ending at the legacy strong endpoint.',
 	},
-	'state-skewed': {
-		label: 'State-skewed APCA · fixed Step 5',
-		description:
-			'Reserves 40% of the APCA range for the resting-to-active transition ending at the legacy strong endpoint.',
-	},
-	'state-skewed-relative-chroma': {
-		label: 'State-skewed APCA · relative chroma',
-		description:
-			"Uses the same state spacing and fixed Step 5, while Steps 1–4 preserve the seed's share of available sRGB chroma.",
-	},
-	'uniform-free-endpoint': {
-		label: 'Uniform APCA · released Step 5',
-		description:
-			'Uses equal intervals and the least-extreme Step 5 that supports useful spacing.',
-	},
 	'semantic-anchors': {
 		label: 'Semantic anchors',
 		description:
@@ -99,6 +84,21 @@ const METHOD_DETAILS: Record<
 		label: 'Eased APCA',
 		description:
 			'Uses progressively larger intervals toward the fixed strong endpoint.',
+	},
+	'uniform-free-endpoint': {
+		label: 'Uniform APCA · released Step 5',
+		description:
+			'Uses equal intervals and the least-extreme Step 5 that supports useful spacing.',
+	},
+	'state-skewed': {
+		label: 'State-skewed APCA · fixed Step 5',
+		description:
+			'Reserves 40% of the APCA range for the resting-to-active transition ending at the legacy strong endpoint.',
+	},
+	'state-skewed-relative-chroma': {
+		label: 'State-skewed APCA · relative chroma',
+		description:
+			"Uses the same state spacing and fixed Step 5, while Steps 1–4 preserve the seed's share of available sRGB chroma.",
 	},
 };
 

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -1,0 +1,441 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { buildAccentRamp, buildBgRamp } from '..';
+import { getContrast } from '../lib/color-utils';
+import { DEFAULT_SEED_COLORS } from '../lib/constants';
+import type { RampResult } from '../lib/types';
+import {
+	EXPERIMENTAL_FOREGROUND_METHODS,
+	buildPerceptualForegroundScale,
+	getPerceptualContrast,
+	type ExperimentalForegroundMethod,
+	type ExperimentalForegroundScale,
+} from './perceptual-foreground-experiment';
+import styles from './perceptual-foreground-pilot.module.css';
+
+const meta = {
+	title: 'Design System/Theme/Theme Provider/Perceptual Foreground Pilot',
+	parameters: {
+		controls: { disable: true },
+		docs: { canvas: { sourceState: 'hidden' } },
+	},
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj< typeof meta >;
+
+const SAMPLE_COMBINATIONS = [
+	{
+		label: 'Default light',
+		background: DEFAULT_SEED_COLORS.background,
+		primary: DEFAULT_SEED_COLORS.primary,
+	},
+	{
+		label: 'Default dark',
+		background: '#1e1e1e',
+		primary: DEFAULT_SEED_COLORS.primary,
+	},
+	{
+		label: 'Ectoplasm stress case',
+		background: '#4f386e',
+		primary: '#608010',
+	},
+	{
+		label: 'Middle-gray polarity boundary',
+		background: '#777777',
+		primary: '#d63638',
+	},
+] as const;
+
+const METHOD_DETAILS: Record<
+	ExperimentalForegroundMethod,
+	{ label: string; description: string }
+> = {
+	current: {
+		label: 'Current control',
+		description:
+			'Current four-step ramp, with the strongest value repeated for the fifth step.',
+	},
+	uniform: {
+		label: 'Uniform APCA',
+		description:
+			'Five equal perceptual intervals. The weak endpoint can move to preserve every WCAG floor.',
+	},
+	'semantic-anchors': {
+		label: 'Semantic anchors',
+		description:
+			'Keeps compliant lower steps, then divides the remaining normal-to-strong headroom.',
+	},
+	eased: {
+		label: 'Eased APCA',
+		description:
+			'Uses progressively larger perceptual intervals toward resting and active foregrounds.',
+	},
+};
+
+type ScaleData = {
+	label: string;
+	scale: ExperimentalForegroundScale;
+};
+
+function getSwatchTextColor( color: string ) {
+	return getContrast( color, '#000000' ) >= getContrast( color, '#ffffff' )
+		? '#000000'
+		: '#ffffff';
+}
+
+function ForegroundScale( {
+	data,
+	displayBackground,
+}: {
+	data: ScaleData;
+	displayBackground: string;
+} ) {
+	const contrasts = data.scale.colors.map( ( color ) =>
+		getPerceptualContrast( displayBackground, color )
+	);
+
+	return (
+		<section
+			className={ styles.scale }
+			aria-label={ `${ data.label } scale` }
+		>
+			<div className={ styles[ 'scale-heading' ] }>
+				<h4>{ data.label }</h4>
+				<span
+					className={ styles.status }
+					data-pass={ data.scale.meetsWcagFloors }
+				>
+					{ data.scale.meetsWcagFloors
+						? 'WCAG floors pass'
+						: 'WCAG floor warning' }
+				</span>
+			</div>
+			<div className={ styles.swatches }>
+				{ data.scale.colors.map( ( color, index ) => {
+					const interval =
+						index === 0
+							? undefined
+							: contrasts[ index ] - contrasts[ index - 1 ];
+
+					return (
+						<div
+							className={ styles.swatch }
+							key={ `${ color }-${ index }` }
+							style={ {
+								background: color,
+								color: getSwatchTextColor( color ),
+							} }
+						>
+							<strong>FGS{ index + 1 }</strong>
+							<code>{ color }</code>
+							<span>
+								WCAG{ ' ' }
+								{ getContrast(
+									displayBackground,
+									color
+								).toFixed( 2 ) }
+							</span>
+							<span>
+								APCA { contrasts[ index ].toFixed( 1 ) }
+							</span>
+							{ interval === undefined ? null : (
+								<span>Δ { interval.toFixed( 1 ) }</span>
+							) }
+						</div>
+					);
+				} ) }
+			</div>
+		</section>
+	);
+}
+
+function ComponentPanel( {
+	backgroundRamp,
+	neutral,
+	brand,
+	error,
+	method,
+}: {
+	backgroundRamp: RampResult;
+	neutral: ExperimentalForegroundScale;
+	brand: ExperimentalForegroundScale;
+	error: ExperimentalForegroundScale;
+	method: ExperimentalForegroundMethod;
+} ) {
+	const pilotStyles = {
+		'--pilot-surface': backgroundRamp.ramp.surface2,
+		'--pilot-border': backgroundRamp.ramp.stroke2,
+		'--pilot-content-disabled': neutral.colors[ 1 ],
+		'--pilot-content-weak': neutral.colors[ 2 ],
+		'--pilot-content': neutral.colors[ 4 ],
+		'--pilot-neutral-rest': neutral.colors[ 3 ],
+		'--pilot-neutral-active': neutral.colors[ 4 ],
+		'--pilot-brand-rest': brand.colors[ 3 ],
+		'--pilot-brand-active': brand.colors[ 4 ],
+		'--pilot-error-rest': error.colors[ 3 ],
+		'--pilot-error-active': error.colors[ 4 ],
+		'--pilot-focus': brand.colors[ 4 ],
+	} as React.CSSProperties;
+
+	return (
+		<section
+			aria-label={ `${ METHOD_DETAILS[ method ].label } component examples` }
+			className={ styles[ 'component-panel' ] }
+			style={ pilotStyles }
+		>
+			<div className={ styles[ 'text-hierarchy' ] }>
+				<p className={ styles[ 'weak-text' ] }>Weak supporting text</p>
+				<p>Normal content remains deliberately strong.</p>
+				<button disabled type="button">
+					Disabled action
+				</button>
+			</div>
+
+			<div className={ styles[ 'control-group' ] }>
+				<button
+					className={ `${ styles[ 'text-button' ] } ${ styles[ 'neutral-interactive' ] }` }
+					type="button"
+				>
+					Resting neutral button
+				</button>
+				<button
+					aria-pressed="true"
+					className={ `${ styles[ 'text-button' ] } ${ styles[ 'neutral-interactive' ] } ${ styles[ 'forced-active' ] }` }
+					type="button"
+				>
+					Pressed neutral button
+				</button>
+			</div>
+
+			<p className={ styles.links }>
+				<a
+					className={ styles[ 'brand-interactive' ] }
+					href="#pilot-link"
+				>
+					Brand link
+				</a>{ ' ' }
+				<a
+					aria-current="page"
+					className={ `${ styles[ 'brand-interactive' ] } ${ styles[ 'forced-active' ] }` }
+					href="#pilot-current-link"
+				>
+					Current brand link
+				</a>
+			</p>
+
+			<nav aria-label="Example view switcher">
+				<ul className={ styles[ 'view-switcher' ] }>
+					<li>
+						<a
+							className={ styles[ 'neutral-interactive' ] }
+							href="#pilot-overview"
+						>
+							Overview
+						</a>
+					</li>
+					<li>
+						<a
+							aria-current="page"
+							className={ `${ styles[ 'neutral-interactive' ] } ${ styles[ 'forced-active' ] }` }
+							href="#pilot-settings"
+						>
+							Settings
+						</a>
+					</li>
+				</ul>
+			</nav>
+
+			<nav aria-label="Example menu" className={ styles.menu }>
+				<strong className={ styles[ 'menu-label' ] }>Appearance</strong>
+				<ul>
+					<li>
+						<a
+							className={ styles[ 'neutral-interactive' ] }
+							href="#pilot-dashboard"
+						>
+							Dashboard
+						</a>
+					</li>
+					<li>
+						<a
+							aria-current="page"
+							className={ `${ styles[ 'neutral-interactive' ] } ${ styles[ 'forced-active' ] }` }
+							href="#pilot-styles"
+						>
+							Styles
+						</a>
+					</li>
+					<li>
+						<button disabled type="button">
+							Plugins
+						</button>
+					</li>
+				</ul>
+			</nav>
+
+			<div className={ styles[ 'control-group' ] }>
+				<button
+					className={ `${ styles[ 'text-button' ] } ${ styles[ 'error-interactive' ] }` }
+					type="button"
+				>
+					Delete
+				</button>
+				<button
+					aria-pressed="true"
+					className={ `${ styles[ 'text-button' ] } ${ styles[ 'error-interactive' ] } ${ styles[ 'forced-active' ] }` }
+					type="button"
+				>
+					Confirm delete
+				</button>
+			</div>
+		</section>
+	);
+}
+
+function buildScaleData( {
+	label,
+	method,
+	ramp,
+	backgroundRamp,
+	seed,
+}: {
+	label: string;
+	method: ExperimentalForegroundMethod;
+	ramp: RampResult;
+	backgroundRamp: RampResult;
+	seed: string;
+} ): ScaleData {
+	return {
+		label,
+		scale: buildPerceptualForegroundScale( {
+			method,
+			ramp,
+			backgroundRamp,
+			seed,
+		} ),
+	};
+}
+
+function VariantCard( {
+	method,
+	backgroundRamp,
+	primaryRamp,
+	errorRamp,
+}: {
+	method: ExperimentalForegroundMethod;
+	backgroundRamp: RampResult;
+	primaryRamp: RampResult;
+	errorRamp: RampResult;
+} ) {
+	const scales = [
+		buildScaleData( {
+			label: 'Neutral',
+			method,
+			ramp: backgroundRamp,
+			backgroundRamp,
+			seed: backgroundRamp.ramp.surface2,
+		} ),
+		buildScaleData( {
+			label: 'Brand',
+			method,
+			ramp: primaryRamp,
+			backgroundRamp,
+			seed: primaryRamp.ramp.bgFill1,
+		} ),
+		buildScaleData( {
+			label: 'Error',
+			method,
+			ramp: errorRamp,
+			backgroundRamp,
+			seed: errorRamp.ramp.bgFill1,
+		} ),
+	] as const;
+
+	return (
+		<article className={ styles[ 'variant-card' ] }>
+			<header>
+				<h3>{ METHOD_DETAILS[ method ].label }</h3>
+				<p>{ METHOD_DETAILS[ method ].description }</p>
+			</header>
+			{ scales.map( ( data ) => (
+				<ForegroundScale
+					data={ data }
+					displayBackground={ backgroundRamp.ramp.surface2 }
+					key={ data.label }
+				/>
+			) ) }
+			<ComponentPanel
+				backgroundRamp={ backgroundRamp }
+				brand={ scales[ 1 ].scale }
+				error={ scales[ 2 ].scale }
+				method={ method }
+				neutral={ scales[ 0 ].scale }
+			/>
+		</article>
+	);
+}
+
+function PilotComparison() {
+	return (
+		<div className={ styles.page }>
+			<header className={ styles.introduction }>
+				<h1>Perceptual foreground scale pilot</h1>
+				<p>
+					APCA controls experimental spacing only. WCAG contrast
+					remains a hard constraint against every reference surface
+					assigned to a step.
+				</p>
+				<p>
+					Control warnings identify values that miss this pilot&apos;s
+					broader multi-surface checks. They do not describe a runtime
+					regression.
+				</p>
+			</header>
+			{ SAMPLE_COMBINATIONS.map( ( combination ) => {
+				const backgroundRamp = buildBgRamp( combination.background );
+				const primaryRamp = buildAccentRamp(
+					combination.primary,
+					backgroundRamp
+				);
+				const errorRamp = buildAccentRamp(
+					DEFAULT_SEED_COLORS.error,
+					backgroundRamp
+				);
+
+				return (
+					<section
+						className={ styles[ 'seed-section' ] }
+						key={ combination.label }
+					>
+						<header>
+							<h2>{ combination.label }</h2>
+							<p>
+								Background{ ' ' }
+								<code>{ combination.background }</code> ·
+								Primary <code>{ combination.primary }</code>
+							</p>
+						</header>
+						<div className={ styles.variants }>
+							{ EXPERIMENTAL_FOREGROUND_METHODS.map(
+								( method ) => (
+									<VariantCard
+										backgroundRamp={ backgroundRamp }
+										errorRamp={ errorRamp }
+										key={ method }
+										method={ method }
+										primaryRamp={ primaryRamp }
+									/>
+								)
+							) }
+						</div>
+					</section>
+				);
+			} ) }
+		</div>
+	);
+}
+
+export const Comparison: Story = {
+	render: () => <PilotComparison />,
+};

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -17,18 +17,6 @@ import {
 } from './perceptual-foreground-experiment';
 import styles from './perceptual-foreground-pilot.module.css';
 
-const meta = {
-	title: 'Design System/Theme/Theme Provider/Perceptual Foreground Pilot',
-	parameters: {
-		controls: { disable: true },
-		docs: { canvas: { sourceState: 'hidden' } },
-	},
-} satisfies Meta;
-
-export default meta;
-
-type Story = StoryObj< typeof meta >;
-
 const SAMPLE_COMBINATIONS = [
 	{
 		label: 'Default light',
@@ -113,6 +101,37 @@ const METHOD_DETAILS: Record<
 	},
 };
 
+type PilotComparisonArgs = {
+	approaches: ExperimentalForegroundMethod[];
+};
+
+const meta = {
+	title: 'Design System/Theme/Theme Provider/Perceptual Foreground Pilot',
+	parameters: {
+		controls: { expanded: true },
+		docs: { canvas: { sourceState: 'hidden' } },
+	},
+	argTypes: {
+		approaches: {
+			control: {
+				type: 'inline-check',
+				labels: Object.fromEntries(
+					EXPERIMENTAL_FOREGROUND_METHODS.map( ( method ) => [
+						method,
+						METHOD_DETAILS[ method ].label,
+					] )
+				),
+			},
+			description: 'Approaches shown in each scale comparison.',
+			options: EXPERIMENTAL_FOREGROUND_METHODS,
+		},
+	},
+} satisfies Meta< PilotComparisonArgs >;
+
+export default meta;
+
+type Story = StoryObj< PilotComparisonArgs >;
+
 type ScaleData = {
 	label: string;
 	scale: ExperimentalForegroundScale;
@@ -130,13 +149,17 @@ function formatSignedContrast( contrast: number ) {
 }
 
 function ForegroundScale( {
+	ariaLabel,
 	data,
 	displayBackground,
+	showScaleName = true,
 	showGamutRelativeChroma,
 	showOkhslSaturation,
 }: {
+	ariaLabel?: string;
 	data: ScaleData;
 	displayBackground: string;
+	showScaleName?: boolean;
 	showGamutRelativeChroma: boolean;
 	showOkhslSaturation: boolean;
 } ) {
@@ -151,10 +174,10 @@ function ForegroundScale( {
 	return (
 		<section
 			className={ styles.scale }
-			aria-label={ `${ data.label } scale` }
+			aria-label={ ariaLabel ?? `${ data.label } scale` }
 		>
 			<div className={ styles[ 'scale-heading' ] }>
-				<h4>{ data.label }</h4>
+				{ showScaleName ? <h4>{ data.label }</h4> : null }
 				<div className={ styles[ 'scale-meta' ] }>
 					<span className={ styles[ 'state-difference' ] }>
 						FGS4→5 ΔEOK2 { stateColorDifference.toFixed( 3 ) }
@@ -236,13 +259,16 @@ function ComponentPanel( {
 	brand,
 	error,
 	method,
+	seedLabel,
 }: {
 	backgroundRamp: RampResult;
 	neutral: ExperimentalForegroundScale;
 	brand: ExperimentalForegroundScale;
 	error: ExperimentalForegroundScale;
 	method: ExperimentalForegroundMethod;
+	seedLabel: string;
 } ) {
+	const approachLabel = METHOD_DETAILS[ method ].label;
 	const pilotStyles = {
 		'--pilot-surface': backgroundRamp.ramp.surface2,
 		'--pilot-border': backgroundRamp.ramp.stroke2,
@@ -260,7 +286,7 @@ function ComponentPanel( {
 
 	return (
 		<section
-			aria-label={ `${ METHOD_DETAILS[ method ].label } component examples` }
+			aria-label={ `${ seedLabel }, ${ approachLabel } component examples` }
 			className={ styles[ 'component-panel' ] }
 			style={ pilotStyles }
 		>
@@ -304,7 +330,9 @@ function ComponentPanel( {
 				</a>
 			</p>
 
-			<nav aria-label="Example view switcher">
+			<nav
+				aria-label={ `${ seedLabel }, ${ approachLabel } view switcher` }
+			>
 				<ul className={ styles[ 'view-switcher' ] }>
 					<li>
 						<a
@@ -326,7 +354,10 @@ function ComponentPanel( {
 				</ul>
 			</nav>
 
-			<nav aria-label="Example menu" className={ styles.menu }>
+			<nav
+				aria-label={ `${ seedLabel }, ${ approachLabel } menu` }
+				className={ styles.menu }
+			>
 				<strong className={ styles[ 'menu-label' ] }>Appearance</strong>
 				<ul>
 					<li>
@@ -401,7 +432,33 @@ function buildScaleData( {
 	};
 }
 
-function VariantCard( {
+type ScaleName = 'neutral' | 'brand' | 'error';
+
+type MethodScaleData = {
+	method: ExperimentalForegroundMethod;
+	scales: Record< ScaleName, ScaleData >;
+};
+
+const SCALE_COMPARISONS = [
+	{ label: 'Neutral', name: 'neutral' },
+	{ label: 'Brand', name: 'brand' },
+	{ label: 'Error', name: 'error' },
+] as const;
+
+const GAMUT_CHROMA_METHODS = new Set< ExperimentalForegroundMethod >( [
+	'state-skewed',
+	'state-skewed-relative-chroma',
+	'state-skewed-okhsl',
+	'anchored-state-skewed-relative-chroma',
+] );
+
+const OKHSL_SATURATION_METHODS = new Set< ExperimentalForegroundMethod >( [
+	'state-skewed-relative-chroma',
+	'state-skewed-okhsl',
+	'anchored-state-skewed-relative-chroma',
+] );
+
+function buildMethodScaleData( {
 	method,
 	backgroundRamp,
 	primaryRamp,
@@ -411,72 +468,162 @@ function VariantCard( {
 	backgroundRamp: RampResult;
 	primaryRamp: RampResult;
 	errorRamp: RampResult;
-} ) {
-	const scales = [
-		buildScaleData( {
-			label: 'Neutral',
-			method,
-			ramp: backgroundRamp,
-			backgroundRamp,
-			seed: backgroundRamp.ramp.surface2,
-			scaleType: 'neutral',
-		} ),
-		buildScaleData( {
-			label: 'Brand',
-			method,
-			ramp: primaryRamp,
-			backgroundRamp,
-			seed: primaryRamp.ramp.bgFill1,
-			scaleType: 'accent',
-		} ),
-		buildScaleData( {
-			label: 'Error',
-			method,
-			ramp: errorRamp,
-			backgroundRamp,
-			seed: errorRamp.ramp.bgFill1,
-			scaleType: 'accent',
-		} ),
-	] as const;
+} ): MethodScaleData {
+	return {
+		method,
+		scales: {
+			neutral: buildScaleData( {
+				label: 'Neutral',
+				method,
+				ramp: backgroundRamp,
+				backgroundRamp,
+				seed: backgroundRamp.ramp.surface2,
+				scaleType: 'neutral',
+			} ),
+			brand: buildScaleData( {
+				label: 'Brand',
+				method,
+				ramp: primaryRamp,
+				backgroundRamp,
+				seed: primaryRamp.ramp.bgFill1,
+				scaleType: 'accent',
+			} ),
+			error: buildScaleData( {
+				label: 'Error',
+				method,
+				ramp: errorRamp,
+				backgroundRamp,
+				seed: errorRamp.ramp.bgFill1,
+				scaleType: 'accent',
+			} ),
+		},
+	};
+}
 
+function ApproachCard( {
+	children,
+	method,
+}: {
+	children: React.ReactNode;
+	method: ExperimentalForegroundMethod;
+} ) {
 	return (
-		<article className={ styles[ 'variant-card' ] }>
+		<article className={ styles[ 'approach-card' ] }>
 			<header>
-				<h3>{ METHOD_DETAILS[ method ].label }</h3>
-				<p>{ METHOD_DETAILS[ method ].description }</p>
+				<h4>{ METHOD_DETAILS[ method ].label }</h4>
 			</header>
-			{ scales.map( ( data ) => (
-				<ForegroundScale
-					data={ data }
-					displayBackground={ backgroundRamp.ramp.surface2 }
-					key={ data.label }
-					showGamutRelativeChroma={
-						data.scaleType === 'accent' &&
-						( method === 'state-skewed' ||
-							method === 'state-skewed-relative-chroma' ||
-							method === 'state-skewed-okhsl' ||
-							method === 'anchored-state-skewed-relative-chroma' )
-					}
-					showOkhslSaturation={
-						data.scaleType === 'accent' &&
-						( method === 'state-skewed-relative-chroma' ||
-							method === 'state-skewed-okhsl' ||
-							method === 'anchored-state-skewed-relative-chroma' )
-					}
-				/>
-			) ) }
-			<ComponentPanel
-				backgroundRamp={ backgroundRamp }
-				brand={ scales[ 1 ].scale }
-				error={ scales[ 2 ].scale }
-				method={ method }
-				neutral={ scales[ 0 ].scale }
-			/>
+			{ children }
 		</article>
 	);
 }
 
-function PilotComparison() {
+function ScaleComparison( {
+	comparison,
+	displayBackground,
+	methods,
+	seedLabel,
+}: {
+	comparison: ( typeof SCALE_COMPARISONS )[ number ];
+	displayBackground: string;
+	methods: MethodScaleData[];
+	seedLabel: string;
+} ) {
+	return (
+		<section className={ styles[ 'scale-comparison' ] }>
+			<h3>{ comparison.label }</h3>
+			<div
+				aria-label={ `${ seedLabel }, ${ comparison.label } scale approaches` }
+				className={ styles.approaches }
+				role="region"
+				tabIndex={ 0 }
+			>
+				{ methods.map( ( { method, scales } ) => {
+					const data = scales[ comparison.name ];
+
+					return (
+						<ApproachCard key={ method } method={ method }>
+							<ForegroundScale
+								ariaLabel={ `${ seedLabel }, ${ METHOD_DETAILS[ method ].label } ${ data.label } scale` }
+								data={ data }
+								displayBackground={ displayBackground }
+								showGamutRelativeChroma={
+									data.scaleType === 'accent' &&
+									GAMUT_CHROMA_METHODS.has( method )
+								}
+								showOkhslSaturation={
+									data.scaleType === 'accent' &&
+									OKHSL_SATURATION_METHODS.has( method )
+								}
+								showScaleName={ false }
+							/>
+						</ApproachCard>
+					);
+				} ) }
+			</div>
+		</section>
+	);
+}
+
+function ComponentComparison( {
+	backgroundRamp,
+	methods,
+	seedLabel,
+}: {
+	backgroundRamp: RampResult;
+	methods: MethodScaleData[];
+	seedLabel: string;
+} ) {
+	return (
+		<section className={ styles[ 'scale-comparison' ] }>
+			<h3>Representative components</h3>
+			<div
+				aria-label={ `${ seedLabel }, representative component approaches` }
+				className={ styles.approaches }
+				role="region"
+				tabIndex={ 0 }
+			>
+				{ methods.map( ( { method, scales } ) => (
+					<ApproachCard key={ method } method={ method }>
+						<ComponentPanel
+							backgroundRamp={ backgroundRamp }
+							brand={ scales.brand.scale }
+							error={ scales.error.scale }
+							method={ method }
+							neutral={ scales.neutral.scale }
+							seedLabel={ seedLabel }
+						/>
+					</ApproachCard>
+				) ) }
+			</div>
+		</section>
+	);
+}
+
+function ApproachDescriptions( {
+	methods,
+}: {
+	methods: ExperimentalForegroundMethod[];
+} ) {
+	return (
+		<details className={ styles[ 'approach-descriptions' ] }>
+			<summary>Approach descriptions</summary>
+			<dl>
+				{ methods.map( ( method ) => (
+					<div key={ method }>
+						<dt>{ METHOD_DETAILS[ method ].label }</dt>
+						<dd>{ METHOD_DETAILS[ method ].description }</dd>
+					</div>
+				) ) }
+			</dl>
+		</details>
+	);
+}
+
+function PilotComparison( { approaches }: PilotComparisonArgs ) {
+	const visibleMethods = EXPERIMENTAL_FOREGROUND_METHODS.filter( ( method ) =>
+		approaches.includes( method )
+	);
+
 	return (
 		<div className={ styles.page }>
 			<header className={ styles.introduction }>
@@ -510,51 +657,83 @@ function PilotComparison() {
 					endpoint constraint. It targets a seven-point APCA interval,
 					or the largest available interval when space is limited.
 				</p>
+				<p>
+					Use the Approaches control to show or hide methods. Each
+					scale keeps the methods ordered from the current control to
+					the latest iteration.
+				</p>
 			</header>
-			{ SAMPLE_COMBINATIONS.map( ( combination ) => {
-				const backgroundRamp = buildBgRamp( combination.background );
-				const primaryRamp = buildAccentRamp(
-					combination.primary,
-					backgroundRamp
-				);
-				const errorRamp = buildAccentRamp(
-					DEFAULT_SEED_COLORS.error,
-					backgroundRamp
-				);
+			{ visibleMethods.length === 0 ? (
+				<p className={ styles[ 'empty-state' ] }>
+					Select at least one approach in the Controls panel.
+				</p>
+			) : null }
+			{ visibleMethods.length > 0 ? (
+				<ApproachDescriptions methods={ visibleMethods } />
+			) : null }
+			{ visibleMethods.length > 0
+				? SAMPLE_COMBINATIONS.map( ( combination ) => {
+						const backgroundRamp = buildBgRamp(
+							combination.background
+						);
+						const primaryRamp = buildAccentRamp(
+							combination.primary,
+							backgroundRamp
+						);
+						const errorRamp = buildAccentRamp(
+							DEFAULT_SEED_COLORS.error,
+							backgroundRamp
+						);
+						const methods = visibleMethods.map( ( method ) =>
+							buildMethodScaleData( {
+								backgroundRamp,
+								errorRamp,
+								method,
+								primaryRamp,
+							} )
+						);
 
-				return (
-					<section
-						className={ styles[ 'seed-section' ] }
-						key={ combination.label }
-					>
-						<header>
-							<h2>{ combination.label }</h2>
-							<p>
-								Background{ ' ' }
-								<code>{ combination.background }</code> ·
-								Primary <code>{ combination.primary }</code>
-							</p>
-						</header>
-						<div className={ styles.variants }>
-							{ EXPERIMENTAL_FOREGROUND_METHODS.map(
-								( method ) => (
-									<VariantCard
-										backgroundRamp={ backgroundRamp }
-										errorRamp={ errorRamp }
-										key={ method }
-										method={ method }
-										primaryRamp={ primaryRamp }
+						return (
+							<section
+								className={ styles[ 'seed-section' ] }
+								key={ combination.label }
+							>
+								<header>
+									<h2>{ combination.label }</h2>
+									<p>
+										Background{ ' ' }
+										<code>{ combination.background }</code>{ ' ' }
+										· Primary{ ' ' }
+										<code>{ combination.primary }</code>
+									</p>
+								</header>
+								{ SCALE_COMPARISONS.map( ( comparison ) => (
+									<ScaleComparison
+										comparison={ comparison }
+										displayBackground={
+											backgroundRamp.ramp.surface2
+										}
+										key={ comparison.name }
+										methods={ methods }
+										seedLabel={ combination.label }
 									/>
-								)
-							) }
-						</div>
-					</section>
-				);
-			} ) }
+								) ) }
+								<ComponentComparison
+									backgroundRamp={ backgroundRamp }
+									methods={ methods }
+									seedLabel={ combination.label }
+								/>
+							</section>
+						);
+				  } )
+				: null }
 		</div>
 	);
 }
 
 export const Comparison: Story = {
-	render: () => <PilotComparison />,
+	args: {
+		approaches: [ ...EXPERIMENTAL_FOREGROUND_METHODS ],
+	},
+	render: ( args ) => <PilotComparison { ...args } />,
 };

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -7,8 +7,10 @@ import {
 	EXPERIMENTAL_FOREGROUND_METHODS,
 	buildPerceptualForegroundScale,
 	getPerceptualContrast,
+	getStateColorDifference,
 	type ExperimentalForegroundMethod,
 	type ExperimentalForegroundScale,
+	type ExperimentalForegroundScaleType,
 } from './perceptual-foreground-experiment';
 import styles from './perceptual-foreground-pilot.module.css';
 
@@ -59,22 +61,27 @@ const METHOD_DETAILS: Record<
 	uniform: {
 		label: 'Uniform APCA · fixed Step 5',
 		description:
-			'Preserves seed chroma and uses five equal intervals ending at the legacy strong endpoint.',
+			'Uses five equal intervals ending at the legacy strong endpoint.',
+	},
+	'state-skewed': {
+		label: 'State-skewed APCA · fixed Step 5',
+		description:
+			'Reserves 40% of the APCA range for the resting-to-active transition ending at the legacy strong endpoint.',
 	},
 	'uniform-free-endpoint': {
 		label: 'Uniform APCA · released Step 5',
 		description:
-			'The same chroma-preserving method, using the least-extreme Step 5 that supports useful spacing.',
+			'Uses equal intervals and the least-extreme Step 5 that supports useful spacing.',
 	},
 	'semantic-anchors': {
 		label: 'Semantic anchors',
 		description:
-			'Keeps compliant lower steps and the legacy strong endpoint, then inserts a chroma-preserving resting step.',
+			'Keeps compliant lower steps and the legacy strong endpoint, then inserts a resting step.',
 	},
 	eased: {
 		label: 'Eased APCA',
 		description:
-			'Uses progressively larger chroma-preserving intervals toward the fixed strong endpoint.',
+			'Uses progressively larger intervals toward the fixed strong endpoint.',
 	},
 };
 
@@ -99,6 +106,7 @@ function ForegroundScale( {
 	const contrasts = data.scale.colors.map( ( color ) =>
 		getPerceptualContrast( displayBackground, color )
 	);
+	const stateColorDifference = getStateColorDifference( data.scale.colors );
 
 	return (
 		<section
@@ -107,14 +115,19 @@ function ForegroundScale( {
 		>
 			<div className={ styles[ 'scale-heading' ] }>
 				<h4>{ data.label }</h4>
-				<span
-					className={ styles.status }
-					data-pass={ data.scale.meetsWcagFloors }
-				>
-					{ data.scale.meetsWcagFloors
-						? 'WCAG floors pass'
-						: 'WCAG floor warning' }
-				</span>
+				<div className={ styles[ 'scale-meta' ] }>
+					<span className={ styles[ 'state-difference' ] }>
+						FGS4→5 ΔEOK { stateColorDifference.toFixed( 3 ) }
+					</span>
+					<span
+						className={ styles.status }
+						data-pass={ data.scale.meetsWcagFloors }
+					>
+						{ data.scale.meetsWcagFloors
+							? 'WCAG floors pass'
+							: 'WCAG floor warning' }
+					</span>
+				</div>
 			</div>
 			<div className={ styles.swatches }>
 				{ data.scale.colors.map( ( color, index ) => {
@@ -303,12 +316,14 @@ function buildScaleData( {
 	ramp,
 	backgroundRamp,
 	seed,
+	scaleType,
 }: {
 	label: string;
 	method: ExperimentalForegroundMethod;
 	ramp: RampResult;
 	backgroundRamp: RampResult;
 	seed: string;
+	scaleType: ExperimentalForegroundScaleType;
 } ): ScaleData {
 	return {
 		label,
@@ -317,6 +332,7 @@ function buildScaleData( {
 			ramp,
 			backgroundRamp,
 			seed,
+			scaleType,
 		} ),
 	};
 }
@@ -339,6 +355,7 @@ function VariantCard( {
 			ramp: backgroundRamp,
 			backgroundRamp,
 			seed: backgroundRamp.ramp.surface2,
+			scaleType: 'neutral',
 		} ),
 		buildScaleData( {
 			label: 'Brand',
@@ -346,6 +363,7 @@ function VariantCard( {
 			ramp: primaryRamp,
 			backgroundRamp,
 			seed: primaryRamp.ramp.bgFill1,
+			scaleType: 'accent',
 		} ),
 		buildScaleData( {
 			label: 'Error',
@@ -353,6 +371,7 @@ function VariantCard( {
 			ramp: errorRamp,
 			backgroundRamp,
 			seed: errorRamp.ramp.bgFill1,
+			scaleType: 'accent',
 		} ),
 	] as const;
 
@@ -396,11 +415,16 @@ function PilotComparison() {
 					regression.
 				</p>
 				<p>
-					Every perceptual variant preserves seed chroma where sRGB
-					permits. Only Uniform APCA · released Step 5 removes the
-					legacy endpoint constraint. It targets a seven-point APCA
-					interval, or the largest available interval when space is
-					limited.
+					Neutral scales use the production foreground chroma taper.
+					Brand and error scales preserve seed chroma where sRGB
+					permits. FGS4→5 ΔEOK measures the resting-to-active color
+					difference. State-skewed APCA reserves 40% of the available
+					APCA range for that transition.
+				</p>
+				<p>
+					Only Uniform APCA · released Step 5 removes the legacy
+					endpoint constraint. It targets a seven-point APCA interval,
+					or the largest available interval when space is limited.
 				</p>
 			</header>
 			{ SAMPLE_COMBINATIONS.map( ( combination ) => {

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -106,6 +106,11 @@ const METHOD_DETAILS: Record<
 		description:
 			"Uses the same state spacing and fixed Step 5, while Steps 1–4 preserve the seed's OKHSL saturation and hue.",
 	},
+	'anchored-state-skewed-relative-chroma': {
+		label: 'Anchored state-skewed · relative chroma',
+		description:
+			"Keeps production Steps 1–2 when they meet the hard floors, then applies state-skewed spacing and the seed's relative chroma to Steps 3–4.",
+	},
 };
 
 type ScaleData = {
@@ -449,12 +454,14 @@ function VariantCard( {
 						data.scaleType === 'accent' &&
 						( method === 'state-skewed' ||
 							method === 'state-skewed-relative-chroma' ||
-							method === 'state-skewed-okhsl' )
+							method === 'state-skewed-okhsl' ||
+							method === 'anchored-state-skewed-relative-chroma' )
 					}
 					showOkhslSaturation={
 						data.scaleType === 'accent' &&
 						( method === 'state-skewed-relative-chroma' ||
-							method === 'state-skewed-okhsl' )
+							method === 'state-skewed-okhsl' ||
+							method === 'anchored-state-skewed-relative-chroma' )
 					}
 				/>
 			) ) }
@@ -488,13 +495,15 @@ function PilotComparison() {
 				<p>
 					Neutral scales use the production foreground chroma taper.
 					Most brand and error scales preserve absolute seed chroma.
-					The relative-chroma variant preserves the seed&apos;s share
-					of available sRGB chroma across Steps 1–4 instead. The OKHSL
-					variant preserves the seed&apos;s OKHSL saturation and hue.
-					The three state-skewed cards report Gamut chroma. The last
-					two also report OKHSL saturation. FGS4→5 ΔEOK2 measures the
-					resting-to-active color difference. Signed APCA Lc exposes
-					contrast polarity, while its magnitude controls spacing.
+					The global relative-chroma variant preserves the seed&apos;s
+					share of available sRGB chroma across Steps 1–4. The
+					anchored variant keeps production Steps 1–2 and applies
+					relative chroma to Steps 3–4. The OKHSL variant preserves
+					the seed&apos;s OKHSL saturation and hue. The state-skewed
+					cards report Gamut chroma. The last three also report OKHSL
+					saturation. FGS4→5 ΔEOK2 measures the resting-to-active
+					color difference. Signed APCA Lc exposes contrast polarity,
+					while its magnitude controls spacing.
 				</p>
 				<p>
 					Only Uniform APCA · released Step 5 removes the legacy

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -135,6 +135,7 @@ type Story = StoryObj< PilotComparisonArgs >;
 type ScaleData = {
 	scale: ExperimentalForegroundScale;
 	scaleType: ExperimentalForegroundScaleType;
+	seed: string;
 };
 
 function getSwatchTextColor( color: string ) {
@@ -371,6 +372,7 @@ function buildScaleData( {
 } ): ScaleData {
 	return {
 		scaleType,
+		seed,
 		scale: buildPerceptualForegroundScale( {
 			method,
 			ramp,
@@ -474,9 +476,22 @@ function ScaleComparison( {
 	methods: MethodScaleData[];
 	seedLabel: string;
 } ) {
+	const seed = methods[ 0 ].scales[ comparison.name ].seed;
+
 	return (
 		<section className={ styles[ 'scale-comparison' ] }>
-			<h3>{ comparison.label }</h3>
+			<div className={ styles[ 'scale-comparison-heading' ] }>
+				<h3>{ comparison.label }</h3>
+				<div className={ styles[ 'scale-seed' ] }>
+					<span
+						aria-hidden="true"
+						className={ styles[ 'scale-seed-swatch' ] }
+						style={ { background: seed } }
+					/>
+					<span>Scale seed</span>
+					<code>{ seed }</code>
+				</div>
+			</div>
 			<div
 				aria-label={ `${ seedLabel }, ${ comparison.label } scale approaches` }
 				className={ styles[ 'scale-table-scroll' ] }

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -56,20 +56,25 @@ const METHOD_DETAILS: Record<
 		description:
 			'Current four-step ramp, with the strongest value repeated for the fifth step.',
 	},
+	'chroma-first': {
+		label: 'Chroma-first',
+		description:
+			'Preserves seed chroma and frees the legacy 7:1 endpoint while keeping every WCAG floor.',
+	},
 	uniform: {
 		label: 'Uniform APCA',
 		description:
-			'Five equal perceptual intervals. The weak endpoint can move to preserve every WCAG floor.',
+			'Five equal intervals on the tapered path. The legacy strong endpoint remains fixed.',
 	},
 	'semantic-anchors': {
 		label: 'Semantic anchors',
 		description:
-			'Keeps compliant lower steps, then divides the remaining normal-to-strong headroom.',
+			'Keeps compliant lower steps and the legacy strong endpoint, then inserts a resting step.',
 	},
 	eased: {
 		label: 'Eased APCA',
 		description:
-			'Uses progressively larger perceptual intervals toward resting and active foregrounds.',
+			'Uses progressively larger intervals on the tapered path toward the fixed strong endpoint.',
 	},
 };
 
@@ -130,11 +135,10 @@ function ForegroundScale( {
 							<strong>FGS{ index + 1 }</strong>
 							<code>{ color }</code>
 							<span>
-								WCAG{ ' ' }
-								{ getContrast(
-									displayBackground,
-									color
-								).toFixed( 2 ) }
+								Min WCAG{ ' ' }
+								{ data.scale.minimumWcagContrasts[
+									index
+								].toFixed( 2 ) }
 							</span>
 							<span>
 								APCA { contrasts[ index ].toFixed( 1 ) }
@@ -390,6 +394,12 @@ function PilotComparison() {
 					Control warnings identify values that miss this pilot&apos;s
 					broader multi-surface checks. They do not describe a runtime
 					regression.
+				</p>
+				<p>
+					Chroma-first preserves seed chroma where sRGB permits and
+					uses the least-extreme endpoint that can maintain a
+					seven-point APCA interval, or the largest available interval
+					when space is limited.
 				</p>
 			</header>
 			{ SAMPLE_COMBINATIONS.map( ( combination ) => {

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -7,6 +7,7 @@ import {
 	EXPERIMENTAL_FOREGROUND_METHODS,
 	buildPerceptualForegroundScale,
 	getGamutRelativeChroma,
+	getOkhslSaturation,
 	getPerceptualContrastMagnitude,
 	getSignedPerceptualContrast,
 	getStateColorDifference,
@@ -100,6 +101,11 @@ const METHOD_DETAILS: Record<
 		description:
 			"Uses the same state spacing and fixed Step 5, while Steps 1–4 preserve the seed's share of available sRGB chroma.",
 	},
+	'state-skewed-okhsl': {
+		label: 'State-skewed APCA · OKHSL saturation',
+		description:
+			"Uses the same state spacing and fixed Step 5, while Steps 1–4 preserve the seed's OKHSL saturation and hue.",
+	},
 };
 
 type ScaleData = {
@@ -122,10 +128,12 @@ function ForegroundScale( {
 	data,
 	displayBackground,
 	showGamutRelativeChroma,
+	showOkhslSaturation,
 }: {
 	data: ScaleData;
 	displayBackground: string;
 	showGamutRelativeChroma: boolean;
+	showOkhslSaturation: boolean;
 } ) {
 	const contrastMagnitudes = data.scale.colors.map( ( color ) =>
 		getPerceptualContrastMagnitude( displayBackground, color )
@@ -193,6 +201,15 @@ function ForegroundScale( {
 									Gamut chroma{ ' ' }
 									{ (
 										getGamutRelativeChroma( color ) * 100
+									).toFixed( 0 ) }
+									%
+								</span>
+							) : null }
+							{ showOkhslSaturation ? (
+								<span>
+									OKHSL saturation{ ' ' }
+									{ (
+										getOkhslSaturation( color ) * 100
 									).toFixed( 0 ) }
 									%
 								</span>
@@ -431,7 +448,13 @@ function VariantCard( {
 					showGamutRelativeChroma={
 						data.scaleType === 'accent' &&
 						( method === 'state-skewed' ||
-							method === 'state-skewed-relative-chroma' )
+							method === 'state-skewed-relative-chroma' ||
+							method === 'state-skewed-okhsl' )
+					}
+					showOkhslSaturation={
+						data.scaleType === 'accent' &&
+						( method === 'state-skewed-relative-chroma' ||
+							method === 'state-skewed-okhsl' )
 					}
 				/>
 			) ) }
@@ -466,11 +489,12 @@ function PilotComparison() {
 					Neutral scales use the production foreground chroma taper.
 					Most brand and error scales preserve absolute seed chroma.
 					The relative-chroma variant preserves the seed&apos;s share
-					of available sRGB chroma across Steps 1–4 instead. The two
-					state-skewed cards report that share as Gamut chroma. FGS4→5
-					ΔEOK2 measures the resting-to-active color difference.
-					Signed APCA Lc exposes contrast polarity, while its
-					magnitude controls spacing.
+					of available sRGB chroma across Steps 1–4 instead. The OKHSL
+					variant preserves the seed&apos;s OKHSL saturation and hue.
+					The three state-skewed cards report Gamut chroma. The last
+					two also report OKHSL saturation. FGS4→5 ΔEOK2 measures the
+					resting-to-active color difference. Signed APCA Lc exposes
+					contrast polarity, while its magnitude controls spacing.
 				</p>
 				<p>
 					Only Uniform APCA · released Step 5 removes the legacy

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -6,7 +6,9 @@ import type { RampResult } from '../lib/types';
 import {
 	EXPERIMENTAL_FOREGROUND_METHODS,
 	buildPerceptualForegroundScale,
-	getPerceptualContrast,
+	getGamutRelativeChroma,
+	getPerceptualContrastMagnitude,
+	getSignedPerceptualContrast,
 	getStateColorDifference,
 	type ExperimentalForegroundMethod,
 	type ExperimentalForegroundScale,
@@ -47,6 +49,16 @@ const SAMPLE_COMBINATIONS = [
 		background: '#777777',
 		primary: '#d63638',
 	},
+	{
+		label: 'Yellow gamut edge',
+		background: '#fcfcfc',
+		primary: '#ffd700',
+	},
+	{
+		label: 'Cyan gamut edge',
+		background: '#1e1e1e',
+		primary: '#00ffff',
+	},
 ] as const;
 
 const METHOD_DETAILS: Record<
@@ -68,6 +80,11 @@ const METHOD_DETAILS: Record<
 		description:
 			'Reserves 40% of the APCA range for the resting-to-active transition ending at the legacy strong endpoint.',
 	},
+	'state-skewed-relative-chroma': {
+		label: 'State-skewed APCA · relative chroma',
+		description:
+			"Uses the same state spacing and fixed Step 5, while Steps 1–4 preserve the seed's share of available sRGB chroma.",
+	},
 	'uniform-free-endpoint': {
 		label: 'Uniform APCA · released Step 5',
 		description:
@@ -88,6 +105,7 @@ const METHOD_DETAILS: Record<
 type ScaleData = {
 	label: string;
 	scale: ExperimentalForegroundScale;
+	scaleType: ExperimentalForegroundScaleType;
 };
 
 function getSwatchTextColor( color: string ) {
@@ -96,15 +114,24 @@ function getSwatchTextColor( color: string ) {
 		: '#ffffff';
 }
 
+function formatSignedContrast( contrast: number ) {
+	return `${ contrast >= 0 ? '+' : '' }${ contrast.toFixed( 1 ) }`;
+}
+
 function ForegroundScale( {
 	data,
 	displayBackground,
+	showGamutRelativeChroma,
 }: {
 	data: ScaleData;
 	displayBackground: string;
+	showGamutRelativeChroma: boolean;
 } ) {
-	const contrasts = data.scale.colors.map( ( color ) =>
-		getPerceptualContrast( displayBackground, color )
+	const contrastMagnitudes = data.scale.colors.map( ( color ) =>
+		getPerceptualContrastMagnitude( displayBackground, color )
+	);
+	const signedContrasts = data.scale.colors.map( ( color ) =>
+		getSignedPerceptualContrast( displayBackground, color )
 	);
 	const stateColorDifference = getStateColorDifference( data.scale.colors );
 
@@ -117,15 +144,15 @@ function ForegroundScale( {
 				<h4>{ data.label }</h4>
 				<div className={ styles[ 'scale-meta' ] }>
 					<span className={ styles[ 'state-difference' ] }>
-						FGS4→5 ΔEOK { stateColorDifference.toFixed( 3 ) }
+						FGS4→5 ΔEOK2 { stateColorDifference.toFixed( 3 ) }
 					</span>
 					<span
 						className={ styles.status }
-						data-pass={ data.scale.meetsWcagFloors }
+						data-pass={ data.scale.meetsContrastTargets }
 					>
-						{ data.scale.meetsWcagFloors
-							? 'WCAG floors pass'
-							: 'WCAG floor warning' }
+						{ data.scale.meetsContrastTargets
+							? 'Contrast targets pass'
+							: 'Contrast target warning' }
 					</span>
 				</div>
 			</div>
@@ -134,7 +161,8 @@ function ForegroundScale( {
 					const interval =
 						index === 0
 							? undefined
-							: contrasts[ index ] - contrasts[ index - 1 ];
+							: contrastMagnitudes[ index ] -
+							  contrastMagnitudes[ index - 1 ];
 
 					return (
 						<div
@@ -148,16 +176,29 @@ function ForegroundScale( {
 							<strong>FGS{ index + 1 }</strong>
 							<code>{ color }</code>
 							<span>
-								Min WCAG{ ' ' }
-								{ data.scale.minimumWcagContrasts[
-									index
-								].toFixed( 2 ) }
+								Min contrast{ ' ' }
+								{ data.scale.minimumContrasts[ index ].toFixed(
+									2
+								) }{ ' ' }
+								/ { data.scale.contrastTargets[ index ] }
 							</span>
 							<span>
-								APCA { contrasts[ index ].toFixed( 1 ) }
+								APCA Lc{ ' ' }
+								{ formatSignedContrast(
+									signedContrasts[ index ]
+								) }
 							</span>
+							{ showGamutRelativeChroma ? (
+								<span>
+									Gamut chroma{ ' ' }
+									{ (
+										getGamutRelativeChroma( color ) * 100
+									).toFixed( 0 ) }
+									%
+								</span>
+							) : null }
 							{ interval === undefined ? null : (
-								<span>Δ { interval.toFixed( 1 ) }</span>
+								<span>Δ |Lc| { interval.toFixed( 1 ) }</span>
 							) }
 						</div>
 					);
@@ -327,6 +368,7 @@ function buildScaleData( {
 } ): ScaleData {
 	return {
 		label,
+		scaleType,
 		scale: buildPerceptualForegroundScale( {
 			method,
 			ramp,
@@ -386,6 +428,11 @@ function VariantCard( {
 					data={ data }
 					displayBackground={ backgroundRamp.ramp.surface2 }
 					key={ data.label }
+					showGamutRelativeChroma={
+						data.scaleType === 'accent' &&
+						( method === 'state-skewed' ||
+							method === 'state-skewed-relative-chroma' )
+					}
 				/>
 			) ) }
 			<ComponentPanel
@@ -405,9 +452,10 @@ function PilotComparison() {
 			<header className={ styles.introduction }>
 				<h1>Perceptual foreground scale pilot</h1>
 				<p>
-					APCA controls experimental spacing only. WCAG contrast
-					remains a hard constraint against every reference surface
-					assigned to a step.
+					APCA controls experimental spacing only. WCAG 2.1 contrast
+					ratios measure hard role targets against every reference
+					surface assigned to a step. The 2:1 and 3:1 targets are
+					design targets, not general text-conformance thresholds.
 				</p>
 				<p>
 					Control warnings identify values that miss this pilot&apos;s
@@ -416,10 +464,13 @@ function PilotComparison() {
 				</p>
 				<p>
 					Neutral scales use the production foreground chroma taper.
-					Brand and error scales preserve seed chroma where sRGB
-					permits. FGS4→5 ΔEOK measures the resting-to-active color
-					difference. State-skewed APCA reserves 40% of the available
-					APCA range for that transition.
+					Most brand and error scales preserve absolute seed chroma.
+					The relative-chroma variant preserves the seed&apos;s share
+					of available sRGB chroma across Steps 1–4 instead. The two
+					state-skewed cards report that share as Gamut chroma. FGS4→5
+					ΔEOK2 measures the resting-to-active color difference.
+					Signed APCA Lc exposes contrast polarity, while its
+					magnitude controls spacing.
 				</p>
 				<p>
 					Only Uniform APCA · released Step 5 removes the legacy

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -133,7 +133,6 @@ export default meta;
 type Story = StoryObj< PilotComparisonArgs >;
 
 type ScaleData = {
-	label: string;
 	scale: ExperimentalForegroundScale;
 	scaleType: ExperimentalForegroundScaleType;
 };
@@ -148,108 +147,61 @@ function formatSignedContrast( contrast: number ) {
 	return `${ contrast >= 0 ? '+' : '' }${ contrast.toFixed( 1 ) }`;
 }
 
-function ForegroundScale( {
-	ariaLabel,
+function ScaleCell( {
+	color,
+	contrastMagnitudes,
 	data,
-	displayBackground,
-	showScaleName = true,
+	index,
 	showGamutRelativeChroma,
 	showOkhslSaturation,
+	signedContrasts,
 }: {
-	ariaLabel?: string;
+	color: string;
+	contrastMagnitudes: number[];
 	data: ScaleData;
-	displayBackground: string;
-	showScaleName?: boolean;
+	index: number;
 	showGamutRelativeChroma: boolean;
 	showOkhslSaturation: boolean;
+	signedContrasts: number[];
 } ) {
-	const contrastMagnitudes = data.scale.colors.map( ( color ) =>
-		getPerceptualContrastMagnitude( displayBackground, color )
-	);
-	const signedContrasts = data.scale.colors.map( ( color ) =>
-		getSignedPerceptualContrast( displayBackground, color )
-	);
-	const stateColorDifference = getStateColorDifference( data.scale.colors );
+	const interval =
+		index === 0
+			? undefined
+			: contrastMagnitudes[ index ] - contrastMagnitudes[ index - 1 ];
 
 	return (
-		<section
-			className={ styles.scale }
-			aria-label={ ariaLabel ?? `${ data.label } scale` }
+		<td
+			className={ styles[ 'scale-cell' ] }
+			style={ {
+				background: color,
+				color: getSwatchTextColor( color ),
+			} }
 		>
-			<div className={ styles[ 'scale-heading' ] }>
-				{ showScaleName ? <h4>{ data.label }</h4> : null }
-				<div className={ styles[ 'scale-meta' ] }>
-					<span className={ styles[ 'state-difference' ] }>
-						FGS4→5 ΔEOK2 { stateColorDifference.toFixed( 3 ) }
-					</span>
-					<span
-						className={ styles.status }
-						data-pass={ data.scale.meetsContrastTargets }
-					>
-						{ data.scale.meetsContrastTargets
-							? 'Contrast targets pass'
-							: 'Contrast target warning' }
-					</span>
-				</div>
-			</div>
-			<div className={ styles.swatches }>
-				{ data.scale.colors.map( ( color, index ) => {
-					const interval =
-						index === 0
-							? undefined
-							: contrastMagnitudes[ index ] -
-							  contrastMagnitudes[ index - 1 ];
-
-					return (
-						<div
-							className={ styles.swatch }
-							key={ `${ color }-${ index }` }
-							style={ {
-								background: color,
-								color: getSwatchTextColor( color ),
-							} }
-						>
-							<strong>FGS{ index + 1 }</strong>
-							<code>{ color }</code>
-							<span>
-								Min contrast{ ' ' }
-								{ data.scale.minimumContrasts[ index ].toFixed(
-									2
-								) }{ ' ' }
-								/ { data.scale.contrastTargets[ index ] }
-							</span>
-							<span>
-								APCA Lc{ ' ' }
-								{ formatSignedContrast(
-									signedContrasts[ index ]
-								) }
-							</span>
-							{ showGamutRelativeChroma ? (
-								<span>
-									Gamut chroma{ ' ' }
-									{ (
-										getGamutRelativeChroma( color ) * 100
-									).toFixed( 0 ) }
-									%
-								</span>
-							) : null }
-							{ showOkhslSaturation ? (
-								<span>
-									OKHSL saturation{ ' ' }
-									{ (
-										getOkhslSaturation( color ) * 100
-									).toFixed( 0 ) }
-									%
-								</span>
-							) : null }
-							{ interval === undefined ? null : (
-								<span>Δ |Lc| { interval.toFixed( 1 ) }</span>
-							) }
-						</div>
-					);
-				} ) }
-			</div>
-		</section>
+			<code>{ color }</code>
+			<span>
+				Min contrast{ ' ' }
+				{ data.scale.minimumContrasts[ index ].toFixed( 2 ) } /{ ' ' }
+				{ data.scale.contrastTargets[ index ] }
+			</span>
+			<span>
+				APCA Lc { formatSignedContrast( signedContrasts[ index ] ) }
+			</span>
+			{ showGamutRelativeChroma ? (
+				<span>
+					Gamut chroma{ ' ' }
+					{ ( getGamutRelativeChroma( color ) * 100 ).toFixed( 0 ) }%
+				</span>
+			) : null }
+			{ showOkhslSaturation ? (
+				<span>
+					OKHSL saturation{ ' ' }
+					{ ( getOkhslSaturation( color ) * 100 ).toFixed( 0 ) }%
+				</span>
+			) : null }
+			{ interval === undefined ? null : (
+				<span>Δ |Lc| { interval.toFixed( 1 ) }</span>
+			) }
+		</td>
 	);
 }
 
@@ -405,14 +357,12 @@ function ComponentPanel( {
 }
 
 function buildScaleData( {
-	label,
 	method,
 	ramp,
 	backgroundRamp,
 	seed,
 	scaleType,
 }: {
-	label: string;
 	method: ExperimentalForegroundMethod;
 	ramp: RampResult;
 	backgroundRamp: RampResult;
@@ -420,7 +370,6 @@ function buildScaleData( {
 	scaleType: ExperimentalForegroundScaleType;
 } ): ScaleData {
 	return {
-		label,
 		scaleType,
 		scale: buildPerceptualForegroundScale( {
 			method,
@@ -473,7 +422,6 @@ function buildMethodScaleData( {
 		method,
 		scales: {
 			neutral: buildScaleData( {
-				label: 'Neutral',
 				method,
 				ramp: backgroundRamp,
 				backgroundRamp,
@@ -481,7 +429,6 @@ function buildMethodScaleData( {
 				scaleType: 'neutral',
 			} ),
 			brand: buildScaleData( {
-				label: 'Brand',
 				method,
 				ramp: primaryRamp,
 				backgroundRamp,
@@ -489,7 +436,6 @@ function buildMethodScaleData( {
 				scaleType: 'accent',
 			} ),
 			error: buildScaleData( {
-				label: 'Error',
 				method,
 				ramp: errorRamp,
 				backgroundRamp,
@@ -533,32 +479,113 @@ function ScaleComparison( {
 			<h3>{ comparison.label }</h3>
 			<div
 				aria-label={ `${ seedLabel }, ${ comparison.label } scale approaches` }
-				className={ styles.approaches }
+				className={ styles[ 'scale-table-scroll' ] }
 				role="region"
 				tabIndex={ 0 }
 			>
-				{ methods.map( ( { method, scales } ) => {
-					const data = scales[ comparison.name ];
+				<table
+					aria-label={ `${ seedLabel }, ${ comparison.label } scale comparison` }
+					className={ styles[ 'scale-table' ] }
+				>
+					<thead>
+						<tr>
+							<th scope="col">Approach</th>
+							{ [ 1, 2, 3, 4, 5 ].map( ( step ) => (
+								<th key={ step } scope="col">
+									FGS{ step }
+								</th>
+							) ) }
+						</tr>
+					</thead>
+					<tbody>
+						{ methods.map( ( { method, scales } ) => {
+							const data = scales[ comparison.name ];
+							const contrastMagnitudes = data.scale.colors.map(
+								( color ) =>
+									getPerceptualContrastMagnitude(
+										displayBackground,
+										color
+									)
+							);
+							const signedContrasts = data.scale.colors.map(
+								( color ) =>
+									getSignedPerceptualContrast(
+										displayBackground,
+										color
+									)
+							);
+							const showGamutRelativeChroma =
+								data.scaleType === 'accent' &&
+								GAMUT_CHROMA_METHODS.has( method );
+							const showOkhslSaturation =
+								data.scaleType === 'accent' &&
+								OKHSL_SATURATION_METHODS.has( method );
 
-					return (
-						<ApproachCard key={ method } method={ method }>
-							<ForegroundScale
-								ariaLabel={ `${ seedLabel }, ${ METHOD_DETAILS[ method ].label } ${ data.label } scale` }
-								data={ data }
-								displayBackground={ displayBackground }
-								showGamutRelativeChroma={
-									data.scaleType === 'accent' &&
-									GAMUT_CHROMA_METHODS.has( method )
-								}
-								showOkhslSaturation={
-									data.scaleType === 'accent' &&
-									OKHSL_SATURATION_METHODS.has( method )
-								}
-								showScaleName={ false }
-							/>
-						</ApproachCard>
-					);
-				} ) }
+							return (
+								<tr key={ method }>
+									<th
+										className={ styles[ 'method-cell' ] }
+										scope="row"
+									>
+										<strong>
+											{ METHOD_DETAILS[ method ].label }
+										</strong>
+										<div
+											className={
+												styles[ 'method-meta' ]
+											}
+										>
+											<span
+												className={
+													styles[ 'state-difference' ]
+												}
+											>
+												FGS4→5 ΔEOK2{ ' ' }
+												{ getStateColorDifference(
+													data.scale.colors
+												).toFixed( 3 ) }
+											</span>
+											<span
+												className={ styles.status }
+												data-pass={
+													data.scale
+														.meetsContrastTargets
+												}
+											>
+												{ data.scale
+													.meetsContrastTargets
+													? 'Contrast targets pass'
+													: 'Contrast target warning' }
+											</span>
+										</div>
+									</th>
+									{ data.scale.colors.map(
+										( color, index ) => (
+											<ScaleCell
+												color={ color }
+												contrastMagnitudes={
+													contrastMagnitudes
+												}
+												data={ data }
+												index={ index }
+												key={ `${ color }-${ index }` }
+												showGamutRelativeChroma={
+													showGamutRelativeChroma
+												}
+												showOkhslSaturation={
+													showOkhslSaturation
+												}
+												signedContrasts={
+													signedContrasts
+												}
+											/>
+										)
+									) }
+								</tr>
+							);
+						} ) }
+					</tbody>
+				</table>
 			</div>
 		</section>
 	);

--- a/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
+++ b/packages/theme/src/color-ramps/stories/perceptual-foreground-pilot.story.tsx
@@ -56,25 +56,25 @@ const METHOD_DETAILS: Record<
 		description:
 			'Current four-step ramp, with the strongest value repeated for the fifth step.',
 	},
-	'chroma-first': {
-		label: 'Chroma-first',
-		description:
-			'Preserves seed chroma and frees the legacy 7:1 endpoint while keeping every WCAG floor.',
-	},
 	uniform: {
-		label: 'Uniform APCA',
+		label: 'Uniform APCA · fixed Step 5',
 		description:
-			'Five equal intervals on the tapered path. The legacy strong endpoint remains fixed.',
+			'Preserves seed chroma and uses five equal intervals ending at the legacy strong endpoint.',
+	},
+	'uniform-free-endpoint': {
+		label: 'Uniform APCA · released Step 5',
+		description:
+			'The same chroma-preserving method, using the least-extreme Step 5 that supports useful spacing.',
 	},
 	'semantic-anchors': {
 		label: 'Semantic anchors',
 		description:
-			'Keeps compliant lower steps and the legacy strong endpoint, then inserts a resting step.',
+			'Keeps compliant lower steps and the legacy strong endpoint, then inserts a chroma-preserving resting step.',
 	},
 	eased: {
 		label: 'Eased APCA',
 		description:
-			'Uses progressively larger intervals on the tapered path toward the fixed strong endpoint.',
+			'Uses progressively larger chroma-preserving intervals toward the fixed strong endpoint.',
 	},
 };
 
@@ -396,10 +396,11 @@ function PilotComparison() {
 					regression.
 				</p>
 				<p>
-					Chroma-first preserves seed chroma where sRGB permits and
-					uses the least-extreme endpoint that can maintain a
-					seven-point APCA interval, or the largest available interval
-					when space is limited.
+					Every perceptual variant preserves seed chroma where sRGB
+					permits. Only Uniform APCA · released Step 5 removes the
+					legacy endpoint constraint. It targets a seven-point APCA
+					interval, or the largest available interval when space is
+					limited.
 				</p>
 			</header>
 			{ SAMPLE_COMBINATIONS.map( ( combination ) => {

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -1,3 +1,4 @@
+import { get, OKLCH, parse } from 'colorjs.io/fn';
 import { buildAccentRamp, buildBgRamp } from '../..';
 import { getContrast } from '../../lib/color-utils';
 import { DEFAULT_SEED_COLORS } from '../../lib/constants';
@@ -128,6 +129,7 @@ describe( 'perceptual foreground experiment', () => {
 				backgroundRamp
 			);
 			const floors = [ 2, 3, 4.5, 4.5, 4.5 ];
+			const violations: string[] = [];
 
 			for ( const method of EXPERIMENTAL_METHODS ) {
 				for ( const [ ramp, seed ] of [
@@ -148,13 +150,20 @@ describe( 'perceptual foreground experiment', () => {
 							ramp,
 							backgroundRamp
 						) ) {
-							expect(
-								getContrast( reference, color )
-							).toBeGreaterThanOrEqual( floors[ index ] );
+							const contrast = getContrast( reference, color );
+							if ( contrast < floors[ index ] ) {
+								violations.push(
+									`${ method } step ${
+										index + 1
+									}: ${ contrast }`
+								);
+							}
 						}
 					} );
 				}
 			}
+
+			expect( violations ).toEqual( [] );
 		}
 	);
 
@@ -196,6 +205,62 @@ describe( 'perceptual foreground experiment', () => {
 		expect( scale.colors[ 4 ] ).toBe( backgroundRamp.ramp.fgSurface4 );
 		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 2 ] );
 		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 4 ] );
+	} );
+
+	it( 'releases the legacy strong endpoint in the chroma-first variant', () => {
+		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
+		const primaryRamp = buildAccentRamp(
+			DEFAULT_SEED_COLORS.primary,
+			backgroundRamp
+		);
+		const scale = buildScale(
+			'chroma-first',
+			primaryRamp,
+			backgroundRamp,
+			primaryRamp.ramp.bgFill1
+		);
+
+		expect( scale.colors[ 4 ] ).not.toBe( primaryRamp.ramp.fgSurface4 );
+		expect(
+			getPerceptualContrast(
+				backgroundRamp.ramp.surface2,
+				scale.colors[ 4 ]
+			)
+		).toBeLessThan(
+			getPerceptualContrast(
+				backgroundRamp.ramp.surface2,
+				primaryRamp.ramp.fgSurface4
+			)
+		);
+	} );
+
+	it( 'preserves more accent chroma at the middle-gray polarity boundary', () => {
+		const backgroundRamp = buildBgRamp( '#777777' );
+		const primaryRamp = buildAccentRamp( '#d63638', backgroundRamp );
+		const taperedScale = buildScale(
+			'uniform',
+			primaryRamp,
+			backgroundRamp,
+			primaryRamp.ramp.bgFill1
+		);
+		const chromaFirstScale = buildScale(
+			'chroma-first',
+			primaryRamp,
+			backgroundRamp,
+			primaryRamp.ramp.bgFill1
+		);
+		const getTotalChroma = ( colors: readonly string[] ) =>
+			colors
+				.slice( 0, -1 )
+				.reduce(
+					( total, color ) =>
+						total + get( parse( color ), [ OKLCH, 'c' ] ),
+					0
+				);
+
+		expect( getTotalChroma( chromaFirstScale.colors ) ).toBeGreaterThan(
+			getTotalChroma( taperedScale.colors )
+		);
 	} );
 
 	it( 'produces the same palette for identical seeds', () => {

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -6,7 +6,9 @@ import type { RampResult } from '../../lib/types';
 import {
 	EXPERIMENTAL_FOREGROUND_METHODS,
 	buildPerceptualForegroundScale,
-	getPerceptualContrast,
+	getGamutRelativeChroma,
+	getPerceptualContrastMagnitude,
+	getSignedPerceptualContrast,
 	getStateColorDifference,
 	type ExperimentalForegroundMethod,
 	type ExperimentalForegroundScaleType,
@@ -20,10 +22,16 @@ const SAMPLE_COMBINATIONS = [
 	{ background: '#1e1e1e', primary: DEFAULT_SEED_COLORS.primary },
 	{ background: '#4f386e', primary: '#608010' },
 	{ background: '#777777', primary: '#d63638' },
+	{ background: '#fcfcfc', primary: '#ffd700' },
+	{ background: '#1e1e1e', primary: '#00ffff' },
 ] as const;
 
 const EXPERIMENTAL_METHODS = EXPERIMENTAL_FOREGROUND_METHODS.filter(
 	( method ) => method !== 'current'
+);
+
+const ABSOLUTE_CHROMA_METHODS = EXPERIMENTAL_METHODS.filter(
+	( method ) => method !== 'state-skewed-relative-chroma'
 );
 
 function buildScale(
@@ -47,6 +55,12 @@ function getTotalChroma( colors: readonly string[] ) {
 		( total, color ) => total + get( parse( color ), [ OKLCH, 'c' ] ),
 		0
 	);
+}
+
+function getHueDifference( first: number, second: number ) {
+	const difference = Math.abs( first - second ) % 360;
+
+	return Math.min( difference, 360 - difference );
 }
 
 function getConstraintReferences(
@@ -118,7 +132,7 @@ describe( 'perceptual foreground experiment', () => {
 						seed,
 						scaleType
 					).colors.map( ( color ) =>
-						getPerceptualContrast(
+						getPerceptualContrastMagnitude(
 							backgroundRamp.ramp.surface2,
 							color
 						)
@@ -133,7 +147,7 @@ describe( 'perceptual foreground experiment', () => {
 	);
 
 	it.each( SAMPLE_COMBINATIONS )(
-		'meets every foreground WCAG floor for $background and $primary',
+		'meets every foreground contrast target for $background and $primary',
 		( { background, primary } ) => {
 			const backgroundRamp = buildBgRamp( background );
 			const primaryRamp = buildAccentRamp( primary, backgroundRamp );
@@ -141,7 +155,6 @@ describe( 'perceptual foreground experiment', () => {
 				DEFAULT_SEED_COLORS.error,
 				backgroundRamp
 			);
-			const floors = [ 2, 3, 4.5, 4.5, 4.5 ];
 			const violations: string[] = [];
 
 			for ( const method of EXPERIMENTAL_METHODS ) {
@@ -165,7 +178,7 @@ describe( 'perceptual foreground experiment', () => {
 							backgroundRamp
 						) ) {
 							const contrast = getContrast( reference, color );
-							if ( contrast < floors[ index ] ) {
+							if ( contrast < scale.contrastTargets[ index ] ) {
 								violations.push(
 									`${ method } step ${
 										index + 1
@@ -195,7 +208,10 @@ describe( 'perceptual foreground experiment', () => {
 				'neutral'
 			);
 			const contrasts = scale.colors.map( ( color ) =>
-				getPerceptualContrast( backgroundRamp.ramp.surface2, color )
+				getPerceptualContrastMagnitude(
+					backgroundRamp.ramp.surface2,
+					color
+				)
 			);
 			const intervals = contrasts
 				.slice( 1 )
@@ -228,7 +244,7 @@ describe( 'perceptual foreground experiment', () => {
 		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 4 ] );
 	} );
 
-	it( 'uses the neutral chroma taper for every perceptual method', () => {
+	it( 'uses the neutral chroma taper at every Ectoplasm step', () => {
 		const backgroundRamp = buildBgRamp( '#4f386e' );
 
 		for ( const method of EXPERIMENTAL_METHODS ) {
@@ -247,20 +263,31 @@ describe( 'perceptual foreground experiment', () => {
 				'accent'
 			);
 
+			for ( const [ index, color ] of neutralScale.colors.entries() ) {
+				expect(
+					get( parse( color ), [ OKLCH, 'c' ] )
+				).toBeLessThanOrEqual(
+					get( parse( untaperedScale.colors[ index ] ), [
+						OKLCH,
+						'c',
+					] )
+				);
+			}
+
 			expect( getTotalChroma( neutralScale.colors ) ).toBeLessThan(
 				getTotalChroma( untaperedScale.colors )
 			);
 		}
 	} );
 
-	it( 'preserves accent chroma for every perceptual method', () => {
-		const backgroundRamp = buildBgRamp( '#777777' );
-		const primaryRamp = buildAccentRamp( '#d63638', backgroundRamp );
+	it( 'preserves accent chroma and hue at every Ectoplasm intermediate step', () => {
+		const backgroundRamp = buildBgRamp( '#4f386e' );
+		const primaryRamp = buildAccentRamp( '#608010', backgroundRamp );
 		const seed = parse( primaryRamp.ramp.bgFill1 );
 		const seedChroma = get( seed, [ OKLCH, 'c' ] );
 		const seedHue = get( seed, [ OKLCH, 'h' ] );
 
-		for ( const method of EXPERIMENTAL_METHODS ) {
+		for ( const method of ABSOLUTE_CHROMA_METHODS ) {
 			const scale = buildScale(
 				method,
 				primaryRamp,
@@ -268,32 +295,68 @@ describe( 'perceptual foreground experiment', () => {
 				primaryRamp.ramp.bgFill1,
 				'accent'
 			);
-			const chromaTotals = scale.colors.slice( 0, -1 ).reduce(
-				( totals, color ) => {
-					const parsed = parse( color );
-					const expected = clampToGamut( {
-						space: OKLCH,
-						coords: [
-							get( parsed, [ OKLCH, 'l' ] ),
-							seedChroma,
-							seedHue,
-						],
-						alpha: seed.alpha ?? null,
-					} );
+			for ( const color of scale.colors.slice( 0, -1 ) ) {
+				const parsed = parse( color );
+				const expected = clampToGamut( {
+					space: OKLCH,
+					coords: [
+						get( parsed, [ OKLCH, 'l' ] ),
+						seedChroma,
+						seedHue,
+					],
+					alpha: seed.alpha ?? null,
+				} );
+				const expectedChroma = get( expected, [ OKLCH, 'c' ] );
 
-					return {
-						actual: totals.actual + get( parsed, [ OKLCH, 'c' ] ),
-						expected:
-							totals.expected + get( expected, [ OKLCH, 'c' ] ),
-					};
-				},
-				{ actual: 0, expected: 0 }
+				expect(
+					get( parsed, [ OKLCH, 'c' ] ) / expectedChroma
+				).toBeGreaterThan( 0.9 );
+				expect(
+					getHueDifference( get( parsed, [ OKLCH, 'h' ] ), seedHue )
+				).toBeLessThan( 2 );
+			}
+		}
+	} );
+
+	it.each( [
+		{ background: '#4f386e', primary: '#608010' },
+		{ background: '#fcfcfc', primary: '#ffd700' },
+		{ background: '#1e1e1e', primary: '#00ffff' },
+	] )(
+		"preserves the seed's relative chroma for $background and $primary",
+		( { background, primary } ) => {
+			const backgroundRamp = buildBgRamp( background );
+			const primaryRamp = buildAccentRamp( primary, backgroundRamp );
+			const seedRelativeChroma = getGamutRelativeChroma(
+				primaryRamp.ramp.bgFill1
+			);
+			const scale = buildScale(
+				'state-skewed-relative-chroma',
+				primaryRamp,
+				backgroundRamp,
+				primaryRamp.ramp.bgFill1,
+				'accent'
 			);
 
-			expect(
-				chromaTotals.actual / chromaTotals.expected
-			).toBeGreaterThan( 0.9 );
+			for ( const color of scale.colors.slice( 0, -1 ) ) {
+				expect(
+					Math.abs(
+						getGamutRelativeChroma( color ) - seedRelativeChroma
+					)
+				).toBeLessThan( 0.04 );
+			}
 		}
+	);
+
+	it( 'reports APCA polarity separately from its spacing magnitude', () => {
+		const darkOnLight = getSignedPerceptualContrast( '#ffffff', '#000000' );
+		const lightOnDark = getSignedPerceptualContrast( '#000000', '#ffffff' );
+
+		expect( darkOnLight ).toBeGreaterThan( 0 );
+		expect( lightOnDark ).toBeLessThan( 0 );
+		expect( getPerceptualContrastMagnitude( '#ffffff', '#000000' ) ).toBe(
+			Math.abs( darkOnLight )
+		);
 	} );
 
 	it( 'isolates endpoint release to the uniform free-endpoint variant', () => {
@@ -306,6 +369,7 @@ describe( 'perceptual foreground experiment', () => {
 		for ( const method of [
 			'uniform',
 			'state-skewed',
+			'state-skewed-relative-chroma',
 			'semantic-anchors',
 			'eased',
 		] as const ) {
@@ -332,16 +396,41 @@ describe( 'perceptual foreground experiment', () => {
 			primaryRamp.ramp.fgSurface4
 		);
 		expect(
-			getPerceptualContrast(
+			getPerceptualContrastMagnitude(
 				backgroundRamp.ramp.surface2,
 				releasedScale.colors[ 4 ]
 			)
 		).toBeLessThan(
-			getPerceptualContrast(
+			getPerceptualContrastMagnitude(
 				backgroundRamp.ramp.surface2,
 				primaryRamp.ramp.fgSurface4
 			)
 		);
+	} );
+
+	it( 'preserves the legacy Step 5 in the floating-point regression case', () => {
+		const backgroundRamp = buildBgRamp( '#000040' );
+		const primaryRamp = buildAccentRamp(
+			DEFAULT_SEED_COLORS.primary,
+			backgroundRamp
+		);
+
+		for ( const method of [
+			'uniform',
+			'state-skewed',
+			'state-skewed-relative-chroma',
+			'eased',
+		] as const ) {
+			expect(
+				buildScale(
+					method,
+					primaryRamp,
+					backgroundRamp,
+					primaryRamp.ramp.bgFill1,
+					'accent'
+				).colors[ 4 ]
+			).toBe( primaryRamp.ramp.fgSurface4 );
+		}
 	} );
 
 	it( 'reserves more state difference in the state-skewed fixed-endpoint variant', () => {
@@ -362,7 +451,10 @@ describe( 'perceptual foreground experiment', () => {
 			'neutral'
 		);
 		const contrasts = stateSkewedScale.colors.map( ( color ) =>
-			getPerceptualContrast( backgroundRamp.ramp.surface2, color )
+			getPerceptualContrastMagnitude(
+				backgroundRamp.ramp.surface2,
+				color
+			)
 		);
 		const finalInterval = contrasts[ 4 ] - contrasts[ 3 ];
 		const totalRange = contrasts[ 4 ] - contrasts[ 0 ];

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -1,4 +1,4 @@
-import { get, OKLCH, Okhsl, parse } from 'colorjs.io/fn';
+import { deltaEOK2, get, OKLCH, Okhsl, parse } from 'colorjs.io/fn';
 import { buildAccentRamp, buildBgRamp } from '../..';
 import { clampToGamut, getContrast } from '../../lib/color-utils';
 import { DEFAULT_SEED_COLORS } from '../../lib/constants';
@@ -33,7 +33,8 @@ const EXPERIMENTAL_METHODS = EXPERIMENTAL_FOREGROUND_METHODS.filter(
 const ABSOLUTE_OKLCH_CHROMA_METHODS = EXPERIMENTAL_METHODS.filter(
 	( method ) =>
 		method !== 'state-skewed-relative-chroma' &&
-		method !== 'state-skewed-okhsl'
+		method !== 'state-skewed-okhsl' &&
+		method !== 'anchored-state-skewed-relative-chroma'
 );
 
 function buildScale(
@@ -355,6 +356,77 @@ describe( 'perceptual foreground experiment', () => {
 		{ background: '#fcfcfc', primary: '#ffd700' },
 		{ background: '#1e1e1e', primary: '#00ffff' },
 	] )(
+		"preserves the seed's relative chroma in the anchored tail for $background and $primary",
+		( { background, primary } ) => {
+			const backgroundRamp = buildBgRamp( background );
+			const primaryRamp = buildAccentRamp( primary, backgroundRamp );
+			const seedRelativeChroma = getGamutRelativeChroma(
+				primaryRamp.ramp.bgFill1
+			);
+			const scale = buildScale(
+				'anchored-state-skewed-relative-chroma',
+				primaryRamp,
+				backgroundRamp,
+				primaryRamp.ramp.bgFill1,
+				'accent'
+			);
+
+			for ( const color of scale.colors.slice( 2, -1 ) ) {
+				expect(
+					Math.abs(
+						getGamutRelativeChroma( color ) - seedRelativeChroma
+					)
+				).toBeLessThan( 0.04 );
+			}
+		}
+	);
+
+	it( 'keeps the middle-gray accent anchors close to production', () => {
+		const backgroundRamp = buildBgRamp( '#777777' );
+		const primaryRamp = buildAccentRamp( '#d63638', backgroundRamp );
+		const seed = primaryRamp.ramp.bgFill1;
+		const currentScale = buildScale(
+			'current',
+			primaryRamp,
+			backgroundRamp,
+			seed,
+			'accent'
+		);
+		const globalScale = buildScale(
+			'state-skewed-relative-chroma',
+			primaryRamp,
+			backgroundRamp,
+			seed,
+			'accent'
+		);
+		const anchoredScale = buildScale(
+			'anchored-state-skewed-relative-chroma',
+			primaryRamp,
+			backgroundRamp,
+			seed,
+			'accent'
+		);
+
+		for ( const index of [ 0, 1 ] ) {
+			const anchoredDifference = deltaEOK2(
+				parse( currentScale.colors[ index ] ),
+				parse( anchoredScale.colors[ index ] )
+			);
+			const globalDifference = deltaEOK2(
+				parse( currentScale.colors[ index ] ),
+				parse( globalScale.colors[ index ] )
+			);
+
+			expect( anchoredDifference ).toBeLessThan( 0.03 );
+			expect( anchoredDifference ).toBeLessThan( globalDifference );
+		}
+	} );
+
+	it.each( [
+		{ background: '#4f386e', primary: '#608010' },
+		{ background: '#fcfcfc', primary: '#ffd700' },
+		{ background: '#1e1e1e', primary: '#00ffff' },
+	] )(
 		"preserves the seed's OKHSL saturation and hue for $background and $primary",
 		( { background, primary } ) => {
 			const backgroundRamp = buildBgRamp( background );
@@ -405,6 +477,7 @@ describe( 'perceptual foreground experiment', () => {
 			'state-skewed',
 			'state-skewed-relative-chroma',
 			'state-skewed-okhsl',
+			'anchored-state-skewed-relative-chroma',
 			'semantic-anchors',
 			'eased',
 		] as const ) {
@@ -455,6 +528,7 @@ describe( 'perceptual foreground experiment', () => {
 			'state-skewed',
 			'state-skewed-relative-chroma',
 			'state-skewed-okhsl',
+			'anchored-state-skewed-relative-chroma',
 			'eased',
 		] as const ) {
 			expect(
@@ -502,6 +576,33 @@ describe( 'perceptual foreground experiment', () => {
 		expect(
 			getStateColorDifference( stateSkewedScale.colors )
 		).toBeGreaterThan( getStateColorDifference( uniformScale.colors ) );
+	} );
+
+	it( 'reserves the final 40 percent after keeping the early anchors', () => {
+		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
+		const seed = backgroundRamp.ramp.surface2;
+		const scale = buildScale(
+			'anchored-state-skewed-relative-chroma',
+			backgroundRamp,
+			backgroundRamp,
+			seed,
+			'neutral'
+		);
+		const contrasts = scale.colors.map( ( color ) =>
+			getPerceptualContrastMagnitude(
+				backgroundRamp.ramp.surface2,
+				color
+			)
+		);
+		const finalInterval = contrasts[ 4 ] - contrasts[ 3 ];
+		const totalRange = contrasts[ 4 ] - contrasts[ 0 ];
+
+		expect( scale.colors.slice( 0, 2 ) ).toEqual( [
+			backgroundRamp.ramp.fgSurface1,
+			backgroundRamp.ramp.fgSurface2,
+		] );
+		expect( scale.colors[ 4 ] ).toBe( backgroundRamp.ramp.fgSurface4 );
+		expect( finalInterval / totalRange ).toBeGreaterThanOrEqual( 0.35 );
 	} );
 
 	it( 'produces the same palette for identical seeds', () => {

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -1,4 +1,4 @@
-import { get, OKLCH, parse } from 'colorjs.io/fn';
+import { get, OKLCH, Okhsl, parse } from 'colorjs.io/fn';
 import { buildAccentRamp, buildBgRamp } from '../..';
 import { clampToGamut, getContrast } from '../../lib/color-utils';
 import { DEFAULT_SEED_COLORS } from '../../lib/constants';
@@ -30,8 +30,10 @@ const EXPERIMENTAL_METHODS = EXPERIMENTAL_FOREGROUND_METHODS.filter(
 	( method ) => method !== 'current'
 );
 
-const ABSOLUTE_CHROMA_METHODS = EXPERIMENTAL_METHODS.filter(
-	( method ) => method !== 'state-skewed-relative-chroma'
+const ABSOLUTE_OKLCH_CHROMA_METHODS = EXPERIMENTAL_METHODS.filter(
+	( method ) =>
+		method !== 'state-skewed-relative-chroma' &&
+		method !== 'state-skewed-okhsl'
 );
 
 function buildScale(
@@ -287,7 +289,7 @@ describe( 'perceptual foreground experiment', () => {
 		const seedChroma = get( seed, [ OKLCH, 'c' ] );
 		const seedHue = get( seed, [ OKLCH, 'h' ] );
 
-		for ( const method of ABSOLUTE_CHROMA_METHODS ) {
+		for ( const method of ABSOLUTE_OKLCH_CHROMA_METHODS ) {
 			const scale = buildScale(
 				method,
 				primaryRamp,
@@ -348,6 +350,38 @@ describe( 'perceptual foreground experiment', () => {
 		}
 	);
 
+	it.each( [
+		{ background: '#4f386e', primary: '#608010' },
+		{ background: '#fcfcfc', primary: '#ffd700' },
+		{ background: '#1e1e1e', primary: '#00ffff' },
+	] )(
+		"preserves the seed's OKHSL saturation and hue for $background and $primary",
+		( { background, primary } ) => {
+			const backgroundRamp = buildBgRamp( background );
+			const primaryRamp = buildAccentRamp( primary, backgroundRamp );
+			const seed = parse( primaryRamp.ramp.bgFill1 );
+			const seedSaturation = get( seed, [ Okhsl, 's' ] );
+			const seedHue = get( seed, [ Okhsl, 'h' ] );
+			const scale = buildScale(
+				'state-skewed-okhsl',
+				primaryRamp,
+				backgroundRamp,
+				primaryRamp.ramp.bgFill1,
+				'accent'
+			);
+
+			for ( const color of scale.colors.slice( 0, -1 ) ) {
+				const parsed = parse( color );
+				expect(
+					Math.abs( get( parsed, [ Okhsl, 's' ] ) - seedSaturation )
+				).toBeLessThan( 0.04 );
+				expect(
+					getHueDifference( get( parsed, [ Okhsl, 'h' ] ), seedHue )
+				).toBeLessThan( 2 );
+			}
+		}
+	);
+
 	it( 'reports APCA polarity separately from its spacing magnitude', () => {
 		const darkOnLight = getSignedPerceptualContrast( '#ffffff', '#000000' );
 		const lightOnDark = getSignedPerceptualContrast( '#000000', '#ffffff' );
@@ -370,6 +404,7 @@ describe( 'perceptual foreground experiment', () => {
 			'uniform',
 			'state-skewed',
 			'state-skewed-relative-chroma',
+			'state-skewed-okhsl',
 			'semantic-anchors',
 			'eased',
 		] as const ) {
@@ -419,6 +454,7 @@ describe( 'perceptual foreground experiment', () => {
 			'uniform',
 			'state-skewed',
 			'state-skewed-relative-chroma',
+			'state-skewed-okhsl',
 			'eased',
 		] as const ) {
 			expect(

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -1,0 +1,214 @@
+import { buildAccentRamp, buildBgRamp } from '../..';
+import { getContrast } from '../../lib/color-utils';
+import { DEFAULT_SEED_COLORS } from '../../lib/constants';
+import type { RampResult } from '../../lib/types';
+import {
+	EXPERIMENTAL_FOREGROUND_METHODS,
+	buildPerceptualForegroundScale,
+	getPerceptualContrast,
+	type ExperimentalForegroundMethod,
+} from '../perceptual-foreground-experiment';
+
+const SAMPLE_COMBINATIONS = [
+	{
+		background: DEFAULT_SEED_COLORS.background,
+		primary: DEFAULT_SEED_COLORS.primary,
+	},
+	{ background: '#1e1e1e', primary: DEFAULT_SEED_COLORS.primary },
+	{ background: '#4f386e', primary: '#608010' },
+	{ background: '#777777', primary: '#d63638' },
+] as const;
+
+const EXPERIMENTAL_METHODS = EXPERIMENTAL_FOREGROUND_METHODS.filter(
+	( method ) => method !== 'current'
+);
+
+function buildScale(
+	method: ExperimentalForegroundMethod,
+	ramp: RampResult,
+	backgroundRamp: RampResult,
+	seed: string
+) {
+	return buildPerceptualForegroundScale( {
+		method,
+		ramp,
+		backgroundRamp,
+		seed,
+	} );
+}
+
+function getConstraintReferences(
+	stepIndex: number,
+	ramp: RampResult,
+	backgroundRamp: RampResult
+) {
+	let surfaceNames: readonly ( keyof RampResult[ 'ramp' ] )[];
+	if ( stepIndex < 2 ) {
+		surfaceNames = [ 'surface3' ];
+	} else if ( stepIndex < 4 ) {
+		surfaceNames = [ 'surface1', 'surface2', 'surface3' ];
+	} else {
+		surfaceNames = [
+			'surface1',
+			'surface2',
+			'surface3',
+			'surface4',
+			'surface5',
+		];
+	}
+
+	return [
+		...surfaceNames.map( ( name ) => ramp.ramp[ name ] ),
+		...surfaceNames.map( ( name ) => backgroundRamp.ramp[ name ] ),
+	];
+}
+
+describe( 'perceptual foreground experiment', () => {
+	it( 'keeps the current control foreground values unchanged', () => {
+		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
+		const scale = buildScale(
+			'current',
+			backgroundRamp,
+			backgroundRamp,
+			backgroundRamp.ramp.surface2
+		);
+
+		expect( scale.colors ).toEqual( [
+			backgroundRamp.ramp.fgSurface1,
+			backgroundRamp.ramp.fgSurface2,
+			backgroundRamp.ramp.fgSurface3,
+			backgroundRamp.ramp.fgSurface4,
+			backgroundRamp.ramp.fgSurface4,
+		] );
+	} );
+
+	it.each( SAMPLE_COMBINATIONS )(
+		'orders every experimental foreground scale for $background and $primary',
+		( { background, primary } ) => {
+			const backgroundRamp = buildBgRamp( background );
+			const primaryRamp = buildAccentRamp( primary, backgroundRamp );
+			const errorRamp = buildAccentRamp(
+				DEFAULT_SEED_COLORS.error,
+				backgroundRamp
+			);
+
+			for ( const method of EXPERIMENTAL_METHODS ) {
+				for ( const [ ramp, seed ] of [
+					[ backgroundRamp, backgroundRamp.ramp.surface2 ],
+					[ primaryRamp, primaryRamp.ramp.bgFill1 ],
+					[ errorRamp, errorRamp.ramp.bgFill1 ],
+				] as const ) {
+					const perceptualContrasts = buildScale(
+						method,
+						ramp,
+						backgroundRamp,
+						seed
+					).colors.map( ( color ) =>
+						getPerceptualContrast(
+							backgroundRamp.ramp.surface2,
+							color
+						)
+					);
+
+					expect( perceptualContrasts ).toEqual(
+						[ ...perceptualContrasts ].sort( ( a, b ) => a - b )
+					);
+				}
+			}
+		}
+	);
+
+	it.each( SAMPLE_COMBINATIONS )(
+		'meets every foreground WCAG floor for $background and $primary',
+		( { background, primary } ) => {
+			const backgroundRamp = buildBgRamp( background );
+			const primaryRamp = buildAccentRamp( primary, backgroundRamp );
+			const errorRamp = buildAccentRamp(
+				DEFAULT_SEED_COLORS.error,
+				backgroundRamp
+			);
+			const floors = [ 2, 3, 4.5, 4.5, 4.5 ];
+
+			for ( const method of EXPERIMENTAL_METHODS ) {
+				for ( const [ ramp, seed ] of [
+					[ backgroundRamp, backgroundRamp.ramp.surface2 ],
+					[ primaryRamp, primaryRamp.ramp.bgFill1 ],
+					[ errorRamp, errorRamp.ramp.bgFill1 ],
+				] as const ) {
+					const scale = buildScale(
+						method,
+						ramp,
+						backgroundRamp,
+						seed
+					);
+
+					scale.colors.forEach( ( color, index ) => {
+						for ( const reference of getConstraintReferences(
+							index,
+							ramp,
+							backgroundRamp
+						) ) {
+							expect(
+								getContrast( reference, color )
+							).toBeGreaterThanOrEqual( floors[ index ] );
+						}
+					} );
+				}
+			}
+		}
+	);
+
+	it( 'spaces the uniform variant within one APCA point after serialization', () => {
+		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
+		const scale = buildScale(
+			'uniform',
+			backgroundRamp,
+			backgroundRamp,
+			backgroundRamp.ramp.surface2
+		);
+		const contrasts = scale.colors.map( ( color ) =>
+			getPerceptualContrast( backgroundRamp.ramp.surface2, color )
+		);
+		const intervals = contrasts
+			.slice( 1 )
+			.map( ( contrast, index ) =>
+				Math.abs( contrast - contrasts[ index ] )
+			);
+		expect(
+			Math.max( ...intervals ) - Math.min( ...intervals )
+		).toBeLessThan( 1 );
+	} );
+
+	it( 'preserves lower anchors in the semantic-anchor variant', () => {
+		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
+		const scale = buildScale(
+			'semantic-anchors',
+			backgroundRamp,
+			backgroundRamp,
+			backgroundRamp.ramp.surface2
+		);
+
+		expect( scale.colors.slice( 0, 3 ) ).toEqual( [
+			backgroundRamp.ramp.fgSurface1,
+			backgroundRamp.ramp.fgSurface2,
+			backgroundRamp.ramp.fgSurface3,
+		] );
+		expect( scale.colors[ 4 ] ).toBe( backgroundRamp.ramp.fgSurface4 );
+		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 2 ] );
+		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 4 ] );
+	} );
+
+	it( 'produces the same palette for identical seeds', () => {
+		const backgroundRamp = buildBgRamp( '#1e1e1e' );
+		const args = {
+			method: 'eased' as const,
+			ramp: backgroundRamp,
+			backgroundRamp,
+			seed: backgroundRamp.ramp.surface2,
+		};
+
+		expect( buildPerceptualForegroundScale( args ) ).toEqual(
+			buildPerceptualForegroundScale( args )
+		);
+	} );
+} );

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -7,7 +7,9 @@ import {
 	EXPERIMENTAL_FOREGROUND_METHODS,
 	buildPerceptualForegroundScale,
 	getPerceptualContrast,
+	getStateColorDifference,
 	type ExperimentalForegroundMethod,
+	type ExperimentalForegroundScaleType,
 } from '../perceptual-foreground-experiment';
 
 const SAMPLE_COMBINATIONS = [
@@ -28,14 +30,23 @@ function buildScale(
 	method: ExperimentalForegroundMethod,
 	ramp: RampResult,
 	backgroundRamp: RampResult,
-	seed: string
+	seed: string,
+	scaleType: ExperimentalForegroundScaleType
 ) {
 	return buildPerceptualForegroundScale( {
 		method,
 		ramp,
 		backgroundRamp,
 		seed,
+		scaleType,
 	} );
+}
+
+function getTotalChroma( colors: readonly string[] ) {
+	return colors.reduce(
+		( total, color ) => total + get( parse( color ), [ OKLCH, 'c' ] ),
+		0
+	);
 }
 
 function getConstraintReferences(
@@ -71,7 +82,8 @@ describe( 'perceptual foreground experiment', () => {
 			'current',
 			backgroundRamp,
 			backgroundRamp,
-			backgroundRamp.ramp.surface2
+			backgroundRamp.ramp.surface2,
+			'neutral'
 		);
 
 		expect( scale.colors ).toEqual( [
@@ -94,16 +106,17 @@ describe( 'perceptual foreground experiment', () => {
 			);
 
 			for ( const method of EXPERIMENTAL_METHODS ) {
-				for ( const [ ramp, seed ] of [
-					[ backgroundRamp, backgroundRamp.ramp.surface2 ],
-					[ primaryRamp, primaryRamp.ramp.bgFill1 ],
-					[ errorRamp, errorRamp.ramp.bgFill1 ],
+				for ( const [ ramp, seed, scaleType ] of [
+					[ backgroundRamp, backgroundRamp.ramp.surface2, 'neutral' ],
+					[ primaryRamp, primaryRamp.ramp.bgFill1, 'accent' ],
+					[ errorRamp, errorRamp.ramp.bgFill1, 'accent' ],
 				] as const ) {
 					const perceptualContrasts = buildScale(
 						method,
 						ramp,
 						backgroundRamp,
-						seed
+						seed,
+						scaleType
 					).colors.map( ( color ) =>
 						getPerceptualContrast(
 							backgroundRamp.ramp.surface2,
@@ -132,16 +145,17 @@ describe( 'perceptual foreground experiment', () => {
 			const violations: string[] = [];
 
 			for ( const method of EXPERIMENTAL_METHODS ) {
-				for ( const [ ramp, seed ] of [
-					[ backgroundRamp, backgroundRamp.ramp.surface2 ],
-					[ primaryRamp, primaryRamp.ramp.bgFill1 ],
-					[ errorRamp, errorRamp.ramp.bgFill1 ],
+				for ( const [ ramp, seed, scaleType ] of [
+					[ backgroundRamp, backgroundRamp.ramp.surface2, 'neutral' ],
+					[ primaryRamp, primaryRamp.ramp.bgFill1, 'accent' ],
+					[ errorRamp, errorRamp.ramp.bgFill1, 'accent' ],
 				] as const ) {
 					const scale = buildScale(
 						method,
 						ramp,
 						backgroundRamp,
-						seed
+						seed,
+						scaleType
 					);
 
 					scale.colors.forEach( ( color, index ) => {
@@ -177,7 +191,8 @@ describe( 'perceptual foreground experiment', () => {
 				method,
 				backgroundRamp,
 				backgroundRamp,
-				backgroundRamp.ramp.surface2
+				backgroundRamp.ramp.surface2,
+				'neutral'
 			);
 			const contrasts = scale.colors.map( ( color ) =>
 				getPerceptualContrast( backgroundRamp.ramp.surface2, color )
@@ -199,7 +214,8 @@ describe( 'perceptual foreground experiment', () => {
 			'semantic-anchors',
 			backgroundRamp,
 			backgroundRamp,
-			backgroundRamp.ramp.surface2
+			backgroundRamp.ramp.surface2,
+			'neutral'
 		);
 
 		expect( scale.colors.slice( 0, 3 ) ).toEqual( [
@@ -212,7 +228,32 @@ describe( 'perceptual foreground experiment', () => {
 		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 4 ] );
 	} );
 
-	it( 'uses the chroma-preserving path for every perceptual variant', () => {
+	it( 'uses the neutral chroma taper for every perceptual method', () => {
+		const backgroundRamp = buildBgRamp( '#4f386e' );
+
+		for ( const method of EXPERIMENTAL_METHODS ) {
+			const neutralScale = buildScale(
+				method,
+				backgroundRamp,
+				backgroundRamp,
+				backgroundRamp.ramp.surface2,
+				'neutral'
+			);
+			const untaperedScale = buildScale(
+				method,
+				backgroundRamp,
+				backgroundRamp,
+				backgroundRamp.ramp.surface2,
+				'accent'
+			);
+
+			expect( getTotalChroma( neutralScale.colors ) ).toBeLessThan(
+				getTotalChroma( untaperedScale.colors )
+			);
+		}
+	} );
+
+	it( 'preserves accent chroma for every perceptual method', () => {
 		const backgroundRamp = buildBgRamp( '#777777' );
 		const primaryRamp = buildAccentRamp( '#d63638', backgroundRamp );
 		const seed = parse( primaryRamp.ramp.bgFill1 );
@@ -224,7 +265,8 @@ describe( 'perceptual foreground experiment', () => {
 				method,
 				primaryRamp,
 				backgroundRamp,
-				primaryRamp.ramp.bgFill1
+				primaryRamp.ramp.bgFill1,
+				'accent'
 			);
 			const chromaTotals = scale.colors.slice( 0, -1 ).reduce(
 				( totals, color ) => {
@@ -263,6 +305,7 @@ describe( 'perceptual foreground experiment', () => {
 
 		for ( const method of [
 			'uniform',
+			'state-skewed',
 			'semantic-anchors',
 			'eased',
 		] as const ) {
@@ -271,7 +314,8 @@ describe( 'perceptual foreground experiment', () => {
 					method,
 					primaryRamp,
 					backgroundRamp,
-					primaryRamp.ramp.bgFill1
+					primaryRamp.ramp.bgFill1,
+					'accent'
 				).colors[ 4 ]
 			).toBe( primaryRamp.ramp.fgSurface4 );
 		}
@@ -280,7 +324,8 @@ describe( 'perceptual foreground experiment', () => {
 			'uniform-free-endpoint',
 			primaryRamp,
 			backgroundRamp,
-			primaryRamp.ramp.bgFill1
+			primaryRamp.ramp.bgFill1,
+			'accent'
 		);
 
 		expect( releasedScale.colors[ 4 ] ).not.toBe(
@@ -299,6 +344,38 @@ describe( 'perceptual foreground experiment', () => {
 		);
 	} );
 
+	it( 'reserves more state difference in the state-skewed fixed-endpoint variant', () => {
+		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
+		const seed = backgroundRamp.ramp.surface2;
+		const uniformScale = buildScale(
+			'uniform',
+			backgroundRamp,
+			backgroundRamp,
+			seed,
+			'neutral'
+		);
+		const stateSkewedScale = buildScale(
+			'state-skewed',
+			backgroundRamp,
+			backgroundRamp,
+			seed,
+			'neutral'
+		);
+		const contrasts = stateSkewedScale.colors.map( ( color ) =>
+			getPerceptualContrast( backgroundRamp.ramp.surface2, color )
+		);
+		const finalInterval = contrasts[ 4 ] - contrasts[ 3 ];
+		const totalRange = contrasts[ 4 ] - contrasts[ 0 ];
+
+		expect( stateSkewedScale.colors[ 4 ] ).toBe(
+			backgroundRamp.ramp.fgSurface4
+		);
+		expect( finalInterval / totalRange ).toBeGreaterThanOrEqual( 0.35 );
+		expect(
+			getStateColorDifference( stateSkewedScale.colors )
+		).toBeGreaterThan( getStateColorDifference( uniformScale.colors ) );
+	} );
+
 	it( 'produces the same palette for identical seeds', () => {
 		const backgroundRamp = buildBgRamp( '#1e1e1e' );
 		const args = {
@@ -306,6 +383,7 @@ describe( 'perceptual foreground experiment', () => {
 			ramp: backgroundRamp,
 			backgroundRamp,
 			seed: backgroundRamp.ramp.surface2,
+			scaleType: 'neutral' as const,
 		};
 
 		expect( buildPerceptualForegroundScale( args ) ).toEqual(

--- a/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
+++ b/packages/theme/src/color-ramps/stories/test/perceptual-foreground-experiment.test.ts
@@ -1,6 +1,6 @@
 import { get, OKLCH, parse } from 'colorjs.io/fn';
 import { buildAccentRamp, buildBgRamp } from '../..';
-import { getContrast } from '../../lib/color-utils';
+import { clampToGamut, getContrast } from '../../lib/color-utils';
 import { DEFAULT_SEED_COLORS } from '../../lib/constants';
 import type { RampResult } from '../../lib/types';
 import {
@@ -167,26 +167,31 @@ describe( 'perceptual foreground experiment', () => {
 		}
 	);
 
-	it( 'spaces the uniform variant within one APCA point after serialization', () => {
-		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
-		const scale = buildScale(
-			'uniform',
-			backgroundRamp,
-			backgroundRamp,
-			backgroundRamp.ramp.surface2
-		);
-		const contrasts = scale.colors.map( ( color ) =>
-			getPerceptualContrast( backgroundRamp.ramp.surface2, color )
-		);
-		const intervals = contrasts
-			.slice( 1 )
-			.map( ( contrast, index ) =>
-				Math.abs( contrast - contrasts[ index ] )
+	it.each( [ 'uniform', 'uniform-free-endpoint' ] as const )(
+		'spaces the %s variant within one APCA point after serialization',
+		( method ) => {
+			const backgroundRamp = buildBgRamp(
+				DEFAULT_SEED_COLORS.background
 			);
-		expect(
-			Math.max( ...intervals ) - Math.min( ...intervals )
-		).toBeLessThan( 1 );
-	} );
+			const scale = buildScale(
+				method,
+				backgroundRamp,
+				backgroundRamp,
+				backgroundRamp.ramp.surface2
+			);
+			const contrasts = scale.colors.map( ( color ) =>
+				getPerceptualContrast( backgroundRamp.ramp.surface2, color )
+			);
+			const intervals = contrasts
+				.slice( 1 )
+				.map( ( contrast, index ) =>
+					Math.abs( contrast - contrasts[ index ] )
+				);
+			expect(
+				Math.max( ...intervals ) - Math.min( ...intervals )
+			).toBeLessThan( 1 );
+		}
+	);
 
 	it( 'preserves lower anchors in the semantic-anchor variant', () => {
 		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
@@ -207,59 +212,90 @@ describe( 'perceptual foreground experiment', () => {
 		expect( scale.colors[ 3 ] ).not.toBe( scale.colors[ 4 ] );
 	} );
 
-	it( 'releases the legacy strong endpoint in the chroma-first variant', () => {
+	it( 'uses the chroma-preserving path for every perceptual variant', () => {
+		const backgroundRamp = buildBgRamp( '#777777' );
+		const primaryRamp = buildAccentRamp( '#d63638', backgroundRamp );
+		const seed = parse( primaryRamp.ramp.bgFill1 );
+		const seedChroma = get( seed, [ OKLCH, 'c' ] );
+		const seedHue = get( seed, [ OKLCH, 'h' ] );
+
+		for ( const method of EXPERIMENTAL_METHODS ) {
+			const scale = buildScale(
+				method,
+				primaryRamp,
+				backgroundRamp,
+				primaryRamp.ramp.bgFill1
+			);
+			const chromaTotals = scale.colors.slice( 0, -1 ).reduce(
+				( totals, color ) => {
+					const parsed = parse( color );
+					const expected = clampToGamut( {
+						space: OKLCH,
+						coords: [
+							get( parsed, [ OKLCH, 'l' ] ),
+							seedChroma,
+							seedHue,
+						],
+						alpha: seed.alpha ?? null,
+					} );
+
+					return {
+						actual: totals.actual + get( parsed, [ OKLCH, 'c' ] ),
+						expected:
+							totals.expected + get( expected, [ OKLCH, 'c' ] ),
+					};
+				},
+				{ actual: 0, expected: 0 }
+			);
+
+			expect(
+				chromaTotals.actual / chromaTotals.expected
+			).toBeGreaterThan( 0.9 );
+		}
+	} );
+
+	it( 'isolates endpoint release to the uniform free-endpoint variant', () => {
 		const backgroundRamp = buildBgRamp( DEFAULT_SEED_COLORS.background );
 		const primaryRamp = buildAccentRamp(
 			DEFAULT_SEED_COLORS.primary,
 			backgroundRamp
 		);
-		const scale = buildScale(
-			'chroma-first',
+
+		for ( const method of [
+			'uniform',
+			'semantic-anchors',
+			'eased',
+		] as const ) {
+			expect(
+				buildScale(
+					method,
+					primaryRamp,
+					backgroundRamp,
+					primaryRamp.ramp.bgFill1
+				).colors[ 4 ]
+			).toBe( primaryRamp.ramp.fgSurface4 );
+		}
+
+		const releasedScale = buildScale(
+			'uniform-free-endpoint',
 			primaryRamp,
 			backgroundRamp,
 			primaryRamp.ramp.bgFill1
 		);
 
-		expect( scale.colors[ 4 ] ).not.toBe( primaryRamp.ramp.fgSurface4 );
+		expect( releasedScale.colors[ 4 ] ).not.toBe(
+			primaryRamp.ramp.fgSurface4
+		);
 		expect(
 			getPerceptualContrast(
 				backgroundRamp.ramp.surface2,
-				scale.colors[ 4 ]
+				releasedScale.colors[ 4 ]
 			)
 		).toBeLessThan(
 			getPerceptualContrast(
 				backgroundRamp.ramp.surface2,
 				primaryRamp.ramp.fgSurface4
 			)
-		);
-	} );
-
-	it( 'preserves more accent chroma at the middle-gray polarity boundary', () => {
-		const backgroundRamp = buildBgRamp( '#777777' );
-		const primaryRamp = buildAccentRamp( '#d63638', backgroundRamp );
-		const taperedScale = buildScale(
-			'uniform',
-			primaryRamp,
-			backgroundRamp,
-			primaryRamp.ramp.bgFill1
-		);
-		const chromaFirstScale = buildScale(
-			'chroma-first',
-			primaryRamp,
-			backgroundRamp,
-			primaryRamp.ramp.bgFill1
-		);
-		const getTotalChroma = ( colors: readonly string[] ) =>
-			colors
-				.slice( 0, -1 )
-				.reduce(
-					( total, color ) =>
-						total + get( parse( color ), [ OKLCH, 'c' ] ),
-					0
-				);
-
-		expect( getTotalChroma( chromaFirstScale.colors ) ).toBeGreaterThan(
-			getTotalChroma( taperedScale.colors )
 		);
 	} );
 


### PR DESCRIPTION
## What?

Adds a Storybook-only pilot that compares the current Theme foreground ramps with eight perception-aware, five-step variants. This does not change ThemeProvider runtime output or public tokens.

## Why?

The current neutral resting and active foreground tokens share the same ramp step. The existing constraints can also produce uneven perceptual jumps, especially near contrast-polarity boundaries.

This pilot separates five questions before selecting a production algorithm: perceptual spacing, the fixed strong endpoint, neutral chroma treatment, accent saturation strategy, and preservation of the production ramp's colorful early steps.

## How?

- Keeps the existing per-step contrast targets as hard constraints against every assigned reference surface. The 2:1 and 3:1 values remain design targets, not general WCAG text-conformance thresholds.
- Uses signed APCA Lc to expose polarity and its magnitude only as an experimental spacing coordinate.
- Applies the production foreground chroma taper to neutral scales.
- Adds a global state-skewed relative-chroma variant. Its accent Steps 1–4 preserve the seed's share of the available sRGB chroma instead of its absolute OKLCH chroma.
- Adds a state-skewed OKHSL variant. Its accent Steps 1–4 preserve the seed's OKHSL saturation and hue.
- Adds an anchored state-skewed variant. It keeps production Steps 1–2 when they meet the hard floors, then applies relative chroma and state-skewed spacing to Steps 3–4.
- Keeps the legacy Step 5 exact for every fixed-endpoint method and uses Delta E OK2 for the resting-to-active diagnostic.
- Exercises default light, default dark, Ectoplasm, middle-gray, yellow, and cyan seed pairs across neutral, brand, and error scales.
- Shows the scales in content, button-like, link, navigation, and destructive examples.

<details>
<summary>Current findings</summary>

- The state-skewed method makes room for the resting-to-active transition by reducing the first three APCA intervals and reserving 40% of the APCA range for FGS4 to FGS5.
- The global relative-chroma and OKHSL variants keep the same state spacing and neutral ramp as the existing state-skewed method.
- The anchored variant avoids darkening FGS1 and FGS2 to fit a global curve. It changes an anchor only when the broader hard-floor checks require it.
- OKHSL restores stronger saturation in the default-light blue scale. Ectoplasm stays close to relative chroma, while the yellow and cyan gamut-edge cases converge at full saturation.
- OKHSL does not yet clearly dominate relative chroma: its default-light blue FGS4-to-FGS5 difference is slightly smaller (0.254 versus 0.282 Delta E OK2).
- The released-Step-5 variant remains useful as the softer-scale control, but it reduces the default-light neutral state difference.
- This remains a color-only experiment. Production pressed and selected states still need a non-color cue.

</details>

## Testing Instructions

1. Open Storybook and go to **Design System > Theme > Theme Provider > Perceptual Foreground Pilot > Comparison**.
2. Compare the four state-skewed cards in the default-light, Ectoplasm, middle-gray, yellow, and cyan sections.
3. Confirm that the anchored card keeps FGS1 and FGS2 close to the current control, while the other state-skewed cards fit all five steps to a global curve.
4. Confirm that the anchored accent scales keep a steady **Gamut chroma** percentage across Steps 3–4. The global relative-chroma scales should keep it steady across Steps 1–4.
5. Compare each resting and pressed or current example. Every state-skewed variant should show a larger FGS4-to-FGS5 change than uniform spacing.
6. Confirm that every experimental scale reports **Contrast targets pass**. A warning on the current control means the existing color missed the pilot's broader multi-surface checks.
7. Confirm that **APCA Lc** is positive for dark text on light backgrounds and negative for light text on dark backgrounds.
8. Use **FGS4→5 ΔEOK2**, **Δ |Lc|**, **Gamut chroma**, **OKHSL saturation**, and minimum contrast values to compare the variants.

### Testing Instructions for Keyboard

1. Tab through the representative component examples.
2. Confirm that interactive controls have a visible focus outline.
3. Confirm that selected, pressed, current, and disabled states have cues besides color.

## Screenshots or screencast

The Storybook comparison is the review surface for this experiment.

## Use of AI Tools

Codex was used to investigate the current Theme algorithm, implement the experimental solver and Storybook pilot, and run verification. This draft is intended for human visual review before any production integration.
