### PR TITLE
Block Library: Fix categories block handling of invalid taxonomy

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -23,6 +23,10 @@ function render_block_core_categories( $attributes, $content, $block ) {
 
 	$taxonomy = get_taxonomy( $attributes['taxonomy'] );
 
+	if ( ! $taxonomy ) {
+		return '';
+	}
+
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),

--- a/phpunit/blocks/render-block-categories-test.php
+++ b/phpunit/blocks/render-block-categories-test.php
@@ -50,13 +50,14 @@ class Tests_Blocks_Render_Categories extends WP_UnitTestCase {
 			)
 		);
 
-		$block = new WP_Block(
+		$attributes = array(
+			'taxonomy'          => 'category',
+			'displayAsDropdown' => false,
+		);
+		$block      = new WP_Block(
 			array(
 				'blockName' => 'core/categories',
-				'attrs'     => array(
-					'taxonomy'          => 'category',
-					'displayAsDropdown' => false,
-				),
+				'attrs'     => $attributes,
 			)
 		);
 

--- a/phpunit/blocks/render-block-categories-test.php
+++ b/phpunit/blocks/render-block-categories-test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Categories block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Categories block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Categories extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::gutenberg_render_block_core_categories
+	 */
+	public function test_invalid_taxonomy_returns_empty_string() {
+		$attributes = array(
+			'taxonomy' => 'nonexistent-taxonomy',
+		);
+		$block      = new WP_Block(
+			array(
+				'blockName' => 'core/categories',
+				'attrs'     => $attributes,
+			)
+		);
+
+		$output = gutenberg_render_block_core_categories( $attributes, '', $block );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_categories
+	 */
+	public function test_valid_taxonomy_renders_list_markup() {
+		$category_id = self::factory()->category->create(
+			array(
+				'name' => 'Categories block test term',
+				'slug' => 'categories-block-test-term',
+			)
+		);
+
+		self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_category' => array( $category_id ),
+			)
+		);
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/categories',
+				'attrs'     => array(
+					'taxonomy'          => 'category',
+					'displayAsDropdown' => false,
+				),
+			)
+		);
+
+		$output = gutenberg_render_block_core_categories( $attributes, '', $block );
+
+		$this->assertStringContainsString( 'wp-block-categories-list', $output );
+		$this->assertStringContainsString( 'Categories block test term', $output );
+	}
+}


### PR DESCRIPTION
## What?

Fixes an issue where the Categories block may produce warnings if its `taxonomy` attribute references an invalid taxonomy.

Related: #65272 

## Why?

Blocks should gracefully degrade when unable to render and not produce warnings.

## How?

Adds an early return guard to check that `$taxonomy` is valid before trying to reference properties on it.

## Testing Instructions

You can try pasting a block markup like this and previewing it on the frontend:

```
<!-- wp:categories {"taxonomy":"wrong"} /-->
```

If your site is configured to emit PHP warnings, it will show warnings on `trunk` and not on this branch.

For example:

```
Warning: Attempt to read property "labels" on bool in /wp-content/plugins/gutenberg/build/scripts/block-library/categories.php on line 70

Warning: Attempt to read property "no_terms" on null in /wp-content/plugins/gutenberg/build/scripts/block-library/categories.php on line 70
```

This likely wouldn't happen often in real usage since the block inspector dropdown only shows valid taxonomies, but (a) nothing stops someone from manipulating block content to insert an invalid taxonomy and (b) it could happen in situations such as a plugin registering a custom post type and then the plugin being disabled later.

Included regression tests can be verified by running the PHPUnit tests:

```
npm run wp-env-test start
npm run test:unit:php:base -- --filter Tests_Blocks_Render_Categories
```

## Screenshots or screencast <!-- if applicable -->

<img width="1392" height="650" alt="image" src="https://github.com/user-attachments/assets/fc9498e1-3f62-469a-a0f2-22c3b8ec4ade" />


## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to implement regression test and then fix, reviewed manually with follow-up iteration prompts.