### PR TITLE
Performance tests: Build once and shard the suites across parallel CI jobs

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,8 +36,7 @@ jobs:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}
         outputs:
-            # JSON array of `{ name, ref }`: `name` labels the results table and
-            # `ref` is what gets checked out and built.
+            # JSON array of `{ name, ref, artifact }`, see tools/release/resolve-performance-branches.mjs.
             branches: ${{ steps.branches.outputs.branches }}
             wp-version: ${{ steps.branches.outputs.wp-version }}
 
@@ -47,6 +46,11 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
+            - name: Use desired version of Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: '.nvmrc'
+
             - name: Resolve branches
               id: branches
               env:
@@ -55,55 +59,7 @@ jobs:
                   RELEASE_TAG: ${{ github.event.release.tag_name }}
                   INPUT_BRANCHES: ${{ github.event.inputs.branches }}
                   INPUT_WP_VERSION: ${{ github.event.inputs.wpversion }}
-              run: |
-                  WP_VERSION=""
-                  WP_MAJOR="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt | cut -d. -f1,2)"
-                  case "$GITHUB_EVENT_NAME" in
-                    pull_request)
-                      BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" --arg base "$BASE_REF" --arg baseSha "$BASE_SHA" '[{name: $head, ref: $head}, {name: $base, ref: $baseSha}]')"
-                      ;;
-                    push)
-                      # The base hash used here need to be a commit that is compatible with the current WP version
-                      # The current one is 28d414f1327652e2b49e784ddc12098768991c62 and it needs to be updated every WP major release.
-                      # It is used as a base comparison point to avoid fluctuation in the performance metrics.
-                      # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
-                      BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" '[{name: $head, ref: $head}, {name: "28d414f1327652e2b49e784ddc12098768991c62", ref: "28d414f1327652e2b49e784ddc12098768991c62"}]')"
-                      WP_VERSION="$WP_MAJOR"
-                      ;;
-                    release)
-                      PLUGIN_VERSION="${RELEASE_TAG#v}"
-                      if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-                        echo "::error::Release tag '$RELEASE_TAG' does not resolve to a valid Gutenberg plugin version."
-                        exit 1
-                      fi
-
-                      IFS=. read -ra PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
-                      CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
-                      PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))
-                      PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
-                      if ! git ls-remote --exit-code --tags origin "$RELEASE_TAG" > /dev/null; then
-                        echo "::error::Expected release tag '$RELEASE_TAG' to exist in the Gutenberg repository."
-                        exit 1
-                      fi
-                      if ! git ls-remote --exit-code --heads origin "$CURRENT_RELEASE_BRANCH" > /dev/null; then
-                        echo "::error::Expected current release branch '$CURRENT_RELEASE_BRANCH' to exist in the Gutenberg repository."
-                        exit 1
-                      fi
-                      if ! git ls-remote --exit-code --heads origin "$PREVIOUS_RELEASE_BRANCH" > /dev/null; then
-                        echo "::error::Expected previous release branch '$PREVIOUS_RELEASE_BRANCH' to exist in the Gutenberg repository."
-                        exit 1
-                      fi
-                      BRANCHES="$(jq -cn --arg wp "wp/$WP_MAJOR" --arg prev "$PREVIOUS_RELEASE_BRANCH" --arg cur "$CURRENT_RELEASE_BRANCH" '[$wp, $prev, $cur] | map({name: ., ref: .})')"
-                      WP_VERSION="$WP_MAJOR"
-                      ;;
-                    workflow_dispatch)
-                      BRANCHES="$(jq -cn --arg list "$INPUT_BRANCHES" '$list | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map({name: ., ref: .})')"
-                      WP_VERSION="$INPUT_WP_VERSION"
-                      ;;
-                  esac
-                  echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
-                  echo "wp-version=$WP_VERSION" >> "$GITHUB_OUTPUT"
-                  echo "$BRANCHES" | jq .
+              run: node tools/release/resolve-performance-branches.mjs
 
     build:
         timeout-minutes: 30
@@ -151,17 +107,10 @@ jobs:
                     | tar -xf - -C "$PLUGIN_DIR"
                   test -f "$PLUGIN_DIR/gutenberg.php"
 
-            - name: Sanitize artifact name
-              id: artifact
-              env:
-                  BRANCH_NAME: ${{ matrix.branch.name }}
-              # Same replacement as `sanitizeBranchName()` in tools/release/commands/performance.js.
-              run: echo "name=plugin-$(node -e 'process.stdout.write( process.env.BRANCH_NAME.replace( /[^a-zA-Z0-9-]/g, "-" ) )')" >> "$GITHUB_OUTPUT"
-
             - name: Upload plugin
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
-                  name: ${{ steps.artifact.outputs.name }}
+                  name: ${{ matrix.branch.artifact }}
                   path: ${{ runner.temp }}/plugin
                   compression-level: 1
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -208,17 +208,18 @@ jobs:
         name: Run performance tests
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         needs: [prepare, performance]
-        if: ${{ !cancelled() && needs.prepare.result == 'success' }}
+        # Runs unless the whole workflow was skipped (forks), so a failure anywhere fails the check.
+        if: ${{ !cancelled() && needs.prepare.result != 'skipped' }}
         permissions:
             contents: read
         env:
             WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
 
         steps:
-            - name: Check shard results
-              if: needs.performance.result != 'success'
+            - name: Check job results
+              if: needs.prepare.result != 'success' || needs.performance.result != 'success'
               run: |
-                  echo "::error::At least one performance tests shard failed."
+                  echo "::error::Resolving the branches, building a plugin or a performance tests shard failed."
                   exit 1
 
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -260,6 +261,8 @@ jobs:
               if: github.event_name == 'push'
               env:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
+                  BRANCHES: ${{ needs.prepare.outputs.branches }}
               run: |
                   COMMITTED_AT="$(git show -s "$GITHUB_SHA" --format="%cI")"
-                  node tools/release/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 "$COMMITTED_AT"
+                  REFERENCE_COMMIT="$(echo "$BRANCHES" | jq -r '.[1].name')"
+                  node tools/release/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" "$REFERENCE_COMMIT" "$COMMITTED_AT"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -96,6 +96,7 @@ jobs:
                   PLUGIN_FILES: ${{ needs.prepare.outputs.plugin-files }}
               run: |
                   mkdir -p "$PLUGIN_DIR"
+                  # post-content.php is gone from trunk but refs up to WP 6.x still require it from lib/demo.php.
                   # shellcheck disable=SC2086 # The list holds globs that must expand.
                   tar --ignore-failed-read -cf - $PLUGIN_FILES post-content.php \
                     | tar -xf - -C "$PLUGIN_DIR"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -40,6 +40,7 @@ jobs:
             branches: ${{ steps.branches.outputs.branches }}
             shards: ${{ steps.branches.outputs.shards }}
             wp-version: ${{ steps.branches.outputs.wp-version }}
+            plugin-files: ${{ steps.branches.outputs.plugin-files }}
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -87,24 +88,16 @@ jobs:
             - name: Build
               run: npm run build -- --skip-types || npm run build
 
-            # Same file list as bin/build-plugin-zip.sh. Older refs may lack some of them.
+            # The list comes from bin/plugin-files.txt on the tested commit, so older refs
+            # are packaged the same way. They may lack some of the files.
             - name: Package plugin
               env:
                   PLUGIN_DIR: ${{ runner.temp }}/plugin
+                  PLUGIN_FILES: ${{ needs.prepare.outputs.plugin-files }}
               run: |
                   mkdir -p "$PLUGIN_DIR"
