### PR TITLE
Reusable Blocks: Remove leftover merge conflict markers from the changelog

### DIFF
--- a/packages/reusable-blocks/CHANGELOG.md
+++ b/packages/reusable-blocks/CHANGELOG.md
@@ -26,11 +26,6 @@
 ## 5.50.0 (2026-07-01)
 
 ## 5.49.0 (2026-06-24)
-=======
-### Breaking Changes
-
--   Turn `@wordpress/reusable-blocks` into a deprecated no-op compatibility package. `ReusableBlocksMenuItems` renders nothing, the store selectors and actions no longer have runtime effects, and the convert/delete utilities are now no-ops. The `core/reusable-blocks` store remains registered for backward compatibility.
->>>>>>> 849feff6d55 (Reusable Blocks: Turn package into a deprecated no-op)
 
 ## 5.48.1 (2026-06-16)
 


### PR DESCRIPTION
## What?
Follow up to #79186.

Removes stranded merge conflict markers from `packages/reusable-blocks/CHANGELOG.md`.

## Use of AI Tools
Assisted by Claude.
