### PR TITLE
Packages: Restore the August 26 npm release versions on wp/latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50156,7 +50156,7 @@
 		},
 		"packages/a11y": {
 			"name": "@wordpress/a11y",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dom-ready": "file:../dom-ready",
@@ -50173,7 +50173,7 @@
 		},
 		"packages/abilities": {
 			"name": "@wordpress/abilities",
-			"version": "0.19.0",
+			"version": "0.20.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/data": "file:../data",
@@ -50209,7 +50209,7 @@
 		},
 		"packages/admin-ui": {
 			"name": "@wordpress/admin-ui",
-			"version": "2.8.0",
+			"version": "2.9.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "file:../components",
@@ -50246,7 +50246,7 @@
 		},
 		"packages/annotations": {
 			"name": "@wordpress/annotations",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/data": "file:../data",
@@ -50269,7 +50269,7 @@
 		},
 		"packages/api-fetch": {
 			"name": "@wordpress/api-fetch",
-			"version": "7.53.0",
+			"version": "7.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/i18n": "file:../i18n",
@@ -50286,7 +50286,7 @@
 		},
 		"packages/asset-loader": {
 			"name": "@wordpress/asset-loader",
-			"version": "1.19.0",
+			"version": "1.20.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -50295,7 +50295,7 @@
 		},
 		"packages/autop": {
 			"name": "@wordpress/autop",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0"
@@ -50307,7 +50307,7 @@
 		},
 		"packages/babel-plugin-import-jsx-pragma": {
 			"name": "@wordpress/babel-plugin-import-jsx-pragma",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@babel/plugin-syntax-jsx": "^7.25.7"
@@ -50322,7 +50322,7 @@
 		},
 		"packages/babel-plugin-makepot": {
 			"name": "@wordpress/babel-plugin-makepot",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"deepmerge": "^4.3.1",
@@ -50342,7 +50342,7 @@
 		},
 		"packages/babel-preset-default": {
 			"name": "@wordpress/babel-preset-default",
-			"version": "8.53.0",
+			"version": "8.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "^7.25.7",
@@ -50397,7 +50397,7 @@
 		},
 		"packages/base-styles": {
 			"name": "@wordpress/base-styles",
-			"version": "12.1.0",
+			"version": "13.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/stylelint-tools": "file:../../tools/stylelint"
@@ -50409,7 +50409,7 @@
 		},
 		"packages/blob": {
 			"name": "@wordpress/blob",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.9.1",
@@ -50423,7 +50423,7 @@
 		},
 		"packages/block-directory": {
 			"name": "@wordpress/block-directory",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -50466,7 +50466,7 @@
 		},
 		"packages/block-editor": {
 			"name": "@wordpress/block-editor",
-			"version": "16.2.0",
+			"version": "17.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -50561,7 +50561,7 @@
 		},
 		"packages/block-library": {
 			"name": "@wordpress/block-library",
-			"version": "10.4.0",
+			"version": "10.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@arraypress/waveform-player": "^1.26.0",
@@ -50641,7 +50641,7 @@
 		},
 		"packages/block-serialization-default-parser": {
 			"name": "@wordpress/block-serialization-default-parser",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/block-serialization-spec-parser": "file:../block-serialization-spec-parser"
@@ -50653,7 +50653,7 @@
 		},
 		"packages/block-serialization-spec-parser": {
 			"name": "@wordpress/block-serialization-spec-parser",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"pegjs": "^0.10.0",
@@ -50666,7 +50666,7 @@
 		},
 		"packages/blocks": {
 			"name": "@wordpress/blocks",
-			"version": "15.26.0",
+			"version": "15.27.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/autop": "file:../autop",
@@ -50722,7 +50722,7 @@
 		},
 		"packages/boot": {
 			"name": "@wordpress/boot",
-			"version": "0.20.0",
+			"version": "0.21.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -50770,7 +50770,7 @@
 		},
 		"packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"browserslist": "^4.28.4"