-                  tar --ignore-failed-read -cf - \
-                    gutenberg.php \
-                    lib \
-                    packages/block-serialization-default-parser/*.php \
-                    packages/icons/src/manifest.php \
-                    packages/icons/src/library/*.svg \
-                    build \
-                    build-module \
-                    post-content.php \
-                    readme.txt \
-                    changelog.txt \
-                    README.md \
+                  # shellcheck disable=SC2086 # The list holds globs that must expand.
+                  tar --ignore-failed-read -cf - $PLUGIN_FILES post-content.php \
                     | tar -xf - -C "$PLUGIN_DIR"
                   test -f "$PLUGIN_DIR/gutenberg.php"
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -116,7 +116,7 @@ jobs:
 
     performance:
         timeout-minutes: 60
-        name: Run performance tests (${{ matrix.shard }})
+        name: Run perf tests (${{ matrix.shard }})
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         needs: [prepare, build]
         permissions:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,8 +36,9 @@ jobs:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}
         outputs:
-            # JSON array of `{ name, ref, artifact }`, see tools/release/resolve-performance-branches.mjs.
+            # See tools/release/resolve-performance-branches.mjs for the shapes.
             branches: ${{ steps.branches.outputs.branches }}
+            shards: ${{ steps.branches.outputs.shards }}
             wp-version: ${{ steps.branches.outputs.wp-version }}
 
         steps:
@@ -126,13 +127,7 @@ jobs:
             # Shards run in parallel to cut the wall clock time. Every shard still
             # measures all branches on the same runner, so results stay comparable.
             matrix:
-                include:
-                    - shard: post-editor
-                      suites: post-editor
-                    - shard: site-editor
-                      suites: site-editor
-                    - shard: media-and-front-end
-                      suites: front-end-block-theme,front-end-classic-theme,media-processing,media-upload
+                include: ${{ fromJSON( needs.prepare.outputs.shards ) }}
         env:
             WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
             PERF_SUITES: ${{ matrix.suites }}
@@ -238,17 +233,6 @@ jobs:
                   pattern: performance-results-*
                   path: ${{ env.WP_ARTIFACTS_PATH }}
                   merge-multiple: true
-
-            # Fails when a suite is missing from every shard of the matrix above.
-            - name: Check that every suite ran
-              run: |
-                  for spec in test/performance/specs/*.spec.js; do
-                    suite="$(basename "$spec" .spec.js)"
-                    if [[ ! -f "${WP_ARTIFACTS_PATH}/${suite}.performance-results.json" ]]; then
-                      echo "::error::No results for the '${suite}' suite. Add it to a shard in performance.yml."
-                      exit 1
-                    fi
-                  done
 
             # Keep the single artifact that existed before the tests were sharded.
             - name: Archive merged performance results

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -144,8 +144,14 @@ jobs:
             # The command expects `<plugins dir>/<sanitized branch name>`.
             - name: Rename plugin directories
               run: |
+                  shopt -s nullglob
+                  dirs=("$RUNNER_TEMP"/artifacts/plugin-*)
+                  if [[ ${#dirs[@]} -eq 0 ]]; then
+                    echo "::error::No plugin artifacts were downloaded."
+                    exit 1
+                  fi
                   mkdir -p "$RUNNER_TEMP/plugins"
-                  for dir in "$RUNNER_TEMP"/artifacts/plugin-*; do
+                  for dir in "${dirs[@]}"; do
                     mv "$dir" "$RUNNER_TEMP/plugins/$(basename "$dir" | sed 's/^plugin-//')"
                   done
                   ls -la "$RUNNER_TEMP/plugins"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -115,7 +115,9 @@ jobs:
               if: matrix.branch.name == fromJSON( needs.prepare.outputs.branches )[0].name
               run: |
                   mkdir -p "$RUNNER_TEMP/source-maps"
-                  find build/scripts -name '*.map' | tar -cf - -T - | tar -xf - -C "$RUNNER_TEMP/source-maps"
+                  if [[ -d build/scripts ]]; then
+                    find build/scripts -name '*.map' | tar -cf - -T - | tar -xf - -C "$RUNNER_TEMP/source-maps"
+                  fi
 
             - name: Upload source maps
               if: matrix.branch.name == fromJSON( needs.prepare.outputs.branches )[0].name
@@ -123,6 +125,7 @@ jobs:
               with:
                   name: performance-source-maps
                   path: ${{ runner.temp }}/source-maps
+                  if-no-files-found: ignore
 
     performance:
         timeout-minutes: 60

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -109,6 +109,21 @@ jobs:
                   path: ${{ runner.temp }}/plugin
                   compression-level: 1
 
+            # Lets the trace artifacts be resolved with tools/build-scripts/packages/resolve-trace-source-maps.cjs
+            # after extracting both next to each other. Only the first branch records traces.
+            - name: Collect source maps
+              if: matrix.branch.name == fromJSON( needs.prepare.outputs.branches )[0].name
+              run: |
+                  mkdir -p "$RUNNER_TEMP/source-maps"
+                  find build/scripts -name '*.map' | tar -cf - -T - | tar -xf - -C "$RUNNER_TEMP/source-maps"
+
+            - name: Upload source maps
+              if: matrix.branch.name == fromJSON( needs.prepare.outputs.branches )[0].name
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: performance-source-maps
+                  path: ${{ runner.temp }}/source-maps
+
     performance:
         timeout-minutes: 60
         name: Run perf tests (${{ matrix.shard }})
@@ -183,9 +198,7 @@ jobs:
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: performance-traces-${{ matrix.shard }}
-                  path: |
-                      ${{ env.WP_ARTIFACTS_PATH }}/traces
-                      ${{ env.WP_ARTIFACTS_PATH }}/build
+                  path: ${{ env.WP_ARTIFACTS_PATH }}/traces
                   if-no-files-found: ignore
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -28,15 +28,165 @@ concurrency:
 permissions: {}
 
 jobs:
-    performance:
-        timeout-minutes: 60
-        name: Run performance tests
+    prepare:
+        timeout-minutes: 5
+        name: Resolve branches to compare
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}
+        outputs:
+            # JSON array of `{ name, ref }`: `name` labels the results table and
+            # `ref` is what gets checked out and built.
+            branches: ${{ steps.branches.outputs.branches }}
+            wp-version: ${{ steps.branches.outputs.wp-version }}
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Resolve branches
+              id: branches
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  BASE_REF: ${{ github.base_ref }}
+                  RELEASE_TAG: ${{ github.event.release.tag_name }}
+                  INPUT_BRANCHES: ${{ github.event.inputs.branches }}
+                  INPUT_WP_VERSION: ${{ github.event.inputs.wpversion }}
+              run: |
+                  WP_VERSION=""
+                  WP_MAJOR="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt | cut -d. -f1,2)"
+                  case "$GITHUB_EVENT_NAME" in
+                    pull_request)
+                      BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" --arg base "$BASE_REF" --arg baseSha "$BASE_SHA" '[{name: $head, ref: $head}, {name: $base, ref: $baseSha}]')"
+                      ;;
+                    push)
+                      # The base hash used here need to be a commit that is compatible with the current WP version
+                      # The current one is 28d414f1327652e2b49e784ddc12098768991c62 and it needs to be updated every WP major release.
+                      # It is used as a base comparison point to avoid fluctuation in the performance metrics.
+                      # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
+                      BRANCHES="$(jq -cn --arg head "$GITHUB_SHA" '[{name: $head, ref: $head}, {name: "28d414f1327652e2b49e784ddc12098768991c62", ref: "28d414f1327652e2b49e784ddc12098768991c62"}]')"
+                      WP_VERSION="$WP_MAJOR"
+                      ;;
+                    release)
+                      PLUGIN_VERSION="${RELEASE_TAG#v}"
+                      if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+                        echo "::error::Release tag '$RELEASE_TAG' does not resolve to a valid Gutenberg plugin version."
+                        exit 1
+                      fi
+
+                      IFS=. read -ra PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
+                      CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
+                      PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))
+                      PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
+                      if ! git ls-remote --exit-code --tags origin "$RELEASE_TAG" > /dev/null; then
+                        echo "::error::Expected release tag '$RELEASE_TAG' to exist in the Gutenberg repository."
+                        exit 1
+                      fi
+                      if ! git ls-remote --exit-code --heads origin "$CURRENT_RELEASE_BRANCH" > /dev/null; then
+                        echo "::error::Expected current release branch '$CURRENT_RELEASE_BRANCH' to exist in the Gutenberg repository."
+                        exit 1
+                      fi
+                      if ! git ls-remote --exit-code --heads origin "$PREVIOUS_RELEASE_BRANCH" > /dev/null; then
+                        echo "::error::Expected previous release branch '$PREVIOUS_RELEASE_BRANCH' to exist in the Gutenberg repository."
+                        exit 1
+                      fi
+                      BRANCHES="$(jq -cn --arg wp "wp/$WP_MAJOR" --arg prev "$PREVIOUS_RELEASE_BRANCH" --arg cur "$CURRENT_RELEASE_BRANCH" '[$wp, $prev, $cur] | map({name: ., ref: .})')"
+                      WP_VERSION="$WP_MAJOR"
+                      ;;
+                    workflow_dispatch)
+                      BRANCHES="$(jq -cn --arg list "$INPUT_BRANCHES" '$list | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | map({name: ., ref: .})')"
+                      WP_VERSION="$INPUT_WP_VERSION"
+                      ;;
+                  esac
+                  echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+                  echo "wp-version=$WP_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "$BRANCHES" | jq .
+
+    build:
+        timeout-minutes: 30
+        name: Build plugin (${{ matrix.branch.name }})
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
+        needs: prepare
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                branch: ${{ fromJSON( needs.prepare.outputs.branches ) }}
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  ref: ${{ matrix.branch.ref }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
+            - name: Build
+              run: npm run build -- --skip-types || npm run build
+
+            # Same file list as bin/build-plugin-zip.sh. Older refs may lack some of them.
+            - name: Package plugin
+              env:
+                  PLUGIN_DIR: ${{ runner.temp }}/plugin
+              run: |
+                  mkdir -p "$PLUGIN_DIR"
+                  tar --ignore-failed-read -cf - \
+                    gutenberg.php \
+                    lib \
+                    packages/block-serialization-default-parser/*.php \
+                    packages/icons/src/manifest.php \
+                    packages/icons/src/library/*.svg \
+                    build \
+                    build-module \
+                    post-content.php \
+                    readme.txt \
+                    changelog.txt \
+                    README.md \
+                    | tar -xf - -C "$PLUGIN_DIR"
+                  test -f "$PLUGIN_DIR/gutenberg.php"
+
+            - name: Sanitize artifact name
+              id: artifact
+              env:
+                  BRANCH_NAME: ${{ matrix.branch.name }}
+              # Same replacement as `sanitizeBranchName()` in tools/release/commands/performance.js.
+              run: echo "name=plugin-$(node -e 'process.stdout.write( process.env.BRANCH_NAME.replace( /[^a-zA-Z0-9-]/g, "-" ) )')" >> "$GITHUB_OUTPUT"
+
+            - name: Upload plugin
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: ${{ steps.artifact.outputs.name }}
+                  path: ${{ runner.temp }}/plugin
+                  compression-level: 1
+
+    performance:
+        timeout-minutes: 60
+        name: Run performance tests (${{ matrix.shard }})
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
+        needs: [prepare, build]
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            # Shards run in parallel to cut the wall clock time. Every shard still
+            # measures all branches on the same runner, so results stay comparable.
+            matrix:
+                include:
+                    - shard: post-editor
+                      suites: post-editor
+                    - shard: site-editor
+                      suites: site-editor
+                    - shard: media-and-front-end
+                      suites: front-end-block-theme,front-end-classic-theme,media-processing,media-upload
         env:
             WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+            PERF_SUITES: ${{ matrix.suites }}
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,70 +197,32 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 
-            - name: Install NVM
+            - name: Download prebuilt plugins
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  pattern: plugin-*
+                  path: ${{ runner.temp }}/artifacts
+
+            # The command expects `<plugins dir>/<sanitized branch name>`.
+            - name: Rename plugin directories
               run: |
-                  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-                  export NVM_DIR="$HOME/.nvm"
-                  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-                  nvm -v
+                  mkdir -p "$RUNNER_TEMP/plugins"
+                  for dir in "$RUNNER_TEMP"/artifacts/plugin-*; do
+                    mv "$dir" "$RUNNER_TEMP/plugins/$(basename "$dir" | sed 's/^plugin-//')"
+                  done
+                  ls -la "$RUNNER_TEMP/plugins"
 
-            - name: Compare performance with base branch
-              if: github.event_name == 'pull_request'
-              run: npm exec --no release-cli -- perf "$GITHUB_SHA" "$GITHUB_BASE_REF" --tests-branch "$GITHUB_SHA"
-
-            - name: Compare performance with current WordPress Core and previous Gutenberg versions
-              if: github.event_name == 'release'
+            - name: Compare performance
               env:
-                  RELEASE_TAG: ${{ github.event.release.tag_name }}
-              shell: bash
+                  BRANCHES: ${{ needs.prepare.outputs.branches }}
+                  WP_VERSION: ${{ needs.prepare.outputs.wp-version }}
               run: |
-                  PLUGIN_VERSION="${RELEASE_TAG#v}"
-                  if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-                    echo "::error::Release tag '$RELEASE_TAG' does not resolve to a valid Gutenberg plugin version."
-                    exit 1
+                  readarray -t BRANCH_ARGS < <(echo "$BRANCHES" | jq -r '.[].name')
+                  WP_VERSION_ARGS=()
+                  if [[ -n "$WP_VERSION" ]]; then
+                    WP_VERSION_ARGS=(--wp-version "$WP_VERSION")
                   fi
-
-                  IFS=. read -ra PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
-                  CURRENT_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
-                  PREVIOUS_VERSION_BASE_10=$((PLUGIN_VERSION_ARRAY[0] * 10 + PLUGIN_VERSION_ARRAY[1] - 1))
-                  PREVIOUS_RELEASE_BRANCH="release/$((PREVIOUS_VERSION_BASE_10 / 10)).$((PREVIOUS_VERSION_BASE_10 % 10))"
-                  if ! git ls-remote --exit-code --tags origin "$RELEASE_TAG" > /dev/null; then
-                    echo "::error::Expected release tag '$RELEASE_TAG' to exist in the Gutenberg repository."
-                    exit 1
-                  fi
-                  if ! git ls-remote --exit-code --heads origin "$CURRENT_RELEASE_BRANCH" > /dev/null; then
-                    echo "::error::Expected current release branch '$CURRENT_RELEASE_BRANCH' to exist in the Gutenberg repository."
-                    exit 1
-                  fi
-                  if ! git ls-remote --exit-code --heads origin "$PREVIOUS_RELEASE_BRANCH" > /dev/null; then
-                    echo "::error::Expected previous release branch '$PREVIOUS_RELEASE_BRANCH' to exist in the Gutenberg repository."
-                    exit 1
-                  fi
-
-                  WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
-                  IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
-                  WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  npm exec --no release-cli -- perf "wp/$WP_MAJOR" "$PREVIOUS_RELEASE_BRANCH" "$CURRENT_RELEASE_BRANCH" --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
-
-            - name: Compare performance with base branch
-              if: github.event_name == 'push'
-              # The base hash used here need to be a commit that is compatible with the current WP version
-              # The current one is 28d414f1327652e2b49e784ddc12098768991c62 and it needs to be updated every WP major release.
-              # It is used as a base comparison point to avoid fluctuation in the performance metrics.
-              # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
-              run: |
-                  WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
-                  IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
-                  WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  npm exec --no release-cli -- perf "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
-
-            - name: Compare performance with custom branches
-              if: github.event_name == 'workflow_dispatch'
-              env:
-                  BRANCHES: ${{ github.event.inputs.branches }}
-                  WP_VERSION: ${{ github.event.inputs.wpversion }}
-              run: |
-                  npm exec --no release-cli -- perf "$(echo "$BRANCHES" | tr ',' ' ')" --tests-branch "$GITHUB_SHA" --wp-version "$WP_VERSION"
+                  npm exec --no release-cli -- perf "${BRANCH_ARGS[@]}" --plugins-dir "$RUNNER_TEMP/plugins" --suites "$PERF_SUITES" "${WP_VERSION_ARGS[@]}"
 
             - name: Add workflow summary
               run: cat "${WP_ARTIFACTS_PATH}/summary.md" >> "$GITHUB_STEP_SUMMARY"
@@ -119,18 +231,81 @@ jobs:
               if: success()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
-                  name: performance-results
+                  name: performance-results-${{ matrix.shard }}
                   path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
 
             - name: Archive performance traces
               if: always()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
-                  name: performance-traces
+                  name: performance-traces-${{ matrix.shard }}
                   path: |
                       ${{ env.WP_ARTIFACTS_PATH }}/traces
                       ${{ env.WP_ARTIFACTS_PATH }}/build
                   if-no-files-found: ignore
+
+            - name: Archive debug artifacts (screenshots, HTML snapshots)
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              if: failure()
+              with:
+                  name: failures-artifacts-${{ matrix.shard }}
+                  path: ${{ env.WP_ARTIFACTS_PATH }}
+                  if-no-files-found: ignore
+
+    results:
+        timeout-minutes: 10
+        # Keeps the name of the job that existed before sharding, so it stays
+        # the required status check. It fails whenever a shard fails.
+        name: Run performance tests
+        runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
+        needs: [prepare, performance]
+        if: ${{ !cancelled() && needs.prepare.result == 'success' }}
+        permissions:
+            contents: read
+        env:
+            WP_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+
+        steps:
+            - name: Check shard results
+              if: needs.performance.result != 'success'
+              run: |
+                  echo "::error::At least one performance tests shard failed."
+                  exit 1
+
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Use desired version of Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version-file: '.nvmrc'
+
+            - name: Download shard results
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  pattern: performance-results-*
+                  path: ${{ env.WP_ARTIFACTS_PATH }}
+                  merge-multiple: true
+
+            # Fails when a suite is missing from every shard of the matrix above.
+            - name: Check that every suite ran
+              run: |
+                  for spec in test/performance/specs/*.spec.js; do
+                    suite="$(basename "$spec" .spec.js)"
+                    if [[ ! -f "${WP_ARTIFACTS_PATH}/${suite}.performance-results.json" ]]; then
+                      echo "::error::No results for the '${suite}' suite. Add it to a shard in performance.yml."
+                      exit 1
+                    fi
+                  done
+
+            # Keep the single artifact that existed before the tests were sharded.
+            - name: Archive merged performance results
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: performance-results
+                  path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
 
             - name: Publish performance results
               if: github.event_name == 'push'
@@ -138,12 +313,4 @@ jobs:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: |
                   COMMITTED_AT="$(git show -s "$GITHUB_SHA" --format="%cI")"
-                  npm run --workspace=tools/release log-performance-results -- "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 "$COMMITTED_AT"
-
-            - name: Archive debug artifacts (screenshots, HTML snapshots)
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              if: failure()
-              with:
-                  name: failures-artifacts
-                  path: ${{ env.WP_ARTIFACTS_PATH }}
-                  if-no-files-found: ignore
+                  node tools/release/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 28d414f1327652e2b49e784ddc12098768991c62 "$COMMITTED_AT"

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -98,18 +98,10 @@ fi
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
+# shellcheck disable=SC2046 # The list holds globs that must expand.
 zip --recurse-paths --no-dir-entries \
 	gutenberg.zip \
-	gutenberg.php \
-	lib \
-	packages/block-serialization-default-parser/*.php \
-	packages/icons/src/manifest.php \
-	packages/icons/src/library/*.svg \
-	build \
-	build-module \
-	readme.txt \
-	changelog.txt \
-	README.md
+	$(grep -v '^#' bin/plugin-files.txt)
 
 status "Restoring non-public icons... 🔁"
 git diff --name-only --diff-filter=D -- packages/icons/src | sed 's|^|  Restoring |'

--- a/bin/plugin-files.txt
+++ b/bin/plugin-files.txt
@@ -1,0 +1,12 @@
+# Files and directories that make up the Gutenberg plugin. Used by
+# bin/build-plugin-zip.sh and the performance tests workflow.
+gutenberg.php
+lib
+packages/block-serialization-default-parser/*.php
+packages/icons/src/manifest.php
+packages/icons/src/library/*.svg
+build
+build-module
+readme.txt
+changelog.txt
+README.md

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -34,6 +34,8 @@ A tool to compare performance across multiple branches/tags/commits is provided.
 npm exec release-cli -- perf trunk v8.1.0 v8.0.0
 ```
 
+On pull requests, the base branch column (for example `trunk`) is measured at the commit the pull request is based on, not at the current tip of the branch, so both columns match what the merge commit was built from.
+
 Pass `--suites` with a comma separated list of spec names (`test/performance/specs/*.spec.js` without the extension) to run a subset of the suites. The CI workflow uses it to split the suites into shards that run in parallel, each shard measuring all branches on the same runner. It also builds the plugins once in a separate job and passes them to each shard with `--plugins-dir <dir>` (a prebuilt plugin per branch in `<dir>/<sanitized branch name>`), which makes the command use the current checkout as the test runner instead of cloning and building.
 
 To get the most accurate results, it's is important to use the exact same version of the tests and environment (theme...) when running the tests, the only thing that need to be different between the branches is the Gutenberg plugin version (or branch used to build the plugin).

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -79,7 +79,7 @@ Gutenberg supports only two WP versions, this impacts the performance job in two
 
  - The base WP version used to run the performance job needs to be updated, when the minimum version supported by Gutenberg changes. In order to do that, we rely on the `Tested up to` flag of the plugin's `readme.txt` file. So each time that flag is changed, the version used for the performance job is changed as well.
 
- - Updating the WP version used for performance jobs means that there's a high chance that the reference commit used for performance test stability becomes incompatible with the WP version that is used. So every time, the `Tested up to` flag is updated in the `readme.txt` is changed, we also have to update the reference commit that is used in `.github/workflows/performance.yml`.
+ - Updating the WP version used for performance jobs means that there's a high chance that the reference commit used for performance test stability becomes incompatible with the WP version that is used. So every time, the `Tested up to` flag is updated in the `readme.txt` is changed, we also have to update the reference commit that is used in `tools/release/resolve-performance-branches.mjs`.
 
 The new reference commit hash that is chosen needs to meet the following requirements:
 

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -34,6 +34,8 @@ A tool to compare performance across multiple branches/tags/commits is provided.
 npm exec release-cli -- perf trunk v8.1.0 v8.0.0
 ```
 
+Pass `--suites` with a comma separated list of spec names (`test/performance/specs/*.spec.js` without the extension) to run a subset of the suites. The CI workflow uses it to split the suites into shards that run in parallel, each shard measuring all branches on the same runner. It also builds the plugins once in a separate job and passes them to each shard with `--plugins-dir <dir>` (a prebuilt plugin per branch in `<dir>/<sanitized branch name>`), which makes the command use the current checkout as the test runner instead of cloning and building.
+
 To get the most accurate results, it's is important to use the exact same version of the tests and environment (theme...) when running the tests, the only thing that need to be different between the branches is the Gutenberg plugin version (or branch used to build the plugin).
 
 To achieve that the command first prepares the following folder structure:

--- a/tools/release/cli.js
+++ b/tools/release/cli.js
@@ -80,6 +80,14 @@ program
 		'Run each test suite this many times for each branch; results are summarized, default = 1'
 	)
 	.option(
+		'--plugins-dir <dir>',
+		'Use prebuilt plugins from <dir>/<branch> and the current checkout as the test runner'
+	)
+	.option(
+		'--suites <suites>',
+		'Comma separated names of the test suites to run, default = all'
+	)
+	.option(
 		'--tests-branch <branch>',
 		"Use this branch's performance test files"
 	)

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -595,9 +595,6 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 0, 'Calculating results' );
 
-	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file ) =>
-		file.endsWith( RAW_RESULTS_FILE_SUFFIX )
-	);
 	/** @type {Record<string,Record<string, Record<string, Record<string, number>>>>} */
 	const results = {};
 
