### PR TITLE
DataForm: treat combined form fields purely as layout containers

### DIFF
--- a/backport-changelog/7.2/13308.md
+++ b/backport-changelog/7.2/13308.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13308
+
+* https://github.com/WordPress/gutenberg/pull/82175

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -71,6 +71,10 @@ function _gutenberg_get_default_posttype_form() {
 			array(
 				'id'       => 'status',
 				'label'    => __( 'Status', 'gutenberg' ),
+				'layout'   => array(
+					'type'    => 'panel',
+					'summary' => 'status',
+				),
 				'children' => array(
 					array(
 						'id'     => 'status',
@@ -91,6 +95,10 @@ function _gutenberg_get_default_posttype_form() {
 			array(
 				'id'       => 'discussion',
 				'label'    => __( 'Discussion', 'gutenberg' ),
+				'layout'   => array(
+					'type'    => 'panel',
+					'summary' => 'discussion',
+				),
 				'children' => array(
 					array(
 						'id'     => 'comment_status',

--- a/lib/compat/wordpress-7.1/view-config-api.php
+++ b/lib/compat/wordpress-7.1/view-config-api.php
@@ -71,10 +71,6 @@ function _gutenberg_get_default_posttype_form() {
 			array(
 				'id'       => 'status',
 				'label'    => __( 'Status', 'gutenberg' ),
-				'layout'   => array(
-					'type'    => 'panel',
-					'summary' => 'status',
-				),
 				'children' => array(
 					array(
 						'id'     => 'status',
@@ -95,10 +91,6 @@ function _gutenberg_get_default_posttype_form() {
 			array(
 				'id'       => 'discussion',
 				'label'    => __( 'Discussion', 'gutenberg' ),
-				'layout'   => array(
-					'type'    => 'panel',
-					'summary' => 'discussion',
-				),
 				'children' => array(
 					array(
 						'id'     => 'comment_status',

--- a/lib/compat/wordpress-7.2/view-config-api.php
+++ b/lib/compat/wordpress-7.2/view-config-api.php
@@ -105,6 +105,78 @@ function _gutenberg_get_entity_view_config_posttype_wp_navigation( $data ) {
 }
 
 /**
+ * Post types whose base definition provides its own `form`, without the
+ * `status` and `discussion` groups of the default post type form.
+ *
+ * @var string[]
+ */
+const GUTENBERG_VIEW_CONFIG_POST_TYPES_WITH_OWN_FORM = array( 'wp_block', 'wp_template', 'wp_template_part' );
+
+/**
+ * Makes the panel summary of the `status` and `discussion` groups explicit in
+ * the default post type form.
+ *
+ * Both groups used to be summarized by the field sharing their id (`status`,
+ * and the composite `discussion` field). A combined form field no longer
+ * resolves its own id against the field definitions, so the summary field is
+ * declared through `layout.summary` instead. The patch merges into the existing
+ * group members by id, leaving the rest of the form untouched.
+ *
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
+ */
+function _gutenberg_add_group_summaries_to_default_posttype_form( $data ) {
+	return $data->merge(
+		array(
+			'form' => array(
+				'fields' => array(
+					array(
+						'id'     => 'status',
+						'layout' => array(
+							'type'    => 'panel',
+							'summary' => 'status',
+						),
+					),
+					array(
+						'id'     => 'discussion',
+						'layout' => array(
+							'type'    => 'panel',
+							'summary' => 'discussion',
+						),
+					),
+				),
+			),
+		),
+		1
+	);
+}
+
+/**
+ * Layers the group summaries on top of the view configuration of every post
+ * type that uses the default form, including custom post types registered at
+ * any point.
+ *
+ * The callback merges by member id, and a member that is absent would be
+ * appended instead, so post types whose base definition provides its own form
+ * are skipped.
+ *
+ * @param string $post_type The post type being registered.
+ */
+function gutenberg_register_default_posttype_form_summaries_7_2( $post_type ) {
+	if ( in_array( $post_type, GUTENBERG_VIEW_CONFIG_POST_TYPES_WITH_OWN_FORM, true ) ) {
+		return;
+	}
+
+	add_filter(
+		gutenberg_get_entity_view_config_hook_name( 'postType', $post_type ),
+		'_gutenberg_add_group_summaries_to_default_posttype_form',
+		6,
+		1
+	);
+}
+add_action( 'registered_post_type', 'gutenberg_register_default_posttype_form_summaries_7_2' );
+
+/**
  * Registers the entity view configuration filters that layer on top of the base
  * definitions, at a priority between those (5) and third-party callbacks (10),
  * and the base definitions for entities that gained one in 7.2, at the base

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,31 @@
 
 ### Breaking Changes
 
--   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions: a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout no longer uses it for the collapsed summary or `readOnly` state, falling back to the group's first leaf child instead. Use `layout.summary` to pick the summary field explicitly ([#82175](https://github.com/WordPress/gutenberg/pull/82175)).
+-   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions: a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout no longer uses it for the collapsed summary or `readOnly` state, falling back to the group's first leaf child instead ([#82175](https://github.com/WordPress/gutenberg/pull/82175)).
+
+    If a combined field relied on sharing its `id` with a field to pick the panel summary, declare it through `layout.summary` instead:
+
+    ```js
+    // Before: the summary came from the `status` field because the group shares its id.
+    const form = {
+    	layout: { type: 'panel' },
+    	fields: [ { id: 'status', children: [ 'status', 'password' ] } ],
+    };
+
+    // After: the summary field is explicit.
+    const form = {
+    	layout: { type: 'panel' },
+    	fields: [
+    		{
+    			id: 'status',
+    			layout: { type: 'panel', summary: 'status' },
+    			children: [ 'status', 'password' ],
+    		},
+    	],
+    };
+    ```
+
+    If a combined field relied on a same-id field's `isValid` rules being applied to the group, move those rules to the child fields.
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Bug Fixes
+### Breaking Changes
 
--   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions, so a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout summarizes the group with its first leaf child instead. ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER))
+-   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions: a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout no longer uses it for the collapsed summary or `readOnly` state, falling back to the group's first leaf child instead. Use `layout.summary` to pick the summary field explicitly ([#82175](https://github.com/WordPress/gutenberg/pull/82175)).
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,23 +6,26 @@
 
 -   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions: a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout no longer uses it for the collapsed summary or `readOnly` state, falling back to the group's first leaf child instead ([#82175](https://github.com/WordPress/gutenberg/pull/82175)).
 
-    If a combined field relied on sharing its `id` with a field to pick the panel summary, declare it through `layout.summary` instead:
+    If a combined field relied on sharing its `id` with a field to pick the panel summary, declare it through `layout.summary` instead. For example, a `discussion` field whose `render` summarizes `comment_status` and `ping_status` together:
 
     ```js
-    // Before: the summary came from the `status` field because the group shares its id.
+    // Before: the summary came from the `discussion` field because the group shares its id.
     const form = {
     	layout: { type: 'panel' },
-    	fields: [ { id: 'status', children: [ 'status', 'password' ] } ],
+    	fields: [
+    		{ id: 'discussion', children: [ 'comment_status', 'ping_status' ] },
+    	],
     };
 
-    // After: the summary field is explicit.
+    // After: the summary field is explicit. Without it, the group would
+    // now be summarized by its first child, `comment_status`.
     const form = {
     	layout: { type: 'panel' },
     	fields: [
     		{
-    			id: 'status',
-    			layout: { type: 'panel', summary: 'status' },
-    			children: [ 'status', 'password' ],
+    			id: 'discussion',
+    			layout: { type: 'panel', summary: 'discussion' },
+    			children: [ 'comment_status', 'ping_status' ],
     		},
     	],
     };

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions, so a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout summarizes the group with its first leaf child instead. ([#PR_NUMBER](https://github.com/WordPress/gutenberg/pull/PR_NUMBER))
+
 ### Internal
 
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/dataviews/src/components/dataform-layouts/panel/utils/use-field-from-form-field.ts
+++ b/packages/dataviews/src/components/dataform-layouts/panel/utils/use-field-from-form-field.ts
@@ -11,27 +11,25 @@ const getFieldDefinition = < Item >(
 	field: NormalizedFormField,
 	fields: NormalizedField< Item >[]
 ) => {
-	const fieldDefinition = fields.find( ( _field ) => _field.id === field.id );
+	// A combined form field is a layout container, not a field: its id is
+	// never resolved against the field definitions. Fall back to its first
+	// leaf child so the panel has a definition for the summary and
+	// `readOnly` state.
+	if ( !! field.children ) {
+		const simpleChildren = field.children.filter(
+			( child ) => ! child.children
+		);
 
-	if ( ! fieldDefinition ) {
-		return fields.find( ( _field ) => {
-			if ( !! field.children ) {
-				const simpleChildren = field.children.filter(
-					( child ) => ! child.children
-				);
+		if ( simpleChildren.length === 0 ) {
+			return undefined;
+		}
 
-				if ( simpleChildren.length === 0 ) {
-					return false;
-				}
-
-				return _field.id === simpleChildren[ 0 ].id;
-			}
-
-			return _field.id === field.id;
-		} );
+		return fields.find(
+			( _field ) => _field.id === simpleChildren[ 0 ].id
+		);
 	}
 
-	return fieldDefinition;
+	return fields.find( ( _field ) => _field.id === field.id );
 };
 
 /**
@@ -39,8 +37,8 @@ const getFieldDefinition = < Item >(
  *
  * Summary fields are determined with the following priority:
  * 1. Use layout.summary fields if they exist
- * 2. Fall back to the field definition that matches the form field's id
- * 3. If the form field id doesn't exist, pick the first child field
+ * 2. For a leaf form field, fall back to its field definition
+ * 3. For a combined form field, fall back to its first leaf child
  * 4. If no field definition is found, return empty summary fields
  *
  * @param field The form field to get definition for

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -355,6 +355,12 @@ const LayoutPanelComponent = ( {
 					id: 'status',
 					label: 'Status & visibility',
 					children: [ 'status', 'password' ],
+					layout: getPanelLayoutFromStoryArgs( {
+						summary: [ 'status' ],
+						labelPosition,
+						openAs,
+						editVisibility,
+					} ),
 				},
 				'order',
 				'author',
@@ -370,6 +376,12 @@ const LayoutPanelComponent = ( {
 					id: 'address1',
 					label: 'Combined address',
 					children: [ 'address1', 'address2', 'city' ],
+					layout: getPanelLayoutFromStoryArgs( {
+						summary: [ 'address1' ],
+						labelPosition,
+						openAs,
+						editVisibility,
+					} ),
 				},
 				{
 					id: 'flight_info',

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -371,6 +371,12 @@ const LayoutPanelComponent = ( {
 					id: 'discussion',
 					label: 'Discussion',
 					children: [ 'comment_status', 'ping_status' ],
+					layout: getPanelLayoutFromStoryArgs( {
+						summary: [ 'discussion' ],
+						labelPosition,
+						openAs,
+						editVisibility,
+					} ),
 				},
 				{
 					id: 'address1',

--- a/packages/dataviews/src/hooks/test/use-form-validity.jsdom.test.ts
+++ b/packages/dataviews/src/hooks/test/use-form-validity.jsdom.test.ts
@@ -322,6 +322,44 @@ describe( 'useFormValidity', () => {
 			expect( isValid ).toBe( false );
 		} );
 
+		// See https://github.com/WordPress/gutenberg/pull/81377#discussion_r3750984349
+		it( 'a combined field never resolves its own id against the field definitions', () => {
+			type Item = { isActive: boolean; a?: string };
+			const combinedFields: Field< Item >[] = [
+				// Shares the id of the form's combined field. It must be
+				// ignored: a combined field is a container, not a field, so
+				// neither its `isValid` nor its `isVisible` apply to the group.
+				{
+					id: 'group',
+					type: 'text',
+					isVisible: () => false,
+					isValid: { required: true },
+				},
+				{
+					id: 'a',
+					type: 'text',
+					isVisible: () => false,
+					isValid: { required: true },
+				},
+			];
+			const combinedForm = {
+				fields: [ { id: 'group', children: [ 'a' ] } ],
+			};
+			const item: Item = { isActive: false, a: undefined };
+			const {
+				result: {
+					current: { validity, isValid },
+				},
+			} = renderHook( () =>
+				useFormValidity( item, combinedFields, combinedForm )
+			);
+
+			// The hidden child `a` is skipped and the `group` definition's
+			// `required` rule is not applied to the combined field.
+			expect( validity ).toEqual( undefined );
+			expect( isValid ).toBe( true );
+		} );
+
 		it( 'a stale async result does not resurface after the field is hidden', async () => {
 			let resolveCustom: ( value: string | null ) => void = () => {};
 			const asyncFields: Field< TestItem >[] = [

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -73,19 +73,10 @@ function getFormFieldsToValidate< Item >(
 				return null;
 			}
 
-			const fieldDef = fieldsMap.get( formField.id );
-			if ( fieldDef ) {
-				const [ normalizedField ] = normalizeFields< Item >( [
-					fieldDef,
-				] );
-
-				return {
-					id: formField.id,
-					children: processedChildren,
-					field: normalizedField,
-				} satisfies FormFieldToValidate< Item >;
-			}
-
+			// A combined form field is a layout container, not a field:
+			// its id is never resolved against the field definitions, so
+			// no validation rules are attached to it. Only its children
+			// are validated.
 			return {
 				id: formField.id,
 				children: processedChildren,

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -72,6 +72,96 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Returns the form field with the given id from a view configuration.
+	 *
+	 * @param array  $config The view configuration.
+	 * @param string $id     The form field id.
+	 * @return array|null The form field, or null when absent.
+	 */
+	private function get_form_field( $config, $id ) {
+		foreach ( $config['form']['fields'] as $field ) {
+			if ( is_array( $field ) && isset( $field['id'] ) && $id === $field['id'] ) {
+				return $field;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The `status` and `discussion` groups of the default post type form declare
+	 * their panel summary explicitly, for built-in and custom post types alike.
+	 *
+	 * @dataProvider data_default_form_post_types
+	 *
+	 * @param string $post_type The post type.
+	 */
+	public function test_default_form_groups_declare_summary( $post_type ) {
+		if ( ! post_type_exists( $post_type ) ) {
+			register_post_type( $post_type );
+		}
+
+		$config = gutenberg_get_entity_view_config( 'postType', $post_type );
+
+		foreach ( array( 'status', 'discussion' ) as $group ) {
+			$field = $this->get_form_field( $config, $group );
+			$this->assertNotNull( $field, "The `{$group}` group is present." );
+			$this->assertNotEmpty( $field['children'], "The `{$group}` group keeps its children." );
+			$this->assertSame(
+				array(
+					'type'    => 'panel',
+					'summary' => $group,
+				),
+				$field['layout'],
+				"The `{$group}` group summary is explicit."
+			);
+		}
+
+		if ( 'page' !== $post_type && 'post' !== $post_type ) {
+			unregister_post_type( $post_type );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_default_form_post_types() {
+		return array(
+			'page'             => array( 'page' ),
+			'post'             => array( 'post' ),
+			'custom post type' => array( 'summaries_cpt' ),
+		);
+	}
+
+	/**
+	 * Post types with their own form do not receive the default form groups.
+	 *
+	 * @dataProvider data_post_types_with_own_form
+	 *
+	 * @param string $post_type The post type.
+	 */
+	public function test_own_form_post_types_do_not_get_default_groups( $post_type ) {
+		$config = gutenberg_get_entity_view_config( 'postType', $post_type );
+
+		$this->assertNull( $this->get_form_field( $config, 'status' ) );
+		$this->assertNull( $this->get_form_field( $config, 'discussion' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_post_types_with_own_form() {
+		return array(
+			'wp_block'         => array( 'wp_block' ),
+			'wp_template'      => array( 'wp_template' ),
+			'wp_template_part' => array( 'wp_template_part' ),
+		);
+	}
+
+	/**
 	 * The default configuration exposes the documented shape for an unknown entity.
 	 */
 	public function test_default_config_for_unknown_entity() {

--- a/routes/post-list/quick-edit-modal.tsx
+++ b/routes/post-list/quick-edit-modal.tsx
@@ -154,6 +154,10 @@ export function QuickEditModal( {
 			{
 				id: 'status',
 				label: __( 'Status' ),
+				layout: {
+					type: 'panel',
+					summary: 'status',
+				},
 				children: [
 					{
 						id: 'status',

--- a/routes/post-list/quick-edit-modal.tsx
+++ b/routes/post-list/quick-edit-modal.tsx
@@ -174,6 +174,10 @@ export function QuickEditModal( {
 			{
 				id: 'discussion',
 				label: __( 'Discussion' ),
+				layout: {
+					type: 'panel',
+					summary: 'discussion',
+				},
 				children: [
 					{
 						id: 'comment_status',

--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -69,6 +69,13 @@ test.describe( 'Page List', () => {
 					const TEST_IMAGE_FILE_PATH =
 						'./assets/10x10_e2e_test_image_z9T8jK.png';
 
+					// The media modal opens on the "Media Library" tab once
+					// the library has items (e.g. after a previous upload),
+					// so make sure the upload tab is the active one.
+					await mediaLibrary
+						.getByRole( 'tab', { name: 'Upload files' } )
+						.click();
+
 					const fileChooserPromise =
 						page.waitForEvent( 'filechooser' );
 					await mediaLibrary.getByText( 'Select files' ).click();


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/81377#discussion_r3750984349

## What?

A combined form field (a form field with `children`) no longer resolves its own `id` against the field definitions, in validation or in rendering. Form fields (aka groups) are now pure layout containers everywhere.

## Why?

A combined form field could share its `id` with a field definition, and the codebase treated that overlap inconsistently.

```tsx
const fields = [
	{ id: 'group', isValid: { required: true } }, // definition shares the group's id
	{ id: 'a', type: 'text', isVisible: () => false },
];

const form = { fields: [ { id: 'group', children: [ 'a' ] } ] };
```

- validation & visibility: `useFormValidity` attached the same-id definition to the group and ran its `isValid` rules on the group, in addition to the children. However, https://github.com/WordPress/gutenberg/pull/81377#discussion_r3750984349 raised this inconsistency: what should happen with combined fields whose id is the same as an existing field and are invisible? Should the whole group be invisible?

- rendering: `DataFormLayout` and the regular/card/details layouts ignored the definition for groups. However, the `panel` layout used the same-id definition for the summary, but that's what `layout.summary` is for (there's also a fallback to the first leaf-child).

## How?

- `useFormValidity`: `getFormFieldsToValidate` no longer looks up a field definition for a combined form field. Only its children are validated.
- Panel layout: `getFieldDefinition` in `use-field-from-form-field.ts` no longer resolves a group's own id; it goes straight to the first leaf child (`layout.summary` still takes precedence, as before).
- The consumers that relied on the id overlap for the panel summary (QuickEdit's `status` group; the `status` and `address1` groups in the panel story) now declare `layout.summary` explicitly, in separate commits.

## Testing Instructions

1. `npm run test:unit -- packages/dataviews/src/hooks/test/use-form-validity.ts` passes, including the new "a combined field never resolves its own id against the field definitions" case.
2. `npm run storybook:dev`, open DataViews / DataForm → Layout panel. The "Status & visibility" and "Combined address" rows should still summarize with the status and first address line respectively, and open to edit their children.
3. Enable the QuickEdit experiment (Gutenberg > Experiments), visit the Pages screen, open QuickEdit for a page. The "Status" row still shows the current status as summary and edits status, scheduled date and password.


## Use of AI Tools

Investigation, implementation, tests and this description were drafted with Claude Code; reviewed and edited by me.
