### PR TITLE
Extensible site editor: Fall back to the raw title in edit route document titles

### DIFF
--- a/routes/navigation-edit/route.ts
+++ b/routes/navigation-edit/route.ts
@@ -53,10 +53,16 @@ export const route = {
 			'postType',
 			NAVIGATION_POST_TYPE,
 			navigationId
-		) ) as { title?: { rendered?: string } } | undefined;
+		) ) as { title?: { rendered?: string; raw?: string } } | undefined;
 
 		if ( navigation?.title?.rendered ) {
 			return decodeEntities( navigation.title.rendered );
+		}
+
+		// A record received from a save carries no rendered fields, only raw
+		// ones — that's what the cache holds for a menu created this session.
+		if ( navigation?.title?.raw ) {
+			return navigation.title.raw;
 		}
 
 		return __( 'Navigation' );

--- a/routes/post-edit/route.ts
+++ b/routes/post-edit/route.ts
@@ -62,10 +62,17 @@ export const route = {
 			'postType',
 			params.type,
 			postId
-		) ) as { title?: { rendered?: string } } | undefined;
+		) ) as { title?: { rendered?: string; raw?: string } } | undefined;
 
 		if ( post?.title?.rendered ) {
 			return decodeEntities( post.title.rendered );
+		}
+
+		// Some records only carry a raw title: the blocks REST controller
+		// strips `title.rendered` from patterns in every context, and a
+		// record received from a save has no rendered fields either.
+		if ( post?.title?.raw ) {
+			return post.title.raw;
 		}
 
 		const postType = await resolveSelect( coreStore ).getPostType(


### PR DESCRIPTION
## What?

Makes the extensible site editor's edit routes fall back to the entity's **raw** title when composing the browser document title, instead of jumping straight to the generic post type label.

## Why?

The `post-edit` route's `title()` resolver only considered `title.rendered`. Two kinds of records never have it:

- **Patterns**: the blocks REST controller strips rendered title/content fields from `wp_block` responses in every context, so `title.rendered` never exists for a pattern.
- **Records cached from a save**: a record received from `saveEntityRecord`'s response carries only raw fields, and it satisfies the resolver's cache, so any entity created in the same session resolves to a raw-only record.

In both cases the resolver fell back to the post type label — so client-side navigation into *any* pattern (and into any entity created in the same session) titled the tab "Edit Block Pattern" instead of the pattern's name. Deep links only looked right because PHP renders the initial title server-side; the surfaced e2e adaptation blamed "entities created in the same session", but the pattern case reproduces on every client-side navigation.

Router invalidation wouldn't help here: re-running the loader re-reads the same raw-only data.

## How?

In the `post-edit` and `navigation-edit` route `title()` resolvers, check `title.raw` after `title.rendered` and before the post type label fallback. Raw titles are plain text, so they are used as-is (no entity decoding).

## Testing Instructions

1. Enable the **Extensible site editor** experiment.
2. Open **Patterns** and create a pattern named "My pattern". After the editor opens, the browser tab reads "My pattern ‹ Site — WordPress" (previously "Edit Block Pattern ‹ …").
3. Navigate back to the list and click into an existing user pattern: the tab shows the pattern's name.
4. Create a page from the Pages screen and open it in the same session: the tab shows its title rather than "Edit Page".

## Testing Instructions for Keyboard

None beyond the above; the document title is also what's announced on route changes, so screen reader users now hear the entity's name instead of the generic label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
