### PR TITLE
Performance tests: Build each branch once and share it with the shards

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -101,6 +101,12 @@ jobs:
                       WP_VERSION="$INPUT_WP_VERSION"
                       ;;
                   esac
+                  # Artifact names are derived from sanitized branch names and must be unique.
+                  DUPLICATES="$(echo "$BRANCHES" | jq -r '[.[].name | gsub("[^a-zA-Z0-9-]"; "-")] | group_by(.) | map(select(length > 1) | .[0]) | .[]')"
+                  if [[ -n "$DUPLICATES" ]]; then
+                    echo "::error::Branches must not share a sanitized name: $DUPLICATES"
+                    exit 1
+                  fi
                   echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
                   echo "wp-version=$WP_VERSION" >> "$GITHUB_OUTPUT"
                   echo "$BRANCHES" | jq .
@@ -144,6 +150,7 @@ jobs:
                     packages/icons/src/library/*.svg \
                     build \
                     build-module \
+                    post-content.php \
                     readme.txt \
                     changelog.txt \
                     README.md \
@@ -154,8 +161,8 @@ jobs:
               id: artifact
               env:
                   BRANCH_NAME: ${{ matrix.branch.name }}
-              # Must match `sanitizeBranchName()` in tools/release/commands/performance.js.
-              run: echo "name=plugin-$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g')" >> "$GITHUB_OUTPUT"
+              # Same replacement as `sanitizeBranchName()` in tools/release/commands/performance.js.
+              run: echo "name=plugin-$(node -e 'process.stdout.write( process.env.BRANCH_NAME.replace( /[^a-zA-Z0-9-]/g, "-" ) )')" >> "$GITHUB_OUTPUT"
 
             - name: Upload plugin
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -28,13 +28,149 @@ concurrency:
 permissions: {}
 
 jobs:
-    performance:
-        timeout-minutes: 60
-        name: Run performance tests (${{ matrix.shard }})
+    prepare:
+        timeout-minutes: 5
+        name: Resolve branches to compare
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}
+        outputs:
+            # JSON array of `{ name, ref }`: `name` labels the results table and
+            # `ref` is what gets checked out and built.
+            branches: ${{ steps.branches.outputs.branches }}
+            wp-version: ${{ steps.branches.outputs.wp-version }}
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Resolve branches
+              id: branches
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  BASE_REF: ${{ github.base_ref }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  INPUT_BRANCHES: ${{ github.event.inputs.branches }}
+                  INPUT_WP_VERSION: ${{ github.event.inputs.wpversion }}
+              run: |
+                  WP_VERSION=""
+                  WP_MAJOR="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt | cut -d. -f1,2)"
+                  case "$GITHUB_EVENT_NAME" in
+                    pull_request)
+                      BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" --arg base "$BASE_REF" --arg baseSha "$BASE_SHA" '[{name: $head, ref: $head}, {name: $base, ref: $baseSha}]')"
+                      ;;
+                    push)
+                      # The base hash used here need to be a commit that is compatible with the current WP version
+                      # The current one is 28d414f1327652e2b49e784ddc12098768991c62 and it needs to be updated every WP major release.
+                      # It is used as a base comparison point to avoid fluctuation in the performance metrics.
+                      # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
+                      BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" '[{name: $head, ref: $head}, {name: "28d414f1327652e2b49e784ddc12098768991c62", ref: "28d414f1327652e2b49e784ddc12098768991c62"}]')"
+                      WP_VERSION="$WP_MAJOR"
+                      ;;
+                    release)
+                      PLUGIN_VERSION="${RELEASE_TAG#v}"
+                      if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+                        echo "::error::Release tag '$RELEASE_TAG' does not resolve to a valid Gutenberg plugin version."
+                        exit 1
+                      fi
+
+                      IFS=. read -ra PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
+                      CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
+                      PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))
+                      PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
+                      if ! git ls-remote --exit-code --tags origin "$RELEASE_TAG" > /dev/null; then
+                        echo "::error::Expected release tag '$RELEASE_TAG' to exist in the Gutenberg repository."
+                        exit 1
+                      fi
+                      if ! git ls-remote --exit-code --heads origin "$CURRENT_RELEASE_BRANCH" > /dev/null; then
+                        echo "::error::Expected current release branch '$CURRENT_RELEASE_BRANCH' to exist in the Gutenberg repository."
+                        exit 1
+                      fi
+                      if ! git ls-remote --exit-code --heads origin "$PREVIOUS_RELEASE_BRANCH" > /dev/null; then
+                        echo "::error::Expected previous release branch '$PREVIOUS_RELEASE_BRANCH' to exist in the Gutenberg repository."
+                        exit 1
+                      fi
+                      BRANCHES="$(jq -cn --arg wp "wp/$WP_MAJOR" --arg prev "$PREVIOUS_RELEASE_BRANCH" --arg cur "$CURRENT_RELEASE_BRANCH" '[$wp, $prev, $cur] | map({name: ., ref: .})')"
+                      WP_VERSION="$WP_MAJOR"
+                      ;;
+                    workflow_dispatch)
+                      BRANCHES="$(jq -cn --arg list "$INPUT_BRANCHES" '$list | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map({name: ., ref: .})')"
+                      WP_VERSION="$INPUT_WP_VERSION"
+                      ;;
+                  esac
+                  echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+                  echo "wp-version=$WP_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "$BRANCHES" | jq .
+
+    build:
+        timeout-minutes: 30
+        name: Build plugin (${{ matrix.branch.name }})
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
+        needs: prepare
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                branch: ${{ fromJSON( needs.prepare.outputs.branches ) }}
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  ref: ${{ matrix.branch.ref }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
+            - name: Build
+              run: npm run build -- --skip-types || npm run build
+
+            # Same file list as bin/build-plugin-zip.sh. Older refs may lack some of them.
+            - name: Package plugin
+              env:
+                  PLUGIN_DIR: ${{ runner.temp }}/plugin
+              run: |
+                  mkdir -p "$PLUGIN_DIR"
+                  tar --ignore-failed-read -cf - \
+                    gutenberg.php \
+                    lib \
+                    packages/block-serialization-default-parser/*.php \
+                    packages/icons/src/manifest.php \
+                    packages/icons/src/library/*.svg \
+                    build \
+                    build-module \
+                    readme.txt \
+                    changelog.txt \
+                    README.md \
+                    | tar -xf - -C "$PLUGIN_DIR"
+                  test -f "$PLUGIN_DIR/gutenberg.php"
+
+            - name: Sanitize artifact name
+              id: artifact
+              env:
+                  BRANCH_NAME: ${{ matrix.branch.name }}
+              # Must match `sanitizeBranchName()` in tools/release/commands/performance.js.
+              run: echo "name=plugin-$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g')" >> "$GITHUB_OUTPUT"
+
+            - name: Upload plugin
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: ${{ steps.artifact.outputs.name }}
+                  path: ${{ runner.temp }}/plugin
+                  compression-level: 1
+
+    performance:
+        timeout-minutes: 60
+        name: Run performance tests (${{ matrix.shard }})
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
+        needs: [prepare, build]
+        permissions:
+            contents: read
         strategy:
             fail-fast: false
             # Shards run in parallel to cut the wall clock time. Every shard still
@@ -60,71 +196,31 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 
-            - name: Install NVM
+            - name: Download prebuilt plugins
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  pattern: plugin-*
+                  path: ${{ runner.temp }}/plugins
+
+            # The command expects `<plugins dir>/<sanitized branch name>`.
+            - name: Rename plugin directories
               run: |
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-                  export NVM_DIR="$HOME/.nvm"
-                  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-                  nvm -v
+                  for dir in "$RUNNER_TEMP"/plugins/plugin-*; do
+                    mv "$dir" "$RUNNER_TEMP/plugins/$(basename "$dir" | sed 's/^plugin-//')"
+                  done
+                  ls -la "$RUNNER_TEMP/plugins"
 
-            - name: Compare performance with base branch
-              if: github.event_name == 'pull_request'
-              run: npm exec --no release-cli -- perf "$GITHUB_SHA" "$GITHUB_BASE_REF" --tests-branch "$GITHUB_SHA" --suites "$PERF_SUITES"
-
-            - name: Compare performance with current WordPress Core and previous Gutenberg versions
-              if: github.event_name == 'release'
+            - name: Compare performance
               env:
-                  RELEASE_TAG: ${{ github.event.release.tag_name }}
-              shell: bash
+                  BRANCHES: ${{ needs.prepare.outputs.branches }}
+                  WP_VERSION: ${{ needs.prepare.outputs.wp-version }}
               run: |
-                  PLUGIN_VERSION="${RELEASE_TAG#v}"
-                  if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-                    echo "::error::Release tag '$RELEASE_TAG' does not resolve to a valid Gutenberg plugin version."
-                    exit 1
+                  readarray -t BRANCH_ARGS < <(echo "$BRANCHES" | jq -r '.[].name')
+                  WP_VERSION_ARGS=()
+                  if [[ -n "$WP_VERSION" ]]; then
+                    WP_VERSION_ARGS=(--wp-version "$WP_VERSION")
                   fi
-
-                  IFS=. read -ra PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
-                  CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
-                  PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))
-                  PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
-                  if ! git ls-remote --exit-code --tags origin "$RELEASE_TAG" > /dev/null; then
-                    echo "::error::Expected release tag '$RELEASE_TAG' to exist in the Gutenberg repository."
-                    exit 1
-                  fi
-                  if ! git ls-remote --exit-code --heads origin "$CURRENT_RELEASE_BRANCH" > /dev/null; then
-                    echo "::error::Expected current release branch '$CURRENT_RELEASE_BRANCH' to exist in the Gutenberg repository."
-                    exit 1
-                  fi
-                  if ! git ls-remote --exit-code --heads origin "$PREVIOUS_RELEASE_BRANCH" > /dev/null; then
-                    echo "::error::Expected previous release branch '$PREVIOUS_RELEASE_BRANCH' to exist in the Gutenberg repository."
-                    exit 1
-                  fi
-
-                  WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
-                  IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
-                  WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  npm exec --no release-cli -- perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR" --suites "$PERF_SUITES"
-
-            - name: Compare performance with base branch
-              if: github.event_name == 'push'
-              # The base hash used here need to be a commit that is compatible with the current WP version
-              # The current one is 28d414f1327652e2b49e784ddc12098768991c62 and it needs to be updated every WP major release.
-              # It is used as a base comparison point to avoid fluctuation in the performance metrics.
-              # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
-              run: |
-                  WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
-                  IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
-                  WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  npm exec --no release-cli -- perf "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR" --suites "$PERF_SUITES"
-
-            - name: Compare performance with custom branches
-              if: github.event_name == 'workflow_dispatch'
-              env:
-                  BRANCHES: ${{ github.event.inputs.branches }}
-                  WP_VERSION: ${{ github.event.inputs.wpversion }}
-              run: |
-                  IFS=, read -ra BRANCH_ARGS <<< "$BRANCHES"
-                  npm exec --no release-cli -- perf "${BRANCH_ARGS[@]}" --tests-branch "$GITHUB_SHA" --wp-version "$WP_VERSION" --suites "$PERF_SUITES"
+                  npm exec --no release-cli -- perf "${BRANCH_ARGS[@]}" --tests-dir "$GITHUB_WORKSPACE" --plugins-dir "$RUNNER_TEMP/plugins" --suites "$PERF_SUITES" "${WP_VERSION_ARGS[@]}"
 
             - name: Add workflow summary
               run: cat "${WP_ARTIFACTS_PATH}/summary.md" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -211,12 +211,13 @@ jobs:
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   pattern: plugin-*
-                  path: ${{ runner.temp }}/plugins
+                  path: ${{ runner.temp }}/artifacts
 
             # The command expects `<plugins dir>/<sanitized branch name>`.
             - name: Rename plugin directories
               run: |
-                  for dir in "$RUNNER_TEMP"/plugins/plugin-*; do
+                  mkdir -p "$RUNNER_TEMP/plugins"
+                  for dir in "$RUNNER_TEMP"/artifacts/plugin-*; do
                     mv "$dir" "$RUNNER_TEMP/plugins/$(basename "$dir" | sed 's/^plugin-//')"
                   done
                   ls -la "$RUNNER_TEMP/plugins"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -102,7 +102,11 @@ jobs:
                       ;;
                   esac
                   # Artifact names are derived from sanitized branch names and must be unique.
-                  DUPLICATES="$(echo "$BRANCHES" | jq -r '[.[].name | gsub("[^a-zA-Z0-9-]"; "-")] | group_by(.) | map(select(length > 1) | .[0]) | .[]')"
+                  # Same replacement as `sanitizeBranchName()` in tools/release/commands/performance.js.
+                  DUPLICATES="$(echo "$BRANCHES" | node -e '
+                    const names = JSON.parse( require( "fs" ).readFileSync( 0, "utf8" ) ).map( ( branch ) => branch.name.replace( /[^a-zA-Z0-9-]/g, "-" ) );
+                    process.stdout.write( [ ...new Set( names.filter( ( name, i ) => names.indexOf( name ) !== i ) ) ].join( " " ) );
+                  ')"
                   if [[ -n "$DUPLICATES" ]]; then
                     echo "::error::Branches must not share a sanitized name: $DUPLICATES"
                     exit 1

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -36,6 +36,8 @@ npm exec release-cli -- perf trunk v8.1.0 v8.0.0
 
 Pass `--suites` with a comma separated list of spec names (`test/performance/specs/*.spec.js` without the extension) to run a subset of the suites. The CI workflow uses it to split the suites into shards that run in parallel, each shard measuring all branches on the same runner.
 
+By default the command clones and builds every branch. In CI the plugins are built once in a separate job, and each shard passes `--plugins-dir <dir>` (a prebuilt plugin per branch in `<dir>/<sanitized branch name>`) and `--tests-dir <checkout>` (an existing checkout with installed dependencies to use as the test runner) to skip that work.
+
 To get the most accurate results, it's is important to use the exact same version of the tests and environment (theme...) when running the tests, the only thing that need to be different between the branches is the Gutenberg plugin version (or branch used to build the plugin).
 
 To achieve that the command first prepares the following folder structure:

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -80,6 +80,14 @@ program
 		'Run each test suite this many times for each branch; results are summarized, default = 1'
 	)
 	.option(
+		'--plugins-dir <dir>',
+		'Use prebuilt plugins from <dir>/<branch> instead of building each branch'
+	)
+	.option(
+		'--tests-dir <dir>',
+		'Use an existing checkout with installed dependencies as the test runner'
+	)
+	.option(
 		'--suites <suites>',
 		'Comma separated names of the test suites to run, default = all'
 	)

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -20,9 +20,11 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @typedef WPPerformanceCommandOptions
  *
  * @property {boolean=} ci          Run on CI.
+ * @property {string=}  pluginsDir  Directory holding a prebuilt plugin per branch, in `<sanitized branch>/`.
  * @property {number=}  rounds      Run each test suite this many times for each branch.
  * @property {string=}  suites      Comma separated names of the test suites to run (default: all).
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
+ * @property {string=}  testsDir    Existing checkout (with installed dependencies) to use as the test runner.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
 
@@ -294,67 +296,89 @@ async function runPerformanceTests( branches, options ) {
 	logAtIndent( 1, 'Creating base directory:', formats.success( baseDir ) );
 	fs.mkdirSync( baseDir );
 
-	logAtIndent( 1, 'Setting up repository' );
+	const pluginsDir = options.pluginsDir
+		? path.resolve( options.pluginsDir )
+		: null;
+	const testsDir = options.testsDir ? path.resolve( options.testsDir ) : null;
+
 	const sourceDir = path.join( baseDir, 'source' );
+	let sourceGit = null;
+	if ( ! pluginsDir || ! testsDir ) {
+		logAtIndent( 1, 'Setting up repository' );
 
-	logAtIndent( 2, 'Creating directory:', formats.success( sourceDir ) );
-	fs.mkdirSync( sourceDir );
+		logAtIndent( 2, 'Creating directory:', formats.success( sourceDir ) );
+		fs.mkdirSync( sourceDir );
 
-	// @ts-expect-error The `simple-git` module namespace has no call signatures.
-	const sourceGit = SimpleGit( sourceDir );
-	logAtIndent(
-		2,
-		'Initializing:',
-		formats.success( config.gitRepositoryURL )
-	);
-	await sourceGit
-		.raw( 'init' )
-		.raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
-
-	for ( const [ i, branch ] of branches.entries() ) {
+		// @ts-expect-error The `simple-git` module namespace has no call signatures.
+		sourceGit = SimpleGit( sourceDir );
 		logAtIndent(
 			2,
-			`Fetching environment branch (${ i + 1 } of ${ branches.length }):`,
-			formats.success( branch )
+			'Initializing:',
+			formats.success( config.gitRepositoryURL )
 		);
-		await sourceGit.raw( 'fetch', '--depth=1', 'origin', branch );
+		await sourceGit
+			.raw( 'init' )
+			.raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
+	}
+
+	if ( sourceGit && ! pluginsDir ) {
+		for ( const [ i, branch ] of branches.entries() ) {
+			logAtIndent(
+				2,
+				`Fetching environment branch (${ i + 1 } of ${
+					branches.length
+				}):`,
+				formats.success( branch )
+			);
+			await sourceGit.raw( 'fetch', '--depth=1', 'origin', branch );
+		}
 	}
 
 	const testRunnerBranch = options.testsBranch || branches[ 0 ];
-	if ( options.testsBranch && ! branches.includes( options.testsBranch ) ) {
-		logAtIndent(
-			2,
-			'Fetching test runner branch:',
-			formats.success( options.testsBranch )
-		);
-		await sourceGit.raw(
-			'fetch',
-			'--depth=1',
-			'origin',
-			options.testsBranch
-		);
-	} else {
-		logAtIndent(
-			2,
-			'Using test runner branch:',
-			formats.success( testRunnerBranch )
-		);
+	if ( sourceGit && ! testsDir ) {
+		if ( pluginsDir || ! branches.includes( testRunnerBranch ) ) {
+			logAtIndent(
+				2,
+				'Fetching test runner branch:',
+				formats.success( testRunnerBranch )
+			);
+			await sourceGit.raw(
+				'fetch',
+				'--depth=1',
+				'origin',
+				testRunnerBranch
+			);
+		} else {
+			logAtIndent(
+				2,
+				'Using test runner branch:',
+				formats.success( testRunnerBranch )
+			);
+		}
 	}
 
 	logAtIndent( 1, 'Setting up test runner' );
 
-	const testRunnerDir = path.join( baseDir + '/tests' );
+	const testRunnerDir = testsDir || path.join( baseDir + '/tests' );
 
-	logAtIndent( 2, 'Copying source to:', formats.success( testRunnerDir ) );
-	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
+	if ( testsDir ) {
+		logAtIndent( 2, 'Using checkout:', formats.success( testRunnerDir ) );
+	} else {
+		logAtIndent(
+			2,
+			'Copying source to:',
+			formats.success( testRunnerDir )
+		);
+		await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
 
-	logAtIndent(
-		2,
-		'Checking out branch:',
-		formats.success( testRunnerBranch )
-	);
-	// @ts-expect-error The `simple-git` module namespace has no call signatures.
-	await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
+		logAtIndent(
+			2,
+			'Checking out branch:',
+			formats.success( testRunnerBranch )
+		);
+		// @ts-expect-error The `simple-git` module namespace has no call signatures.
+		await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
+	}
 
 	logAtIndent( 2, 'Looking for test files' );
 	const availableSuites = getFilesFromDir(
@@ -382,11 +406,12 @@ async function runPerformanceTests( branches, options ) {
 		logAtIndent( 3, 'Found:', formats.success( suite ) );
 	}
 
+	// An existing checkout already has its dependencies installed.
+	const testRunnerSetup = testsDir
+		? 'npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps'
+		: 'source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps';
 	logAtIndent( 2, 'Installing dependencies and building' );
-	await runShellScript(
-		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps"`,
-		testRunnerDir
-	);
+	await runShellScript( `bash -c "${ testRunnerSetup }"`, testRunnerDir );
 
 	logAtIndent( 1, 'Setting up test environments' );
 
@@ -406,7 +431,10 @@ async function runPerformanceTests( branches, options ) {
 		wpZipUrl = `https://wordpress.org/wordpress-${ zipVersion }.zip`;
 	}
 
+	/** @type {Record<string, string>} */
 	const branchDirs = {};