@@ -608,22 +605,23 @@ async function runPerformanceTests( branches, options ) {
 		results[ testSuite ] = {};
 		for ( const branch of branches ) {
 			const sanitizedBranchName = sanitizeBranchName( branch );
-			const resultsRounds = resultFiles
-				.filter( ( file ) =>
-					file.includes(
-						`${ testSuite }_${ sanitizedBranchName }_round-`
+			// Only this run's rounds: the artifacts directory may hold files from previous runs.
+			const resultsRounds = Array.from(
+				{ length: TEST_ROUNDS },
+				( _, round ) =>
+					path.join(
+						ARTIFACTS_PATH,
+						`${ testSuite }_${ sanitizedBranchName }_round-${
+							round + 1
+						}${ RAW_RESULTS_FILE_SUFFIX }`
 					)
-				)
-				.map( ( file ) => {
-					logAtIndent( 2, 'Reading from:', formats.success( file ) );
-					return readJSONFile( file );
-				} );
-
-			if ( resultsRounds.length !== TEST_ROUNDS ) {
-				throw new Error(
-					`Expected ${ TEST_ROUNDS } result file(s) for the "${ testSuite }" suite on "${ branch }", found ${ resultsRounds.length }.`
-				);
-			}
+			).map( ( file ) => {
+				if ( ! fs.existsSync( file ) ) {
+					throw new Error( `Missing results file: ${ file }` );
+				}
+				logAtIndent( 2, 'Reading from:', formats.success( file ) );
+				return readJSONFile( file );
+			} );
 
 			const metrics = Object.keys( resultsRounds[ 0 ] );
 			results[ testSuite ][ branch ] = {};

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -384,6 +384,31 @@ async function runPerformanceTests( branches, options ) {
 		);
 	}
 
+	logAtIndent( 1, 'Looking for test files' );
+	const requestedSuites = ( options.suites || '' )
+		.split( ',' )
+		.map( ( suite ) => suite.trim() )
+		.filter( Boolean );
+	const availableSuites = getFilesFromDir(
+		path.join( testRunnerDir, 'test/performance/specs' )
+	).map( ( file ) => path.basename( file, '.spec.js' ) );
+	const unknownSuites = requestedSuites.filter(
+		( suite ) => ! availableSuites.includes( suite )
+	);
+	if ( unknownSuites.length ) {
+		throw new Error(
+			`Unknown test suite(s): ${ unknownSuites.join( ', ' ) }. ` +
+				`Available: ${ availableSuites.join( ', ' ) }`
+		);
+	}
+	const testSuites = availableSuites.filter(
+		( suite ) =>
+			requestedSuites.length === 0 || requestedSuites.includes( suite )
+	);
+	for ( const suite of testSuites ) {
+		logAtIndent( 2, 'Found:', formats.success( suite ) );
+	}
+
 	logAtIndent( 1, 'Setting up test environments' );
 
 	const envsDir = path.join( baseDir, 'environments' );
@@ -494,32 +519,6 @@ async function runPerformanceTests( branches, options ) {
 			),
 			'utf8'
 		);
-	}
-
-	logAtIndent( 0, 'Looking for test files' );
-
-	const requestedSuites = ( options.suites || '' )
-		.split( ',' )
-		.map( ( suite ) => suite.trim() )
-		.filter( Boolean );
-	const availableSuites = getFilesFromDir(
-		path.join( testRunnerDir, 'test/performance/specs' )
-	).map( ( file ) => path.basename( file, '.spec.js' ) );
-	const unknownSuites = requestedSuites.filter(
-		( suite ) => ! availableSuites.includes( suite )
-	);
-	if ( unknownSuites.length ) {
-		throw new Error(
-			`Unknown test suite(s): ${ unknownSuites.join( ', ' ) }. ` +
-				`Available: ${ availableSuites.join( ', ' ) }`
-		);
-	}
-	const testSuites = availableSuites.filter(
-		( suite ) =>
-			requestedSuites.length === 0 || requestedSuites.includes( suite )
-	);
-	for ( const suite of testSuites ) {
-		logAtIndent( 1, 'Found:', formats.success( suite ) );
 	}
 
 	logAtIndent( 0, 'Running tests' );

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -10,6 +10,7 @@ const {
 	getFilesFromDir,
 } = require( '../lib/utils' );
 const config = require( '../config' );
