### PR TITLE
Editor assets endpoint: prime the theme JSON resolver before capturing

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -399,6 +399,16 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 			wp_enqueue_style( 'wp-format-library' );
 			wp_enqueue_media();
 
+			/*
+			 * Block style variations provided by the theme's theme.json
+			 * partials are registered lazily, when the theme JSON resolver
+			 * first runs in a request. Nothing has run it in this REST
+			 * request yet, so prime it — otherwise the block styles registry
+			 * is still empty when `enqueue_editor_block_styles_assets()`
+			 * serializes it into the `wp-block-styles` inline script below.
+			 */
+			WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
+
 			do_action( 'enqueue_block_editor_assets' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 			// Never allow old admin styles as a dependency.


### PR DESCRIPTION
## What?

Makes server-registered block styles reach editors that load their assets through the `/wp-block-editor/v1/assets` endpoint — the extensible site editor. One line (plus a comment): prime `WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()` before firing `enqueue_block_editor_assets`.

## Why?

In the extensible site editor, block style variations provided by a theme's `styles/block-style-variation-*.json` partials never showed up: `core/blocks`' `getBlockStyles()` only contained block-provided styles, so the Styles inspector had no variation buttons (found via #82117, where `block-style-variations.spec.js` is tagged `@site-editor-v1-only`).

The assets endpoint itself is built to carry this data: it fires `enqueue_block_editor_assets`, and core's `enqueue_editor_block_styles_assets()` serializes the block styles registry into the inline-only `wp-block-styles` handle, which the endpoint captures and `@wordpress/asset-loader` replays. The missing link: theme-partial variations are registered **lazily**, the first time the theme JSON resolver runs in a request. On a regular editor screen that always happens before the enqueue hook; in this REST request nothing had run it, so the registry was empty at capture time and the inline script contained zero registrations.

## How?

Prime the resolver in `get_assets()` before `do_action( 'enqueue_block_editor_assets' )`. Verified end-to-end on a test site with the `style-variations` test theme:

- Before: assets payload contains `wp-block-styles` with an empty IIFE; `getBlockStyles( 'core/group' )` → `[]` in the v2 editor.
- After: payload carries both `registerBlockStyle` calls; `getBlockStyles( 'core/group' )` → `[ 'block-style-variation-a', 'block-style-variation-b' ]`, and the "Block Style Variation A/B" buttons render in the v2 block inspector.

Follow-up: once this lands, `block-style-variations.spec.js` can be un-tagged in #82117 so it runs against both editors (its setup flow needs a small editor-agnostic adjustment there).

## Testing Instructions

1. Activate a theme with block style variation partials (e.g. `test/gutenberg-test-themes/style-variations`) and enable the **Extensible site editor** experiment.
2. Open the extensible site editor, edit any template or page, insert a **Group** block, select it, and open its inspector.
3. Before this PR: no style variation buttons. After: "Block Style Variation A" and "Block Style Variation B" appear and apply their border styles.
4. The classic editors are unaffected (they never used this endpoint's inline scripts — same screens keep working).

### Testing Instructions for Keyboard

Same as above; the variation buttons are regular inspector buttons reachable with Tab once the Group block is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)