### PR TITLE
Performance tests: Measure test runner suites once

### DIFF
--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -36,6 +36,8 @@ npm exec release-cli -- perf trunk v8.1.0 v8.0.0
 
 Pass `--suites` with a comma separated list of spec names (`test/performance/specs/*.spec.js` without the extension) to run a subset of the suites. The CI workflow uses it to split the suites into shards that run in parallel, each shard measuring all branches on the same runner.
 
+Suites that measure the test runner rather than the plugin (currently `media-processing`) only run for the first branch; the others get `WP_PERF_COMPARISON_BRANCH=1`.
+
 By default the command clones and builds every branch. In CI the plugins are built once in a separate job, and each shard passes `--plugins-dir <dir>` (a prebuilt plugin per branch in `<dir>/<sanitized branch name>`) and `--tests-dir <checkout>` (an existing checkout with installed dependencies to use as the test runner) to skip that work.
 
 To get the most accurate results, it's is important to use the exact same version of the tests and environment (theme...) when running the tests, the only thing that need to be different between the branches is the Gutenberg plugin version (or branch used to build the plugin).

--- a/test/performance/specs/media-processing.spec.js
+++ b/test/performance/specs/media-processing.spec.js
@@ -172,6 +172,16 @@ async function measureCrossFormatProcessing( buffer, srcType, dstType, sizes ) {
 }
 
 test.describe( 'Media Processing Performance', () => {
+	/*
+	 * This suite benchmarks the wasm-vips build installed with the test runner,
+	 * which is the same for every branch under comparison.
+	 */
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip(
+		!! process.env.WP_PERF_COMPARISON_BRANCH,
+		'Only measured once, on the first branch.'
+	);
+
 	// Read test images once at module level.
 	const jpegBuffer = readFileSync(
 		path.join( ASSETS_PATH, 'test-image-3000x2000.jpeg' )

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -173,10 +173,11 @@ function printStats( m, s ) {
  * @param {string}  testSuite     Name of the tests set.
  * @param {string}  testRunnerDir Path to the performance tests' clone.
  * @param {string}  runKey        Unique identifier for the test run.
- * @param {boolean} saveTraces    Whether the test runner should save Chromium
- *                                traces as artifacts (only the head branch).
+ * @param {boolean} isHeadBranch  Whether this is the first branch. Only it saves
+ *                                Chromium traces and runs the suites that measure
+ *                                the test runner itself.
  */
-async function runTestSuite( testSuite, testRunnerDir, runKey, saveTraces ) {
+async function runTestSuite( testSuite, testRunnerDir, runKey, isHeadBranch ) {
 	await runShellScript(
 		`npm run test:performance -- ${ testSuite }`,
 		testRunnerDir,
@@ -188,7 +189,8 @@ async function runTestSuite( testSuite, testRunnerDir, runKey, saveTraces ) {
 			RESULTS_ID: runKey,
 			// Suppress trace writes on comparison branches so they don't
 			// overwrite the head branch's traces in the shared artifacts dir.
-			WP_PERF_NO_TRACE: saveTraces ? '' : '1',
+			WP_PERF_NO_TRACE: isHeadBranch ? '' : '1',
+			WP_PERF_COMPARISON_BRANCH: isHeadBranch ? '' : '1',
 		}
 	);
 }
@@ -694,7 +696,11 @@ async function runPerformanceTests( branches, options ) {
 				);
 			}
 
-			if ( branches.length === 2 ) {
+			// A metric can be missing on comparison branches, see `WP_PERF_COMPARISON_BRANCH`.
+			if (
+				branches.length === 2 &&
+				branches.every( ( branchName ) => branch[ branchName ] )
+			) {
 				const [ branch1, branch2 ] = branches;
 				const value1 = branch[ branch1 ].q50;
 				const value2 = branch[ branch2 ].q50;


### PR DESCRIPTION
## What?

Runs the `media-processing` suite only for the first branch of a comparison instead of once per branch.

Stacked on #82151.

## Why?

The suite benchmarks `wasm-vips` as installed with the test runner, so every branch executes exactly the same code and the `% Change` column it produces is noise. Skipping it on comparison branches removes a misleading table and about 1.6 minutes from the media shard.

## How?

- [performance.js](tools/release/commands/performance.js) sets `WP_PERF_COMPARISON_BRANCH=1` for every branch after the first, next to the existing `WP_PERF_NO_TRACE`, and only computes `% Change` when both branches have the metric.
- [media-processing.spec.js](test/performance/specs/media-processing.spec.js) skips itself when that variable is set. Running the suite directly is unchanged.
- `log-performance-results.js` already tolerates a missing base entry, so the codevitals publish on `push` keeps working.

## Testing Instructions

1. On this PR, the `media-and-front-end` shard summary shows `media-processing` with a single column for the head branch and no `% Change`.
2. The `trunk` pass of that shard logs the suite as skipped.

## Use of AI Tools

Drafted with Claude Code and reviewed with Codex; every change was reviewed by me.
