### PR TITLE
Inserter: Keep the block preview inside the viewport

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug Fixes
 
+-   Inserter: Keep the hovered block preview inside the viewport. Its 16px gap below the panel was applied as CSS that `floating-ui` could not account for ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Inserter: Keep the hovered block preview inside the viewport, so a tall preview in a short window is no longer clipped ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 
 ## 17.0.0 (2026-08-26)
@@ -25,7 +26,6 @@
 
 ### Bug Fixes
 
--   Inserter: Keep the hovered block preview inside the viewport. Its 16px gap below the panel was applied as CSS that `floating-ui` could not account for ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### Bug Fixes
 
--   Inserter: Keep the hovered block preview inside the viewport. Its 16px gap below the panel was applied as CSS that `floating-ui` could not account for ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Inserter: Keep the hovered block preview inside the viewport. Its 16px gap below the panel was applied as CSS that `floating-ui` could not account for ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -415,7 +415,7 @@ function InserterMenu(
 				<Popover
 					className="block-editor-inserter__preview-container__popover"
 					placement="right-start"
-					offset={ 16 }
+					offset={ { mainAxis: 16, crossAxis: 16 } }
 					focusOnMount={ false }
 					animate={ false }
 				>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -203,10 +203,6 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__preview-container__popover {
-	top: $grid-unit-20 !important;
-}
-
 .block-editor-inserter__preview-container {
 	display: none;
 	width: $sidebar-width;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### TypeScript
 
--   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
+-   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 
 ## 40.0.0 (2026-08-26)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### TypeScript
+
+-   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
+
 ## 40.0.0 (2026-08-26)
 
 ### Breaking Changes
@@ -45,7 +49,6 @@
 
 ### TypeScript
 
--   `Popover`: Widen `offset` to accept `floating-ui`'s offset object, so a popover can also be displaced along its cross axis ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#81568](https://github.com/WordPress/gutenberg/pull/81568)).
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### TypeScript
 
+-   `Popover`: Widen `offset` to accept `floating-ui`'s offset object, so a popover can also be displaced along its cross axis ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#81568](https://github.com/WordPress/gutenberg/pull/81568)).
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### TypeScript
 
--   `Popover`: Widen `offset` to accept `floating-ui`'s offset object, so a popover can also be displaced along its cross axis ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `Popover`: Widen `offset` to accept `floating-ui`'s offset object, so a popover can also be displaced along its cross axis ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ComboboxControl`: Narrow the `onChange` callback parameter type to `string | null`, matching the values the component actually passes. The previous indexed-access type on the optional `value` prop leaked an accidental `undefined` into the union ([#81568](https://github.com/WordPress/gutenberg/pull/81568)).
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### TypeScript
+### Enhancements
 
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -130,9 +130,9 @@ The available base placements are 'top', 'right', 'bottom', 'left'. Each of thes
 
 -   Required: No
 
-### `popoverOffset`: `number`
+### `popoverOffset`: `number | { mainAxis?: number; crossAxis?: number }`
 
-The space between the popover and the control wrapper.
+The space between the popover and the control wrapper. A number displaces the popover along its main axis; pass an object to also displace it along its cross axis.
 
 -   Required: No
 

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -34,7 +34,9 @@ export type BorderBoxControlProps = ColorProps &
 		 */
 		popoverPlacement?: PopoverProps[ 'placement' ];
 		/**
-		 * The space between the popover and the control wrapper.
+		 * The space between the popover and the control wrapper. A number
+		 * displaces the popover along its main axis; pass an object to also
+		 * displace it along its cross axis.
 		 */
 		popoverOffset?: PopoverProps[ 'offset' ];
 		/**
@@ -83,7 +85,9 @@ export type SplitControlsProps = ColorProps &
 		 */
 		popoverPlacement?: PopoverProps[ 'placement' ];
 		/**
-		 * The space between the popover and the control wrapper.
+		 * The space between the popover and the control wrapper. A number
+		 * displaces the popover along its main axis; pass an object to also
+		 * displace it along its cross axis.
 		 */
 		popoverOffset?: PopoverProps[ 'offset' ];
 		/**

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -183,9 +183,9 @@ Used to show/hide the arrow that points at the popover's anchor.
 -   Required: No
 -   Default: `true`
 
-### `offset`: `number`
+### `offset`: `number | { mainAxis?: number; crossAxis?: number; alignmentAxis?: number | null }`
 
-The distance (in px) between the anchor and the popover.
+The distance (in px) between the anchor and the popover. A number displaces the popover along its main axis; pass an object to also displace it along its cross axis.
 
 -   Required: No
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -183,7 +183,7 @@ Used to show/hide the arrow that points at the popover's anchor.
 -   Required: No
 -   Default: `true`
 
-### `offset`: `number | { mainAxis?: number; crossAxis?: number; alignmentAxis?: number | null }`
+### `offset`: `number | { mainAxis?: number; crossAxis?: number }`
 
 The distance (in px) between the anchor and the popover. A number displaces the popover along its main axis; pass an object to also displace it along its cross axis.
 

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -174,6 +174,29 @@ describe( 'Popover', () => {
 			} );
 		} );
 
+		describe( 'offset', () => {
+			it( 'should displace the popover along its cross axis when passed an offset object', async () => {
+				render(
+					<Popover
+						placement="right-start"
+						offset={ { mainAxis: 16, crossAxis: 24 } }
+						animate={ false }
+						flip={ false }
+						shift={ false }
+						data-testid="popover-element"
+					>
+						Hello
+					</Popover>
+				);
+				const popover = screen.getByTestId( 'popover-element' );
+
+				await waitFor( () => expect( popover ).toBeVisible() );
+				expect( popover ).toHaveStyle(
+					'transform: translateX(16px) translateY(24px)'
+				);
+			} );
+		} );
+
 		describe( 'style', () => {
 			it( 'outputs inline styles added through the style prop in addition to built-in popover positioning styles', async () => {
 				render(

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -113,7 +113,6 @@ export type PopoverProps = {
 		| {
 				mainAxis?: number;
 				crossAxis?: number;
-				alignmentAxis?: number | null;
 		  };
 	/**
 	 * A callback invoked when the popover should be closed.

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -105,9 +105,16 @@ export type PopoverProps = {
 	 */
 	noArrow?: boolean;
 	/**
-	 * The distance (in px) between the anchor and the popover.
+	 * The distance (in px) between the anchor and the popover. Pass an object to
+	 * also displace the popover along its cross axis.
 	 */
-	offset?: number;
+	offset?:
+		| number
+		| {
+				mainAxis?: number;
+				crossAxis?: number;
+				alignmentAxis?: number | null;
+		  };
 	/**
 	 * A callback invoked when the popover should be closed.
 	 */

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -806,6 +806,38 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		).toBeInViewport();
 	} );
 
+	test( 'keeps the block preview inside a short viewport', async ( {
+		admin,
+		page,
+	} ) => {
+		await page.setViewportSize( { width: 1280, height: 400 } );
+		await admin.createNewPost();
+		await page
+			.getByRole( 'toolbar', { name: 'Document tools' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Block Library' } )
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Cover' );
+		await page
+			.getByRole( 'listbox', { name: 'Blocks' } )
+			.getByRole( 'option', { name: 'Cover', exact: true } )
+			.hover();
+
+		// The popover grows to its final height once the preview has been
+		// measured, so wait for that before checking containment.
+		await expect(
+			page.locator(
+				'.block-editor-inserter__preview-content .block-editor-block-preview__content'
+			)
+		).toBeVisible();
+
+		await expect(
+			page.locator( '.block-editor-inserter__preview-container__popover' )
+		).toBeInViewport( { ratio: 1 } );
+	} );
+
 	[ 'large', 'small' ].forEach( ( viewport ) => {
 		test( `last-inserted block should be given and keep the selection (${ viewport } viewport)`, async ( {
 			admin,


### PR DESCRIPTION
## What?

Moves the inserter block preview's 16px top gap out of CSS and into the popover's `offset`, and widens `Popover`'s `offset` prop to also accept an object with separate main and cross axis offsets.

Closes #70329.

## Why?

The gap was applied as `top: 16px !important` on top of the popover's own positioning, so `floating-ui`'s `shift` and `size` middleware could not see it and the preview overflowed the viewport's bottom edge by 8px.

## How?

`offset={ { mainAxis: 16, crossAxis: 16 } }` replaces the CSS rule. The offset middleware already accepted the object form; only the prop type refused it, so the `components` change is a type widening with no runtime change.

## Testing Instructions

1. Set the browser window to about 1440x560.
2. Open a new post, open the inserter, hover the Cover block.
3. The preview ends inside the viewport instead of being clipped at the bottom edge.

Measured at a 417px viewport, hovering Cover: bottom 425 against the viewport's 417 before, 409 after. At normal window sizes the position is unchanged (top 113, bottom 381, height 268 either way). When space is tight the panel is capped 16px shorter, which is what keeps it on screen. Also checked in RTL.

- [x] `npm run test:unit -- packages/components`
- [x] `npm run test:unit -- packages/block-editor`
- [x] `npm run typecheck`
- [x] `npm run test:e2e -- test/e2e/specs/editor/various/inserting-blocks.spec.js`

## Testing Instructions for Keyboard

The preview only appears on pointer hover, so there is no keyboard path to it.

## Screenshots or screencast

### Before
<img width="1440" height="417" alt="before" src="https://github.com/user-attachments/assets/2442b473-9300-48b5-96af-13f219ae8aed" />


### After
<img width="1440" height="417" alt="after" src="https://github.com/user-attachments/assets/a9ab7321-8a8a-4b33-a05d-0aae08c9b29b" />


## Use of AI Tools

Claude Code was used to diagnose the cause, write the change and its test, and run the verification.

