### PR TITLE
Site editor v2: pages take view config from endpoint

### DIFF
--- a/routes/post-list/stage.tsx
+++ b/routes/post-list/stage.tsx
@@ -5,10 +5,10 @@ import {
 	Link,
 	useInvalidate,
 } from '@wordpress/route';
-import { useView } from '@wordpress/views';
+import { useView, useViewConfig } from '@wordpress/views';
 import { DataViews } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
-import type { View, Action } from '@wordpress/dataviews';
+import type { View, Action, SupportedLayouts } from '@wordpress/dataviews';
 import {
 	store as coreStore,
 	privateApis as coreDataPrivateApis,
@@ -25,11 +25,10 @@ import { drawerRight } from '@wordpress/icons';
 import type { Post } from '@wordpress/core-data';
 import { unlock } from '@wordpress/routes-lock-unlock';
 import {
-	getDefaultView,
-	getActiveViewOverridesForTab,
-	DEFAULT_VIEWS,
-	DEFAULT_LAYOUTS,
+	getActiveViewOverrides,
 	viewToQuery,
+	type ViewListEntry,
+	type ViewOverrides,
 } from './view-utils';
 import { QuickEditModal } from './quick-edit-modal';
 // Unlock WordPress private APIs
@@ -52,10 +51,56 @@ function getItemLevel( item: Post ) {
 }
 
 function PostList() {
-	const invalidate = useInvalidate();
 	const { type: postType, slug = 'all' } = useParams( {
 		from: '/types/$type/list/$slug',
 	} );
+	const {
+		default_view: defaultView,
+		default_layouts: defaultLayouts,
+		view_list: viewList,
+	} = useViewConfig( {
+		kind: 'postType',
+		name: postType,
+	} );
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverrides( viewList, slug ),
+		[ viewList, slug ]
+	);
+
+	if ( ! defaultView ) {
+		// The route canvas resolves the view configuration before the stage
+		// mounts, so this only guards against the store being reset.
+		return null;
+	}
+
+	return (
+		<PostListView
+			postType={ postType }
+			slug={ slug }
+			defaultView={ defaultView }
+			defaultLayouts={ defaultLayouts }
+			viewList={ viewList }
+			activeViewOverrides={ activeViewOverrides }
+		/>
+	);
+}
+
+function PostListView( {
+	postType,
+	slug,
+	defaultView,
+	defaultLayouts,
+	viewList,
+	activeViewOverrides,
+}: {
+	postType: string;
+	slug: string;
+	defaultView: View;
+	defaultLayouts: SupportedLayouts | undefined;
+	viewList: ViewListEntry[] | undefined;
+	activeViewOverrides: ViewOverrides;
+} ) {
+	const invalidate = useInvalidate();
 	const navigate = useNavigate();
 	const searchParams = useSearch( { from: '/types/$type/list/$slug' } );
 	const postTypeObject = useSelect(
@@ -71,15 +116,6 @@ function PostList() {
 				name: postType,
 			} ),
 		[ postType ]
-	);
-
-	const defaultView: View = useMemo( () => {
-		return getDefaultView( postTypeObject );
-	}, [ postTypeObject ] );
-
-	const activeViewOverrides = useMemo(
-		() => getActiveViewOverridesForTab( slug ),
-		[ slug ]
 	);
 
 	// Callback to handle URL query parameter changes
