### PR TITLE
Extensible Site Editor: Load media assets before the media fields open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54532,6 +54532,7 @@
 				"@wordpress/fields": "file:../../packages/fields",
 				"@wordpress/i18n": "file:../../packages/i18n",
 				"@wordpress/icons": "file:../../packages/icons",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
 				"@wordpress/route": "file:../../packages/route",
 				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 				"@wordpress/views": "file:../../packages/views"

--- a/package-lock.json
+++ b/package-lock.json
@@ -54393,12 +54393,15 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@wordpress/admin-ui": "file:../../packages/admin-ui",
+				"@wordpress/components": "file:../../packages/components",
 				"@wordpress/core-data": "file:../../packages/core-data",
 				"@wordpress/data": "file:../../packages/data",
 				"@wordpress/dataviews": "file:../../packages/dataviews",
+				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/fields": "file:../../packages/fields",
 				"@wordpress/html-entities": "file:../../packages/html-entities",
-				"@wordpress/i18n": "file:../../packages/i18n"
+				"@wordpress/i18n": "file:../../packages/i18n",
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor"
 			}
 		},
 		"routes/lock-unlock": {

--- a/routes/identity/package.json
+++ b/routes/identity/package.json
@@ -8,11 +8,14 @@
 	},
 	"dependencies": {
 		"@wordpress/admin-ui": "file:../../packages/admin-ui",
+		"@wordpress/components": "file:../../packages/components",
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
+		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/fields": "file:../../packages/fields",
 		"@wordpress/html-entities": "file:../../packages/html-entities",
-		"@wordpress/i18n": "file:../../packages/i18n"
+		"@wordpress/i18n": "file:../../packages/i18n",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor"
 	}
 }

--- a/routes/identity/stage.tsx
+++ b/routes/identity/stage.tsx
@@ -5,7 +5,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { DataForm, type Field, type Form } from '@wordpress/dataviews';
 import { MediaEdit } from '@wordpress/fields';
 import { loadEditorAssets } from '@wordpress/lazy-editor';
-import { Spinner } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -37,10 +36,18 @@ function MediaEditWithEditorAssets( props: any ) {
 		}
 	}, [ isReady ] );
 
