### PR TITLE
Media: Refuse a multi-file drop on a placeholder that takes one file

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
+
 ## 17.0.0 (2026-08-26)
 
 ### Breaking Changes

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -61,11 +61,12 @@ const HEIC_MIME_TYPES = [ 'image/heic', 'image/heif' ];
  * @return {boolean} Whether the batch was refused.
  */
 function refuseExtraFiles( filesList, multiple, onError ) {
-	if ( multiple || filesList.length <= 1 ) {
-		return false;
+	if ( ! multiple && filesList.length > 1 ) {
+		onError( __( 'Only one file can be used here.' ) );
+		return true;
 	}
-	onError( __( 'Only one file can be used here.' ) );
-	return true;
+
+	return false;
 }
 
 /**

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -1,6 +1,7 @@
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import {
 	MediaUploadProvider,
 	store as uploadStore,
@@ -43,6 +44,29 @@ let isHeicCanvasEnabledCache = null;
  * when in HEIC-only mode.
  */
 const HEIC_MIME_TYPES = [ 'image/heic', 'image/heif' ];
+
+/**
+ * Refuses a batch of more than one file on behalf of a caller that only takes
+ * one - a Cover block's placeholder, say.
+ *
+ * `uploadMedia()` in `@wordpress/media-utils` refuses such a batch with the
+ * same wording, but the `@wordpress/upload-media` pipeline below is a separate
+ * transport that never reaches that function. Without this check every dropped
+ * file uploads and the caller keeps whichever one lands last (gutenberg#82041).
+ *
+ * @param {Array<File>} filesList List of files.
+ * @param {boolean}     multiple  Whether the caller accepts more than one file.
+ * @param {Function}    onError   Function called when an error happens.
+ *
+ * @return {boolean} Whether the batch was refused.
+ */
+function refuseExtraFiles( filesList, multiple, onError ) {
+	if ( multiple || filesList.length <= 1 ) {
+		return false;
+	}
+	onError( __( 'Only one file can be used here.' ) );
+	return true;
+}
 
 /**
  * Checks if client-side media processing should be enabled.
@@ -143,6 +167,7 @@ function shouldEnableHeicCanvasProcessing() {
  * @param {Function}       $3.onFileChange   Function called each time a file or a temporary representation of the file is available.
  * @param {Function}       $3.onSuccess      Function called once a file has completely finished uploading, including thumbnails.
  * @param {Function}       $3.onBatchSuccess Function called once all files in a group have completely finished uploading, including thumbnails.
+ * @param {boolean}        $3.multiple       Whether the caller accepts more than one file.
  */
 function mediaUpload(
 	registry,
@@ -155,8 +180,13 @@ function mediaUpload(
 		onFileChange,
 		onSuccess,
 		onBatchSuccess,
+		multiple = true,
 	}
 ) {
+	if ( refuseExtraFiles( filesList, multiple, onError ) ) {
+		return;
+	}
+
 	void registry.dispatch( uploadStore ).addItems( {
 		files: Array.from( filesList ),
 		onChange: onFileChange,
@@ -189,6 +219,7 @@ function mediaUpload(
  * @param {Function}       $3.onFileChange   Function called each time a file or a temporary representation of the file is available.
  * @param {Function}       $3.onSuccess      Function called once a file has completely finished uploading, including thumbnails.
  * @param {Function}       $3.onBatchSuccess Function called once all files in a group have completely finished uploading, including thumbnails.
+ * @param {boolean}        $3.multiple       Whether the caller accepts more than one file.
  */
 function heicMediaUpload(
 	registry,
@@ -201,8 +232,13 @@ function heicMediaUpload(
 		onFileChange,
 		onSuccess,
 		onBatchSuccess,
+		multiple = true,
 	}
 ) {
+	if ( refuseExtraFiles( filesList, multiple, onError ) ) {
+		return;
+	}
+
 	const files = Array.from( filesList );
 	const heicFiles = files.filter( ( file ) =>
 		HEIC_MIME_TYPES.includes( file.type )
@@ -254,6 +290,7 @@ function heicMediaUpload(
 			onFileChange,
 			onSuccess,
 			onBatchSuccess: coordinatedBatchSuccess,
+			multiple,
 		} );
 	}
 }

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `mediaUpload`: Refuse a batch of more than one file before registering it with the upload progress snackbar when the caller only takes one, such as a Cover block placeholder. `uploadMedia()` reported the refusal as a single error, leaving the rest of the batch counted as uploading forever - and every later upload in the session was folded into that stuck notice ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
+
 ## 14.54.0 (2026-08-26)
 
 ### New Features

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -2,6 +2,7 @@ import { v4 as uuid } from 'uuid';
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { uploadMedia } from '@wordpress/media-utils';
+import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '../../store';
 import {
 	addFiles as trackStart,
@@ -39,6 +40,17 @@ export default function mediaUpload( {
 	multiple = true,
 	isTransportOnly = false,
 } ) {
+	// A caller that takes a single file refuses a multi-file batch outright.
+	// `uploadMedia()` makes the same check, but reports the refusal as one
+	// error for the whole batch, which would leave every other file in it
+	// counted as still in flight by the progress tracker below - and the
+	// tracker folds every later upload into that stuck session
+	// (see gutenberg#82041). Refusing here keeps the batch out of it.
+	if ( ! multiple && filesList.length > 1 ) {
+		onError( __( 'Only one file can be used here.' ) );
+		return;
+	}
+
 	const { receiveEntityRecords } = dispatch( coreDataStore );
 	const { getCurrentPost, getEditorSettings } = select( editorStore );
 	const {

--- a/packages/editor/src/utils/media-upload/test/index.js
+++ b/packages/editor/src/utils/media-upload/test/index.js
@@ -1,0 +1,103 @@
+import { select, dispatch } from '@wordpress/data';
+import { uploadMedia } from '@wordpress/media-utils';
+import mediaUpload from '../';
+import {
+	addFiles,
+	getState,
+	reset,
+} from '../../../components/upload-progress-snackbar/tracker';
+
+jest.mock( '@wordpress/media-utils', () => ( {
+	uploadMedia: jest.fn(),
+} ) );
+
+// The module under test only reaches the stores through `select`/`dispatch`,
+// so they stand in for the whole data layer here - importing the real editor
+// store pulls in most of the editor.
+jest.mock( '@wordpress/data', () => ( {
+	select: jest.fn(),
+	dispatch: jest.fn(),
+} ) );
+jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
+jest.mock( '../../../store', () => ( { store: 'core/editor' } ) );
+
+function file( name ) {
+	return new window.File( [ 'x' ], name, { type: 'image/png' } );
+}
+
+describe( 'mediaUpload', () => {
+	beforeEach( () => {
+		reset();
+		uploadMedia.mockClear();
+		select.mockReturnValue( {
+			getCurrentPost: () => ( { id: 1 } ),
+			getEditorSettings: () => ( {} ),
+		} );
+		dispatch.mockReturnValue( {
+			receiveEntityRecords: jest.fn(),
+			lockPostSaving: jest.fn(),
+			unlockPostSaving: jest.fn(),
+			lockPostAutosaving: jest.fn(),
+			unlockPostAutosaving: jest.fn(),
+		} );
+	} );
+
+	it( 'uploads a batch when the caller takes more than one file', () => {
+		mediaUpload( {
+			filesList: [ file( 'a.png' ), file( 'b.png' ) ],
+			multiple: true,
+		} );
+
+		expect( uploadMedia ).toHaveBeenCalled();
+		expect( getState() ).toEqual(
+			expect.objectContaining( { total: 2, completed: 0 } )
+		);
+	} );
+
+	it( 'uploads a single file for a caller that only takes one', () => {
+		mediaUpload( {
+			filesList: [ file( 'a.png' ) ],
+			multiple: false,
+		} );
+
+		expect( uploadMedia ).toHaveBeenCalled();
+		expect( getState() ).toEqual(
+			expect.objectContaining( { total: 1, completed: 0 } )
+		);
+	} );
+
+	it( 'refuses a batch of more than one file for a caller that only takes one', () => {
+		const onError = jest.fn();
+
+		mediaUpload( {
+			filesList: [ file( 'a.png' ), file( 'b.png' ), file( 'c.png' ) ],
+			multiple: false,
+			onError,
+		} );
+
+		expect( onError ).toHaveBeenCalledTimes( 1 );
+		expect( onError ).toHaveBeenCalledWith(
+			'Only one file can be used here.'
+		);
+		expect( uploadMedia ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps a refused batch out of the upload progress tracker', () => {
+		// `uploadMedia()` reports the refusal as a single error, so registering
+		// the batch here would strand the rest of it as "uploading" forever -
+		// and the tracker folds every later upload into that stuck session
+		// (see gutenberg#82041).
+		mediaUpload( {
+			filesList: [ file( 'a.png' ), file( 'b.png' ), file( 'c.png' ) ],
+			multiple: false,
+		} );
+
+		expect( getState() ).toBeNull();
+
+		// The next upload therefore starts a session of its own.
+		addFiles( [ 'later.png' ] );
+		expect( getState() ).toEqual(
+			expect.objectContaining( { total: 1, completed: 0 } )
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/various/client-side-media-processing.spec.js
+++ b/test/e2e/specs/editor/various/client-side-media-processing.spec.js
@@ -18,6 +18,9 @@ const wasmVipsEntry = pathToFileURL(
 	)
 ).href;
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const {
+	skipIfClientSideMediaInactive,
+} = require( './client-side-media-utils' );
 
 /**
  * Probes a remote JPEG for an embedded UltraHDR gain map.
@@ -105,41 +108,12 @@ class MediaProcessingUtils {
 
 	/**
 	 * Skip the test unless the client-side media processing pipeline is the
-	 * active upload path. This mirrors the gate used in the editor's
-	 * media-upload util: the global flag must be set AND the browser must
-	 * meet the feature detection requirements (cross-origin isolation,
-	 * SharedArrayBuffer, Web Workers, WebAssembly).
+	 * active upload path.
 	 *
-	 * @param {import('@playwright/test').TestInfo} testInstance The test object for skipping.
+	 * @param {import('@playwright/test').TestType} testInstance The test object for skipping.
 	 */
 	async skipIfClientSideMediaInactive( testInstance ) {
-		const isActive = await this.page.evaluate( () => {
-			if ( ! window.__clientSideMediaProcessing ) {
-				return false;
-			}
-			// Prefer the package's own detection when available so the
-			// gate stays in sync with the editor's runtime decision.
-			if (
-				window.wp?.uploadMedia &&
-				typeof window.wp.uploadMedia.isClientSideMediaSupported ===
-					'function'
-			) {
-				return window.wp.uploadMedia.isClientSideMediaSupported();
-			}
-			// Fall back to the core preconditions for CSM. These are the
-			// signals the package's feature detection inspects first.
-			return (
-				window.crossOriginIsolated === true &&
-				typeof SharedArrayBuffer !== 'undefined' &&
-				typeof WebAssembly !== 'undefined' &&
-				typeof Worker !== 'undefined'
-			);
-		} );
-
-		testInstance.skip(
-			! isActive,
-			'Client-side media processing is not active in this environment'
-		);
+		await skipIfClientSideMediaInactive( this.page, testInstance );
 	}
 
 	/**

--- a/test/e2e/specs/editor/various/client-side-media-utils.js
+++ b/test/e2e/specs/editor/various/client-side-media-utils.js
@@ -1,0 +1,41 @@
+/**
+ * Skip the test unless the client-side media processing pipeline is the
+ * active upload path. This mirrors the gate used in the editor's media-upload
+ * util: the global flag must be set AND the browser must meet the feature
+ * detection requirements (cross-origin isolation, SharedArrayBuffer, Web
+ * Workers, WebAssembly).
+ *
+ * @param {import('@playwright/test').Page}     page         Playwright page.
+ * @param {import('@playwright/test').TestType} testInstance The test object for skipping.
+ */
+async function skipIfClientSideMediaInactive( page, testInstance ) {
+	const isActive = await page.evaluate( () => {
+		if ( ! window.__clientSideMediaProcessing ) {
+			return false;
+		}
+		// Prefer the package's own detection when available so the gate stays
+		// in sync with the editor's runtime decision.
+		if (
+			window.wp?.uploadMedia &&
+			typeof window.wp.uploadMedia.isClientSideMediaSupported ===
+				'function'
+		) {
+			return window.wp.uploadMedia.isClientSideMediaSupported();
+		}
+		// Fall back to the core preconditions for CSM. These are the signals
+		// the package's feature detection inspects first.
+		return (
+			window.crossOriginIsolated === true &&
+			typeof SharedArrayBuffer !== 'undefined' &&
+			typeof WebAssembly !== 'undefined' &&
+			typeof Worker !== 'undefined'
+		);
+	} );
+
+	testInstance.skip(
+		! isActive,
+		'Client-side media processing is not active in this environment'
+	);
+}
+
+module.exports = { skipIfClientSideMediaInactive };

--- a/test/e2e/specs/editor/various/single-file-placeholder-drop.spec.js
+++ b/test/e2e/specs/editor/various/single-file-placeholder-drop.spec.js
@@ -1,0 +1,151 @@
+const path = require( 'path' );
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const IMAGES = [
+	path.join( __dirname, '../../../assets/10x10_e2e_test_image_z9T8jK.png' ),
+	path.join( __dirname, '../../../assets/10x10_e2e_test_image_green.png' ),
+];
+
+/**
+ * Drops both images at once on the Cover block's placeholder, which does not
+ * set `multiple` and so takes a single file (see gutenberg#82041).
+ *
+ * @param {Object} editor    Editor utils.
+ * @param {Object} pageUtils Page utils.
+ *
+ * @return {Promise<Object>} Locator for the Cover block.
+ */
+async function dropTwoImagesOnCoverPlaceholder( editor, pageUtils ) {
+	await editor.insertBlock( { name: 'core/cover' } );
+
+	const coverBlock = editor.canvas.getByRole( 'document', {
+		name: 'Block: Cover',
+	} );
+	await expect( coverBlock ).toBeVisible();
+
+	const dragging = await pageUtils.dragFiles( IMAGES );
+	await dragging.dragOver( coverBlock );
+	await dragging.drop();
+
+	return coverBlock;
+}
+
+/**
+ * Skips the current test when the editor is not on the client-side media
+ * processing path, so it never asserts on server-side fallback behavior.
+ *
+ * @param {Object} page         Playwright page.
+ * @param {Object} testInstance The `test` object to skip through.
+ */
+async function skipIfClientSideMediaInactive( page, testInstance ) {
+	const isActive = await page.evaluate( () => {
+		// Prefer the package's own detection so this stays in sync with the
+		// editor's runtime decision.
+		if (
+			typeof window.wp?.uploadMedia?.isClientSideMediaSupported ===
+			'function'
+		) {
+			return window.wp.uploadMedia.isClientSideMediaSupported();
+		}
+		return (
+			window.crossOriginIsolated === true &&
+			typeof SharedArrayBuffer !== 'undefined'
+		);
+	} );
+
+	testInstance.skip(
+		! isActive,
+		'Client-side media processing is not active in this environment'
+	);
+}
+
+test.describe( 'Dropping multiple files on a single-file placeholder', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test.describe( 'with client-side media processing', () => {
+		test.beforeEach( async ( { page } ) => {
+			await skipIfClientSideMediaInactive( page, test );
+		} );
+
+		test( 'refuses the drop and uploads nothing', async ( {
+			editor,
+			page,
+			pageUtils,
+			requestUtils,
+		} ) => {
+			const coverBlock = await dropTwoImagesOnCoverPlaceholder(
+				editor,
+				pageUtils
+			);
+
+			await expect(
+				page
+					.locator( '.components-snackbar-list' )
+					.getByText( 'Only one file can be used here.' )
+			).toBeVisible();
+
+			// The client-side path used to ignore the limit entirely: every
+			// dropped file was uploaded and the block kept whichever one
+			// finished last.
+			await expect( coverBlock.locator( 'img' ) ).toHaveCount( 0 );
+			expect( await requestUtils.listMedia() ).toHaveLength( 0 );
+		} );
+	} );
+
+	test.describe( 'with client-side media processing disabled', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-plugin-disable-client-side-media-processing'
+			);
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-plugin-disable-client-side-media-processing'
+			);
+		} );
+
+		test( 'refuses the drop without stranding the progress snackbar', async ( {
+			editor,
+			page,
+			pageUtils,
+		} ) => {
+			await dropTwoImagesOnCoverPlaceholder( editor, pageUtils );
+
+			const snackbarList = page.locator( '.components-snackbar-list' );
+			await expect(
+				snackbarList.getByText( 'Only one file can be used here.' )
+			).toBeVisible();
+
+			// The refusal used to register every dropped file with the progress
+			// snackbar while only ever finishing one of them, leaving
+			// "Uploading …" up for the rest of the session.
+			await expect( snackbarList.getByText( /^Uploading/ ) ).toBeHidden();
+
+			// So a later single-file upload still reports completion, rather
+			// than being folded into the stranded session.
+			await editor.insertBlock( { name: 'core/image' } );
+			const imageBlock = editor.canvas.locator(
+				'role=document[name="Block: Image"i]'
+			);
+			await imageBlock
+				.locator( 'data-testid=form-file-upload-input' )
+				.setInputFiles( IMAGES[ 0 ] );
+
+			await expect(
+				imageBlock.getByRole( 'img', {
+					name: 'This image has an empty alt attribute',
+				} )
+			).toHaveAttribute( 'src', /^https?:\/\//, { timeout: 30_000 } );
+			await expect(
+				snackbarList.getByText( 'Upload complete' )
+			).toBeVisible( { timeout: 10_000 } );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/single-file-placeholder-drop.spec.js
+++ b/test/e2e/specs/editor/various/single-file-placeholder-drop.spec.js
@@ -1,5 +1,8 @@
 const path = require( 'path' );
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const {
+	skipIfClientSideMediaInactive,
+} = require( './client-side-media-utils' );
 
 const IMAGES = [
 	path.join( __dirname, '../../../assets/10x10_e2e_test_image_z9T8jK.png' ),
@@ -28,35 +31,6 @@ async function dropTwoImagesOnCoverPlaceholder( editor, pageUtils ) {
 	await dragging.drop();
 
 	return coverBlock;
-}
-
-/**
- * Skips the current test when the editor is not on the client-side media
- * processing path, so it never asserts on server-side fallback behavior.
- *
- * @param {Object} page         Playwright page.
- * @param {Object} testInstance The `test` object to skip through.
- */
-async function skipIfClientSideMediaInactive( page, testInstance ) {
-	const isActive = await page.evaluate( () => {
-		// Prefer the package's own detection so this stays in sync with the
-		// editor's runtime decision.
-		if (
-			typeof window.wp?.uploadMedia?.isClientSideMediaSupported ===
-			'function'
-		) {
-			return window.wp.uploadMedia.isClientSideMediaSupported();
-		}
-		return (
-			window.crossOriginIsolated === true &&
-			typeof SharedArrayBuffer !== 'undefined'
-		);
-	} );
-
-	testInstance.skip(
-		! isActive,
-		'Client-side media processing is not active in this environment'
-	);
 }
 
 test.describe( 'Dropping multiple files on a single-file placeholder', () => {


### PR DESCRIPTION
_Claude did the digging and the typing on this one:_

## What?

Closes https://github.com/WordPress/gutenberg/issues/82041

Dropping several files at once on a media placeholder that only takes one - the Cover block's is the easy one to hit - now refuses the drop with "Only one file can be used here." on both upload paths, and takes the progress snackbar down with it.

## Why?

`MediaPlaceholder` defaults to `multiple = false` and the Cover placeholder does not opt in, so the drop is already meant to be refused. Two different things happened instead, depending on which upload path was active.

**Server-side path: the progress snackbar stuck.** `uploadMedia()` refuses the batch as a unit and calls `onError` once, but the editor's `mediaUpload` wrapper had already registered every dropped file with the progress tracker, and it only advances that tracker by one per error. Dropping three files left two counted as in flight forever. The tracker also appends to the session in progress rather than starting a new one, so **every later upload in the page session was folded into the same stuck notice** and never reported completion either. Reloading the editor was the only way out.

**Client-side path: the limit was ignored.** The `mediaUpload` replacement installed for client-side media processing never destructured `multiple` at all, and handed every file to the upload queue. Each one arrived back through `onChange` on its own, so the Cover background swapped between the files as they landed and the block kept whichever finished last - the rest sat in the media library with nothing referencing them.

Both halves are pre-existing on trunk. They were spotted by @andrewserong while testing https://github.com/WordPress/gutenberg/pull/81397, which neither causes nor fixes them. This branch was stacked on that PR while both were in flight; it is now based on `trunk` and can land on its own.

## How?

-   `packages/editor/src/utils/media-upload/index.js` makes the same `multiple` check `uploadMedia()` makes, before it registers anything with the progress tracker. A refused batch never reaches the tracker, so nothing is stranded.
-   `packages/block-editor/src/components/provider/index.js` accepts `multiple` in both the client-side and the HEIC-only `mediaUpload` interceptors and refuses the batch with the same wording. `@wordpress/media-utils` is not a `block-editor` dependency, so the check is a small local helper rather than a shared export.

Taking the first file and quietly ignoring the rest was the other option. It reads as friendlier for a drag gesture, but it would be a behavior change on the server-side path, and dropping files someone deliberately selected without saying so seemed worse than saying no. Happy to switch if reviewers prefer it.

## Testing Instructions

[![Test in WordPress Playground](https://img.shields.io/badge/Test_in-WP_Playground-blue?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=82046)

1. Add a Cover block and leave it in its placeholder state.
2. Drag two or more images onto the placeholder at once.
3. Expect the "Only one file can be used here." error, no upload, no background image, and no "Uploading …" snackbar left behind.
4. Add an Image block and upload a single image. It should still report "Upload complete" - before this, the stranded session swallowed every later upload.

Worth trying both paths. Client-side media processing is on by default where the browser supports it; for the server-side path, filter `wp_client_side_media_processing_enabled` to false, or use a browser without cross-origin isolation.

New tests:

-   `packages/editor/src/utils/media-upload/test/index.js` - the wrapper refuses the batch and leaves the tracker idle, so a later upload starts a session of its own.
-   `test/e2e/specs/editor/various/single-file-placeholder-drop.spec.js` - a two-file drop on the Cover placeholder, covering both upload paths.

### Testing Instructions for Keyboard

No UI changes. The placeholder's file picker already only accepts one file when `multiple` is false, so this is reachable by drag and drop only.

## Screenshots or screencast

See the screencasts of both broken behaviors in https://github.com/WordPress/gutenberg/pull/81397#pullrequestreview-5014098547

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.

