### PR TITLE
Zoom Out: Keep the selected block's inserter keyboard-reachable when scrolled off-screen

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+-   Zoom Out mode: Keep the inserter after the selected block reachable by keyboard when the block's lower boundary is scrolled out of view. It previously relied on the same viewport-intersection check used to skip rendering off-screen instances of the default in-between inserter, but Zoom Out mode only ever mounts one, so gating it just removed the only inserter a keyboard user could reach for a tall selected block ([#66346](https://github.com/WordPress/gutenberg/issues/66346)).
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/src/components/block-popover/README.md
+++ b/packages/block-editor/src/components/block-popover/README.md
@@ -54,3 +54,11 @@ The client ID of the block after the popover.
 
 -   Type: `String`
 -   Required: Yes
+
+#### alwaysVisible
+
+By default, the popover is only rendered while `previousClientId` and `nextClientId` are both scrolled into view, so that mounting many of these at once (e.g. the default in-between inserter) doesn't do unnecessary off-screen work. Pass `true` when a caller only ever mounts a single instance and needs it to stay reachable (e.g. focusable via keyboard) regardless of scroll position, such as the Zoom Out mode inserter.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -17,6 +17,16 @@ function BlockPopoverInbetween( {
 	__unstableContentRef,
 	operation = 'insert',
 	nearestSide = 'right',
+	// Callers that only ever mount a single instance of this popover (e.g.
+	// the Zoom Out mode inserter, which tracks the current block selection
+	// rather than a hover position) don't need it hidden while its anchor
+	// blocks are scrolled out of view: unlike the default in-between
+	// inserter, there isn't a large number of these mounted at once whose
+	// off-screen instances need skipping for performance, and gating on
+	// intersection removes the only keyboard-reachable inserter for a tall,
+	// selected block whenever its lower boundary is off-screen. See
+	// https://github.com/WordPress/gutenberg/issues/66346.
+	alwaysVisible = false,
 	...props
 } ) {
 	// This is a temporary hack to get the inbetween inserter to recompute properly.
@@ -43,11 +53,12 @@ function BlockPopoverInbetween( {
 					'vertical',
 				rootClientId: _rootClientId,
 				isVisible:
-					isBlockVisible( previousClientId ) &&
-					isBlockVisible( nextClientId ),
+					alwaysVisible ||
+					( isBlockVisible( previousClientId ) &&
+						isBlockVisible( nextClientId ) ),
 			};
 		},
-		[ previousClientId, nextClientId ]
+		[ previousClientId, nextClientId, alwaysVisible ]
 	);
 	const previousElement = useBlockElement( previousClientId );
 	const nextElement = useBlockElement( nextClientId );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -79,6 +79,13 @@ function ZoomOutModeInserters() {
 		<BlockPopoverInbetween
 			previousClientId={ previousClientId }
 			nextClientId={ nextClientId }
+			// Only one of these is ever mounted at a time here (it tracks
+			// the current block selection, not hover), so there's no
+			// performance need to hide it while off-screen — and doing so
+			// made the inserter for a tall selected block unreachable by
+			// keyboard whenever its lower boundary was scrolled out of
+			// view. See https://github.com/WordPress/gutenberg/issues/66346.
+			alwaysVisible
 		>
 			<ZoomOutModeInserterButton
 				onClick={ () => {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -288,4 +288,26 @@ test.describe( 'Zoom Out', () => {
 
 		await expect( page.locator( '.is-zoomed-out' ) ).toBeHidden();
 	} );
+
+	test( 'Zoom Out inserter for the selected block stays reachable when the next section is scrolled out of view', async ( {
+		page,
+		editor,
+	} ) => {
+		// Each section is 100vh tall, so at the top of the scroll
+		// container the gap (and inserter) after the first section is
+		// positioned below the viewport.
+		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT );
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+
+		// In Zoom Out mode, clicking anywhere in a section selects the
+		// section itself rather than entering it.
+		await editor.canvas.locator( 'text=First Section Start' ).click();
+
+		// See https://github.com/WordPress/gutenberg/issues/66346: the
+		// inserter used to be removed from the DOM entirely whenever the
+		// gap it belongs to was scrolled out of view, which made it
+		// unreachable by keyboard. It must stay attached (and therefore
+		// focusable) regardless of scroll position.
+		await expect( page.getByLabel( 'Add pattern' ) ).toBeAttached();
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes #66346. In Zoom Out mode, the inserter that appears after the selected block became unreachable by keyboard whenever the block's lower boundary was scrolled out of the viewport.

## Why?

`BlockPopoverInbetween` is shared by two callers:

- The default hover-driven in-between inserter, where many instances can be mounted at once across a long post.
- The Zoom Out mode inserter, which mounts a single instance tied to the current block selection.

Both were gated behind `isBlockVisible( previousClientId ) && isBlockVisible( nextClientId )`, an IntersectionObserver-backed check that skips rendering while the anchor blocks are off-screen. That's a reasonable optimization for the many-instances case, but for Zoom Out mode's single, selection-driven instance it means the only keyboard target after the selected block disappears from the DOM entirely once that block is tall enough for its lower boundary to scroll out of view.

## How?

Added an `alwaysVisible` prop to `BlockPopoverInbetween` that bypasses the intersection-based gate. Zoom Out mode's inserter opts into it; the default in-between inserter's behavior is unchanged.

## Testing Instructions

1. Apply the patch (or check out this branch).
2. In the site editor, insert a few full-viewport-height (100vh) sections/patterns stacked vertically.
3. Enter Zoom Out mode.
4. Select the first section, so the gap/inserter after it is scrolled below the current viewport.
5. Press Tab from the selected block.

**Before:** focus skips past the inserter entirely — it isn't in the DOM.
**After:** focus reaches the "Add pattern" button even though it's off-screen (the browser scrolls it into view).

Also added an e2e regression test (`test/e2e/specs/site-editor/zoom-out.spec.js`) asserting the inserter stays attached to the DOM in this scenario. I wasn't able to run the e2e suite locally (no network access to `wp-env` in my sandbox), so please double check it in CI.
