### PR TITLE
UI: Move controlled prop guidance to contributing docs

### DIFF
--- a/packages/ui/CONTRIBUTING.md
+++ b/packages/ui/CONTRIBUTING.md
@@ -53,6 +53,34 @@ The package follows [semantic versioning](https://semver.org/), and the followin
 -   Component props (e.g. renaming, removing, or changing a props supported types such that existing usage would break in an update)
 -   CSS properties prefixed with `--wp-ui-` (e.g. changing a CSS property such that it would negatively impact a user's experience)
 
+### Controlled and uncontrolled props
+
+When designing props for a new component:
+
+-   Always offer both controlled and uncontrolled modes when the component has user-facing state.
+-   Name the uncontrolled prop `defaultX`, the controlled prop `x`, and the callback `onXChange`.
+-   In JSDoc comments, indicate which mode each prop is for and cross-reference the alternative:
+
+    ```ts
+    /**
+     * Whether the panel is currently open (controlled).
+     *
+     * To render an uncontrolled component, use the `defaultOpen` prop instead.
+     */
+    open?: boolean;
+    /**
+     * Whether the panel is initially open (uncontrolled).
+     * @default false
+     */
+    defaultOpen?: boolean;
+    /**
+     * Event handler called when the open state changes.
+     */
+    onOpenChange?: ( open: boolean ) => void;
+    ```
+
+-   Provide a `@default` JSDoc tag for the uncontrolled prop when there is a sensible default.
+
 ## Compound Components
 
 This package follows the [compound component approach outlined in the `@wordpress/components` contributing guidelines](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#compound-components).

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -231,31 +231,7 @@ The `onXChange` callback is distinct from the native DOM `onChange` event handle
 
 Components that wrap native form elements may still support native event handlers (like `onChange`, `onInput`) for interoperability, but `onXChange` is the recommended approach within this package.
 
-#### Guidelines for component authors
-
-When designing props for a new component:
-
--   Always offer both controlled and uncontrolled modes when the component has user-facing state.
--   Name the uncontrolled prop `defaultX`, the controlled prop `x`, and the callback `onXChange`.
--   In JSDoc comments, indicate which mode each prop is for and cross-reference the alternative:
-    ```ts
-    /**
-     * Whether the panel is currently open (controlled).
-     *
-     * To render an uncontrolled component, use the `defaultOpen` prop instead.
-     */
-    open?: boolean;
-    /**
-     * Whether the panel is initially open (uncontrolled).
-     * @default false
-     */
-    defaultOpen?: boolean;
-    /**
-     * Event handler called when the open state changes.
-     */
-    onOpenChange?: ( open: boolean ) => void;
-    ```
--   Provide a `@default` JSDoc tag for the uncontrolled prop when there is a sensible default.
+For guidance on implementing this pattern in new components, see [Controlled and uncontrolled props](./CONTRIBUTING.md#controlled-and-uncontrolled-props).
 
 ## Contributing to this package
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/76281#discussion_r3856608721

## What?

Move the contributor-specific controlled and uncontrolled prop guidance from the `@wordpress/ui` README to its contribution guide.

## Why?

The README primarily serves package consumers. Implementation and JSDoc conventions are contributor guidance.

## How?

Move the component-author checklist under the contribution guide's public API guidance, and replace it in the README with a link.

## Testing Instructions

1. Review `packages/ui/README.md#controlled-and-uncontrolled-modes` and confirm that the consumer guidance remains.
2. Follow its link to `packages/ui/CONTRIBUTING.md#controlled-and-uncontrolled-props` and confirm that the authoring checklist and JSDoc example are present.

## Use of AI Tools

Codex helped assess the documentation split, make the edits, and draft the pull request. I reviewed the final diff.
