### PR TITLE
Build Tooling: Add browserslist config for build targeting

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,0 @@
-extends @wordpress/browserslist-config

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+extends @wordpress/browserslist-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -54024,8 +54024,10 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@emotion/babel-plugin": "^11.13.5",
+				"@wordpress/browserslist-config": "file:../browserslist-config",
 				"@wordpress/style-runtime": "file:../style-runtime",
 				"autoprefixer": "^10.4.21",
+				"browserslist": "^4.28.4",
 				"browserslist-to-esbuild": "^2.1.1",
 				"change-case": "^4.1.2",
 				"chokidar": "^4.0.0",

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Target `@wordpress/browserslist-config` for JavaScript and CSS when the project has no Browserslist config, instead of Browserslist's implicit defaults ([#82179](https://github.com/WordPress/gutenberg/pull/82179)).
 -   Transpile `.jsx` package, route, and widget source files alongside the existing JavaScript and TypeScript extensions, and ignore JSX tests during watch rebuilds ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
 
 ### Bug Fixes

--- a/packages/wp-build/README.md
+++ b/packages/wp-build/README.md
@@ -59,6 +59,13 @@ Generated CSS module output skips automatic style injection when `NODE_ENV` is
 modern CSS features, so tests that need actual styles in the DOM should
 run in a browser environment.
 
