### PR TITLE
Site editor v2: Fix template part list pagination and sorting

### DIFF
--- a/routes/template-part-list/route.ts
+++ b/routes/template-part-list/route.ts
@@ -59,7 +59,7 @@ export const route = {
 		const posts = await resolveSelect( coreStore ).getEntityRecords(
 			'postType',
 			'wp_template_part',
-			{ ...query, per_page: 1 }
+			query
 		);
 
 		// Return first template part if available

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -6,7 +6,7 @@ import {
 	useInvalidate,
 } from '@wordpress/route';
 import { useView } from '@wordpress/views';
-import { DataViews } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
 import type { View, Action } from '@wordpress/dataviews';
 import {
@@ -114,12 +114,7 @@ function TemplatePartList() {
 	};
 
 	const postTypeQuery = useMemo( () => viewToQuery( view ), [ view ] );
-	const {
-		records: posts,
-		totalItems,
-		totalPages,
-		isResolving,
-	} = useEntityRecordsWithPermissions(
+	const { records, isResolving } = useEntityRecordsWithPermissions(
 		'postType',
 		'wp_template_part',
 		postTypeQuery
@@ -153,6 +148,10 @@ function TemplatePartList() {
 				} )
 		);
 	}, [ allFields, area ] );
+
+	const { data: posts, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( records, view, fields );
+	}, [ records, view, fields ] );
 
 	// Helper function to clean up postIds from URL after deletion
 	const cleanupDeletedPostIdsFromUrl = useCallback(
@@ -285,10 +284,7 @@ function TemplatePartList() {
 				onChangeView={ onChangeView }
 				actions={ actions }
 				isLoading={ isResolving }
-				paginationInfo={ {
-					totalItems,
-					totalPages,
-				} }
+				paginationInfo={ paginationInfo }
 				getItemId={ getItemId }
 				selection={ selection }
 				onReset={ isModified ? onReset : false }

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -86,30 +86,9 @@ export async function ensureView(
 }
 
 export function viewToQuery( view: View ) {
-	const result: Record< string, any > = {};
+	// The endpoint only supports `area`. Everything else is handled client-side.
+	const result: Record< string, any > = { per_page: -1 };
 
-	// Pagination, sorting, search.
-	if ( undefined !== view.perPage ) {
-		result.per_page = view.perPage;
-	}
-
-	if ( undefined !== view.page ) {
-		result.page = view.page;
-	}
-
-	if ( ! [ undefined, '' ].includes( view.search ) ) {
-		result.search = view.search;
-	}
-
-	if ( undefined !== view.sort?.field ) {
-		result.orderby = view.sort.field;
-	}
-
-	if ( undefined !== view.sort?.direction ) {
-		result.order = view.sort.direction;
-	}
-
-	// Area filtering for template parts
 	const areaFilter = view.filters?.find(
 		( filter ) => filter.field === 'area'
 	);


### PR DESCRIPTION
## What?
The template part list now fetches every record and lets DataViews handle pagination, sorting, and search on the client. Before this, the pagination footer read "NaN pages", and sorting or searching the list did nothing.

## Why?
`WP_REST_Templates_Controller::get_collection_params()` registers only `context`, `wp_id`, `area`, and `post_type`. The list was passing `page`, `per_page`, `orderby`, `order`, and `search`, which the endpoint ignores. It also returns the full collection with no `X-WP-Total` headers, so the resolver's `parseInt( response.headers.get( 'X-WP-Total' ) )` produced `NaN` and stored it as the query total.

## How?
`viewToQuery` now returns `per_page: -1` plus `area`, the one argument the endpoint honors, and the stage derives `data` and `paginationInfo` from `filterSortAndPaginate`. This follows what the template list and the v1 templates page already do.

Area filtering stays on the server because the `area` field is removed from `fields` on the area tabs, and `filterSortAndPaginate` skips filters whose field is missing.

Left for a follow-up: guard the `NaN` in the `getEntityRecords` resolver, and set `supportsPagination` correctly for template entities.

## Testing Instructions
1. Enable the Extensible Site Editor experiment and open a block theme.
2. Go to Template Parts.
3. Confirm there's no `useSelect` warning.
4. Search for a template part.
5. Confirm filtering works.

### Testing Instructions for Keyboard
Same.

## Screenshot

<img width="892" height="84" alt="CleanShot 2026-08-26 at 12 22 26" src="https://github.com/user-attachments/assets/19b61456-b6af-4128-8bf2-55a3d6c0c42c" />


## Use of AI Tools

Assisted by Claude.