### PR TITLE
Fix: Retain focus and caret position after Backspace undo of a prefix block transform

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Bug Fixes
 
--	Retain focus and caret position when undoing a prefix transform (e.g., ## , - , > ) with Backspace or Escape.
+-	Retain focus and caret position when undoing a prefix transform (e.g., ## , - , > ) with Backspace or Escape ([#82116](https://github.com/WordPress/gutenberg/pull/82116)).
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+-	Retain focus and caret position when undoing a prefix transform (e.g., ## , - , > ) with Backspace or Escape.
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Bug Fixes
 
--	Retain focus and caret position when undoing a prefix transform (e.g., ## , - , > ) with Backspace or Escape ([#82116](https://github.com/WordPress/gutenberg/pull/82116)).
+-   Retain focus and caret position when undoing a prefix transform (e.g. `## `, `- `, `> `) with Backspace or Escape ([#82116](https://github.com/WordPress/gutenberg/pull/82116)).
 -   Hide the Layout panel when a block has layout editing enabled but all controls for its layout type are disabled ([#81968](https://github.com/WordPress/gutenberg/pull/81968)).
 -   `DuotoneControl`: Keep the picked preset's identity when applying a duotone to a block. Two presets can hold the same pair of colors, and the applied preset was resolved by matching colors, so the first of any duplicate pair was saved and both appeared selected ([#81605](https://github.com/WordPress/gutenberg/pull/81605)).
 -   `InnerBlocks`: Resolve the `default` of a block's `layout` support before providing it to inner blocks. A block that declared its layout only as a support default, such as the Gallery, previously handed its children the raw support config, which has no `type`, so the children resolved to the flow layout instead. As a result an Image nested in a Gallery offered left/center/right alignment, which the flex layout does not permit ([#81606](https://github.com/WordPress/gutenberg/pull/81606)).

--- a/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
@@ -84,8 +84,11 @@ export default ( props ) => ( element ) => {
 		} );
 		const block = transformation.transform( content );
 
-		selectionChange( ...findSelection( [ block ] ) );
-		onReplace( [ block ] );
+		registry.batch( () => {
+			selectionChange( ...findSelection( [ block ] ) );
+			onReplace( [ block ] );
+		} );
+
 		registry.dispatch( blockEditorStore ).__unstableMarkAutomaticChange();
 
 		return true;

--- a/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/input-rules.js
@@ -84,6 +84,8 @@ export default ( props ) => ( element ) => {
 		} );
 		const block = transformation.transform( content );
 
+		// Batch so the undo history records the pre-transform selection,
+		// instead of the selection change here overwriting it first.
 		registry.batch( () => {
 			selectionChange( ...findSelection( [ block ] ) );
 			onReplace( [ block ] );

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -187,6 +187,79 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		] );
 	} );
 
+	test( 'should retain focus after backspace-undo of heading prefix transform', async ( {
+		page,
+		editor,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=document[name="Add default block"i]' )
+			.click();
+		await page.keyboard.type( '## ' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/heading' } ] );
+
+		await page.keyboard.press( 'Backspace' );
+
+		await expect
+			.poll( editor.getBlocks )
+			.toMatchObject( [ { name: 'core/paragraph' } ] );
+
+		await page.keyboard.type( 'hello' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: { content: '## hello' },
+			},
+		] );
+	} );
+
+	test( 'should retain focus after backspace-undo of a nested prefix transform', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [ { name: 'core/paragraph' } ],
+		} );
+		await editor.canvas.locator( '[data-type="core/paragraph"]' ).click();
+		await page.keyboard.type( '## ' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [ { name: 'core/heading' } ],
+			},
+		] );
+
+		await page.keyboard.press( 'Backspace' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [ { name: 'core/paragraph' } ],
+			},
+		] );
+
+		await page.keyboard.type( 'hello' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: '## hello' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should not undo backtick transform with backspace after typing', async ( {
 		page,
 		editor,

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -195,7 +195,6 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			.locator( 'role=document[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## ' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 
 		await expect
 			.poll( editor.getBlocks )
@@ -213,49 +212,6 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 			{
 				name: 'core/paragraph',
 				attributes: { content: '## hello' },
-			},
-		] );
-	} );
-
-	test( 'should retain focus after backspace-undo of a nested prefix transform', async ( {
-		editor,
-		page,
-	} ) => {
-		await editor.insertBlock( {
-			name: 'core/group',
-			innerBlocks: [ { name: 'core/paragraph' } ],
-		} );
-		await editor.canvas.locator( '[data-type="core/paragraph"]' ).click();
-		await page.keyboard.type( '## ' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/group',
-				innerBlocks: [ { name: 'core/heading' } ],
-			},
-		] );
-
-		await page.keyboard.press( 'Backspace' );
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/group',
-				innerBlocks: [ { name: 'core/paragraph' } ],
-			},
-		] );
-
-		await page.keyboard.type( 'hello' );
-
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/group',
-				innerBlocks: [
-					{
-						name: 'core/paragraph',
-						attributes: { content: '## hello' },
-					},
-				],
 			},
 		] );
 	} );


### PR DESCRIPTION
## What?
Closes #82079

Fixes lost focus and caret position when you press Backspace right after a prefix transform (like `## `, `- `, or `> `) turns a Paragraph into a Heading, List, or Quote block.

## Why?
When a prefix transform runs, the block is replaced and the cursor is moved to the new block, but these two things were dispatched as separate, unbatched updates. Because of that, the undo history recorded the new block's cursor position as both the "before" and "after" state, instead of the original block's. So when Backspace triggered undo, Gutenberg tried to restore focus using a block that no longer existed after the undo, and focus was lost. The user then had to click back into the block to keep typing, which is also an accessibility problem.

## How?
`selectionChange()` and `onReplace()` in `input-rules.js` now run inside a single `registry.batch()` call, so they are recorded as one atomic update. This way the undo history correctly keeps the original block's cursor position as the "before" state, and `restoreSelection()` can put the caret back where it was after Backspace-undo.

## Testing Instructions
1. Open a post or page.
2. Click into the empty paragraph block.
3. Type `## ` (hash, hash, space). The block turns into a Heading.
4. Press Backspace. The block turns back into a Paragraph.
5. Without clicking anywhere, start typing. The text should be added right where the cursor was, no need to click back in.
6. Repeat with `- ` (List) and `> ` (Quote) to confirm the same fix applies to other prefix transforms.
7. Try the same steps with the paragraph nested inside a Group block, to confirm focus is retained there too.

## Screenshots or screencast


https://github.com/user-attachments/assets/10e23e9c-19d6-4a74-a196-42d11de3f7a9



## Use of AI Tools
Used AI assistance (GitHub Copilot) to help write PR description and validate the fix and tests. I reviewed the analysis, tested the change manually and with the added e2e tests, and I take responsibility for the code in this PR.
