### PR TITLE
Release: Use the CLI Node.js version for all package publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -74,21 +74,12 @@ jobs:
                   git config user.name "Gutenberg Repository Automation"
                   git config user.email gutenberg@wordpress.org
 
+            # The release CLI is always loaded from trunk, so use its runtime for every release.
+            # The selected publishing branch must remain installable under this runtime.
             - name: Setup Node.js
-              if: ${{ github.event.inputs.release_type != 'wp' }}
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version-file: 'cli/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
-                  check-latest: true
-
-            # Keep the release CLI and publish checkout on one runtime;
-            # active wp release branches must stay compatible with the trunk release CLI.
-            - name: Setup Node.js (for WP major version)
-              if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version-file: 'publish/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true
 


### PR DESCRIPTION
Follow-up to #80395. See #72973.

## What?

Uses the release CLI checkout's Node.js version for every npm package release, including WordPress major releases.

## Why?

Since #79905, WordPress package releases run the current release CLI from `trunk`. Selecting Node.js from the historical publishing branch can run that CLI under an unsupported runtime when `trunk` upgrades Node.js.

## How?

Removes the WordPress-specific `setup-node` step and makes the existing `cli/.nvmrc` setup apply to every release type.

## Testing Instructions

1. Confirm `.github/workflows/publish-npm-packages.yml` has one `setup-node` step and it reads `cli/.nvmrc`.
2. Parse the workflow:

   ```sh
   ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0), aliases: true)' .github/workflows/publish-npm-packages.yml
   ```

3. In separate `wp/7.1`, `wp/7.0`, and `wp/6.9` checkouts, use Node.js `24.18.0` and npm `11.18.0` from #80395, then run `npm ci` and `npx --no-install lerna --version`. Each install should complete. Lerna should report:

   - `wp/7.1`: `9.0.7`
   - `wp/7.0`: `8.1.9`
   - `wp/6.9`: `8.1.9`

## Follow-ups

Compatibility was verified through `wp/6.9`. Older `wp/*` branches still need a separate compatibility strategy because the release CLI installs dependencies inside the publishing checkout. This PR does not change that behavior.

## Use of AI Tools

Codex helped inspect the release workflow, prepare the change, and run verification. I reviewed the resulting diff and test results.
