### PR TITLE
Scaffold e2e tests for the editor inspector consolidation experiment

### DIFF
--- a/test/e2e/specs/editor/various/post-summary-dataform/post-status.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/post-status.spec.js
@@ -1,0 +1,37 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, openPostSummary } = require( './utils' );
+
+/*
+ * Covers the status field of the DataForm summary. This is net-new coverage:
+ * there is no classic spec these tests supersede.
+ */
+test.describe( 'Post status', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'shows Draft for a new post before it has been saved', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		const summary = await openPostSummary( { editor, page } );
+
+		// A new post is an `auto-draft`, which should be presented as
+		// a Draft.
+		const editButton = summary.getByRole( 'button', {
+			name: 'Edit Status',
+		} );
+		await expect( editButton ).toHaveAccessibleDescription( 'Draft' );
+
+		await editButton.click();
+		await expect(
+			page.getByRole( 'radio', { name: 'Draft' } )
+		).toBeChecked();
+	} );
+} );

--- a/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
@@ -236,27 +236,4 @@ test.describe( 'Post Summary', () => {
 			};
 		}
 	} );
-
-	test.describe( 'post status', () => {
-		test( 'shows Draft for a new post before it has been saved', async ( {
-			admin,
-			editor,
-			page,
-		} ) => {
-			await admin.createNewPost();
-			const summary = await openPostSummary( { editor, page } );
-
-			// A new post is an `auto-draft`, which should be presented as
-			// a Draft.
-			const editButton = summary.getByRole( 'button', {
-				name: 'Edit Status',
-			} );
-			await expect( editButton ).toHaveAccessibleDescription( 'Draft' );
-
-			await editButton.click();
-			await expect(
-				page.getByRole( 'radio', { name: 'Draft' } )
-			).toBeChecked();
-		} );
-	} );
 } );