+const { sanitizeBranchName } = require( '../lib/sanitize-branch-name' );
 
 const ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
@@ -53,17 +54,6 @@ function logAtIndent( indent, msg, ...args ) {
 		newline + timestamp + ' ' + '    '.repeat( indent ) + prefix + msg,
 		...args
 	);
-}
-
-/**
- * Sanitizes branch name to be used in a path or a filename.
- *
- * @param {string} branch
- *
- * @return {string} Sanitized branch name.
- */
-function sanitizeBranchName( branch ) {
-	return branch.replace( /[^a-zA-Z0-9-]/g, '-' );
 }
 
 /**

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -20,7 +20,10 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @typedef WPPerformanceCommandOptions
  *
  * @property {boolean=} ci          Run on CI.
+ * @property {string=}  pluginsDir  Directory with a prebuilt plugin per branch in `<sanitized branch>/`.
+ *                                  The current checkout is then used as the test runner.
  * @property {number=}  rounds      Run each test suite this many times for each branch.
+ * @property {string=}  suites      Comma separated names of the test suites to run (default: all).
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
@@ -293,73 +296,97 @@ async function runPerformanceTests( branches, options ) {
 	logAtIndent( 1, 'Creating base directory:', formats.success( baseDir ) );
 	fs.mkdirSync( baseDir );
 
-	logAtIndent( 1, 'Setting up repository' );
+	const pluginsDir = options.pluginsDir
+		? path.resolve( options.pluginsDir )
+		: null;
 	const sourceDir = path.join( baseDir, 'source' );
+	const testRunnerDir = pluginsDir
+		? process.cwd()
+		: path.join( baseDir, 'tests' );
 
-	logAtIndent( 2, 'Creating directory:', formats.success( sourceDir ) );
-	fs.mkdirSync( sourceDir );
-
-	// @ts-expect-error The `simple-git` module namespace has no call signatures.
-	const sourceGit = SimpleGit( sourceDir );
-	logAtIndent(
-		2,
-		'Initializing:',
-		formats.success( config.gitRepositoryURL )
-	);
-	await sourceGit
-		.raw( 'init' )
-		.raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
-
-	for ( const [ i, branch ] of branches.entries() ) {
-		logAtIndent(
-			2,
-			`Fetching environment branch (${ i + 1 } of ${ branches.length }):`,
-			formats.success( branch )
-		);
-		await sourceGit.raw( 'fetch', '--depth=1', 'origin', branch );
-	}
-
-	const testRunnerBranch = options.testsBranch || branches[ 0 ];
-	if ( options.testsBranch && ! branches.includes( options.testsBranch ) ) {
-		logAtIndent(
-			2,
-			'Fetching test runner branch:',
-			formats.success( options.testsBranch )
-		);
-		await sourceGit.raw(
-			'fetch',
-			'--depth=1',
-			'origin',
-			options.testsBranch
+	if ( pluginsDir ) {
+		logAtIndent( 1, 'Setting up test runner' );
+		logAtIndent( 2, 'Using checkout:', formats.success( testRunnerDir ) );
+		logAtIndent( 2, 'Building test utilities' );
+		await runShellScript(
+			`bash -c "npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps"`,
+			testRunnerDir
 		);
 	} else {
+		logAtIndent( 1, 'Setting up repository' );
+
+		logAtIndent( 2, 'Creating directory:', formats.success( sourceDir ) );
+		fs.mkdirSync( sourceDir );
+
+		// @ts-expect-error The `simple-git` module namespace has no call signatures.
+		const sourceGit = SimpleGit( sourceDir );
 		logAtIndent(
 			2,
-			'Using test runner branch:',
+			'Initializing:',
+			formats.success( config.gitRepositoryURL )
+		);
+		await sourceGit
+			.raw( 'init' )
+			.raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
+
+		for ( const [ i, branch ] of branches.entries() ) {
+			logAtIndent(
+				2,
+				`Fetching environment branch (${ i + 1 } of ${
+					branches.length
+				}):`,
+				formats.success( branch )
+			);
+			await sourceGit.raw( 'fetch', '--depth=1', 'origin', branch );
+		}
+
+		const testRunnerBranch = options.testsBranch || branches[ 0 ];
+		if (
+			options.testsBranch &&
+			! branches.includes( options.testsBranch )
+		) {
+			logAtIndent(
+				2,
+				'Fetching test runner branch:',
+				formats.success( options.testsBranch )
+			);
+			await sourceGit.raw(
+				'fetch',
+				'--depth=1',
+				'origin',
+				options.testsBranch
+			);
+		} else {
+			logAtIndent(
+				2,
+				'Using test runner branch:',
+				formats.success( testRunnerBranch )
+			);
+		}
+
+		logAtIndent( 1, 'Setting up test runner' );
+
+		logAtIndent(
+			2,
+			'Copying source to:',
+			formats.success( testRunnerDir )
+		);
+		await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
+
+		logAtIndent(
+			2,
+			'Checking out branch:',
 			formats.success( testRunnerBranch )
 		);
+		// @ts-expect-error The `simple-git` module namespace has no call signatures.
+		await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
+
+		logAtIndent( 2, 'Installing dependencies and building' );
+		await runShellScript(
+			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps"`,
+			testRunnerDir
+		);
 	}
-
-	logAtIndent( 1, 'Setting up test runner' );
-
-	const testRunnerDir = path.join( baseDir + '/tests' );
-
-	logAtIndent( 2, 'Copying source to:', formats.success( testRunnerDir ) );
-	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
-
-	logAtIndent(
-		2,
-		'Checking out branch:',
-		formats.success( testRunnerBranch )
-	);
-	// @ts-expect-error The `simple-git` module namespace has no call signatures.
-	await SimpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
-
-	logAtIndent( 2, 'Installing dependencies and building' );
-	await runShellScript(
-		`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && npm run build --workspace @wordpress/e2e-test-utils-playwright && npx playwright install chromium --with-deps"`,
-		testRunnerDir
-	);
 
 	logAtIndent( 1, 'Setting up test environments' );
 
@@ -379,7 +406,10 @@ async function runPerformanceTests( branches, options ) {
 		wpZipUrl = `https://wordpress.org/wordpress-${ zipVersion }.zip`;
 	}
 
+	/** @type {Record<string, string>} */
 	const branchDirs = {};
