### PR TITLE
UI: Remove unused outset-ring--focus-within-visible class.

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 ### Internal
 
+-   Remove unused `outset-ring--focus-within-visible` CSS module class.
 -   Restrict `@wordpress/private-apis` imports via lint, with the `ThemeProvider` compatibility fallback as the only exemption. ([#82015](https://github.com/WordPress/gutenberg/pull/82015))
 -   Update `@base-ui/react` from `1.6.0` to `1.7.0`. ([#81390](https://github.com/WordPress/gutenberg/pull/81390))
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -53,11 +53,11 @@
 
 ### Internal
 
--   Remove unused `outset-ring--focus-within-visible` CSS module class.
 -   Restrict `@wordpress/private-apis` imports via lint, with the `ThemeProvider` compatibility fallback as the only exemption. ([#82015](https://github.com/WordPress/gutenberg/pull/82015))
 -   Update `@base-ui/react` from `1.6.0` to `1.7.0`. ([#81390](https://github.com/WordPress/gutenberg/pull/81390))
 -   Point tsconfig references at split dependencies' build projects. ([#81509](https://github.com/WordPress/gutenberg/pull/81509), [#81514](https://github.com/WordPress/gutenberg/pull/81514), [#81516](https://github.com/WordPress/gutenberg/pull/81516), [#81518](https://github.com/WordPress/gutenberg/pull/81518))
 -   Split tsconfig into a build project and a default dev project so dev files are type checked without publishing their declarations. ([#81515](https://github.com/WordPress/gutenberg/pull/81515))
+-   Remove unused `outset-ring--focus-within-visible` CSS module class. ([#82077](https://github.com/WordPress/gutenberg/pull/82077))
 
 ## 0.20.0 (2026-08-12)
 

--- a/packages/ui/src/utils/css/focus.module.scss
+++ b/packages/ui/src/utils/css/focus.module.scss
@@ -7,7 +7,6 @@
 		.outset-ring--focus:focus,
 		.outset-ring--focus-visible:focus-visible,
 		.outset-ring--focus-within:focus-within,
-		.outset-ring--focus-within-visible:focus-within:has(:focus-visible),
 		:focus-visible .outset-ring--focus-parent-visible {
 			@include mixins.focus-ring();
 		}


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
 Remove unused outset-ring--focus-within-visible class.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The utility is not referenced from JS, composes, or docs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
yes