### PR TITLE
Font Library: keep deactivated theme font variants listed

### DIFF
--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   Font Library: Keep deactivated theme font variants listed in the font details view so they can be activated again. Deactivating a variant removes it from the user's global styles, so the selected font was previously looked up in the activated fonts only, and an unchecked variant (or a fully deactivated family) vanished from the modal.
+-   Font Library: Keep deactivated theme font variants listed in the font details view so they can be activated again, and count them in the family card's "N of M active" text. Deactivating a variant removes it from the user's global styles, so the modal previously looked fonts up in the activated fonts only, and an unchecked variant (or a fully deactivated family) vanished ([#82091](https://github.com/WordPress/gutenberg/pull/82091)).
 
 ## 1.20.0 (2026-08-12)
 

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Expose typography and color controls for citations, inputs, and selects in Global Styles ([#80852](https://github.com/WordPress/gutenberg/pull/80852)).
 
+### Bug Fixes
+
+-   Font Library: Keep deactivated theme font variants listed in the font details view so they can be activated again. Deactivating a variant removes it from the user's global styles, so the selected font was previously looked up in the activated fonts only, and an unchecked variant (or a fully deactivated family) vanished from the modal.
+
 ## 1.20.0 (2026-08-12)
 
 ### Internal

--- a/packages/global-styles-ui/src/font-library/context.tsx
+++ b/packages/global-styles-ui/src/font-library/context.tsx
@@ -86,6 +86,13 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 		Record< string, FontFamilyPreset[] > | undefined
 	>( 'typography.fontFamilies' );
 
+	// The theme.json font families, before any user activation/deactivation is
+	// applied. Deactivating a font removes it from the user's global styles, so
+	// this is the only complete list of the fonts a theme provides.
+	const [ baseFontFamilies ] = useSetting<
+		Record< string, FontFamilyPreset[] > | undefined
+	>( 'typography.fontFamilies', undefined, 'base' );
+
 	/*
 	 * Save the font families to the database.
 
@@ -133,6 +140,20 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
 		: [];
 
+	// The theme fonts as declared by the theme, merged with the ones the user
+	// has activated. Deactivating a variant removes it from the user's global
+	// styles, so `themeFonts` alone can't describe the full set of variants a
+	// theme offers. Merging (rather than replacing) keeps fonts that only an
+	// applied style variation defines, and unions the variants of both.
+	const baseThemeFonts = baseFontFamilies?.theme
+		? mergeFontFamilies(
+				baseFontFamilies.theme.map( ( f ) =>
+					setUIValuesNeeded( f, { source: 'theme' } )
+				),
+				themeFonts
+		  ).sort( ( a, b ) => a.name.localeCompare( b.name ) )
+		: themeFonts;
+
 	const customFonts = fontFamilies?.custom
 		? fontFamilies.custom
 				.map( ( f ) => setUIValuesNeeded( f, { source: 'custom' } ) )
@@ -158,7 +179,8 @@ function FontLibraryProvider( { children }: { children: React.ReactNode } ) {
 			return;
 		}
 
-		const fonts = font.source === 'theme' ? themeFonts : baseCustomFonts;
+		const fonts =
+			font.source === 'theme' ? baseThemeFonts : baseCustomFonts;
 
 		// Tries to find the font in the installed fonts
 		const fontSelected = fonts.find( ( f ) => f.slug === font.slug );

--- a/packages/global-styles-ui/src/font-library/installed-fonts.tsx
+++ b/packages/global-styles-ui/src/font-library/installed-fonts.tsx
@@ -28,6 +28,7 @@ import FontCard from './font-card';
 import LibraryFontVariant from './library-font-variant';
 import { sortFontFaces } from './utils/sort-font-faces';
 import {
+	mergeFontFamilies,
 	setUIValuesNeeded,
 	loadFontFaceInBrowser,
 	unloadFontFaceInBrowser,
@@ -119,15 +120,18 @@ function InstalledFonts() {
 				.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
 				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
 		: [];
-	const themeFontsSlugs = new Set( themeFonts.map( ( f ) => f.slug ) );
+	// Merge at the variant level, not just the family level: a family with some
+	// variants deactivated exists in both lists, and only the union of both
+	// describes everything the theme offers, so the card can report
+	// "2 of 3 active" rather than counting the activated variants twice.
 	const baseThemeFonts = baseFontFamilies?.theme
-		? themeFonts.concat(
-				baseFontFamilies.theme
-					.filter( ( f ) => ! themeFontsSlugs.has( f.slug ) )
-					.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
-					.sort( ( a, b ) => a.name.localeCompare( b.name ) )
-		  )
-		: [];
+		? mergeFontFamilies(
+				baseFontFamilies.theme.map( ( f ) =>
+					setUIValuesNeeded( f, { source: 'theme' } )
+				),
+				themeFonts
+		  ).sort( ( a, b ) => a.name.localeCompare( b.name ) )
+		: themeFonts;
 
 	const customFontFamilyId =
 		libraryFontSelected?.source === 'custom' && libraryFontSelected?.id;


### PR DESCRIPTION
Fixes #60392

## What?

Keep deactivated theme font variants listed in the Font Library so they can be activated again. Deactivating every variant no longer removes the family from the modal, and the family card counts the variants the theme ships rather than only the activated ones.

## Why?

Deactivating a variant removes it from the user's global styles, and both the details-view lookup and the list merge only considered the activated fonts. Unchecking a variant and saving made its row disappear, with no way to re-activate it, and left the card reporting e.g. "2 of 2 active" for a font the theme ships three variants of.

Worth noting for testers: this only reproduces when a strict subset of a multi-variant font is deactivated and the change is saved (Update) before reopening. Deactivating the only variant, or all of them. removes the family from the user's global styles entirely and the base-fonts fallback brings everything back, so single-variant fonts (which most variable fonts are) never show it. Reproduced on current trunk and on WordPress Playground (WP stable) with TT4's Cardo, which ships three variants.

## How?

Look theme fonts up in the theme's own (`base` origin) font families merged with the activated ones, using `mergeFontFamilies` so families are merged at the variant level, both when selecting a font for the details view and when building the Library list. Merging rather than replacing keeps fonts that only an applied style variation defines, which is the constraint described in https://github.com/WordPress/gutenberg/issues/60392#issuecomment-2034506914.

## Testing Instructions

1. With Twenty Twenty-Four active, open the Site editor → Styles → Typography → Manage fonts.
2. Click Cardo, uncheck one variant (e.g. Cardo Normal Italic), click Update, and close the modal.
3. Reopen Manage fonts → Cardo: the unchecked variant is still listed and can be re-activated, and the card reads "2 of 3 active".
4. Also uncheck all three variants and update: the family stays in the list.

On trunk, step 3 shows only two rows and the deactivated variant cannot be restored from the UI.

## AI Disclosure?

- Yes, Used to test & investigate. Claude Opus/Fable

## Before

[60392-before-trunk.webm](https://github.com/user-attachments/assets/f53bbe02-4780-48e3-bf7e-57308c02c0df)

## After
[60392-after-fix.webm](https://github.com/user-attachments/assets/edd5d989-4127-426f-9bcc-3053eed9edbb)