-	if ( ! isReady ) {
-		return <Spinner />;
-	}
-	return <MediaEdit { ...props } />;
+	// Render the field right away — only opening the modal needs the
+	// assets — and keep it inert until they have loaded.
+	return (
+		<div
+			aria-busy={ ! isReady || undefined }
+			style={ ! isReady ? { opacity: 0.6 } : undefined }
+			// @ts-expect-error inert not typed properly
+			inert={ ! isReady ? 'true' : undefined }
+		>
+			<MediaEdit { ...props } />
+		</div>
+	);
 }
 
 const fields: Field< SiteSettings >[] = [

--- a/routes/identity/stage.tsx
+++ b/routes/identity/stage.tsx
@@ -4,6 +4,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { DataForm, type Field, type Form } from '@wordpress/dataviews';
 import { MediaEdit } from '@wordpress/fields';
+import { loadEditorAssets } from '@wordpress/lazy-editor';
+import { Spinner } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
 type SiteSettings = {
@@ -12,6 +15,33 @@ type SiteSettings = {
 	site_logo?: number;
 	site_icon?: number;
 };
+
+/*
+ * The media fields open the WordPress media modal, which needs the media
+ * assets (`wp.media` and friends) that the editor canvas loads lazily. This
+ * screen mounts a preview canvas, so they normally arrive moments after the
+ * screen does — but a fast click would still beat them and crash the route.
+ * Gate the field's edit component on the shared editor assets.
+ *
+ * A stopgap owned by the route, like the identical wrapper in
+ * `routes/post-list`: ultimately a field should be able to declare this kind
+ * of asset dependency itself; once that exists, remove this wrapper.
+ */
+function MediaEditWithEditorAssets( props: any ) {
+	const [ isReady, setIsReady ] = useState(
+		() => !! ( window as any ).wp?.media
+	);
+	useEffect( () => {
+		if ( ! isReady ) {
+			loadEditorAssets().then( () => setIsReady( true ) );
+		}
+	}, [ isReady ] );
+
+	if ( ! isReady ) {
+		return <Spinner />;
+	}
+	return <MediaEdit { ...props } />;
+}
 
 const fields: Field< SiteSettings >[] = [
 	{
@@ -40,7 +70,7 @@ const fields: Field< SiteSettings >[] = [
 			"Displays in your site's layout via the Site Logo block."
 		),
 		placeholder: __( 'Choose logo' ),
-		Edit: MediaEdit,
+		Edit: MediaEditWithEditorAssets,
 		setValue: ( { value } ) => ( {
 			site_logo: value ?? 0,
 		} ),
@@ -53,7 +83,7 @@ const fields: Field< SiteSettings >[] = [
 			'Shown in browser tabs, bookmarks, and mobile apps. It should be square and at least 512 by 512 pixels.'
 		),
 		placeholder: __( 'Choose icon' ),
-		Edit: MediaEdit,
+		Edit: MediaEditWithEditorAssets,
 		setValue: ( { value } ) => ( {
 			site_icon: value ?? 0,
 		} ),

--- a/routes/identity/tsconfig.json
+++ b/routes/identity/tsconfig.json
@@ -11,12 +11,15 @@
 	},
 	"references": [
 		{ "path": "../../packages/admin-ui/tsconfig.build.json" },
+		{ "path": "../../packages/components/tsconfig.build.json" },
 		{ "path": "../../packages/core-data/tsconfig.build.json" },
+		{ "path": "../../packages/element/tsconfig.build.json" },
 		{ "path": "../../packages/data" },
 		{ "path": "../../packages/dataviews/tsconfig.build.json" },
 		{ "path": "../../packages/fields/tsconfig.build.json" },
 		{ "path": "../../packages/html-entities/tsconfig.build.json" },
-		{ "path": "../../packages/i18n/tsconfig.build.json" }
+		{ "path": "../../packages/i18n/tsconfig.build.json" },
+		{ "path": "../../packages/lazy-editor" }
 	],
 	"include": [ "**/*.ts", "**/*.tsx" ],
 	"exclude": [ "build", "node_modules" ]

--- a/routes/post-list/package.json
+++ b/routes/post-list/package.json
@@ -13,13 +13,14 @@
 		"@wordpress/core-data": "file:../../packages/core-data",
 		"@wordpress/data": "file:../../packages/data",
 		"@wordpress/dataviews": "file:../../packages/dataviews",
-		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/editor": "file:../../packages/editor",
+		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/fields": "file:../../packages/fields",
 		"@wordpress/i18n": "file:../../packages/i18n",
 		"@wordpress/icons": "file:../../packages/icons",
-		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
 		"@wordpress/route": "file:../../packages/route",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
 		"@wordpress/views": "file:../../packages/views"
 	}
 }

--- a/routes/post-list/quick-edit-modal.tsx
+++ b/routes/post-list/quick-edit-modal.tsx
@@ -6,13 +6,45 @@ import type { Form } from '@wordpress/dataviews';
 import {
 	Button,
 	Modal,
+	Spinner,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { loadEditorAssets } from '@wordpress/lazy-editor';
 import { unlock } from '@wordpress/routes-lock-unlock';
 
 const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
+
+/*
+ * The featured image field opens the WordPress media modal, which needs the
+ * media assets (`wp.media` and friends) that the editor canvas loads but this
+ * screen never does — without them, opening the field crashes the route.
+ * Wrap the field's edit component so the shared editor assets are loaded
+ * first.
+ *
+ * This is a stopgap owned by the route because the route is what knows the
+ * screen is asset-less. Ultimately a field should be able to declare this
+ * kind of asset dependency itself so every DataForm consumer gets it for
+ * free; once that exists, remove this wrapper.
+ */
+function withEditorAssets( FieldEdit: any ) {
+	return function EditWithEditorAssets( props: any ) {
+		const [ isReady, setIsReady ] = useState(
+			() => !! ( window as any ).wp?.media
+		);
+		useEffect( () => {
+			if ( ! isReady ) {
+				loadEditorAssets().then( () => setIsReady( true ) );
+			}
+		}, [ isReady ] );
+
+		if ( ! isReady ) {
+			return <Spinner />;
+		}
+		return <FieldEdit { ...props } />;
+	};
+}
 
 const fieldsWithBulkEditSupport = [ 'status', 'date', 'author', 'discussion' ];
 
@@ -89,6 +121,12 @@ export function QuickEditModal( {
 					return {
 						...field,
 						readOnly: ! canSwitchTemplate,
+					};
+				}
+				if ( field.id === 'featured_media' && field.Edit ) {
+					return {
+						...field,
+						Edit: withEditorAssets( field.Edit ),
 					};
 				}
 

--- a/routes/post-list/quick-edit-modal.tsx
+++ b/routes/post-list/quick-edit-modal.tsx
@@ -6,7 +6,6 @@ import type { Form } from '@wordpress/dataviews';
 import {
 	Button,
 	Modal,
-	Spinner,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
@@ -39,10 +38,18 @@ function withEditorAssets( FieldEdit: any ) {
 			}
 		}, [ isReady ] );
 
-		if ( ! isReady ) {
-			return <Spinner />;
-		}
-		return <FieldEdit { ...props } />;
+		// Render the field right away — only opening the modal needs the
+		// assets — and keep it inert until they have loaded.
+		return (
+			<div
+				aria-busy={ ! isReady || undefined }
+				style={ ! isReady ? { opacity: 0.6 } : undefined }
+				// @ts-expect-error inert not typed properly
+				inert={ ! isReady ? 'true' : undefined }
+			>
+				<FieldEdit { ...props } />
+			</div>
+		);
 	};
 }
 