+	/** @type {Record<string, string>} */
+	const pluginDirs = {};
 	for ( const branch of branches ) {
 		logAtIndent( 2, 'Branch:', formats.success( branch ) );
 		const sanitizedBranchName = sanitizeBranchName( branch );
@@ -387,22 +417,37 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Creating directory:', formats.success( envDir ) );
 		fs.mkdirSync( envDir );
-		// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 		branchDirs[ branch ] = envDir;
-		const buildDir = path.join( envDir, 'plugin' );
+		const buildDir = pluginsDir
+			? path.join( pluginsDir, sanitizedBranchName )
+			: path.join( envDir, 'plugin' );
+		pluginDirs[ branch ] = buildDir;
 
-		logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
-		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
+		if ( pluginsDir ) {
+			if ( ! fs.existsSync( path.join( buildDir, 'gutenberg.php' ) ) ) {
+				throw new Error(
+					`No prebuilt plugin for "${ branch }" in ${ buildDir }`
+				);
+			}
+			logAtIndent(
+				3,
+				'Using prebuilt plugin:',
+				formats.success( buildDir )
+			);
+		} else {
+			logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
+			await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
 
-		logAtIndent( 3, 'Checking out:', formats.success( branch ) );
-		// @ts-expect-error The `simple-git` module namespace has no call signatures.
-		await SimpleGit( buildDir ).raw( 'checkout', branch );
+			logAtIndent( 3, 'Checking out:', formats.success( branch ) );
+			// @ts-expect-error The `simple-git` module namespace has no call signatures.
+			await SimpleGit( buildDir ).raw( 'checkout', branch );
 
-		logAtIndent( 3, 'Installing dependencies and building' );
-		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && (npm run build -- --skip-types || npm run build)"`,
-			buildDir
-		);
+			logAtIndent( 3, 'Installing dependencies and building' );
+			await runShellScript(
+				`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && (npm run build -- --skip-types || npm run build)"`,
+				buildDir
+			);
+		}
 
 		const wpEnvConfigPath = path.join( envDir, '.wp-env.json' );
 