@@ -50782,7 +50782,7 @@
 		},
 		"packages/commands": {
 			"name": "@wordpress/commands",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -50810,7 +50810,7 @@
 		},
 		"packages/components": {
 			"name": "@wordpress/components",
-			"version": "39.0.0",
+			"version": "40.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.37",
@@ -50952,7 +50952,7 @@
 		},
 		"packages/compose": {
 			"name": "@wordpress/compose",
-			"version": "8.6.0",
+			"version": "8.7.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
@@ -51017,7 +51017,7 @@
 		},
 		"packages/core-abilities": {
 			"name": "@wordpress/core-abilities",
-			"version": "0.18.0",
+			"version": "0.19.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/abilities": "file:../abilities",
@@ -51031,7 +51031,7 @@
 		},
 		"packages/core-commands": {
 			"name": "@wordpress/core-commands",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "file:../block-editor",
@@ -51059,7 +51059,7 @@
 		},
 		"packages/core-data": {
 			"name": "@wordpress/core-data",
-			"version": "7.53.0",
+			"version": "7.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -51151,7 +51151,7 @@
 		},
 		"packages/create-block": {
 			"name": "@wordpress/create-block",
-			"version": "4.96.0",
+			"version": "4.97.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
@@ -51178,7 +51178,7 @@
 		},
 		"packages/create-block-interactive-template": {
 			"name": "@wordpress/create-block-interactive-template",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -51187,7 +51187,7 @@
 		},
 		"packages/create-block-tutorial-template": {
 			"name": "@wordpress/create-block-tutorial-template",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -51196,7 +51196,7 @@
 		},
 		"packages/customize-widgets": {
 			"name": "@wordpress/customize-widgets",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../admin-ui",
@@ -51259,7 +51259,7 @@
 		},
 		"packages/data": {
 			"name": "@wordpress/data",
-			"version": "10.53.0",
+			"version": "10.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/compose": "file:../compose",
@@ -51299,7 +51299,7 @@
 		},
 		"packages/data-controls": {
 			"name": "@wordpress/data-controls",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -51316,7 +51316,7 @@
 		},
 		"packages/dataviews": {
 			"name": "@wordpress/dataviews",
-			"version": "18.0.0",
+			"version": "18.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.37",
@@ -51372,7 +51372,7 @@
 		},
 		"packages/date": {
 			"name": "@wordpress/date",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "file:../deprecated",
@@ -51386,7 +51386,7 @@
 		},
 		"packages/dependency-extraction-webpack-plugin": {
 			"name": "@wordpress/dependency-extraction-webpack-plugin",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"json2php": "^0.0.9"
@@ -51411,7 +51411,7 @@
 		},
 		"packages/deprecated": {
 			"name": "@wordpress/deprecated",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/hooks": "file:../hooks"
@@ -51427,7 +51427,7 @@
 		},
 		"packages/design-system-mcp": {
 			"name": "@wordpress/design-system-mcp",
-			"version": "0.10.0",
+			"version": "0.11.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
@@ -51457,7 +51457,7 @@
 		},
 		"packages/docgen": {
 			"name": "@wordpress/docgen",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "^7.25.7",
@@ -51481,7 +51481,7 @@
 		},
 		"packages/dom": {
 			"name": "@wordpress/dom",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "file:../deprecated"
@@ -51493,7 +51493,7 @@
 		},
 		"packages/dom-ready": {
 			"name": "@wordpress/dom-ready",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0"
@@ -51505,7 +51505,7 @@
 		},
 		"packages/e2e-test-utils-playwright": {
 			"name": "@wordpress/e2e-test-utils-playwright",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2",
@@ -51535,7 +51535,7 @@
 		},
 		"packages/e2e-tests": {
 			"name": "@wordpress/e2e-tests",
-			"version": "9.18.0",
+			"version": "9.19.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/interactivity": "file:../interactivity",
@@ -51556,7 +51556,7 @@
 		},
 		"packages/edit-post": {
 			"name": "@wordpress/edit-post",
-			"version": "8.53.0",
+			"version": "8.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -51610,7 +51610,7 @@
 		},
 		"packages/edit-site": {
 			"name": "@wordpress/edit-site",
-			"version": "7.2.0",
+			"version": "7.3.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -51692,7 +51692,7 @@
 		},
 		"packages/edit-widgets": {
 			"name": "@wordpress/edit-widgets",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../admin-ui",
@@ -51743,7 +51743,7 @@
 		},
 		"packages/editor": {
 			"name": "@wordpress/editor",
-			"version": "14.53.0",
+			"version": "14.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -51832,7 +51832,7 @@
 		},
 		"packages/element": {
 			"name": "@wordpress/element",
-			"version": "8.5.0",
+			"version": "8.6.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "file:../deprecated",
@@ -51867,7 +51867,7 @@
 		},
 		"packages/env": {
 			"name": "@wordpress/env",
-			"version": "11.13.0",
+			"version": "11.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
@@ -51894,7 +51894,7 @@
 		},
 		"packages/escape-html": {
 			"name": "@wordpress/escape-html",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0"
@@ -51906,7 +51906,7 @@
 		},
 		"packages/eslint-plugin": {
 			"name": "@wordpress/eslint-plugin",
-			"version": "25.9.0",
+			"version": "25.10.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.28.6",
@@ -52082,7 +52082,7 @@
 		},
 		"packages/fields": {
 			"name": "@wordpress/fields",
-			"version": "0.45.0",
+			"version": "0.46.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@react-spring/web": "^9.4.5",
@@ -52136,7 +52136,7 @@
 		},
 		"packages/format-library": {
 			"name": "@wordpress/format-library",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52171,7 +52171,7 @@
 		},
 		"packages/global-styles-engine": {
 			"name": "@wordpress/global-styles-engine",
-			"version": "1.20.0",
+			"version": "1.21.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/blocks": "file:../blocks",
@@ -52195,7 +52195,7 @@
 		},
 		"packages/global-styles-ui": {
 			"name": "@wordpress/global-styles-ui",
-			"version": "1.20.0",
+			"version": "1.21.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52241,7 +52241,7 @@
 		},
 		"packages/grid": {
 			"name": "@wordpress/grid",
-			"version": "0.5.0",
+			"version": "0.6.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",
@@ -52279,7 +52279,7 @@
 		},
 		"packages/hooks": {
 			"name": "@wordpress/hooks",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"benchmark": "^2.1.4"
@@ -52291,7 +52291,7 @@
 		},
 		"packages/html-entities": {
 			"name": "@wordpress/html-entities",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0",
@@ -52304,7 +52304,7 @@
 		},
 		"packages/i18n": {
 			"name": "@wordpress/i18n",
-			"version": "6.26.0",
+			"version": "6.27.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
@@ -52326,7 +52326,7 @@
 		},
 		"packages/icons": {
 			"name": "@wordpress/icons",
-			"version": "15.4.0",
+			"version": "15.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "file:../element",
@@ -52353,7 +52353,7 @@
 		},
 		"packages/image-cropper": {
 			"name": "@wordpress/image-cropper",
-			"version": "1.17.0",
+			"version": "1.18.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "file:../components",
@@ -52383,7 +52383,7 @@
 		},
 		"packages/interactivity": {
 			"name": "@wordpress/interactivity",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
@@ -52400,7 +52400,7 @@
 		},
 		"packages/interactivity-router": {
 			"name": "@wordpress/interactivity-router",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52418,7 +52418,7 @@
 		},
 		"packages/interface": {
 			"name": "@wordpress/interface",
-			"version": "9.38.0",
+			"version": "10.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52451,7 +52451,7 @@
 		},
 		"packages/is-shallow-equal": {
 			"name": "@wordpress/is-shallow-equal",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0",
@@ -52465,7 +52465,7 @@
 		},
 		"packages/jest-console": {
 			"name": "@wordpress/jest-console",
-			"version": "9.1.0",
+			"version": "9.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"jest-matcher-utils": "^30.4.1",
@@ -52568,7 +52568,7 @@
 		},
 		"packages/jest-preset-default": {
 			"name": "@wordpress/jest-preset-default",
-			"version": "14.0.0",
+			"version": "14.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/jest-console": "file:../jest-console",
@@ -52589,7 +52589,7 @@
 		},
 		"packages/kebab-case": {
 			"name": "@wordpress/kebab-case",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2"
@@ -52601,7 +52601,7 @@
 		},
 		"packages/keyboard-shortcuts": {
 			"name": "@wordpress/keyboard-shortcuts",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/data": "file:../data",
@@ -52624,7 +52624,7 @@
 		},
 		"packages/keycodes": {
 			"name": "@wordpress/keycodes",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/i18n": "file:../i18n"
@@ -52647,7 +52647,7 @@
 		},
 		"packages/latex-to-mathml": {
 			"name": "@wordpress/latex-to-mathml",
-			"version": "1.21.0",
+			"version": "1.22.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"temml": "^0.10.33"
@@ -52659,7 +52659,7 @@
 		},
 		"packages/lazy-editor": {
 			"name": "@wordpress/lazy-editor",
-			"version": "1.19.0",
+			"version": "1.20.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/asset-loader": "file:../asset-loader",
@@ -52691,7 +52691,7 @@
 		},
 		"packages/lazy-import": {
 			"name": "@wordpress/lazy-import",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"execa": "^4.0.2",
@@ -52710,7 +52710,7 @@
 		},
 		"packages/list-reusable-blocks": {
 			"name": "@wordpress/list-reusable-blocks",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -52740,7 +52740,7 @@
 		},
 		"packages/media-editor": {
 			"name": "@wordpress/media-editor",
-			"version": "0.16.0",
+			"version": "0.17.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52788,7 +52788,7 @@
 		},
 		"packages/media-fields": {
 			"name": "@wordpress/media-fields",
-			"version": "0.18.0",
+			"version": "0.19.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -52828,7 +52828,7 @@
 		},
 		"packages/media-utils": {
 			"name": "@wordpress/media-utils",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -52872,7 +52872,7 @@
 		},
 		"packages/notices": {
 			"name": "@wordpress/notices",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52903,7 +52903,7 @@
 		},
 		"packages/npm-package-json-lint-config": {
 			"name": "@wordpress/npm-package-json-lint-config",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -52915,7 +52915,7 @@
 		},
 		"packages/nux": {
 			"name": "@wordpress/nux",
-			"version": "10.5.0",
+			"version": "10.6.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/data": "file:../data",
@@ -52937,7 +52937,7 @@
 		},
 		"packages/patterns": {
 			"name": "@wordpress/patterns",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -52968,7 +52968,7 @@
 		},
 		"packages/plugins": {
 			"name": "@wordpress/plugins",
-			"version": "7.53.0",
+			"version": "7.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "file:../components",
@@ -53009,7 +53009,7 @@
 		},
 		"packages/postcss-plugins-preset": {
 			"name": "@wordpress/postcss-plugins-preset",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -53027,7 +53027,7 @@
 		},
 		"packages/postcss-themes": {
 			"name": "@wordpress/postcss-themes",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -53039,7 +53039,7 @@
 		},
 		"packages/preferences": {
 			"name": "@wordpress/preferences",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -53074,7 +53074,7 @@
 		},
 		"packages/preferences-persistence": {
 			"name": "@wordpress/preferences-persistence",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch"
@@ -53086,7 +53086,7 @@
 		},
 		"packages/prettier-config": {
 			"name": "@wordpress/prettier-config",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/node": "^20.19.39",
@@ -53103,7 +53103,7 @@
 		},
 		"packages/primitives": {
 			"name": "@wordpress/primitives",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "file:../element",
@@ -53125,7 +53125,7 @@
 		},
 		"packages/priority-queue": {
 			"name": "@wordpress/priority-queue",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -53141,7 +53141,7 @@
 		},
 		"packages/private-apis": {
 			"name": "@wordpress/private-apis",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"react": "^18.3.1"
@@ -53153,7 +53153,7 @@
 		},
 		"packages/project-management-automation": {
 			"name": "@wordpress/project-management-automation",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@actions/core": "^1.9.1",
@@ -53185,7 +53185,7 @@
 		},
 		"packages/react-i18n": {
 			"name": "@wordpress/react-i18n",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "file:../element",
@@ -53208,7 +53208,7 @@
 		},
 		"packages/readable-js-assets-webpack-plugin": {
 			"name": "@wordpress/readable-js-assets-webpack-plugin",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"glob": "^7.1.2",
@@ -53227,7 +53227,7 @@
 		},
 		"packages/redux-routine": {
 			"name": "@wordpress/redux-routine",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.1.0",
@@ -53396,7 +53396,7 @@
 		},
 		"packages/reusable-blocks": {
 			"name": "@wordpress/reusable-blocks",
-			"version": "5.53.0",
+			"version": "5.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
@@ -53428,7 +53428,7 @@
 		},
 		"packages/rich-text": {
 			"name": "@wordpress/rich-text",
-			"version": "7.53.0",
+			"version": "7.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "file:../a11y",
@@ -53462,7 +53462,7 @@
 		},
 		"packages/route": {
 			"name": "@wordpress/route",
-			"version": "0.19.0",
+			"version": "0.20.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tanstack/history": "^1.133.28",
@@ -53479,7 +53479,7 @@
 		},
 		"packages/router": {
 			"name": "@wordpress/router",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/compose": "file:../compose",
@@ -53505,7 +53505,7 @@
 		},
 		"packages/scripts": {
 			"name": "@wordpress/scripts",
-			"version": "34.1.0",
+			"version": "34.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "^7.25.7",
@@ -53898,7 +53898,7 @@
 		},
 		"packages/server-side-render": {
 			"name": "@wordpress/server-side-render",
-			"version": "6.29.0",
+			"version": "6.30.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -53931,7 +53931,7 @@
 		},
 		"packages/shortcode": {
 			"name": "@wordpress/shortcode",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"memize": "^2.1.1"
@@ -53946,7 +53946,7 @@
 		},
 		"packages/style-engine": {
 			"name": "@wordpress/style-engine",
-			"version": "2.53.0",
+			"version": "2.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2"
@@ -53966,7 +53966,7 @@
 		},
 		"packages/style-runtime": {
 			"name": "@wordpress/style-runtime",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.9.1",
@@ -53979,7 +53979,7 @@
 		},
 		"packages/stylelint-config": {
 			"name": "@wordpress/stylelint-config",
-			"version": "24.2.0",
+			"version": "24.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.1.3",
@@ -54046,7 +54046,7 @@
 		},
 		"packages/sync": {
 			"name": "@wordpress/sync",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -54071,7 +54071,7 @@
 		},
 		"packages/theme": {
 			"name": "@wordpress/theme",
-			"version": "1.2.0",
+			"version": "2.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/compose": "file:../compose",
@@ -54219,7 +54219,7 @@
 		},
 		"packages/token-list": {
 			"name": "@wordpress/token-list",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0"
@@ -54231,7 +54231,7 @@
 		},
 		"packages/ui": {
 			"name": "@wordpress/ui",
-			"version": "0.20.0",
+			"version": "0.21.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@base-ui/react": "^1.7.0",
@@ -54281,7 +54281,7 @@
 		},
 		"packages/undo-manager": {
 			"name": "@wordpress/undo-manager",
-			"version": "1.53.0",
+			"version": "1.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal"
@@ -54296,7 +54296,7 @@
 		},
 		"packages/upload-media": {
 			"name": "@wordpress/upload-media",
-			"version": "0.38.0",
+			"version": "0.39.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/blob": "file:../blob",
@@ -54332,7 +54332,7 @@
 		},
 		"packages/url": {
 			"name": "@wordpress/url",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"remove-accents": "^0.5.0"
@@ -54344,7 +54344,7 @@
 		},
 		"packages/video-conversion": {
 			"name": "@wordpress/video-conversion",
-			"version": "0.4.0",
+			"version": "0.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/worker-threads": "file:../worker-threads",
@@ -54360,7 +54360,7 @@
 		},
 		"packages/viewport": {
 			"name": "@wordpress/viewport",
-			"version": "6.53.0",
+			"version": "6.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/compose": "file:../compose",
@@ -54388,7 +54388,7 @@
 		},
 		"packages/views": {
 			"name": "@wordpress/views",
-			"version": "1.20.0",
+			"version": "1.21.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/core-data": "file:../core-data",
@@ -54412,7 +54412,7 @@
 		},
 		"packages/vips": {
 			"name": "@wordpress/vips",
-			"version": "3.1.0",
+			"version": "4.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/worker-threads": "file:../worker-threads",
@@ -54429,7 +54429,7 @@
 		},
 		"packages/warning": {
 			"name": "@wordpress/warning",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@babel/core": "^7.25.7"
@@ -54441,7 +54441,7 @@
 		},
 		"packages/widget-dashboard": {
 			"name": "@wordpress/widget-dashboard",
-			"version": "0.5.0",
+			"version": "0.6.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/commands": "file:../commands",
@@ -54489,7 +54489,7 @@
 		},
 		"packages/widget-primitives": {
 			"name": "@wordpress/widget-primitives",
-			"version": "0.5.0",
+			"version": "0.6.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dataviews": "file:../dataviews",
@@ -54522,7 +54522,7 @@
 		},
 		"packages/widgets": {
 			"name": "@wordpress/widgets",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -54550,7 +54550,7 @@
 		},
 		"packages/wordcount": {
 			"name": "@wordpress/wordcount",
-			"version": "4.53.0",
+			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@types/jest": "^30.0.0"
@@ -54562,7 +54562,7 @@
 		},
 		"packages/worker-threads": {
 			"name": "@wordpress/worker-threads",
-			"version": "1.13.0",
+			"version": "1.14.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"comctx": "^1.4.3"
@@ -54605,7 +54605,7 @@
 		},
 		"packages/wp-build": {
 			"name": "@wordpress/build",
-			"version": "0.21.0",
+			"version": "0.22.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@emotion/babel-plugin": "^11.13.5",

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/a11y",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Accessibility (a11y) utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/abilities/package.json
+++ b/packages/abilities/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/abilities",
-	"version": "0.20.0-prerelease",
+	"version": "0.20.0",
 	"description": "JavaScript client for WordPress Abilities API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/admin-ui",
-	"version": "2.9.0-prerelease",
+	"version": "2.9.0",
 	"description": "Generic components to be used in the Admin UI.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/annotations",
-	"version": "3.54.0-prerelease",
+	"version": "3.54.0",
 	"description": "Annotate content in the Gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/api-fetch",
-	"version": "7.54.0-prerelease",
+	"version": "7.54.0",
 	"description": "Utility to make WordPress REST API requests.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/asset-loader/package.json
+++ b/packages/asset-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/asset-loader",
-	"version": "1.20.0-prerelease",
+	"version": "1.20.0",
 	"description": "Utility to dynamically load WordPress scripts and styles with dependency resolution.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/autop",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "WordPress's automatic paragraph functions `autop` and `removep`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-plugin-import-jsx-pragma",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-plugin-makepot",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "WordPress Babel internationalization (i18n) plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/babel-preset-default",
-	"version": "8.54.0-prerelease",
+	"version": "8.54.0",
 	"description": "Default Babel preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/base-styles/package.json
+++ b/packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/base-styles",
-	"version": "13.0.0-prerelease",
+	"version": "13.0.0",
 	"description": "Base SCSS utilities and variables for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/blob",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Blob utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-directory",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Extend editor with block directory features to search, download and install blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-editor",
-	"version": "17.0.0-prerelease",
+	"version": "17.0.0",
 	"description": "Generic block editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "10.5.0-prerelease",
+	"version": "10.5.0",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-default-parser",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-serialization-spec-parser",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Block serialization specification parser for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/blocks",
-	"version": "15.27.0-prerelease",
+	"version": "15.27.0",
 	"description": "Block API for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/boot",
-	"version": "0.21.0-prerelease",
+	"version": "0.21.0",
 	"description": "Minimal boot package for WordPress admin pages.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/browserslist-config",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "WordPress Browserslist shared configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/commands",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "Handles the commands menu.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/components",
-	"version": "40.0.0-prerelease",
+	"version": "40.0.0",
 	"description": "UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/compose",
-	"version": "8.7.0-prerelease",
+	"version": "8.7.0",
 	"description": "WordPress higher-order components (HOCs).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-abilities/package.json
+++ b/packages/core-abilities/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-abilities",
-	"version": "0.19.0-prerelease",
+	"version": "0.19.0",
 	"description": "WordPress core abilities integration for the Abilities API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-commands",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "WordPress core reusable commands.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/core-data",
-	"version": "7.54.0-prerelease",
+	"version": "7.54.0",
 	"description": "Access to and manipulation of core WordPress entities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/create-block-interactive-template/package.json
+++ b/packages/create-block-interactive-template/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/create-block-interactive-template",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "Template for @wordpress/create-block to create interactive blocks with the Interactivity API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/create-block-tutorial-template/package.json
+++ b/packages/create-block-tutorial-template/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/create-block-tutorial-template",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "This is a template for @wordpress/create-block that creates an example 'Copyright Date' block. This block is used in the official WordPress block development Quick Start Guide.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/create-block",
-	"version": "4.97.0-prerelease",
+	"version": "4.97.0",
 	"description": "Generates PHP, JS and CSS code for registering a block for a WordPress plugin.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/customize-widgets",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Widgets blocks in Customizer Module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/data-controls",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "A set of common controls for the @wordpress/data api.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/data",
-	"version": "10.54.0-prerelease",
+	"version": "10.54.0",
 	"description": "Data module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dataviews",
-	"version": "18.1.0-prerelease",
+	"version": "18.1.0",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/date",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Date module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dependency-extraction-webpack-plugin",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "Extract WordPress script dependencies from webpack bundles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/deprecated",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Deprecation utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/design-system-mcp",
-	"version": "0.11.0-prerelease",
+	"version": "0.11.0",
 	"description": "MCP server for the WordPress Design System.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/docgen",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "Autogenerate public API documentation from exports and JSDoc comments.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom-ready",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Execute callback after the DOM is loaded.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dom",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "DOM utilities module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/e2e-test-utils-playwright",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "End-To-End (E2E) test utils for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/e2e-tests",
-	"version": "9.19.0-prerelease",
+	"version": "9.19.0",
 	"description": "Test plugins and mu-plugins for E2E tests in WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "8.54.0-prerelease",
+	"version": "8.54.0",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "7.3.0-prerelease",
+	"version": "7.3.0",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-widgets",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "Widgets Page module for WordPress..",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "14.54.0-prerelease",
+	"version": "14.54.0",
 	"description": "Enhanced block editor for WordPress posts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/element",
-	"version": "8.6.0-prerelease",
+	"version": "8.6.0",
 	"description": "Element React module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/env",
-	"version": "11.14.0-prerelease",
+	"version": "11.14.0",
 	"description": "A zero-config, self contained local WordPress environment for development and testing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/escape-html",
-	"version": "3.54.0-prerelease",
+	"version": "3.54.0",
 	"description": "Escape HTML utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/eslint-plugin",
-	"version": "25.10.0-prerelease",
+	"version": "25.10.0",
 	"description": "ESLint plugin for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/fields",
-	"version": "0.46.0-prerelease",
+	"version": "0.46.0",
 	"description": "DataViews is a component that provides an API to render datasets using different types of layouts (table, grid, list, etc.).",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/format-library",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Format library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/global-styles-engine/package.json
+++ b/packages/global-styles-engine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/global-styles-engine",
-	"version": "1.21.0-prerelease",
+	"version": "1.21.0",
 	"description": "Pure CSS generation engine for WordPress global styles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/global-styles-ui",
-	"version": "1.21.0-prerelease",
+	"version": "1.21.0",
 	"description": "Global Styles UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/grid",
-	"version": "0.6.0-prerelease",
+	"version": "0.6.0",
 	"description": "Grid layout components for arranging tiles in dashboard-style surfaces, with drag-to-reorder and tile resizing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/hooks",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "WordPress hooks library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/html-entities",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "HTML entity utilities for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/i18n",
-	"version": "6.27.0-prerelease",
+	"version": "6.27.0",
 	"description": "WordPress internationalization (i18n) library.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/icons",
-	"version": "15.5.0-prerelease",
+	"version": "15.5.0",
 	"description": "WordPress Icons package, based on dashicon.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/image-cropper/package.json
+++ b/packages/image-cropper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/image-cropper",
-	"version": "1.18.0-prerelease",
+	"version": "1.18.0",
 	"description": "A basic image cropper component.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/interactivity-router",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "Package that exposes state and actions from the `core/router` store, part of the Interactivity API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/interactivity",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "Package that provides a standard and simple way to handle the frontend interactivity of Gutenberg blocks.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/interface",
-	"version": "10.0.0-prerelease",
+	"version": "10.0.0",
 	"description": "Interface module for WordPress. The package contains shared functionality across the modern JavaScript-based WordPress screens.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/is-shallow-equal",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Test for shallow equality between two objects or arrays.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-console",
-	"version": "9.2.0-prerelease",
+	"version": "9.2.0",
 	"description": "Custom Jest matchers for the Console object.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/jest-preset-default",
-	"version": "14.1.0-prerelease",
+	"version": "14.1.0",
 	"description": "Default Jest preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/kebab-case/package.json
+++ b/packages/kebab-case/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/kebab-case",
-	"version": "1.1.0-prerelease",
+	"version": "1.1.0",
 	"description": "Convert strings to kebab-case, matching WordPress Core's `_wp_to_kebab_case()`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/keyboard-shortcuts",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Handling keyboard shortcuts.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/keycodes",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Keycodes utilities for WordPress. Used to check for keyboard events across browsers/operating systems.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/latex-to-mathml/package.json
+++ b/packages/latex-to-mathml/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/latex-to-mathml",
-	"version": "1.22.0-prerelease",
+	"version": "1.22.0",
 	"description": "Convert LaTeX math syntax to MathML.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/lazy-editor/package.json
+++ b/packages/lazy-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/lazy-editor",
-	"version": "1.20.0-prerelease",
+	"version": "1.20.0",
 	"description": "Lazy-loading editor component with automatic asset and settings management.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/lazy-import/package.json
+++ b/packages/lazy-import/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/lazy-import",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "Lazily import a module, installing it automatically if missing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/list-reusable-blocks",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Adding Export/Import support to the reusable blocks listing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-editor/package.json
+++ b/packages/media-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-editor",
-	"version": "0.17.0-prerelease",
+	"version": "0.17.0",
 	"description": "Media editor components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-fields/package.json
+++ b/packages/media-fields/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-fields",
-	"version": "0.19.0-prerelease",
+	"version": "0.19.0",
 	"description": "Reusable field definitions for displaying and editing media attachment properties in WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/media-utils",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "WordPress Media Upload Utils.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/notices",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "State management for notices.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/npm-package-json-lint-config",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "WordPress npm-package-json-lint shareable configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/nux",
-	"version": "10.6.0-prerelease",
+	"version": "10.6.0",
 	"description": "Deprecated no-op NUX (New User eXperience) compatibility module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/patterns",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "Management of user pattern editing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/plugins",
-	"version": "7.54.0-prerelease",
+	"version": "7.54.0",
 	"description": "Plugins module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/postcss-plugins-preset",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "PostCSS sharable plugins preset for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/postcss-themes",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "PostCSS plugin to generate theme colors.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/preferences-persistence",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "Persistence utilities for `wordpress/preferences`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/preferences",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Utilities for managing WordPress preferences.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/prettier-config",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "WordPress Prettier shared configuration.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/primitives",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "WordPress cross-platform primitives.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/priority-queue",
-	"version": "3.54.0-prerelease",
+	"version": "3.54.0",
 	"description": "Generic browser priority queue.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/private-apis/package.json
+++ b/packages/private-apis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/private-apis",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "Internal experimental APIs for WordPress core.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/project-management-automation",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "GitHub Action that implements various automation to assist with managing the Gutenberg GitHub repository.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-i18n",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "React bindings for @wordpress/i18n.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/readable-js-assets-webpack-plugin/package.json
+++ b/packages/readable-js-assets-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/readable-js-assets-webpack-plugin",
-	"version": "3.54.0-prerelease",
+	"version": "3.54.0",
 	"description": "Generate a readable JS file for each JS asset.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/redux-routine",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Redux middleware for generator coroutines.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/reusable-blocks",
-	"version": "5.54.0-prerelease",
+	"version": "5.54.0",
 	"description": "Reusable blocks utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/rich-text",
-	"version": "7.54.0-prerelease",
+	"version": "7.54.0",
 	"description": "Rich text value and manipulation API.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/route/package.json
+++ b/packages/route/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/route",
-	"version": "0.20.0-prerelease",
+	"version": "0.20.0",
 	"description": "Routing utilities for WordPress admin interfaces.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/router",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "Router API for WordPress pages.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/scripts",
-	"version": "34.2.0-prerelease",
+	"version": "34.2.0",
 	"description": "Collection of reusable scripts for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/server-side-render",
-	"version": "6.30.0-prerelease",
+	"version": "6.30.0",
 	"description": "The component used with WordPress to server-side render a preview of dynamic blocks to display in the editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/shortcode",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Shortcode module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/style-engine/package.json
+++ b/packages/style-engine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/style-engine",
-	"version": "2.54.0-prerelease",
+	"version": "2.54.0",
 	"description": "A suite of parsers and compilers for WordPress styles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/style-runtime/package.json
+++ b/packages/style-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/style-runtime",
-	"version": "0.10.0-prerelease",
+	"version": "0.10.0",
 	"description": "Runtime helpers for injecting WordPress package styles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/stylelint-config",
-	"version": "24.3.0-prerelease",
+	"version": "24.3.0",
 	"description": "stylelint config for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/sync",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "Sync Data.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/theme",
-	"version": "2.0.0-prerelease",
+	"version": "2.0.0",
 	"description": "Theme and context provider for the WordPress Design System.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/token-list",
-	"version": "3.54.0-prerelease",
+	"version": "3.54.0",
 	"description": "Constructable, plain JavaScript DOMTokenList implementation, supporting non-browser runtimes.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/ui",
-	"version": "0.21.0-prerelease",
+	"version": "0.21.0",
 	"description": "Themeable React UI components for the WordPress Design System.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/undo-manager/package.json
+++ b/packages/undo-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/undo-manager",
-	"version": "1.54.0-prerelease",
+	"version": "1.54.0",
 	"description": "A small package to manage undo/redo.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/upload-media",
-	"version": "0.39.0-prerelease",
+	"version": "0.39.0",
 	"description": "Core media upload logic.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/url",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "WordPress URL utilities.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/video-conversion/package.json
+++ b/packages/video-conversion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/video-conversion",
-	"version": "0.5.0-prerelease",
+	"version": "0.5.0",
 	"description": "Client-side video conversion for WordPress. Currently converts animated GIFs to MP4/WebM via WebCodecs.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/viewport",
-	"version": "6.54.0-prerelease",
+	"version": "6.54.0",
 	"description": "Viewport module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/views",
-	"version": "1.21.0-prerelease",
+	"version": "1.21.0",
 	"description": "View persistence and management for WordPress DataViews.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/vips/package.json
+++ b/packages/vips/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/vips",
-	"version": "4.0.0-prerelease",
+	"version": "4.0.0",
 	"description": "Utils for working with libvips.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/warning/package.json
+++ b/packages/warning/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/warning",
-	"version": "3.54.0-prerelease",
+	"version": "3.54.0",
 	"description": "Warning utility for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widget-dashboard/package.json
+++ b/packages/widget-dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widget-dashboard",
-	"version": "0.6.0-prerelease",
+	"version": "0.6.0",
 	"description": "Stateless rendering engine for widget dashboards: the WidgetDashboard compound component and its grid-settings kit.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widget-primitives/package.json
+++ b/packages/widget-primitives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widget-primitives",
-	"version": "0.6.0-prerelease",
+	"version": "0.6.0",
 	"description": "Host-agnostic toolkit for dashboard widgets: the widget contract types, the discovery hook, and the render entry point.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/widgets",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "Functionality used by the widgets block editor in the Widgets screen and the Customizer.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/wordcount",
-	"version": "4.54.0-prerelease",
+	"version": "4.54.0",
 	"description": "WordPress word count utility.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/worker-threads/package.json
+++ b/packages/worker-threads/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/worker-threads",
-	"version": "1.14.0-prerelease",
+	"version": "1.14.0",
 	"description": "Utilities for type-safe Web Worker communication with RPC.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/build",
-	"version": "0.22.0-prerelease",
+	"version": "0.22.0",
 	"description": "Build tool for WordPress plugins.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What?

Restores the `package.json` versions and `package-lock.json` workspace entries on `wp/latest` to match the 121 WordPress packages published to npm on August 26, 2026.

This is the `chore(release): publish` commit that the 23.9 RC1 package job created but never pushed. It publishes nothing and creates no tags.

## Why?

The [23.9 RC1 package job](https://github.com/WordPress/gutenberg/actions/runs/32980455745/job/98217425322) published all 121 packages successfully, then failed in the post-publish verification phase while the npm registry was still propagating. The verification allowed roughly three minutes; the last package (`@wordpress/ui@0.21.0`) became visible after about twenty-five.

Because verification runs *before* `pushNpmReleaseGitMetadata`, the run threw before pushing anything, and the version commit — which `lerna version --no-push` had created on the runner — was lost when the runner was torn down.

`wp/latest` is therefore stuck one commit short:

- all 121 `package.json` files still read `X.Y.Z-prerelease`
- `package-lock.json` still holds the previous release's versions
- Static Analysis has been failing on the branch since the changelog commit, because `npm install` rewrites the lockfile to match and leaves the tree dirty

The CHANGELOG sections are already correct — they landed in `0790fa5`.

## How?

Ran `npx lerna version minor --no-private --no-push --yes` from `wp/latest`, which is exactly what the release job runs. On a `-prerelease` version a minor bump resolves to the same number (`0.21.0-prerelease` → `0.21.0`), so this reproduces the published versions rather than advancing them.

Verified before opening: all 121 versions in this commit match what is on npm, and 0 packages still carry a `-prerelease` suffix.

The 121 package tags are deliberately **not** included. They must point at the commit that actually lands on `wp/latest`, so they will be created and pushed against the merged SHA in a follow-up step.

## Testing Instructions

Confirm every version in this commit is already published:

```sh
git checkout packages/restore-wp-latest-23-9-versions
npx lerna list --json --no-private \
  | jq -r '.[] | "\(.name)@\(.version)"' \
  | while read pv; do
      npm view "$pv" version >/dev/null 2>&1 || echo "NOT ON NPM: $pv"
    done
```

This should print nothing — every local version should already exist on npm.

Confirm the lockfile agrees with the manifests, and that Static Analysis passes on this branch.

### Testing Instructions for Keyboard

Not applicable; this does not change UI.

## Screenshots or screencast

Not applicable.

---

### Remaining recovery steps (not in this PR)

1. Push the 121 package tags, pointing at the merged commit on `wp/latest`.
2. Backport the release metadata to `trunk` and `release/23.9`, following the approach in #81303 and #81304 — using the prepared release sections and leaving post-publication entries under `Unreleased`.

Note that npm's `gitHead` on all 121 packages permanently references `5ef24f60261976bb198ad035db24bf81c1fb92b4`, the lost runner commit. That reference cannot be repaired, since published manifests are immutable. Nothing reads `gitHead` at install time.

Related: #78253, #79904, #80187, and #79906 — the closed PR that would have pushed the release branch during preparation and made this class of failure recoverable.
