### PR TITLE
Performance tests: Shard suites across parallel CI jobs

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,13 +30,26 @@ permissions: {}
 jobs:
     performance:
         timeout-minutes: 60
-        name: Run performance tests
+        name: Run performance tests (${{ matrix.shard }})
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}
+        strategy:
+            fail-fast: false
+            # Shards run in parallel to cut the wall clock time. Every shard still
+            # measures all branches on the same runner, so results stay comparable.
+            matrix:
+                include:
+                    - shard: post-editor
+                      suites: post-editor
+                    - shard: site-editor
+                      suites: site-editor
+                    - shard: media-and-front-end
+                      suites: front-end-block-theme,front-end-classic-theme,media-processing,media-upload
         env:
             WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+            PERF_SUITES: ${{ matrix.suites }}
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -56,7 +69,7 @@ jobs:
 
             - name: Compare performance with base branch
               if: github.event_name == 'pull_request'
-              run: npm exec --no release-cli -- perf "$GITHUB_SHA" "$GITHUB_BASE_REF" --tests-branch "$GITHUB_SHA"
+              run: npm exec --no release-cli -- perf "$GITHUB_SHA" "$GITHUB_BASE_REF" --tests-branch "$GITHUB_SHA" --suites "$PERF_SUITES"
 
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'
@@ -90,7 +103,7 @@ jobs:
                   WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  npm exec --no release-cli -- perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
+                  npm exec --no release-cli -- perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR" --suites "$PERF_SUITES"
 
             - name: Compare performance with base branch
               if: github.event_name == 'push'
@@ -102,7 +115,7 @@ jobs:
                   WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  npm exec --no release-cli -- perf "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
+                  npm exec --no release-cli -- perf "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR" --suites "$PERF_SUITES"
 
             - name: Compare performance with custom branches
               if: github.event_name == 'workflow_dispatch'
@@ -110,7 +123,8 @@ jobs:
                   BRANCHES: ${{ github.event.inputs.branches }}
                   WP_VERSION: ${{ github.event.inputs.wpversion }}
               run: |
-                  npm exec --no release-cli -- perf "$(echo "$BRANCHES" | tr ',' ' ')" --tests-branch "$GITHUB_SHA" --wp-version "$WP_VERSION"
+                  IFS=, read -ra BRANCH_ARGS <<< "$BRANCHES"
+                  npm exec --no release-cli -- perf "${BRANCH_ARGS[@]}" --tests-branch "$GITHUB_SHA" --wp-version "$WP_VERSION" --suites "$PERF_SUITES"
 
             - name: Add workflow summary
               run: cat "${WP_ARTIFACTS_PATH}/summary.md" >> "$GITHUB_STEP_SUMMARY"
@@ -119,18 +133,99 @@ jobs:
               if: success()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
-                  name: performance-results
+                  name: performance-results-${{ matrix.shard }}
                   path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
+
+            - name: Archive performance summary
+              if: success()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: performance-summary-${{ matrix.shard }}
+                  path: ${{ env.WP_ARTIFACTS_PATH }}/summary.md
 
             - name: Archive performance traces
               if: always()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
-                  name: performance-traces
+                  name: performance-traces-${{ matrix.shard }}
                   path: |
                       ${{ env.WP_ARTIFACTS_PATH }}/traces
                       ${{ env.WP_ARTIFACTS_PATH }}/build
                   if-no-files-found: ignore
