### PR TITLE
Border Box Control: Try moving the unlink button to the label row, and rename the panel to Borders

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `BackgroundImageControl`: Support setting the background image from a URL, through the URL field in the media replace popover ([#82230](https://github.com/WordPress/gutenberg/pull/82230)).
 
+### Enhancements
+
+-   Borders: rename the "Border & Shadow" panel to "Borders", and always show the Border control's visible label so its "Unlink sides" toggle lines up with the border radius one ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
+
 ### Internal
 
 -   Remove unused dependencies `@wordpress/escape-html`, `@wordpress/wordcount` and `deepmerge` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
+-   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#73596](https://github.com/WordPress/gutenberg/issues/73596)) ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#73596](https://github.com/WordPress/gutenberg/issues/73596)) ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
+-   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Borders: rename the "Border & Shadow" panel to "Borders", and always show the Border control's visible label so its "Unlink sides" toggle lines up with the border radius one ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
+-   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
 
 ### Internal
 

--- a/packages/block-editor/src/components/block-inspector/index.jsx
+++ b/packages/block-editor/src/components/block-inspector/index.jsx
@@ -29,7 +29,6 @@ import InspectorControlsLastItem from '../inspector-controls/last-item';
 import AdvancedControls from '../inspector-controls-tabs/advanced-controls-panel';
 import PositionControls from '../inspector-controls-tabs/position-controls-panel';
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
-import { useBorderPanelLabel } from '../../hooks/border';
 import { BlockStateBadges, BlockStatesControl } from '../../hooks/states';
 import ContentTab from '../inspector-controls-tabs/content-tab';
 import ViewportVisibilityInfo from '../block-visibility/viewport-visibility-info';
@@ -42,12 +41,10 @@ import {
 } from '../../hooks/block-style-state';
 
 function StyleInspectorSlots( {
-	clientId,
 	showAdvancedControls = true,
 	showPositionControls = true,
 	showBindingsControls = true,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 	return (
 		<>
 			<InspectorControls.Slot />
@@ -70,7 +67,7 @@ function StyleInspectorSlots( {
 				group="dimensions"
 				label={ __( 'Dimensions' ) }
 			/>
-			<InspectorControls.Slot group="border" label={ borderPanelLabel } />
+			<InspectorControls.Slot group="border" label={ __( 'Borders' ) } />
 			<InspectorControls.Slot
 				group="elements"
 				label={ __( 'Elements' ) }
@@ -97,7 +94,6 @@ function StyleStateInspectorSlots( {
 	isSectionBlock,
 	selectedBlockStyleState,
 } ) {
-	const borderPanelLabel = useBorderPanelLabel( { clientId } );
 	const isViewportStyleState =
 		hasViewportBlockStyleState( selectedBlockStyleState ) &&
 		! hasPseudoBlockStyleState( selectedBlockStyleState );
@@ -142,7 +138,7 @@ function StyleStateInspectorSlots( {
 					/>
 					<InspectorControls.Slot
 						group="border"
-						label={ borderPanelLabel }
+						label={ __( 'Borders' ) }
 					/>
 					<InspectorControls.Slot
 						group="elements"
@@ -530,11 +526,7 @@ const BlockInspectorSingleBlock = ( {
 					<InspectorControls.Slot group="content" />
 					<InspectorControls.Slot group="list" ref={ listViewRef } />
 					<ListViewContentPopover listViewRef={ listViewRef } />
-					{ ! isSectionBlock && (
-						<StyleInspectorSlots
-							clientId={ renderedBlockClientId }
-						/>
-					) }
+					{ ! isSectionBlock && <StyleInspectorSlots /> }
 				</>
 			) }
 			{ ! isEditingStyleState && <InspectorControlsLastItem.Slot /> }

--- a/packages/block-editor/src/components/global-styles/border-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/border-panel.jsx
@@ -12,7 +12,6 @@ import BorderRadiusControl from '../border-radius-control';
 import { useColorsPerOrigin } from './hooks';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
-import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';
 import {
 	getInheritanceProps,
@@ -365,24 +364,18 @@ export default function BorderPanel( {
 	const showBorderByDefault =
 		defaultControls?.color || defaultControls?.width;
 
-	const hasBorderControl =
-		showBorderColor ||
-		showBorderStyle ||
-		showBorderWidth ||
-		showBorderRadius;
-
-	const label = useBorderPanelLabel( {
-		hasShadowControl,
-		hasBorderControl,
-	} );
-
 	return (
 		<Wrapper
 			resetAllFilter={ resetAllFilter }
 			value={ value }
 			onChange={ onChange }
 			panelId={ panelId }
-			label={ label }
+			// A shadow is treated as a soft border, so the panel keeps one
+			// name whichever of its controls a theme or block opts into.
+			// A stable title is what lets each control show its own label
+			// unconditionally, which in turn keeps their unlink toggles
+			// aligned.
+			label={ __( 'Borders' ) }
 		>
 			{ ( showBorderWidth || showBorderColor ) && (
 				<InheritanceToolsPanelItem
@@ -458,11 +451,9 @@ export default function BorderPanel( {
 					showLocalOverrideActionsInLabel={ false }
 					panelId={ panelId }
 				>
-					{ hasBorderControl ? (
-						<BaseControl.VisualLabel as="legend">
-							{ __( 'Shadow' ) }
-						</BaseControl.VisualLabel>
-					) : null }
+					<BaseControl.VisualLabel as="legend">
+						{ __( 'Shadow' ) }
+					</BaseControl.VisualLabel>
 
 					<ShadowPopover
 						shadow={ shadow }

--- a/packages/block-editor/src/components/global-styles/border-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/border-panel.jsx
@@ -394,37 +394,23 @@ export default function BorderPanel( {
 					) }
 					hasValue={ () => isDefinedBorder( value?.border ) }
 					label={ __( 'Border' ) }
+					hasInlineEndToggle
 					onDeselect={ () => resetBorder() }
 					isShownByDefault={ showBorderByDefault }
 					panelId={ panelId }
 				>
-					{ ( showInheritanceLabelIndicators ||
-						hasShadowControl ) && (
-						// Render the visible label as `BaseControl.VisualLabel`
-						// (which produces `.components-base-control__label`)
-						// rather than passing `label` to `BorderBoxControl`,
-						// whose internal `<StyledLabel>` carries no stable
-						// className. The inheritance treatment and the
-						// local-override reset affordance both target
-						// `.components-base-control__label`, so the visible
-						// "Border" label has to be a `BaseControl` label to
-						// receive them.
-						//
-						// Render it whenever a Shadow control is also present so
-						// the two controls stay disambiguated (mirrors the
-						// Shadow label's `hasBorderControl` guard below, and
-						// trunk's `hideLabelFromVision={ ! hasShadowControl }`),
-						// even when inheritance indicators are off (e.g. in
-						// Global Styles).
-						<BaseControl.VisualLabel as="legend">
-							{ __( 'Border' ) }
-						</BaseControl.VisualLabel>
-					) }
+					{ /* The visible label is always rendered, so the control's
+					    linked/unlinked toggle sits in a label row and lines up
+					    with the Radius control's. `BorderBoxControl` renders the
+					    label as `BaseControl.VisualLabel`, which is what the
+					    inheritance treatment and the local-override reset
+					    affordance target. */ }
 					<BorderBoxControl
 						colors={ colors }
 						disableCustomColors={ ! areCustomSolidsEnabled }
 						enableAlpha
 						enableStyle={ showBorderStyle }
+						label={ __( 'Border' ) }
 						onChange={ onBorderChange }
 						popoverOffset={ 40 }
 						popoverPlacement="left-start"

--- a/packages/block-editor/src/components/global-styles/border-panel.jsx
+++ b/packages/block-editor/src/components/global-styles/border-panel.jsx
@@ -451,7 +451,7 @@ export default function BorderPanel( {
 					showLocalOverrideActionsInLabel={ false }
 					panelId={ panelId }
 				>
-					<BaseControl.VisualLabel as="legend">
+					<BaseControl.VisualLabel>
 						{ __( 'Shadow' ) }
 					</BaseControl.VisualLabel>
 

--- a/packages/block-editor/src/components/global-styles/test/border-panel.jsdom.test.jsx
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.jsdom.test.jsx
@@ -54,6 +54,7 @@ const settingsAll = {
 };
 
 const shadowOnlySettings = { shadow: settingsAll.shadow };
+const borderOnlySettings = { border: settingsAll.border };
 
 describe( 'BorderPanel — panel and control labels', () => {
 	it( 'titles the panel "Borders" when border and shadow controls are available', () => {
@@ -87,6 +88,52 @@ describe( 'BorderPanel — panel and control labels', () => {
 		expect(
 			screen.getByRole( 'heading', { name: 'Borders' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'labels the border control, and puts its unlink toggle in that label row, when no shadow control is available', () => {
+		// The case that motivated the change: with no Shadow control to
+		// disambiguate it from, the Border label used to be hidden, which left
+		// its unlink toggle beside the inputs while the Radius one sat in a
+		// label row. Both now share the same layout.
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ borderOnlySettings }
+				onChange={ () => {} }
+				panelId="test-panel"
+			/>
+		);
+
+		expect( screen.getByText( 'Border' ) ).toBeInTheDocument();
+
+		// `getAllByRole` returns document order, so the toggle preceding the
+		// border color/style picker is what places it in the label row rather
+		// than alongside the inputs.
+		const buttons = screen.getAllByRole( 'button' );
+		expect(
+			buttons.indexOf( screen.getByLabelText( 'Unlink sides' ) )
+		).toBeLessThan(
+			buttons.indexOf(
+				screen.getByLabelText( /Border color( and style)* picker/ )
+			)
+		);
+	} );
+
+	it( 'labels the border control when the inheritance indicators are off', () => {
+		// Global Styles renders the panel without the inheritance treatment.
+		// That used to be the other half of the condition hiding the label, so
+		// a border-only panel showed no label there either.
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ borderOnlySettings }
+				onChange={ () => {} }
+				panelId="test-panel"
+				showInheritanceLabelIndicators={ false }
+			/>
+		);
+
+		expect( screen.getByText( 'Border' ) ).toBeInTheDocument();
 	} );
 
 	it( 'labels the shadow control even when no border control is available', () => {

--- a/packages/block-editor/src/components/global-styles/test/border-panel.jsdom.test.jsx
+++ b/packages/block-editor/src/components/global-styles/test/border-panel.jsdom.test.jsx
@@ -53,6 +53,56 @@ const settingsAll = {
 	},
 };
 
+const shadowOnlySettings = { shadow: settingsAll.shadow };
+
+describe( 'BorderPanel — panel and control labels', () => {
+	it( 'titles the panel "Borders" when border and shadow controls are available', () => {
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ settingsAll }
+				onChange={ () => {} }
+				panelId="test-panel"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Borders' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'titles the panel "Borders" when only a shadow control is available', () => {
+		// A shadow is treated as a soft border, so the title does not change
+		// with whichever controls a theme or block opts into. A stable title
+		// is what lets each control keep its own visible label.
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowOnlySettings }
+				onChange={ () => {} }
+				panelId="test-panel"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Borders' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'labels the shadow control even when no border control is available', () => {
+		render(
+			<BorderPanel
+				value={ {} }
+				settings={ shadowOnlySettings }
+				onChange={ () => {} }
+				panelId="test-panel"
+			/>
+		);
+
+		expect( screen.getByText( 'Shadow' ) ).toBeInTheDocument();
+	} );
+} );
+
 describe( 'BorderPanel — inherited Global Styles label treatment', () => {
 	describe( 'Border radius (input archetype)', () => {
 		it( 'renders an inherited string radius as the displayed value when local is empty', () => {

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.jsx
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.jsx
@@ -4,7 +4,6 @@ import { useMemo } from '@wordpress/element';
 import BlockStyles from '../block-styles';
 import InspectorControls from '../inspector-controls';
 import PositionControls from './position-controls-panel';
-import { useBorderPanelLabel } from '../../hooks/border';
 import { useBlockSettings } from '../../hooks/utils';
 import { store as blockEditorStore } from '../../store';
 import { ElementsEdit } from '../../hooks/elements';
@@ -103,8 +102,6 @@ const StylesTab = ( {
 	isSectionBlock,
 	contentClientIds,
 } ) => {
-	const borderPanelLabel = useBorderPanelLabel( { clientId } );
-
 	return (
 		<>
 			{ hasBlockStyles && <BlockStyles clientId={ clientId } /> }
@@ -148,7 +145,7 @@ const StylesTab = ( {
 					/>
 					<InspectorControls.Slot
 						group="border"
-						label={ borderPanelLabel }
+						label={ __( 'Borders' ) }
 					/>
 					<InspectorControls.Slot
 						group="elements"

--- a/packages/block-editor/src/hooks/border.jsx
+++ b/packages/block-editor/src/hooks/border.jsx
@@ -4,14 +4,12 @@ import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/com
 import { useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '../components/colors';
 import InspectorControls from '../components/inspector-controls';
 import useMultipleOriginColorsAndGradients from '../components/colors-gradients/use-multiple-origin-colors-and-gradients';
 import { cleanEmptyObject, shouldSkipSerialization } from './utils';
 import {
 	useHasBorderPanel,
-	useHasBorderPanelControls,
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { useResolvedStyle } from '../components/global-styles/inherited-value-context';
@@ -22,12 +20,9 @@ import {
 	setStyleForState,
 	useBlockStyleState,
 } from './block-style-state';
-import { unlock } from '../lock-unlock';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';
-
-const EMPTY_ARRAY = [];
 
 const getColorByProperty = ( colors, property, value ) => {
 	let matchedColor;
@@ -247,55 +242,6 @@ export function hasBorderSupport( blockName, feature = 'any' ) {
  */
 export function hasShadowSupport( blockName ) {
 	return hasBlockSupport( blockName, SHADOW_SUPPORT_KEY );
-}
-
-export function useBorderPanelLabel( {
-	clientId,
-	hasBorderControl,
-	hasShadowControl,
-} = {} ) {
-	const [ color, radius, style, width, shadow ] = useSelect(
-		( select ) => {
-			if ( ! clientId ) {
-				return EMPTY_ARRAY;
-			}
-			const { getBlockSettings } = unlock( select( blockEditorStore ) );
-			return getBlockSettings(
-				clientId,
-				'border.color',
-				'border.radius',
-				'border.style',
-				'border.width',
-				'shadow'
-			);
-		},
-		[ clientId ]
-	);
-	const settings = useMemo(
-		() => ( { border: { color, radius, style, width }, shadow } ),
-		[ color, radius, style, width, shadow ]
-	);
-	const controls = useHasBorderPanelControls( settings );
-
-	if ( ! hasBorderControl && ! hasShadowControl && clientId ) {
-		hasBorderControl =
-			controls?.hasBorderColor ||
-			controls?.hasBorderStyle ||
-			controls?.hasBorderWidth ||
-			controls?.hasBorderRadius;
-		hasShadowControl = controls?.hasShadow;
-	}
-
-	// A shadow is treated as a soft border, so a panel that offers any border
-	// control is "Borders" whether or not it also offers a shadow. Keeping the
-	// title stable is what lets the Border control show its own visible label
-	// unconditionally, which in turn keeps its unlink toggle aligned with the
-	// Radius one.
-	if ( hasShadowControl && ! hasBorderControl ) {
-		return __( 'Shadow' );
-	}
-
-	return __( 'Borders' );
 }
 
 /**

--- a/packages/block-editor/src/hooks/border.jsx
+++ b/packages/block-editor/src/hooks/border.jsx
@@ -286,15 +286,16 @@ export function useBorderPanelLabel( {
 		hasShadowControl = controls?.hasShadow;
 	}
 
-	if ( hasBorderControl && hasShadowControl ) {
-		return __( 'Border & Shadow' );
-	}
-
-	if ( hasShadowControl ) {
+	// A shadow is treated as a soft border, so a panel that offers any border
+	// control is "Borders" whether or not it also offers a shadow. Keeping the
+	// title stable is what lets the Border control show its own visible label
+	// unconditionally, which in turn keeps its unlink toggle aligned with the
+	// Radius one.
+	if ( hasShadowControl && ! hasBorderControl ) {
 		return __( 'Shadow' );
 	}
 
-	return __( 'Border' );
+	return __( 'Borders' );
 }
 
 /**

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
+-   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the input, as before. The visible label is now a `BaseControl.VisualLabel` ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
--   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
+-   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#73596](https://github.com/WordPress/gutenberg/issues/73596)) ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
--   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the input, as before. The visible label is now a `BaseControl.VisualLabel` ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
+-   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#73596](https://github.com/WordPress/gutenberg/issues/73596)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
--   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#73596](https://github.com/WordPress/gutenberg/issues/73596)) ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
+-   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 
 ### Bug Fixes
 

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -103,7 +103,9 @@ Provides control over whether the label will only be visible to screen readers.
 
 ### `label`: `string`
 
-If provided, a label will be generated using this as the content.
+If provided, a label will be generated using this as the content. A visible
+label is rendered in a row alongside the linked/unlinked toggle; when there is
+no visible label the toggle is rendered beside the border inputs instead.
 
 _Whether it is visible only to screen readers is controlled via
 `hideLabelFromVision`._

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -5,7 +5,7 @@ import BorderBoxControlLinkedButton from '../border-box-control-linked-button';
 import BorderBoxControlSplitControls from '../border-box-control-split-controls';
 import { BorderControl } from '../../border-control';
 import BaseControl from '../../base-control';
-import { HStack } from '../../h-stack';
+import { Grid } from '../../grid';
 import { View } from '../../view';
 import { VisuallyHidden } from '../../visually-hidden';
 import type { WordPressComponentProps } from '../../context';
@@ -93,7 +93,12 @@ const UnconnectedBorderBoxControl = (
 				// The toggle shares the label's row so that it lines up with
 				// the equivalent toggle on sibling controls, e.g. the border
 				// radius one.
-				<HStack className={ headerClassName }>
+				<Grid
+					className={ headerClassName }
+					columns={ 2 }
+					templateColumns="1fr min-content"
+					alignment="center"
+				>
 					<BorderLabel
 						label={ label }
 						hideLabelFromVision={ hideLabelFromVision }
@@ -102,7 +107,7 @@ const UnconnectedBorderBoxControl = (
 						onClick={ toggleLinked }
 						isLinked={ isLinked }
 					/>
-				</HStack>
+				</Grid>
 			) : (
 				<BorderLabel
 					label={ label }

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -17,8 +17,8 @@ import type {
 	BorderControlProps,
 } from '../../border-control/types';
 
-const BorderLabel = ( props: LabelProps & { className?: string } ) => {
-	const { className, label, hideLabelFromVision } = props;
+const BorderLabel = ( props: LabelProps ) => {
+	const { label, hideLabelFromVision } = props;
 
 	if ( ! label ) {
 		return null;
@@ -28,13 +28,9 @@ const BorderLabel = ( props: LabelProps & { className?: string } ) => {
 	// the stable `.components-base-control__label` className consumers style
 	// against; `StyledLabel` is an emotion component with a generated one.
 	return hideLabelFromVision ? (
-		<VisuallyHidden as="label" className={ className }>
-			{ label }
-		</VisuallyHidden>
+		<VisuallyHidden as="label">{ label }</VisuallyHidden>
 	) : (
-		<BaseControl.VisualLabel className={ className }>
-			{ label }
-		</BaseControl.VisualLabel>
+		<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 	);
 };
 
@@ -52,7 +48,6 @@ const UnconnectedBorderBoxControl = (
 		hasMixedBorders,
 		hasVisibleLabel,
 		headerClassName,
-		headerLabelClassName,
 		hideLabelFromVision,
 		isLinked,
 		label,
@@ -100,7 +95,6 @@ const UnconnectedBorderBoxControl = (
 				// radius one.
 				<HStack className={ headerClassName }>
 					<BorderLabel
-						className={ headerLabelClassName }
 						label={ label }
 						hideLabelFromVision={ hideLabelFromVision }
 					/>

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -4,7 +4,8 @@ import { useMergeRefs } from '@wordpress/compose';
 import BorderBoxControlLinkedButton from '../border-box-control-linked-button';
 import BorderBoxControlSplitControls from '../border-box-control-split-controls';
 import { BorderControl } from '../../border-control';
-import { StyledLabel } from '../../base-control/styles/base-control-styles';
+import BaseControl from '../../base-control';
+import { HStack } from '../../h-stack';
 import { View } from '../../view';
 import { VisuallyHidden } from '../../visually-hidden';
 import type { WordPressComponentProps } from '../../context';
@@ -23,10 +24,13 @@ const BorderLabel = ( props: LabelProps ) => {
 		return null;
 	}
 
+	// The visible label is rendered as `BaseControl.VisualLabel` so it carries
+	// the stable `.components-base-control__label` className consumers style
+	// against; `StyledLabel` is an emotion component with a generated one.
 	return hideLabelFromVision ? (
 		<VisuallyHidden as="label">{ label }</VisuallyHidden>
 	) : (
-		<StyledLabel>{ label }</StyledLabel>
+		<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 	);
 };
 
@@ -42,6 +46,8 @@ const UnconnectedBorderBoxControl = (
 		enableAlpha,
 		enableStyle,
 		hasMixedBorders,
+		hasVisibleLabel,
+		headerClassName,
 		hideLabelFromVision,
 		isLinked,
 		label,
@@ -80,12 +86,29 @@ const UnconnectedBorderBoxControl = (
 		);
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
+	const linkedButton = (
+		<BorderBoxControlLinkedButton
+			onClick={ toggleLinked }
+			isLinked={ isLinked }
+		/>
+	);
+	const borderLabel = (
+		<BorderLabel
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+		/>
+	);
+
 	return (
 		<View className={ className } { ...otherProps } ref={ mergedRef }>
-			<BorderLabel
-				label={ label }
-				hideLabelFromVision={ hideLabelFromVision }
-			/>
+			{ hasVisibleLabel ? (
+				<HStack className={ headerClassName }>
+					{ borderLabel }
+					{ linkedButton }
+				</HStack>
+			) : (
+				borderLabel
+			) }
 			<View className={ wrapperClassName }>
 				{ isLinked ? (
 					<BorderControl
@@ -123,10 +146,7 @@ const UnconnectedBorderBoxControl = (
 						}
 					/>
 				) }
-				<BorderBoxControlLinkedButton
-					onClick={ toggleLinked }
-					isLinked={ isLinked }
-				/>
+				{ ! hasVisibleLabel && linkedButton }
 			</View>
 		</View>
 	);

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -86,28 +86,28 @@ const UnconnectedBorderBoxControl = (
 		);
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );
-	const linkedButton = (
-		<BorderBoxControlLinkedButton
-			onClick={ toggleLinked }
-			isLinked={ isLinked }
-		/>
-	);
-	const borderLabel = (
-		<BorderLabel
-			label={ label }
-			hideLabelFromVision={ hideLabelFromVision }
-		/>
-	);
 
 	return (
 		<View className={ className } { ...otherProps } ref={ mergedRef }>
 			{ hasVisibleLabel ? (
+				// The toggle shares the label's row so that it lines up with
+				// the equivalent toggle on sibling controls, e.g. the border
+				// radius one.
 				<HStack className={ headerClassName }>
-					{ borderLabel }
-					{ linkedButton }
+					<BorderLabel
+						label={ label }
+						hideLabelFromVision={ hideLabelFromVision }
+					/>
+					<BorderBoxControlLinkedButton
+						onClick={ toggleLinked }
+						isLinked={ isLinked }
+					/>
 				</HStack>
 			) : (
-				borderLabel
+				<BorderLabel
+					label={ label }
+					hideLabelFromVision={ hideLabelFromVision }
+				/>
 			) }
 			<View className={ wrapperClassName }>
 				{ isLinked ? (
@@ -146,7 +146,14 @@ const UnconnectedBorderBoxControl = (
 						}
 					/>
 				) }
-				{ ! hasVisibleLabel && linkedButton }
+				{ /* With no label row to join, the toggle sits alongside the
+				     inputs instead. */ }
+				{ ! hasVisibleLabel && (
+					<BorderBoxControlLinkedButton
+						onClick={ toggleLinked }
+						isLinked={ isLinked }
+					/>
+				) }
 			</View>
 		</View>
 	);

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -17,8 +17,8 @@ import type {
 	BorderControlProps,
 } from '../../border-control/types';
 
-const BorderLabel = ( props: LabelProps ) => {
-	const { label, hideLabelFromVision } = props;
+const BorderLabel = ( props: LabelProps & { className?: string } ) => {
+	const { className, label, hideLabelFromVision } = props;
 
 	if ( ! label ) {
 		return null;
@@ -28,9 +28,13 @@ const BorderLabel = ( props: LabelProps ) => {
 	// the stable `.components-base-control__label` className consumers style
 	// against; `StyledLabel` is an emotion component with a generated one.
 	return hideLabelFromVision ? (
-		<VisuallyHidden as="label">{ label }</VisuallyHidden>
+		<VisuallyHidden as="label" className={ className }>
+			{ label }
+		</VisuallyHidden>
 	) : (
-		<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
+		<BaseControl.VisualLabel className={ className }>
+			{ label }
+		</BaseControl.VisualLabel>
 	);
 };
 
@@ -48,6 +52,7 @@ const UnconnectedBorderBoxControl = (
 		hasMixedBorders,
 		hasVisibleLabel,
 		headerClassName,
+		headerLabelClassName,
 		hideLabelFromVision,
 		isLinked,
 		label,
@@ -95,6 +100,7 @@ const UnconnectedBorderBoxControl = (
 				// radius one.
 				<HStack className={ headerClassName }>
 					<BorderLabel
+						className={ headerLabelClassName }
 						label={ label }
 						hideLabelFromVision={ hideLabelFromVision }
 					/>

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useState } from '@wordpress/element';
 import styles from '../style.module.scss';
 import {
@@ -23,6 +24,8 @@ export function useBorderBoxControl(
 		onChange,
 		enableAlpha = false,
 		enableStyle = true,
+		hideLabelFromVision,
+		label,
 		value,
 		__experimentalIsRenderedInSidebar = false,
 		// Deprecated props, no longer used.
@@ -30,6 +33,11 @@ export function useBorderBoxControl(
 		__next40pxDefaultSize: _next40pxDefaultSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderBoxControl' );
+
+	// A visible label gives the control a header row to place the linked/
+	// unlinked toggle in, alongside that label. Without one the toggle stays
+	// inside the input wrapper, positioned absolutely.
+	const hasVisibleLabel = !! label && ! hideLabelFromVision;
 
 	const mixedBorders = hasMixedBorders( value );
 	const splitBorders = hasSplitBorders( value );
@@ -99,13 +107,23 @@ export function useBorderBoxControl(
 		}
 	};
 
-	const linkedControlClassName = styles[ 'linked-border-control' ];
+	// The linked control reserves an inline-end gutter for the absolutely
+	// positioned toggle. Once the toggle moves up into the header row that
+	// gutter only shortens the input, so drop it.
+	const linkedControlClassName = clsx( styles[ 'linked-border-control' ], {
+		[ styles[ 'linked-border-control-full-width' ] ]: hasVisibleLabel,
+	} );
 	const wrapperClassName = styles.wrapper;
+	const headerClassName = styles.header;
 
 	return {
 		...otherProps,
 		className,
 		colors,
+		hasVisibleLabel,
+		headerClassName,
+		hideLabelFromVision,
+		label,
 		disableUnits: mixedBorders && ! hasWidthValue,
 		enableAlpha,
 		enableStyle,

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -115,7 +115,6 @@ export function useBorderBoxControl(
 	} );
 	const wrapperClassName = styles.wrapper;
 	const headerClassName = styles.header;
-	const headerLabelClassName = styles[ 'header-label' ];
 
 	return {
 		...otherProps,
@@ -123,7 +122,6 @@ export function useBorderBoxControl(
 		colors,
 		hasVisibleLabel,
 		headerClassName,
-		headerLabelClassName,
 		hideLabelFromVision,
 		label,
 		disableUnits: mixedBorders && ! hasWidthValue,

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -115,6 +115,7 @@ export function useBorderBoxControl(
 	} );
 	const wrapperClassName = styles.wrapper;
 	const headerClassName = styles.header;
+	const headerLabelClassName = styles[ 'header-label' ];
 
 	return {
 		...otherProps,
@@ -122,6 +123,7 @@ export function useBorderBoxControl(
 		colors,
 		hasVisibleLabel,
 		headerClassName,
+		headerLabelClassName,
 		hideLabelFromVision,
 		label,
 		disableUnits: mixedBorders && ! hasWidthValue,

--- a/packages/components/src/border-box-control/stories/index.story.tsx
+++ b/packages/components/src/border-box-control/stories/index.story.tsx
@@ -79,3 +79,13 @@ Default.args = {
 	label: 'Borders',
 	enableStyle: true,
 };
+
+/**
+ * With no visible label there is no label row for the linked/unlinked toggle to
+ * join, so it is rendered alongside the border inputs instead.
+ */
+export const WithoutLabel = Template.bind( {} );
+WithoutLabel.args = {
+	...Default.args,
+	label: undefined,
+};

--- a/packages/components/src/border-box-control/style.module.scss
+++ b/packages/components/src/border-box-control/style.module.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/variables" as *;
+
 .linked-border-control {
 	/* Preserve the original `&&` specificity so this beats BorderControl's margin reset. */
 	&#{&} {
@@ -6,14 +8,40 @@
 	}
 }
 
+/* No inline-end gutter is needed when the toggle sits in the header row. */
+.linked-border-control-full-width {
+	&#{&} {
+		margin-inline-end: 0;
+	}
+}
+
+/* The label row the linked/unlinked toggle joins when a visible label is
+   rendered. Metrics match `.components-border-radius-control__header` so the
+   two controls' toggles line up in the inspector. */
+.header {
+	height: $grid-unit-20;
+	margin-bottom: $grid-unit-15;
+
+	/* The label supplies its own bottom margin as the gap to the input below.
+	   In the header row that gap comes from the row itself, and the margin
+	   would knock the vertically centered label off center. */
+	:global(.components-base-control__label) {
+		margin-bottom: 0;
+	}
+}
+
 .wrapper {
 	position: relative;
+
+	/* Without a header row the toggle is positioned against the input instead. */
+	.linked-button {
+		position: absolute;
+		top: 8px;
+		inset-inline-end: 0;
+	}
 }
 
 .linked-button {
-	position: absolute;
-	top: 8px;
-	inset-inline-end: 0;
 	line-height: 0;
 }
 

--- a/packages/components/src/border-box-control/style.module.scss
+++ b/packages/components/src/border-box-control/style.module.scss
@@ -25,7 +25,7 @@
 	/* The label supplies its own bottom margin as the gap to the input below.
 	   In the header row that gap comes from the row itself, and the margin
 	   would knock the vertically centered label off center. */
-	:global(.components-base-control__label) {
+	.header-label {
 		margin-bottom: 0;
 	}
 }

--- a/packages/components/src/border-box-control/style.module.scss
+++ b/packages/components/src/border-box-control/style.module.scss
@@ -16,16 +16,18 @@
 }
 
 /* The label row the linked/unlinked toggle joins when a visible label is
-   rendered. Metrics match `.components-border-radius-control__header` so the
-   two controls' toggles line up in the inspector. */
+   rendered. Laid out as a content-driven grid like `BoxControl`'s label row, so
+   a label that wraps grows the row rather than overflowing a fixed height. */
 .header {
-	height: $grid-unit-20;
-	margin-bottom: $grid-unit-15;
+	/* The row is as tall as the toggle (24px, `Button` `size="small"`), so 4px
+	   here leaves the same 28px between label and inputs as the sibling
+	   controls, which instead pair a fixed 16px row with a 12px margin. */
+	margin-bottom: $grid-unit-05;
 
 	/* The label (a `BaseControl.VisualLabel`, so a `span`) supplies its own
 	   bottom margin as the gap to the input below. In the header row that gap
-	   comes from the row itself, and the margin would knock the vertically
-	   centered label off center. */
+	   comes from the row itself, and the margin would both pull the vertically
+	   centred label off centre and pad the row out once the label wraps. */
 	> span {
 		margin-bottom: 0;
 	}

--- a/packages/components/src/border-box-control/style.module.scss
+++ b/packages/components/src/border-box-control/style.module.scss
@@ -22,10 +22,11 @@
 	height: $grid-unit-20;
 	margin-bottom: $grid-unit-15;
 
-	/* The label supplies its own bottom margin as the gap to the input below.
-	   In the header row that gap comes from the row itself, and the margin
-	   would knock the vertically centered label off center. */
-	.header-label {
+	/* The label (a `BaseControl.VisualLabel`, so a `span`) supplies its own
+	   bottom margin as the gap to the input below. In the header row that gap
+	   comes from the row itself, and the margin would knock the vertically
+	   centered label off center. */
+	> span {
 		margin-bottom: 0;
 	}
 }

--- a/packages/components/src/border-box-control/test/index.jsdom.test.tsx
+++ b/packages/components/src/border-box-control/test/index.jsdom.test.tsx
@@ -76,27 +76,40 @@ describe( 'BorderBoxControl', () => {
 			expect( linkedButton ).toBeInTheDocument();
 		} );
 
-		it( 'should place the linked button in the label row when the label is visible', async () => {
-			const user = userEvent.setup();
+		// `getAllByRole` returns document order, so the sign of this offset is
+		// which side of the border inputs the linked button sits on. The color
+		// button is the first of those inputs.
+		const getLinkedButtonOffsetFromColorButton = () => {
+			const buttons = screen.getAllByRole( 'button' );
+			const linkedButtonIndex = buttons.indexOf(
+				screen.getByLabelText( 'Unlink sides' )
+			);
+			const colorButtonIndex = buttons.indexOf(
+				screen.getByLabelText( toggleLabelRegex )
+			);
+
+			// Both queries throw when absent, and `indexOf` gives -1 for a
+			// button outside the list, which would read as "earlier than".
+			expect( linkedButtonIndex ).toBeGreaterThanOrEqual( 0 );
+			expect( colorButtonIndex ).toBeGreaterThanOrEqual( 0 );
+
+			return linkedButtonIndex - colorButtonIndex;
+		};
+
+		it( 'should place the linked button before the border inputs when the label is visible', () => {
 			render( <TestBorderBoxControl { ...props } /> );
 
-			// The toggle shares the label's row — ahead of the border inputs
-			// rather than beside them — so it lines up with the equivalent
-			// toggle on sibling controls such as border radius. Tab order is
-			// how that placement is observable to a user.
-			await user.tab();
-
-			expect( screen.getByLabelText( 'Unlink sides' ) ).toHaveFocus();
+			// Sharing the label's row is what lines it up with the equivalent
+			// button on sibling controls such as border radius.
+			expect( getLinkedButtonOffsetFromColorButton() ).toBeLessThan( 0 );
 		} );
 
-		it( 'should place the linked button after the border inputs when the label is hidden', async () => {
-			const user = userEvent.setup();
+		it( 'should place the linked button after the border inputs when the label is hidden', () => {
 			render( <TestBorderBoxControl { ...props } hideLabelFromVision /> );
 
-			// With no label row to join, the toggle stays alongside the inputs.
-			await user.tab();
-
-			expect( screen.getByLabelText( toggleLabelRegex ) ).toHaveFocus();
+			expect( getLinkedButtonOffsetFromColorButton() ).toBeGreaterThan(
+				0
+			);
 		} );
 
 		it( 'should hide label', () => {

--- a/packages/components/src/border-box-control/test/index.jsdom.test.tsx
+++ b/packages/components/src/border-box-control/test/index.jsdom.test.tsx
@@ -76,6 +76,29 @@ describe( 'BorderBoxControl', () => {
 			expect( linkedButton ).toBeInTheDocument();
 		} );
 
+		it( 'should place the linked button in the label row when the label is visible', async () => {
+			const user = userEvent.setup();
+			render( <TestBorderBoxControl { ...props } /> );
+
+			// The toggle shares the label's row — ahead of the border inputs
+			// rather than beside them — so it lines up with the equivalent
+			// toggle on sibling controls such as border radius. Tab order is
+			// how that placement is observable to a user.
+			await user.tab();
+
+			expect( screen.getByLabelText( 'Unlink sides' ) ).toHaveFocus();
+		} );
+
+		it( 'should place the linked button after the border inputs when the label is hidden', async () => {
+			const user = userEvent.setup();
+			render( <TestBorderBoxControl { ...props } hideLabelFromVision /> );
+
+			// With no label row to join, the toggle stays alongside the inputs.
+			await user.tab();
+
+			expect( screen.getByLabelText( toggleLabelRegex ) ).toHaveFocus();
+		} );
+
 		it( 'should hide label', () => {
 			render( <TestBorderBoxControl { ...props } hideLabelFromVision /> );
 

--- a/test/integration/fixtures/blocks/core__avatar.json
+++ b/test/integration/fixtures/blocks/core__avatar.json
@@ -7,8 +7,8 @@
 			"size": 85,
 			"isLink": true,
 			"linkTarget": "_self",
-			"borderColor": "vivid-red",
 			"align": "right",
+			"borderColor": "vivid-red",
 			"style": {
 				"spacing": {
 					"margin": {

--- a/test/integration/fixtures/blocks/core__avatar.serialized.html
+++ b/test/integration/fixtures/blocks/core__avatar.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:avatar {"userId":4,"size":85,"isLink":true,"borderColor":"vivid-red","align":"right","style":{"spacing":{"margin":{"bottom":"40px"}},"border":{"radius":"47px","width":"3px"},"color":{"duotone":["#000000","#ffe2c7"]}}} /-->
+<!-- wp:avatar {"userId":4,"size":85,"isLink":true,"align":"right","borderColor":"vivid-red","style":{"spacing":{"margin":{"bottom":"40px"}},"border":{"radius":"47px","width":"3px"},"color":{"duotone":["#000000","#ffe2c7"]}}} /-->

--- a/test/integration/fixtures/blocks/core__comment-author-avatar.json
+++ b/test/integration/fixtures/blocks/core__comment-author-avatar.json
@@ -5,8 +5,8 @@
 		"attributes": {
 			"width": 120,
 			"height": 120,
-			"borderColor": "recommended-color-02",
 			"backgroundColor": "text-color",
+			"borderColor": "recommended-color-02",
 			"style": {
 				"border": {
 					"width": "3px",

--- a/test/integration/fixtures/blocks/core__comment-author-avatar.serialized.html
+++ b/test/integration/fixtures/blocks/core__comment-author-avatar.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:comment-author-avatar {"width":120,"height":120,"borderColor":"recommended-color-02","backgroundColor":"text-color","style":{"border":{"width":"3px","style":"solid","radius":"100px"}}} /-->
+<!-- wp:comment-author-avatar {"width":120,"height":120,"backgroundColor":"text-color","borderColor":"recommended-color-02","style":{"border":{"width":"3px","style":"solid","radius":"100px"}}} /-->

--- a/test/integration/fixtures/blocks/core__comments-title.json
+++ b/test/integration/fixtures/blocks/core__comments-title.json
@@ -6,10 +6,10 @@
 			"showPostTitle": true,
 			"showCommentsCount": true,
 			"level": 4,
-			"borderColor": "vivid-red",
 			"backgroundColor": "primary",
 			"textColor": "background",
 			"fontSize": "large",
+			"borderColor": "vivid-red",
 			"style": {
 				"spacing": {
 					"padding": {

--- a/test/integration/fixtures/blocks/core__comments-title.serialized.html
+++ b/test/integration/fixtures/blocks/core__comments-title.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:comments-title {"level":4,"borderColor":"vivid-red","backgroundColor":"primary","textColor":"background","fontSize":"large","style":{"spacing":{"padding":{"top":"6px","right":"6px","bottom":"6px","left":"6px"}},"border":{"width":"3px","radius":"100px"}}} /-->
+<!-- wp:comments-title {"level":4,"backgroundColor":"primary","textColor":"background","fontSize":"large","borderColor":"vivid-red","style":{"spacing":{"padding":{"top":"6px","right":"6px","bottom":"6px","left":"6px"}},"border":{"width":"3px","radius":"100px"}}} /-->


### PR DESCRIPTION
## What?

Fixes: https://github.com/WordPress/gutenberg/issues/73596

Based on an idea from @jasmussen in https://github.com/WordPress/gutenberg/issues/73596#issuecomment-5421401623.

* Rename the Border panel to Borders and remove the conditional for shadows so that the panel is always called "Borders".
* Move the unlink button for the BorderBoxControl up so that it's on the same line as the label, making it consistent with the other controls in the sidebar.
* Always show the Border and Shadow labels for those controls.

## Why?

This is an effort to create more consistency for the unlink button in the sidebar, and it's also an attempt to simplify things a little. I'm not sure how successful I've been on the "simplify" front, but this PR is to try out the idea we discussed in #73596.

Does this feel simpler and more consistent? Or does it read weirdly seeing "Borders" as a panel and having the extra labels?

I _think_ I like this change, but I'm not at all wedded to it, happy to close it out or iterate on it if we have better ideas.

## How?

* Rename and simplify the logic for the Border panel heading label (i.e. remove `useBorderPanelLabel`) and call it "Borders"
* Always render the Shadow and `BorderBoxControl` labels
* Move the unlink button up when the border box control label is in use, so that it sits on the same row as the label
* Because we removed `useBorderPanelLabel` and the order in which things are imported for the border hook, I also needed to update some block fixtures. These fixtures have the same block attributes, just serialized in a different order — the change won't break any blocks out in the wild, so this regeneration of fixtures should be safe.

## Testing Instructions

* Open up the block editor and add a Group block
* Have a play with the Borders panel and the controls within, unlink sides, etc
* Similarly do the same with the Group block in global styles
* To test how the controls look when all the Border controls have been disabled (so Shadow is the only one available), you can add the following to your theme.json for the Group block (under `settings`):

```
		"blocks": {
			"core/group": {
				"border": {
					"color": false,
					"radius": false,
					"style": false,
					"width": false
				}
			},
```
## Screenshots or screencast <!-- if applicable -->

### Before

| Collapsed | Expanded |
| --- | --- |
| <img width="568" height="450" alt="image" src="https://github.com/user-attachments/assets/67efe0e3-9f7d-4c78-b06a-461794ae6626" /> | <img width="560" height="658" alt="image" src="https://github.com/user-attachments/assets/85f0a8b4-2d65-458d-a471-347844bc3cc7" /> |

### After

| Collapsed | Expanded |
| --- | --- |
| <img width="566" height="466" alt="image" src="https://github.com/user-attachments/assets/46f765bb-42aa-47dc-8fc4-081163d24826" /> | <img width="562" height="670" alt="image" src="https://github.com/user-attachments/assets/5b120217-4a1d-498c-a7ed-9bd0990ed2bb" /> |

### When shadow is the only control available:

#### Before

<img width="1134" height="356" alt="image" src="https://github.com/user-attachments/assets/94db34a5-a6ce-43fd-a49e-c004ca8ac1bd" />

#### After

<img width="1128" height="342" alt="image" src="https://github.com/user-attachments/assets/9158568a-c4a9-405a-a498-0e5a51dda685" />

## Use of AI Tools

Claude Code (Opus 5)