### PR TITLE
Navigation: Change WCText to Text

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
+++ b/packages/block-library/src/navigation/edit/overlay-template-part-selector.js
@@ -8,12 +8,12 @@ import {
 	FlexBlock,
 	FlexItem,
 	__experimentalHStack as HStack,
-	__experimentalText as WCText,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as noticesStore } from '@wordpress/notices';
 import { plus } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
 import useCreateOverlayTemplatePart from './use-create-overlay';
 import DeletedOverlayWarning from './deleted-overlay-warning';
@@ -343,15 +343,11 @@ export default function OverlayTemplatePartSelector( {
 				alignment="flex-start"
 				className="wp-block-navigation__overlay-help-text-wrapper"
 			>
-				<WCText
-					variant="muted"
-					isBlock
-					className="wp-block-navigation__overlay-help-text"
-				>
+				<Text>
 					{ __(
 						'An overlay template allows you to customize the appearance of the dialog that opens when the menu button is pressed.'
 					) }
-				</WCText>
+				</Text>
 			</HStack>
 		</div>
 	);

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -3447,7 +3447,7 @@
 	},
 	"packages/block-library/src/navigation/edit/overlay-template-part-selector.js": {
 		"@wordpress/use-recommended-components": {
-			"count": 4
+			"count": 3
 		},
 		"react/jsx-filename-extension": {
 			"count": 1


### PR DESCRIPTION
## What?

Related to https://github.com/WordPress/gutenberg/pull/69978#issuecomment-5438231667.

Changes the use of old WCText to Text in Navigation. Before:

<img width="283" height="345" alt="before" src="https://github.com/user-attachments/assets/b7615653-1d05-4dfb-bb23-e567c410c818" />

After:

<img width="285" height="381" alt="after" src="https://github.com/user-attachments/assets/8d256d39-3824-47d4-a8c1-c5a4cdf647bc" />

Note: in order for me to be able to push this PR, I had to run a lint command which updated suppressions.json. This is news and confusing to me, so let me know if this is expected. 


## Use of AI Tools

No.