### PR TITLE
UI: Remove ESLint ref suppressions and refactor AlertDialog state

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -37,6 +37,10 @@
 
 -   Add a Form best practices Storybook page for labeling composed controls ([#82197](https://github.com/WordPress/gutenberg/pull/82197)).
 
+### Internal
+
+-   Remove the remaining `react-hooks/refs` ESLint suppressions. ([#82131](https://github.com/WordPress/gutenberg/pull/82131))
+
 ## 0.21.0 (2026-08-26)
 
 ### New Features

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -39,7 +39,8 @@
 
 ### Internal
 
--   Remove the remaining `react-hooks/refs` ESLint suppressions. ([#82131](https://github.com/WordPress/gutenberg/pull/82131))
+-   `AlertDialog`: Move confirmation lifecycle state to a private external store so event handlers and React renders read the same synchronous snapshot. ([#82131](https://github.com/WordPress/gutenberg/pull/82131))
+-   Use stable event callbacks and remove the remaining `react-hooks/refs` ESLint suppressions. ([#82131](https://github.com/WordPress/gutenberg/pull/82131))
 
 ## 0.21.0 (2026-08-26)
 

--- a/packages/ui/src/alert-dialog/root.tsx
+++ b/packages/ui/src/alert-dialog/root.tsx
@@ -7,6 +7,7 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from '@wordpress/element';
 import { AlertDialogContext } from './context';
 import type { Phase } from './context';
@@ -18,6 +19,35 @@ function isThenable( value: unknown ): value is PromiseLike< unknown > {
 		value !== undefined &&
 		typeof ( value as PromiseLike< unknown > ).then === 'function'
 	);
+}
+
+interface LifecycleState {
+	phase: Phase;
+	showSpinner: boolean;
+	errorMessage?: string;
+}
+
+function createLifecycleState() {
+	let value: LifecycleState = {
+		phase: 'idle',
+		showSpinner: false,
+		errorMessage: undefined,
+	};
+	const listeners = new Set< () => void >();
+
+	return {
+		getValue: () => value,
+		subscribe: ( listener: () => void ) => {
+			listeners.add( listener );
+			return () => {
+				listeners.delete( listener );
+			};
+		},
+		update: ( updates: Partial< LifecycleState > ) => {
+			value = { ...value, ...updates };
+			listeners.forEach( ( listener ) => listener() );
+		},
+	};
 }
 
 /**
@@ -71,17 +101,16 @@ function Root( {
 	//
 	// Buttons are disabled whenever phase !== 'idle'.
 	// Dismiss (Escape / Cancel) is blocked during 'pending'.
-	const [ phase, setPhase ] = useState< Phase >( 'idle' );
-	const [ showSpinner, setShowSpinner ] = useState( false );
-	const [ errorMessage, setErrorMessage ] = useState< string >();
+	const [ lifecycle ] = useState( createLifecycleState );
+	const lifecycleState = useSyncExternalStore(
+		lifecycle.subscribe,
+		lifecycle.getValue,
+		lifecycle.getValue
+	);
 
 	const actionsRef = useRef< _AlertDialog.Root.Actions | null >( null );
 
 	const onConfirmEvent = useEvent( onConfirm );
-
-	// Ref keeps phase accessible synchronously from callbacks that may
-	// run between a setState call and the subsequent React re-render.
-	const phaseRef = useRef( phase );
 
 	// Generation counter — safety net for the edge case where the component
 	// unmounts while an async confirm is in flight. Also incremented when
@@ -95,12 +124,10 @@ function Root( {
 	// (i.e. does not react to `onOpenChange`), the phase would be stuck
 	// at 'closing'. Detect the contradiction and reset to idle.
 	useEffect( () => {
-		if ( effectiveOpen && phase === 'closing' ) {
-			phaseRef.current = 'idle';
-			setPhase( 'idle' );
-			setShowSpinner( false );
+		if ( effectiveOpen && lifecycleState.phase === 'closing' ) {
+			lifecycle.update( { phase: 'idle', showSpinner: false } );
 		}
-	}, [ effectiveOpen, phase ] );
+	}, [ effectiveOpen, lifecycle, lifecycleState.phase ] );
 
 	const handleOpenChange = useCallback(
 		(
@@ -108,29 +135,26 @@ function Root( {
 			eventDetails: _AlertDialog.Root.ChangeEventDetails
 		) => {
 			// Block dismiss while a confirm action is pending.
-			if ( ! nextOpen && phaseRef.current === 'pending' ) {
+			if ( ! nextOpen && lifecycle.getValue().phase === 'pending' ) {
 				return;
 			}
 
-			if ( ! nextOpen && phaseRef.current === 'idle' ) {
-				phaseRef.current = 'closing';
-				setPhase( 'closing' );
+			if ( ! nextOpen && lifecycle.getValue().phase === 'idle' ) {
+				lifecycle.update( { phase: 'closing' } );
 			}
 
 			setInternalOpen( nextOpen );
 			onOpenChange?.( nextOpen, eventDetails );
 		},
-		[ onOpenChange ]
+		[ lifecycle, onOpenChange ]
 	);
 
 	const confirm = useCallback( async () => {
-		if ( phaseRef.current !== 'idle' ) {
+		if ( lifecycle.getValue().phase !== 'idle' ) {
 			return;
 		}
 
-		phaseRef.current = 'pending';
-		setPhase( 'pending' );
-		setErrorMessage( undefined );
+		lifecycle.update( { phase: 'pending', errorMessage: undefined } );
 
 		const id = ++confirmIdRef.current;
 
@@ -140,7 +164,7 @@ function Root( {
 			// Show spinner only for async handlers (Promises).
 			// Sync handlers resolve in the same tick — no spinner needed.
 			if ( isThenable( rawResult ) ) {
-				setShowSpinner( true );
+				lifecycle.update( { showSpinner: true } );
 			}
 
 			const result = await Promise.resolve( rawResult );
@@ -153,10 +177,11 @@ function Root( {
 
 			// An error message implies the dialog should stay open.
 			if ( result?.error ) {
-				phaseRef.current = 'idle';
-				setPhase( 'idle' );
-				setShowSpinner( false );
-				setErrorMessage( result.error );
+				lifecycle.update( {
+					phase: 'idle',
+					showSpinner: false,
+					errorMessage: result.error,
+				} );
 				speak( result.error, 'assertive' );
 				return;
 			}
@@ -164,46 +189,43 @@ function Root( {
 			const shouldClose = result?.close !== false;
 
 			if ( shouldClose ) {
-				phaseRef.current = 'closing';
-				setPhase( 'closing' );
+				lifecycle.update( { phase: 'closing' } );
 				actionsRef.current?.close();
 			} else {
-				phaseRef.current = 'idle';
-				setPhase( 'idle' );
-				setShowSpinner( false );
+				lifecycle.update( { phase: 'idle', showSpinner: false } );
 			}
 		} catch ( error ) {
 			if ( confirmIdRef.current !== id ) {
 				return;
 			}
-			phaseRef.current = 'idle';
-			setPhase( 'idle' );
-			setShowSpinner( false );
+			lifecycle.update( { phase: 'idle', showSpinner: false } );
 			// eslint-disable-next-line no-console
 			console.error( error );
 		}
-	}, [ onConfirmEvent ] );
+	}, [ lifecycle, onConfirmEvent ] );
 
-	const handleOpenChangeComplete = useCallback( ( open: boolean ) => {
-		if ( ! open ) {
-			// Invalidate any in-flight async so a stale promise settling
-			// after dismiss+reopen doesn't close the new session.
-			confirmIdRef.current++;
-			phaseRef.current = 'idle';
-			setPhase( 'idle' );
-			setShowSpinner( false );
-			setErrorMessage( undefined );
-		}
-	}, [] );
+	const handleOpenChangeComplete = useCallback(
+		( open: boolean ) => {
+			if ( ! open ) {
+				// Invalidate any in-flight async so a stale promise settling
+				// after dismiss+reopen doesn't close the new session.
+				confirmIdRef.current++;
+				lifecycle.update( {
+					phase: 'idle',
+					showSpinner: false,
+					errorMessage: undefined,
+				} );
+			}
+		},
+		[ lifecycle ]
+	);
 
 	const contextValue = useMemo(
 		() => ( {
-			phase,
-			showSpinner,
-			errorMessage,
+			...lifecycleState,
 			confirm,
 		} ),
-		[ phase, showSpinner, errorMessage, confirm ]
+		[ lifecycleState, confirm ]
 	);
 
 	return (

--- a/packages/ui/src/alert-dialog/root.tsx
+++ b/packages/ui/src/alert-dialog/root.tsx
@@ -1,5 +1,6 @@
 import { AlertDialog as _AlertDialog } from '@base-ui/react/alert-dialog';
 import { speak } from '@wordpress/a11y';
+import { useEvent } from '@wordpress/compose';
 import {
 	useCallback,
 	useEffect,
@@ -76,13 +77,11 @@ function Root( {
 
 	const actionsRef = useRef< _AlertDialog.Root.Actions | null >( null );
 
-	const onConfirmRef = useRef( onConfirm );
-	onConfirmRef.current = onConfirm;
+	const onConfirmEvent = useEvent( onConfirm );
 
 	// Ref keeps phase accessible synchronously from callbacks that may
 	// run between a setState call and the subsequent React re-render.
 	const phaseRef = useRef( phase );
-	phaseRef.current = phase;
 
 	// Generation counter — safety net for the edge case where the component
 	// unmounts while an async confirm is in flight. Also incremented when
@@ -136,7 +135,7 @@ function Root( {
 		const id = ++confirmIdRef.current;
 
 		try {
-			const rawResult = onConfirmRef.current?.();
+			const rawResult = onConfirmEvent?.();
 
 			// Show spinner only for async handlers (Promises).
 			// Sync handlers resolve in the same tick — no spinner needed.
@@ -183,7 +182,7 @@ function Root( {
 			// eslint-disable-next-line no-console
 			console.error( error );
 		}
-	}, [] );
+	}, [ onConfirmEvent ] );
 
 	const handleOpenChangeComplete = useCallback( ( open: boolean ) => {
 		if ( ! open ) {

--- a/packages/ui/src/utils/test/use-deprioritized-initial-focus.jsdom.test.tsx
+++ b/packages/ui/src/utils/test/use-deprioritized-initial-focus.jsdom.test.tsx
@@ -15,17 +15,17 @@ function TestHarness( {
 		result: ReturnType< typeof useDeprioritizedInitialFocus >
 	) => void;
 } ) {
-	const result = useDeprioritizedInitialFocus( {
+	const { resolvedInitialFocus, popupRef } = useDeprioritizedInitialFocus( {
 		initialFocus,
 		deprioritizedAttributes: [ ATTR ],
 	} );
 
 	useEffect( () => {
-		onResolved( result );
+		onResolved( { resolvedInitialFocus, popupRef } );
 	} );
 
 	return (
-		<div ref={ result.popupRef } data-testid="popup">
+		<div ref={ popupRef } data-testid="popup">
 			<button { ...{ [ ATTR ]: '' } }>Close</button>
 			<button>Action</button>
 			<input type="text" />
@@ -154,17 +154,18 @@ describe( 'useDeprioritizedInitialFocus', () => {
 					r: ReturnType< typeof useDeprioritizedInitialFocus >
 				) => void;
 			} ) {
-				const result = useDeprioritizedInitialFocus( {
-					initialFocus: undefined,
-					deprioritizedAttributes: [ ATTR ],
-				} );
+				const { resolvedInitialFocus, popupRef } =
+					useDeprioritizedInitialFocus( {
+						initialFocus: undefined,
+						deprioritizedAttributes: [ ATTR ],
+					} );
 
 				useEffect( () => {
-					onResolvedProp( result );
+					onResolvedProp( { resolvedInitialFocus, popupRef } );
 				} );
 
 				return (
-					<div ref={ result.popupRef } data-testid="popup">
+					<div ref={ popupRef } data-testid="popup">
 						<button { ...{ [ ATTR ]: '' } }>Close</button>
 						<p>No other tabbable elements</p>
 					</div>

--- a/packages/ui/src/utils/test/use-deprioritized-initial-focus.jsdom.test.tsx
+++ b/packages/ui/src/utils/test/use-deprioritized-initial-focus.jsdom.test.tsx
@@ -15,13 +15,14 @@ function TestHarness( {
 		result: ReturnType< typeof useDeprioritizedInitialFocus >
 	) => void;
 } ) {
-	const { resolvedInitialFocus, popupRef } = useDeprioritizedInitialFocus( {
+	const result = useDeprioritizedInitialFocus( {
 		initialFocus,
 		deprioritizedAttributes: [ ATTR ],
 	} );
+	const { popupRef } = result;
 
 	useEffect( () => {
-		onResolved( { resolvedInitialFocus, popupRef } );
+		onResolved( result );
 	} );
 
 	return (
@@ -154,14 +155,14 @@ describe( 'useDeprioritizedInitialFocus', () => {
 					r: ReturnType< typeof useDeprioritizedInitialFocus >
 				) => void;
 			} ) {
-				const { resolvedInitialFocus, popupRef } =
-					useDeprioritizedInitialFocus( {
-						initialFocus: undefined,
-						deprioritizedAttributes: [ ATTR ],
-					} );
+				const result = useDeprioritizedInitialFocus( {
+					initialFocus: undefined,
+					deprioritizedAttributes: [ ATTR ],
+				} );
+				const { popupRef } = result;
 
 				useEffect( () => {
-					onResolvedProp( { resolvedInitialFocus, popupRef } );
+					onResolvedProp( result );
 				} );
 
 				return (

--- a/packages/ui/src/utils/use-schedule-validation.ts
+++ b/packages/ui/src/utils/use-schedule-validation.ts
@@ -1,3 +1,4 @@
+import { useEvent } from '@wordpress/compose';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**
@@ -9,11 +10,10 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
  * and calls after unmount are silently ignored.
  *
  * @param validate Callback that performs the actual validation.
- *                 Stored in a ref — safe to pass an unstable closure.
+ *                 Wrapped in `useEvent`, so it can be an unstable closure.
  */
 export function useScheduleValidation( validate: () => void ) {
-	const validateRef = useRef( validate );
-	validateRef.current = validate;
+	const validateEvent = useEvent( validate );
 
 	const timerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const unmountedRef = useRef( false );
@@ -26,10 +26,10 @@ export function useScheduleValidation( validate: () => void ) {
 			clearTimeout( timerRef.current );
 		}
 		timerRef.current = setTimeout( () => {
-			validateRef.current();
+			validateEvent();
 			timerRef.current = null;
 		}, 0 );
-	}, [] );
+	}, [ validateEvent ] );
 
 	useEffect( () => {
 		unmountedRef.current = false;

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -8024,21 +8024,6 @@
 			"count": 12
 		}
 	},
-	"packages/ui/src/alert-dialog/root.tsx": {
-		"react-hooks/refs": {
-			"count": 2
-		}
-	},
-	"packages/ui/src/utils/test/use-deprioritized-initial-focus.jsdom.test.tsx": {
-		"react-hooks/refs": {
-			"count": 2
-		}
-	},
-	"packages/ui/src/utils/use-schedule-validation.ts": {
-		"react-hooks/refs": {
-			"count": 1
-		}
-	},
 	"packages/viewport/src/test/if-viewport-matches.jsdom.test.jsx": {
 		"react/jsx-filename-extension": {
 			"count": 1


### PR DESCRIPTION
## What?

Remove the five remaining `react-hooks/refs` ESLint suppressions from `@wordpress/ui`. This also replaces AlertDialog's render-mutated lifecycle refs with a private external store.

## Why?

AlertDialog callbacks need the current phase synchronously to block duplicate confirmation or dismissal while a promise is pending, and to ignore stale promise completion after a close and reopen. Updating refs during render met that need but violates `react-hooks/refs`.

## How?

- Subscribe React to a private lifecycle store with `useSyncExternalStore`, while event handlers read the same snapshot directly.
- Use `useEvent` for the latest `onConfirm` and scheduled validation callbacks.
- Destructure hook refs before using them in JSX, then remove the resolved suppressions.

## Testing Instructions

1. Run `npm run storybook:dev` and open **Design System / Components / AlertDialog / Async Confirm**.
2. With **Success** selected, open the dialog and confirm. Verify that both buttons become disabled, the confirm button shows a spinner, and the dialog closes after the async task finishes.
3. Select **Failure**, open the dialog, and confirm. Verify the same pending state, then confirm that the dialog stays open, shows the error, and re-enables both buttons.
4. Confirm again and verify that the previous error clears while the next attempt is pending.

### Testing Instructions for Keyboard

Repeat the success and failure flows using Tab, Shift+Tab, Space, Enter, and Escape. Verify that focus stays in the open dialog, pending actions cannot be activated, Escape does not dismiss the dialog while confirmation is pending, and Escape closes it after a failed confirmation returns it to idle.

<details>
<summary>Automated verification</summary>

- `npm run lint:js -- packages/ui`
- `npm run typecheck -- packages/ui/tsconfig.json`
- `npm run test:unit -- packages/ui/src/alert-dialog/test/index.jsdom.test.tsx packages/ui/src/dialog/test/index.jsdom.test.tsx packages/ui/src/popover/test/index.jsdom.test.tsx packages/ui/src/tabs/test/index.jsdom.test.tsx packages/ui/src/utils/test/use-deprioritized-initial-focus.jsdom.test.tsx --runInBand`
- `npm run build`

</details>

## Use of AI Tools

Codex was used to inspect the suppressions, implement and document the changes, rebase the branch, and run verification. I reviewed the resulting diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `SearchableSelect` component.
  - Added `Breadcrumb` to the list of available new UI features.

- **Improvements**
  - Improved AlertDialog lifecycle synchronization and close handling.
  - Improved callback stability for deferred validation and confirmation actions.

- **Maintenance**
  - Removed obsolete linting suppressions and updated the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->