### PR TITLE
Performance tests: Skip pull requests that cannot affect the results

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -57,17 +57,25 @@ jobs:
                   BASE_SHA: ${{ github.event.pull_request.base.sha }}
               run: |
                   git fetch --no-tags --depth=1 origin "$BASE_SHA"
-                  CHANGED="$(git diff --name-only "$BASE_SHA" HEAD)"
-                  # Everything that is not documentation, changelogs, Storybook or an unrelated workflow.
-                  RELEVANT="$(echo "$CHANGED" | grep -Ev '^(docs/|storybook/|changelog\.txt$|\.github/)|\.md$' || true)"
-                  RELEVANT="$RELEVANT$(echo "$CHANGED" | grep -E '^\.github/(workflows/performance\.yml|setup-node/)' || true)"
-                  if [[ -n "$CHANGED" && -z "$RELEVANT" ]]; then
+                  COUNT=0
+                  RELEVANT=0
+                  # Renames are listed as a deletion and an addition, so both paths are classified.
+                  while IFS= read -r -d '' file; do
+                    COUNT=$(( COUNT + 1 ))
+                    echo "changed: $file"
+                    case "$file" in
+                      .github/workflows/performance.yml|.github/setup-node/*) RELEVANT=1 ;;
+                      # Documentation, changelogs, Storybook and other workflows cannot change the results.
+                      docs/*|storybook/*|changelog.txt|.github/*|*.md) ;;
+                      *) RELEVANT=1 ;;
+                    esac
+                  done < <(git diff --no-renames --name-only -z "$BASE_SHA" HEAD)
+                  if [[ "$COUNT" -gt 0 && "$RELEVANT" -eq 0 ]]; then
                     echo "skip=true" >> "$GITHUB_OUTPUT"
                     echo "Skipping the performance tests: only documentation or unrelated files changed."
                   else
                     echo "skip=false" >> "$GITHUB_OUTPUT"
                   fi
-                  echo "$CHANGED"
 
             - name: Resolve branches
               id: branches

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -62,7 +62,7 @@ jobs:
                   # Renames are listed as a deletion and an addition, so both paths are classified.
                   while IFS= read -r -d '' file; do
                     COUNT=$(( COUNT + 1 ))
-                    echo "changed: $file"
+                    printf 'changed: %q\n' "$file"
                     case "$file" in
                       .github/workflows/performance.yml|.github/setup-node/*) RELEVANT=1 ;;
                       # Documentation, changelogs, Storybook and other workflows cannot change the results.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -41,12 +41,33 @@ jobs:
             branches: ${{ steps.branches.outputs.branches }}
             wp-version: ${{ steps.branches.outputs.wp-version }}
             wp-source: ${{ steps.branches.outputs.wp-source }}
+            # 'true' when a pull request only touches files that cannot change the results.
+            skip: ${{ steps.changes.outputs.skip }}
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
+
+            - name: Check whether the changes can affect performance
+              id: changes
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+              run: |
+                  git fetch --no-tags --depth=1 origin "$BASE_SHA"
+                  CHANGED="$(git diff --name-only "$BASE_SHA" HEAD)"
+                  # Everything that is not documentation, changelogs, Storybook or an unrelated workflow.
+                  RELEVANT="$(echo "$CHANGED" | grep -Ev '^(docs/|storybook/|changelog\.txt$|\.github/)|\.md$' || true)"
+                  RELEVANT="$RELEVANT$(echo "$CHANGED" | grep -E '^\.github/(workflows/performance\.yml|setup-node/)' || true)"
+                  if [[ -n "$CHANGED" && -z "$RELEVANT" ]]; then
+                    echo "skip=true" >> "$GITHUB_OUTPUT"
+                    echo "Skipping the performance tests: only documentation or unrelated files changed."
+                  else
+                    echo "skip=false" >> "$GITHUB_OUTPUT"
+                  fi
+                  echo "$CHANGED"
 
             - name: Resolve branches
               id: branches
@@ -126,6 +147,7 @@ jobs:
         name: Build plugin (${{ matrix.branch.name }})
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         needs: prepare
+        if: needs.prepare.outputs.skip != 'true'
         permissions:
             contents: read
         strategy:
@@ -186,6 +208,7 @@ jobs:
         name: Run performance tests (${{ matrix.shard }})
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         needs: [prepare, build]
+        if: needs.prepare.outputs.skip != 'true'
         permissions:
             contents: read
         strategy:


### PR DESCRIPTION
## What?

Skips the build and measurement jobs of the performance workflow when a pull request only changes documentation, changelogs, Storybook or unrelated workflows.

Stacked on #82150.

## Why?

The performance job is the check PRs wait longest for, and today a README fix pays the full cost. A workflow level `paths-ignore` would leave the required check pending forever, so the decision is made by a job that always runs.

## How?

- The `prepare` job diffs the PR against its base with plain `git`, and outputs `skip=true` when every changed file is inert. [performance.yml](.github/workflows/performance.yml) treats this workflow and `.github/setup-node` as relevant even though the rest of `.github/` is not.
- `build` and `performance` carry `if: needs.prepare.outputs.skip != 'true'`; `results` is skipped with them. Skipped jobs satisfy required checks.
- `push`, `release` and `workflow_dispatch` never skip.

## Testing Instructions

1. On this PR the tests run, since the workflow file changed.
2. Push a docs only commit to a branch based on this one: `Resolve branches to compare` logs "Skipping the performance tests" and the remaining jobs show as skipped.

## Use of AI Tools

Drafted with Claude Code and reviewed with Codex; every change was reviewed by me.