+## Browser support
+
+JavaScript and CSS builds use [Browserslist](https://github.com/browserslist/browserslist)
+when specifying build targets. You can either [provide your own](https://github.com/browserslist/browserslist#config-file),
+or the default [`@wordpress/browserslist-config`](https://www.npmjs.com/package/@wordpress/browserslist-config)
+will be used to follow [WordPress browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/).
+
 ## Package Configuration
 
 Configure your `package.json` with the following optional fields:

--- a/packages/wp-build/lib/browserslist.mjs
+++ b/packages/wp-build/lib/browserslist.mjs
@@ -1,0 +1,15 @@
+import browserslist from 'browserslist';
+import wordpressBrowserslistConfig from '@wordpress/browserslist-config';
+
+/**
+ * Resolve the Browserslist queries for a project.
+ *
+ * Uses the project's own config if one is present, otherwise falling back to
+ * `@wordpress/browserslist-config` instead of Browserslist's implicit defaults.
+ *
+ * @return {string[]} Browserslist queries.
+ */
+export function getBrowserslistQueries() {
+	const config = browserslist.findConfig( process.cwd() );
+	return config?.defaults || wordpressBrowserslistConfig;
+}

--- a/packages/wp-build/lib/build.mjs
+++ b/packages/wp-build/lib/build.mjs
@@ -28,6 +28,7 @@ import {
 	renderTemplateToString,
 } from './php-generator.mjs';
 import { getPackageInfo, getPackageInfoFromFile } from './package-utils.mjs';
+import { getBrowserslistQueries } from './browserslist.mjs';
 import { getSourceFileGlob, isTestSourceFile } from './source-files.mjs';
 import { createWordpressExternalsPlugin } from './wordpress-externals-plugin.mjs';
 import {
@@ -47,6 +48,14 @@ import {
 	generateWorkerCode,
 } from './worker-build.mjs';
 
+/**
+ * Resolve the ESBuild target from the project's Browserslist config.
+ *
+ * @return {string[]} ESBuild target strings.
+ */
+function getEsbuildTarget() {
+	return browserslistToEsbuild( getBrowserslistQueries() );
+}
 // Optional dependency: @wordpress/theme provides plugins that inject fallback
 // values for design system tokens. Fails gracefully when the package is not
 // installed (it is an optional peerDependency).
@@ -587,7 +596,7 @@ async function bundlePackage( packageName, options = {} ) {
 	if ( packageJson.wpScript ) {
 		const entryPoint = resolveEntryPoint( packageDir, packageJson );
 		const outputDir = path.join( BUILD_DIR, 'scripts', packageName );
-		const target = browserslistToEsbuild();
+		const target = getEsbuildTarget();
 
 		// Check if package matches the namespace and should expose a global
 		const packageFullName = packageJson.name;
@@ -684,7 +693,7 @@ async function bundlePackage( packageName, options = {} ) {
 	}
 
 	if ( packageJson.wpScriptModuleExports ) {
-		const target = browserslistToEsbuild();
+		const target = getEsbuildTarget();
 		const rootBuildModuleDir = path.join(
 			BUILD_DIR,
 			'modules',
@@ -1368,7 +1377,7 @@ async function transpilePackage( packageName ) {
 	const buildDir = path.join( packageDir, 'build' );
 	const buildModuleDir = path.join( packageDir, 'build-module' );
 	const srcDir = path.join( packageDir, 'src' );
-	const target = browserslistToEsbuild();
+	const target = getEsbuildTarget();
 
 	const builds = [];
 
@@ -1623,7 +1632,11 @@ async function compileStyles( packageName ) {
 							const ltrResult = await postcss(
 								[
 									dsTokenFallbacks,
-									autoprefixer( { grid: true } ),
+									autoprefixer( {
+										grid: true,
+										overrideBrowserslist:
+											getBrowserslistQueries(),
+									} ),
 								].filter( Boolean )
 							).process( source, { from: undefined } );
 
@@ -1744,7 +1757,7 @@ async function buildRoute( routeName ) {
 					outfile: path.join( outputDir, 'route.min.js' ),
 					bundle: true,
 					format: 'esm',
-					target: browserslistToEsbuild(),
+					target: getEsbuildTarget(),
 					minify: true,
 					define: getDefine( false ),
 					plugins: [
@@ -1762,7 +1775,7 @@ async function buildRoute( routeName ) {
 					outfile: path.join( outputDir, 'route.js' ),
 					bundle: true,
 					format: 'esm',
-					target: browserslistToEsbuild(),
+					target: getEsbuildTarget(),
 					minify: false,
 					define: getDefine( true ),
 					plugins: [
@@ -1795,7 +1808,7 @@ async function buildRoute( routeName ) {
 				outfile: path.join( outputDir, 'content.min.js' ),
 				bundle: true,
 				format: 'esm',
-				target: browserslistToEsbuild(),
+				target: getEsbuildTarget(),
 				minify: true,
 				define: getDefine( false ),
 				plugins: [
@@ -1813,7 +1826,7 @@ async function buildRoute( routeName ) {
 				outfile: path.join( outputDir, 'content.js' ),
 				bundle: true,
 				format: 'esm',
-				target: browserslistToEsbuild(),
+				target: getEsbuildTarget(),
 				minify: false,
 				define: getDefine( true ),
 				plugins: [
@@ -1907,7 +1920,7 @@ async function buildWidget( widgetName ) {
 					outfile: path.join( outputDir, 'render.min.js' ),
 					bundle: true,
 					format: 'esm',
-					target: browserslistToEsbuild(),
+					target: getEsbuildTarget(),
 					minify: true,
 					define: getDefine( false ),
 					plugins: [
@@ -1925,7 +1938,7 @@ async function buildWidget( widgetName ) {
 					outfile: path.join( outputDir, 'render.js' ),
 					bundle: true,
 					format: 'esm',
-					target: browserslistToEsbuild(),
+					target: getEsbuildTarget(),
 					minify: false,
 					define: getDefine( true ),
 					plugins: [
@@ -1957,7 +1970,7 @@ async function buildWidget( widgetName ) {
 					outfile: path.join( outputDir, 'widget.min.js' ),
 					bundle: true,
 					format: 'esm',
-					target: browserslistToEsbuild(),
+					target: getEsbuildTarget(),
 					minify: true,
 					define: getDefine( false ),
 					plugins: [
@@ -1975,7 +1988,7 @@ async function buildWidget( widgetName ) {
 					outfile: path.join( outputDir, 'widget.js' ),
 					bundle: true,
 					format: 'esm',
-					target: browserslistToEsbuild(),
+					target: getEsbuildTarget(),
 					minify: false,
 					define: getDefine( true ),
 					plugins: [

--- a/packages/wp-build/lib/test/browserslist.js
+++ b/packages/wp-build/lib/test/browserslist.js
@@ -1,0 +1,27 @@
+import browserslist from 'browserslist';
+import wordpressBrowserslistConfig from '@wordpress/browserslist-config';
+import { getBrowserslistQueries } from '../browserslist.mjs';
+
+describe( 'browserslist targeting', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'falls back to @wordpress/browserslist-config when the project has no config', () => {
+		jest.spyOn( browserslist, 'findConfig' ).mockReturnValue( undefined );
+
+		expect( getBrowserslistQueries() ).toEqual(
+			wordpressBrowserslistConfig
+		);
+	} );
+
+	it( 'uses the project browserslist config when one is present', () => {
+		jest.spyOn( browserslist, 'findConfig' ).mockReturnValue( {
+			defaults: [ 'last 1 chrome version' ],
+		} );
+
+		expect( getBrowserslistQueries() ).toEqual( [
+			'last 1 chrome version',
+		] );
+	} );
+} );

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -36,8 +36,10 @@
 	},
 	"dependencies": {
 		"@emotion/babel-plugin": "^11.13.5",
+		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/style-runtime": "file:../style-runtime",
 		"autoprefixer": "^10.4.21",
+		"browserslist": "^4.28.4",
 		"browserslist-to-esbuild": "^2.1.1",
 		"change-case": "^4.1.2",
 		"chokidar": "^4.0.0",


### PR DESCRIPTION
## What?

~Adds an explicit browserslist configuration pointing to the project's own `@wordpress/browserslist-config`.~

**Edit after https://github.com/WordPress/gutenberg/pull/82179/commits/496bd83c31895008d3e85f68b99a3406f410d305:** Updates `@wordpress/build` to default to `@wordpress/browserslist-config` instead of Browserlist's internal defaults when a Browserslist configuration is not provided by the project.

## Why?

So that the build tooling actually respects browserslist configuration.

`@wordpress/build` [detects and uses browserslist configuration as a target](https://github.com/WordPress/gutenberg/blob/aa1b24c90a9b7399b9f13cc5bc5ae7cc48727d85/packages/wp-build/lib/build.mjs#L590), and we have a [`@wordpress/browserslist-config` package](https://github.com/WordPress/gutenberg/tree/trunk/packages/browserslist-config) as our intended browserslist configuration, but nothing existed to actually wire the project itself to use standard browserslist configuration to point to this package. We essentially missed our [own usage instructions](https://github.com/WordPress/gutenberg/tree/trunk/packages/browserslist-config#usage) for the package.

This regressed with the transition to `@wordpress/build`. In the previous Babel-based build, it was specified through the Babel preset:

https://github.com/WordPress/gutenberg/blob/aa1b24c90a9b7399b9f13cc5bc5ae7cc48727d85/packages/babel-preset-default/index.js#L42-L46

## How?

Adds `.browserslistrc` extending to `@wordpress/browserslist-config`.

## Testing Instructions

For impact, it's likely that the performance checks on this pull request will reveal some change due to the difference between default targets and our intended targets. It's unclear yet if this will be an improvement or a regression, but in any case the output is more accurate to what we'd expect given our stated browser support.

You could also manually diff local build outputs in `build/` after running `npm run build` to verify that expected polyfilling is in place.

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to trace browserlist support and missing configuration, and to implement the fix. Changes were reviewed by myself.