@@ -101,6 +137,7 @@ function PostList() {
 		name: postType,
 		slug: 'default-new',
 		defaultView,
+		defaultLayouts,
 		activeViewOverrides,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
@@ -333,23 +370,18 @@ function PostList() {
 			}
 			hasPadding={ false }
 		>
-			{ DEFAULT_VIEWS.length > 1 && (
+			{ viewList && viewList.length > 1 && (
 				<div className="routes-post-list__tabs-wrapper">
-					<Tabs
-						onSelect={ handleTabChange }
-						selectedTabId={ slug ?? 'all' }
-					>
+					<Tabs onSelect={ handleTabChange } selectedTabId={ slug }>
 						<Tabs.TabList>
-							{ DEFAULT_VIEWS.map(
-								( filter: { slug: string; label: string } ) => (
-									<Tabs.Tab
-										tabId={ filter.slug }
-										key={ filter.slug }
-									>
-										{ filter.label }
-									</Tabs.Tab>
-								)
-							) }
+							{ viewList.map( ( entry ) => (
+								<Tabs.Tab
+									tabId={ entry.slug }
+									key={ entry.slug }
+								>
+									{ entry.title }
+								</Tabs.Tab>
+							) ) }
 						</Tabs.TabList>
 					</Tabs>
 				</div>
@@ -365,7 +397,7 @@ function PostList() {
 					totalItems,
 					totalPages,
 				} }
-				defaultLayouts={ DEFAULT_LAYOUTS }
+				defaultLayouts={ defaultLayouts }
 				getItemId={ getItemId }
 				getItemLevel={ getItemLevel }
 				selection={ selection }

--- a/routes/post-list/view-utils.ts
+++ b/routes/post-list/view-utils.ts
@@ -1,103 +1,65 @@
 import { loadView } from '@wordpress/views';
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import type { Type } from '@wordpress/core-data';
-import type {
-	View,
-	Filter,
-	SupportedLayouts,
-	ViewTable,
-} from '@wordpress/dataviews';
+import type { View, SupportedLayouts } from '@wordpress/dataviews';
+import { unlock } from '@wordpress/routes-lock-unlock';
 
-const DEFAULT_VIEW: View = {
-	type: 'table' as const,
-	sort: {
-		field: 'date',
-		direction: 'desc' as const,
-	},
-	fields: [ 'author', 'status', 'date' ],
-	titleField: 'title',
-	mediaField: 'featured_media',
-	descriptionField: 'excerpt',
-};
-
-const DEFAULT_TABLE_LAYOUT: Omit< ViewTable, 'type' > = {
-	layout: {
-		styles: {
-			author: {
-				align: 'start',
-			},
-		},
-	},
-};
-
-export const DEFAULT_LAYOUTS: SupportedLayouts = {
-	table: DEFAULT_TABLE_LAYOUT,
-	grid: true,
-	list: true,
-};
-
-export const DEFAULT_VIEWS: {
-	slug: string;
-	label: string;
-}[] = [
-	{
-		slug: 'all',
-		label: 'All',
-	},
-	{
-		slug: 'publish',
-		label: 'Published',
-	},
-	{
-		slug: 'draft',
-		label: 'Draft',
-	},
-	{
-		slug: 'pending',
-		label: 'Pending',
-	},
-	{
-		slug: 'private',
-		label: 'Private',
-	},
-	{
-		slug: 'trash',
-		label: 'Trash',
-	},
-];
-
-type ActiveViewOverrides = {
-	filters?: Filter[];
-	sort?: View[ 'sort' ];
+/**
+ * A layer merged on top of a view. Mirrors the `ViewOverrides` type of
+ * `@wordpress/views`, which is not exported.
+ */
+export type ViewOverrides = Partial< Omit< View, 'type' | 'layout' > > & {
+	type?: View[ 'type' ];
 	layout?: Record< string, unknown >;
 };
 
-export function getActiveViewOverridesForTab(
-	slug: string
-): ActiveViewOverrides {
-	if ( slug === 'all' ) {
-		return {
-			...DEFAULT_TABLE_LAYOUT,
-		};
-	}
+export interface ViewListEntry {
+	title: string;
+	slug: string;
+	view?: ViewOverrides;
+}
+
+interface EntityViewConfig {
+	default_view: View | undefined;
+	default_layouts: SupportedLayouts | undefined;
+	view_list: ViewListEntry[] | undefined;
+}
+
+/**
+ * Resolves the server-provided view configuration for the given post type,
+ * for use in the route loader that runs outside React (where `useViewConfig`
+ * is unavailable).
+ *
+ * @param postType The post type name.
+ * @return The entity view configuration.
+ */
+export async function loadPostTypeViewConfig(
+	postType: string
+): Promise< EntityViewConfig > {
+	const config = await unlock( resolveSelect( coreStore ) ).getViewConfig(
+		'postType',
+		postType
+	);
 	return {
-		...DEFAULT_TABLE_LAYOUT,
-		filters: [
-			{
-				field: 'status',
-				operator: 'is',
-				value: slug,
-			},
-		],
+		default_view: config?.default_view,
+		default_layouts: config?.default_layouts,
+		view_list: config?.view_list,
 	};
 }
 
-export function getDefaultView( postType: Type | undefined ): View {
-	return {
-		...DEFAULT_VIEW,
-		showLevels: postType?.hierarchical,
-	};
+/**
+ * Returns the view overrides of the entry in the view list matching the
+ * given slug, or an empty object when there is none.
+ *
+ * @param viewList The `view_list` of an entity view configuration.
+ * @param slug     Slug of the active view.
+ * @return The view overrides for the active view.
+ */
+export function getActiveViewOverrides(
+	viewList: ViewListEntry[] | undefined,
+	slug: string
+): ViewOverrides {
+	return viewList?.find( ( v ) => v.slug === slug )?.view ?? {};
 }
 
 export async function ensureView(
@@ -105,18 +67,26 @@ export async function ensureView(
 	slug?: string,
 	search?: { page?: number; search?: string }
 ) {
-	const postTypeObject = await resolveSelect( coreStore ).getPostType( type );
-	const defaultView = getDefaultView( postTypeObject );
+	const {
+		default_view: defaultView,
+		default_layouts: defaultLayouts,
+		view_list: viewList,
+	} = await loadPostTypeViewConfig( type );
+	if ( ! defaultView ) {
+		throw new Error(
+			`Missing view configuration for the ${ type } post type.`
+		);
+	}
 	return loadView( {
 		kind: 'postType',
 		name: type,
 		slug: 'default-new',
 		defaultView,
-		activeViewOverrides: getActiveViewOverridesForTab( slug ?? 'all' ),
+		defaultLayouts,
+		activeViewOverrides: getActiveViewOverrides( viewList, slug ?? 'all' ),
 		queryParams: search,
 	} );
 }
-
 export function viewToQuery( view: View, postType: string ) {
 	const result: Record< string, any > = { _embed: 'author,wp:featuredmedia' };
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/79895

## What?

Ports the extensible site editor's **Pages** list screen (`routes/post-list`) from hard-coded view defaults to the server-provided view configuration served by `GET /wp/v2/view-config?kind=postType&name=page`.

## Why?

See https://github.com/WordPress/gutenberg/issues/79895

## How?

- JS (`routes/post-list/`): use the data from the endpoint (`default_view`, `default_layouts`, `view_list`). The status tabs are built from `view_list`, so the tab slugs in the URL are now the server ones (`published`, `drafts`, ...).
- No PHP changes: the `page` configuration already ships in core (`_wp_get_entity_view_config_posttype_page`).

## Testing Instructions

1. Enable the **Extensible Site Editor** experiment under Gutenberg → Experiments, with a block theme active (e.g. Twenty Twenty-Five).
2. Go to `/wp-admin/admin.php?page=site-editor-v2` and click **Pages** in the sidebar.
3. Confirm the list renders with the server defaults: list layout, sorted by title, levels shown, the first page previewed on the canvas, and the tabs "All Pages, Published, Scheduled, Drafts, Pending, Private, Trash".
4. Switch tabs and confirm each one filters by status. **Trash** switches to the table layout and hides the canvas.
5. Open DevTools → Network and confirm a request to `/wp/v2/view-config?kind=postType&name=page` returning `default_view.type === "list"`. (You'll see it twice until https://github.com/WordPress/gutenberg/pull/82141 lands: the route's `canvas` and the stage resolve it under different cache keys.)
6. Add a filter in a plugin or `functions.php` and confirm it's honored, e.g.:
   ```php
   add_filter( 'get_entity_view_config_posttype_page', function ( $data ) {
       return $data->merge( array( 'default_view' => array( 'sort' => array( 'field' => 'date', 'direction' => 'desc' ) ) ), 1 );
   } );
   ```

## Use of AI Tools

Implemented with Claude Code (Claude Fable 5). Reviewed and adjusted by the author.
