### PR TITLE
Text: Use pretty wrapping by default

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Enhancements
 
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `popupWidth` prop with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087)).
+-   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
 
 ## 0.21.0 (2026-08-26)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Enhancements
 
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `popupWidth` prop with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087)).
--   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
+-   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. Remove the existing component-specific declarations from field descriptions and details and `Notice.Description`. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
 
 ## 0.21.0 (2026-08-26)
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Enhancements
 
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `popupWidth` prop with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087)).
--   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. Remove the existing component-specific declarations from field descriptions and details and `Notice.Description`. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
+-   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
 
 ## 0.21.0 (2026-08-26)
 

--- a/packages/ui/src/empty-state/style.module.css
+++ b/packages/ui/src/empty-state/style.module.css
@@ -52,4 +52,11 @@
 			}
 		}
 	}
+
+	@layer compositions {
+		.title,
+		.description {
+			text-wrap: balance;
+		}
+	}
 }

--- a/packages/ui/src/notice/style.module.css
+++ b/packages/ui/src/notice/style.module.css
@@ -41,7 +41,6 @@
 
 			padding-block: var(--text-vertical-padding);
 
-			text-wrap: pretty;
 			color: var(--wp-ui-notice-text-color);
 		}
 

--- a/packages/ui/src/text/style.module.css
+++ b/packages/ui/src/text/style.module.css
@@ -4,6 +4,7 @@
 	@layer components {
 		.text {
 			margin: 0;
+			text-wrap: pretty;
 		}
 
 		/* Text variants can render as either paragraphs or headings, so each variant

--- a/packages/ui/src/utils/css/field.module.css
+++ b/packages/ui/src/utils/css/field.module.css
@@ -27,6 +27,7 @@
 			font-size: var(--wpds-typography-font-size-sm);
 			line-height: var(--wpds-typography-line-height-xs);
 			color: var(--wpds-color-foreground-content-neutral-weak);
+			text-wrap: pretty;
 		}
 	}
 }

--- a/packages/ui/src/utils/css/field.module.css
+++ b/packages/ui/src/utils/css/field.module.css
@@ -27,7 +27,6 @@
 			font-size: var(--wpds-typography-font-size-sm);
 			line-height: var(--wpds-typography-line-height-xs);
 			color: var(--wpds-color-foreground-content-neutral-weak);
-			text-wrap: pretty;
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #82130.

Related: #58728, #60164, #75089.

## What?

Applies `text-wrap: pretty` to `@wordpress/ui`'s `Text` component by default. Existing component-specific wrapping choices remain unchanged.

## Why?

The legacy `@wordpress/components` Text component already provides this behavior. Migrating to the recommended `@wordpress/ui` Text currently loses widow prevention, as seen in #82130.

## How?

Adds `text-wrap: pretty` to Text's base class and removes the redundant declaration from `Notice.Description`, which renders through Text. Field and Fieldset descriptions and details keep their own `pretty` declaration because they do not render through Text. `EmptyState.Title` and `EmptyState.Description` keep their deliberate `balance` behavior through a higher-priority composition style.

## Testing Instructions

1. Start Storybook with `npm run storybook:dev`.
2. Open **Design System > Components > Text**, set a long `children` value, and narrow the preview until the text wraps.
3. Confirm that Text's computed `text-wrap` value is `pretty`.
4. Open the Notice stories and confirm that `Notice.Description` computes to `pretty` through Text.
5. Open the EmptyState stories and confirm that the title and description compute to `balance`.
6. Open the Field and Fieldset primitive stories and confirm that descriptions and details still compute to `pretty`.

### Testing Instructions for Keyboard

No keyboard behavior changes.

## Use of AI Tools

Codex was used to research prior decisions, implement the CSS change, run repository checks, perform an adversarial review, and draft this pull request.
