### PR TITLE
Core Data: Stop storing NaN pagination totals for unpaginated endpoints

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Validate the shared parsed-blocks cache against the registered block types as well as the content, so a record resolved before the block types register — as happens when the editor's assets load lazily — is re-parsed instead of rendering, and one save later persisting, an empty block list ([#81809](https://github.com/WordPress/gutenberg/pull/81809)).
 -   Allow keyless entities to be addressed without a record ID in the entity record selectors and actions ([#81857](https://github.com/WordPress/gutenberg/pull/81857)).
+-   Fix `getEntityRecordsTotalItems` and `getEntityRecordsTotalPages` returning `NaN` for endpoints that send no pagination headers.
 
 ### Internal
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -395,7 +395,13 @@ async function loadPostTypeEntities() {
 			__unstablePrePersist: ( persistedRecord, edits ) =>
 				prePersistPostType( persistedRecord, edits, name, isTemplate ),
 			__unstable_rest_base: postType.rest_base,
-			supportsPagination: true,
+			// The templates controller returns the whole collection and never
+			// paginates. It serves `wp_template_part` always, and `wp_template`
+			// until the template activate experiment moves it to a posts
+			// controller.
+			supportsPagination: window?.__experimentalTemplateActivate
+				? name !== 'wp_template_part'
+				: ! isTemplate,
 			getRevisionsUrl: ( parentId, revisionId ) =>
 				`/${ namespace }/${
 					postType.rest_base

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -15,6 +15,7 @@ import {
 	isNumericID,
 	normalizeQueryForResolution,
 	saveCRDTDoc,
+	getPaginationMeta,
 } from './utils';
 import { fetchBlockPatterns } from './fetch';
 import { restoreSelection, getSelectionHistory } from './utils/crdt-selection';
@@ -446,14 +447,7 @@ export const getEntityRecords =
 			if ( entityConfig.supportsPagination && query.per_page !== -1 ) {
 				const response = await apiFetch( { path, parse: false } );
 				records = Object.values( await response.json() );
-				meta = {
-					totalItems: parseInt(
-						response.headers.get( 'X-WP-Total' )
-					),
-					totalPages: parseInt(
-						response.headers.get( 'X-WP-TotalPages' )
-					),
-				};
+				meta = getPaginationMeta( response.headers );
 			} else if (
 				query.per_page === -1 &&
 				query[ RECEIVE_INTERMEDIATE_RESULTS ] === true
@@ -468,15 +462,14 @@ export const getEntityRecords =
 					} );
 					const pageRecords = Object.values( await response.json() );
 
-					totalPages = parseInt(
-						response.headers.get( 'X-WP-TotalPages' )
-					);
+					const pageMeta = getPaginationMeta( response.headers );
+					// An endpoint that doesn't paginate answers the first
+					// request with the whole collection.
+					totalPages = pageMeta.totalPages ?? 1;
 
 					if ( ! meta ) {
 						meta = {
-							totalItems: parseInt(
-								response.headers.get( 'X-WP-Total' )
-							),
+							totalItems: pageMeta.totalItems,
 							totalPages: 1,
 						};
 					}
@@ -1119,9 +1112,9 @@ export const getRevisions =
 			if ( response ) {
 				if ( isPaginated ) {
 					records = Object.values( await response.json() );
-					meta.totalItems = parseInt(
-						response.headers.get( 'X-WP-Total' )
-					);
+					meta.totalItems = getPaginationMeta(
+						response.headers
+					).totalItems;
 				} else {
 					records = Object.values( response );
 				}

--- a/packages/core-data/src/utils/get-pagination-meta.ts
+++ b/packages/core-data/src/utils/get-pagination-meta.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the pagination metadata reported by a collection response. Endpoints
+ * that don't paginate send no headers, in which case the totals are unknown.
+ *
+ * @param headers Response headers.
+ */
+export default function getPaginationMeta( headers: Headers ): {
+	totalItems: number | null;
+	totalPages: number | null;
+} {
+	const totalItems = parseInt( headers.get( 'X-WP-Total' ) ?? '' );
+	const totalPages = parseInt( headers.get( 'X-WP-TotalPages' ) ?? '' );
+
+	return {
+		totalItems: Number.isFinite( totalItems ) ? totalItems : null,
+		totalPages: Number.isFinite( totalPages ) ? totalPages : null,
+	};
+}

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -16,3 +16,4 @@ export {
 export { RECEIVE_INTERMEDIATE_RESULTS } from './receive-intermediate-results';
 export { default as normalizeQueryForResolution } from './normalize-query-for-resolution';
 export { saveCRDTDoc } from './save-crdt-doc';
+export { default as getPaginationMeta } from './get-pagination-meta';

--- a/packages/core-data/src/utils/test/get-pagination-meta.js
+++ b/packages/core-data/src/utils/test/get-pagination-meta.js
@@ -1,0 +1,24 @@
+import getPaginationMeta from '../get-pagination-meta';
+
+const createHeaders = ( values ) => ( {
+	get: ( header ) => values[ header ] ?? null,
+} );
+
+describe( 'getPaginationMeta', () => {
+	it( 'returns the totals reported by the headers', () => {
+		const result = getPaginationMeta(
+			createHeaders( {
+				'X-WP-Total': '10',
+				'X-WP-TotalPages': '5',
+			} )
+		);
+
+		expect( result ).toEqual( { totalItems: 10, totalPages: 5 } );
+	} );
+
+	it( 'returns null for totals the headers do not report', () => {
+		const result = getPaginationMeta( createHeaders( {} ) );
+
+		expect( result ).toEqual( { totalItems: null, totalPages: null } );
+	} );
+} );


### PR DESCRIPTION
## What?
Related to #82054.

Normalize the `X-WP-Total` / `X-WP-TotalPages` header parsing in the `getEntityRecords` and `getRevisions` resolvers to `null` when the headers are absent, and stop setting `supportsPagination` on the entities served by `WP_REST_Templates_Controller`.

## Why?

`WP_REST_Templates_Controller` returns the whole collection and sends no pagination headers. `parseInt( null )` is `NaN`, the reducer stored that as `meta`, and `getEntityRecordsTotalItems` / `getEntityRecordsTotalPages` returned it verbatim. The selectors already treat a missing total as `null` (`meta?.totalItems ?? null`, and `getEntityRecordsTotalPages` short-circuits on a falsy `totalItems`), so `null` is the value they were written for; `NaN` was the only thing they could not handle.

`wp_template` is served by that same controller until the `active_templates` experiment moves it to `/wp/v2/created-templates`, hence gating on `window.__experimentalTemplateActivate` rather than checking the entity name alone.

## Testing Instructions

1. Enable the extensible site editor experiment.
2. Go to Appearance > Design > Patterns > Template Parts.
3. The pagination footer shows the number of template parts.
4. Confirm `useSelect` doesn't log a warning.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
