### PR TITLE
Site editor v2: Fix block error with navigation-edit route

### DIFF
--- a/routes/navigation-edit/editor/leaf-more-menu.tsx
+++ b/routes/navigation-edit/editor/leaf-more-menu.tsx
@@ -12,12 +12,11 @@ const POPOVER_PROPS = {
 };
 
 export default function LeafMoreMenu( {
-	block,
+	clientId,
 	...props
 }: {
-	block: { clientId: string; name: string };
+	clientId: string;
 } ) {
-	const { clientId } = block;
 	const {
 		moveBlocksDown,
 		moveBlocksUp,
@@ -38,6 +37,7 @@ export default function LeafMoreMenu( {
 			( select ) => {
 				const {
 					getBlockRootClientId,
+					getBlockName,
 					canInsertBlockType,
 					getDirectInsertBlock,
 					getBlockIndex,
@@ -46,6 +46,7 @@ export default function LeafMoreMenu( {
 				const { getDefaultBlockName } = select( blocksStore );
 
 				const _rootClientId = getBlockRootClientId( clientId );
+				const _blockName = getBlockName( clientId );
 				const canInsertDefaultBlock = canInsertBlockType(
 					getDefaultBlockName(),
 					_rootClientId
@@ -57,20 +58,18 @@ export default function LeafMoreMenu( {
 				return {
 					rootClientId: _rootClientId,
 					canDuplicate:
-						!! block &&
-						hasBlockSupport( block.name, 'multiple', true ) &&
-						canInsertBlockType( block.name, _rootClientId ),
+						hasBlockSupport( _blockName, 'multiple', true ) &&
+						canInsertBlockType( _blockName, _rootClientId ),
 					canInsertBlock:
 						( canInsertDefaultBlock || !! directInsertBlock ) &&
-						!! block &&
-						canInsertBlockType( block.name, _rootClientId ),
+						canInsertBlockType( _blockName, _rootClientId ),
 					isFirst: getBlockIndex( clientId ) === 0,
 					isLast:
 						getBlockIndex( clientId ) ===
 						getBlockCount( _rootClientId ) - 1,
 				};
 			},
-			[ clientId, block ]
+			[ clientId ]
 		);
 
 	return (


### PR DESCRIPTION
## What?

Fix a block error in the Site editor v2 Navigation screen when editing a navigation block that contains blocks.

## Why?

Noticed while testing out the "Extensible site editor" experiment that this screen was erroring. From a quick look, I _think_ this error likely cropped up around #81111, looks like we just missed updating this route to match the new structure? 

## How?

* Grab the `clientId` from props instead of the now no longer existent `block` object
* Get the block name from `getBlockName( clientId );` and wire things through

## Testing Instructions

Enable the experiment:

<img width="605" height="65" alt="image" src="https://github.com/user-attachments/assets/56c698ac-74e0-4e22-a410-7335691391c7" />

* Open up the v2 site editor
* Go to the Navigation screen and create a new Navigation Menu if you haven't already
* To see anything in the sidebar I had to go to the editor view and manually add some blocks to the navigation block in order to see the list
* On `trunk` that whole sidebar area crashes
* With this PR, you should see the list view and be able to rearrange menu items

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="2950" height="1520" alt="image" src="https://github.com/user-attachments/assets/f0e28ef2-0efa-4003-a9d6-0deec66bb6b6" />

### After

<img width="1274" height="661" alt="image" src="https://github.com/user-attachments/assets/d78a7073-455c-4f66-84aa-f727dbefce95" />

## Use of AI Tools

Claude Code (Opus 5)