+
+            - name: Archive debug artifacts (screenshots, HTML snapshots)
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              if: failure()
+              with:
+                  name: failures-artifacts-${{ matrix.shard }}
+                  path: ${{ env.WP_ARTIFACTS_PATH }}
+                  if-no-files-found: ignore
+
+    results:
+        timeout-minutes: 10
+        name: Merge performance results
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
+        needs: performance
+        if: ${{ github.repository == 'WordPress/gutenberg' }}
+        permissions:
+            contents: read
+        env:
+            WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Use desired version of Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: '.nvmrc'
+
+            - name: Download shard results
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  pattern: performance-results-*
+                  path: ${{ env.WP_ARTIFACTS_PATH }}
+                  merge-multiple: true
+
+            - name: Download shard summaries
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  pattern: performance-summary-*
+                  path: ${{ env.WP_ARTIFACTS_PATH }}/summaries
+
+            # Fails when a suite is missing from every shard of the matrix above.
+            - name: Check that every suite ran
+              run: |
+                  for spec in test/performance/specs/*.spec.js; do
+                    suite="$(basename "$spec" .spec.js)"
+                    if [[ ! -f "${WP_ARTIFACTS_PATH}/${suite}.performance-results.json" ]]; then
+                      echo "::error::No results for the '${suite}' suite. Add it to a shard in performance.yml."
+                      exit 1
+                    fi
+                  done
+
+            - name: Add workflow summary
+              run: |
+                  {
+                    echo "## Performance Test Results"
+                    echo
+                    echo "Please note that client side metrics **exclude** the server response time."
+                    echo
+                    for shard in post-editor site-editor media-and-front-end; do
+                      # Skip the header the shard summary repeats.
+                      tail -n +5 "${WP_ARTIFACTS_PATH}/summaries/performance-summary-${shard}/summary.md"
+                    done
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            # Keep the single artifact that existed before the tests were sharded.
+            - name: Archive merged performance results
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: performance-results
+                  path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
 
             - name: Publish performance results
               if: github.event_name == 'push'
@@ -138,12 +233,4 @@ jobs:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: |
                   COMMITTED_AT="$(git show -s "$GITHUB_SHA" --format="%cI")"
-                  npm run --workspace=tools/release log-performance-results -- "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 "$COMMITTED_AT"
-
-            - name: Archive debug artifacts (screenshots, HTML snapshots)
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              if: failure()
-              with:
-                  name: failures-artifacts
-                  path: ${{ env.WP_ARTIFACTS_PATH }}
-                  if-no-files-found: ignore
+                  node tools/release/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 "$COMMITTED_AT"

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -34,6 +34,8 @@ A tool to compare performance across multiple branches/tags/commits is provided.
 npm exec release-cli -- perf trunk v8.1.0 v8.0.0
 ```
 
+Pass `--suites` with a comma separated list of spec names (`test/performance/specs/*.spec.js` without the extension) to run a subset of the suites. The CI workflow uses it to split the suites into shards that run in parallel, each shard measuring all branches on the same runner.
+
 To get the most accurate results, it's is important to use the exact same version of the tests and environment (theme...) when running the tests, the only thing that need to be different between the branches is the Gutenberg plugin version (or branch used to build the plugin).
 
 To achieve that the command first prepares the following folder structure:

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -80,6 +80,10 @@ program
 		'Run each test suite this many times for each branch; results are summarized, default = 1'
 	)
 	.option(
+		'--suites <suites>',
+		'Comma separated names of the test suites to run, default = all'
+	)
+	.option(
 		'--tests-branch <branch>',
 		"Use this branch's performance test files"
 	)

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -21,6 +21,7 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  *
  * @property {boolean=} ci          Run on CI.
  * @property {number=}  rounds      Run each test suite this many times for each branch.
+ * @property {string=}  suites      Comma separated names of the test suites to run (default: all).
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
@@ -355,6 +356,32 @@ async function runPerformanceTests( branches, options ) {
 	// @ts-expect-error The `simple-git` module namespace has no call signatures.
 	await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
 
+	logAtIndent( 2, 'Looking for test files' );
+	const availableSuites = getFilesFromDir(
+		path.join( testRunnerDir, 'test/performance/specs' )
+	).map( ( file ) => path.basename( file, '.spec.js' ) );
+	const requestedSuites = ( options.suites || '' )
+		.split( ',' )
+		.map( ( suite ) => suite.trim() )
+		.filter( Boolean );
+	const unknownSuites = requestedSuites.filter(
+		( suite ) => ! availableSuites.includes( suite )
+	);
+	if ( unknownSuites.length ) {
+		throw new Error(
+			`Unknown test suite(s): ${ unknownSuites.join(
+				', '
+			) }. Available: ${ availableSuites.join( ', ' ) }`
+		);
+	}
+	const testSuites = availableSuites.filter(
+		( suite ) =>
+			requestedSuites.length === 0 || requestedSuites.includes( suite )
+	);
+	for ( const suite of testSuites ) {
+		logAtIndent( 3, 'Found:', formats.success( suite ) );
+	}
+
 	logAtIndent( 2, 'Installing dependencies and building' );
 	await runShellScript(
 		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps"`,
@@ -454,15 +481,6 @@ async function runPerformanceTests( branches, options ) {
 			'utf8'
 		);
 	}
-
-	logAtIndent( 0, 'Looking for test files' );
-
-	const testSuites = getFilesFromDir(
-		path.join( testRunnerDir, 'test/performance/specs' )
-	).map( ( file ) => {
-		logAtIndent( 1, 'Found:', formats.success( file ) );
-		return path.basename( file, '.spec.js' );
-	} );
 
 	logAtIndent( 0, 'Running tests' );
 


### PR DESCRIPTION
## What?

Splits the performance tests workflow into three parallel shards and adds a `--suites` option to `release-cli perf`.

## Why?

The performance job takes 35 to 40 minutes and is the slowest check on every PR, so PRs routinely sit waiting on it after everything else is green. In [30103099688](https://github.com/WordPress/gutenberg/actions/runs/30103099688) each branch spent 14 minutes running suites serially. Sharding brings the critical path to about 18 minutes.

## How?

- [performance.js](tools/release/commands/performance.js) accepts `--suites` (comma separated spec names, default all).
- [performance.yml](.github/workflows/performance.yml) runs three shards. Each measures every branch back to back on one runner, so head and base are never compared across machines.
- A `results` job merges shard artifacts into the single `performance-results` artifact and runs the codevitals publish on `push`.
- Runner minutes rise; sharing one build across shards is a follow up.

## Testing Instructions

1. On this PR, three `Run performance tests (...)` jobs run in parallel and `Merge performance results` uploads `performance-results` with all six result files.
2. Locally, `npm exec release-cli -- perf trunk trunk --suites front-end-block-theme` runs only that suite.

## Use of AI Tools

Drafted with Claude Code and reviewed with Codex; every change was reviewed by me.
