### PR TITLE
Storybook: Demonstrate light, dark, and nested themes

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Documentation
 
+-   Explain how consumers define light and dark themes through `ThemeProvider` color seeds ([#82039](https://github.com/WordPress/gutenberg/pull/82039)).
 -   Route contributors and coding agents to the canonical Design System package guidance ([#80597](https://github.com/WordPress/gutenberg/pull/80597)).
 
 ### Internal

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -106,7 +106,11 @@ The `color` prop accepts an object with the following optional properties:
 -   `primary`: The primary/accent seed color (default: `'#3858e9'`).
 -   `background`: The background seed color (default: `'#fcfcfc'`).
 
-Both properties accept a fully opaque sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Non-opaque alpha values, `transparent`, and other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error. The theme system automatically generates appropriate color ramps and determines light/dark mode based on these seed colors.
+Both properties accept a fully opaque sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Non-opaque alpha values, `transparent`, and other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error. The theme system automatically generates appropriate color ramps from these seed colors.
+
+### Light and dark themes
+
+`ThemeProvider` has no light or dark mode. It accepts color seeds and turns them into semantic design tokens. Consumers define light and dark themes by choosing those seeds: a light background seed makes the generated color ramp favor darker contrasting colors, while a dark background seed makes it favor lighter contrasting colors. The primary seed controls the accent color rather than the overall light or dark appearance.
 
 Use `onColorWarnings` to receive structured warnings after the provider calculates its colors. Warnings identify generated ramp steps or semantic foreground/background pairs that do not meet their contrast targets:
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -108,10 +108,6 @@ The `color` prop accepts an object with the following optional properties:
 
 Both properties accept a fully opaque sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Non-opaque alpha values, `transparent`, and other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error. The theme system automatically generates appropriate color ramps from these seed colors.
 
-### Light and dark themes
-
-`ThemeProvider` has no light or dark mode. It accepts color seeds and turns them into semantic design tokens. Consumers define light and dark themes by choosing those seeds: a light background seed makes the generated color ramp favor darker contrasting colors, while a dark background seed makes it favor lighter contrasting colors. The primary seed controls the accent color rather than the overall light or dark appearance.
-
 Use `onColorWarnings` to receive structured warnings after the provider calculates its colors. Warnings identify generated ramp steps or semantic foreground/background pairs that do not meet their contrast targets:
 
 ```js
@@ -139,6 +135,10 @@ The `cornerRadius` prop sets the overall roundness preset for the theme subtree.
 When a setting is omitted, it inherits from the closest parent `ThemeProvider`. If there is no parent value, the prebuilt defaults from the design-tokens stylesheet apply.
 
 `ThemeProvider` does not accept wrapper customization props such as `className`, `style`, `as`, `render`, or `ref`.
+
+### Light and dark themes
+
+`ThemeProvider` has no light or dark mode. It accepts color seeds and turns them into semantic design tokens. Consumers define light and dark themes by choosing those seeds: a light background seed makes the generated color ramp favor darker contrasting colors, while a dark background seed makes it favor lighter contrasting colors. The primary seed controls the accent color rather than the overall light or dark appearance.
 
 ### Nesting Providers
 

--- a/storybook/addons/design-system-theme/constants.ts
+++ b/storybook/addons/design-system-theme/constants.ts
@@ -1,0 +1,27 @@
+export const LIGHT_THEME_COLORS = {
+	primary: '#3858e9',
+	background: '#fcfcfc',
+} as const;
+
+export const DARK_THEME_COLORS = {
+	primary: LIGHT_THEME_COLORS.primary,
+	background: '#1e1e1e',
+} as const;
+
+export type ColorTheme = 'light' | 'dark' | 'custom';
+
+const isHexColor = ( value: unknown ): value is string =>
+	typeof value === 'string' && /^#[\da-f]{6}$/i.test( value );
+
+export function getColorTheme( value: unknown ): ColorTheme {
+	return value === 'dark' || value === 'custom' ? value : 'light';
+}
+
+export function getCustomThemeColors( primary: unknown, background: unknown ) {
+	return {
+		primary: isHexColor( primary ) ? primary : LIGHT_THEME_COLORS.primary,
+		background: isHexColor( background )
+			? background
+			: LIGHT_THEME_COLORS.background,
+	};
+}

--- a/storybook/addons/design-system-theme/constants.ts
+++ b/storybook/addons/design-system-theme/constants.ts
@@ -8,30 +8,12 @@ export const DARK_THEME_COLORS = {
 	background: '#1e1e1e',
 } as const;
 
-export const SIDEBAR_THEME_PRESETS = [
-	{
-		id: 'fresh',
-		title: 'Fresh',
-		colors: { primary: '#3858e9', background: '#25292b' },
-	},
-	{
-		id: 'blue',
-		title: 'Blue',
-		colors: { primary: '#437aa8', background: '#3876a8' },
-	},
-	{
-		id: 'ectoplasm',
-		title: 'Ectoplasm',
-		colors: { primary: '#646c3e', background: '#4f386e' },
-	},
-] as const;
-
 export type ColorTheme = 'light' | 'dark' | 'custom';
 
 const isHexColor = ( value: unknown ): value is string =>
 	typeof value === 'string' && /^#[\da-f]{6}$/i.test( value );
 
-export function getColorTheme( value: unknown ): ColorTheme {
+export function normalizeColorTheme( value: unknown ): ColorTheme {
 	return value === 'dark' || value === 'custom' ? value : 'light';
 }
 
@@ -42,11 +24,4 @@ export function getCustomThemeColors( primary: unknown, background: unknown ) {
 			? background
 			: LIGHT_THEME_COLORS.background,
 	};
-}
-
-export function getSidebarThemePreset( value: unknown ) {
-	return (
-		SIDEBAR_THEME_PRESETS.find( ( preset ) => preset.id === value ) ??
-		SIDEBAR_THEME_PRESETS[ 0 ]
-	);
 }

--- a/storybook/addons/design-system-theme/constants.ts
+++ b/storybook/addons/design-system-theme/constants.ts
@@ -8,6 +8,24 @@ export const DARK_THEME_COLORS = {
 	background: '#1e1e1e',
 } as const;
 
+export const SIDEBAR_THEME_PRESETS = [
+	{
+		id: 'fresh',
+		title: 'Fresh',
+		colors: { primary: '#3858e9', background: '#25292b' },
+	},
+	{
+		id: 'blue',
+		title: 'Blue',
+		colors: { primary: '#437aa8', background: '#3876a8' },
+	},
+	{
+		id: 'ectoplasm',
+		title: 'Ectoplasm',
+		colors: { primary: '#646c3e', background: '#4f386e' },
+	},
+] as const;
+
 export type ColorTheme = 'light' | 'dark' | 'custom';
 
 const isHexColor = ( value: unknown ): value is string =>
@@ -24,4 +42,11 @@ export function getCustomThemeColors( primary: unknown, background: unknown ) {
 			? background
 			: LIGHT_THEME_COLORS.background,
 	};
+}
+
+export function getSidebarThemePreset( value: unknown ) {
+	return (
+		SIDEBAR_THEME_PRESETS.find( ( preset ) => preset.id === value ) ??
+		SIDEBAR_THEME_PRESETS[ 0 ]
+	);
 }

--- a/storybook/addons/design-system-theme/manager.ts
+++ b/storybook/addons/design-system-theme/manager.ts
@@ -159,16 +159,25 @@ function ThemeColorControls() {
 			},
 			...COLOR_OPTIONS.map( ( option ) => {
 				const colors = getOptionColors( option.id );
+				const isSelected = colorTheme === option.id;
 				return createElement(
 					ToggleButton,
 					{
 						key: option.id,
 						type: 'button',
 						ariaLabel: false,
-						pressed: colorTheme === option.id,
+						pressed: isSelected,
 						size: 'small',
 						variant: 'outline',
-						style: colorPresetButtonStyle,
+						style: {
+							...colorPresetButtonStyle,
+							background: isSelected
+								? theme.background.hoverable
+								: undefined,
+							boxShadow: isSelected
+								? `${ theme.barSelectedColor } 0 0 0 2px inset`
+								: undefined,
+						},
 						onClick: () =>
 							updateGlobals( {
 								dsColorTheme:

--- a/storybook/addons/design-system-theme/manager.ts
+++ b/storybook/addons/design-system-theme/manager.ts
@@ -1,19 +1,25 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { createElement, Fragment, type ChangeEvent } from 'react';
+import {
+	createElement,
+	Fragment,
+	type ChangeEvent,
+	type CSSProperties,
+} from 'react';
 import { addons, types, useGlobals } from 'storybook/manager-api';
 import { MirrorIcon } from '@storybook/icons';
 import {
 	Button,
+	ToggleButton,
 	WithTooltip,
 	TooltipMessage,
 	TooltipLinkList,
 } from 'storybook/internal/components';
-import { styled } from 'storybook/theming';
+import { useTheme } from 'storybook/theming';
 import {
 	DARK_THEME_COLORS,
-	getColorTheme,
 	getCustomThemeColors,
 	LIGHT_THEME_COLORS,
+	normalizeColorTheme,
 	type ColorTheme,
 } from './constants';
 
@@ -49,114 +55,63 @@ const CORNER_RADIUS_OPTIONS: ThemeOption[] = [
 	{ id: 'pronounced', title: 'Pronounced' },
 ];
 
-const ColorSection = styled.div( ( { theme } ) => ( {
-	boxSizing: 'border-box',
-	color: theme.color.defaultText,
-	lineHeight: '18px',
-	padding: 15,
-	width: 280,
-} ) );
-
-const SectionTitle = styled.div( ( { theme } ) => ( {
-	fontWeight: theme.typography.weight.bold,
-} ) );
-
-const ColorPresetGrid = styled.div( {
+const colorPresetGridStyle = {
 	display: 'grid',
 	gap: 6,
 	gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
 	marginTop: 8,
-} );
+} satisfies CSSProperties;
 
-const ColorPresetButton = styled.button< { $active: boolean } >(
-	( { $active, theme } ) => ( {
-		alignItems: 'center',
-		appearance: 'none',
-		background: $active ? theme.background.hoverable : 'transparent',
-		border: `1px solid ${
-			$active ? theme.color.secondary : theme.appBorderColor
-		}`,
-		borderRadius: theme.input.borderRadius,
-		color: theme.color.defaultText,
-		cursor: 'pointer',
-		display: 'grid',
-		font: 'inherit',
-		fontSize: 11,
-		fontWeight: $active
-			? theme.typography.weight.bold
-			: theme.typography.weight.regular,
-		gap: 6,
-		justifyItems: 'center',
-		lineHeight: '14px',
-		minWidth: 0,
-		padding: '8px 6px',
-		'&:hover': {
-			background: theme.background.hoverable,
-		},
-		'&:focus-visible': {
-			outline: `2px solid ${ theme.color.secondary }`,
-			outlineOffset: 2,
-		},
-	} )
-);
+const colorPresetButtonStyle = {
+	display: 'grid',
+	gap: 6,
+	height: 'auto',
+	justifyItems: 'center',
+	lineHeight: '14px',
+	minWidth: 0,
+	padding: '8px 6px',
+} satisfies CSSProperties;
 
-const ColorSwatches = styled.span( {
+const colorSwatchesStyle = {
 	display: 'flex',
 	isolation: 'isolate',
-} );
+} satisfies CSSProperties;
 
-const ColorSwatch = styled.span( ( { theme } ) => ( {
-	border: `1px solid ${ theme.appBorderColor }`,
+const colorSwatchStyle = {
 	borderRadius: '50%',
 	boxSizing: 'border-box',
 	display: 'block',
 	height: 18,
 	width: 18,
-	'& + &': {
-		marginInlineStart: -4,
-		zIndex: -1,
-	},
-} ) );
+} satisfies CSSProperties;
 
-const CustomColorFields = styled.div( ( { theme } ) => ( {
-	borderTop: `1px solid ${ theme.appBorderColor }`,
+const customColorFieldsStyle = {
 	display: 'grid',
 	gap: 8,
 	marginTop: 12,
 	paddingTop: 12,
-} ) );
+} satisfies CSSProperties;
 
-const ColorField = styled.label( {
+const colorFieldStyle = {
 	alignItems: 'center',
 	display: 'grid',
 	fontSize: 11,
 	gap: 8,
 	gridTemplateColumns: '1fr auto auto',
-} );
+} satisfies CSSProperties;
 
-const ColorInput = styled.input( ( { theme } ) => ( {
-	background: theme.input.background,
-	border: `1px solid ${ theme.input.border }`,
-	borderRadius: theme.input.borderRadius,
+const colorInputStyle = {
 	boxSizing: 'border-box',
 	cursor: 'pointer',
 	height: 28,
 	padding: 2,
 	width: 36,
-	'&:focus-visible': {
-		outline: `2px solid ${ theme.color.secondary }`,
-		outlineOffset: 2,
-	},
-} ) );
-
-const ColorValue = styled.code( ( { theme } ) => ( {
-	color: theme.textMutedColor,
-	fontSize: 10,
-} ) );
+} satisfies CSSProperties;
 
 function ThemeColorControls() {
 	const [ globals, updateGlobals ] = useGlobals();
-	const colorTheme = getColorTheme( globals.dsColorTheme );
+	const theme = useTheme();
+	const colorTheme = normalizeColorTheme( globals.dsColorTheme );
 	const customColors = getCustomThemeColors(
 		globals.dsPrimaryColor,
 		globals.dsBackgroundColor
@@ -180,21 +135,40 @@ function ThemeColorControls() {
 			updateGlobals( { [ globalName ]: event.currentTarget.value } );
 
 	return createElement(
-		ColorSection,
-		null,
-		createElement( SectionTitle, null, 'Color' ),
+		'div',
+		{
+			style: {
+				boxSizing: 'border-box',
+				color: theme.color.defaultText,
+				lineHeight: '18px',
+				padding: 15,
+				width: 280,
+			},
+		},
 		createElement(
-			ColorPresetGrid,
-			{ role: 'group', 'aria-label': 'Color theme' },
+			'div',
+			{ style: { fontWeight: theme.typography.weight.bold } },
+			'Color'
+		),
+		createElement(
+			'div',
+			{
+				role: 'group',
+				'aria-label': 'Color theme',
+				style: colorPresetGridStyle,
+			},
 			...COLOR_OPTIONS.map( ( option ) => {
 				const colors = getOptionColors( option.id );
 				return createElement(
-					ColorPresetButton,
+					ToggleButton,
 					{
 						key: option.id,
 						type: 'button',
-						$active: colorTheme === option.id,
-						'aria-pressed': colorTheme === option.id,
+						ariaLabel: false,
+						pressed: colorTheme === option.id,
+						size: 'small',
+						variant: 'outline',
+						style: colorPresetButtonStyle,
 						onClick: () =>
 							updateGlobals( {
 								dsColorTheme:
@@ -204,13 +178,26 @@ function ThemeColorControls() {
 							} ),
 					},
 					createElement(
-						ColorSwatches,
-						{ 'aria-hidden': true },
-						createElement( ColorSwatch, {
-							style: { backgroundColor: colors.primary },
+						'span',
+						{
+							'aria-hidden': true,
+							style: colorSwatchesStyle,
+						},
+						createElement( 'span', {
+							style: {
+								...colorSwatchStyle,
+								backgroundColor: colors.primary,
+								border: `1px solid ${ theme.appBorderColor }`,
+							},
 						} ),
-						createElement( ColorSwatch, {
-							style: { backgroundColor: colors.background },
+						createElement( 'span', {
+							style: {
+								...colorSwatchStyle,
+								backgroundColor: colors.background,
+								border: `1px solid ${ theme.appBorderColor }`,
+								marginInlineStart: -4,
+								zIndex: -1,
+							},
 						} )
 					),
 					option.title
@@ -219,37 +206,66 @@ function ThemeColorControls() {
 		),
 		colorTheme === 'custom' &&
 			createElement(
-				CustomColorFields,
-				null,
+				'div',
+				{
+					style: {
+						...customColorFieldsStyle,
+						borderTop: `1px solid ${ theme.appBorderColor }`,
+					},
+				},
 				createElement(
-					ColorField,
-					null,
+					'label',
+					{ style: colorFieldStyle },
 					'Primary',
-					createElement( ColorInput, {
+					createElement( 'input', {
 						type: 'color',
 						'aria-label': 'Primary',
 						value: customColors.primary,
+						style: {
+							...colorInputStyle,
+							background: theme.input.background,
+							border: `1px solid ${ theme.input.border }`,
+							borderRadius: theme.input.borderRadius,
+						},
 						onChange: updateCustomColor( 'dsPrimaryColor' ),
 					} ),
 					createElement(
-						ColorValue,
-						{ 'aria-hidden': true },
+						'code',
+						{
+							'aria-hidden': true,
+							style: {
+								color: theme.textMutedColor,
+								fontSize: 10,
+							},
+						},
 						customColors.primary
 					)
 				),
 				createElement(
-					ColorField,
-					null,
+					'label',
+					{ style: colorFieldStyle },
 					'Background',
-					createElement( ColorInput, {
+					createElement( 'input', {
 						type: 'color',
 						'aria-label': 'Background',
 						value: customColors.background,
+						style: {
+							...colorInputStyle,
+							background: theme.input.background,
+							border: `1px solid ${ theme.input.border }`,
+							borderRadius: theme.input.borderRadius,
+						},
 						onChange: updateCustomColor( 'dsBackgroundColor' ),
 					} ),
 					createElement(
-						ColorValue,
-						{ 'aria-hidden': true },
+						'code',
+						{
+							'aria-hidden': true,
+							style: {
+								color: theme.textMutedColor,
+								fontSize: 10,
+							},
+						},
 						customColors.background
 					)
 				)

--- a/storybook/addons/design-system-theme/manager.ts
+++ b/storybook/addons/design-system-theme/manager.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { createElement, Fragment } from 'react';
+import { createElement, Fragment, type ChangeEvent } from 'react';
 import { addons, types, useGlobals } from 'storybook/manager-api';
 import { MirrorIcon } from '@storybook/icons';
 import {
@@ -8,6 +8,15 @@ import {
 	TooltipMessage,
 	TooltipLinkList,
 } from 'storybook/internal/components';
+import { styled } from 'storybook/theming';
+import {
+	DARK_THEME_COLORS,
+	getColorTheme,
+	getCustomThemeColors,
+	LIGHT_THEME_COLORS,
+	type ColorTheme,
+} from './constants';
+
 interface ThemeOption {
 	id: string;
 	title: string;
@@ -21,9 +30,10 @@ interface ThemeTooltipMessageProps {
 
 const ADDON_ID = '@wordpress/storybook-addon-design-system-theme';
 
-const COLOR_OPTIONS: ThemeOption[] = [
-	{ id: '', title: 'Default' },
+const COLOR_OPTIONS: Array< { id: ColorTheme; title: string } > = [
+	{ id: 'light', title: 'Light' },
 	{ id: 'dark', title: 'Dark' },
+	{ id: 'custom', title: 'Custom' },
 ];
 
 const CURSOR_CONTROL_OPTIONS: ThemeOption[] = [
@@ -38,6 +48,214 @@ const CORNER_RADIUS_OPTIONS: ThemeOption[] = [
 	{ id: 'moderate', title: 'Moderate' },
 	{ id: 'pronounced', title: 'Pronounced' },
 ];
+
+const ColorSection = styled.div( ( { theme } ) => ( {
+	boxSizing: 'border-box',
+	color: theme.color.defaultText,
+	lineHeight: '18px',
+	padding: 15,
+	width: 280,
+} ) );
+
+const SectionTitle = styled.div( ( { theme } ) => ( {
+	fontWeight: theme.typography.weight.bold,
+} ) );
+
+const ColorPresetGrid = styled.div( {
+	display: 'grid',
+	gap: 6,
+	gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+	marginTop: 8,
+} );
+
+const ColorPresetButton = styled.button< { $active: boolean } >(
+	( { $active, theme } ) => ( {
+		alignItems: 'center',
+		appearance: 'none',
+		background: $active ? theme.background.hoverable : 'transparent',
+		border: `1px solid ${
+			$active ? theme.color.secondary : theme.appBorderColor
+		}`,
+		borderRadius: theme.input.borderRadius,
+		color: theme.color.defaultText,
+		cursor: 'pointer',
+		display: 'grid',
+		font: 'inherit',
+		fontSize: 11,
+		fontWeight: $active
+			? theme.typography.weight.bold
+			: theme.typography.weight.regular,
+		gap: 6,
+		justifyItems: 'center',
+		lineHeight: '14px',
+		minWidth: 0,
+		padding: '8px 6px',
+		'&:hover': {
+			background: theme.background.hoverable,
+		},
+		'&:focus-visible': {
+			outline: `2px solid ${ theme.color.secondary }`,
+			outlineOffset: 2,
+		},
+	} )
+);
+
+const ColorSwatches = styled.span( {
+	display: 'flex',
+	isolation: 'isolate',
+} );
+
+const ColorSwatch = styled.span( ( { theme } ) => ( {
+	border: `1px solid ${ theme.appBorderColor }`,
+	borderRadius: '50%',
+	boxSizing: 'border-box',
+	display: 'block',
+	height: 18,
+	width: 18,
+	'& + &': {
+		marginInlineStart: -4,
+		zIndex: -1,
+	},
+} ) );
+
+const CustomColorFields = styled.div( ( { theme } ) => ( {
+	borderTop: `1px solid ${ theme.appBorderColor }`,
+	display: 'grid',
+	gap: 8,
+	marginTop: 12,
+	paddingTop: 12,
+} ) );
+
+const ColorField = styled.label( {
+	alignItems: 'center',
+	display: 'grid',
+	fontSize: 11,
+	gap: 8,
+	gridTemplateColumns: '1fr auto auto',
+} );
+
+const ColorInput = styled.input( ( { theme } ) => ( {
+	background: theme.input.background,
+	border: `1px solid ${ theme.input.border }`,
+	borderRadius: theme.input.borderRadius,
+	boxSizing: 'border-box',
+	cursor: 'pointer',
+	height: 28,
+	padding: 2,
+	width: 36,
+	'&:focus-visible': {
+		outline: `2px solid ${ theme.color.secondary }`,
+		outlineOffset: 2,
+	},
+} ) );
+
+const ColorValue = styled.code( ( { theme } ) => ( {
+	color: theme.textMutedColor,
+	fontSize: 10,
+} ) );
+
+function ThemeColorControls() {
+	const [ globals, updateGlobals ] = useGlobals();
+	const colorTheme = getColorTheme( globals.dsColorTheme );
+	const customColors = getCustomThemeColors(
+		globals.dsPrimaryColor,
+		globals.dsBackgroundColor
+	);
+
+	const getOptionColors = ( option: ColorTheme ) => {
+		if ( option === 'dark' ) {
+			return DARK_THEME_COLORS;
+		}
+
+		if ( option === 'custom' ) {
+			return customColors;
+		}
+
+		return LIGHT_THEME_COLORS;
+	};
+
+	const updateCustomColor =
+		( globalName: 'dsPrimaryColor' | 'dsBackgroundColor' ) =>
+		( event: ChangeEvent< HTMLInputElement > ) =>
+			updateGlobals( { [ globalName ]: event.currentTarget.value } );
+
+	return createElement(
+		ColorSection,
+		null,
+		createElement( SectionTitle, null, 'Color' ),
+		createElement(
+			ColorPresetGrid,
+			{ role: 'group', 'aria-label': 'Color theme' },
+			...COLOR_OPTIONS.map( ( option ) => {
+				const colors = getOptionColors( option.id );
+				return createElement(
+					ColorPresetButton,
+					{
+						key: option.id,
+						type: 'button',
+						$active: colorTheme === option.id,
+						'aria-pressed': colorTheme === option.id,
+						onClick: () =>
+							updateGlobals( {
+								dsColorTheme:
+									option.id === 'light'
+										? undefined
+										: option.id,
+							} ),
+					},
+					createElement(
+						ColorSwatches,
+						{ 'aria-hidden': true },
+						createElement( ColorSwatch, {
+							style: { backgroundColor: colors.primary },
+						} ),
+						createElement( ColorSwatch, {
+							style: { backgroundColor: colors.background },
+						} )
+					),
+					option.title
+				);
+			} )
+		),
+		colorTheme === 'custom' &&
+			createElement(
+				CustomColorFields,
+				null,
+				createElement(
+					ColorField,
+					null,
+					'Primary',
+					createElement( ColorInput, {
+						type: 'color',
+						'aria-label': 'Primary',
+						value: customColors.primary,
+						onChange: updateCustomColor( 'dsPrimaryColor' ),
+					} ),
+					createElement(
+						ColorValue,
+						{ 'aria-hidden': true },
+						customColors.primary
+					)
+				),
+				createElement(
+					ColorField,
+					null,
+					'Background',
+					createElement( ColorInput, {
+						type: 'color',
+						'aria-label': 'Background',
+						value: customColors.background,
+						onChange: updateCustomColor( 'dsBackgroundColor' ),
+					} ),
+					createElement(
+						ColorValue,
+						{ 'aria-hidden': true },
+						customColors.background
+					)
+				)
+			)
+	);
+}
 
 function ThemeTooltipMessage( {
 	title,
@@ -66,11 +284,7 @@ const ThemeTool = () => {
 	const tooltip = createElement(
 		Fragment,
 		null,
-		createElement( ThemeTooltipMessage, {
-			title: 'Color',
-			globalName: 'dsColorTheme',
-			options: COLOR_OPTIONS,
-		} ),
+		createElement( ThemeColorControls ),
 		createElement( ThemeTooltipMessage, {
 			title: 'Cursor control',
 			globalName: 'dsCursorControl',

--- a/storybook/decorators/with-design-system-theme.tsx
+++ b/storybook/decorators/with-design-system-theme.tsx
@@ -2,9 +2,9 @@ import { ThemeProvider } from '@wordpress/theme';
 import type { StoryContext } from 'storybook/internal/types';
 import {
 	DARK_THEME_COLORS,
-	getColorTheme,
 	getCustomThemeColors,
 	LIGHT_THEME_COLORS,
+	normalizeColorTheme,
 } from '../addons/design-system-theme/constants';
 
 type ThemeProviderProps = React.ComponentProps< typeof ThemeProvider >;
@@ -16,7 +16,7 @@ type ThemeProviderSettings = Pick<
 export function getDesignSystemThemeSettings(
 	globals: StoryContext[ 'globals' ]
 ): ThemeProviderSettings {
-	const colorTheme = getColorTheme( globals.dsColorTheme );
+	const colorTheme = normalizeColorTheme( globals.dsColorTheme );
 	const cursorControl = globals.dsCursorControl || undefined;
 	const cornerRadiusPreset: ThemeProviderProps[ 'cornerRadius' ] =
 		globals.dsCornerRadius || undefined;
@@ -49,7 +49,7 @@ export function WithDesignSystemTheme(
 	Story: React.ComponentType< any >,
 	context: StoryContext
 ) {
-	const colorTheme = getColorTheme( context.globals.dsColorTheme );
+	const colorTheme = normalizeColorTheme( context.globals.dsColorTheme );
 	const themeSettings = getDesignSystemThemeSettings( context.globals );
 	const hasColorOverride = colorTheme !== 'light';
 
@@ -64,6 +64,7 @@ export function WithDesignSystemTheme(
 						? {
 								background:
 									'var(--wpds-color-background-surface-neutral-strong)',
+								color: 'var(--wpds-color-foreground-content-neutral)',
 								padding:
 									'var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-sm)',
 								outline:

--- a/storybook/decorators/with-design-system-theme.tsx
+++ b/storybook/decorators/with-design-system-theme.tsx
@@ -1,5 +1,10 @@
 import { ThemeProvider } from '@wordpress/theme';
 import type { StoryContext } from 'storybook/internal/types';
+import {
+	DARK_THEME_COLORS,
+	getColorTheme,
+	getCustomThemeColors,
+} from '../addons/design-system-theme/constants';
 
 type ThemeProviderCornerRadius = React.ComponentProps<
 	typeof ThemeProvider
@@ -16,14 +21,19 @@ export function WithDesignSystemTheme(
 	Story: React.ComponentType< any >,
 	context: StoryContext
 ) {
-	const colorTheme = context.globals.dsColorTheme;
+	const colorTheme = getColorTheme( context.globals.dsColorTheme );
 	const cursorControl = context.globals.dsCursorControl || undefined;
 	const cornerRadiusPreset: ThemeProviderCornerRadius =
 		context.globals.dsCornerRadius || undefined;
 
 	let color;
 	if ( colorTheme === 'dark' ) {
-		color = { background: '#1e1e1e', primary: '#3858e9' };
+		color = DARK_THEME_COLORS;
+	} else if ( colorTheme === 'custom' ) {
+		color = getCustomThemeColors(
+			context.globals.dsPrimaryColor,
+			context.globals.dsBackgroundColor
+		);
 	}
 
 	return (

--- a/storybook/decorators/with-design-system-theme.tsx
+++ b/storybook/decorators/with-design-system-theme.tsx
@@ -4,11 +4,39 @@ import {
 	DARK_THEME_COLORS,
 	getColorTheme,
 	getCustomThemeColors,
+	LIGHT_THEME_COLORS,
 } from '../addons/design-system-theme/constants';
 
-type ThemeProviderCornerRadius = React.ComponentProps<
-	typeof ThemeProvider
->[ 'cornerRadius' ];
+type ThemeProviderProps = React.ComponentProps< typeof ThemeProvider >;
+type ThemeProviderSettings = Pick<
+	ThemeProviderProps,
+	'color' | 'cornerRadius' | 'cursor'
+>;
+
+export function getDesignSystemThemeSettings(
+	globals: StoryContext[ 'globals' ]
+): ThemeProviderSettings {
+	const colorTheme = getColorTheme( globals.dsColorTheme );
+	const cursorControl = globals.dsCursorControl || undefined;
+	const cornerRadiusPreset: ThemeProviderProps[ 'cornerRadius' ] =
+		globals.dsCornerRadius || undefined;
+
+	let color: ThemeProviderProps[ 'color' ] = LIGHT_THEME_COLORS;
+	if ( colorTheme === 'dark' ) {
+		color = DARK_THEME_COLORS;
+	} else if ( colorTheme === 'custom' ) {
+		color = getCustomThemeColors(
+			globals.dsPrimaryColor,
+			globals.dsBackgroundColor
+		);
+	}
+
+	return {
+		color,
+		cursor: cursorControl ? { control: cursorControl } : undefined,
+		cornerRadius: cornerRadiusPreset,
+	};
+}
 
 /**
  * Decorator that applies Design System theme based on toolbar selections.
@@ -22,30 +50,17 @@ export function WithDesignSystemTheme(
 	context: StoryContext
 ) {
 	const colorTheme = getColorTheme( context.globals.dsColorTheme );
-	const cursorControl = context.globals.dsCursorControl || undefined;
-	const cornerRadiusPreset: ThemeProviderCornerRadius =
-		context.globals.dsCornerRadius || undefined;
-
-	let color;
-	if ( colorTheme === 'dark' ) {
-		color = DARK_THEME_COLORS;
-	} else if ( colorTheme === 'custom' ) {
-		color = getCustomThemeColors(
-			context.globals.dsPrimaryColor,
-			context.globals.dsBackgroundColor
-		);
-	}
+	const themeSettings = getDesignSystemThemeSettings( context.globals );
+	const hasColorOverride = colorTheme !== 'light';
 
 	return (
 		<ThemeProvider
-			color={ color }
-			cursor={ cursorControl ? { control: cursorControl } : undefined }
-			cornerRadius={ cornerRadiusPreset }
+			{ ...themeSettings }
 			isRoot={ context.viewMode !== 'docs' }
 		>
 			<div
 				style={
-					color?.background
+					hasColorOverride
 						? {
 								background:
 									'var(--wpds-color-background-surface-neutral-strong)',
@@ -59,7 +74,7 @@ export function WithDesignSystemTheme(
 				}
 			>
 				<Story { ...context } />
-				{ color?.background && (
+				{ hasColorOverride && (
 					<small
 						style={ {
 							display: 'block',

--- a/storybook/preview.jsx
+++ b/storybook/preview.jsx
@@ -65,6 +65,8 @@ export const globalTypes = {
 		},
 	},
 	dsColorTheme: {},
+	dsPrimaryColor: {},
+	dsBackgroundColor: {},
 	dsCursorControl: {},
 	dsCornerRadius: {},
 };

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,14 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useId, useState } from '@wordpress/element';
 import { wordpress } from '@wordpress/icons';
 import { ThemeProvider } from '@wordpress/theme';
 import {
 	Badge,
 	Button,
 	Card,
+	Dialog,
 	Icon,
 	InputControl,
 	Link,
+	Menu,
 	Notice,
 	SelectControl,
 	Stack,
@@ -52,6 +55,10 @@ export default meta;
  */
 export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 	render: () => {
+		const [ isSiteDetailsOpen, setIsSiteDetailsOpen ] = useState( false );
+		const generalSettingsId = useId();
+		const displaySettingsId = useId();
+
 		return (
 			<div>
 				<ThemeProvider>
@@ -107,6 +114,90 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 									) ) }
 								</Stack>
 							</nav>
+							<div
+								style={ {
+									marginBlockStart:
+										'var(--wpds-dimension-gap-xl)',
+								} }
+							>
+								<Dialog.Root
+									open={ isSiteDetailsOpen }
+									onOpenChange={ setIsSiteDetailsOpen }
+								>
+									<Menu.Root>
+										<Menu.Trigger
+											render={
+												<Button
+													size="compact"
+													variant="outline"
+													tone="neutral"
+													style={ {
+														justifyContent:
+															'flex-start',
+														width: '100%',
+													} }
+												/>
+											}
+										>
+											Site actions
+										</Menu.Trigger>
+										<Menu.Popup>
+											<Menu.LinkItem
+												href={ `#${ generalSettingsId }` }
+											>
+												<Menu.ItemLabel>
+													General settings
+												</Menu.ItemLabel>
+											</Menu.LinkItem>
+											<Menu.LinkItem
+												href={ `#${ displaySettingsId }` }
+											>
+												<Menu.ItemLabel>
+													Display settings
+												</Menu.ItemLabel>
+											</Menu.LinkItem>
+											<Menu.Separator />
+											<Menu.Item
+												onClick={ () =>
+													setIsSiteDetailsOpen( true )
+												}
+											>
+												<Menu.ItemLabel>
+													View site details…
+												</Menu.ItemLabel>
+											</Menu.Item>
+										</Menu.Popup>
+									</Menu.Root>
+									<Dialog.Popup size="small">
+										<Dialog.Header>
+											<Dialog.Title>
+												Site details
+											</Dialog.Title>
+											<Dialog.CloseIcon />
+										</Dialog.Header>
+										<Dialog.Content>
+											<Stack direction="column" gap="sm">
+												<Dialog.Description>
+													This sample dialog shows
+													information about the
+													current site.
+												</Dialog.Description>
+												<Text>
+													<strong>Site title:</strong>{ ' ' }
+													My WordPress site
+												</Text>
+												<Text>
+													<strong>Language:</strong>{ ' ' }
+													English (United States)
+												</Text>
+											</Stack>
+										</Dialog.Content>
+										<Dialog.Footer>
+											<Dialog.Action>Done</Dialog.Action>
+										</Dialog.Footer>
+									</Dialog.Popup>
+								</Dialog.Root>
+							</div>
 						</div>
 
 						<Page
@@ -157,7 +248,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 								</Notice.Root>
 
 								{ /* Card 1: General */ }
-								<Card.Root>
+								<Card.Root id={ generalSettingsId }>
 									<Card.Header>
 										<Card.Title>General</Card.Title>
 									</Card.Header>
@@ -207,7 +298,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 								</Card.Root>
 
 								{ /* Card 2: Display */ }
-								<Card.Root>
+								<Card.Root id={ displaySettingsId }>
 									<Card.Header>
 										<Card.Title>Display</Card.Title>
 									</Card.Header>

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
-import { useId, useRef, useState } from '@wordpress/element';
+import { useId, useState } from '@wordpress/element';
 import { wordpress } from '@wordpress/icons';
 import { ThemeProvider } from '@wordpress/theme';
 import {
@@ -136,7 +136,6 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 			useState< SidebarThemeId >( SIDEBAR_THEME_PRESETS[ 0 ].id );
 		const generalSettingsId = useId();
 		const displaySettingsId = useId();
-		const overlayContainerRef = useRef< HTMLDivElement >( null );
 		const rootThemeSettings = getDesignSystemThemeSettings(
 			context.globals
 		);
@@ -149,7 +148,6 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 					onSelectTheme={ setSidebarThemeId }
 				/>
 				<ThemeProvider color={ sidebarTheme.colors }>
-					<div ref={ overlayContainerRef } />
 					<div
 						style={ {
 							display: 'grid',
@@ -229,15 +227,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 										>
 											Site actions
 										</Menu.Trigger>
-										<Menu.Popup
-											portal={
-												<Menu.Portal
-													container={
-														overlayContainerRef
-													}
-												/>
-											}
-										>
+										<Menu.Popup>
 											<Menu.LinkItem
 												href={ `#${ generalSettingsId }` }
 											>
@@ -264,16 +254,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 											</Menu.Item>
 										</Menu.Popup>
 									</Menu.Root>
-									<Dialog.Popup
-										size="small"
-										portal={
-											<Dialog.Portal
-												container={
-													overlayContainerRef
-												}
-											/>
-										}
-									>
+									<Dialog.Popup size="small">
 										<Dialog.Header>
 											<Dialog.Title>
 												Site details

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -20,12 +20,33 @@ import {
 } from '@wordpress/ui';
 import { withRouter } from '../../decorators/with-router';
 import { getDesignSystemThemeSettings } from '../../decorators/with-design-system-theme';
-import {
-	getSidebarThemePreset,
-	SIDEBAR_THEME_PRESETS,
-} from '../../addons/design-system-theme/constants';
+
+const SIDEBAR_THEME_PRESETS = [
+	{
+		id: 'fresh',
+		title: 'Fresh',
+		colors: { primary: '#3858e9', background: '#25292b' },
+	},
+	{
+		id: 'blue',
+		title: 'Blue',
+		colors: { primary: '#437aa8', background: '#3876a8' },
+	},
+	{
+		id: 'ectoplasm',
+		title: 'Ectoplasm',
+		colors: { primary: '#646c3e', background: '#4f386e' },
+	},
+] as const;
 
 type SidebarThemeId = ( typeof SIDEBAR_THEME_PRESETS )[ number ][ 'id' ];
+
+function getSidebarThemePreset( value: unknown ) {
+	return (
+		SIDEBAR_THEME_PRESETS.find( ( preset ) => preset.id === value ) ??
+		SIDEBAR_THEME_PRESETS[ 0 ]
+	);
+}
 
 function SidebarThemeControls( {
 	selectedTheme,
@@ -160,7 +181,9 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 						} }
 					>
 						{ /* Sidebar */ }
-						<div
+						<Stack
+							direction="column"
+							gap="xl"
 							style={ {
 								backgroundColor:
 									'var(--wpds-color-background-surface-neutral-weak)',
@@ -170,14 +193,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 									'var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak)',
 							} }
 						>
-							<Text
-								variant="heading-sm"
-								render={ <h2 /> }
-								style={ {
-									marginBlockEnd:
-										'var(--wpds-dimension-gap-xl)',
-								} }
-							>
+							<Text variant="heading-sm" render={ <h2 /> }>
 								My App
 							</Text>
 							<nav>
@@ -200,12 +216,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 									) ) }
 								</Stack>
 							</nav>
-							<div
-								style={ {
-									marginBlockStart:
-										'var(--wpds-dimension-gap-xl)',
-								} }
-							>
+							<div>
 								<Dialog.Root
 									open={ isSiteDetailsOpen }
 									onOpenChange={ setIsSiteDetailsOpen }
@@ -284,7 +295,7 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 									</Dialog.Popup>
 								</Dialog.Root>
 							</div>
-						</div>
+						</Stack>
 
 						<Page
 							ariaLabel="Level 1 breadcrumb"

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
-import { useState } from '@wordpress/element';
 import { wordpress } from '@wordpress/icons';
 import { ThemeProvider } from '@wordpress/theme';
 import {
@@ -17,11 +16,6 @@ import {
 	Text,
 } from '@wordpress/ui';
 import { withRouter } from '../../decorators/with-router';
-
-type ThemeProviderCornerRadius = React.ComponentProps<
-	typeof ThemeProvider
->[ 'cornerRadius' ];
-type CornerRadiusPreset = NonNullable< ThemeProviderCornerRadius >;
 
 const sidebarNavItems = [
 	'Dashboard',
@@ -52,92 +46,15 @@ export default meta;
 
 /**
  * A mock application page demonstrating how `ThemeProvider` affects
- * `@wordpress/ui` and `@wordpress/admin-ui` components in concert. Use the inline controls to adjust
- * the `primary` and `background` seed colors, the corner radius preset, and observe how every surface, text
- * element, and interactive control adapts accordingly.
+ * `@wordpress/ui` and `@wordpress/admin-ui` components in concert. Use the
+ * Storybook Theme toolbar to adjust the colors, cursor, and corner radius, and
+ * observe how every surface, text element, and interactive control adapts.
  */
 export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 	render: () => {
-		const [ primary, setPrimary ] = useState< string | undefined >();
-		const [ background, setBackground ] = useState< string | undefined >();
-		const [ cornerRadiusPreset, setCornerRadiusPreset ] =
-			useState< CornerRadiusPreset >( 'subtle' );
-
 		return (
 			<div>
-				<div
-					style={ {
-						display: 'flex',
-						alignItems: 'center',
-						gap: '16px',
-						padding: '12px 16px',
-						marginBlockEnd: '16px',
-						borderRadius: '8px',
-						background: '#f0f0f0',
-						fontSize: '13px',
-						flexWrap: 'wrap',
-					} }
-				>
-					{ /* eslint-disable jsx-a11y/label-has-associated-control */ }
-					<label
-						style={ {
-							display: 'inline-flex',
-							alignItems: 'center',
-							gap: '6px',
-						} }
-					>
-						Primary
-						<input
-							type="color"
-							value={ primary ?? '#3858e9' }
-							onChange={ ( e ) => setPrimary( e.target.value ) }
-						/>
-					</label>
-					<label
-						style={ {
-							display: 'inline-flex',
-							alignItems: 'center',
-							gap: '6px',
-						} }
-					>
-						Background
-						<input
-							type="color"
-							value={ background ?? '#fcfcfc' }
-							onChange={ ( e ) =>
-								setBackground( e.target.value )
-							}
-						/>
-					</label>
-					<label
-						style={ {
-							display: 'inline-flex',
-							alignItems: 'center',
-							gap: '6px',
-						} }
-					>
-						Corner radius
-						<select
-							value={ cornerRadiusPreset }
-							onChange={ ( e ) =>
-								setCornerRadiusPreset(
-									e.target.value as CornerRadiusPreset
-								)
-							}
-						>
-							<option value="none">None</option>
-							<option value="subtle">Subtle</option>
-							<option value="moderate">Moderate</option>
-							<option value="pronounced">Pronounced</option>
-						</select>
-					</label>
-					{ /* eslint-enable jsx-a11y/label-has-associated-control */ }
-				</div>
-				<ThemeProvider
-					color={ { primary, background } }
-					cornerRadius={ cornerRadiusPreset }
-					isRoot
-				>
+				<ThemeProvider>
 					<div
 						style={ {
 							display: 'grid',

--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
-import { useId, useState } from '@wordpress/element';
+import { useId, useRef, useState } from '@wordpress/element';
 import { wordpress } from '@wordpress/icons';
 import { ThemeProvider } from '@wordpress/theme';
 import {
@@ -19,6 +19,83 @@ import {
 	Text,
 } from '@wordpress/ui';
 import { withRouter } from '../../decorators/with-router';
+import { getDesignSystemThemeSettings } from '../../decorators/with-design-system-theme';
+import {
+	getSidebarThemePreset,
+	SIDEBAR_THEME_PRESETS,
+} from '../../addons/design-system-theme/constants';
+
+type SidebarThemeId = ( typeof SIDEBAR_THEME_PRESETS )[ number ][ 'id' ];
+
+function SidebarThemeControls( {
+	selectedTheme,
+	onSelectTheme,
+}: {
+	selectedTheme: SidebarThemeId;
+	onSelectTheme: ( theme: SidebarThemeId ) => void;
+} ) {
+	return (
+		<Stack
+			direction="row"
+			gap="sm"
+			align="center"
+			justify="space-between"
+			style={ {
+				flexWrap: 'wrap',
+				marginBlockEnd: 'var(--wpds-dimension-gap-md)',
+			} }
+		>
+			<Text variant="heading-sm">Sidebar theme</Text>
+			<Stack
+				direction="row"
+				gap="xs"
+				render={ <div role="group" aria-label="Sidebar theme" /> }
+			>
+				{ SIDEBAR_THEME_PRESETS.map( ( preset ) => (
+					<Button
+						key={ preset.id }
+						size="compact"
+						variant={
+							selectedTheme === preset.id ? 'solid' : 'outline'
+						}
+						aria-pressed={ selectedTheme === preset.id }
+						onClick={ () => onSelectTheme( preset.id ) }
+						style={ { gap: 'var(--wpds-dimension-gap-xs)' } }
+					>
+						<span
+							aria-hidden="true"
+							style={ {
+								display: 'flex',
+								isolation: 'isolate',
+							} }
+						>
+							{ Object.values( preset.colors ).map(
+								( color, index ) => (
+									<span
+										key={ color }
+										style={ {
+											backgroundColor: color,
+											border: 'var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral)',
+											borderRadius: '50%',
+											boxSizing: 'border-box',
+											display: 'block',
+											height: 'var(--wpds-dimension-size-xs)',
+											marginInlineStart:
+												index === 0 ? 0 : '-4px',
+											width: 'var(--wpds-dimension-size-xs)',
+											zIndex: -index,
+										} }
+									/>
+								)
+							) }
+						</span>
+						{ preset.title }
+					</Button>
+				) ) }
+			</Stack>
+		</Stack>
+	);
+}
 
 const sidebarNavItems = [
 	'Dashboard',
@@ -48,20 +125,31 @@ const meta: Meta< typeof ThemeProvider > = {
 export default meta;
 
 /**
- * A mock application page demonstrating how `ThemeProvider` affects
- * `@wordpress/ui` and `@wordpress/admin-ui` components in concert. Use the
- * Storybook Theme toolbar to adjust the colors, cursor, and corner radius, and
- * observe how every surface, text element, and interactive control adapts.
+ * A mock application demonstrating nested `ThemeProvider` components. The
+ * application shell uses its own color preset, while the main content
+ * explicitly reapplies the root settings from the Storybook Theme toolbar.
  */
 export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
-	render: () => {
+	render: ( _, context ) => {
 		const [ isSiteDetailsOpen, setIsSiteDetailsOpen ] = useState( false );
+		const [ sidebarThemeId, setSidebarThemeId ] =
+			useState< SidebarThemeId >( SIDEBAR_THEME_PRESETS[ 0 ].id );
 		const generalSettingsId = useId();
 		const displaySettingsId = useId();
+		const overlayContainerRef = useRef< HTMLDivElement >( null );
+		const rootThemeSettings = getDesignSystemThemeSettings(
+			context.globals
+		);
+		const sidebarTheme = getSidebarThemePreset( sidebarThemeId );
 
 		return (
 			<div>
-				<ThemeProvider>
+				<SidebarThemeControls
+					selectedTheme={ sidebarTheme.id }
+					onSelectTheme={ setSidebarThemeId }
+				/>
+				<ThemeProvider color={ sidebarTheme.colors }>
+					<div ref={ overlayContainerRef } />
 					<div
 						style={ {
 							display: 'grid',
@@ -141,7 +229,15 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 										>
 											Site actions
 										</Menu.Trigger>
-										<Menu.Popup>
+										<Menu.Popup
+											portal={
+												<Menu.Portal
+													container={
+														overlayContainerRef
+													}
+												/>
+											}
+										>
 											<Menu.LinkItem
 												href={ `#${ generalSettingsId }` }
 											>
@@ -168,7 +264,16 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 											</Menu.Item>
 										</Menu.Popup>
 									</Menu.Root>
-									<Dialog.Popup size="small">
+									<Dialog.Popup
+										size="small"
+										portal={
+											<Dialog.Portal
+												container={
+													overlayContainerRef
+												}
+											/>
+										}
+									>
 										<Dialog.Header>
 											<Dialog.Title>
 												Site details
@@ -226,165 +331,212 @@ export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
 								</>
 							}
 							showSidebarToggle={ false }
-							hasPadding
 						>
-							<Stack
-								direction="column"
-								gap="lg"
+							<div
 								style={ {
-									width: '100%',
-									maxWidth: '640px',
-									marginInline: 'auto',
+									display: 'grid',
+									flex: 1,
 								} }
 							>
-								<Notice.Root intent="info">
-									<Notice.Title>
-										Welcome to your new site
-									</Notice.Title>
-									<Notice.Description>
-										Complete the steps below to finish
-										setting up.
-									</Notice.Description>
-								</Notice.Root>
+								<ThemeProvider { ...rootThemeSettings }>
+									<div
+										style={ {
+											boxSizing: 'border-box',
+											backgroundColor:
+												'var(--wpds-color-background-surface-neutral)',
+											color: 'var(--wpds-color-foreground-content-neutral)',
+											height: '100%',
+											padding:
+												'var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl)',
+										} }
+									>
+										<Stack
+											direction="column"
+											gap="lg"
+											style={ {
+												width: '100%',
+												maxWidth: '640px',
+												marginInline: 'auto',
+											} }
+										>
+											<Notice.Root intent="info">
+												<Notice.Title>
+													Welcome to your new site
+												</Notice.Title>
+												<Notice.Description>
+													Complete the steps below to
+													finish setting up.
+												</Notice.Description>
+											</Notice.Root>
 
-								{ /* Card 1: General */ }
-								<Card.Root id={ generalSettingsId }>
-									<Card.Header>
-										<Card.Title>General</Card.Title>
-									</Card.Header>
-									<Card.Content>
-										<Stack direction="column" gap="md">
-											<Text>
-												Configure the basic settings for
-												your site. The fields below
-												adopt the corner radius preset
-												alongside cards, buttons, and
-												other surfaces.
-											</Text>
-											<InputControl
-												label="Site title"
-												placeholder="My WordPress site"
-												defaultValue="My WordPress site"
-											/>
-											<InputControl
-												label="Tagline"
-												description="A short phrase shown below the site title."
-												placeholder="Just another WordPress site"
-											/>
-											<InputControl
-												label="Admin email address"
-												type="email"
-												placeholder="you@example.com"
-												defaultValue="admin@example.com"
-											/>
-											<SelectControl
-												label="Site language"
-												description="The default language for the site interface."
-												items={ siteLanguageOptions }
-												defaultValue={
-													siteLanguageOptions[ 0 ]
-												}
-											/>
-											<Stack
-												direction="row"
-												style={ {
-													justifyContent: 'flex-end',
-												} }
-											>
-												<Button>Save</Button>
-											</Stack>
+											{ /* Card 1: General */ }
+											<Card.Root id={ generalSettingsId }>
+												<Card.Header>
+													<Card.Title>
+														General
+													</Card.Title>
+												</Card.Header>
+												<Card.Content>
+													<Stack
+														direction="column"
+														gap="md"
+													>
+														<Text>
+															Configure the basic
+															settings for your
+															site. The fields
+															below adopt the
+															corner radius preset
+															alongside cards,
+															buttons, and other
+															surfaces.
+														</Text>
+														<InputControl
+															label="Site title"
+															placeholder="My WordPress site"
+															defaultValue="My WordPress site"
+														/>
+														<InputControl
+															label="Tagline"
+															description="A short phrase shown below the site title."
+															placeholder="Just another WordPress site"
+														/>
+														<InputControl
+															label="Admin email address"
+															type="email"
+															placeholder="you@example.com"
+															defaultValue="admin@example.com"
+														/>
+														<SelectControl
+															label="Site language"
+															description="The default language for the site interface."
+															items={
+																siteLanguageOptions
+															}
+															defaultValue={
+																siteLanguageOptions[ 0 ]
+															}
+														/>
+														<Stack
+															direction="row"
+															style={ {
+																justifyContent:
+																	'flex-end',
+															} }
+														>
+															<Button>
+																Save
+															</Button>
+														</Stack>
+													</Stack>
+												</Card.Content>
+											</Card.Root>
+
+											{ /* Card 2: Display */ }
+											<Card.Root id={ displaySettingsId }>
+												<Card.Header>
+													<Card.Title>
+														Display
+													</Card.Title>
+												</Card.Header>
+												<Card.Content>
+													<Tabs.Root defaultValue="appearance">
+														<Tabs.List variant="minimal">
+															<Tabs.Tab value="appearance">
+																Appearance
+															</Tabs.Tab>
+															<Tabs.Tab value="layout">
+																Layout
+															</Tabs.Tab>
+															<Tabs.Tab value="accessibility">
+																Accessibility
+															</Tabs.Tab>
+														</Tabs.List>
+														<Tabs.Panel value="appearance">
+															<Stack
+																direction="column"
+																gap="md"
+																style={ {
+																	paddingBlockStart:
+																		'var(--wpds-dimension-padding-md)',
+																} }
+															>
+																<Text>
+																	Control how
+																	your site
+																	looks to
+																	visitors.
+																	Adjust{ ' ' }
+																	<Link href="#">
+																		typography
+																	</Link>
+																	,{ ' ' }
+																	<Link href="#">
+																		colors
+																	</Link>
+																	, and
+																	spacing to
+																	match your
+																	brand.
+																</Text>
+															</Stack>
+														</Tabs.Panel>
+														<Tabs.Panel value="layout">
+															<Stack
+																direction="column"
+																gap="md"
+																style={ {
+																	paddingBlockStart:
+																		'var(--wpds-dimension-padding-md)',
+																} }
+															>
+																<Text>
+																	Choose a
+																	layout
+																	structure
+																	for your
+																	pages.
+																	Options
+																	include
+																	full-width,
+																	boxed, and{ ' ' }
+																	<Link href="#">
+																		custom
+																		layouts
+																	</Link>
+																	.
+																</Text>
+															</Stack>
+														</Tabs.Panel>
+														<Tabs.Panel value="accessibility">
+															<Stack
+																direction="column"
+																gap="md"
+																style={ {
+																	paddingBlockStart:
+																		'var(--wpds-dimension-padding-md)',
+																} }
+															>
+																<Text>
+																	Review your
+																	site&apos;s{ ' ' }
+																	<Link href="#">
+																		accessibility
+																		settings
+																	</Link>{ ' ' }
+																	to ensure it
+																	meets WCAG
+																	guidelines.
+																</Text>
+															</Stack>
+														</Tabs.Panel>
+													</Tabs.Root>
+												</Card.Content>
+											</Card.Root>
 										</Stack>
-									</Card.Content>
-								</Card.Root>
-
-								{ /* Card 2: Display */ }
-								<Card.Root id={ displaySettingsId }>
-									<Card.Header>
-										<Card.Title>Display</Card.Title>
-									</Card.Header>
-									<Card.Content>
-										<Tabs.Root defaultValue="appearance">
-											<Tabs.List variant="minimal">
-												<Tabs.Tab value="appearance">
-													Appearance
-												</Tabs.Tab>
-												<Tabs.Tab value="layout">
-													Layout
-												</Tabs.Tab>
-												<Tabs.Tab value="accessibility">
-													Accessibility
-												</Tabs.Tab>
-											</Tabs.List>
-											<Tabs.Panel value="appearance">
-												<Stack
-													direction="column"
-													gap="md"
-													style={ {
-														paddingBlockStart:
-															'var(--wpds-dimension-padding-md)',
-													} }
-												>
-													<Text>
-														Control how your site
-														looks to visitors.
-														Adjust{ ' ' }
-														<Link href="#">
-															typography
-														</Link>
-														,{ ' ' }
-														<Link href="#">
-															colors
-														</Link>
-														, and spacing to match
-														your brand.
-													</Text>
-												</Stack>
-											</Tabs.Panel>
-											<Tabs.Panel value="layout">
-												<Stack
-													direction="column"
-													gap="md"
-													style={ {
-														paddingBlockStart:
-															'var(--wpds-dimension-padding-md)',
-													} }
-												>
-													<Text>
-														Choose a layout
-														structure for your
-														pages. Options include
-														full-width, boxed, and{ ' ' }
-														<Link href="#">
-															custom layouts
-														</Link>
-														.
-													</Text>
-												</Stack>
-											</Tabs.Panel>
-											<Tabs.Panel value="accessibility">
-												<Stack
-													direction="column"
-													gap="md"
-													style={ {
-														paddingBlockStart:
-															'var(--wpds-dimension-padding-md)',
-													} }
-												>
-													<Text>
-														Review your site&apos;s{ ' ' }
-														<Link href="#">
-															accessibility
-															settings
-														</Link>{ ' ' }
-														to ensure it meets WCAG
-														guidelines.
-													</Text>
-												</Stack>
-											</Tabs.Panel>
-										</Tabs.Root>
-									</Card.Content>
-								</Card.Root>
-							</Stack>
+									</div>
+								</ThemeProvider>
+							</div>
 						</Page>
 					</div>
 				</ThemeProvider>


### PR DESCRIPTION
Related: #82038

## What?

Makes light and dark themes easier to understand through clear Storybook toolbar presets and short `ThemeProvider` documentation.

It also expands the example application into a WordPress-editor-like layout with a separately themed sidebar, a toolbar-controlled canvas, and themed overlays.

## Why?

`ThemeProvider` accepts color seeds, not a light or dark mode. Consumers need a clear mapping from light and dark background seeds to generated tokens, plus a practical example of theme inheritance across an application.

## How?

The toolbar controls the root and canvas themes. Inline presets control the application shell and sidebar, while nested providers reapply the root settings to the canvas.

The menu and dialog currently retain the sidebar theme through React context when portaled to the document body. #82038 will make overlays follow their portal destination instead, and this example will clearly demonstrate that change.

## Testing Instructions

1. Run `npm run storybook:dev` and open **Design System > Theme > Theme Provider > Example Application**.
2. Change the toolbar theme and confirm that the controls and canvas update.
3. Change **Sidebar theme** and confirm that only the application shell and sidebar update.
4. Open **Site actions > View site details** and confirm that the menu and dialog use the sidebar theme.
5. Open **Design System > Theme > Introduction** and review **Light and dark themes**.

### Testing Instructions for Keyboard

Use Tab, Enter, Space, and Escape to operate the theme controls, menu, and dialog. Confirm that closing the dialog returns focus to **Site actions**.

## Screen recording

Here are the new Theme tools used on the new version of the "example application" story:


https://github.com/user-attachments/assets/8cac5478-90a1-4ee9-8d9d-bdea98d6a28d



## Use of AI Tools

Codex was used to implement, inspect, and verify this change.
