### PR TITLE
Documentation: Remove invalid references to Babel in packages README

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -71,16 +71,13 @@ When creating a new package, you need to provide at least the following. Package
     	"wpScriptModuleExports": "./build-module/index.js",
     	"types": "build-types",
     	"sideEffects": false,
-    	"dependencies": {
-    		"@babel/runtime": "7.25.7"
-    	},
     	"publishConfig": {
     		"access": "public"
     	}
     }
     ```
 
-    This assumes that your code is located in the `src` folder and will be transpiled with `Babel`.
+    This assumes that your code is located in the `src` folder and will be transpiled by the build system.
 
     For production packages that will ship as a WordPress script, include `wpScript: true` in the `package.json` file. This tells the build system to bundle the package for use as a WordPress script.
 


### PR DESCRIPTION
## What?

Updates `packages/README.md` to remove expectations around Babel runtime in the build tooling.

Related: #14373

## Why?

The previous recommendations were assuming the previous, Babel-based build system. With the new `@wordpress/build` package, we don't need `@babel/runtime` as a dependency in these packages, nor is it accurate to describe as being tranpsiled by Babel.

## Testing Instructions

Review documentation for accuracy.

## Use of AI Tools

Discovered in the course of AI-assisted triage around status of #14373 with Cursor IDE + Auto (likely Composer) model.