### PR TITLE
CI: Collapse package CHANGELOG check exclusions into a single grep pattern

### DIFF
--- a/.github/workflows/check-package-changelogs.yml
+++ b/.github/workflows/check-package-changelogs.yml
@@ -83,13 +83,8 @@ jobs:
                   # The workflow's `paths:` filter triggers on the union of all
                   # tracked packages, so this matrix entry may run on a PR that
                   # doesn't touch its package. Short-circuit if that's the case.
-                  #
-                  # Changes to the CHANGELOG itself don't warrant a CHANGELOG
-                  # entry of their own, so a PR that only corrects an existing
-                  # entry isn't asked to add a new one.
                   relevant_changes=$(git diff --name-only "$BASE_SHA"...HEAD -- "${PACKAGE_PATH}/" \
-                      | grep -Ev "^${PACKAGE_PATH}/src/(.+/)?(stories|test)/" \
-                      | grep -Fxv "${PACKAGE_PATH}/CHANGELOG.md" || true)
+                      | grep -Ev "^${PACKAGE_PATH}/(src/(.+/)?(stories|test)/|CHANGELOG\.md$)" || true)
 
                   if [ -z "$relevant_changes" ]; then
                       echo "No relevant changes under ${PACKAGE_PATH}; skipping CHANGELOG check."


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/pull/82069#discussion_r3862700545

Addresses @aduth's review feedback, which landed just before the PR was merged.

## Why?
The exclusions had grown to one `grep` stage each, and the comment added in #82069 restated what the comment above it already covered.

## How?
- Drop the added comment block, per the review suggestion.
- Merge the `stories|test` and `CHANGELOG.md` greps into one ERE alternation.

## Testing Instructions
CI only. Verify on this PR:
1. Edit only a package `CHANGELOG.md` → check is skipped.
2. Edit a package `src/` file → check runs.

## Use of AI Tools
Claude Code; 