### PR TITLE
Gallery: translate the WordPress link option to the block's own values

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
--   Gallery: Translate the `image_default_link_type` option into the block's own link values, so the Link control shows the matching option as selected on sites where that option is set to Media File or Attachment Page ([#82157](https://github.com/WordPress/gutenberg/pull/82157)).
+-   Gallery: Read the WordPress link values `file` and `post` as the block's own `media` and `attachment`, in both the editor and the front end, so the Link control shows the matching option as selected on sites where `image_default_link_type` is set. Stored content is left as it is ([#82157](https://github.com/WordPress/gutenberg/pull/82157)).
 
 ### Internal
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
+-   Gallery: Translate the `image_default_link_type` option into the block's own link values, so the Link control shows the matching option as selected on sites where that option is set to Media File or Attachment Page ([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN)).
 
 ### Internal
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,10 +8,11 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
--   Gallery: Read the WordPress link values `file` and `post` as the block's own `media` and `attachment`, in both the editor and the front end, so the Link control shows the matching option as selected on sites where `image_default_link_type` is set. Stored content is left as it is ([#82157](https://github.com/WordPress/gutenberg/pull/82157)).
+-   Gallery: Read the WordPress link values `file` and `post` as the block's own `media` and `attachment`, so the Link control shows the matching option as selected on sites where `image_default_link_type` is set. Stored content is left as it is ([#82157](https://github.com/WordPress/gutenberg/pull/82157)).
 
 ### Internal
 
