### PR TITLE
CI: Skip the package CHANGELOG check when only the CHANGELOG changed

### DIFF
--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -24,6 +24,7 @@ on:
             - 'packages/wp-build/**'
             - '!packages/*/src/**/stories/**'
             - '!packages/*/src/**/test/**'
+            - '!packages/*/CHANGELOG.md'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -82,8 +83,13 @@ jobs:
                   # The workflow's `paths:` filter triggers on the union of all
                   # tracked packages, so this matrix entry may run on a PR that
                   # doesn't touch its package. Short-circuit if that's the case.
+                  #
+                  # Changes to the CHANGELOG itself don't warrant a CHANGELOG
+                  # entry of their own, so a PR that only corrects an existing
+                  # entry isn't asked to add a new one.
                   relevant_changes=$(git diff --name-only "$BASE_SHA"...HEAD -- "${PACKAGE_PATH}/" \
-                      | grep -Ev "^${PACKAGE_PATH}/src/(.+/)?(stories|test)/" || true)
+                      | grep -Ev "^${PACKAGE_PATH}/src/(.+/)?(stories|test)/" \
+                      | grep -Fxv "${PACKAGE_PATH}/CHANGELOG.md" || true)
 
                   if [ -z "$relevant_changes" ]; then
                       echo "No relevant changes under ${PACKAGE_PATH}; skipping CHANGELOG check."

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+<!-- TEMP — delete before merge. Testing that a CHANGELOG-only PR skips this check rather than failing it; deliberately no PR link here. -->
+
 ### Breaking Changes
 
 -   Components that compose Emotion style fragments with `cx()` should pass source-order-dependent fragments in a single `css()` call. Passing separate fragments can change override order after the following components stopped rendering styles through Emotion:

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-<!-- TEMP — delete before merge. Testing that a CHANGELOG-only PR skips this check rather than failing it; deliberately no PR link here. -->
-
 ### Breaking Changes
 
 -   Components that compose Emotion style fragments with `cx()` should pass source-order-dependent fragments in a single `css()` call. Passing separate fragments can change override order after the following components stopped rendering styles through Emotion:


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/81923#issuecomment-5372069001

## Why?
- A PR that only fixes an existing changelog entry gets flagged for a missing entry.
- False positive: correcting an entry doesn't warrant a new one.

## How?
- Excludes `packages/*/CHANGELOG.md` from the workflow's `paths:` trigger.
- Excludes it from the per-package relevant-changes filter too, mirroring stories/tests.
- Only skips when the CHANGELOG is the *sole* change in that package.

## Testing Instructions
1. This PR includes a temporary one-line edit to `packages/components/CHANGELOG.md` with no PR link.
2. Confirm "Check CHANGELOG diff (components)" does not run, absent, not green.
3. Before merge, that temporary line is removed.

`pull_request` reads `on:` filters from the head branch, so the fix is live in this PR.

## Use of AI Tools
Claude Code 
