### PR TITLE
Build: Enforce NodeNext resolution for ESM packages

### DIFF
--- a/packages/design-system-mcp/CHANGELOG.md
+++ b/packages/design-system-mcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
+
 ## 0.11.0 (2026-08-26)
 
 ### Breaking Changes

--- a/packages/design-system-mcp/tsconfig.build.json
+++ b/packages/design-system-mcp/tsconfig.build.json
@@ -3,6 +3,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"allowImportingTsExtensions": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"types": [ "node" ]
 	}
 }

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Explain how consumers define light and dark themes through `ThemeProvider` color seeds ([#82039](https://github.com/WordPress/gutenberg/pull/82039)).
 
+### Internal
+
+-   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
+
 ## 2.0.0 (2026-08-26)
 
 ### Breaking Changes

--- a/packages/theme/tsconfig.build.json
+++ b/packages/theme/tsconfig.build.json
@@ -3,6 +3,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"allowImportingTsExtensions": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"types": [ "node", "style-imports", "react-css-custom-properties" ]
 	},
 	"references": [

--- a/packages/video-conversion/CHANGELOG.md
+++ b/packages/video-conversion/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
+
 ## 0.5.0 (2026-08-26)
 
 ### Breaking Changes

--- a/packages/video-conversion/tsconfig.build.json
+++ b/packages/video-conversion/tsconfig.build.json
@@ -2,7 +2,9 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"allowImportingTsExtensions": true
+		"allowImportingTsExtensions": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext"
 	},
 	"references": [ { "path": "../worker-threads/tsconfig.build.json" } ]
 }

--- a/packages/vips/CHANGELOG.md
+++ b/packages/vips/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
+
 ## 4.0.0 (2026-08-26)
 
 ### Breaking Changes

--- a/packages/vips/tsconfig.build.json
+++ b/packages/vips/tsconfig.build.json
@@ -2,7 +2,9 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"allowImportingTsExtensions": true
+		"allowImportingTsExtensions": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext"
 	},
 	"references": [ { "path": "../worker-threads/tsconfig.build.json" } ]
 }


### PR DESCRIPTION
Follow-up to #82022.
Addresses https://github.com/WordPress/gutenberg/pull/82022#issuecomment-5427440915.

## What?

Enforces NodeNext module resolution in the TypeScript build projects for the four ESM packages updated in #82022.

## Why?

The shared `bundler` resolution mode accepts extensionless relative imports. These packages publish ESM declarations that Node consumers resolve with Node rules, so their build projects should reject extensionless imports before they reach the published package checks.

## How?

Overrides the shared TypeScript defaults with `module: "nodenext"` and `moduleResolution: "nodenext"` in the affected package build configs.

## Testing Instructions

1. Run `npm run lint:tsconfig`.
2. Run `npm run typecheck`.
3. Run `npm run build`.
4. Run `npm run --workspace @wordpress/build-scripts check-type-declarations --`.
5. Confirm all commands pass and each affected package reports `NodeNext declarations valid`.

### Testing Instructions for Keyboard

Not applicable. This PR does not change the UI.

## Screenshots or screencast

Not applicable. This PR does not change the UI.

## Use of AI Tools

Codex was used to investigate the feedback, update the TypeScript configs, run verification, and draft this description. I reviewed the resulting changes and verification output.