--- a/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
@@ -1,10 +1,9 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, EDITOR_CONTEXTS, openPostSummary } = require( './utils' );
 
 test.describe( 'Post Summary', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
-		await requestUtils.setGutenbergExperiments( [
-			'gutenberg-dataform-inspector',
-		] );
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
@@ -16,41 +15,6 @@ test.describe( 'Post Summary', () => {
 		const UPDATED_DESCRIPTION =
 			'Updated pattern description from DataForm.';
 		const FINAL_CONTENT = `<!-- wp:paragraph -->\n<p>Pattern summary content with eight words here again.</p>\n<!-- /wp:paragraph -->`;
-		const EDITOR_CONTEXTS = [
-			{
-				name: 'post editor',
-				openPattern: async ( { admin, pattern } ) => {
-					await admin.editPost( pattern.id );
-				},
-				savePattern: async ( { page } ) => {
-					await page
-						.getByRole( 'region', { name: 'Editor top bar' } )
-						.getByRole( 'button', { name: 'Save', exact: true } )
-						.click();
-					await page
-						.getByRole( 'button', {
-							name: 'Dismiss this notice',
-						} )
-						.filter( { hasText: 'Pattern updated.' } )
-						.waitFor();
-				},
-			},
-			{
-				name: 'site editor',
-				openPattern: async ( { admin, pattern } ) => {
-					await admin.visitSiteEditor( {
-						postId: pattern.id,
-						postType: 'wp_block',
-						canvas: 'edit',
-					} );
-				},
-				savePattern: async ( { editor } ) => {
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: true,
-					} );
-				},
-			},
-		];
 
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.activateTheme( 'emptytheme' );
@@ -65,7 +29,7 @@ test.describe( 'Post Summary', () => {
 			await requestUtils.activateTheme( 'twentytwentyone' );
 		} );
 
-		for ( const { name, openPattern, savePattern } of EDITOR_CONTEXTS ) {
+		for ( const { name, open, save } of EDITOR_CONTEXTS ) {
 			test( `shows pattern summary fields in the ${ name }`, async ( {
 				admin,
 				editor,
@@ -74,9 +38,16 @@ test.describe( 'Post Summary', () => {
 			} ) => {
 				const pattern =
 					await createPatternWithSummaryData( requestUtils );
-				await openPattern( { admin, pattern } );
+				await open(
+					{ admin, page },
+					{ postType: 'wp_block', postId: pattern.id }
+				);
 
-				const summary = await openPatternSummary( { editor, page } );
+				const summary = await openPostSummary( {
+					editor,
+					page,
+					tab: 'Pattern',
+				} );
 				const fields = getPatternSummaryFields( { page, summary } );
 
 				await expect(
@@ -106,12 +77,13 @@ test.describe( 'Post Summary', () => {
 					fields.syncStatus.row.getByRole( 'button' )
 				).toHaveCount( 0 );
 
-				await savePattern( { editor, page } );
+				await save( { editor, page } );
 				await page.reload();
 
-				const reloadedSummary = await openPatternSummary( {
+				const reloadedSummary = await openPostSummary( {
 					editor,
 					page,
+					tab: 'Pattern',
 				} );
 				await expect(
 					getPatternSummaryFields( {
@@ -132,7 +104,11 @@ test.describe( 'Post Summary', () => {
 			const title = 'DataForm direct synced pattern';
 			await createPatternFromModal( { admin, page, title } );
 
-			const summary = await openPatternSummary( { editor, page } );
+			const summary = await openPostSummary( {
+				editor,
+				page,
+				tab: 'Pattern',
+			} );
 			const fields = getPatternSummaryFields( { page, summary } );
 
 			await expect( fields.title ).toHaveText( title );
@@ -154,7 +130,11 @@ test.describe( 'Post Summary', () => {
 				isSynced: false,
 			} );
 
-			const summary = await openPatternSummary( { editor, page } );
+			const summary = await openPostSummary( {
+				editor,
+				page,
+				tab: 'Pattern',
+			} );
 			const fields = getPatternSummaryFields( { page, summary } );
 
 			await expect( fields.title ).toHaveText( title );
@@ -216,22 +196,6 @@ test.describe( 'Post Summary', () => {
 			await expect( modal ).toBeHidden();
 		}
 
-		async function openPatternSummary( { editor, page } ) {
-			await editor.openDocumentSettingsSidebar();
-
-			const settingsSidebar = page.getByRole( 'region', {
-				name: 'Editor settings',
-			} );
-			await settingsSidebar
-				.getByRole( 'tab', { name: 'Pattern' } )
-				.click();
-
-			const summary = page.locator( '.editor-post-summary' );
-			await expect( summary ).toBeVisible();
-
-			return summary;
-		}
-
 		function getPatternSummaryFields( { page, summary } ) {
 			return {
 				title: summary.locator( '.editor-post-card-panel__title-name' ),
@@ -280,10 +244,7 @@ test.describe( 'Post Summary', () => {
 			page,
 		} ) => {
 			await admin.createNewPost();
-			await editor.openDocumentSettingsSidebar();
-
-			const summary = page.locator( '.editor-post-summary' );
-			await expect( summary ).toBeVisible();
+			const summary = await openPostSummary( { editor, page } );
 
 			// A new post is an `auto-draft`, which should be presented as
 			// a Draft.

--- a/test/e2e/specs/editor/various/post-summary-dataform/utils.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/utils.js
@@ -1,0 +1,77 @@
+const { expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/*
+ * Specs in this folder cover the post summary rendered by the
+ * `gutenberg-dataform-inspector` experiment. A spec that supersedes classic
+ * summary coverage names the classic spec file(s) it mirrors in a header
+ * comment; those are the tests to delete when the experiment graduates.
+ */
+const EXPERIMENTS = [ 'gutenberg-dataform-inspector' ];
+
+/*
+ * The DataForm summary is rendered by the same `editor` package component in
+ * every editor, so specs parametrize over the contexts, which differ only in
+ * how an entity is opened and saved.
+ */
+const EDITOR_CONTEXTS = [
+	{
+		name: 'post editor',
+		open: async ( { admin }, { postId } ) => {
+			await admin.editPost( postId );
+		},
+		save: async ( { page } ) => {
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Save', exact: true } )
+				.click();
+			await page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.getByText( /(updated|published)\./ )
+				.first()
+				.waitFor();
+		},
+	},
+	{
+		name: 'site editor',
+		open: async ( { admin }, { postId, postType } ) => {
+			await admin.visitSiteEditor( {
+				postId,
+				postType,
+				canvas: 'edit',
+			} );
+		},
+		save: async ( { editor } ) => {
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+		},
+	},
+];
+
+/**
+ * Opens the settings sidebar on the summary panel and returns its locator.
+ *
+ * @param {Object}                          config
+ * @param {Object}                          config.editor Editor fixture.
+ * @param {import('@playwright/test').Page} config.page   Playwright page.
+ * @param {string}                          [config.tab]  Settings sidebar tab holding the summary,
+ *                                                        when it is not the initially selected one.
+ * @return {Promise<import('@playwright/test').Locator>} The `.editor-post-summary` locator.
+ */
+async function openPostSummary( { editor, page, tab } ) {
+	await editor.openDocumentSettingsSidebar();
+
+	if ( tab ) {
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: tab } )
+			.click();
+	}
+
+	const summary = page.locator( '.editor-post-summary' );
+	await expect( summary ).toBeVisible();
+
+	return summary;
+}
+
+module.exports = { EXPERIMENTS, EDITOR_CONTEXTS, openPostSummary };


### PR DESCRIPTION
## What?

Part of the e2e testing task in #76076.

This scaffolds a `test/e2e/specs/editor/various/post-summary-dataform/` folder for the e2e tests of the editor inspector consolidation experiment (`gutenberg-dataform-inspector`). 

There are no test behavior changes but it splits the post status test into its own `post-status.spec.js`, so that each behavior area gets its own file and follow-up PRs add tests there instead of growing `post-summary.spec.js`.


Follow-up PRs will add specs to this folder mirroring the classic summary coverage (visibility, scheduling, permalink, etc.), all running with the experiment enabled, plus new tests for DataForm-only behavior. The folder follows a few conventions:

- Mirror specs are named after the classic spec they supersede, keep the same test titles (only the top-level describe gets a `(DataForm inspector)` suffix to avoid duplicate titles), and name the superseded file in a header comment.
- Tests with no classic counterpart (like `post-status.spec.js`) live in behavior-named files.
- A single test runs in every editor that can edit the entity, via the shared `EDITOR_CONTEXTS` loop.


When the experiment stabilizes, we delete the superseded classic specs and move these files up into `editor/various/` in their place, removing the experiment toggles.

## Testing Instructions
1. CI should be 🟢 

## Use of AI Tools
Generated with Fable 5 and adjusted/reviewed manually.