### PR TITLE
Components: Keep foreign items out of a ToolsPanel menu

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `Snackbar`: Restart the auto-dismiss timer when a notice is recreated with the same ID during removal ([#81764](https://github.com/WordPress/gutenberg/pull/81764)).
+-   `ToolsPanel`: Stop a panel item whose `panelId` doesn't match the panel from writing its value into that panel's menu, which could leave an orphaned entry in the dropdown ([#82127](https://github.com/WordPress/gutenberg/pull/82127)).
 
 ### Internal
 

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -1153,6 +1153,45 @@ describe( 'ToolsPanel', () => {
 			expect( altControlProps.onDeselect ).not.toHaveBeenCalled();
 		} );
 
+		it( 'should not contain menu items for an item belonging to another panel', async () => {
+			// A fill can mount after the panel it is rendered into has already
+			// settled. An item whose `panelId` doesn't match must stay out of
+			// that panel's menu entirely, including out of the value flagging
+			// that populates it.
+			const Panel = ( { withForeign }: { withForeign: boolean } ) => (
+				<ToolsPanel { ...defaultProps } panelId="1234">
+					<ToolsPanelItem
+						label="Mine"
+						panelId="1234"
+						isShownByDefault
+						hasValue={ () => false }
+					>
+						<div>My control</div>
+					</ToolsPanelItem>
+					{ withForeign && (
+						<ToolsPanelItem
+							label="Foreign"
+							panelId="9999"
+							hasValue={ () => true }
+						>
+							<div>Foreign control</div>
+						</ToolsPanelItem>
+					) }
+				</ToolsPanel>
+			);
+
+			// Let the panel settle with only its own item registered, then
+			// bring in an item that belongs to a different panel.
+			const { rerender } = render( <Panel withForeign={ false } /> );
+			rerender( <Panel withForeign /> );
+
+			await openDropdownMenu();
+
+			expect(
+				screen.queryByRole( 'menuitemcheckbox', { name: /Foreign/i } )
+			).not.toBeInTheDocument();
+		} );
+
 		it( 'should not contain orphaned menu items when panelId changes', async () => {
 			// As fills and the panel can update independently this aims to
 			// test that no orphaned items appear registered in the panel menu.

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -113,13 +113,16 @@ export function useToolsPanelItem(
 	const isValueSet = hasValue();
 	// Notify the panel when an item's value has changed except for optional
 	// items without value because the item should not cause itself to hide.
+	// Items that don't belong to the panel on screen stay silent, otherwise
+	// they would leave an orphaned entry in its menu.
 	useEffect( () => {
-		if ( ! isShownByDefault && ! isValueSet ) {
+		if ( ! hasMatchingPanel || ( ! isShownByDefault && ! isValueSet ) ) {
 			return;
 		}
 
 		flagItemCustomization( isValueSet, label, menuGroup );
 	}, [
+		hasMatchingPanel,
 		isValueSet,
 		menuGroup,
 		label,


### PR DESCRIPTION
## What?
A `ToolsPanelItem` whose `panelId` doesn't match the panel flagged its value into that panel's menu regardless, leaving an orphaned entry in the dropdown. Registration was already gated on a matching panel; the value flagging was not.

Only reachable when nothing re-registers afterward to regenerate the menu and sweep the entry, which is why it shows up for items arriving via SlotFills after the panel has settled rather than for a panel's own children.

## Testing Instructions
PR includes a unit test. Smoke test ToolsPanel for blocks and global styles.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
