### PR TITLE
List: Merge into the previous line on Backspace instead of outdenting

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -151,8 +151,7 @@ export default function useMerge( clientId, onMerge ) {
 		} else {
 			// Merge into the previous line: the trailing item of the
 			// previous sibling, or the parent item's own line for a first
-			// child. Backspace deletes backwards; outdenting stays on
-			// Shift+Tab and on Enter in an empty item.
+			// child.
 			const previousBlockClientId = getPreviousBlockClientId( clientId );
 			if ( previousBlockClientId ) {
 				const trailingId = getTrailingId( previousBlockClientId );

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -9,6 +9,7 @@ export default function useMerge( clientId, onMerge ) {
 		getPreviousBlockClientId,
 		getNextBlockClientId,
 		getBlockOrder,
+		getBlockIndex,
 		getBlockRootClientId,
 		getBlockName,
 		getBlock,
@@ -60,6 +61,18 @@ export default function useMerge( clientId, onMerge ) {
 							clientIdB,
 							clientIdA
 						);
+					} else if (
+						getParentListItemId( clientIdB ) === clientIdA
+					) {
+						// Merging into the parent item's own line: the
+						// children take the item's place in its list, one
+						// level up, since their line moved there.
+						moveBlocksToPosition(
+							getBlockOrder( nestedListClientId ),
+							nestedListClientId,
+							getBlockRootClientId( clientIdB ),
+							getBlockIndex( clientIdB ) + 1
+						);
 					} else {
 						moveBlocksToPosition(
 							getBlockOrder( nestedListClientId ),
@@ -68,7 +81,13 @@ export default function useMerge( clientId, onMerge ) {
 						);
 					}
 				}
+				const listId = getBlockRootClientId( clientIdB );
 				mergeBlocks( clientIdA, clientIdB );
+				// Merging the last item of a nested list into its parent
+				// line leaves the list block empty.
+				if ( ! getBlockOrder( listId ).length ) {
+					removeBlock( listId, false );
+				}
 			} );
 		}
 
@@ -126,22 +145,23 @@ export default function useMerge( clientId, onMerge ) {
 						}
 					}
 				}
