### PR TITLE
DataViews: Fix invisible sticky Actions column divider

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fix
 
+-   DataViews: Restore the divider that marks the sticky Actions column when a table layout is horizontally scrollable. It was drawn with a surface background token rather than a stroke one, making it invisible against the table, so nothing indicated there were more properties to scroll to. PRNUMBER
 -   Picker grid layout: Clip item previews to the media box's rounded corners, as the grid layout already does, so an image no longer squares off its corners ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
 -   DataForm: Keep the displayed calendar month of the `date` and `datetime` controls in sync when the value changes from outside the control, e.g. after an undo, a reset, or switching the edited item. [#81635](https://github.com/WordPress/gutenberg/pull/81635)
 -   DataForms: Fix the `date` and `datetime` controls selecting and highlighting the day next to the one clicked. A site configured with a UTC offset rather than a named timezone reports no timezone the calendar can work in, so it fell back to the browser's while the values stayed anchored to the site's. The `datetime` calendar is now given the site's UTC offset itself — which also keeps the day it marks as today the site's — and a `date` value is treated as a plain calendar day, parsed in the same browser timezone the calendar reads it in. [#81498](https://github.com/WordPress/gutenberg/pull/81498)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fix
 
--   DataViews: Restore the divider that marks the sticky Actions column when a table layout is horizontally scrollable. It was drawn with a surface background token rather than a stroke one, making it invisible against the table, so nothing indicated there were more properties to scroll to. PRNUMBER
+-   DataViews: Restore the divider that marks the sticky Actions column when a table layout is horizontally scrollable. It was drawn with a surface background token rather than a stroke one, making it invisible against the table, so nothing indicated there were more properties to scroll to. [#82055](https://github.com/WordPress/gutenberg/pull/82055)
 -   Picker grid layout: Clip item previews to the media box's rounded corners, as the grid layout already does, so an image no longer squares off its corners ([#81604](https://github.com/WordPress/gutenberg/pull/81604)).
 -   DataForm: Keep the displayed calendar month of the `date` and `datetime` controls in sync when the value changes from outside the control, e.g. after an undo, a reset, or switching the edited item. [#81635](https://github.com/WordPress/gutenberg/pull/81635)
 -   DataForms: Fix the `date` and `datetime` controls selecting and highlighting the day next to the one clicked. A site configured with a UTC offset rather than a named timezone reports no timezone the calendar can work in, so it fell back to the browser's while the values stayed anchored to the site's. The `datetime` calendar is now given the site's UTC offset itself — which also keeps the day it marks as today the site's — and a `date` value is treated as a plain calendar day, parsed in the same browser timezone the calendar reads it in. [#81498](https://github.com/WordPress/gutenberg/pull/81498)

--- a/packages/dataviews/src/components/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/components/dataviews-layouts/table/style.scss
@@ -40,7 +40,7 @@
 				bottom: 0;
 				left: 0;
 				width: 1px;
-				background-color: var(--wpds-color-background-surface-neutral);
+				background-color: var(--wpds-color-stroke-surface-neutral-weak);
 			}
 		}
 


### PR DESCRIPTION
## What?

Restores the divider that marks the sticky Actions column in the table layout, so it is visible again when the table scrolls horizontally.

## Why?

When a table layout has more fields than fit the viewport, it scrolls horizontally and the Actions column stays pinned to the right edge. The pinned column is meant to be separated from the scrolling content by a hairline divider, which is the only cue that there is more to scroll to. Right now that cue is missing: the columns simply appear to be cut off mid-cell, and nothing tells the user the table scrolls.

The divider itself has been there all along. It used to be drawn in `$gray-100`. When DataViews adopted the design tokens (#75204), that value was mapped to a surface *background* token rather than a *stroke* one, which is very close to the table's own background — so the divider is drawn, it's just invisible.

## How?

Uses the weak neutral stroke token, which resolves to the same value the divider had before the token migration. It is also the token already used for the divider under the sticky table header, so both pinned edges now match.

## Testing Instructions

1. Run `npm run storybook:dev` and open **DataViews → DataViews → Layout Table**.
2. Open the view options (gear icon) and enable enough properties — Type, Date, Datetime, Email, Author — that the table becomes wider than the story frame. Narrow the browser window if it still fits.
3. The Actions column stays pinned to the right edge, separated from the scrolling columns by a vertical hairline. On trunk that hairline is invisible, so the columns just look cut off.
4. Scroll the table fully to the right — the hairline disappears once there is nothing left to scroll.
5. Repeat with **Color → Dark** in the design system theme toolbar (the mirror icon).

### Testing Instructions for Keyboard

Tab through the table cells until focus moves past the right edge of the frame; the table scrolls and the hairline behaves as above.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1800" height="840" alt="before" src="https://github.com/user-attachments/assets/fec5e125-3793-465f-86f2-ec281cbcb410" />|<img width="1800" height="840" alt="after" src="https://github.com/user-attachments/assets/fd522638-6db8-4f52-9fbf-e3b6848b7999" />|

## Use of AI Tools

Claude Code was used to trace the regression to the token migration and to make the change. The result has been reviewed by me.

