### PR TITLE
Query: Don't write excludeCurrent into blocks that never had it

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it.
+
 ### Internal
 
 -   Remove unused dependencies `@wordpress/keyboard-shortcuts`, `@wordpress/reusable-blocks` and `@wordpress/viewport` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it.
+-   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 
 ### Internal
 

--- a/packages/block-library/src/query/edit/inspector-controls/index.jsx
+++ b/packages/block-library/src/query/edit/inspector-controls/index.jsx
@@ -476,7 +476,10 @@ export default function QueryInspectorControls( props ) {
 					{ showExcludeCurrentControl && (
 						<ToolsPanelItem
 							label={ __( 'Exclude' ) }
-							hasValue={ () => excludeCurrent !== null }
+							hasValue={ () =>
+								excludeCurrent !== undefined &&
+								excludeCurrent !== null
+							}
 							onDeselect={ () =>
 								setQuery( { excludeCurrent: null } )
 							}

--- a/packages/block-library/src/query/edit/query-content.jsx
+++ b/packages/block-library/src/query/edit/query-content.jsx
@@ -102,8 +102,15 @@ export default function QueryContent( {
 			newQuery.perPage = postsPerPage;
 		}
 		// Remove the exclusion when it no longer applies, so the filters stay
-		// clean. We never force it on: enabling the exclusion is left to the user.
-		if ( ! shouldExcludeCurrentPost && query.excludeCurrent !== null ) {
+		// clean. We never force it on: enabling the exclusion is left to the
+		// user. An absent key is already clean — writing `null` into it would
+		// change the serialized markup of every pre-existing Query block just
+		// by opening the editor.
+		if (
+			! shouldExcludeCurrentPost &&
+			query.excludeCurrent !== undefined &&
+			query.excludeCurrent !== null
+		) {
 			newQuery.excludeCurrent = null;
 		}
 		if ( !! Object.keys( newQuery ).length ) {


### PR DESCRIPTION
## What?

Stops the Query block from writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key.

## Why?

#64916 added a mount effect that clears a stale `excludeCurrent` when the exclusion no longer applies. Its staleness check is `query.excludeCurrent !== null`, which an **absent** key (`undefined`) also fails — so the effect writes `excludeCurrent: null` into every pre-existing Query block as soon as the editor opens it. The change is marked not-persistent, but it still alters the block's serialized markup: any template or post containing a Query block re-serializes differently after merely being opened (`"excludeCurrent":null` appears in the comment attributes). This surfaced as timing-dependent content-comparison failures in the template revert e2e tests on #82117, where a capture could race the mount effect.

## How?

Treat the absent key as already clean in the mount effect, and mirror the check in the Filters panel's `hasValue` so a never-set exclusion doesn't render as a set filter for legacy blocks. A user-set value (`true`/`false`) still gets cleared to `null` exactly as before when the exclusion no longer applies.

## Testing Instructions

1. Create a post or template containing a Query block with pre-#64916 markup (no `excludeCurrent` key in its `query` attribute), e.g. any theme template like emptytheme's index.
2. Open it in the editor and inspect `wp.data.select( 'core/block-editor' ).getBlocks()` (or copy the block): the `query` attribute no longer gains an `excludeCurrent` key.
3. Toggle "Exclude current" on and off in a singular-template Query block: the attribute is written as before, and switching to a context where the exclusion doesn't apply still clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
