### PR TITLE
Performance tests: Start one site per branch and pin WordPress core

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -40,6 +40,7 @@ jobs:
             # `ref` is what gets checked out and built.
             branches: ${{ steps.branches.outputs.branches }}
             wp-version: ${{ steps.branches.outputs.wp-version }}
+            wp-source: ${{ steps.branches.outputs.wp-source }}
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -57,10 +58,13 @@ jobs:
                   INPUT_WP_VERSION: ${{ github.event.inputs.wpversion }}
               run: |
                   WP_VERSION=""
+                  WP_SOURCE=""
                   WP_MAJOR="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt | cut -d. -f1,2)"
                   case "$GITHUB_EVENT_NAME" in
                     pull_request)
                       BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" --arg base "$BASE_REF" --arg baseSha "$BASE_SHA" '[{name: $head, ref: $head}, {name: $base, ref: $baseSha}]')"
+                      # Pin WordPress trunk so every shard and branch runs on the same core commit.
+                      WP_SOURCE="WordPress/WordPress#$(git ls-remote https://github.com/WordPress/WordPress.git HEAD | cut -f1)"
                       ;;
                     push)
                       # The base hash used here need to be a commit that is compatible with the current WP version
@@ -113,6 +117,8 @@ jobs:
                   fi
                   echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
                   echo "wp-version=$WP_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "wp-source=$WP_SOURCE" >> "$GITHUB_OUTPUT"
+                  echo "WordPress: ${WP_SOURCE:-${WP_VERSION:-trunk}}"
                   echo "$BRANCHES" | jq .
 
     build:
@@ -207,6 +213,16 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 
+            - name: Get Playwright version
+              id: playwright
+              run: echo "version=$(node -p 'require("@playwright/test/package.json").version')" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Playwright browsers
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.playwright.outputs.version }}
+
             - name: Download prebuilt plugins
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
@@ -226,10 +242,13 @@ jobs:
               env:
                   BRANCHES: ${{ needs.prepare.outputs.branches }}
                   WP_VERSION: ${{ needs.prepare.outputs.wp-version }}
+                  WP_SOURCE: ${{ needs.prepare.outputs.wp-source }}
               run: |
                   readarray -t BRANCH_ARGS < <(echo "$BRANCHES" | jq -r '.[].name')
                   WP_VERSION_ARGS=()
-                  if [[ -n "$WP_VERSION" ]]; then
+                  if [[ -n "$WP_SOURCE" ]]; then
+                    WP_VERSION_ARGS=(--wp-source "$WP_SOURCE")
+                  elif [[ -n "$WP_VERSION" ]]; then
                     WP_VERSION_ARGS=(--wp-version "$WP_VERSION")
                   fi
                   npm exec --no release-cli -- perf "${BRANCH_ARGS[@]}" --tests-dir "$GITHUB_WORKSPACE" --plugins-dir "$RUNNER_TEMP/plugins" --suites "$PERF_SUITES" "${WP_VERSION_ARGS[@]}"

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -96,6 +96,10 @@ program
 		"Use this branch's performance test files"
 	)
 	.option(
+		'--wp-source <source>',
+		'wp-env core source for all branches, e.g. WordPress/WordPress#<sha>; takes precedence over --wp-version'
+	)
+	.option(
 		'--wp-version <version>',
 		'Specify a WordPress version on which to test all branches'
 	)

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -14,6 +14,7 @@ const config = require( '../config' );
 const ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
 const RAW_RESULTS_FILE_SUFFIX = '.performance-results.raw.json';
