### PR TITLE
RichText: Remove empty link formats during parse and edit.

### DIFF
--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Remove empty link formats during RichText parsing and editing so invalid anchors are cleaned up automatically ([#81936](https://github.com/WordPress/gutenberg/issues/81936)).
+-   Remove empty link formats during RichText parsing and editing so invalid anchors are cleaned up automatically ([#82174](https://github.com/WordPress/gutenberg/pull/82174)).
 
 ## 7.54.0 (2026-08-26)
 

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Remove empty link formats during RichText parsing and editing so invalid anchors are cleaned up automatically ([#81936](https://github.com/WordPress/gutenberg/issues/81936)).
+
 ## 7.54.0 (2026-08-26)
 
 ## 7.53.0 (2026-08-12)

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -5,6 +5,10 @@ import { mergePair } from './concat';
 import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from './special-characters';
 import { toHTMLString } from './to-html-string';
 import { getTextContent } from './get-text-content';
+import {
+	isLinkFormat,
+	removeEmptyLinkFormats,
+} from './remove-empty-link-formats';
 
 /** @typedef {import('./types').RichTextValue} RichTextValue */
 
@@ -245,11 +249,11 @@ export function create( {
 	__unstableIsEditableTree: isEditableTree,
 } = {} ) {
 	if ( html instanceof RichTextData ) {
-		return {
+		return removeEmptyLinkFormats( {
 			text: html.text,
 			formats: html.formats,
 			replacements: html.replacements,
-		};
+		} );
 	}
 
 	if ( typeof text === 'string' && text.length > 0 ) {
@@ -270,11 +274,13 @@ export function create( {
 		return createEmptyValue();
 	}
 
-	return createFromElement( {
-		element,
-		range,
-		isEditableTree,
-	} );
+	return removeEmptyLinkFormats(
+		createFromElement( {
+			element,
+			range,
+			isEditableTree,
+		} )
+	);
 }
 
 /**
@@ -622,7 +628,7 @@ function createFromElement( { element, range, isEditableTree } ) {
 		) {
 			mergePair( accumulator, value );
 		} else if ( value.text.length === 0 ) {
-			if ( format.attributes ) {
+			if ( format.attributes && ! isLinkFormat( format ) ) {
 				mergePair( accumulator, {
 					formats: [ , ],
 					replacements: [ format ],

--- a/packages/rich-text/src/hook/index.js
+++ b/packages/rich-text/src/hook/index.js
@@ -6,6 +6,7 @@ import { create, RichTextData } from '../create';
 import { apply } from '../to-dom';
 import { toHTMLString } from '../to-html-string';
 import { removeFormat } from '../remove-format';
+import { removeEmptyLinkFormats } from '../remove-empty-link-formats';
 import { ownsSelection } from '../owns-selection';
 import { useDefaultStyle } from './use-default-style';
 import { useBoundaryStyle } from './use-boundary-style';
@@ -114,6 +115,7 @@ function useRichTextBase( {
 	 * @param {Object} newRecord The record to sync and apply.
 	 */
 	function handleChange( newRecord ) {
+		newRecord = removeEmptyLinkFormats( newRecord );
 		recordRef.current = newRecord;
 		applyRecord( newRecord );
 

--- a/packages/rich-text/src/remove-empty-link-formats.js
+++ b/packages/rich-text/src/remove-empty-link-formats.js
@@ -19,6 +19,22 @@ export function isLinkFormat( format ) {
 }
 
 /**
+ * @param {Object|null|undefined} replacement A rich text replacement.
+ * @return {boolean} Whether the replacement is an empty link.
+ */
+export function isEmptyLinkReplacement( replacement ) {
+	if ( ! isLinkFormat( replacement ) ) {
+		return false;
+	}
+
+	if ( replacement.innerHTML ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * @param {RichTextValue} value Value to inspect.
  * @return {boolean} Whether the value contains an empty link replacement.
  */
@@ -28,7 +44,7 @@ function hasEmptyLinkReplacement( value ) {
 	for ( let index = 0; index < text.length; index++ ) {
 		if (
 			text[ index ] === OBJECT_REPLACEMENT_CHARACTER &&
-			isLinkFormat( replacements[ index ] )
+			isEmptyLinkReplacement( replacements[ index ] )
 		) {
 			return true;
 		}
@@ -61,7 +77,7 @@ export function removeEmptyLinkFormats( value ) {
 
 		if (
 			character === OBJECT_REPLACEMENT_CHARACTER &&
-			isLinkFormat( replacement )
+			isEmptyLinkReplacement( replacement )
 		) {
 			if ( start !== undefined ) {
 				if ( index < start ) {

--- a/packages/rich-text/src/remove-empty-link-formats.js
+++ b/packages/rich-text/src/remove-empty-link-formats.js
@@ -1,0 +1,105 @@
+import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
+
+/** @typedef {import('./types').RichTextValue} RichTextValue */
+
+/**
+ * @param {Object|null|undefined} format A rich text format or replacement.
+ * @return {boolean} Whether the format represents a link.
+ */
+export function isLinkFormat( format ) {
+	if ( ! format ) {
+		return false;
+	}
+
+	return (
+		format.type === 'core/link' ||
+		format.type === 'a' ||
+		format.tagName === 'a'
+	);
+}
+
+/**
+ * @param {RichTextValue} value Value to inspect.
+ * @return {boolean} Whether the value contains an empty link replacement.
+ */
+function hasEmptyLinkReplacement( value ) {
+	const { text, replacements } = value;
+
+	for ( let index = 0; index < text.length; index++ ) {
+		if (
+			text[ index ] === OBJECT_REPLACEMENT_CHARACTER &&
+			isLinkFormat( replacements[ index ] )
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Remove empty link object replacements from a rich text value.
+ *
+ * @param {RichTextValue} value Value to clean up.
+ * @return {RichTextValue} A new value with empty links removed.
+ */
+export function removeEmptyLinkFormats( value ) {
+	if ( ! value?.text || ! hasEmptyLinkReplacement( value ) ) {
+		return value;
+	}
+
+	const { text, formats, replacements, start, end } = value;
+	let removedBeforeStart = 0;
+	let removedBeforeEnd = 0;
+	const newText = [];
+	const newFormats = [];
+	const newReplacements = [];
+
+	for ( let index = 0; index < text.length; index++ ) {
+		const character = text[ index ];
+		const replacement = replacements[ index ];
+
+		if (
+			character === OBJECT_REPLACEMENT_CHARACTER &&
+			isLinkFormat( replacement )
+		) {
+			if ( start !== undefined ) {
+				if ( index < start ) {
+					removedBeforeStart++;
+				}
+				if ( index < end ) {
+					removedBeforeEnd++;
+				}
+			}
+			continue;
+		}
+
+		newText.push( character );
+
+		const formatIndex = newFormats.length;
+		const format = formats[ index ];
+		const nextReplacement = replacements[ index ];
+
+		if ( format ) {
+			newFormats[ formatIndex ] = format;
+		}
+
+		if ( nextReplacement ) {
+			newReplacements[ formatIndex ] = nextReplacement;
+		}
+	}
+
+	const nextValue = {
+		...value,
+		text: newText.join( '' ),
+		formats: newFormats,
+		replacements: newReplacements,
+	};
+
+	if ( start !== undefined ) {
+		nextValue.start = start - removedBeforeStart;
+		nextValue.end = end - removedBeforeEnd;
+	}
+
+	return nextValue;
+}

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -119,6 +119,13 @@ exports[`recordToDom should create an empty value from empty tags 1`] = `
 </body>
 `;
 
+exports[`recordToDom should create an empty value from empty anchor tags 1`] = `
+<body>
+  
+  ﻿
+</body>
+`;
+
 exports[`recordToDom should disarm on* attribute 1`] = `
 <body>
   

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -112,6 +112,25 @@ export const spec = [
 		},
 	},
 	{
+		description: 'should create an empty value from empty anchor tags',
+		html: '<a href="https://google.com"></a>',
+		createRange: ( element ) => ( {
+			startOffset: 0,
+			startContainer: element,
+			endOffset: 1,
+			endContainer: element,
+		} ),
+		startPath: [ 0, 0 ],
+		endPath: [ 0, 0 ],
+		record: {
+			start: 0,
+			end: 0,
+			formats: [],
+			replacements: [],
+			text: '',
+		},
+	},
+	{
 		description: 'should create a value without formatting',
 		html: 'test',
 		createRange: ( element ) => ( {

--- a/packages/rich-text/src/test/remove-empty-link-formats.js
+++ b/packages/rich-text/src/test/remove-empty-link-formats.js
@@ -1,6 +1,7 @@
 import { create } from '../create';
 import { toHTMLString } from '../to-html-string';
 import {
+	isEmptyLinkReplacement,
 	isLinkFormat,
 	removeEmptyLinkFormats,
 } from '../remove-empty-link-formats';
@@ -55,6 +56,22 @@ describe( 'removeEmptyLinkFormats', () => {
 		expect( removeEmptyLinkFormats( value ) ).toEqual( value );
 	} );
 
+	it( 'preserves non-editable link replacements with inner HTML', () => {
+		const value = {
+			text: OBJECT_REPLACEMENT_CHARACTER,
+			formats: [ , ],
+			replacements: [
+				{
+					type: 'my-plugin/non-editable',
+					tagName: 'a',
+					innerHTML: 'a',
+				},
+			],
+		};
+
+		expect( removeEmptyLinkFormats( value ) ).toEqual( value );
+	} );
+
 	it( 'adjusts selection after removing empty links', () => {
 		const value = {
 			text: `a${ OBJECT_REPLACEMENT_CHARACTER }b`,
@@ -76,6 +93,24 @@ describe( 'removeEmptyLinkFormats', () => {
 			start: 1,
 			end: 1,
 		} );
+	} );
+} );
+
+describe( 'isEmptyLinkReplacement', () => {
+	it( 'detects empty link replacements', () => {
+		expect(
+			isEmptyLinkReplacement( {
+				type: 'core/link',
+				attributes: { url: 'https://example.com' },
+			} )
+		).toBe( true );
+		expect(
+			isEmptyLinkReplacement( {
+				type: 'my-plugin/non-editable',
+				tagName: 'a',
+				innerHTML: 'a',
+			} )
+		).toBe( false );
 	} );
 } );
 

--- a/packages/rich-text/src/test/remove-empty-link-formats.js
+++ b/packages/rich-text/src/test/remove-empty-link-formats.js
@@ -1,0 +1,126 @@
+import { create } from '../create';
+import { toHTMLString } from '../to-html-string';
+import {
+	isLinkFormat,
+	removeEmptyLinkFormats,
+} from '../remove-empty-link-formats';
+import { OBJECT_REPLACEMENT_CHARACTER } from '../special-characters';
+
+describe( 'removeEmptyLinkFormats', () => {
+	beforeAll( () => {
+		require( '../store' );
+	} );
+	it( 'removes empty link object replacements', () => {
+		const value = {
+			text: `hello${ OBJECT_REPLACEMENT_CHARACTER }world`,
+			formats: [ , , , , , , , , , , , ],
+			replacements: [
+				,
+				,
+				,
+				,
+				,
+				{
+					type: 'core/link',
+					attributes: { url: 'https://google.com' },
+				},
+				,
+				,
+				,
+				,
+				,
+				,
+			],
+		};
+
+		expect( removeEmptyLinkFormats( value ) ).toEqual( {
+			text: 'helloworld',
+			formats: [ , , , , , , , , , ],
+			replacements: [ , , , , , , , , , ],
+		} );
+	} );
+
+	it( 'preserves non-link object replacements', () => {
+		const value = {
+			text: OBJECT_REPLACEMENT_CHARACTER,
+			formats: [ , ],
+			replacements: [
+				{
+					type: 'img',
+					attributes: { src: 'test.jpg' },
+				},
+			],
+		};
+
+		expect( removeEmptyLinkFormats( value ) ).toEqual( value );
+	} );
+
+	it( 'adjusts selection after removing empty links', () => {
+		const value = {
+			text: `a${ OBJECT_REPLACEMENT_CHARACTER }b`,
+			formats: [ , , , ],
+			replacements: [
+				,
+				{ type: 'a', attributes: { href: 'https://example.com' } },
+				,
+				,
+			],
+			start: 2,
+			end: 2,
+		};
+
+		expect( removeEmptyLinkFormats( value ) ).toEqual( {
+			text: 'ab',
+			formats: [ , , ],
+			replacements: [ , , ],
+			start: 1,
+			end: 1,
+		} );
+	} );
+} );
+
+describe( 'isLinkFormat', () => {
+	it( 'detects registered and bare link formats', () => {
+		expect(
+			isLinkFormat( {
+				type: 'core/link',
+				attributes: { url: 'https://example.com' },
+			} )
+		).toBe( true );
+		expect(
+			isLinkFormat( {
+				type: 'a',
+				attributes: { href: 'https://example.com' },
+			} )
+		).toBe( true );
+		expect( isLinkFormat( { type: 'strong' } ) ).toBe( false );
+	} );
+} );
+
+describe( 'create empty link cleanup', () => {
+	it( 'drops empty anchor tags when parsing HTML', () => {
+		const record = create( {
+			html: '<p>Hello<a href="https://google.com"></a> world</p>',
+		} );
+
+		expect( record.text ).toBe( 'Hello world' );
+		expect(
+			record.replacements.every( ( replacement ) => ! replacement )
+		).toBe( true );
+	} );
+
+	it( 'serializes parsed content without empty anchors', () => {
+		const record = create( {
+			html: '<h2>Heading<a href="https://google.com"></a></h2>',
+		} );
+
+		expect( toHTMLString( { value: record } ) ).toBe( '<h2>Heading</h2>' );
+	} );
+
+	it( 'preserves links that contain inline images', () => {
+		const html = '<a href="#"><img src="test.jpg"></a>';
+		const record = create( { html } );
+
+		expect( toHTMLString( { value: record } ) ).toBe( html );
+	} );
+} );


### PR DESCRIPTION
Fixes #81936

## What?

Automatically removes empty link formats from rich text content during parsing and editing, instead of preserving invisible zero-width anchors in the block editor.

## Why?

Empty `<a href="..."></a>` elements were stored as object replacements and serialized back to HTML, creating inaccessible links that users could not see or edit in visual mode. Maintainers agreed on auto-cleanup rather than visual highlighting.

## How?

- Skip promoting empty anchor tags to object replacements in `createFromElement()`.
- Add `removeEmptyLinkFormats()` to strip any remaining empty link object replacements.
- Run cleanup when parsing HTML and before serializing edited values in the RichText hook.
- Add unit tests and a create spec for empty anchor tags.

## Testing Instructions

1. Paste the HTML repro from #81936 into a Paragraph or Heading block in the code editor.
2. Switch to visual editor, empty links should not be present.
3. Inspect serialized content, no `<a href="..."></a>` without text.
4. Confirm links with inline images still work.

Unit tests:
`npm run test:unit -- packages/rich-text/src/test/remove-empty-link-formats.js`