### PR TITLE
Editor: Apply the showListViewByDefault preference in the shared editor

### DIFF
--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Remove the `showListViewByDefault` handling from `initializeEditor`; the `editor` package now applies the preference itself.
+
 ## 8.54.0 (2026-08-26)
 
 ### Internal

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -47,7 +47,6 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
-	const isMediumOrBigger = window.matchMedia( '(min-width: 782px)' ).matches;
 	const target = document.getElementById( id );
 	const root = createRoot( target );
 
@@ -85,17 +84,6 @@ export function initializeEditor(
 	}
 
 	dispatch( blocksStore ).reapplyBlockTypeFilters();
-
-	// Check if the block list view should be open by default.
-	// If `distractionFree` mode is enabled, the block list view should not be open.
-	// This behavior is disabled for small viewports.
-	if (
-		isMediumOrBigger &&
-		select( preferencesStore ).get( 'core', 'showListViewByDefault' ) &&
-		! select( preferencesStore ).get( 'core', 'distractionFree' )
-	) {
-		dispatch( editorStore ).setIsListViewOpened( true );
-	}
 
 	registerCoreBlocks();
 	registerCoreBlockBindingsSources();

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Remove the `showListViewByDefault` handling from `useAdaptEditorToCanvas`; the `editor` package now applies the preference on the preview ↔ edit transition itself.
+
 ## 7.3.0 (2026-08-26)
 
 ### Enhancements