+const WP_ENV_PORT = 8889;
 const RESULTS_FILE_SUFFIX = '.performance-results.json';
 
 /**
@@ -25,6 +26,7 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @property {string=}  suites      Comma separated names of the test suites to run (default: all).
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
  * @property {string=}  testsDir    Existing checkout (with installed dependencies) to use as the test runner.
+ * @property {string=}  wpSource    wp-env `core` source (e.g. `WordPress/WordPress#<sha>`); takes precedence over `wpVersion`.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
 
@@ -181,6 +183,7 @@ async function runTestSuite( testSuite, testRunnerDir, runKey, saveTraces ) {
 		{
 			...process.env,
 			PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+			WP_BASE_URL: `http://localhost:${ WP_ENV_PORT }`,
 			WP_ARTIFACTS_PATH: ARTIFACTS_PATH,
 			RESULTS_ID: runKey,
 			// Suppress trace writes on comparison branches so they don't
@@ -268,7 +271,7 @@ async function runPerformanceTests( branches, options ) {
 	if ( ! runningInCI ) {
 		log(
 			formats.warning(
-				'\nIn order to run the tests, the tool is going to load a WordPress environment on ports 8888 and 8889.' +
+				'\nIn order to run the tests, the tool is going to load a WordPress environment on port 8889.' +
 					'\nMake sure these ports are not used before continuing.\n'
 			)
 		);
@@ -487,36 +490,33 @@ async function runPerformanceTests( branches, options ) {
 			wpEnvConfigPath,
 			JSON.stringify(
 				{
+					// The tests only use one site, so skip the second WordPress and MySQL containers.
+					testsEnvironment: false,
+					port: WP_ENV_PORT,
 					config: {
 						WP_DEBUG: false,
 						SCRIPT_DEBUG: false,
 					},
-					core: wpZipUrl || 'WordPress/WordPress',
+					core: options.wpSource || wpZipUrl || 'WordPress/WordPress',
 					plugins: [ buildDir ],
 					themes: [ path.join( testRunnerDir, 'test/emptytheme' ) ],
-					env: {
-						tests: {
-							mappings: {
-								'wp-content/mu-plugins': path.join(
-									testRunnerDir,
-									'packages/e2e-tests/mu-plugins'
-								),
-								'wp-content/plugins/gutenberg-test-plugins':
-									path.join(
-										testRunnerDir,
-										'packages/e2e-tests/plugins'
-									),
-								'wp-content/themes/gutenberg-test-themes':
-									path.join(
-										testRunnerDir,
-										'test/gutenberg-test-themes'
-									),
-								'wp-content/themes/gutenberg-test-themes/twentytwentyone':
-									'https://downloads.wordpress.org/theme/twentytwentyone.1.7.zip',
-								'wp-content/themes/gutenberg-test-themes/twentytwentythree':
-									'https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip',
-							},
-						},
+					mappings: {
+						'wp-content/mu-plugins': path.join(
+							testRunnerDir,
+							'packages/e2e-tests/mu-plugins'
+						),
+						'wp-content/plugins/gutenberg-test-plugins': path.join(
+							testRunnerDir,
+							'packages/e2e-tests/plugins'
+						),
+						'wp-content/themes/gutenberg-test-themes': path.join(
+							testRunnerDir,
+							'test/gutenberg-test-themes'
+						),
+						'wp-content/themes/gutenberg-test-themes/twentytwentyone':
+							'https://downloads.wordpress.org/theme/twentytwentyone.1.7.zip',
+						'wp-content/themes/gutenberg-test-themes/twentytwentythree':
+							'https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip',
 					},
 				},
 				null,
@@ -528,7 +528,9 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 0, 'Running tests' );
 
-	if ( wpZipUrl ) {
+	if ( options.wpSource ) {
+		logAtIndent( 1, 'Using:', formats.success( options.wpSource ) );
+	} else if ( wpZipUrl ) {
 		logAtIndent(
 			1,
 			'Using:',

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -272,7 +272,7 @@ async function runPerformanceTests( branches, options ) {
 		log(
 			formats.warning(
 				'\nIn order to run the tests, the tool is going to load a WordPress environment on port 8889.' +
-					'\nMake sure these ports are not used before continuing.\n'
+					'\nMake sure this port is not in use before continuing.\n'
 			)
 		);
 


### PR DESCRIPTION
## What?

Starts a single WordPress site per branch instead of two, pins WordPress core to one commit for every shard, and caches the Playwright browser download.

Stacked on #82148.

## Why?

The performance job is still the check PRs wait longest for. Each shard cold starts wp-env, which today boots two WordPress and two MySQL containers although the suites use one site, and each shard and branch could end up on a different WordPress trunk commit, which adds noise to the comparison.

## How?

- [performance.js](tools/release/commands/performance.js) writes `testsEnvironment: false` into the generated `.wp-env.json`, keeps the site on port 8889, and sets `WP_BASE_URL` for the suites.
- A new `--wp-source` option accepts any wp-env `core` source; the `prepare` job resolves `WordPress/WordPress` to its current SHA for PR runs and passes it to every shard.
- Shards cache `~/.cache/ms-playwright` keyed on the Playwright version, so `playwright install` only installs the OS dependencies.

## Testing Instructions

1. On this PR, `Resolve branches to compare` prints `WordPress: WordPress/WordPress#<sha>` and every shard logs the same source under `Using:`.
2. The shards' `Starting environment` step is faster than on #82148 and all six suites still report results.

## Use of AI Tools

Drafted with Claude Code and reviewed with Codex; every change was reviewed by me.
