### PR TITLE
Editor: Show the revision fields plugins register

### DIFF
--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-revisions-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-revisions-controller.php
@@ -14,6 +14,9 @@
  * (e.g. content.raw without content.rendered) via the _fields parameter,
  * avoiding expensive rendering when only raw data is needed.
  *
+ * It also adds a `revision_fields` field, holding the fields plugins add to
+ * revisions through the `_wp_post_revision_fields` filter.
+ *
  * @see WP_REST_Revisions_Controller
  */
 class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
@@ -120,7 +123,12 @@ class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+
+		if ( 'edit' === $context && rest_is_field_included( 'revision_fields', $fields ) ) {
+			$data['revision_fields'] = $this->get_revision_fields( $post );
+		}
+
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
@@ -139,5 +147,79 @@ class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
 		return apply_filters( 'rest_prepare_revision', $response, $post, $request );
+	}
+
+	/**
+	 * Returns the fields plugins add to a revision through the
+	 * `_wp_post_revision_fields` filter, the same list the classic revisions
+	 * screen shows, without the fields already in the response.
+	 *
+	 * @param WP_Post $revision Post revision object.
+	 * @return array Map of field name to its label and value.
+	 */
+	protected function get_revision_fields( $revision ) {
+		$core_fields = array( 'post_title', 'post_content', 'post_excerpt' );
+		$fields      = array();
+
+		foreach ( _wp_post_revision_fields( $revision->post_parent ) as $field => $label ) {
+			if ( in_array( $field, $core_fields, true ) ) {
+				continue;
+			}
+
+			/*
+			 * WP_Post reads an unknown property from post meta, so a field
+			 * backed by meta needs no filter of its own. This is the same
+			 * call the classic screen makes for the newer of the two
+			 * revisions it compares.
+			 */
+			/** This filter is documented in wp-admin/includes/revision.php */
+			$value = apply_filters( "_wp_post_revision_field_{$field}", $revision->$field, $field, $revision, 'to' );
+
+			if ( ! is_scalar( $value ) || '' === (string) $value ) {
+				continue;
+			}
+
+			$fields[ $field ] = array(
+				'label' => (string) $label,
+				'value' => (string) $value,
+			);
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Adds the plugin revision fields to the schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['revision_fields'] = array(
+			'description'          => __( 'Fields added to revisions by plugins, as shown on the classic revisions screen.' ),
+			'type'                 => 'object',
+			'context'              => array( 'edit' ),
+			'readonly'             => true,
+			'additionalProperties' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'label' => array(
+						'description' => __( 'Human readable name for the field.' ),
+						'type'        => 'string',
+						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+					'value' => array(
+						'description' => __( 'Value of the field in this revision.' ),
+						'type'        => 'string',
+						'context'     => array( 'edit' ),
+						'readonly'    => true,
+					),
+				),
+			),
+		);
+
+		return $schema;
 	}
 }

--- a/packages/e2e-tests/plugins/revision-fields.php
+++ b/packages/e2e-tests/plugins/revision-fields.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Revision Fields
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-revision-fields
+ */
+
+/**
+ * Registers a revisioned meta field and gives it a name on the revisions
+ * screens through the filter plugins have always used for this.
+ */
+function gutenberg_test_revision_fields_register_meta() {
+	register_post_meta(
+		'post',
+		'gutenberg_test_revision_field',
+		array(
+			'type'              => 'string',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'revisions_enabled' => true,
+			'sanitize_callback' => 'sanitize_text_field',
+			'auth_callback'     => function () {
+				return current_user_can( 'edit_posts' );
+			},
+		)
+	);
+}
+add_action( 'init', 'gutenberg_test_revision_fields_register_meta' );
+
+/**
+ * Adds the field to the list of revision fields.
+ *
+ * @param string[] $fields List of fields to revision.
+ * @return string[] The filtered list.
+ */
+function gutenberg_test_revision_fields_add_field( $fields ) {
+	$fields['gutenberg_test_revision_field'] = 'Release date';
+	return $fields;
+}
+add_filter( '_wp_post_revision_fields', 'gutenberg_test_revision_fields_add_field' );

