### PR TITLE
Edit Widgets: Guard canInsertBlockInWidgetArea against an empty block list

### DIFF
--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevent an error in `canInsertBlockInWidgetArea` when no widget area blocks are present.
+
 ## 6.54.0 (2026-08-26)
 
 ## 6.53.0 (2026-08-12)

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -287,6 +287,10 @@ export const canInsertBlockInWidgetArea = createRegistrySelector(
 		// widget area can be inserted into any widget area. Uses the first
 		// widget area for testing whether the block can be inserted.
 		const [ firstWidgetArea ] = widgetAreas;
+		if ( ! firstWidgetArea ) {
+			return false;
+		}
+
 		return select( blockEditorStore ).canInsertBlockType(
 			blockName,
 			firstWidgetArea.clientId


### PR DESCRIPTION
## What?

Follow up to #81231

Stops the widgets screen from logging an error while it loads.

## Why?

Opening **Appearance → Widgets** logs `TypeError: Cannot read properties of undefined (reading 'clientId')`.

The `canInsertBlockInWidgetArea` selector assumes there is always at least one widget area. During the brief moment before the widget areas load, that is not true, and the selector throws.

The selector has been written this way for years. It only started to throw with #81231, which renders a placeholder block in an empty block list — on the widgets screen that placeholder now shows up before the widget areas have loaded, and the selector runs against the empty list.

## How?

Return `false` when there is no widget area to test against.

## Testing Instructions

1. Activate a classic theme with widget areas (e.g. Twenty Twenty).
2. Open the browser console and go to **Appearance → Widgets**.
3. Confirm no `Cannot read properties of undefined (reading 'clientId')` error is logged.
4. Add widgets to two different widget areas, select a block, and confirm **Move to widget area** still works.

The error is timing dependent, so it may take a reload to see it on `trunk`.

### Screenshot

<img width="1470" height="801" alt="image" src="https://github.com/user-attachments/assets/def0bdad-cd41-4794-b040-71f1fab12b58" />


## Use of AI Tools

Claude Code was used to reproduce the error, track down its cause, and draft this patch. I reviewed the change before submitting.
