### PR TITLE
Build: allow wp-theme 2.x peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54244,7 +54244,7 @@
 				"@wordpress/boot": ">=0.3.0 <1.0.0",
 				"@wordpress/private-apis": "^1.0.0",
 				"@wordpress/route": ">=0.2.0 <1.0.0",
-				"@wordpress/theme": ">=0.8.0 <2.0.0"
+				"@wordpress/theme": ">=0.8.0 <3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@wordpress/boot": {

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Widen the optional `@wordpress/theme` peer dependency range to allow 2.x releases.
+-   Widen the optional `@wordpress/theme` peer dependency range to allow 2.x releases. ([#82139](https://github.com/WordPress/gutenberg/pull/82139))
 -   Pages: preserve the Core Boot layout compatibility class in generated wp-admin page templates so short pages fill the viewport when using Core's bundled Boot module ([#82112](https://github.com/WordPress/gutenberg/pull/82112)).
 
 ## 0.22.0 (2026-08-26)

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Widen the optional `@wordpress/theme` peer dependency range to allow 2.x releases.
 -   Pages: preserve the Core Boot layout compatibility class in generated wp-admin page templates so short pages fill the viewport when using Core's bundled Boot module ([#82112](https://github.com/WordPress/gutenberg/pull/82112)).
 
 ## 0.22.0 (2026-08-26)

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/boot": ">=0.3.0 <1.0.0",
 		"@wordpress/private-apis": "^1.0.0",
 		"@wordpress/route": ">=0.2.0 <1.0.0",
-		"@wordpress/theme": ">=0.8.0 <2.0.0"
+		"@wordpress/theme": ">=0.8.0 <3.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@wordpress/boot": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Found out that wp-build consumer had to do a workaround (https://github.com/Automattic/jetpack/pull/51654) to update also wp-theme to the latest.

Similar range widening change like we did in:
- https://github.com/WordPress/gutenberg/pull/80089

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I don't think there's really anything particular to test other than CI is passing. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
yes