+	/** @type {Record<string, string>} */
+	const pluginDirs = {};
 	for ( const branch of branches ) {
 		logAtIndent( 2, 'Branch:', formats.success( branch ) );
 		const sanitizedBranchName = sanitizeBranchName( branch );
@@ -414,22 +442,38 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Creating directory:', formats.success( envDir ) );
 		fs.mkdirSync( envDir );
-		// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 		branchDirs[ branch ] = envDir;
-		const buildDir = path.join( envDir, 'plugin' );
 
-		logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
-		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
+		let buildDir;
+		if ( pluginsDir ) {
+			buildDir = path.join( pluginsDir, sanitizedBranchName );
+			if ( ! fs.existsSync( path.join( buildDir, 'gutenberg.php' ) ) ) {
+				throw new Error(
+					`No prebuilt plugin for "${ branch }" in ${ buildDir }`
+				);
+			}
+			logAtIndent(
+				3,
+				'Using prebuilt plugin:',
+				formats.success( buildDir )
+			);
+		} else {
+			buildDir = path.join( envDir, 'plugin' );
 
-		logAtIndent( 3, 'Checking out:', formats.success( branch ) );
-		// @ts-expect-error The `simple-git` module namespace has no call signatures.
-		await SimpleGit( buildDir ).raw( 'checkout', branch );
+			logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
+			await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
 
-		logAtIndent( 3, 'Installing dependencies and building' );
-		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && (npm run build -- --skip-types || npm run build)"`,
-			buildDir
-		);
+			logAtIndent( 3, 'Checking out:', formats.success( branch ) );
+			// @ts-expect-error The `simple-git` module namespace has no call signatures.
+			await SimpleGit( buildDir ).raw( 'checkout', branch );
+
+			logAtIndent( 3, 'Installing dependencies and building' );
+			await runShellScript(
+				`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && (npm run build -- --skip-types || npm run build)"`,
+				buildDir
+			);
+		}
+		pluginDirs[ branch ] = buildDir;
 
 		const wpEnvConfigPath = path.join( envDir, '.wp-env.json' );
 