+-   Gallery: Remove the `isEligible` check on the v5 deprecation. It looks for the link values the block uses today, so every valid gallery opted into a migration that could never apply ([#82157](https://github.com/WordPress/gutenberg/pull/82157)).
 -   Remove unused dependencies `@wordpress/keyboard-shortcuts`, `@wordpress/reusable-blocks` and `@wordpress/viewport` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Use the `.jsx` extension for JavaScript source files that contain JSX ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
--   Gallery: Translate the `image_default_link_type` option into the block's own link values, so the Link control shows the matching option as selected on sites where that option is set to Media File or Attachment Page ([#NNNNN](https://github.com/WordPress/gutenberg/pull/NNNNN)).
+-   Gallery: Translate the `image_default_link_type` option into the block's own link values, so the Link control shows the matching option as selected on sites where that option is set to Media File or Attachment Page ([#82157](https://github.com/WordPress/gutenberg/pull/82157)).
 
 ### Internal
 

--- a/packages/block-library/src/gallery/deprecated.jsx
+++ b/packages/block-library/src/gallery/deprecated.jsx
@@ -477,9 +477,6 @@ const v5 = {
 	supports: {
 		align: true,
 	},
-	isEligible( { linkTo } ) {
-		return ! linkTo || linkTo === 'attachment' || linkTo === 'media';
-	},
 	migrate( attributes ) {
 		return runV2Migration( attributes );
 	},

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -171,12 +171,10 @@ export default function GalleryEdit( props ) {
 		aspectRatio,
 		layout,
 	} = attributes;
-	// Galleries saved before this value was translated, and galleries created by
+	// Galleries saved before this value was normalized, and galleries created by
 	// older versions of this block, hold WordPress' 'file' and 'post' rather than
-	// this block's 'media' and 'attachment'. Translate on the way in so the rest
-	// of the component only deals with this block's own values. What is stored
-	// stays as it is: rewriting it would change posts nobody asked us to change,
-	// and the front end reads the stored value through the same translation.
+	// this block's 'media' and 'attachment'. Normalize on the way in so the rest
+	// of the component only deals with this block's own values. What is stored stays as it is.
 	const linkTo = normalizeLinkTo( storedLinkTo );
 	const isFlexLayout = isGalleryFlexLayout( layout );
 	const previousLayoutRef = useRef( layout );
@@ -706,7 +704,7 @@ export default function GalleryEdit( props ) {
 	useEffect( () => {
 		// linkTo attribute must be saved so blocks don't break when changing image_default_link_type in options.php.
 		// That option stores 'file' or 'post', which this block calls 'media'
-		// and 'attachment', so translate it before storing it.
+		// and 'attachment', so normalize it before storing it.
 		if ( ! storedLinkTo ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -166,11 +166,18 @@ export default function GalleryEdit( props ) {
 		imageCrop,
 		randomOrder,
 		linkTarget,
-		linkTo,
+		linkTo: storedLinkTo,
 		sizeSlug,
 		aspectRatio,
 		layout,
 	} = attributes;
+	// Galleries saved before this value was translated, and galleries created by
+	// older versions of this block, hold WordPress' 'file' and 'post' rather than
+	// this block's 'media' and 'attachment'. Translate on the way in so the rest
+	// of the component only deals with this block's own values. What is stored
+	// stays as it is: rewriting it would change posts nobody asked us to change,
+	// and the front end reads the stored value through the same translation.
+	const linkTo = normalizeLinkTo( storedLinkTo );
 	const isFlexLayout = isGalleryFlexLayout( layout );
 	const previousLayoutRef = useRef( layout );
 
@@ -699,19 +706,17 @@ export default function GalleryEdit( props ) {
 	useEffect( () => {
 		// linkTo attribute must be saved so blocks don't break when changing image_default_link_type in options.php.
 		// That option stores 'file' or 'post', which this block calls 'media'
-		// and 'attachment'. Translate both the option and any value an earlier
-		// version of this effect stored untranslated, because a value the Link
-		// control has no option for leaves the control showing nothing selected.
-		const nextLinkTo =
-			normalizeLinkTo(
-				linkTo || window?.wp?.media?.view?.settings?.defaultProps?.link
-			) || LINK_DESTINATION_NONE;
-
-		if ( nextLinkTo !== linkTo ) {
+		// and 'attachment', so translate it before storing it.
+		if ( ! storedLinkTo ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { linkTo: nextLinkTo } );
+			setAttributes( {
+				linkTo:
+					normalizeLinkTo(
+						window?.wp?.media?.view?.settings?.defaultProps?.link
+					) || LINK_DESTINATION_NONE,
+			} );
 		}
-	}, [ linkTo ] );
+	}, [ storedLinkTo ] );
 
 	const hasImageIds = hasImages && images.some( ( image ) => !! image.id );
 	const imagesUploading = images.some(

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -705,7 +705,12 @@ export default function GalleryEdit( props ) {
 		// linkTo attribute must be saved so blocks don't break when changing image_default_link_type in options.php.
 		// That option stores 'file' or 'post', which this block calls 'media'
 		// and 'attachment', so normalize it before storing it.
-		if ( ! storedLinkTo ) {
+		//
+		// Only for a gallery with no images. Images take their link from this
+		// value as they are added, so a gallery that already has some may link
+		// somewhere the option doesn't name, and storing the option would make
+		// the Link control describe the images wrongly.
+		if ( ! storedLinkTo && ! hasImages ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				linkTo:
@@ -714,7 +719,7 @@ export default function GalleryEdit( props ) {
 					) || LINK_DESTINATION_NONE,
 			} );
 		}
-	}, [ storedLinkTo ] );
+	}, [ storedLinkTo, hasImages ] );
 
 	const hasImageIds = hasImages && images.some( ( image ) => !! image.id );
 	const imagesUploading = images.some(

--- a/packages/block-library/src/gallery/edit.jsx
+++ b/packages/block-library/src/gallery/edit.jsx
@@ -43,7 +43,7 @@ import {
 	isObject,
 	pickRelevantMediaFiles,
 } from './shared';
-import { getHrefAndDestination } from './utils';
+import { getHrefAndDestination, normalizeLinkTo } from './utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import {
 	getUpdatedLinkTargetSettings,
@@ -698,13 +698,18 @@ export default function GalleryEdit( props ) {
 
 	useEffect( () => {
 		// linkTo attribute must be saved so blocks don't break when changing image_default_link_type in options.php.
-		if ( ! linkTo ) {
+		// That option stores 'file' or 'post', which this block calls 'media'
+		// and 'attachment'. Translate both the option and any value an earlier
+		// version of this effect stored untranslated, because a value the Link
+		// control has no option for leaves the control showing nothing selected.
+		const nextLinkTo =
+			normalizeLinkTo(
+				linkTo || window?.wp?.media?.view?.settings?.defaultProps?.link
+			) || LINK_DESTINATION_NONE;
+
+		if ( nextLinkTo !== linkTo ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				linkTo:
-					window?.wp?.media?.view?.settings?.defaultProps?.link ||
-					LINK_DESTINATION_NONE,
-			} );
+			setAttributes( { linkTo: nextLinkTo } );
 		}
 	}, [ linkTo ] );
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -265,21 +265,15 @@ function block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attr
 	$link_to = $attributes['linkTo'] ?? 'none';
 	$attrs   = array();
 
-	// Galleries can hold WordPress' 'file' and 'post' as well as this block's
-	// own 'media' and 'attachment'. Translate here so the rest of this function
-	// only deals with the block's own values.
-	if ( 'file' === $link_to ) {
-		$link_to = 'media';
-	} elseif ( 'post' === $link_to ) {
-		$link_to = 'attachment';
-	}
-
 	switch ( $link_to ) {
+		// Gutenberg uses 'media'/'attachment'; WP Core uses 'file'/'post'.
 		case 'media':
+		case 'file':
 			$attrs['href']            = wp_get_attachment_url( $attachment_id );
 			$attrs['linkDestination'] = 'media';
 			break;
 		case 'attachment':
+		case 'post':
 			$attrs['href']            = get_attachment_link( $attachment_id );
 			$attrs['linkDestination'] = 'attachment';
 			break;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -249,6 +249,32 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 }
 
 /**
+ * Translates a link destination stored by WordPress into the value the Gallery
+ * block uses. WordPress records the site-wide default in the
+ * `image_default_link_type` option as `file` or `post`; the block calls the same
+ * two destinations `media` and `attachment`. Galleries saved by older versions
+ * of the block hold the WordPress values too. Any other value, including one the
+ * block already understands, is returned unchanged.
+ *
+ * Mirrors the editor's `normalizeLinkTo()` (see `gallery/utils.js`).
+ *
+ * @since 7.0.0
+ *
+ * @param string $link_to Link destination to translate.
+ * @return string Link destination in the block's own vocabulary.
+ */
+function block_core_gallery_normalize_link_to( $link_to ) {
+	switch ( $link_to ) {
+		case 'file':
+			return 'media';
+		case 'post':
+			return 'attachment';
+		default:
+			return $link_to;
+	}
+}
+
+/**
  * Builds the link-related image block attributes for a dynamically rendered
  * gallery image, mapping the gallery-wide `linkTo` setting onto a single image.
  *
@@ -262,18 +288,15 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
  *               `linkTarget`, `rel`, `lightbox`).
  */
 function block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes ) {
-	$link_to = $attributes['linkTo'] ?? 'none';
+	$link_to = block_core_gallery_normalize_link_to( $attributes['linkTo'] ?? 'none' );
 	$attrs   = array();
 
 	switch ( $link_to ) {
-		// Gutenberg uses 'media'/'attachment'; WP Core uses 'file'/'post'.
 		case 'media':
-		case 'file':
 			$attrs['href']            = wp_get_attachment_url( $attachment_id );
 			$attrs['linkDestination'] = 'media';
 			break;
 		case 'attachment':
-		case 'post':
 			$attrs['href']            = get_attachment_link( $attachment_id );
 			$attrs['linkDestination'] = 'attachment';
 			break;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -249,32 +249,6 @@ function block_core_gallery_resolve_dynamic_source( $source, $block ) {
 }
 
 /**
- * Translates a link destination stored by WordPress into the value the Gallery
- * block uses. WordPress records the site-wide default in the
- * `image_default_link_type` option as `file` or `post`; the block calls the same
- * two destinations `media` and `attachment`. Galleries saved by older versions
- * of the block hold the WordPress values too. Any other value, including one the
- * block already understands, is returned unchanged.
- *
- * Mirrors the editor's `normalizeLinkTo()` (see `gallery/utils.js`).
- *
- * @since 7.0.0
- *
- * @param string $link_to Link destination to translate.
- * @return string Link destination in the block's own vocabulary.
- */
-function block_core_gallery_normalize_link_to( $link_to ) {
-	switch ( $link_to ) {
-		case 'file':
-			return 'media';
-		case 'post':
-			return 'attachment';
-		default:
-			return $link_to;
-	}
-}
-
-/**
  * Builds the link-related image block attributes for a dynamically rendered
  * gallery image, mapping the gallery-wide `linkTo` setting onto a single image.
  *
@@ -288,8 +262,17 @@ function block_core_gallery_normalize_link_to( $link_to ) {
  *               `linkTarget`, `rel`, `lightbox`).
  */
 function block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes ) {
-	$link_to = block_core_gallery_normalize_link_to( $attributes['linkTo'] ?? 'none' );
+	$link_to = $attributes['linkTo'] ?? 'none';
 	$attrs   = array();
+
+	// Galleries can hold WordPress' 'file' and 'post' as well as this block's
+	// own 'media' and 'attachment'. Translate here so the rest of this function
+	// only deals with the block's own values.
+	if ( 'file' === $link_to ) {
+		$link_to = 'media';
+	} elseif ( 'post' === $link_to ) {
+		$link_to = 'attachment';
+	}
 
 	switch ( $link_to ) {
 		case 'media':

--- a/packages/block-library/src/gallery/test/utils.js
+++ b/packages/block-library/src/gallery/test/utils.js
@@ -1,4 +1,4 @@
-import { normalizeLinkTo } from '../utils';
+import { getHrefAndDestination, normalizeLinkTo } from '../utils';
 
 describe( 'normalizeLinkTo', () => {
 	it( 'translates the values WordPress stores in image_default_link_type', () => {
@@ -20,30 +20,57 @@ describe( 'normalizeLinkTo', () => {
 } );
 
 describe( 'linkTo seeding', () => {
-	// Mirrors the expression in GalleryEdit's linkTo effect, which is where the
-	// stored value is decided from the block attribute and the WordPress option.
-	function resolveLinkTo( linkTo, optionValue ) {
-		return normalizeLinkTo( linkTo || optionValue ) || 'none';
+	// Mirrors the expression in GalleryEdit's effect, which only runs when the
+	// gallery has no stored value yet.
+	function seedLinkTo( optionValue ) {
+		return normalizeLinkTo( optionValue ) || 'none';
 	}
 
-	it( "seeds a new gallery from the option in the block's vocabulary", () => {
-		expect( resolveLinkTo( undefined, 'file' ) ).toBe( 'media' );
-		expect( resolveLinkTo( undefined, 'post' ) ).toBe( 'attachment' );
+	it( "stores the option in the block's own vocabulary", () => {
+		expect( seedLinkTo( 'file' ) ).toBe( 'media' );
+		expect( seedLinkTo( 'post' ) ).toBe( 'attachment' );
 	} );
 
 	it( 'falls back to none when the option is unset', () => {
-		expect( resolveLinkTo( undefined, undefined ) ).toBe( 'none' );
-		expect( resolveLinkTo( undefined, '' ) ).toBe( 'none' );
+		expect( seedLinkTo( undefined ) ).toBe( 'none' );
+		expect( seedLinkTo( '' ) ).toBe( 'none' );
+	} );
+} );
+
+describe( 'getHrefAndDestination', () => {
+	const image = {
+		url: 'https://example.com/pic.jpg',
+		link: 'https://example.com/pic/',
+	};
+
+	it( 'accepts the values WordPress stores, without them being migrated', () => {
+		expect( getHrefAndDestination( image, 'file' ) ).toMatchObject( {
+			href: image.url,
+			linkDestination: 'media',
+		} );
+		expect( getHrefAndDestination( image, 'post' ) ).toMatchObject( {
+			href: image.link,
+			linkDestination: 'attachment',
+		} );
 	} );
 
-	it( 'translates a value an earlier version stored untranslated', () => {
-		expect( resolveLinkTo( 'file', 'none' ) ).toBe( 'media' );
-		expect( resolveLinkTo( 'post', 'none' ) ).toBe( 'attachment' );
+	it( "accepts the block's own values", () => {
+		expect( getHrefAndDestination( image, 'media' ) ).toMatchObject( {
+			href: image.url,
+			linkDestination: 'media',
+		} );
+		expect( getHrefAndDestination( image, 'attachment' ) ).toMatchObject( {
+			href: image.link,
+			linkDestination: 'attachment',
+		} );
 	} );
 
-	it( 'leaves a gallery that already has a supported value untouched', () => {
-		expect( resolveLinkTo( 'lightbox', 'file' ) ).toBe( 'lightbox' );
-		expect( resolveLinkTo( 'none', 'file' ) ).toBe( 'none' );
-		expect( resolveLinkTo( 'media', 'post' ) ).toBe( 'media' );
+	it( 'translates a per-image value too', () => {
+		expect( getHrefAndDestination( image, 'none', 'file' ) ).toMatchObject(
+			{
+				href: image.url,
+				linkDestination: 'media',
+			}
+		);
 	} );
 } );

--- a/packages/block-library/src/gallery/test/utils.js
+++ b/packages/block-library/src/gallery/test/utils.js
@@ -1,0 +1,49 @@
+import { normalizeLinkTo } from '../utils';
+
+describe( 'normalizeLinkTo', () => {
+	it( 'translates the values WordPress stores in image_default_link_type', () => {
+		expect( normalizeLinkTo( 'file' ) ).toBe( 'media' );
+		expect( normalizeLinkTo( 'post' ) ).toBe( 'attachment' );
+	} );
+
+	it( "leaves the block's own values alone", () => {
+		expect( normalizeLinkTo( 'media' ) ).toBe( 'media' );
+		expect( normalizeLinkTo( 'attachment' ) ).toBe( 'attachment' );
+		expect( normalizeLinkTo( 'lightbox' ) ).toBe( 'lightbox' );
+		expect( normalizeLinkTo( 'none' ) ).toBe( 'none' );
+	} );
+
+	it( 'passes a missing value through so the caller can fall back', () => {
+		expect( normalizeLinkTo( undefined ) ).toBeUndefined();
+		expect( normalizeLinkTo( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'linkTo seeding', () => {
+	// Mirrors the expression in GalleryEdit's linkTo effect, which is where the
+	// stored value is decided from the block attribute and the WordPress option.
+	function resolveLinkTo( linkTo, optionValue ) {
+		return normalizeLinkTo( linkTo || optionValue ) || 'none';
+	}
+
+	it( "seeds a new gallery from the option in the block's vocabulary", () => {
+		expect( resolveLinkTo( undefined, 'file' ) ).toBe( 'media' );
+		expect( resolveLinkTo( undefined, 'post' ) ).toBe( 'attachment' );
+	} );
+
+	it( 'falls back to none when the option is unset', () => {
+		expect( resolveLinkTo( undefined, undefined ) ).toBe( 'none' );
+		expect( resolveLinkTo( undefined, '' ) ).toBe( 'none' );
+	} );
+
+	it( 'translates a value an earlier version stored untranslated', () => {
+		expect( resolveLinkTo( 'file', 'none' ) ).toBe( 'media' );
+		expect( resolveLinkTo( 'post', 'none' ) ).toBe( 'attachment' );
+	} );
+
+	it( 'leaves a gallery that already has a supported value untouched', () => {
+		expect( resolveLinkTo( 'lightbox', 'file' ) ).toBe( 'lightbox' );
+		expect( resolveLinkTo( 'none', 'file' ) ).toBe( 'none' );
+		expect( resolveLinkTo( 'media', 'post' ) ).toBe( 'media' );
+	} );
+} );

--- a/packages/block-library/src/gallery/test/utils.js
+++ b/packages/block-library/src/gallery/test/utils.js
@@ -6,44 +6,24 @@ describe( 'normalizeLinkTo', () => {
 		expect( normalizeLinkTo( 'post' ) ).toBe( 'attachment' );
 	} );
 
-	it( "leaves the block's own values alone", () => {
+	it( 'passes every other value through unchanged', () => {
 		expect( normalizeLinkTo( 'media' ) ).toBe( 'media' );
 		expect( normalizeLinkTo( 'attachment' ) ).toBe( 'attachment' );
 		expect( normalizeLinkTo( 'lightbox' ) ).toBe( 'lightbox' );
 		expect( normalizeLinkTo( 'none' ) ).toBe( 'none' );
-	} );
-
-	it( 'passes a missing value through so the caller can fall back', () => {
 		expect( normalizeLinkTo( undefined ) ).toBeUndefined();
-		expect( normalizeLinkTo( '' ) ).toBe( '' );
-	} );
-} );
-
-describe( 'linkTo seeding', () => {
-	// Mirrors the expression in GalleryEdit's effect, which only runs when the
-	// gallery has no stored value yet.
-	function seedLinkTo( optionValue ) {
-		return normalizeLinkTo( optionValue ) || 'none';
-	}
-
-	it( "stores the option in the block's own vocabulary", () => {
-		expect( seedLinkTo( 'file' ) ).toBe( 'media' );
-		expect( seedLinkTo( 'post' ) ).toBe( 'attachment' );
-	} );
-
-	it( 'falls back to none when the option is unset', () => {
-		expect( seedLinkTo( undefined ) ).toBe( 'none' );
-		expect( seedLinkTo( '' ) ).toBe( 'none' );
 	} );
 } );
 
 describe( 'getHrefAndDestination', () => {
-	const image = {
-		url: 'https://example.com/pic.jpg',
-		link: 'https://example.com/pic/',
-	};
+	// It no longer has cases of its own for the WordPress values, so check it
+	// still resolves them through normalizeLinkTo.
+	it( 'resolves the values WordPress stores', () => {
+		const image = {
+			url: 'https://example.com/pic.jpg',
+			link: 'https://example.com/pic/',
+		};
 
-	it( 'accepts the values WordPress stores, without them being migrated', () => {
 		expect( getHrefAndDestination( image, 'file' ) ).toMatchObject( {
 			href: image.url,
 			linkDestination: 'media',
@@ -52,25 +32,5 @@ describe( 'getHrefAndDestination', () => {
 			href: image.link,
 			linkDestination: 'attachment',
 		} );
-	} );
-
-	it( "accepts the block's own values", () => {
-		expect( getHrefAndDestination( image, 'media' ) ).toMatchObject( {
-			href: image.url,
-			linkDestination: 'media',
-		} );
-		expect( getHrefAndDestination( image, 'attachment' ) ).toMatchObject( {
-			href: image.link,
-			linkDestination: 'attachment',
-		} );
-	} );
-
-	it( 'translates a per-image value too', () => {
-		expect( getHrefAndDestination( image, 'none', 'file' ) ).toMatchObject(
-			{
-				href: image.url,
-				linkDestination: 'media',
-			}
-		);
 	} );
 } );

--- a/packages/block-library/src/gallery/test/utils.js
+++ b/packages/block-library/src/gallery/test/utils.js
@@ -1,7 +1,7 @@
 import { getHrefAndDestination, normalizeLinkTo } from '../utils';
 
 describe( 'normalizeLinkTo', () => {
-	it( 'translates the values WordPress stores in image_default_link_type', () => {
+	it( 'normalizes the values WordPress stores in image_default_link_type', () => {
 		expect( normalizeLinkTo( 'file' ) ).toBe( 'media' );
 		expect( normalizeLinkTo( 'post' ) ).toBe( 'attachment' );
 	} );

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -72,7 +72,7 @@ export function getHrefAndDestination(
 }
 
 /**
- * Translates a link destination stored by WordPress into the value the Gallery
+ * Normalizes a link destination stored by WordPress into the value the Gallery
  * block uses. WordPress records the site-wide default in the
  * `image_default_link_type` option as `file` or `post`; the block calls the
  * same two destinations `media` and `attachment`. Any other value, including

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -70,3 +70,25 @@ export function getHrefAndDestination(
 
 	return {};
 }
+
+/**
+ * Translates a link destination stored by WordPress into the value the Gallery
+ * block uses. WordPress records the site-wide default in the
+ * `image_default_link_type` option as `file` or `post`; the block calls the
+ * same two destinations `media` and `attachment`. Any other value, including
+ * one the block already understands, is returned unchanged.
+ *
+ * @param {string|undefined} linkTo Link destination to translate.
+ *
+ * @return {string|undefined} Link destination in the block's own vocabulary.
+ */
+export function normalizeLinkTo( linkTo ) {
+	switch ( linkTo ) {
+		case LINK_DESTINATION_MEDIA_WP_CORE:
+			return LINK_DESTINATION_MEDIA;
+		case LINK_DESTINATION_ATTACHMENT_WP_CORE:
+			return LINK_DESTINATION_ATTACHMENT;
+		default:
+			return linkTo;
+	}
+}

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -31,10 +31,11 @@ export function getHrefAndDestination(
 	attributes,
 	lightboxSetting
 ) {
-	// Gutenberg and WordPress use different constants so if image_default_link_type
-	// option is set we need to map from the WP Core values.
-	switch ( imageDestination ? imageDestination : galleryDestination ) {
-		case LINK_DESTINATION_MEDIA_WP_CORE:
+	switch (
+		normalizeLinkTo(
+			imageDestination ? imageDestination : galleryDestination
+		)
+	) {
 		case LINK_DESTINATION_MEDIA:
 			return {
 				href: image?.source_url || image?.url,
@@ -43,7 +44,6 @@ export function getHrefAndDestination(
 					? { ...attributes?.lightbox, enabled: false }
 					: undefined,
 			};
-		case LINK_DESTINATION_ATTACHMENT_WP_CORE:
 		case LINK_DESTINATION_ATTACHMENT:
 			return {
 				href: image?.link,


### PR DESCRIPTION
## What

Maybe closes https://github.com/WordPress/gutenberg/issues/25587

On sites where the WordPress media option `image_default_link_type` has been set, the Gallery block's **Link** menu showed nothing ticked, so there was no way to tell what the images link to.

WordPress writes that option as `file` or `post`. The Gallery block calls the same two things `media` and `attachment`. 

The block stored WordPress' word for it, then compared it against its own, which never matched.

Galleries saved by older versions of the block hold `file` and `post` too, for the same reason.

Only the editor menu was affected. The links themselves have always worked, in the editor and on the front end.

## How

The value is translated where it is read, in the editor:

- the block component works from a translated copy of the stored value, so the menu matches
- `getHrefAndDestination` translates its input, so it no longer needs duplicate cases

**Stored content is left alone.** An old gallery keeps saying `file`.

The site default is only used for a gallery with **no images**. Images take their link from this value as they are added, so a gallery that arrives with images but no value of its own — pasted markup, an imported pattern — may link somewhere the option doesn't name. Reading the option there made the Link control name the wrong destination.

### Also here: a stale check on an old deprecation

#25582 added a deprecation with a matched pair — find galleries holding `media` or `attachment`, convert them to `file` and `post`. #25940 replaced the conversion with one that goes the other way and left the check alone.

So the check now selects galleries already holding the values it converts *to*, and it matches on every valid gallery, since `none`, `media`, `attachment` and unset cover them all. Each one is re-parsed under the old schema and validated against the old save before being thrown away.

Nothing depended on it. #25940 changed the markup as well as the values, so galleries in that format no longer validate against the current save and are already caught by ordinary deprecation matching. Removing it changed nothing across 388 block fixture tests, and a real v5-era gallery still migrates: three Image blocks, valid, legacy `images` attribute dropped.

**Where this is guarded.** `core__gallery__deprecated-5` and `-6` are the fixtures that cover v5 migration. They are not passing by accident: deleting v5 from the deprecation list makes exactly those two fail, so a regression in v5 handling is caught. Between them, `deprecated-1`–`4` cover old galleries with no `linkTo` and `deprecated-5`/`6` cover `linkTo: "media"` — both arms of the removed check — while `core__gallery` and friends cover the current-format galleries that were opting in for nothing.

Happy to pull this out into its own PR if reviewers would rather — it's three lines.



## Testing

You need a site where the media option is set. In WP-CLI:

```
wp option update image_default_link_type file
```

Then:

1. Create a post, add a Gallery block, and put an image in it.
2. Select the Gallery block and open the **Link** menu in the block toolbar.
3. **Link images to media files** should be ticked. On trunk nothing is ticked.
4. Switch to the code editor and confirm the block says `"linkTo":"media"`. On trunk it says `"linkTo":"file"`.

To check a gallery that already holds the wrong value, paste this into the code editor of a new post, switch back to the visual editor, then select the Gallery and open the Link menu:

```
<!-- wp:gallery {"linkTo":"file"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1} -->
<figure class="wp-block-image"><img src="" alt="" class="wp-image-1"/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->
```

**Link images to media files** should be ticked. On trunk nothing is ticked. This case needs no option set.

Setting `wp option update image_default_link_type post` should behave the same way with **Link images to attachment pages**.



| Trunk | This PR |
|--------|--------|
| <img width="488" height="320" alt="Screenshot 2026-08-28 at 3 33 22 pm" src="https://github.com/user-attachments/assets/1c6b1d0d-5998-471e-859d-e45edf89d3f1" /> | <img width="562" height="318" alt="Screenshot 2026-08-28 at 3 33 16 pm" src="https://github.com/user-attachments/assets/b573057f-c393-48b7-9a61-2f227e61ba73" /> | 


