### PR TITLE
Fluid spacing: Add support for fluid spacing sizes in theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -177,7 +177,8 @@ Settings related to spacing.
 | units | List of units the user can use for spacing values. | `[ string ]` | `["px","em","rem","vh","vw","%"]` |
 | customSpacingSize | Allow users to set custom space sizes. | `boolean` | `true` |
 | defaultSpacingSizes | Allow users to choose space sizes from the default space size presets. | `boolean` | `true` |
-| spacingSizes | Space size presets for the space size selector. | `[ { name, slug, size } ]` |  |
+| fluid | Enables fluid spacing and allows users to set global fluid spacing parameters. | `boolean`, `{ maxViewportWidth, minViewportWidth }` | `false` |
+| spacingSizes | Space size presets for the space size selector. | `[ { name, slug, size, fluid } ]` |  |
 | spacingScale | Settings to auto-generate space size presets for the space size selector. | `{ operator, increment, steps, mediumStep, unit }` |  |
 
 ---

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -73,6 +73,97 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 	return $attributes;
 }
 
+/**
+ * Returns a spacing value based on a given spacing-size preset.
+ * Takes into account fluid spacing parameters and attempts to return a CSS
+ * formula depending on available, valid values.
+ *
+ * Unlike fluid typography, fluid spacing has no formula to derive a minimum
+ * value from a single size, so a preset only becomes fluid when it (or the
+ * global `spacing.fluid` setting alongside it) explicitly declares both a
+ * `min` and a `max` value. A preset with `fluid: false`, or fluid enabled
+ * without explicit bounds, falls back to its static `size`.
+ *
+ * @since 7.1.0
+ *
+ * @param array $preset       {
+ *     Required. spacingSizes preset value as seen in theme.json.
+ *
+ *     @type string           $name Name of the spacing size preset.
+ *     @type string           $slug Kebab-case unique identifier for the spacing size preset.
+ *     @type string|int|float $size CSS spacing value, including units where applicable.
+ * }
+ * @param array $settings Optional. Theme JSON settings array that overrides any global theme settings.
+ *                        Default is `array()`.
+ *
+ * @return string|null Spacing value or `null` if a size is not passed in $preset.
+ */
+function gutenberg_get_spacing_size_value( $preset, $settings = array() ) {
+	if ( ! isset( $preset['size'] ) ) {
+		return null;
+	}
+
+	/*
+	 * Catch falsy values and 0/'0'. Fluid calculations cannot be performed on `0`.
+	 * Also return early when a preset spacing size explicitly disables fluid spacing with `false`.
+	 */
+	$fluid_spacing_size_settings = $preset['fluid'] ?? null;
+	if ( false === $fluid_spacing_size_settings || empty( $preset['size'] ) ) {
+		return $preset['size'];
+	}
+
+	// Fallback to global settings as default.
+	$global_settings  = gutenberg_get_global_settings();
+	$settings         = wp_parse_args( $settings, $global_settings );
+	$spacing_settings = $settings['spacing'] ?? array();
+
+	/*
+	 * Return early when fluid spacing is disabled in the settings, and there
+	 * are no local settings to enable it for the individual preset.
+	 */
+	if ( empty( $spacing_settings['fluid'] ) && empty( $fluid_spacing_size_settings ) ) {
+		return $preset['size'];
+	}
+
+	// A preset only goes fluid when it explicitly declares both a min and a max.
+	if ( ! is_array( $fluid_spacing_size_settings ) ) {
+		return $preset['size'];
+	}
+
+	$minimum_spacing_size_raw = $fluid_spacing_size_settings['min'] ?? null;
+	$maximum_spacing_size_raw = $fluid_spacing_size_settings['max'] ?? null;
+	if ( ! $minimum_spacing_size_raw || ! $maximum_spacing_size_raw ) {
+		return $preset['size'];
+	}
+
+	$fluid_settings = $spacing_settings['fluid'] ?? array();
+	$fluid_settings = is_array( $fluid_settings ) ? $fluid_settings : array();
+
+	// Defaults, matching fluid typography's viewport width defaults.
+	$default_maximum_viewport_width = '1600px';
+	$default_minimum_viewport_width = '320px';
+
+	$minimum_viewport_width = $fluid_settings['minViewportWidth'] ?? $default_minimum_viewport_width;
+	$maximum_viewport_width = $fluid_settings['maxViewportWidth'] ?? $default_maximum_viewport_width;
+
+	// Reuses the fluid typography clamp() calculation, which is unit-agnostic.
+	$fluid_spacing_size_value = gutenberg_get_computed_fluid_typography_value(
+		array(
+			'minimum_viewport_width' => $minimum_viewport_width,
+			'maximum_viewport_width' => $maximum_viewport_width,
+			'minimum_font_size'      => $minimum_spacing_size_raw,
+			'maximum_font_size'      => $maximum_spacing_size_raw,
+			'scale_factor'           => 1,
+		)
+	);
+
+	if ( ! empty( $fluid_spacing_size_value ) ) {
+		return $fluid_spacing_size_value;
+	}
+
+	return $preset['size'];
+}
+
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'spacing',

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -190,7 +190,7 @@ class WP_Theme_JSON_Gutenberg {
 			'path'              => array( 'spacing', 'spacingSizes' ),
 			'prevent_override'  => array( 'spacing', 'defaultSpacingSizes' ),
 			'use_default_names' => true,
-			'value_key'         => 'size',
+			'value_func'        => 'gutenberg_get_spacing_size_value',
 			'css_vars'          => '--wp--preset--spacing--$slug',
 			'classes'           => array(),
 			'properties'        => array( 'padding', 'margin' ),
@@ -453,6 +453,7 @@ class WP_Theme_JSON_Gutenberg {
 		'spacing'                       => array(
 			'customSpacingSize'   => null,
 			'defaultSpacingSizes' => null,
+			'fluid'               => null,
 			'spacingSizes'        => null,
 			'spacingScale'        => null,
 			'blockGap'            => null,

--- a/packages/global-styles-engine/src/test/spacing-utils.test.ts
+++ b/packages/global-styles-engine/src/test/spacing-utils.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for spacing utility functions
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getSpacingSizeValue } from '../utils/spacing';
+
+describe( 'spacing utils', () => {
+	describe( 'getSpacingSizeValue', () => {
+		const testCases = [
+			{
+				message: 'should return value when fluid spacing is not active',
+				preset: {
+					size: '1.75rem',
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: undefined,
+				expected: '1.75rem',
+			},
+			{
+				message: 'should return value when size is `0`',
+				preset: {
+					size: 0,
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {
+					spacing: {
+						fluid: true,
+					},
+				},
+				expected: 0,
+			},
+			{
+				message: 'should return value when fluid is `false`',
+				preset: {
+					size: '1.75rem',
+					fluid: false,
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {
+					spacing: {
+						fluid: true,
+					},
+				},
+				expected: '1.75rem',
+			},
+			{
+				message:
+					'should return value when global fluid is enabled but preset has no fluid bounds',
+				preset: {
+					size: '1.75rem',
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {
+					spacing: {
+						fluid: true,
+					},
+				},
+				expected: '1.75rem',
+			},
+			{
+				message:
+					'should return value when preset fluid is `true` with no explicit min/max',
+				preset: {
+					size: '1.75rem',
+					fluid: true,
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {},
+				expected: '1.75rem',
+			},
+			{
+				message:
+					'should return value when preset fluid is missing `max`',
+				preset: {
+					size: '1.75rem',
+					fluid: { min: '1.5rem' },
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {},
+				expected: '1.75rem',
+			},
+			{
+				message:
+					'should return clamp value with explicit min/max and default viewport widths',
+				preset: {
+					size: '1.75rem',
+					fluid: { min: '1.5rem', max: '1.75rem' },
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {},
+				expected:
+					'clamp(1.5rem, 1.5rem + ((1vw - 0.2rem) * 0.313), 1.75rem)',
+			},
+			{
+				message: 'should return clamp value using px units',
+				preset: {
+					size: '32px',
+					fluid: { min: '16px', max: '32px' },
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {},
+				expected: 'clamp(16px, 1rem + ((1vw - 3.2px) * 1.25), 32px)',
+			},
+			{
+				message:
+					'should return clamp value with custom global viewport widths',
+				preset: {
+					size: '2rem',
+					fluid: { min: '1rem', max: '2rem' },
+					name: 'preset',
+					slug: 'preset',
+				},
+				settings: {
+					spacing: {
+						fluid: {
+							minViewportWidth: '768px',
+							maxViewportWidth: '1280px',
+						},
+					},
+				},
+				expected: 'clamp(1rem, 1rem + ((1vw - 0.48rem) * 3.125), 2rem)',
+			},
+		];
+
+		testCases.forEach( ( { message, preset, settings, expected } ) => {
+			// eslint-disable-next-line jest/valid-title
+			it( message, () => {
+				expect(
+					// @ts-expect-error -- test fixtures intentionally omit some optional fields.
+					getSpacingSizeValue( preset, settings || {} )
+				).toEqual( expected );
+			} );
+		} );
+	} );
+} );

--- a/packages/global-styles-engine/src/test/spacing-utils.test.ts
+++ b/packages/global-styles-engine/src/test/spacing-utils.test.ts
@@ -136,10 +136,9 @@ describe( 'spacing utils', () => {
 		testCases.forEach( ( { message, preset, settings, expected } ) => {
 			// eslint-disable-next-line jest/valid-title
 			it( message, () => {
-				expect(
-					// @ts-expect-error -- test fixtures intentionally omit some optional fields.
-					getSpacingSizeValue( preset, settings || {} )
-				).toEqual( expected );
+				expect( getSpacingSizeValue( preset, settings || {} ) ).toEqual(
+					expected
+				);
 			} );
 		} );
 	} );

--- a/packages/global-styles-engine/src/types.ts
+++ b/packages/global-styles-engine/src/types.ts
@@ -176,12 +176,38 @@ export interface LayoutSettings {
 }
 
 /**
+ * Fluid spacing settings for responsive spacing sizes
+ */
+export interface FluidSpacingConfig {
+	min?: string;
+	max?: string;
+}
+
+/**
+ * Global fluid spacing settings
+ */
+export interface FluidSpacingSettings {
+	maxViewportWidth?: string;
+	minViewportWidth?: string;
+}
+
+/**
+ * Spacing size preset definition as found in theme.json
+ */
+export interface SpacingSizePreset extends BasePreset {
+	size: string | number | null;
+	fluid?: boolean | FluidSpacingConfig;
+}
+
+/**
  * Spacing settings
  */
 export interface SpacingSettings {
 	padding?: string | Record< string, string >;
 	margin?: string | Record< string, string >;
 	blockGap?: string;
+	fluid?: boolean | FluidSpacingSettings;
+	spacingSizes?: SpacingSizePreset[] | Record< string, SpacingSizePreset[] >;
 }
 
 // =============================================================================

--- a/packages/global-styles-engine/src/utils/common.ts
+++ b/packages/global-styles-engine/src/utils/common.ts
@@ -10,10 +10,12 @@ import type {
 	GlobalStylesSettings,
 	ThemeFileLink,
 	TypographyPreset,
+	SpacingSizePreset,
 	UnresolvedValue,
 	GlobalStylesConfig,
 } from '../types';
 import { getTypographyFontSizeValue } from './typography';
+import { getSpacingSizeValue } from './spacing';
 import { getValueFromObjectPath } from './object';
 
 export const ROOT_BLOCK_SELECTOR = 'body';
@@ -111,7 +113,10 @@ export const PRESET_METADATA = [
 		path: [ 'spacing', 'spacingSizes' ],
 		valueKey: 'size',
 		cssVarInfix: 'spacing',
-		valueFunc: ( { size }: { size: string } ) => size,
+		valueFunc: (
+			preset: SpacingSizePreset,
+			settings: GlobalStylesSettings
+		) => getSpacingSizeValue( preset, settings ),
 		classes: [],
 	},
 	{

--- a/packages/global-styles-engine/src/utils/spacing.ts
+++ b/packages/global-styles-engine/src/utils/spacing.ts
@@ -1,3 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	SpacingSizePreset,
+	GlobalStylesSettings,
+	FluidSpacingSettings,
+	SpacingSettings,
+} from '../types';
+import { getComputedFluidTypographyValue } from './fluid';
+
 export function getSpacingPresetCssVar( value?: string ) {
 	if ( ! value ) {
 		return;
@@ -10,4 +21,101 @@ export function getSpacingPresetCssVar( value?: string ) {
 	}
 
 	return `var(--wp--preset--spacing--${ slug[ 1 ] })`;
+}
+
+/**
+ * Checks if fluid spacing is enabled in the given spacing settings.
+ *
+ * Fluid spacing is considered enabled if the fluid setting is explicitly set to true,
+ * or if it's an object with properties (which would contain fluid spacing configuration
+ * like minViewportWidth, maxViewportWidth).
+ *
+ * @param spacingSettings       Spacing settings object that may contain fluid spacing configuration.
+ * @param spacingSettings.fluid Fluid spacing configuration. Can be:
+ *                              - `true` to enable with default settings
+ *                              - An object with fluid settings (minViewportWidth, maxViewportWidth)
+ *                              - `false` or `undefined` to disable
+ *
+ * @return True if fluid spacing is enabled, false otherwise.
+ */
+function isFluidSpacingEnabled(
+	spacingSettings?: SpacingSettings | SpacingSizePreset
+) {
+	const fluidSettings = spacingSettings?.fluid;
+	return (
+		true === fluidSettings ||
+		( fluidSettings &&
+			typeof fluidSettings === 'object' &&
+			Object.keys( fluidSettings ).length > 0 )
+	);
+}
+
+/**
+ * Returns a spacing value based on a given spacing-size preset.
+ * Takes into account fluid spacing parameters and attempts to return a css formula depending on available, valid values.
+ *
+ * The Core PHP equivalent is gutenberg_get_spacing_size_value().
+ *
+ * Unlike fluid typography, fluid spacing has no formula to derive a minimum
+ * value from a single size, so a preset only becomes fluid when it explicitly
+ * declares both a `min` and a `max` value. A preset with `fluid: false`, or
+ * fluid enabled without explicit bounds, falls back to its static `size`.
+ *
+ * @param preset   A spacing-size preset object containing size and fluid properties.
+ * @param settings Global styles settings object containing spacing settings.
+ *
+ * @return A spacing value or the value of preset.size.
+ */
+export function getSpacingSizeValue(
+	preset: SpacingSizePreset,
+	settings: GlobalStylesSettings
+) {
+	const { size: defaultSize } = preset;
+
+	/*
+	 * Catch falsy values and 0/'0'. Fluid calculations cannot be performed on `0`.
+	 * Also return early when a preset spacing size explicitly disables fluid spacing with `false`.
+	 */
+	if ( ! defaultSize || '0' === defaultSize || false === preset?.fluid ) {
+		return defaultSize;
+	}
+
+	/*
+	 * Return early when fluid spacing is disabled in the settings, and there
+	 * are no local settings to enable it for the individual preset.
+	 */
+	if (
+		! isFluidSpacingEnabled( settings?.spacing ) &&
+		! isFluidSpacingEnabled( preset )
+	) {
+		return defaultSize;
+	}
+
+	// A preset only goes fluid when it explicitly declares both a min and a max.
+	if ( typeof preset?.fluid !== 'object' ) {
+		return defaultSize;
+	}
+
+	const { min: minimumSpacingSize, max: maximumSpacingSize } = preset.fluid;
+	if ( ! minimumSpacingSize || ! maximumSpacingSize ) {
+		return defaultSize;
+	}
+
+	const fluidSpacingSettings: FluidSpacingSettings =
+		typeof settings?.spacing?.fluid === 'object'
+			? settings.spacing.fluid
+			: {};
+
+	const fluidSpacingSizeValue = getComputedFluidTypographyValue( {
+		minimumFontSize: minimumSpacingSize,
+		maximumFontSize: maximumSpacingSize,
+		maximumViewportWidth: fluidSpacingSettings?.maxViewportWidth,
+		minimumViewportWidth: fluidSpacingSettings?.minViewportWidth,
+	} );
+
+	if ( !! fluidSpacingSizeValue ) {
+		return fluidSpacingSizeValue;
+	}
+
+	return defaultSize;
 }

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -157,4 +157,128 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 	}
+
+	/**
+	 * @dataProvider data_generate_spacing_size_preset_fixtures
+	 *
+	 * @param array  $spacing_size    A spacingSizes preset value as seen in theme.json.
+	 * @param array  $settings        Theme JSON settings array that overrides any global theme settings.
+	 * @param string $expected_output Expected output of gutenberg_get_spacing_size_value().
+	 */
+	public function test_gutenberg_get_spacing_size_value( $spacing_size, $settings, $expected_output ) {
+		$actual = gutenberg_get_spacing_size_value( $spacing_size, $settings );
+
+		$this->assertSame( $expected_output, $actual );
+	}
+
+	/**
+	 * Data provider for test_gutenberg_get_spacing_size_value.
+	 *
+	 * @return array
+	 */
+	public function data_generate_spacing_size_preset_fixtures() {
+		return array(
+			'returns null when size is not set'   => array(
+				'spacing_size'    => array(),
+				'settings'        => array(),
+				'expected_output' => null,
+			),
+
+			'returns value when fluid spacing is deactivated' => array(
+				'spacing_size'    => array(
+					'size' => '28px',
+				),
+				'settings'        => array(),
+				'expected_output' => '28px',
+			),
+
+			'returns value when fluid is `false`' => array(
+				'spacing_size'    => array(
+					'size'  => '1.75rem',
+					'fluid' => false,
+				),
+				'settings'        => array(
+					'spacing' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '1.75rem',
+			),
+
+			'returns value when global fluid is enabled but preset has no fluid bounds' => array(
+				'spacing_size'    => array(
+					'size' => '1.75rem',
+				),
+				'settings'        => array(
+					'spacing' => array(
+						'fluid' => true,
+					),
+				),
+				'expected_output' => '1.75rem',
+			),
+
+			'returns value when preset fluid is `true` with no explicit min/max' => array(
+				'spacing_size'    => array(
+					'size'  => '1.75rem',
+					'fluid' => true,
+				),
+				'settings'        => array(),
+				'expected_output' => '1.75rem',
+			),
+
+			'returns value when preset fluid is missing `max`' => array(
+				'spacing_size'    => array(
+					'size'  => '1.75rem',
+					'fluid' => array(
+						'min' => '1.5rem',
+					),
+				),
+				'settings'        => array(),
+				'expected_output' => '1.75rem',
+			),
+
+			'returns clamp value with explicit min/max and default viewport widths' => array(
+				'spacing_size'    => array(
+					'size'  => '1.75rem',
+					'fluid' => array(
+						'min' => '1.5rem',
+						'max' => '1.75rem',
+					),
+				),
+				'settings'        => array(),
+				'expected_output' => 'clamp(1.5rem, 1.5rem + ((1vw - 0.2rem) * 0.313), 1.75rem)',
+			),
+
+			'returns clamp value using px units'  => array(
+				'spacing_size'    => array(
+					'size'  => '32px',
+					'fluid' => array(
+						'min' => '16px',
+						'max' => '32px',
+					),
+				),
+				'settings'        => array(),
+				'expected_output' => 'clamp(16px, 1rem + ((1vw - 3.2px) * 1.25), 32px)',
+			),
+
+			'returns clamp value with custom global viewport widths' => array(
+				'spacing_size'    => array(
+					'size'  => '2rem',
+					'fluid' => array(
+						'min' => '1rem',
+						'max' => '2rem',
+					),
+				),
+				'settings'        => array(
+					'spacing' => array(
+						'fluid' => array(
+							'minViewportWidth' => '768px',
+							'maxViewportWidth' => '1280px',
+						),
+					),
+				),
+				'expected_output' => 'clamp(1rem, 1rem + ((1vw - 0.48rem) * 3.125), 2rem)',
+			),
+		);
+	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1856,6 +1856,47 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Unlike fluid typography, spacing presets only become fluid when they
+	 * explicitly declare `fluid.min`/`fluid.max` themselves; there is no
+	 * auto-derivation from a single size (see the discussion in #81864).
+	 */
+	public function test_get_stylesheet_generates_fluid_spacing_values() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'spacing' => array(
+						'fluid'        => true,
+						'spacingSizes' => array(
+							array(
+								'size'  => '1.75rem',
+								'slug'  => 'md',
+								'name'  => 'Medium',
+								'fluid' => array(
+									'min' => '1.5rem',
+									'max' => '1.75rem',
+								),
+							),
+							array(
+								'size'  => '1rem',
+								'slug'  => 'sm',
+								'name'  => 'Small',
+								'fluid' => false,
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertSameCSS(
+			':root{--wp--preset--spacing--md: clamp(1.5rem, 1.5rem + ((1vw - 0.2rem) * 0.313), 1.75rem);--wp--preset--spacing--sm: 1rem;}',
+			$theme_json->get_stylesheet( array( 'variables', 'presets' ), null, array( 'skip_root_layout_styles' => true ) )
+		);
+	}
+
 	public function test_allow_indirect_properties() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(

--- a/schemas/CHANGELOG.md
+++ b/schemas/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+-   Add new properties `settings.spacing.fluid` and `settings.spacing.spacingSizes[n].fluid` to theme.json to enable fluid spacing ([#81864](https://github.com/WordPress/gutenberg/issues/81864)).
 -   Add new properties `settings.typography.fluid` and `settings.typography.fontSizes[n].fluidSize` to theme.json to enable fluid typography ([#39529](https://github.com/WordPress/gutenberg/pull/39529)).
 
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -489,6 +489,29 @@
 							"type": "boolean",
 							"default": true
 						},
+						"fluid": {
+							"description": "Enables fluid spacing and allows users to set global fluid spacing parameters.",
+							"oneOf": [
+								{
+									"type": "object",
+									"properties": {
+										"maxViewportWidth": {
+											"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid space size.",
+											"type": "string"
+										},
+										"minViewportWidth": {
+											"description": "Allow users to set a custom min viewport width in px, rem or em, used to set the minimum size boundary of a fluid space size.",
+											"type": "string"
+										}
+									},
+									"additionalProperties": false
+								},
+								{
+									"type": "boolean"
+								}
+							],
+							"default": false
+						},
 						"spacingSizes": {
 							"description": "Space size presets for the space size selector.\nGenerates a custom property (`--wp--preset--spacing--{slug}`) per preset value.",
 							"type": "array",
@@ -506,6 +529,28 @@
 									"size": {
 										"description": "CSS space-size value, including units.",
 										"type": "string"
+									},
+									"fluid": {
+										"description": "Specifies the minimum and maximum space size value of a fluid space size. Set to `false` to bypass fluid calculations and use the static `size` value. There is no automatic derivation of `min`/`max`; both must be set explicitly for fluid calculations to apply.",
+										"oneOf": [
+											{
+												"type": "object",
+												"properties": {
+													"min": {
+														"description": "A min space size for fluid space size calculations in px, rem or em.",
+														"type": "string"
+													},
+													"max": {
+														"description": "A max space size for fluid space size calculations in px, rem or em.",
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											},
+											{
+												"type": "boolean"
+											}
+										]
 									}
 								},
 								"additionalProperties": false


### PR DESCRIPTION
Closes #81864

Adds fluid spacing support to `theme.json`, bringing it to parity with fluid typography.

### What changed

- Added `settings.spacing.fluid` for global `minViewportWidth` / `maxViewportWidth` configuration.
- Added `spacingSizes[].fluid` for per-preset control:
  - `{ min, max }` to enable fluid sizing.
  - `false` to opt out of fluid sizing.

### Why?

Fluid typography (`settings.typography.fluid`, `fontSizes[].fluid`) has been supported since #39529, generating `clamp()` values for `--wp--preset--font-size--*`.

Spacing had no equivalent. `spacingSizes[].size` only accepted a static value, which meant themes had to either write `clamp()` manually or use a `wp_theme_json_data_theme` filter. Hand-authored `fluid` keys also failed schema validation because they weren't declared.

### Implementation

- **PHP:** Added `gutenberg_get_spacing_size_value()` in `lib/block-supports/spacing.php` and wired it as the `value_func` for `spacingSizes` in `PRESETS_METADATA`.
- **JS:** Added the equivalent logic in `packages/global-styles-engine/src/utils/spacing.ts` and wired it into `PRESET_METADATA` in `common.ts`.
- **Schema:** Added `spacing.fluid` and `spacingSizes[].fluid` to `schemas/json/theme.json`, following the existing typography structure.
- Both PHP and JS reuse the existing unit-agnostic `clamp()` calculation used by fluid typography.

### Design decision

Unlike fluid typography, spacing does not automatically derive `min` and `max` values.

Typography derives a minimum from a single value using a log-scale factor and a 14px floor. That approach is tuned for font sizes and doesn't translate well to spacing.

A spacing preset therefore becomes fluid only when both `min` and `max` are explicitly provided.

### Deferred

Fluid `spacingScale` generation is left for a follow-up. `compute_spacing_sizes()` currently runs eagerly in the constructor, unlike the lazy computation used by typography. Reconciling that timing is separate work.

### Testing instructions

1. Add the following to a theme's `theme.json`:

```json
{
  "settings": {
    "spacing": {
      "fluid": {
        "minViewportWidth": "768px",
        "maxViewportWidth": "1280px"
      },
      "spacingSizes": [
        {
          "name": "Medium",
          "slug": "md",
          "size": "1.75rem",
          "fluid": {
            "min": "1.5rem",
            "max": "1.75rem"
          }
        },
        {
          "name": "Small",
          "slug": "sm",
          "size": "1rem",
          "fluid": false
        }
      ]
    }
  }
}
```

2. Load the site/editor and inspect the generated `:root` stylesheet.
3. Confirm that `--wp--preset--spacing--md` uses a `clamp(...)` expression.
4. Confirm that `--wp--preset--spacing--sm` remains static at `1rem`.
5. Confirm that the `theme.json` validates against the updated schema.

### Testing Instructions for Keyboard

N/A.

### Screenshots or screencast

N/A

### Use of AI Tools

Claude Code assisted with implementation and tests, reviewed by me.