--- a/packages/edit-site/src/components/editor/use-adapt-editor-to-canvas.js
+++ b/packages/edit-site/src/components/editor/use-adapt-editor-to-canvas.js
@@ -2,7 +2,6 @@ import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import { useLayoutEffect } from '@wordpress/element';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { DEFAULT_DEVICE_TYPE } from '../block-editor/viewport';
 
 export function useAdaptEditorToCanvas( canvas ) {
@@ -11,15 +10,11 @@ export function useAdaptEditorToCanvas( canvas ) {
 		editPost,
 		setDeviceType,
 		closePublishSidebar,
-		setIsListViewOpened,
 		setIsInserterOpened,
 	} = useDispatch( editorStore );
-	const { get: getPreference } = useSelect( preferencesStore );
 	const { getCurrentPost } = useSelect( editorStore );
 	const registry = useRegistry();
 	useLayoutEffect( () => {
-		const isMediumOrBigger =
-			window.matchMedia( '(min-width: 782px)' ).matches;
 		registry.batch( () => {
 			clearSelectedBlock();
 			if ( getCurrentPost()?.type ) {
@@ -28,20 +23,6 @@ export function useAdaptEditorToCanvas( canvas ) {
 			setDeviceType( DEFAULT_DEVICE_TYPE );
 			closePublishSidebar();
 			setIsInserterOpened( false );
-
-			// Check if the block list view should be open by default.
-			// If `distractionFree` mode is enabled, the block list view should not be open.
-			// This behavior is disabled for small viewports.
-			if (
-				isMediumOrBigger &&
-				canvas === 'edit' &&
-				getPreference( 'core', 'showListViewByDefault' ) &&
-				! getPreference( 'core', 'distractionFree' )
-			) {
-				setIsListViewOpened( true );
-			} else {
-				setIsListViewOpened( false );
-			}
 		} );
 	}, [
 		canvas,
@@ -51,8 +32,6 @@ export function useAdaptEditorToCanvas( canvas ) {
 		setDeviceType,
 		closePublishSidebar,
 		setIsInserterOpened,
-		setIsListViewOpened,
-		getPreference,
 		getCurrentPost,
 	] );
 }

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug Fixes
 
+-   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.
+
+### Bug Fixes
+
 -   `mediaUpload`: Refuse a batch of more than one file before registering it with the upload progress snackbar when the caller only takes one, such as a Cover block placeholder. `uploadMedia()` reported the refusal as a single error, leaving the rest of the batch counted as uploading forever - and every later upload in the session was folded into that stuck notice ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 
 ## 14.54.0 (2026-08-26)

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -9,7 +9,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useViewportMatch } from '@wordpress/compose';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useLayoutEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { InlineNotices } from '@wordpress/notices';
 import { ThemeProvider } from '@wordpress/theme';
@@ -128,6 +128,27 @@ export default function EditorInterface( {
 		};
 	}, [] );
 	const { setShowRevisionDiff } = unlock( useDispatch( editorStore ) );
+	const { setIsListViewOpened } = useDispatch( editorStore );
+	const registry = useRegistry();
+
+	// Apply the `showListViewByDefault` preference whenever the editor enters
+	// edit mode: on mount for editors that are always editable (the post
+	// editor), and on the preview → edit transition for the site editors,
+	// which keep this component mounted across it. The preferences are read at
+	// transition time only, so toggling the list view or the preferences
+	// mid-session is never overridden. Disabled for small viewports, and by
+	// `distractionFree` mode, which has no room for the list view.
+	useLayoutEffect( () => {
+		const isMediumOrBigger =
+			window.matchMedia( '(min-width: 782px)' ).matches;
+		const { get } = registry.select( preferencesStore );
+		setIsListViewOpened(
+			! isPreviewMode &&
+				isMediumOrBigger &&
+				!! get( 'core', 'showListViewByDefault' ) &&
+				! get( 'core', 'distractionFree' )
+		);
+	}, [ isPreviewMode, registry, setIsListViewOpened ] );
 
 	// Runs unconditionally so join/leave/save notifications are dispatched
 	// regardless of viewport width or whether the header centre area is visible.


### PR DESCRIPTION
## What?

Moves the handling of the **"Always open List View"** preference (`showListViewByDefault`) from the host packages into the shared `editor` package, so every editor built on it honors the preference — including the extensible site editor, which ignored it until now.

## Why?

The preference is defined, defaulted, and rendered (Preferences dialog) by the `editor` package, but *applying* it lived in the hosts, twice:

- `edit-post` applied it once in `initializeEditor`.
- `edit-site` applied it in `useAdaptEditorToCanvas` on canvas transitions.

The extensible site editor renders the shared `Editor` directly, so nobody applied it there (found while running the site editor e2e suite against both editors in #82117). This is the recurring "host owns editor state" pattern: the editor package should own its own preference.

## How?

- `EditorInterface` (rendered by all three editors) gains a small layout effect keyed on `isPreviewMode`: when the editor enters edit mode — on mount for always-editable editors like the post editor, or on the preview → edit transition for the site editors, which keep the component mounted across it — it opens the list view if the preference is on, the viewport is `medium`+, and distraction-free mode is off; entering preview closes it, matching edit-site's previous behavior. Preferences are read at transition time only, so toggling the list view (or the preferences) mid-session is never overridden.
- The two host implementations are deleted; behavior is otherwise unchanged for the post editor and classic site editor.

## Testing Instructions

1. In the post editor, enable Preferences → General → "Always open List View". Reload: the list view opens. Disable, reload: closed.
2. Classic site editor: with the preference on, open a template (edit mode) — list view opens; going back to browse mode closes it; re-entering edit reopens it. Toggling the list view manually is not overridden while staying in edit mode.
3. Extensible site editor (enable the experiment): with the preference on, open a template — the list view now opens (previously it never did). With the preference off, it stays closed.
4. Small viewports (< 782px) and distraction-free mode: the list view does not auto-open.
5. E2E: `specs/site-editor/list-view.spec.js` (2 passed) and `specs/editor/various/list-view.spec.js` (18 passed) locally; once this lands, the `@site-editor-v1-only` tag on the corresponding test in #82117 can be dropped so it runs against both editors.

### Testing Instructions for Keyboard

Same flows as above; the list view can still be toggled with `access+o` and its open state after the shortcut is unaffected by this change (covered by the list view e2e specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)