@@ -457,12 +502,29 @@ async function runPerformanceTests( branches, options ) {
 
 	logAtIndent( 0, 'Looking for test files' );
 
-	const testSuites = getFilesFromDir(
+	const requestedSuites = ( options.suites || '' )
+		.split( ',' )
+		.map( ( suite ) => suite.trim() )
+		.filter( Boolean );
+	const availableSuites = getFilesFromDir(
 		path.join( testRunnerDir, 'test/performance/specs' )
-	).map( ( file ) => {
-		logAtIndent( 1, 'Found:', formats.success( file ) );
-		return path.basename( file, '.spec.js' );
-	} );
+	).map( ( file ) => path.basename( file, '.spec.js' ) );
+	const unknownSuites = requestedSuites.filter(
+		( suite ) => ! availableSuites.includes( suite )
+	);
+	if ( unknownSuites.length ) {
+		throw new Error(
+			`Unknown test suite(s): ${ unknownSuites.join( ', ' ) }. ` +
+				`Available: ${ availableSuites.join( ', ' ) }`
+		);
+	}
+	const testSuites = availableSuites.filter(
+		( suite ) =>
+			requestedSuites.length === 0 || requestedSuites.includes( suite )
+	);
+	for ( const suite of testSuites ) {
+		logAtIndent( 1, 'Found:', formats.success( suite ) );
+	}
 
 	logAtIndent( 0, 'Running tests' );
 
@@ -487,7 +549,6 @@ async function runPerformanceTests( branches, options ) {
 			);
 
 			const sanitizedBranchName = sanitizeBranchName( branch );
-			// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
 			const envDir = branchDirs[ branch ];
 
 			logAtIndent( 2, 'Starting environment' );
@@ -523,9 +584,7 @@ async function runPerformanceTests( branches, options ) {
 	//   npm run --workspace @wordpress/build-scripts resolve-trace-source-maps -- <trace> --build-dir <build-dir>
 	const headBranch = branches[ 0 ];
 	const headBuildScriptsDir = path.join(
-		// @ts-expect-error `branchDirs` is inferred as `{}`, which has no string index signature.
-		branchDirs[ headBranch ],
-		'plugin',
+		pluginDirs[ headBranch ],
 		'build',
 		'scripts'
 	);

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -624,7 +624,13 @@ async function runPerformanceTests( branches, options ) {
 					return readJSONFile( file );
 				} );
 
-			const metrics = Object.keys( resultsRounds[ 0 ] ?? {} );
+			if ( resultsRounds.length !== TEST_ROUNDS ) {
+				throw new Error(
+					`Expected ${ TEST_ROUNDS } result file(s) for the "${ testSuite }" suite on "${ branch }", found ${ resultsRounds.length }.`
+				);
+			}
+
+			const metrics = Object.keys( resultsRounds[ 0 ] );
 			results[ testSuite ][ branch ] = {};
 
 			for ( const metric of metrics ) {

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -253,7 +253,7 @@ function formatAsMarkdownTable( rows ) {
  */
 async function runPerformanceTests( branches, options ) {
 	const runningInCI = !! process.env.CI || !! options.ci;
-	const TEST_ROUNDS = options.rounds || 1;
+	const TEST_ROUNDS = Number( options.rounds ) || 1;
 
 	// The default value doesn't work because commander provides an array.
 	if ( branches.length === 0 ) {
@@ -303,6 +303,12 @@ async function runPerformanceTests( branches, options ) {
 	const testRunnerDir = pluginsDir
 		? process.cwd()
 		: path.join( baseDir, 'tests' );
+
+	if ( pluginsDir && options.testsBranch ) {
+		throw new Error(
+			'--tests-branch cannot be combined with --plugins-dir; the current checkout is the test runner.'
+		);
+	}
 
 	if ( pluginsDir ) {
 		logAtIndent( 1, 'Setting up test runner' );

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -22,7 +22,7 @@ const RESULTS_FILE_SUFFIX = '.performance-results.json';
  * @property {boolean=} ci          Run on CI.
  * @property {string=}  pluginsDir  Directory with a prebuilt plugin per branch in `<sanitized branch>/`.
  *                                  The current checkout is then used as the test runner.
- * @property {number=}  rounds      Run each test suite this many times for each branch.
+ * @property {string=}  rounds      Run each test suite this many times for each branch.
  * @property {string=}  suites      Comma separated names of the test suites to run (default: all).
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
@@ -286,6 +286,12 @@ async function runPerformanceTests( branches, options ) {
 		throw new Error( `Need at least two git refs to run` );
 	}
 
+	if ( options.pluginsDir && options.testsBranch ) {
+		throw new Error(
+			'--tests-branch cannot be combined with --plugins-dir; the current checkout is the test runner.'
+		);
+	}
+
 	const baseDir = path.join( os.tmpdir(), 'wp-performance-tests' );
 
 	if ( fs.existsSync( baseDir ) ) {
@@ -303,12 +309,6 @@ async function runPerformanceTests( branches, options ) {
 	const testRunnerDir = pluginsDir
 		? process.cwd()
 		: path.join( baseDir, 'tests' );
-
-	if ( pluginsDir && options.testsBranch ) {
-		throw new Error(
-			'--tests-branch cannot be combined with --plugins-dir; the current checkout is the test runner.'
-		);
-	}
 
 	if ( pluginsDir ) {
 		logAtIndent( 1, 'Setting up test runner' );
@@ -558,7 +558,7 @@ async function runPerformanceTests( branches, options ) {
 			const envDir = branchDirs[ branch ];
 
 			logAtIndent( 2, 'Starting environment' );
-			await runShellScript( `${ wpEnvPath } start`, envDir );
+			await runShellScript( `"${ wpEnvPath }" start`, envDir );
 
 			for ( const testSuite of testSuites ) {
 				logAtIndent( 2, `Suite: ${ formats.success( testSuite ) }` );
@@ -575,7 +575,7 @@ async function runPerformanceTests( branches, options ) {
 			}
 
 			logAtIndent( 2, 'Stopping environment' );
-			await runShellScript( `${ wpEnvPath } stop`, envDir );
+			await runShellScript( `"${ wpEnvPath }" stop`, envDir );
 		}
 	}
 

--- a/tools/release/lib/sanitize-branch-name.js
+++ b/tools/release/lib/sanitize-branch-name.js
@@ -1,0 +1,12 @@
+/**
+ * Sanitizes a branch name to be used in a path, a filename or an artifact name.
+ *
+ * @param {string} branch
+ *
+ * @return {string} Sanitized branch name.
+ */
+function sanitizeBranchName( branch ) {
+	return branch.replace( /[^a-zA-Z0-9-]/g, '-' );
+}
+
+module.exports = { sanitizeBranchName };

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -46,15 +46,15 @@ export function getTestedUpToMajor( readme ) {
 /**
  * @typedef ResolveOptions
  *
- * @property {string}                   event          GitHub event name.
- * @property {string}                   sha            Commit that triggered the workflow.
- * @property {string}                   wpMajor        The `Tested up to` version from readme.txt.
- * @property {(ref: string) => boolean} refExists      Whether a tag or branch exists on origin.
- * @property {string=}                  baseSha        Pull request base commit.
- * @property {string=}                  baseRef        Pull request base branch name.
- * @property {string=}                  releaseTag     Release tag name.
- * @property {string=}                  inputBranches  `workflow_dispatch` branches input.
- * @property {string=}                  inputWpVersion `workflow_dispatch` WP version input.
+ * @property {string}                                         event          GitHub event name.
+ * @property {string}                                         sha            Commit that triggered the workflow.
+ * @property {string}                                         wpMajor        The `Tested up to` version from readme.txt.
+ * @property {(ref: string, kind: 'tag' | 'head') => boolean} refExists      Whether a tag or branch exists on origin.
+ * @property {string=}                                        baseSha        Pull request base commit.
+ * @property {string=}                                        baseRef        Pull request base branch name.
+ * @property {string=}                                        releaseTag     Release tag name.
+ * @property {string=}                                        inputBranches  `workflow_dispatch` branches input.
+ * @property {string=}                                        inputWpVersion `workflow_dispatch` WP version input.
  */
 
 /**
@@ -95,13 +95,13 @@ export function resolveBranches( options ) {
 				previousBase10 % 10
 			}`;
 			const wp = `wp/${ wpMajor }`;
-			for ( const [ ref, description ] of [
-				[ tag, 'release tag' ],
-				[ current, 'current release branch' ],
-				[ previous, 'previous release branch' ],
-				[ wp, 'WordPress branch' ],
+			for ( const [ ref, kind, description ] of [
+				[ tag, 'tag', 'release tag' ],
+				[ current, 'head', 'current release branch' ],
+				[ previous, 'head', 'previous release branch' ],
+				[ wp, 'head', 'WordPress branch' ],
 			] ) {
-				if ( ! refExists( ref ) ) {
+				if ( ! refExists( ref, kind ) ) {
 					throw new Error(
 						`Expected ${ description } '${ ref }' to exist in the Gutenberg repository.`
 					);
@@ -156,11 +156,17 @@ function main() {
 		event: env.GITHUB_EVENT_NAME || '',
 		sha: env.GITHUB_SHA || '',
 		wpMajor: getTestedUpToMajor( fs.readFileSync( 'readme.txt', 'utf8' ) ),
-		refExists: ( ref ) => {
+		refExists: ( ref, kind ) => {
 			try {
 				execFileSync(
 					'git',
-					[ 'ls-remote', '--exit-code', 'origin', ref ],
+					[
+						'ls-remote',
+						'--exit-code',
+						kind === 'tag' ? '--tags' : '--heads',
+						'origin',
+						ref,
+					],
 					{
 						stdio: 'ignore',
 					}

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Resolves the branches and the suite shards the performance workflow runs for a GitHub event.
- * Writes `branches` (`{ name, ref, artifact }[]`), `shards` (`{ shard, suites }[]`) and `wp-version` to `$GITHUB_OUTPUT`.
+ * Writes `branches` (`{ name, ref, artifact }[]`), `shards` (`{ shard, suites }[]`), `wp-version`
+ * and `plugin-files` (space separated globs from bin/plugin-files.txt) to `$GITHUB_OUTPUT`.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -230,13 +231,23 @@ function main() {
 			.map( ( file ) => path.basename( file, '.spec.js' ) )
 	);
 
-	console.log( JSON.stringify( { branches, shards, wpVersion }, null, 2 ) );
+	const pluginFiles = fs
+		.readFileSync( path.join( 'bin', 'plugin-files.txt' ), 'utf8' )
+		.split( '\n' )
+		.map( ( line ) => line.trim() )
+		.filter( ( line ) => line && ! line.startsWith( '#' ) )
+		.join( ' ' );
+
+	console.log(
+		JSON.stringify( { branches, shards, wpVersion, pluginFiles }, null, 2 )
+	);
 	fs.appendFileSync(
 		env.GITHUB_OUTPUT,
 		[
 			`branches=${ JSON.stringify( branches ) }`,
 			`shards=${ JSON.stringify( shards ) }`,
 			`wp-version=${ wpVersion }`,
+			`plugin-files=${ pluginFiles }`,
 			'',
 		].join( '\n' )
 	);

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Resolves the branches the performance workflow compares for a GitHub event.
+ * Writes `branches` (JSON array of `{ name, ref, artifact }`) and `wp-version` to `$GITHUB_OUTPUT`.
+ */
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+/*
+ * The commit trunk is compared against; must be updated on every WP major release, see
+ * https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
+ */
+export const REFERENCE_COMMIT = '28d414f1327652e2b49e784ddc12098768991c62';
+
+/**
+ * Same replacement as `sanitizeBranchName()` in commands/performance.js.
+ *
+ * @param {string} name
+ * @return {string} Name usable in a path or an artifact name.
+ */
+function sanitizeBranchName( name ) {
+	return name.replace( /[^a-zA-Z0-9-]/g, '-' );
+}
+
+/**
+ * @param {string} name Branch label shown in the results.
+ * @param {string} ref  Git ref to build.
+ */
+function branch( name, ref = name ) {
+	return { name, ref, artifact: `plugin-${ sanitizeBranchName( name ) }` };
+}
+
+/**
+ * @param {string} readme Contents of readme.txt.
+ * @return {string} The `Tested up to` version, major.minor only.
+ */
+export function getTestedUpToMajor( readme ) {
+	const match = readme.match( /^Tested up to: (\d+\.\d+)/m );
+	if ( ! match ) {
+		throw new Error( 'Unable to read "Tested up to" from readme.txt.' );
+	}
+	return match[ 1 ];
+}
+
+/**
+ * @typedef ResolveOptions
+ *
+ * @property {string}                   event          GitHub event name.
+ * @property {string}                   sha            Commit that triggered the workflow.
+ * @property {string}                   wpMajor        The `Tested up to` version from readme.txt.
+ * @property {(ref: string) => boolean} refExists      Whether a tag or branch exists on origin.
+ * @property {string=}                  baseSha        Pull request base commit.
+ * @property {string=}                  baseRef        Pull request base branch name.
+ * @property {string=}                  releaseTag     Release tag name.
+ * @property {string=}                  inputBranches  `workflow_dispatch` branches input.
+ * @property {string=}                  inputWpVersion `workflow_dispatch` WP version input.
+ */
+
+/**
+ * @param {ResolveOptions} options
+ * @return {{ branches: Array<{ name: string, ref: string, artifact: string }>, wpVersion: string }} Resolved branches.
+ */
+export function resolveBranches( options ) {
+	const { event, sha, wpMajor, refExists } = options;
+
+	switch ( event ) {
+		case 'pull_request':
+			return {
+				branches: [
+					branch( sha ),
+					branch( options.baseRef || '', options.baseSha ),
+				],
+				wpVersion: '',
+			};
+
+		case 'push':
+			return {
+				branches: [ branch( sha ), branch( REFERENCE_COMMIT ) ],
+				wpVersion: wpMajor,
+			};
+
+		case 'release': {
+			const tag = options.releaseTag || '';
+			const version = tag.replace( /^v/, '' );
+			if ( ! /^\d+\.\d+\.\d+(-rc\.\d+)?$/.test( version ) ) {
+				throw new Error(
+					`Release tag '${ tag }' does not resolve to a valid Gutenberg plugin version.`
+				);
+			}
+			const [ major, minor ] = version.split( '.' ).map( Number );
+			const current = `release/${ major }.${ minor }`;
+			const previousBase10 = major * 10 + minor - 1;
+			const previous = `release/${ Math.floor( previousBase10 / 10 ) }.${
+				previousBase10 % 10
+			}`;
+			for ( const [ ref, description ] of [
+				[ tag, 'release tag' ],
+				[ current, 'current release branch' ],
+				[ previous, 'previous release branch' ],
+			] ) {
+				if ( ! refExists( ref ) ) {
+					throw new Error(
+						`Expected ${ description } '${ ref }' to exist in the Gutenberg repository.`
+					);
+				}
+			}
+			return {
+				branches: [
+					branch( `wp/${ wpMajor }` ),
+					branch( previous ),
+					branch( current ),
+				],
+				wpVersion: wpMajor,
+			};
+		}
+
+		case 'workflow_dispatch':
+			return {
+				branches: ( options.inputBranches || '' )
+					.split( ',' )
+					.map( ( name ) => name.trim() )
+					.filter( Boolean )
+					.map( ( name ) => branch( name ) ),
+				wpVersion: options.inputWpVersion || '',
+			};
+
+		default:
+			throw new Error( `Unsupported event: ${ event }` );
+	}
+}
+
+function main() {
+	const env = process.env;
+	const { branches, wpVersion } = resolveBranches( {
+		event: env.GITHUB_EVENT_NAME || '',
+		sha: env.GITHUB_SHA || '',
+		wpMajor: getTestedUpToMajor( fs.readFileSync( 'readme.txt', 'utf8' ) ),
+		refExists: ( ref ) => {
+			try {
+				execFileSync(
+					'git',
+					[ 'ls-remote', '--exit-code', 'origin', ref ],
+					{
+						stdio: 'ignore',
+					}
+				);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		baseSha: env.BASE_SHA,
+		baseRef: env.BASE_REF,
+		releaseTag: env.RELEASE_TAG,
+		inputBranches: env.INPUT_BRANCHES,
+		inputWpVersion: env.INPUT_WP_VERSION,
+	} );
+
+	console.log( JSON.stringify( branches, null, 2 ) );
+	fs.appendFileSync(
+		env.GITHUB_OUTPUT,
+		`branches=${ JSON.stringify( branches ) }\nwp-version=${ wpVersion }\n`
+	);
+}
+
+if (
+	process.argv[ 1 ] &&
+	import.meta.url === pathToFileURL( process.argv[ 1 ] ).href
+) {
+	main();
+}

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /**
- * Resolves the branches the performance workflow compares for a GitHub event.
- * Writes `branches` (JSON array of `{ name, ref, artifact }`) and `wp-version` to `$GITHUB_OUTPUT`.
+ * Resolves the branches and the suite shards the performance workflow runs for a GitHub event.
+ * Writes `branches` (`{ name, ref, artifact }[]`), `shards` (`{ shard, suites }[]`) and `wp-version` to `$GITHUB_OUTPUT`.
  */
 import fs from 'node:fs';
+import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { sanitizeBranchName } from './lib/sanitize-branch-name.js';
@@ -13,6 +14,46 @@ import { sanitizeBranchName } from './lib/sanitize-branch-name.js';
  * https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
  */
 export const REFERENCE_COMMIT = '28d414f1327652e2b49e784ddc12098768991c62';
+
+/*
+ * Suites grouped into CI jobs that run in parallel, balanced by their duration.
+ * Every spec in test/performance/specs must appear exactly once.
+ */
+export const SHARDS = {
+	'post-editor': [ 'post-editor' ],
+	'site-editor': [ 'site-editor' ],
+	'media-and-front-end': [
+		'front-end-block-theme',
+		'front-end-classic-theme',
+		'media-processing',
+		'media-upload',
+	],
+};
+
+/**
+ * @param {string[]} suites Names of the spec files in test/performance/specs, without extension.
+ * @return {Array<{ shard: string, suites: string }>} Matrix entries for the CI shards.
+ */
+export function resolveShards( suites ) {
+	const assigned = Object.values( SHARDS ).flat();
+	const missing = suites.filter( ( suite ) => ! assigned.includes( suite ) );
+	const unknown = assigned.filter( ( suite ) => ! suites.includes( suite ) );
+	const duplicate = assigned.find(
+		( suite, i ) => assigned.indexOf( suite ) !== i
+	);
+	if ( missing.length || unknown.length || duplicate ) {
+		throw new Error(
+			`SHARDS in resolve-performance-branches.mjs must list every performance suite exactly once. ` +
+				`Missing: ${ missing.join( ', ' ) || 'none' }. Unknown: ${
+					unknown.join( ', ' ) || 'none'
+				}. Duplicate: ${ duplicate || 'none' }.`
+		);
+	}
+	return Object.entries( SHARDS ).map( ( [ shard, shardSuites ] ) => ( {
+		shard,
+		suites: shardSuites.join( ',' ),
+	} ) );
+}
 
 /**
  * @param {string} name Branch label shown in the results.
@@ -182,10 +223,22 @@ function main() {
 		inputWpVersion: env.INPUT_WP_VERSION,
 	} );
 
-	console.log( JSON.stringify( branches, null, 2 ) );
+	const shards = resolveShards(
+		fs
+			.readdirSync( path.join( 'test', 'performance', 'specs' ) )
+			.filter( ( file ) => file.endsWith( '.spec.js' ) )
+			.map( ( file ) => path.basename( file, '.spec.js' ) )
+	);
+
+	console.log( JSON.stringify( { branches, shards, wpVersion }, null, 2 ) );
 	fs.appendFileSync(
 		env.GITHUB_OUTPUT,
-		`branches=${ JSON.stringify( branches ) }\nwp-version=${ wpVersion }\n`
+		[
+			`branches=${ JSON.stringify( branches ) }`,
+			`shards=${ JSON.stringify( shards ) }`,
+			`wp-version=${ wpVersion }`,
+			'',
+		].join( '\n' )
 	);
 }
 

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -53,6 +53,23 @@ export function getTestedUpToMajor( readme ) {
  * @return {{ branches: Array<{ name: string, ref: string, artifact: string }>, wpVersion: string }} Resolved branches.
  */
 export function resolveBranches( options ) {
+	const result = resolveBranchesForEvent( options );
+	const artifacts = result.branches.map( ( { artifact } ) => artifact );
+	const duplicate = artifacts.find(
+		( artifact, i ) => artifacts.indexOf( artifact ) !== i
+	);
+	if ( duplicate ) {
+		throw new Error(
+			`Branches must have distinct names once sanitized, "${ duplicate }" is used twice.`
+		);
+	}
+	return result;
+}
+
+/**
+ * @param {ResolveOptions} options
+ */
+function resolveBranchesForEvent( options ) {
 	const { event, sha, wpMajor, refExists } = options;
 
 	switch ( event ) {
@@ -115,15 +132,6 @@ export function resolveBranches( options ) {
 				.filter( Boolean );
 			if ( names.length < 2 ) {
 				throw new Error( 'Need at least two branches to compare.' );
-			}
-			const artifacts = names.map( ( name ) => branch( name ).artifact );
-			const duplicate = artifacts.find(
-				( artifact, i ) => artifacts.indexOf( artifact ) !== i
-			);
-			if ( duplicate ) {
-				throw new Error(
-					`Branches must have distinct names once sanitized, "${ duplicate }" is used twice.`
-				);
 			}
 			return {
 				branches: names.map( ( name ) => branch( name ) ),

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -6,22 +6,13 @@
 import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+import { sanitizeBranchName } from './lib/sanitize-branch-name.js';
 
 /*
  * The commit trunk is compared against; must be updated on every WP major release, see
  * https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
  */
 export const REFERENCE_COMMIT = '28d414f1327652e2b49e784ddc12098768991c62';
-
-/**
- * Same replacement as `sanitizeBranchName()` in commands/performance.js.
- *
- * @param {string} name
- * @return {string} Name usable in a path or an artifact name.
- */
-function sanitizeBranchName( name ) {
-	return name.replace( /[^a-zA-Z0-9-]/g, '-' );
-}
 
 /**
  * @param {string} name Branch label shown in the results.

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -116,6 +116,8 @@ function resolveBranchesForEvent( options ) {
 
 	switch ( event ) {
 		case 'pull_request':
+			// The base is pinned to the commit the PR is based on, not the branch tip, so
+			// both branches match what the merge commit was built from.
 			return {
 				branches: [
 					branch( sha ),

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -94,10 +94,12 @@ export function resolveBranches( options ) {
 			const previous = `release/${ Math.floor( previousBase10 / 10 ) }.${
 				previousBase10 % 10
 			}`;
+			const wp = `wp/${ wpMajor }`;
 			for ( const [ ref, description ] of [
 				[ tag, 'release tag' ],
 				[ current, 'current release branch' ],
 				[ previous, 'previous release branch' ],
+				[ wp, 'WordPress branch' ],
 			] ) {
 				if ( ! refExists( ref ) ) {
 					throw new Error(
@@ -107,7 +109,7 @@ export function resolveBranches( options ) {
 			}
 			return {
 				branches: [
-					branch( `wp/${ wpMajor }` ),
+					branch( wp ),
 					branch( previous ),
 					branch( current ),
 				],
@@ -115,15 +117,28 @@ export function resolveBranches( options ) {
 			};
 		}
 
-		case 'workflow_dispatch':
+		case 'workflow_dispatch': {
+			const names = ( options.inputBranches || '' )
+				.split( ',' )
+				.map( ( name ) => name.trim() )
+				.filter( Boolean );
+			if ( names.length < 2 ) {
+				throw new Error( 'Need at least two branches to compare.' );
+			}
+			const artifacts = names.map( ( name ) => branch( name ).artifact );
+			const duplicate = artifacts.find(
+				( artifact, i ) => artifacts.indexOf( artifact ) !== i
+			);
+			if ( duplicate ) {
+				throw new Error(
+					`Branches must have distinct names once sanitized, "${ duplicate }" is used twice.`
+				);
+			}
 			return {
-				branches: ( options.inputBranches || '' )
-					.split( ',' )
-					.map( ( name ) => name.trim() )
-					.filter( Boolean )
-					.map( ( name ) => branch( name ) ),
+				branches: names.map( ( name ) => branch( name ) ),
 				wpVersion: options.inputWpVersion || '',
 			};
+		}
 
 		default:
 			throw new Error( `Unsupported event: ${ event }` );
@@ -132,6 +147,11 @@ export function resolveBranches( options ) {
 
 function main() {
 	const env = process.env;
+	if ( ! env.GITHUB_OUTPUT ) {
+		throw new Error(
+			'GITHUB_OUTPUT is not set; this script runs in GitHub Actions.'
+		);
+	}
 	const { branches, wpVersion } = resolveBranches( {
 		event: env.GITHUB_EVENT_NAME || '',
 		sha: env.GITHUB_SHA || '',

--- a/tools/release/test/resolve-performance-branches.js
+++ b/tools/release/test/resolve-performance-branches.js
@@ -1,5 +1,8 @@
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
 const {
 	resolveBranches,
+	resolveShards,
 	getTestedUpToMajor,
 	REFERENCE_COMMIT,
 } = require( '../resolve-performance-branches.mjs' );
@@ -189,5 +192,33 @@ describe( 'resolveBranches', () => {
 				refExists,
 			} )
 		).toThrow( 'Unsupported event' );
+	} );
+} );
+
+describe( 'resolveShards', () => {
+	const specs = fs
+		.readdirSync(
+			path.join( __dirname, '../../../test/performance/specs' )
+		)
+		.filter( ( file ) => file.endsWith( '.spec.js' ) )
+		.map( ( file ) => path.basename( file, '.spec.js' ) );
+
+	it( 'covers every spec file in the repository exactly once', () => {
+		const shards = resolveShards( specs );
+		expect(
+			shards.flatMap( ( { suites } ) => suites.split( ',' ) ).sort()
+		).toEqual( [ ...specs ].sort() );
+	} );
+
+	it( 'fails when a spec is not assigned to a shard', () => {
+		expect( () => resolveShards( [ ...specs, 'new-suite' ] ) ).toThrow(
+			'Missing: new-suite'
+		);
+	} );
+
+	it( 'fails when a shard lists a spec that does not exist', () => {
+		expect( () => resolveShards( specs.slice( 1 ) ) ).toThrow(
+			`Unknown: ${ specs[ 0 ] }`
+		);
 	} );
 } );

--- a/tools/release/test/resolve-performance-branches.js
+++ b/tools/release/test/resolve-performance-branches.js
@@ -124,6 +124,42 @@ describe( 'resolveBranches', () => {
 		} );
 	} );
 
+	it( 'rejects manual runs with fewer than two branches', () => {
+		expect( () =>
+			resolveBranches( {
+				event: 'workflow_dispatch',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+				inputBranches: 'trunk,',
+			} )
+		).toThrow( 'at least two branches' );
+	} );
+
+	it( 'rejects manual runs whose branches collide once sanitized', () => {
+		expect( () =>
+			resolveBranches( {
+				event: 'workflow_dispatch',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+				inputBranches: 'wp/6.9,wp-6.9',
+			} )
+		).toThrow( 'plugin-wp-6-9' );
+	} );
+
+	it( 'rejects releases whose WP branch does not exist', () => {
+		expect( () =>
+			resolveBranches( {
+				event: 'release',
+				sha,
+				wpMajor: '7.1',
+				refExists: ( ref ) => ref !== 'wp/7.1',
+				releaseTag: 'v24.0.0',
+			} )
+		).toThrow( "WordPress branch 'wp/7.1'" );
+	} );
+
 	it( 'rejects unknown events', () => {
 		expect( () =>
 			resolveBranches( {

--- a/tools/release/test/resolve-performance-branches.js
+++ b/tools/release/test/resolve-performance-branches.js
@@ -1,0 +1,137 @@
+const {
+	resolveBranches,
+	getTestedUpToMajor,
+	REFERENCE_COMMIT,
+} = require( '../resolve-performance-branches.mjs' );
+
+const sha = 'a'.repeat( 40 );
+const baseSha = 'b'.repeat( 40 );
+const refExists = () => true;
+
+describe( 'getTestedUpToMajor', () => {
+	it( 'returns major.minor', () => {
+		expect( getTestedUpToMajor( 'Tested up to: 7.1.2\n' ) ).toBe( '7.1' );
+	} );
+
+	it( 'throws when the flag is missing', () => {
+		expect( () => getTestedUpToMajor( '' ) ).toThrow( 'Tested up to' );
+	} );
+} );
+
+describe( 'resolveBranches', () => {
+	it( 'compares a pull request with its base commit', () => {
+		expect(
+			resolveBranches( {
+				event: 'pull_request',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+				baseSha,
+				baseRef: 'trunk',
+			} )
+		).toEqual( {
+			branches: [
+				{ name: sha, ref: sha, artifact: `plugin-${ sha }` },
+				{ name: 'trunk', ref: baseSha, artifact: 'plugin-trunk' },
+			],
+			wpVersion: '',
+		} );
+	} );
+
+	it( 'compares a push with the reference commit on the tested WP version', () => {
+		expect(
+			resolveBranches( { event: 'push', sha, wpMajor: '7.1', refExists } )
+		).toEqual( {
+			branches: [
+				{ name: sha, ref: sha, artifact: `plugin-${ sha }` },
+				{
+					name: REFERENCE_COMMIT,
+					ref: REFERENCE_COMMIT,
+					artifact: `plugin-${ REFERENCE_COMMIT }`,
+				},
+			],
+			wpVersion: '7.1',
+		} );
+	} );
+
+	it( 'compares a release with WP core and the previous release', () => {
+		expect(
+			resolveBranches( {
+				event: 'release',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+				releaseTag: 'v24.0.0-rc.1',
+			} )
+		).toEqual( {
+			branches: [
+				{ name: 'wp/7.1', ref: 'wp/7.1', artifact: 'plugin-wp-7-1' },
+				{
+					name: 'release/23.9',
+					ref: 'release/23.9',
+					artifact: 'plugin-release-23-9',
+				},
+				{
+					name: 'release/24.0',
+					ref: 'release/24.0',
+					artifact: 'plugin-release-24-0',
+				},
+			],
+			wpVersion: '7.1',
+		} );
+	} );
+
+	it( 'rejects release tags that are not plugin versions', () => {
+		expect( () =>
+			resolveBranches( {
+				event: 'release',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+				releaseTag: 'v24.0',
+			} )
+		).toThrow( "Release tag 'v24.0' does not resolve" );
+	} );
+
+	it( 'rejects releases whose branches do not exist', () => {
+		expect( () =>
+			resolveBranches( {
+				event: 'release',
+				sha,
+				wpMajor: '7.1',
+				refExists: ( ref ) => ref !== 'release/23.9',
+				releaseTag: 'v24.0.0',
+			} )
+		).toThrow( "previous release branch 'release/23.9'" );
+	} );
+
+	it( 'splits the branches input of a manual run', () => {
+		expect(
+			resolveBranches( {
+				event: 'workflow_dispatch',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+				inputBranches: ' trunk, v23.8.0 ,,',
+				inputWpVersion: '7.0',
+			} )
+		).toEqual( {
+			branches: [
+				{ name: 'trunk', ref: 'trunk', artifact: 'plugin-trunk' },
+				{ name: 'v23.8.0', ref: 'v23.8.0', artifact: 'plugin-v23-8-0' },
+			],
+			wpVersion: '7.0',
+		} );
+	} );
+
+	it( 'rejects unknown events', () => {
+		expect( () =>
+			resolveBranches( {
+				event: 'schedule',
+				sha,
+				wpMajor: '7.1',
+				refExists,
+			} )
+		).toThrow( 'Unsupported event' );
+	} );
+} );

--- a/tools/release/test/resolve-performance-branches.js
+++ b/tools/release/test/resolve-performance-branches.js
@@ -93,6 +93,26 @@ describe( 'resolveBranches', () => {
 		).toThrow( "Release tag 'v24.0' does not resolve" );
 	} );
 
+	it( 'checks the release tag among tags and the branches among heads', () => {
+		const seen = [];
+		resolveBranches( {
+			event: 'release',
+			sha,
+			wpMajor: '7.1',
+			refExists: ( ref, kind ) => {
+				seen.push( `${ kind }:${ ref }` );
+				return true;
+			},
+			releaseTag: 'v24.0.0',
+		} );
+		expect( seen ).toEqual( [
+			'tag:v24.0.0',
+			'head:release/24.0',
+			'head:release/23.9',
+			'head:wp/7.1',
+		] );
+	} );
+
 	it( 'rejects releases whose branches do not exist', () => {
 		expect( () =>
 			resolveBranches( {


### PR DESCRIPTION
## What?

Builds the plugin once per branch and runs the suites in three parallel shards, each measuring every branch on the same runner.

## Why?

The performance job takes 35 to 40 minutes and is the check PRs wait longest for; each branch runs the suites serially after 5 minutes of installing and building ([30103099688](https://github.com/WordPress/gutenberg/actions/runs/30103099688)). A PR run now takes about 18 minutes ([33149133856](https://github.com/WordPress/gutenberg/actions/runs/33149133856)).

## How?

- A `prepare` job runs [resolve-performance-branches.mjs](tools/release/resolve-performance-branches.mjs) to resolve the branches and the shard matrix per event, and validates that every spec in `test/performance/specs` belongs to exactly one shard, so a new spec fails the run after 20 seconds instead of after the tests.
- `build` jobs package each branch with [plugin-files.txt](bin/plugin-files.txt), which `build-plugin-zip.sh` now reads too, so the two lists cannot drift. The list is taken from the tested commit and older refs are packaged the same way (`post-content.php` is added for refs that still require it).
- [performance.js](tools/release/commands/performance.js) gains `--suites` and `--plugins-dir` (use prebuilt plugins and the current checkout, no cloning or building). Local runs without the options are unchanged.
- The merge job keeps the name `Run performance tests` (the required check) and fails when any shard fails.
- Runner minutes rise from ~35 to ~44 per run: the build jobs add ~4 minutes and each shard pays ~1.5 minutes for wp-env and Playwright setup. Wall clock is what contributors wait on, and the minutes are within the noise of the e2e jobs, so the trade seemed worth it. Docs-only PRs could skip the job in a follow-up.
- A PR's base is measured at `pull_request.base.sha` rather than the branch tip, which matches what the merge commit was built from and keeps the two builds consistent when trunk moves during the run. The column still shows the branch name because `log-performance-results.js` keys on it for trunk pushes; documented in the performance docs.
- Also fixes `workflow_dispatch`, which passed all refs as one argument.

## Testing Instructions

1. On this PR: two `Build plugin` jobs, three shards, then `Run performance tests` uploading `performance-results` with all six suites and `performance-source-maps` uploaded once.
2. Locally: `npm exec release-cli -- perf trunk trunk --suites front-end-block-theme`.

## Use of AI Tools

Drafted with Claude Code and reviewed with Codex; every change was reviewed by me.
