### PR TITLE
Fix/html block link crash

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Prevent the block editor from crashing when links that do not open in a new tab are clicked within the editor canvas (such as in a Custom HTML block) ([#82012](https://github.com/WordPress/gutenberg/issues/82012)).
 -   Inserter: Keep the hovered block preview inside the viewport, so a tall preview in a short window is no longer clipped ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -159,14 +159,21 @@ function Iframe( {
 		function preventFileDropDefault( event ) {
 			event.preventDefault();
 		}
-		// Prevent clicks on link fragments from navigating away. Note that links
-		// inside `contenteditable` are already disabled by the browser, so
-		// this is for links in blocks outside of `contenteditable`.
+		// Prevent clicks on links from navigating away and crashing the editor iframe.
+		// Note that links inside `contenteditable` are already disabled by the browser,
+		// so this is for links in blocks outside of `contenteditable`.
 		function interceptLinkClicks( event ) {
-			if (
-				event.target.tagName === 'A' &&
-				event.target.getAttribute( 'href' )?.startsWith( '#' )
-			) {
+			const anchor = event.target.closest( 'a' );
+			if ( ! anchor ) {
+				return;
+			}
+
+			const href = anchor.getAttribute( 'href' );
+			if ( ! href ) {
+				return;
+			}
+
+			if ( href.startsWith( '#' ) ) {
 				event.preventDefault();
 				// Manually handle link fragment navigation within the iframe. The iframe's
 				// location is a blob URL, which can't be used to resolve relative links like
@@ -177,9 +184,14 @@ function Iframe( {
 				//
 				// Links with fragments are used for example with footnotes. Clicking on these
 				// links will scroll smoothly to the anchors in the editor canvas.
-				iFrameDocument.defaultView.location.hash = event.target
-					.getAttribute( 'href' )
-					.slice( 1 );
+				iFrameDocument.defaultView.location.hash = href.slice( 1 );
+				return;
+			}
+
+			// If the link does not open in a new window/tab, prevent navigation to avoid crashing the editor.
+			const target = anchor.getAttribute( 'target' );
+			if ( ! target || target.toLowerCase() === '_self' ) {
+				event.preventDefault();
 			}
 		}
 


### PR DESCRIPTION
Closes #82012 

This PR resolves an issue where clicking on links inside the editor iframe (such as inside a Custom HTML block) that do not open in a new tab attempts to navigate the editor's iframe itself. This breaks the React app context and crashes the editor with an "unexpected error" message.

To solve this:
- I  intercepted  link clicks inside the block editor's iframe component (`packages/block-editor/src/components/iframe/index.js`).
- If the click is on an anchor element (including elements nested inside a link), and it doesn't target a new window/tab (`target` is not `_blank`), we call `event.preventDefault()` to stop the iframe from navigating.
- Links that open in a new window/tab (`target="_blank"`) are still allowed to execute normally so that valid block UI links (e.g. documentation links) continue to function.


### Testing Instructions
1. Edit any page or post.
2. Insert a **Custom HTML** block.
3. Add a link with `target="_self"` or no target:
   ```html
   <div>Have questions? <a href="https://wordpress.org" target="_self">Contact Us</a></div>
  
4. Click the link in the Custom HTML block preview inside the editor canvas.
5. Verify that clicking the link does nothing, and the editor remains stable without crashing.

### Before fix (Clicking the link in editor- Editor crashes):-
<img width="1470" height="932" alt="Screenshot 2026-08-27 at 7 26 05 PM" src="https://github.com/user-attachments/assets/d553eecd-6303-4485-8fc2-90ed6f630f2f" />

### After fix (Clicking the link in editor- Editor does not crashes):-
<img width="1466" height="678" alt="Screenshot 2026-08-27 at 7 49 01 PM" src="https://github.com/user-attachments/assets/75baa45c-9fef-4dca-9bf1-6c6153b756ee" />