--- a/routes/post-list/tsconfig.json
+++ b/routes/post-list/tsconfig.json
@@ -24,6 +24,7 @@
 		{ "path": "../../packages/i18n/tsconfig.build.json" },
 		{ "path": "../../packages/icons/tsconfig.build.json" },
 		{ "path": "../../packages/keycodes/tsconfig.build.json" },
+		{ "path": "../../packages/lazy-editor" },
 		{ "path": "../../packages/notices/tsconfig.build.json" },
 		{ "path": "../../packages/route" },
 		{ "path": "../../packages/views/tsconfig.build.json" }


### PR DESCRIPTION
## What?

Fixes a crash in the extensible site editor's Pages screen: opening **Set featured image** in the quick edit drawer took down the whole route ("Something went wrong"). The featured image field opens the WordPress media modal, which needs the media assets (`wp.media`, its styles and HTML templates) that the editor canvas loads lazily but this screen never does.

Also applies the same gate to the **Identity screen's site logo and site icon** fields — an audit of the routes found these are the only other `MediaEdit` surfaces in the extensible editor. Identity mounts a preview canvas, so its assets normally arrive moments after the screen does, but a fast click on "Choose logo" would still beat them and crash the route the same way.

Found via #82117, where the two `featuredImage` quick edit tests in `page-list.spec.js` are tagged `@site-editor-v1-only`; a follow-up there will un-tag them once this lands (verified passing against this branch).

## Why?

The asset pipeline itself already covers media: `/wp-block-editor/v1/assets` calls `wp_enqueue_media()` and captures the scripts, styles, and `text/html` templates, and `@wordpress/asset-loader` replays them. The gap is purely that nothing on the Pages screen ever *triggers* that load — `useEditorAssets` only runs where an editor mounts.

## How?

In `routes/post-list`'s quick edit modal (for `featured_media`) and `routes/identity` (for `site_logo` and `site_icon`), the field's `Edit` component is wrapped. Rendering `MediaEdit` is safe without the assets — only opening the modal needs them — so the field renders immediately (label, placeholder, thumbnail included) and is kept `inert` with `aria-busy` until `loadEditorAssets()` (the same cached loader the canvas uses) resolves. In practice that busy window is a few hundred milliseconds at most and usually invisible.

The wrapper is deliberately a **route-level stopgap**, per the inline comment: the route is what knows this screen is asset-less, and the shared `fields` package shouldn't learn about `lazy-editor`. The eventual shape is fields being able to declare asset dependencies themselves so every DataForm consumer gets this for free — this unblocks the crash until that exists.

## Testing Instructions

1. Enable the **Extensible site editor** experiment (block theme active), and make sure you have a page.
2. Site Editor → Pages → select a page's row → **Quick Edit**.
3. Click **Set featured image**. Before this PR: the whole screen is replaced by "Something went wrong". After: the Featured Image media modal opens (library, upload, search all functional) and selecting an image sets it.
4. Identity: Site Editor → **Identity** → click **Choose logo** (or **Choose icon**) quickly after the screen loads — the media modal opens; before this PR a fast enough click crashed the screen.
5. The classic site editor is untouched (`routes/*` code only runs in the extensible editor).

### Testing Instructions for Keyboard

Tab through the quick edit drawer to **Set featured image**, press Enter, and confirm the media modal opens and traps focus as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

