### PR TITLE
Menu: Stabilize iframe reload unit test

### DIFF
--- a/packages/ui/src/menu/test/index.test.tsx
+++ b/packages/ui/src/menu/test/index.test.tsx
@@ -438,6 +438,10 @@ describe( 'Menu', () => {
 			configurable: true,
 			get: () => iframeDocument,
 		} );
+		const firstAddEventListener = jest.spyOn(
+			firstDocument,
+			'addEventListener'
+		);
 		const firstRemoveEventListener = jest.spyOn(
 			firstDocument,
 			'removeEventListener'
@@ -453,6 +457,13 @@ describe( 'Menu', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
 		expect( await screen.findByRole( 'menu' ) ).toBeVisible();
+		await waitFor( () => {
+			expect( firstAddEventListener ).toHaveBeenCalledWith(
+				'pointerdown',
+				expect.any( Function ),
+				true
+			);
+		} );
 
 		iframeDocument = reloadedDocument;
 		act( () => iframe.dispatchEvent( new Event( 'load' ) ) );


### PR DESCRIPTION
Related: #82039

## What?

Stabilizes the Menu iframe reload unit test.

## Why?

The test can simulate an iframe reload before the initial document listener is attached.

## How?

Waits for the initial pointer listener before simulating the reload.

## Testing Instructions

Run: npm run test:unit packages/ui/src/menu/test/index.test.tsx -- --runInBand

## Use of AI Tools

Codex was used to investigate, implement, test, and review this change.