### PR TITLE
Release: Map [Type] Flaky Test to the Tools changelog section

### DIFF
--- a/tools/release/commands/changelog.js
+++ b/tools/release/commands/changelog.js
@@ -66,6 +66,7 @@ const LABEL_TYPE_MAPPING = {
 	'[Package] Scripts': 'Tools',
 	'[Type] Build Tooling': 'Tools',
 	'[Type] Automated Testing': 'Tools',
+	'[Type] Flaky Test': 'Tools',
 	'[Package] Dependency Extraction Webpack Plugin': 'Tools',
 	'[Type] Code Quality': 'Code Quality',
 	'[Focus] Accessibility (a11y)': 'Accessibility',

--- a/tools/release/commands/test/changelog.js
+++ b/tools/release/commands/test/changelog.js
@@ -343,6 +343,14 @@ describe( 'getIssueType', () => {
 
 		expect( result ).toBe( 'Tools' );
 	} );
+
+	it( 'returns the testing type for flaky test fixes', () => {
+		const result = getIssueType( {
+			labels: [ { name: '[Type] Flaky Test' } ],
+		} );
+
+		expect( result ).toBe( 'Tools' );
+	} );
 } );
 
 describe( 'getIssueFeature', () => {


### PR DESCRIPTION
## What?

Adds `[Type] Flaky Test` to `LABEL_TYPE_MAPPING` in the release changelog generator, mapping it to `Tools` — the same section `[Type] Automated Testing` maps to.

## Why?

#81475 added `[Type] Flaky Test` to `LABEL_FEATURE_MAPPING` so flaky test fixes group under a `Testing` sub-heading, but the label was never added to `LABEL_TYPE_MAPPING`. `getIssueType` only reads the latter, so a pull request carrying `[Type] Flaky Test` as its only type label has no readable type and falls through to **Various**.

The result is that two labels describing the same kind of work land in different places. In the 23.9 milestone:

- #81690 "List View: Fix flaky global shortcut test and re-enable it" — `[Type] Automated Testing` → **Tools > Testing**
- #81739 "E2E: Replace flaky router styles screenshot assertions" — `[Type] Flaky Test` → **Various > Testing**

Both are flaky test fixes. Only the label differs.

## How?

One entry in `LABEL_TYPE_MAPPING`, placed next to `[Type] Automated Testing`:

```js
'[Type] Build Tooling': 'Tools',
'[Type] Automated Testing': 'Tools',
'[Type] Flaky Test': 'Tools',
```

The feature mapping is untouched — the `Testing` sub-heading already resolved correctly.

## Testing Instructions

```
npm run test:unit -- tools/release/commands/test/changelog.js
```

A new `getIssueType` case asserts that `[Type] Flaky Test` returns `Tools`; it fails with `Various` before the mapping change. All 55 tests and 4 snapshots pass after it, so existing changelog output is unaffected.

To check against real data:

```
npm run other:changelog -- --milestone="Gutenberg 23.9"
```

#81739 moves from `Various > Testing` to `Tools > Testing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FH5hwWqb4uDzCSp7Ps5Cs4