@@ -505,7 +549,6 @@ async function runPerformanceTests( branches, options ) {
 			);
 
 			const sanitizedBranchName = sanitizeBranchName( branch );
-			// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 			const envDir = branchDirs[ branch ];
 
 			logAtIndent( 2, 'Starting environment' );
@@ -541,9 +584,7 @@ async function runPerformanceTests( branches, options ) {
 	//   npm run --workspace @wordpress/build-scripts resolve-trace-source-maps -- <trace> --build-dir <build-dir>
 	const headBranch = branches[ 0 ];
 	const headBuildScriptsDir = path.join(
-		// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
-		branchDirs[ headBranch ],
-		'plugin',
+		pluginDirs[ headBranch ],
 		'build',
 		'scripts'
 	);


### PR DESCRIPTION
## What?

Builds each branch once in a `build` job and shares the packaged plugin with every performance shard, instead of each shard cloning, installing and building all branches.

Stacked on #82137.

## Why?

The performance job is still the check PRs wait longest for. After sharding, every shard spends about 5 minutes installing and building the test runner, head and base. Building once brings the critical path from ~21 to ~15 minutes.

## How?

- A `prepare` job resolves the branches to compare per event into `{ name, ref }` pairs; a PR's base is now its exact `base.sha` rather than the moving branch name.
- A `build` matrix job checks out each ref, builds with the existing `--skip-types` fallback, and uploads the file list of [build-plugin-zip.sh](bin/build-plugin-zip.sh).
- [performance.js](tools/release/commands/performance.js) gains `--plugins-dir` and `--tests-dir` to skip cloning and building; shards pass the workspace checkout and the downloaded plugins. Local runs are unchanged.

## Testing Instructions

1. On this PR, `Build plugin (...)` runs for head and trunk, then the shards download them and skip building the branches.
2. `Merge performance results` still uploads all six suites.

## Use of AI Tools

Drafted with Claude Code and reviewed with Codex; every change was reviewed by me.
