### PR TITLE
Menu: Stabilize portaled iframe unit test

### DIFF
--- a/packages/ui/src/menu/test/index.test.tsx
+++ b/packages/ui/src/menu/test/index.test.tsx
@@ -318,6 +318,10 @@ describe( 'Menu', () => {
 		if ( ! iframeDocument ) {
 			throw new Error( 'Expected a same-origin iframe document.' );
 		}
+		const addEventListener = jest.spyOn(
+			iframeDocument,
+			'addEventListener'
+		);
 
 		try {
 			const outsideTarget = iframeDocument.createElement( 'button' );
@@ -346,6 +350,13 @@ describe( 'Menu', () => {
 			);
 			const item = within( portaledMenu ).getByRole( 'menuitem', {
 				name: 'Duplicate',
+			} );
+			await waitFor( () => {
+				expect( addEventListener ).toHaveBeenCalledWith(
+					'pointerdown',
+					expect.any( Function ),
+					true
+				);
 			} );
 
 			act( () => {


### PR DESCRIPTION
Follow-up to #82081.

## What?

Stabilizes the Menu test for pointer interactions inside a menu portaled to an iframe.

## Why?

The test can dispatch its iframe pointer events before the dismissal bridge attaches its document listener. This still failed on trunk in https://github.com/WordPress/gutenberg/actions/runs/33004561142.

## How?

Waits for the iframe capture-phase `pointerdown` listener before testing inside and outside pointer interactions. The behavior assertions remain unchanged.

## Testing Instructions

Run: `npm run test:unit packages/ui/src/menu/test/index.test.tsx -- --runInBand`

## Use of AI Tools

Codex was used to investigate the CI failure, implement the synchronization, run repeated verification, and draft this PR.