-			} else if ( getParentListItemId( nextBlockClientId ) ) {
-				outdentListItem( nextBlockClientId );
 			} else {
 				mergeWithNested( clientId, nextBlockClientId );
 			}
 		} else {
-			// Merging is only done from the top level. For lowel levels, the
-			// list item is outdented instead.
-			if ( getParentListItemId( clientId ) ) {
-				outdentListItem( clientId );
-				return;
-			}
+			// Merge into the previous line: the trailing item of the
+			// previous sibling, or the parent item's own line for a first
+			// child. Backspace deletes backwards; outdenting stays on
+			// Shift+Tab and on Enter in an empty item.
 			const previousBlockClientId = getPreviousBlockClientId( clientId );
 			if ( previousBlockClientId ) {
 				const trailingId = getTrailingId( previousBlockClientId );
 				mergeWithNested( trailingId, clientId );
+				return;
+			}
+			const parentListItemId = getParentListItemId( clientId );
+			if ( parentListItemId ) {
+				mergeWithNested( parentListItemId, clientId );
 				return;
 			}
 

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1014,7 +1014,24 @@ test.describe( 'List (@firefox)', () => {
 <!-- /wp:list -->`
 		);
 
-		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' ); // Should delete "i".
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>1<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
 		await page.keyboard.press( 'Backspace' ); // Should merge into "a".
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -1029,7 +1046,20 @@ test.describe( 'List (@firefox)', () => {
 <!-- /wp:list -->`
 		);
 
-		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' ); // Should delete "a".
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>1<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
 		await page.keyboard.press( 'Backspace' ); // Should merge into "1".
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -1040,7 +1070,16 @@ test.describe( 'List (@firefox)', () => {
 <!-- /wp:list -->`
 		);
 
-		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' ); // Should delete "1".
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
 		await page.keyboard.press( 'Backspace' ); // Should remove list.
 
 		await expect.poll( editor.getEditedPostContent ).toBe( '' );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1015,43 +1015,7 @@ test.describe( 'List (@firefox)', () => {
 		);
 
 		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.press( 'Backspace' ); // Should be at level 1.
-
-		await expect.poll( editor.getEditedPostContent ).toBe(
-			`<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li>1<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li>a</li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list --></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->`
-		);
-
-		await page.keyboard.press( 'Backspace' ); // Should be at level 0.
-
-		await expect.poll( editor.getEditedPostContent ).toBe(
-			`<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li>1<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li>a</li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list --></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->`
-		);
-
-		await page.keyboard.press( 'Backspace' ); // Should be at level 1.
+		await page.keyboard.press( 'Backspace' ); // Should merge into "a".
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
 			`<!-- wp:list -->
@@ -1066,21 +1030,7 @@ test.describe( 'List (@firefox)', () => {
 		);
 
 		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.press( 'Backspace' ); // Should be at level 0.
-
-		await expect.poll( editor.getEditedPostContent ).toBe(
-			`<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li>1</li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->`
-		);
-
-		await page.keyboard.press( 'Backspace' ); // Should be at level 0.
+		await page.keyboard.press( 'Backspace' ); // Should merge into "1".
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
 			`<!-- wp:list -->
@@ -1095,7 +1045,7 @@ test.describe( 'List (@firefox)', () => {
 
 		await expect.poll( editor.getEditedPostContent ).toBe( '' );
 
-		// That's 9 key presses to create the list, and 9 key presses to remove
+		// That's 9 key presses to create the list, and 6 key presses to remove
 		// the list. ;)
 	} );
 
@@ -1136,7 +1086,7 @@ test.describe( 'List (@firefox)', () => {
 <!-- /wp:list -->`
 		);
 
-		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Shift+Tab' );
 		// Type to also verify the caret stays in the outdented item.
 		await page.keyboard.type( 'x' );
 
@@ -1175,10 +1125,11 @@ test.describe( 'List (@firefox)', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( ' c' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'd' );
+		await page.keyboard.type( 'd' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.press( 'Backspace' );
+		// Enter on an empty item outdents it, one level per press.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'e' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -1280,102 +1231,8 @@ test.describe( 'List (@firefox)', () => {
 			},
 		] );
 
-		// Now that the item is empty, backspace should outdent it by one level
-		await page.keyboard.press( 'Backspace' );
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/list',
-				innerBlocks: [
-					{
-						name: 'core/list-item',
-						attributes: { content: 'a' },
-						innerBlocks: [
-							{
-								name: 'core/list',
-								innerBlocks: [
-									{
-										name: 'core/list-item',
-										attributes: { content: 'b' },
-									},
-									{
-										name: 'core/list-item',
-										attributes: { content: '' },
-										innerBlocks: [
-											{
-												name: 'core/list',
-												innerBlocks: [
-													{
-														name: 'core/list-item',
-														attributes: {
-															content: 'd',
-														},
-													},
-												],
-											},
-										],
-									},
-								],
-							},
-						],
-					},
-					{
-						name: 'core/list-item',
-						attributes: { content: 'e' },
-					},
-				],
-			},
-		] );
-
-		// Another backspace outdents the item to the root of the list
-		await page.keyboard.press( 'Backspace' );
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/list',
-				innerBlocks: [
-					{
-						name: 'core/list-item',
-						attributes: { content: 'a' },
-						innerBlocks: [
-							{
-								name: 'core/list',
-								innerBlocks: [
-									{
-										name: 'core/list-item',
-										attributes: { content: 'b' },
-									},
-								],
-							},
-						],
-					},
-					{
-						name: 'core/list-item',
-						attributes: { content: '' },
-						innerBlocks: [
-							{
-								name: 'core/list',
-								innerBlocks: [
-									{
-										name: 'core/list-item',
-										attributes: {
-											content: 'd',
-										},
-									},
-								],
-							},
-						],
-					},
-
-					{
-						name: 'core/list-item',
-						attributes: { content: 'e' },
-					},
-				],
-			},
-		] );
-
-		// Finally, backspace at the list root should merge into "b", BUT NOW
-		// IT WOULD BE GREAT IF "d" WENT BACK TO ITS ORIGINAL INDENTATION
-		// LEVEL, I.E. IT SHOULD BECOME A CHILD OF "b", NOT ITS SIBLING.
+		// Now that the item is empty, backspace merges it into "b", and
+		// "d" keeps its original indentation level as a child of "b".
 		await page.keyboard.press( 'Backspace' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1161,6 +1161,263 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
+	test( 'should try to preserve the indentation level of nested items as their parent gets merged', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.canvas
+			.locator( 'role=document[name="Add default block"i]' )
+			.click();
+
+		await page.keyboard.type( '* a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' b' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' c' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'd' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( 'e' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'b' },
+										innerBlocks: [
+											{
+												name: 'core/list',
+												innerBlocks: [
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: 'c',
+														},
+													},
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: 'd',
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'e' },
+					},
+				],
+			},
+		] );
+
+		// Place caret to the right of list-item "c"
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Backspace should empty the text of that list-item, and nothing else
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'b' },
+										innerBlocks: [
+											{
+												name: 'core/list',
+												innerBlocks: [
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: '',
+														},
+													},
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: 'd',
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'e' },
+					},
+				],
+			},
+		] );
+
+		// Now that the item is empty, backspace should outdent it by one level
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'b' },
+									},
+									{
+										name: 'core/list-item',
+										attributes: { content: '' },
+										innerBlocks: [
+											{
+												name: 'core/list',
+												innerBlocks: [
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: 'd',
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'e' },
+					},
+				],
+			},
+		] );
+
+		// Another backspace outdents the item to the root of the list
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'b' },
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: '' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: {
+											content: 'd',
+										},
+									},
+								],
+							},
+						],
+					},
+
+					{
+						name: 'core/list-item',
+						attributes: { content: 'e' },
+					},
+				],
+			},
+		] );
+
+		// Finally, backspace at the list root should merge into "b", BUT NOW
+		// IT WOULD BE GREAT IF "d" WENT BACK TO ITS ORIGINAL INDENTATION
+		// LEVEL, I.E. IT SHOULD BECOME A CHILD OF "b", NOT ITS SIBLING.
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'a' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 'b' },
+										innerBlocks: [
+											{
+												name: 'core/list',
+												innerBlocks: [
+													{
+														name: 'core/list-item',
+														attributes: {
+															content: 'd',
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/list-item',
+						attributes: { content: 'e' },
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should place the caret in the right place with nested list', async ( {
 		editor,
 		page,


### PR DESCRIPTION
Follow-up of #82011
Part of #81453 

## What?

~Currently, this PR only adds an E2E test for an expectation that I propose for the behaviour of Backspace in lists. Initially reported by @sgomes, it stuck with me too. I would love to hear what @ellatrix thinks.~

This is what Sérgio observed; compare the start and end positions of list item "d" as we keep pressing Backspace:

https://github.com/user-attachments/assets/45acb0b5-fde9-4dbf-9c11-9232d10f85ad


## Expected behaviour

I expected that, **somehow**, "d" would end up as a child of "b". The e2e test formalises this step by step:

<details><summary>Step-by-step description</summary>
Starting with a list like:

```
- a
    - b
        - c
        - d
- e
```

Place the caret to the right of "c", then press Backspace once to delete the "c" character. Now, continue pressing Backspace: currently, that will outdent the current list item ("|" marks the caret):

```
- a
    - b
    - |
        - d
- e
```

Pressing more will outdent more, eventually also outdenting the children:

```
- a
    - b
- |
    - d
- e
```

The problem is that, when we press Backspace one last time, we finally merge into the previous list item ("b"), but now "d" has become a sibling of "d", when we expected a child (so as to preserve the original indentation level):

```
EXPECTED          ACTUAL

- a               - a
    - b               - b
        - d           - d
- e               - e
```
</details>

## Solutions

Actually, the intermediate states don't matter to me, I only really care that at some point, when the caret finally reaches "b", the item "d" is its child.

There seem to be two main approaches:
- Keep our convention that Backspace should outdent, and make the system somehow remember that "d" was "supposed" to be twice indented, so that it tries to make that state happen once possible.
  - This seems super difficult.
- Break our convention, and do something closer to other software, which only eliminate without changing indentation. See below how Apple Notes behaves:
  - This seems **very** doable and could make many users happy, but it'd also be an important departure. Risky, or worth the shot?

<img width="740" height="763" alt="list-backspace-apple-notes" src="https://github.com/user-attachments/assets/17ecb94e-c095-4c76-85e1-a54684a76f8a" />