### PR TITLE
Theme: Move post-release changelog entry to Unreleased

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Documentation
+
+-   Explain how consumers define light and dark themes through `ThemeProvider` color seeds ([#82039](https://github.com/WordPress/gutenberg/pull/82039)).
+
 ## 2.0.0 (2026-08-26)
 
 ### Breaking Changes
@@ -19,7 +23,6 @@
 
 ### Documentation
 
--   Explain how consumers define light and dark themes through `ThemeProvider` color seeds ([#82039](https://github.com/WordPress/gutenberg/pull/82039)).
 -   Route contributors and coding agents to the canonical Design System package guidance ([#80597](https://github.com/WordPress/gutenberg/pull/80597)).
 
 ### Internal


### PR DESCRIPTION
Follow up to #82085 and #82039.

## What?

Moves the #82039 `@wordpress/theme` documentation entry from the published `2.0.0` section to `Unreleased`.

## Why?

`@wordpress/theme@2.0.0` was published before #82039 merged. The entry currently makes the published changelog claim that the new documentation shipped in `2.0.0`, even though that package predates the change.

## How?

Moves the existing entry without changing its wording or any published package metadata.

## Testing Instructions

Inspect `packages/theme/CHANGELOG.md` and confirm the #82039 entry is under `Unreleased` and absent from `2.0.0`.

### Testing Instructions for Keyboard

Not applicable. This is a changelog-only correction.

## Use of AI Tools

OpenAI Codex was used to investigate the release discrepancy and prepare this changelog-only fix under maintainer direction.