### PR TITLE
Site title: Add fit-text support.

### DIFF
--- a/backport-changelog/7.2/13287.md
+++ b/backport-changelog/7.2/13287.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13287
+
+* https://github.com/WordPress/gutenberg/pull/82074

--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -964,7 +964,7 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 
 -	**Name:** [core/site-title](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-site-title/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight, textAlign), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fitText, fontSize, lineHeight, textAlign), ~~html~~
 -	**Attributes:** isLink, level, levelOptions, linkTarget
 
 ## Social Icon

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -259,11 +259,6 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 		if ( ! empty( $block_content ) ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
-				/*
-				 * Static blocks serialize this class into their saved markup, but
-				 * dynamically rendered blocks have no save step, so it is added here.
-				 * `add_class()` is a no-op when the class is already present.
-				 */
 				$processor->add_class( 'has-fit-text' );
 				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
 					$processor->set_attribute( 'data-wp-interactive', true );

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -259,6 +259,12 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 		if ( ! empty( $block_content ) ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
+				/*
+				 * Static blocks serialize this class into their saved markup, but
+				 * dynamically rendered blocks have no save step, so it is added here.
+				 * `add_class()` is a no-op when the class is already present.
+				 */
+				$processor->add_class( 'has-fit-text' );
 				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
 					$processor->set_attribute( 'data-wp-interactive', true );
 				}

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 -   Gallery: Support viewport-specific column counts and image cropping in the Flex layout.
 -   `List`: Add wide and full alignment support ([#68002](https://github.com/WordPress/gutenberg/pull/68002)).
+-   Site Title: Add Fit text support, so the title can resize to fill its container as it already can in the Heading and Paragraph blocks.
 
 ### Internal
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -41,7 +41,6 @@
 -   Accordion: Resolve the URL fragment with the `:target` pseudo-class instead of decoding `window.location.hash`, so a hash containing malformed percent-encoding no longer throws a `URIError` when a panel is opened ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
 -   Post Template: Pass an explicit default layout to the inner blocks of the Post Template and Term Template blocks, so the movers, inserters, and child controls of the template's blocks no longer follow the grid used to arrange the post/term items ([#81120](https://github.com/WordPress/gutenberg/pull/81120)).
 -   Accordion Heading: Declare the spacing selector in the block's `selectors` map, so padding set in `theme.json` or Global Styles applies to the toggle button the block writes its own padding to, rather than to the heading wrapper where it could not lower the default ([#81976](https://github.com/WordPress/gutenberg/pull/81976)).
--   Fit text: Apply the non-wrapping style to the descendants of a block using Fit text as well as the block itself, so blocks whose editable element is a child of the block wrapper, such as Site Title, no longer keep wrapping in the editor and grow far beyond their container ([#82074](https://github.com/WordPress/gutenberg/pull/82074)).
 
 ## 10.4.0 (2026-08-12)
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 -   Gallery: Support viewport-specific column counts and image cropping in the Flex layout.
 -   `List`: Add wide and full alignment support ([#68002](https://github.com/WordPress/gutenberg/pull/68002)).
--   Site Title: Add Fit text support, so the title can resize to fill its container as it already can in the Heading and Paragraph blocks.
+-   Site Title: Add Fit text support, so the title can resize to fill its container as it already can in the Heading and Paragraph blocks ([#82074](https://github.com/WordPress/gutenberg/pull/82074)).
 
 ### Internal
 
@@ -41,6 +41,7 @@
 -   Accordion: Resolve the URL fragment with the `:target` pseudo-class instead of decoding `window.location.hash`, so a hash containing malformed percent-encoding no longer throws a `URIError` when a panel is opened ([#81780](https://github.com/WordPress/gutenberg/pull/81780)).
 -   Post Template: Pass an explicit default layout to the inner blocks of the Post Template and Term Template blocks, so the movers, inserters, and child controls of the template's blocks no longer follow the grid used to arrange the post/term items ([#81120](https://github.com/WordPress/gutenberg/pull/81120)).
 -   Accordion Heading: Declare the spacing selector in the block's `selectors` map, so padding set in `theme.json` or Global Styles applies to the toggle button the block writes its own padding to, rather than to the heading wrapper where it could not lower the default ([#81976](https://github.com/WordPress/gutenberg/pull/81976)).
+-   Fit text: Apply the non-wrapping style to the descendants of a block using Fit text as well as the block itself, so blocks whose editable element is a child of the block wrapper, such as Site Title, no longer keep wrapping in the editor and grow far beyond their container ([#82074](https://github.com/WordPress/gutenberg/pull/82074)).
 
 ## 10.4.0 (2026-08-12)
 

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -52,7 +52,15 @@
 
 // Fit Text
 .has-fit-text {
-	white-space: nowrap !important;
+	// Descendants are included because rich text applies an inline
+	// `white-space: pre-wrap` to its editable element. When that element is a
+	// child of the block wrapper rather than the wrapper itself, as in the Site
+	// Title block, the text would otherwise still wrap and the fit calculation
+	// would never detect an overflow.
+	&,
+	:where(*) {
+		white-space: nowrap !important;
+	}
 }
 
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -52,15 +52,7 @@
 
 // Fit Text
 .has-fit-text {
-	// Descendants are included because rich text applies an inline
-	// `white-space: pre-wrap` to its editable element. When that element is a
-	// child of the block wrapper rather than the wrapper itself, as in the Site
-	// Title block, the text would otherwise still wrap and the fit calculation
-	// would never detect an overflow.
-	&,
-	:where(*) {
-		white-space: nowrap !important;
-	}
+	white-space: nowrap !important;
 }
 
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.

--- a/packages/block-library/src/site-title/README.md
+++ b/packages/block-library/src/site-title/README.md
@@ -36,6 +36,7 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
   - [`fontSize`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-fontsize): `true`
   - [`lineHeight`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-lineheight): `true`
   - [`textAlign`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#typography-textalign): `true`
+  - `fitText`: `true`
 - [`interactivity`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#interactivity):
   - `clientNavigation`: `true`
 

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -61,6 +61,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalWritingMode": true,
+			"fitText": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/site-title/editor.scss
+++ b/packages/block-library/src/site-title/editor.scss
@@ -2,3 +2,8 @@
 	padding: 1em 0;
 	border: 1px dashed;
 }
+
+// Overrides the inline `white-space: pre-wrap` rich text sets on the editable.
+.wp-block-site-title.has-fit-text > * {
+	white-space: inherit !important;
+}


### PR DESCRIPTION
## What?

Closes #82061

Adds fit-text block support to Site Title:

<img width="3042" height="1714" alt="2026-08-26 14 26 00 localhost ea5be52cd092" src="https://github.com/user-attachments/assets/0e730bcb-4b06-4cca-8294-57af871ab17e" />

## Why?

It affords some nice new designs, and fits neatly into the typography panel there. 

## Testing Instructions

Insert a site title, click the typography ellipsis menu add add fit text to toggle on, observe full-width text in the site title.

## Use of AI Tools

Claude Opus 5 helped.