### PR TITLE
Quick Draft widget: drop a reference to a class that does not exist

### DIFF
--- a/widgets/quick-draft/render.tsx
+++ b/widgets/quick-draft/render.tsx
@@ -256,10 +256,7 @@ export default function QuickDraft() {
 		<Stack
 			ref={ ref }
 			direction={ listBeside ? 'row' : 'column' }
-			className={ clsx(
-				styles.body,
-				listBeside ? styles.row : styles.column
-			) }
+			className={ clsx( styles.body, listBeside && styles.row ) }
 		>
 			<Stack direction="column" className={ styles.primaryPane }>
 				{ primary }


### PR DESCRIPTION
## What?

Follow-up to reviewing https://github.com/WordPress/gutenberg/pull/82053.

`widgets/quick-draft/render.tsx` picks between two CSS module classes for its root layout, but only one of them exists.

## Why?

`.column` is not defined in `widgets/quick-draft/style.module.css`, and never was. In the stacked layout the ternary therefore resolves to `undefined` and `clsx` drops it, so the class list is the same either way.

Nothing renders differently: the axis is already set by `direction={ listBeside ? 'row' : 'column' }` on the same `Stack`, and `.row` exists only to feed the descendant selector `.row .primary-pane`, which adds the vertical rule in the side-by-side layout.

What the ternary does do is imply a `.column` modifier that is not there, sending the next reader to look for styles that do not exist.

It is also a small illustration of a gap worth naming: CSS modules are typed as `{ [ key: string ]: string }` in `typings/style-imports/index.d.ts`, so a reference to a missing class type checks fine and reaches runtime as `className={ undefined }`. This one survived three refactors of the file without any tool noticing.

## How?

Replaces the ternary with a conditional, so the class is added when it applies and nothing is added when it does not.

```diff
-			className={ clsx(
-				styles.body,
-				listBeside ? styles.row : styles.column
-			) }
+			className={ clsx( styles.body, listBeside && styles.row ) }
```

## Testing Instructions

The change is a no-op visually; the point is to confirm that.

1. Open the dashboard with the Quick Draft widget placed.
2. Give the widget a wide tile, so the drafts list sits beside the form. The vertical rule between the two panes still shows.
3. Narrow the tile until the list stacks below the form. The layout is unchanged from before this PR.

### Testing Instructions for Keyboard

No interaction changes.

## Screenshots or screencast

No visual changes.

## Use of AI Tools

Claude Code was used to review #82053, where this dead reference surfaced, and to draft the change. Reviewed and verified before opening.