--- a/packages/e2e-tests/plugins/revision-fields.php
+++ b/packages/e2e-tests/plugins/revision-fields.php
@@ -36,7 +36,7 @@ add_action( 'init', 'gutenberg_test_revision_fields_register_meta' );
  * @return string[] The filtered list.
  */
 function gutenberg_test_revision_fields_add_field( $fields ) {
-	$fields['gutenberg_test_revision_field'] = 'Release date';
+	$fields['gutenberg_test_revision_field'] = 'Event date';
 	return $fields;
 }
 add_filter( '_wp_post_revision_fields', 'gutenberg_test_revision_fields_add_field' );

--- a/packages/editor/src/components/revision-diff-panel/index.jsx
+++ b/packages/editor/src/components/revision-diff-panel/index.jsx
@@ -7,12 +7,14 @@ import PostPanelRow from '../post-panel-row';
  * @param {Object}  props
  * @param {string}  props.title       Panel title.
  * @param {Object}  props.entries     Map of key → diffWords parts arrays.
+ * @param {Object}  [props.labels]    Map of key → the name to show for it.
  * @param {boolean} props.initialOpen Whether the panel starts open.
  * @param {string}  [props.className] Optional class for the content wrapper.
  */
 export default function RevisionDiffPanel( {
 	title,
 	entries,
+	labels,
 	initialOpen,
 	className,
 } ) {
@@ -21,7 +23,7 @@ export default function RevisionDiffPanel( {
 	}
 
 	const fields = Object.entries( entries ).map( ( [ key, parts ] ) => (
-		<PostPanelRow key={ key } label={ key }>
+		<PostPanelRow key={ key } label={ labels?.[ key ] ?? key }>
 			<span className="editor-revision-fields-diff__value">
 				{ parts.map( ( part, index ) => {
 					if ( part.added ) {

--- a/packages/editor/src/components/revision-fields-diff/index.jsx
+++ b/packages/editor/src/components/revision-fields-diff/index.jsx
@@ -28,18 +28,22 @@ function stringifyValue( value ) {
 }
 
 /**
- * Determines whether a meta value should be treated as empty.
+ * Determines whether a value should be treated as empty.
  *
  * @param {string} str The stringified value.
  * @return {boolean} Whether the value is effectively empty.
  */
-function isEmptyMeta( str ) {
+function isEmptyValue( str ) {
 	return ! str || str === '[]' || str === '{}';
 }
 
 /**
- * Panel that shows meta field diffs between the current revision and
+ * Panel that shows the fields that changed between the current revision and
  * the previous revision in the document sidebar during revision mode.
+ *
+ * Fields a plugin registered with `_wp_post_revision_fields` come with a name
+ * to show, and cover the same ground as the classic revisions screen. The
+ * post meta the REST API exposes is shown under its key.
  */
 export default function RevisionFieldsDiffPanel() {
 	const { revision, previousRevision } = useSelect( ( select ) => {
@@ -53,42 +57,71 @@ export default function RevisionFieldsDiffPanel() {
 		};
 	}, [] );
 
-	const entries = useMemo( () => {
+	const { entries, labels } = useMemo( () => {
+		const nothing = { entries: null, labels: null };
+
 		if ( ! revision ) {
-			return null;
+			return nothing;
 		}
 
+		const revisionFields = revision.revision_fields ?? {};
+		const previousFields = previousRevision?.revision_fields ?? {};
 		const revisionMeta = revision.meta ?? {};
 		const previousMeta = previousRevision?.meta ?? {};
-		const allMetaKeys = new Set( [
-			...Object.keys( revisionMeta ),
-			...Object.keys( previousMeta ),
+
+		const fieldKeys = new Set( [
+			...Object.keys( revisionFields ),
+			...Object.keys( previousFields ),
 		] );
+		const metaKeys = new Set(
+			[
+				...Object.keys( revisionMeta ),
+				...Object.keys( previousMeta ),
+			].filter( ( key ) => ! fieldKeys.has( key ) )
+		);
 
 		const result = {};
+		const names = {};
 
-		for ( const key of allMetaKeys ) {
-			const revStr = stringifyValue( revisionMeta[ key ] );
-			const prevStr = stringifyValue( previousMeta[ key ] );
+		const add = ( key, from, to, label ) => {
+			const fromStr = stringifyValue( from );
+			const toStr = stringifyValue( to );
 
-			if ( isEmptyMeta( revStr ) && isEmptyMeta( prevStr ) ) {
-				continue;
+			if ( isEmptyValue( fromStr ) && isEmptyValue( toStr ) ) {
+				return;
 			}
 
-			result[ key ] = diffWordsWithSpace( prevStr, revStr );
+			result[ key ] = diffWordsWithSpace( fromStr, toStr );
+			names[ key ] = label;
+		};
+
+		for ( const key of fieldKeys ) {
+			add(
+				key,
+				previousFields[ key ]?.value,
+				revisionFields[ key ]?.value,
+				revisionFields[ key ]?.label ??
+					previousFields[ key ]?.label ??
+					key
+			);
+		}
+
+		for ( const key of metaKeys ) {
+			add( key, previousMeta[ key ], revisionMeta[ key ], key );
 		}
 
 		if ( Object.keys( result ).length === 0 ) {
-			return null;
+			return nothing;
 		}
 
-		return result;
+		return { entries: result, labels: names };
 	}, [ revision, previousRevision ] );
 
 	return (
 		<RevisionDiffPanel
-			title={ __( 'Meta' ) }
+			title={ __( 'Fields' ) }
 			entries={ entries }
+			labels={ labels }
 			initialOpen={ false }
 			className="editor-revision-meta-diff__content"
 		/>

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -354,6 +354,7 @@ export function buildRevisionsPageQuery( revisionKey, page ) {
 				'author',
 				'slug',
 				'meta',
+				'revision_fields',
 				'title.raw',
 				'excerpt.raw',
 				'content.raw',

--- a/phpunit/class-gutenberg-rest-revision-fields-test.php
+++ b/phpunit/class-gutenberg-rest-revision-fields-test.php
@@ -32,7 +32,7 @@ class Gutenberg_REST_Revision_Fields_Test extends WP_UnitTestCase {
 
 		register_post_meta(
 			'post',
-			'gutenberg_test_release_date',
+			'gutenberg_test_event_date',
 			array(
 				'type'              => 'string',
 				'single'            => true,
@@ -50,13 +50,13 @@ class Gutenberg_REST_Revision_Fields_Test extends WP_UnitTestCase {
 				'post_content' => 'Content',
 			)
 		);
-		update_post_meta( self::$post_id, 'gutenberg_test_release_date', '3 September' );
+		update_post_meta( self::$post_id, 'gutenberg_test_event_date', 'Saturday' );
 		wp_save_post_revision( self::$post_id );
 	}
 
 	public function tear_down() {
 		remove_filter( '_wp_post_revision_fields', array( $this, 'filter_revision_fields' ) );
-		unregister_post_meta( 'post', 'gutenberg_test_release_date' );
+		unregister_post_meta( 'post', 'gutenberg_test_event_date' );
 		wp_delete_post( self::$post_id, true );
 
 		parent::tear_down();
@@ -69,7 +69,7 @@ class Gutenberg_REST_Revision_Fields_Test extends WP_UnitTestCase {
 	 * @return string[] The filtered list.
 	 */
 	public function filter_revision_fields( $fields ) {
-		$fields['gutenberg_test_release_date'] = 'Release date';
+		$fields['gutenberg_test_event_date'] = 'Event date';
 		$fields['gutenberg_test_missing']      = 'Never set';
 		return $fields;
 	}
@@ -95,13 +95,13 @@ class Gutenberg_REST_Revision_Fields_Test extends WP_UnitTestCase {
 	public function test_it_returns_the_field_with_its_label_and_value() {
 		$fields = $this->get_revision_fields();
 
-		$this->assertArrayHasKey( 'gutenberg_test_release_date', $fields );
+		$this->assertArrayHasKey( 'gutenberg_test_event_date', $fields );
 		$this->assertSame(
 			array(
-				'label' => 'Release date',
-				'value' => '3 September',
+				'label' => 'Event date',
+				'value' => 'Saturday',
 			),
-			$fields['gutenberg_test_release_date']
+			$fields['gutenberg_test_event_date']
 		);
 	}
 
@@ -121,13 +121,13 @@ class Gutenberg_REST_Revision_Fields_Test extends WP_UnitTestCase {
 		$filter = function ( $value ) {
 			return strtoupper( $value );
 		};
-		add_filter( '_wp_post_revision_field_gutenberg_test_release_date', $filter );
+		add_filter( '_wp_post_revision_field_gutenberg_test_event_date', $filter );
 
 		$fields = $this->get_revision_fields();
 
-		remove_filter( '_wp_post_revision_field_gutenberg_test_release_date', $filter );
+		remove_filter( '_wp_post_revision_field_gutenberg_test_event_date', $filter );
 
-		$this->assertSame( '3 SEPTEMBER', $fields['gutenberg_test_release_date']['value'] );
+		$this->assertSame( 'SATURDAY', $fields['gutenberg_test_event_date']['value'] );
 	}
 
 	public function test_it_is_absent_in_the_view_context() {

--- a/phpunit/class-gutenberg-rest-revision-fields-test.php
+++ b/phpunit/class-gutenberg-rest-revision-fields-test.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Unit tests covering the revision fields plugins register through the
+ * `_wp_post_revision_fields` filter.
+ *
+ * @package gutenberg
+ *
+ * @group rest-api
+ */
+class Gutenberg_REST_Revision_Fields_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $post_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		register_post_meta(
+			'post',
+			'gutenberg_test_release_date',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'revisions_enabled' => true,
+			)
+		);
+
+		add_filter( '_wp_post_revision_fields', array( $this, 'filter_revision_fields' ) );
+
+		wp_set_current_user( self::$admin_id );
+
+		self::$post_id = self::factory()->post->create(
+			array(
+				'post_author'  => self::$admin_id,
+				'post_content' => 'Content',
+			)
+		);
+		update_post_meta( self::$post_id, 'gutenberg_test_release_date', '3 September' );
+		wp_save_post_revision( self::$post_id );
+	}
+
+	public function tear_down() {
+		remove_filter( '_wp_post_revision_fields', array( $this, 'filter_revision_fields' ) );
+		unregister_post_meta( 'post', 'gutenberg_test_release_date' );
+		wp_delete_post( self::$post_id, true );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Adds a field the way a plugin does for the classic revisions screen.
+	 *
+	 * @param string[] $fields List of fields to revision.
+	 * @return string[] The filtered list.
+	 */
+	public function filter_revision_fields( $fields ) {
+		$fields['gutenberg_test_release_date'] = 'Release date';
+		$fields['gutenberg_test_missing']      = 'Never set';
+		return $fields;
+	}
+
+	/**
+	 * Returns the revision fields of the latest revision.
+	 *
+	 * @param string $context Request context.
+	 * @return array|null The revision fields, or null when the response has none.
+	 */
+	private function get_revision_fields( $context = 'edit' ) {
+		$revisions = wp_get_post_revisions( self::$post_id );
+		$revision  = reset( $revisions );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $revision->ID );
+		$request->set_param( 'context', $context );
+
+		$data = rest_get_server()->dispatch( $request )->get_data();
+
+		return array_key_exists( 'revision_fields', $data ) ? $data['revision_fields'] : null;
+	}
+
+	public function test_it_returns_the_field_with_its_label_and_value() {
+		$fields = $this->get_revision_fields();
+
+		$this->assertArrayHasKey( 'gutenberg_test_release_date', $fields );
+		$this->assertSame(
+			array(
+				'label' => 'Release date',
+				'value' => '3 September',
+			),
+			$fields['gutenberg_test_release_date']
+		);
+	}
+
+	public function test_it_leaves_out_fields_without_a_value() {
+		$this->assertArrayNotHasKey( 'gutenberg_test_missing', $this->get_revision_fields() );
+	}
+
+	public function test_it_leaves_out_the_fields_already_in_the_response() {
+		$fields = $this->get_revision_fields();
+
+		$this->assertArrayNotHasKey( 'post_title', $fields );
+		$this->assertArrayNotHasKey( 'post_content', $fields );
+		$this->assertArrayNotHasKey( 'post_excerpt', $fields );
+	}
+
+	public function test_it_applies_the_field_filter_of_the_plugin() {
+		$filter = function ( $value ) {
+			return strtoupper( $value );
+		};
+		add_filter( '_wp_post_revision_field_gutenberg_test_release_date', $filter );
+
+		$fields = $this->get_revision_fields();
+
+		remove_filter( '_wp_post_revision_field_gutenberg_test_release_date', $filter );
+
+		$this->assertSame( '3 SEPTEMBER', $fields['gutenberg_test_release_date']['value'] );
+	}
+
+	public function test_it_is_absent_in_the_view_context() {
+		$this->assertNull( $this->get_revision_fields( 'view' ) );
+	}
+}

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -1040,7 +1040,7 @@ test.describe( 'Post revision fields registered by plugins', () => {
 					'<!-- wp:paragraph --><p>Original content</p><!-- /wp:paragraph -->',
 				status: 'draft',
 				meta: {
-					gutenberg_test_revision_field: 'Autumn',
+					gutenberg_test_revision_field: 'Saturday',
 				},
 			},
 		} );
@@ -1059,7 +1059,7 @@ test.describe( 'Post revision fields registered by plugins', () => {
 				content:
 					'<!-- wp:paragraph --><p>Second revision</p><!-- /wp:paragraph -->',
 				meta: {
-					gutenberg_test_revision_field: 'Winter',
+					gutenberg_test_revision_field: 'Sunday',
 				},
 			},
 		} );
@@ -1081,16 +1081,16 @@ test.describe( 'Post revision fields registered by plugins', () => {
 			.click();
 
 		// The name comes from the plugin, so the meta key is not shown.
-		await expect(
-			settingsSidebar.getByText( 'Release date' )
-		).toBeVisible();
+		await expect( settingsSidebar.getByText( 'Event date' ) ).toBeVisible();
 		await expect(
 			settingsSidebar.getByText( 'gutenberg_test_revision_field' )
 		).toHaveCount( 0 );
 
 		// The value of the previous revision is shown as removed, and the
 		// value of this one as added.
-		await expect( settingsSidebar.locator( 'del' ) ).toHaveText( 'Autumn' );
-		await expect( settingsSidebar.locator( 'ins' ) ).toHaveText( 'Winter' );
+		await expect( settingsSidebar.locator( 'del' ) ).toHaveText(
+			'Saturday'
+		);
+		await expect( settingsSidebar.locator( 'ins' ) ).toHaveText( 'Sunday' );
 	} );
 } );

--- a/test/e2e/specs/editor/various/revisions.spec.js
+++ b/test/e2e/specs/editor/various/revisions.spec.js
@@ -1009,3 +1009,88 @@ test.describe( 'Post autosave shareable URLs with revisions disabled', () => {
 			.toBe( String( autosave.id ) );
 	} );
 } );
+
+test.describe( 'Post revision fields registered by plugins', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-revision-fields'
+		);
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-revision-fields'
+		);
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'shows a field under the name the plugin gave it', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Creating a post does not create a revision, so update it twice.
+		const post = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/posts',
+			data: {
+				title: 'Revision Fields Test',
+				content:
+					'<!-- wp:paragraph --><p>Original content</p><!-- /wp:paragraph -->',
+				status: 'draft',
+				meta: {
+					gutenberg_test_revision_field: 'Autumn',
+				},
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/posts/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>First revision</p><!-- /wp:paragraph -->',
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/posts/${ post.id }`,
+			data: {
+				content:
+					'<!-- wp:paragraph --><p>Second revision</p><!-- /wp:paragraph -->',
+				meta: {
+					gutenberg_test_revision_field: 'Winter',
+				},
+			},
+		} );
+
+		await admin.editPost( post.id );
+		await editor.openDocumentSettingsSidebar();
+		const settingsSidebar = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsSidebar.getByRole( 'tab', { name: 'Post' } ).click();
+		await settingsSidebar
+			.getByRole( 'button', {
+				name: 'Open revisions screen: 2 revisions',
+			} )
+			.click();
+
+		await settingsSidebar
+			.getByRole( 'button', { name: 'Fields', exact: true } )
+			.click();
+
+		// The name comes from the plugin, so the meta key is not shown.
+		await expect(
+			settingsSidebar.getByText( 'Release date' )
+		).toBeVisible();
+		await expect(
+			settingsSidebar.getByText( 'gutenberg_test_revision_field' )
+		).toHaveCount( 0 );
+
+		// The value of the previous revision is shown as removed, and the
+		// value of this one as added.
+		await expect( settingsSidebar.locator( 'del' ) ).toHaveText( 'Autumn' );
+		await expect( settingsSidebar.locator( 'ins' ) ).toHaveText( 'Winter' );
+	} );
+} );


### PR DESCRIPTION
## What?
See #78130. The revisions sidebar now shows the fields plugins register with `_wp_post_revision_fields`, under the names they gave them, so a plugin that has no editor JS still has its data shown when comparing revisions.

## Why?
The sidebar panel diffed `revision.meta` from the REST response, which is only the post meta registered with `show_in_rest`, and it labelled every row with the raw meta key. Plugins have always described their revisioned data to the classic screen through `_wp_post_revision_fields`, which returns a key and a human readable name, and `_wp_post_revision_field_{$field}`, which returns the value for a given revision. None of that reached the editor, so a plugin without REST or JS had nothing to show, and a plugin with REST meta got its key printed at the reader.

## How?
1. **The revisions REST response carries the fields.** `Gutenberg_REST_Revisions_Controller` adds a `revision_fields` object of `key => { label, value }`, built from `_wp_post_revision_fields()` minus the fields already in the response, with each value passed through the plugin's own field filter, the same call the classic screen makes. It is in the edit context only, and drops fields with no value.
2. **The panel uses the label.** `RevisionDiffPanel` takes an optional `labels` map, and the fields panel prefers a registered field over the same key in meta, keeping the REST meta rows for keys nothing registered.
3. **The panel is now called "Fields" rather than "Meta"**, because a registered field is not necessarily meta.

Two things worth knowing. Plugins that add these filters inside an `is_admin()` guard will not surface, because a REST request is not an admin request; the "Open classic revisions screen" link stays the way to see those. And the field is only computed for requests that ask for it, which for the editor is the revisions the sidebar diffs.

Best read alongside #82158, which makes restoring reach the same data. Neither depends on the other.

## Testing Instructions
1. Activate the `gutenberg-test-plugin-revision-fields` test plugin, or add your own `_wp_post_revision_fields` entry for a meta key registered with `revisions_enabled`.
2. Create a post, set the meta, and save. Change the content and the meta, then save again.
3. Open Revisions in the sidebar and expand the Fields panel.
4. The field is listed under the name the plugin gave it, with the value diffed against the previous revision, matching what `revision.php` shows.

### Testing Instructions for Keyboard
Tab to Revisions in the sidebar and press <kbd>Enter</kbd>, then tab to the Fields panel and press <kbd>Enter</kbd> to expand it.

## Screenshots or screencast

|Classic revisions screen|Visual revisions with this PR|
|-|-|
|<img width="640" alt="The classic revisions screen showing an Event date section registered by a plugin" src="https://github.com/user-attachments/assets/ca8ef672-56c4-450e-86a6-21aa1752a0f3" />|<img width="640" alt="The revisions sidebar showing the same Event date field in the Fields panel" src="https://github.com/user-attachments/assets/cb31b74b-fbcf-4508-a52d-a7abdcf33c91" />|

## Use of AI Tools
Authored with Claude Code assistance.

