### PR TITLE
Build Package: Restore Core Boot layout compatibility

### DIFF
--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Pages: preserve the Core Boot layout compatibility class in generated wp-admin page templates so short pages fill the viewport when using Core's bundled Boot module ([#82112](https://github.com/WordPress/gutenberg/pull/82112)).
+
 ## 0.22.0 (2026-08-26)
 
 ### Internal

--- a/packages/wp-build/lib/test/php-generator.js
+++ b/packages/wp-build/lib/test/php-generator.js
@@ -1,0 +1,16 @@
+import { renderTemplateToString as generateTemplate } from '../php-generator.mjs';
+
+describe( 'page-wp-admin.php template', () => {
+	it( 'retains the Core Boot compatibility class on the mount element', async () => {
+		const generatedPage = await generateTemplate(
+			'page-wp-admin.php.template',
+			{
+				'{{PAGE_SLUG}}': 'example',
+			}
+		);
+
+		expect( generatedPage ).toContain(
+			'<div id="example-wp-admin-app" class="boot-layout-container"></div>'
+		);
+	} );
+} );

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -328,6 +328,11 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 		);
 		?>
 	</div>
+	<?php
+	// Core's pre-CSS Modules Boot layout uses this class for viewport sizing.
+	// Remove it when the minimum supported WordPress version includes the Boot
+	// changes from Gutenberg #81756.
+	?>
 	<div id="{{PAGE_SLUG}}-wp-admin-app" class="boot-layout-container"></div>
 	<?php
 }

--- a/packages/wp-build/templates/page-wp-admin.php.template
+++ b/packages/wp-build/templates/page-wp-admin.php.template
@@ -328,10 +328,9 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_render_page() {
 		);
 		?>
 	</div>
-	<div id="{{PAGE_SLUG}}-wp-admin-app"></div>
+	<div id="{{PAGE_SLUG}}-wp-admin-app" class="boot-layout-container"></div>
 	<?php
 }
 
 // Hook the enqueue function to admin_enqueue_scripts
 add_action( 'admin_enqueue_scripts', '{{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts' );
-


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/81756#discussion_r3869552743

## What?

Restores the `boot-layout-container` class on generated wp-admin page mount elements.

## Why?

Plugins without a local Boot module fall back to the copy bundled with WordPress Core. That bundle still uses `.boot-layout-container .boot-layout` to make the application fill the admin viewport. Removing the mount class leaves a gap below short pages.

## How?

Keeps the page-specific ID used by the generated critical CSS and restores the class as a compatibility marker for older Core Boot versions. Adds a focused template regression test.

## Testing Instructions

1. Build a plugin that declares a `wpPlugin.pages` wp-admin page without a local `packages/boot` package.
2. Run the plugin against a WordPress version whose bundled Boot module uses `.boot-layout-container .boot-layout`.
3. Open the generated wp-admin page at a desktop viewport.
4. Confirm the application background reaches the bottom of the viewport with no gap below short content.

### Testing Instructions for Keyboard

There is no keyboard interaction change.

## Screenshots or screencast

See the [regression screenshot](https://github.com/WordPress/gutenberg/pull/81756#discussion_r3869552743).

## Use of AI Tools

Codex helped investigate the cross-version failure, implement the template and regression test, and draft this description. The author reviewed the diff and verification results.
