### PR TITLE
useViewConfig: don't request the view config twice

### DIFF
--- a/packages/views/CHANGELOG.md
+++ b/packages/views/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `useViewConfig`: request the full configuration under the same cache key as `getViewConfig( kind, name )`, so a route loader that preloads it no longer triggers a second request. ([#82141](https://github.com/WordPress/gutenberg/pull/82141))
+
 ## 1.21.0 (2026-08-26)
 
 ### Internal

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -40,14 +40,15 @@ export function useViewConfig( {
 		: undefined;
 	return useSelect(
 		( select ) => {
-			const { getViewConfig } = unlock( select( coreStore ) );
-			// Only pass options when a subset is requested, so the selector
-			// resolves under the same cache key as `getViewConfig( kind, name )`
-			// and callers that preload the full config outside React (route
-			// loaders) share the request instead of triggering a second one.
-			return fieldsKey
-				? getViewConfig( kind, name, { fields: fieldsKey } )
-				: getViewConfig( kind, name );
+			return unlock( select( coreStore ) ).getViewConfig(
+				kind,
+				name,
+				fieldsKey
+					? {
+							fields: fieldsKey,
+					  }
+					: undefined
+			);
 		},
 		[ kind, name, fieldsKey ]
 	);

--- a/packages/views/src/use-view-config.ts
+++ b/packages/views/src/use-view-config.ts
@@ -40,9 +40,14 @@ export function useViewConfig( {
 		: undefined;
 	return useSelect(
 		( select ) => {
-			return unlock( select( coreStore ) ).getViewConfig( kind, name, {
-				fields: fieldsKey,
-			} );
+			const { getViewConfig } = unlock( select( coreStore ) );
+			// Only pass options when a subset is requested, so the selector
+			// resolves under the same cache key as `getViewConfig( kind, name )`
+			// and callers that preload the full config outside React (route
+			// loaders) share the request instead of triggering a second one.
+			return fieldsKey
+				? getViewConfig( kind, name, { fields: fieldsKey } )
+				: getViewConfig( kind, name );
 		},
 		[ kind, name, fieldsKey ]
 	);


### PR DESCRIPTION
## What?

`useViewConfig` fires a second request for the view config when the same config was already loaded outside React with `getViewConfig( kind, name )`.

## Why?

The `@wordpress/data` resolver cache is keyed by the full argument list. A route loader calls `getViewConfig( 'postType', 'page' )` (two arguments), while `useViewConfig` always called `getViewConfig( 'postType', 'page', { fields: undefined } )` (three arguments). The store sees two different keys, resolves both, and the browser makes two identical `GET /wp/v2/view-config` requests on every screen that has a loader and a stage.

I discovered this while preparing https://github.com/WordPress/gutenberg/pull/82140

## How?

`useViewConfig` only passes the options object when a subset of `fields` is requested. When it isn't, it calls `getViewConfig( kind, name )`, which is the same key the loaders use, so both share one resolution.

## Testing Instructions

Reproduce on trunk first:

1. Activate a block theme (e.g. Twenty Twenty-Five).
2. Open DevTools → Network and filter by `view-config`.
3. Load `/wp-admin/site-editor.php?p=/page`.
4. You see **two** identical requests to `/wp/v2/view-config?kind=postType&name=page`. One comes from the `isListView()` helper in `packages/edit-site/src/components/site-editor-routes/pages.js`, the other from `useViewConfig` in `packages/edit-site/src/components/post-list/index.js`.

Then check out this branch, rebuild, and reload: only **one** request is made.

Also run `npm run test:unit -- packages/views`.

### Testing Instructions for Keyboard

Not applicable, there is no UI change.

## Use of AI Tools

Implemented with Claude Code (Claude Fable 5). Reviewed and adjusted by the author.
