### PR TITLE
Storybook: Persist sidebar theme in URL

### DIFF
--- a/storybook/stories/design-system/theme-example-application.story.tsx
+++ b/storybook/stories/design-system/theme-example-application.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useArgs, useState } from 'storybook/preview-api';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
-import { useId, useState } from '@wordpress/element';
 import { wordpress } from '@wordpress/icons';
 import { ThemeProvider } from '@wordpress/theme';
 import {
@@ -40,6 +40,9 @@ const SIDEBAR_THEME_PRESETS = [
 ] as const;
 
 type SidebarThemeId = ( typeof SIDEBAR_THEME_PRESETS )[ number ][ 'id' ];
+type ExampleApplicationArgs = React.ComponentProps< typeof ThemeProvider > & {
+	sidebarTheme: SidebarThemeId;
+};
 
 function getSidebarThemePreset( value: unknown ) {
 	return (
@@ -135,7 +138,7 @@ const siteLanguageOptions = [
 	{ value: 'ja', label: '日本語' },
 ];
 
-const meta: Meta< typeof ThemeProvider > = {
+const meta: Meta< ExampleApplicationArgs > = {
 	title: 'Design System/Theme/Theme Provider/Example Application',
 	component: ThemeProvider,
 	parameters: {
@@ -150,25 +153,30 @@ export default meta;
  * application shell uses its own color preset, while the main content
  * explicitly reapplies the root settings from the Storybook Theme toolbar.
  */
-export const ExampleApplication: StoryObj< typeof ThemeProvider > = {
-	render: ( _, context ) => {
+export const ExampleApplication: StoryObj< typeof meta > = {
+	args: {
+		sidebarTheme: SIDEBAR_THEME_PRESETS[ 0 ].id,
+	},
+	render: function Render( _, context ) {
+		const [ { sidebarTheme }, updateArgs ] =
+			useArgs< ExampleApplicationArgs >();
 		const [ isSiteDetailsOpen, setIsSiteDetailsOpen ] = useState( false );
-		const [ sidebarThemeId, setSidebarThemeId ] =
-			useState< SidebarThemeId >( SIDEBAR_THEME_PRESETS[ 0 ].id );
-		const generalSettingsId = useId();
-		const displaySettingsId = useId();
 		const rootThemeSettings = getDesignSystemThemeSettings(
 			context.globals
 		);
-		const sidebarTheme = getSidebarThemePreset( sidebarThemeId );
+		const sidebarThemePreset = getSidebarThemePreset( sidebarTheme );
+		const generalSettingsId = `${ context.id }-general-settings`;
+		const displaySettingsId = `${ context.id }-display-settings`;
 
 		return (
 			<div>
 				<SidebarThemeControls
-					selectedTheme={ sidebarTheme.id }
-					onSelectTheme={ setSidebarThemeId }
+					selectedTheme={ sidebarThemePreset.id }
+					onSelectTheme={ ( selectedSidebarTheme ) =>
+						updateArgs( { sidebarTheme: selectedSidebarTheme } )
+					}
 				/>
-				<ThemeProvider color={ sidebarTheme.colors }>
+				<ThemeProvider color={ sidebarThemePreset.colors }>
 					<div
 						style={ {
 							display: 'grid',


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/82039#discussion_r3866145754

## What?

Persists the Example Application's sidebar theme in the Storybook URL.

## Why?

Changing the root theme from the Storybook toolbar remounts the story. The sidebar theme previously used local React state, so it reset to Fresh after a toolbar change.

## How?

Stores the sidebar theme as a Storybook arg and updates it with `useArgs`. Storybook serializes non-default args into the URL and preserves them when globals change.

## Testing Instructions

1. Run `npm run storybook:dev` and open **Design System > Theme > Theme Provider > Example Application**.
2. Select **Ectoplasm** under **Sidebar theme**. Confirm that the URL includes `args=sidebarTheme:ectoplasm`.
3. Open the **Theme** toolbar and select **Dark**. Confirm that Ectoplasm remains selected.
4. Reload the page. Confirm that Ectoplasm remains selected.

### Screenshots

<img width="2640" height="838" alt="Screenshot 2026-08-27 at 10 07 47" src="https://github.com/user-attachments/assets/845640bf-5241-4fd0-b141-187cf2314b04" />


## Use of AI Tools

Codex was used to implement and verify this change.
