### PR TITLE
Components: Cut the ToolsPanel render cascade

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   Migrate JSX files to TypeScript and remove their ESLint filename suppressions ([#82132](https://github.com/WordPress/gutenberg/pull/82132)).
 -   Use the `.jsx` extension for JavaScript source files that contain JSX ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
+-   `ToolsPanel`: Cut the render cascade panel items set off when the selected block changes, and keep a default control resettable when `Reset all` leaves its value in place ([#82180](https://github.com/WordPress/gutenberg/pull/82180)).
 
 ## 40.0.0 (2026-08-26)
 

--- a/packages/components/src/tools-panel/test/index.jsdom.test.tsx
+++ b/packages/components/src/tools-panel/test/index.jsdom.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from '@wordpress/element';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ToolsPanel, ToolsPanelContext, ToolsPanelItem } from '../';
@@ -886,7 +887,8 @@ describe( 'ToolsPanel', () => {
 			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 1 );
 			// deregisterPanelItem is called, given that we have switched panels.
 			expect( context.deregisterPanelItem ).toHaveBeenCalledWith(
-				altControlProps.label
+				altControlProps.label,
+				expect.objectContaining( { label: altControlProps.label } )
 			);
 
 			// Simulate switching back to the original panelId, e.g. by selecting
@@ -965,7 +967,8 @@ describe( 'ToolsPanel', () => {
 			rerender( <TestPanel defaultShown /> );
 
 			expect( context.deregisterPanelItem ).toHaveBeenCalledWith(
-				altControlProps.label
+				altControlProps.label,
+				expect.objectContaining( { label: altControlProps.label } )
 			);
 			// The item registers again with the saved preference rather than
 			// the value it mounted with.
@@ -1019,23 +1022,24 @@ describe( 'ToolsPanel', () => {
 			expect( context.deregisterPanelItem ).not.toHaveBeenCalled();
 
 			// Simulate another multi-selection where the panelId is `null`.
-			// Item should re-register itself after it deregistered as the
-			// multi-selection occurred.
+			// Still matches the panel, so the registration stands rather than
+			// churning through a deregister/register pair.
 			context.panelId = null;
 			rerender( <TestPanel /> );
-			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 2 );
-			expect( context.deregisterPanelItem ).toHaveBeenCalledTimes( 1 );
+			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 1 );
+			expect( context.deregisterPanelItem ).not.toHaveBeenCalled();
 
 			// Simulate a change in panel e.g. back to a single block selection
 			// Where the item's panelId is not a match.
 			context.panelId = '4321';
 			rerender( <TestPanel /> );
 
-			// As the item no longer matches the panelId it should not have
-			// registered again but instead deregistered.
+			// No longer matches, so it has already deregistered. Unmounting
+			// must not deregister again.
+			expect( context.deregisterPanelItem ).toHaveBeenCalledTimes( 1 );
 			unmount();
-			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 2 );
-			expect( context.deregisterPanelItem ).toHaveBeenCalledTimes( 2 );
+			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 1 );
+			expect( context.deregisterPanelItem ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 
@@ -1529,6 +1533,64 @@ describe( 'ToolsPanel', () => {
 			).not.toBeInTheDocument();
 		} );
 
+		it( "should not let a replacement item inherit the outgoing one's state", async () => {
+			// Two blocks can each contribute a control of the same name. When
+			// selection moves between them, the incoming item starts from its
+			// own value rather than the visibility the user chose for the one
+			// it replaced.
+			const SameLabelInTwoPanels = ( {
+				panelId,
+			}: Pick<
+				React.ComponentProps< typeof ToolsPanelItem >,
+				'panelId'
+			> ) => (
+				<SlotFillProvider>
+					<ToolsPanelItems>
+						<ToolsPanelItem
+							label="Shared"
+							panelId="1234"
+							hasValue={ () => false }
+						>
+							<div>Item 1</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanelItems>
+						<ToolsPanelItem
+							label="Shared"
+							panelId="9999"
+							hasValue={ () => false }
+						>
+							<div>Item 2</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanel { ...defaultProps } panelId={ panelId }>
+						<Slot />
+					</ToolsPanel>
+				</SlotFillProvider>
+			);
+
+			const { rerender } = render(
+				<SameLabelInTwoPanels panelId="1234" />
+			);
+
+			// Show the first block's control.
+			await openDropdownMenu();
+			await selectMenuItem( 'Shared' );
+			expect( screen.getByText( 'Item 1' ) ).toBeInTheDocument();
+
+			// Move to the other block. Its control has no value and was never
+			// shown, so it stays hidden.
+			// The menu stays open across the rerender.
+			rerender( <SameLabelInTwoPanels panelId="9999" /> );
+
+			expect(
+				await screen.findByRole( 'menuitemcheckbox', {
+					name: 'Show Shared',
+				} )
+			).toBeInTheDocument();
+			expect( screen.queryByText( 'Item 2' ) ).not.toBeInTheDocument();
+		} );
+
 		it( 'should not contain orphaned menu items when panelId changes', async () => {
 			// As fills and the panel can update independently this aims to
 			// test that no orphaned items appear registered in the panel menu.
@@ -1667,6 +1729,45 @@ describe( 'ToolsPanel', () => {
 			expect( optionsDisplayedIcon ).not.toHaveAccessibleDescription();
 		} );
 
+		it( 'should pass reset all filters that see the latest props', async () => {
+			let received: unknown[] = [];
+			const ChangingFilter = () => {
+				const [ count, setCount ] = useState( 1 );
+				return (
+					<ToolsPanel
+						label="Panel header"
+						resetAll={ ( filters ) => {
+							received = ( filters ?? [] ).map( ( filter ) =>
+								filter()
+							);
+						} }
+					>
+						<ToolsPanelItem
+							label="Filtered"
+							isShownByDefault
+							hasValue={ () => true }
+							resetAllFilter={ () => count }
+						>
+							<button onClick={ () => setCount( 2 ) }>
+								bump
+							</button>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				);
+			};
+
+			const user = userEvent.setup();
+			render( <ChangingFilter /> );
+
+			// The panelId never changes, which is where a filter frozen at
+			// registration goes stale.
+			await user.click( screen.getByText( 'bump' ) );
+			await openDropdownMenu();
+			await selectMenuItem( 'Reset all' );
+
+			expect( received ).toEqual( [ 2 ] );
+		} );
+
 		it( 'should not call reset all for different panelIds', async () => {
 			const resetItem = jest.fn();
 			const resetItemB = jest.fn();
@@ -1756,6 +1857,48 @@ describe( 'ToolsPanel', () => {
 				'aria-disabled',
 				'true'
 			);
+		} );
+	} );
+
+	describe( 'reset all with values the reset leaves in place', () => {
+		it( 'should keep a default control resettable when its value survives', async () => {
+			// The value arrives after mount, like block library controls whose
+			// `hasValue` closes over an attribute: false at mount, true once
+			// edited. A value read back from registration time misses it.
+			const GainsAValue = () => {
+				const [ hasVal, setHasVal ] = useState( false );
+				return (
+					<ToolsPanel label="Panel header" resetAll={ () => {} }>
+						<ToolsPanelItem
+							label="Survivor"
+							isShownByDefault
+							hasValue={ () => hasVal }
+						>
+							<button onClick={ () => setHasVal( true ) }>
+								set a value
+							</button>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				);
+			};
+
+			const user = userEvent.setup();
+			render( <GainsAValue /> );
+
+			await user.click( screen.getByText( 'set a value' ) );
+			await openDropdownMenu();
+			await selectMenuItem( 'Reset all' );
+
+			// `resetAll` clears nothing here, so the value is still set and
+			// must stay resettable from both menu entries.
+			expect(
+				await screen.findByRole( 'menuitem', { name: 'Reset all' } )
+			).toHaveAttribute( 'aria-disabled', 'false' );
+			expect(
+				await screen.findByRole( 'menuitem', {
+					name: 'Reset Survivor',
+				} )
+			).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useEvent, usePrevious } from '@wordpress/compose';
+import { useEvent } from '@wordpress/compose';
 import {
 	useCallback,
 	useEffect,
@@ -34,8 +34,6 @@ export function useToolsPanelItem(
 	const {
 		panelId: currentPanelId,
 		menuItems,
-		registerResetAllFilter,
-		deregisterResetAllFilter,
 		registerPanelItem,
 		deregisterPanelItem,
 		flagItemCustomization,
@@ -47,12 +45,14 @@ export function useToolsPanelItem(
 		__experimentalLastVisibleItemClass,
 	} = useToolsPanelContext();
 
-	// hasValue is a new function on every render, so do not add it as a
-	// dependency to the useCallback hook! If needed, we should use a ref.
+	// `hasValue` is a new function every render. It can't use `useEvent`
+	// because the panel calls it while deriving the menu during render, which
+	// `useEvent` forbids, so it stays keyed on the panel it was captured for.
 	const hasValueCallback = useCallback( hasValue, [ panelId ] );
-	// resetAllFilter is a new function on every render, so do not add it as a
-	// dependency to the useCallback hook! If needed, we should use a ref.
-	const resetAllFilterCallback = useCallback( resetAllFilter, [ panelId ] );
+	// `resetAllFilter` only runs from the reset handler, so a stable identity
+	// that always sees the latest props is both safe and more correct than
+	// freezing it per panel.
+	const resetAllFilterCallback = useEvent( resetAllFilter );
 
 	// `defaultShown` seeds an item's visibility when it registers, and is
 	// deliberately not reactive. Holding it in a ref keeps it out of the
@@ -70,110 +70,95 @@ export function useToolsPanelItem(
 		defaultShownRef.current = defaultShown;
 	} );
 
-	// `onShownChange` is also a new function on every render. `useEvent` gives
-	// the item a stable callback to register, so it isn't re-registered on
-	// each render, while the panel still invokes the latest one.
+	// `onShownChange` is a new function every render. `useEvent` gives the item
+	// a stable callback to register, while the panel still invokes the latest.
 	const onShownChangeCallback = useEvent( onShownChange );
 
-	const previousPanelId = usePrevious( currentPanelId );
-
+	// A panel spanning a multi-selection has no id of its own, so every item
+	// belongs to it.
 	const hasMatchingPanel =
 		currentPanelId === panelId || currentPanelId === null;
 
-	// Registering the panel item allows the panel to include it in its
-	// automatically generated menu and determine its initial checked status.
-	//
-	// This is performed in a layout effect to ensure that the panel item
-	// is registered before it is rendered preventing a rendering glitch.
+	// A layout effect so the item is registered before it renders, avoiding a
+	// glitch, and so a whole panel's worth of registrations land in one commit
+	// for React to batch.
 	// See: https://github.com/WordPress/gutenberg/issues/56470
 	useLayoutEffect( () => {
-		if ( hasMatchingPanel && previousPanelId !== null ) {
-			registerPanelItem( {
-				defaultShown: defaultShownRef.current,
-				hasValue: hasValueCallback,
-				isShownByDefault,
-				label,
-				onShownChange: onShownChangeCallback,
-				panelId,
-			} );
+		if ( ! hasMatchingPanel ) {
+			return;
 		}
 
+		const item = {
+			defaultShown: defaultShownRef.current,
+			hasValue: hasValueCallback,
+			isShownByDefault,
+			label,
+			onShownChange: onShownChangeCallback,
+			panelId,
+			resetAllFilter: resetAllFilterCallback,
+		};
+		registerPanelItem( item );
+
+		// Passing the registration back lets the panel ignore this cleanup if
+		// a replacement has already claimed the label, which happens when a
+		// panel switches while its items arrive through a Slot.
 		return () => {
-			if (
-				( previousPanelId === null && !! currentPanelId ) ||
-				currentPanelId === panelId
-			) {
-				deregisterPanelItem( label );
-			}
+			deregisterPanelItem( label, item );
 		};
 	}, [
-		currentPanelId,
+		deregisterPanelItem,
 		hasMatchingPanel,
+		hasValueCallback,
 		isShownByDefault,
 		label,
-		hasValueCallback,
 		onShownChangeCallback,
 		panelId,
-		previousPanelId,
 		registerPanelItem,
-		deregisterPanelItem,
-	] );
-
-	useEffect( () => {
-		if ( hasMatchingPanel ) {
-			registerResetAllFilter( resetAllFilterCallback );
-		}
-		return () => {
-			if ( hasMatchingPanel ) {
-				deregisterResetAllFilter( resetAllFilterCallback );
-			}
-		};
-	}, [
-		registerResetAllFilter,
-		deregisterResetAllFilter,
 		resetAllFilterCallback,
-		hasMatchingPanel,
 	] );
 
-	// Note: `label` is used as a key when building menu item state in
-	// `ToolsPanel`.
 	const menuGroup = isShownByDefault ? 'default' : 'optional';
 	const isMenuItemChecked = menuItems?.[ menuGroup ]?.[ label ];
-	const wasMenuItemChecked = usePrevious( isMenuItemChecked );
-	const isRegistered = menuItems?.[ menuGroup ]?.[ label ] !== undefined;
+	const isRegistered = isMenuItemChecked !== undefined;
+	// Tracks the effect below rather than the render, so renders that leave
+	// the checked state alone can't desync it.
+	const wasMenuItemCheckedRef = useRef< boolean | undefined >( undefined );
 
 	const isValueSet = hasValue();
-	// Notify the panel when an item's value has changed except for optional
-	// items without value because the item should not cause itself to hide.
-	// Items that don't belong to the panel on screen stay silent, otherwise
-	// they would leave an orphaned entry in its menu.
-	useEffect( () => {
+
+	// An optional item losing its value must not hide itself, so only default
+	// items report a value going away. Items belonging to another panel stay
+	// silent or they would leave an orphaned entry in this panel's menu.
+	//
+	// Shares the layout phase with registration above so it runs against an
+	// already registered item and batches with it.
+	useLayoutEffect( () => {
 		if ( ! hasMatchingPanel || ( ! isShownByDefault && ! isValueSet ) ) {
 			return;
 		}
 
-		flagItemCustomization( isValueSet, label, menuGroup );
+		flagItemCustomization( isValueSet, label );
 	}, [
 		hasMatchingPanel,
 		isValueSet,
-		menuGroup,
 		label,
 		flagItemCustomization,
 		isShownByDefault,
 	] );
 
-	// An item has no menu entry until it registers with the panel, so on that
-	// first render its previous checked state is `undefined` rather than `false`.
-	// Items that register already shown — because they have a value, or because
-	// `defaultShown` was set — must not be treated as though the user had just
-	// selected them from the menu.
-	const wasRegistered = wasMenuItemChecked !== undefined;
-
-	// Determine if the panel item's corresponding menu is being toggled and
-	// trigger appropriate callback if it is.
+	// Passive so consumer callbacks don't run before the browser has painted.
 	useEffect( () => {
-		// We check whether this item is currently registered as items rendered
-		// via fills can persist through the parent panel being remounted.
+		const wasMenuItemChecked = wasMenuItemCheckedRef.current;
+		wasMenuItemCheckedRef.current = isMenuItemChecked;
+
+		// An item has no menu entry until it registers, so the first time
+		// through there is no previous checked state. Items that register
+		// already shown, because they have a value or `defaultShown` was set,
+		// must not look as though the user just selected them.
+		const wasRegistered = wasMenuItemChecked !== undefined;
+
+		// Items rendered via fills can outlive a remount of the panel they
+		// belong to, leaving them unregistered.
 		// See: https://github.com/WordPress/gutenberg/pull/45673
 		if (
 			! isRegistered ||
@@ -197,18 +182,13 @@ export function useToolsPanelItem(
 		isRegistered,
 		isResetting,
 		isValueSet,
-		wasMenuItemChecked,
-		wasRegistered,
 		onSelect,
 		onDeselect,
 	] );
 
-	// The item is shown if it is a default control regardless of whether it
-	// has a value. Optional items are shown when they are checked or have
-	// a value.
-	const isShown = isShownByDefault
-		? menuItems?.[ menuGroup ]?.[ label ] !== undefined
-		: isMenuItemChecked;
+	// A default control shows whether or not it has a value; an optional one
+	// shows once checked.
+	const isShown = isShownByDefault ? isRegistered : isMenuItemChecked;
 
 	const shouldApplyPlaceholderStyles = shouldRenderPlaceholder && ! isShown;
 	const classes = clsx(

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -123,6 +123,7 @@ function menuItemValuesReducer(
 			// inheriting what an item it replaces recorded under the same
 			// label. Clearing here rather than on deregistration covers both
 			// orderings, since the two are not guaranteed to arrive in one.
+			// Relies on re-registering also re-reporting the value.
 			if ( ! values.hasOwnProperty( action.item.label ) ) {
 				return values;
 			}
@@ -151,11 +152,18 @@ function menuItemValuesReducer(
 			// place, since `onDeselect` and `resetAllFilter` are optional and
 			// `resetAll` need not cover every attribute. Each item reports its
 			// value again if the reset changed it.
+			const hidden = state.panelItems.filter(
+				( item ) =>
+					! item.isShownByDefault && values[ item.label ] !== false
+			);
+
+			if ( ! hidden.length ) {
+				return values;
+			}
+
 			const next = { ...values };
-			state.panelItems.forEach( ( item ) => {
-				if ( ! item.isShownByDefault ) {
-					next[ item.label ] = false;
-				}
+			hidden.forEach( ( { label } ) => {
+				next[ label ] = false;
 			} );
 			return next;
 		}
@@ -284,19 +292,16 @@ export function useToolsPanel(
 			panelItems.map( ( item ) => [ item.label, item ] )
 		);
 
-		const add = ( item: RegisteredToolsPanelItem ) => {
-			result[ getMenuGroup( item ) ][ item.label ] =
-				menuItemValues[ item.label ] ?? getSeedValue( item );
-		};
-
+		// `menuItemOrder` holds every registered label, so it alone drives
+		// the menu.
 		menuItemOrder.forEach( ( label ) => {
 			const item = byLabel.get( label );
-			if ( item ) {
-				add( item );
-				byLabel.delete( label );
+			if ( ! item ) {
+				return;
 			}
+			result[ getMenuGroup( item ) ][ label ] =
+				menuItemValues[ label ] ?? getSeedValue( item );
 		} );
-		byLabel.forEach( add );
 
 		return result;
 	}, [ panelItems, menuItemOrder, menuItemValues ] );

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -4,116 +4,68 @@ import {
 	useEffect,
 	useMemo,
 	useReducer,
-	useRef,
+	useState,
 } from '@wordpress/element';
 import styles from '../style.module.scss';
 import type { WordPressComponentProps } from '../../context';
 import { useContextSystem } from '../../context';
 import type {
-	ToolsPanelItem,
+	RegisteredToolsPanelItem,
 	ToolsPanelMenuItemKey,
 	ToolsPanelMenuItems,
-	ToolsPanelMenuItemsConfig,
 	ToolsPanelProps,
 	ResetAllFilter,
 } from '../types';
 
 type PanelItemsState = {
-	panelItems: ToolsPanelItem[];
+	panelItems: RegisteredToolsPanelItem[];
 	menuItemOrder: string[];
-	menuItems: ToolsPanelMenuItems;
+	/**
+	 * Menu state that can't be read back off the items: an optional item the
+	 * user has shown, or a default item flagged as customized. Anything absent
+	 * here falls back to whether the item currently holds a value.
+	 */
+	menuItemValues: Record< string, boolean >;
 };
 
 type PanelItemsAction =
-	| { type: 'REGISTER_PANEL'; item: ToolsPanelItem }
-	| { type: 'UNREGISTER_PANEL'; label: string }
+	| { type: 'REGISTER_PANEL'; item: RegisteredToolsPanelItem }
 	| {
-			type: 'UPDATE_VALUE';
-			group: ToolsPanelMenuItemKey;
+			type: 'UNREGISTER_PANEL';
 			label: string;
-			value: boolean;
+			item?: RegisteredToolsPanelItem;
 	  }
+	| { type: 'UPDATE_VALUE'; label: string; value: boolean }
 	| { type: 'TOGGLE_VALUE'; label: string }
 	| { type: 'RESET_ALL' };
 
-function emptyMenuItems(): ToolsPanelMenuItems {
-	return { default: {}, optional: {} };
-}
-
 function emptyState(): PanelItemsState {
-	return { panelItems: [], menuItemOrder: [], menuItems: emptyMenuItems() };
+	return { panelItems: [], menuItemOrder: [], menuItemValues: {} };
 }
 
-const generateMenuItems = ( {
-	panelItems,
-	shouldReset,
-	currentMenuItems,
-	menuItemOrder,
-}: ToolsPanelMenuItemsConfig ) => {
-	const newMenuItems: ToolsPanelMenuItems = emptyMenuItems();
-	const menuItems: ToolsPanelMenuItems = emptyMenuItems();
+// An item is always shown while it has a value. `defaultShown` only opts an
+// optional item in when it has none.
+const getSeedValue = ( item: RegisteredToolsPanelItem ) =>
+	item.hasValue() || ( ! item.isShownByDefault && !! item.defaultShown );
 
-	panelItems.forEach(
-		( { defaultShown, hasValue, isShownByDefault, label } ) => {
-			const group = isShownByDefault ? 'default' : 'optional';
-
-			// Any state a menu item already has is preserved, so that a
-			// control flagged as customized (for default controls) or toggled
-			// on (for optional controls) does not lose it. `false` is state
-			// too, so the nullish check must not treat an item the user hid
-			// as unregistered, otherwise registering any other item would
-			// re-show it.
-			const existingItemValue = currentMenuItems?.[ group ]?.[ label ];
-			// An item is always shown while it has a value. `defaultShown`
-			// only opts an optional item in when it has none.
-			const initialValue =
-				hasValue() || ( ! isShownByDefault && !! defaultShown );
-			const value = existingItemValue ?? initialValue;
-
-			newMenuItems[ group ][ label ] = shouldReset ? false : value;
-		}
-	);
-
-	// Loop the known, previously registered items first to maintain menu order.
-	menuItemOrder.forEach( ( key ) => {
-		if ( newMenuItems.default.hasOwnProperty( key ) ) {
-			menuItems.default[ key ] = newMenuItems.default[ key ];
-		}
-
-		if ( newMenuItems.optional.hasOwnProperty( key ) ) {
-			menuItems.optional[ key ] = newMenuItems.optional[ key ];
-		}
-	} );
-
-	// Loop newMenuItems object adding any that aren't in the known items order.
-	Object.keys( newMenuItems.default ).forEach( ( key ) => {
-		if ( ! menuItems.default.hasOwnProperty( key ) ) {
-			menuItems.default[ key ] = newMenuItems.default[ key ];
-		}
-	} );
-
-	Object.keys( newMenuItems.optional ).forEach( ( key ) => {
-		if ( ! menuItems.optional.hasOwnProperty( key ) ) {
-			menuItems.optional[ key ] = newMenuItems.optional[ key ];
-		}
-	} );
-
-	return menuItems;
-};
+const getMenuGroup = (
+	item: RegisteredToolsPanelItem
+): ToolsPanelMenuItemKey => ( item.isShownByDefault ? 'default' : 'optional' );
 
 function panelItemsReducer(
-	panelItems: ToolsPanelItem[],
+	panelItems: RegisteredToolsPanelItem[],
 	action: PanelItemsAction
 ) {
 	switch ( action.type ) {
 		case 'REGISTER_PANEL': {
-			const newItems = [ ...panelItems ];
-			// If an item with this label has already been registered, remove it
-			// first. This can happen when an item is moved between the default
-			// and optional groups.
-			const existingIndex = newItems.findIndex(
-				( oldItem ) => oldItem.label === action.item.label
+			// An existing registration is replaced rather than appended, so
+			// that an item moving between the default and optional groups
+			// doesn't end up in the list twice.
+			const existingIndex = panelItems.findIndex(
+				( item ) => item.label === action.item.label
 			);
+
+			const newItems = [ ...panelItems ];
 			if ( existingIndex !== -1 ) {
 				newItems.splice( existingIndex, 1 );
 			}
@@ -124,12 +76,17 @@ function panelItemsReducer(
 			const index = panelItems.findIndex(
 				( item ) => item.label === action.label
 			);
-			if ( index !== -1 ) {
-				const newItems = [ ...panelItems ];
-				newItems.splice( index, 1 );
-				return newItems;
+			if ( index === -1 ) {
+				return panelItems;
 			}
-			return panelItems;
+			// A replacement may already hold this label, in which case this is
+			// a late cleanup for a registration that is no longer current.
+			if ( action.item && panelItems[ index ] !== action.item ) {
+				return panelItems;
+			}
+			const newItems = [ ...panelItems ];
+			newItems.splice( index, 1 );
+			return newItems;
 		}
 		default:
 			return panelItems;
@@ -142,12 +99,11 @@ function menuItemOrderReducer(
 ) {
 	switch ( action.type ) {
 		case 'REGISTER_PANEL': {
-			// Track the initial order of item registration. This is used for
-			// maintaining menu item order later.
+			// Append-only: an item that unregisters and comes back keeps its
+			// original place in the menu.
 			if ( menuItemOrder.includes( action.item.label ) ) {
 				return menuItemOrder;
 			}
-
 			return [ ...menuItemOrder, action.item.label ];
 		}
 		default:
@@ -155,76 +111,78 @@ function menuItemOrderReducer(
 	}
 }
 
-function menuItemsReducer( state: PanelItemsState, action: PanelItemsAction ) {
+function menuItemValuesReducer(
+	state: PanelItemsState,
+	action: PanelItemsAction
+) {
+	const values = state.menuItemValues;
+
 	switch ( action.type ) {
-		case 'REGISTER_PANEL':
-		case 'UNREGISTER_PANEL':
-			// generate new menu items from original `menuItems` and updated `panelItems` and `menuItemOrder`
-			return generateMenuItems( {
-				currentMenuItems: state.menuItems,
-				panelItems: state.panelItems,
-				menuItemOrder: state.menuItemOrder,
-				shouldReset: false,
-			} );
-		case 'RESET_ALL':
-			return generateMenuItems( {
-				panelItems: state.panelItems,
-				menuItemOrder: state.menuItemOrder,
-				shouldReset: true,
-			} );
-		case 'UPDATE_VALUE': {
-			const oldValue = state.menuItems[ action.group ][ action.label ];
-			if ( action.value === oldValue ) {
-				return state.menuItems;
+		case 'REGISTER_PANEL': {
+			// A new registration starts from its own value rather than
+			// inheriting what an item it replaces recorded under the same
+			// label. Clearing here rather than on deregistration covers both
+			// orderings, since the two are not guaranteed to arrive in one.
+			if ( ! values.hasOwnProperty( action.item.label ) ) {
+				return values;
 			}
-			return {
-				...state.menuItems,
-				[ action.group ]: {
-					...state.menuItems[ action.group ],
-					[ action.label ]: action.value,
-				},
-			};
+			const { [ action.item.label ]: unusedValue, ...rest } = values;
+			return rest;
+		}
+		case 'UPDATE_VALUE': {
+			if ( values[ action.label ] === action.value ) {
+				return values;
+			}
+			return { ...values, [ action.label ]: action.value };
 		}
 		case 'TOGGLE_VALUE': {
-			const currentItem = state.panelItems.find(
-				( item ) => item.label === action.label
+			const item = state.panelItems.find(
+				( { label } ) => label === action.label
 			);
-
-			if ( ! currentItem ) {
-				return state.menuItems;
+			if ( ! item ) {
+				return values;
 			}
-
-			const menuGroup = currentItem.isShownByDefault
-				? 'default'
-				: 'optional';
-
-			const newMenuItems = {
-				...state.menuItems,
-				[ menuGroup ]: {
-					...state.menuItems[ menuGroup ],
-					[ action.label ]:
-						! state.menuItems[ menuGroup ][ action.label ],
-				},
-			};
-			return newMenuItems;
+			const current = values[ action.label ] ?? getSeedValue( item );
+			return { ...values, [ action.label ]: ! current };
 		}
-
+		case 'RESET_ALL': {
+			// Optional items are set to false so they hide right away.
+			// Default items are left alone: a reset can leave a value in
+			// place, since `onDeselect` and `resetAllFilter` are optional and
+			// `resetAll` need not cover every attribute. Each item reports its
+			// value again if the reset changed it.
+			const next = { ...values };
+			state.panelItems.forEach( ( item ) => {
+				if ( ! item.isShownByDefault ) {
+					next[ item.label ] = false;
+				}
+			} );
+			return next;
+		}
 		default:
-			return state.menuItems;
+			return values;
 	}
 }
 
 function panelReducer( state: PanelItemsState, action: PanelItemsAction ) {
 	const panelItems = panelItemsReducer( state.panelItems, action );
 	const menuItemOrder = menuItemOrderReducer( state.menuItemOrder, action );
-	// `menuItemsReducer` is a bit unusual because it generates new state from original `menuItems`
-	// and the updated `panelItems` and `menuItemOrder`.
-	const menuItems = menuItemsReducer(
-		{ panelItems, menuItemOrder, menuItems: state.menuItems },
+	const menuItemValues = menuItemValuesReducer(
+		{ ...state, panelItems },
 		action
 	);
 
-	return { panelItems, menuItemOrder, menuItems };
+	// Items dispatch far more often than they change anything. Holding onto
+	// the existing state lets React skip the render.
+	if (
+		panelItems === state.panelItems &&
+		menuItemOrder === state.menuItemOrder &&
+		menuItemValues === state.menuItemValues
+	) {
+		return state;
+	}
+
+	return { panelItems, menuItemOrder, menuItemValues };
 }
 
 function resetAllFiltersReducer(
@@ -260,45 +218,43 @@ export function useToolsPanel(
 		...otherProps
 	} = useContextSystem( props, 'ToolsPanel' );
 
-	const isResettingRef = useRef( false );
-	const wasResetting = isResettingRef.current;
+	// Marks the render that follows a reset so items can tell a reset apart
+	// from the user switching them off. Clearing it from an effect rather than
+	// as each control updates keeps the whole reset within one pass; otherwise
+	// later controls see it already cleared and reset themselves again from
+	// stale data.
+	const [ isResetting, setIsResetting ] = useState( false );
 
-	// `isResettingRef` is cleared via this hook to effectively batch together
-	// the resetAll task. Without this, the flag is cleared after the first
-	// control updates and forces a rerender with subsequent controls then
-	// believing they need to reset, unfortunately using stale data.
 	useEffect( () => {
-		if ( wasResetting ) {
-			isResettingRef.current = false;
+		if ( isResetting ) {
+			setIsResetting( false );
 		}
-	}, [ wasResetting ] );
+	}, [ isResetting ] );
 
-	// Allow panel items to register themselves.
-	const [ { panelItems, menuItems }, panelDispatch ] = useReducer(
-		panelReducer,
-		undefined,
-		emptyState
-	);
+	const [ { panelItems, menuItemOrder, menuItemValues }, panelDispatch ] =
+		useReducer( panelReducer, undefined, emptyState );
 
-	const [ resetAllFilters, dispatchResetAllFilters ] = useReducer(
+	// Reset all filters registered against the context directly, by consumers
+	// that aren't themselves a panel item. Items supply theirs when they
+	// register.
+	const [ externalResetAllFilters, dispatchResetAllFilters ] = useReducer(
 		resetAllFiltersReducer,
 		[]
 	);
 
-	const registerPanelItem = useCallback( ( item: ToolsPanelItem ) => {
-		// Add item to panel items.
-		panelDispatch( { type: 'REGISTER_PANEL', item } );
-	}, [] );
+	const registerPanelItem = useCallback(
+		( item: RegisteredToolsPanelItem ) => {
+			panelDispatch( { type: 'REGISTER_PANEL', item } );
+		},
+		[]
+	);
 
-	// Panels need to deregister on unmount to avoid orphans in menu state.
-	// This is an issue when panel items are being injected via SlotFills.
-	const deregisterPanelItem = useCallback( ( label: string ) => {
-		// When switching selections between components injecting matching
-		// controls, e.g. both panels have a "padding" control, the
-		// deregistration of the first panel doesn't occur until after the
-		// registration of the next.
-		panelDispatch( { type: 'UNREGISTER_PANEL', label } );
-	}, [] );
+	const deregisterPanelItem = useCallback(
+		( label: string, item?: RegisteredToolsPanelItem ) => {
+			panelDispatch( { type: 'UNREGISTER_PANEL', label, item } );
+		},
+		[]
+	);
 
 	const registerResetAllFilter = useCallback( ( filter: ResetAllFilter ) => {
 		dispatchResetAllFilters( { type: 'REGISTER', filter } );
@@ -311,24 +267,41 @@ export function useToolsPanel(
 		[]
 	);
 
-	// Updates the status of the panel’s menu items. For default items the
-	// value represents whether it differs from the default and for optional
-	// items whether the item is shown.
+	// Argument order is unchanged from before this hook derived the menu; only
+	// the group argument is gone, since it follows from `isShownByDefault`.
 	const flagItemCustomization = useCallback(
-		(
-			value: boolean,
-			label: string,
-			group: ToolsPanelMenuItemKey = 'default'
-		) => {
-			panelDispatch( { type: 'UPDATE_VALUE', group, label, value } );
+		( value: boolean, label: string ) => {
+			panelDispatch( { type: 'UPDATE_VALUE', label, value } );
 		},
 		[]
 	);
 
-	// Whether all optional menu items are hidden or not must be tracked
-	// in order to later determine if the panel display is empty and handle
-	// conditional display of a plus icon to indicate the presence of further
-	// menu items.
+	// Derived during render so the panel can never paint a half-built menu.
+	// See: https://github.com/WordPress/gutenberg/pull/65564
+	const menuItems = useMemo( () => {
+		const result: ToolsPanelMenuItems = { default: {}, optional: {} };
+		const byLabel = new Map(
+			panelItems.map( ( item ) => [ item.label, item ] )
+		);
+
+		const add = ( item: RegisteredToolsPanelItem ) => {
+			result[ getMenuGroup( item ) ][ item.label ] =
+				menuItemValues[ item.label ] ?? getSeedValue( item );
+		};
+
+		menuItemOrder.forEach( ( label ) => {
+			const item = byLabel.get( label );
+			if ( item ) {
+				add( item );
+				byLabel.delete( label );
+			}
+		} );
+		byLabel.forEach( add );
+
+		return result;
+	}, [ panelItems, menuItemOrder, menuItemValues ] );
+
+	// Drives the plus icon and the empty panel styling.
 	const areAllOptionalControlsHidden = useMemo( () => {
 		return (
 			isMenuItemTypeEmpty( menuItems.default ) &&
@@ -347,12 +320,9 @@ export function useToolsPanel(
 		className
 	);
 
-	// Toggle the checked state of a menu item which is then used to determine
-	// display of the item within the panel.
-	//
-	// The item's `onShownChange` callback is invoked from here rather than in
-	// response to the resulting state change, so that it only ever reports an
-	// explicit menu action by the user.
+	// `onShownChange` is invoked from here rather than in response to the
+	// resulting state change, so that it only ever reports an explicit menu
+	// action by the user.
 	const toggleItem = useCallback(
 		( label: string ) => {
 			const currentItem = panelItems.find(
@@ -365,7 +335,7 @@ export function useToolsPanel(
 
 			panelDispatch( { type: 'TOGGLE_VALUE', label } );
 
-			// Default items remain visible when toggled off, which resets them
+			// Default items stay visible when toggled off, which resets them
 			// instead of hiding them. Only optional items have a show or hide
 			// transition to report.
 			if ( currentItem.isShownByDefault ) {
@@ -377,20 +347,26 @@ export function useToolsPanel(
 		[ menuItems, panelItems ]
 	);
 
-	// Resets display of children and executes resetAll callback if available.
+	const resetAllFilters = useMemo( () => {
+		const itemFilters = panelItems
+			.map( ( item ) => item.resetAllFilter )
+			.filter( ( filter ): filter is ResetAllFilter => !! filter );
+
+		return [ ...itemFilters, ...externalResetAllFilters ];
+	}, [ panelItems, externalResetAllFilters ] );
+
 	const resetAllItems = useCallback( () => {
 		if ( typeof resetAll === 'function' ) {
-			isResettingRef.current = true;
+			setIsResetting( true );
 			resetAll( resetAllFilters );
 		}
 
-		// Turn off display of all non-default items.
 		panelDispatch( { type: 'RESET_ALL' } );
 	}, [ resetAllFilters, resetAll ] );
 
-	// Assist ItemGroup styling when there are potentially hidden placeholder
-	// items by identifying first & last items that are toggled on for display.
-	const getFirstVisibleItemLabel = ( items: ToolsPanelItem[] ) => {
+	// Lets `ItemGroup` style the visible ends of the panel when hidden
+	// placeholder items sit among the children.
+	const getFirstVisibleItemLabel = ( items: RegisteredToolsPanelItem[] ) => {
 		const optionalItems = menuItems.optional || {};
 		const firstItem = items.find(
 			( item ) => item.isShownByDefault || optionalItems[ item.label ]
@@ -414,7 +390,7 @@ export function useToolsPanel(
 			firstDisplayedItem,
 			flagItemCustomization,
 			hasMenuItems,
-			isResetting: isResettingRef.current,
+			isResetting,
 			lastDisplayedItem,
 			menuItems,
 			panelId,
@@ -430,6 +406,7 @@ export function useToolsPanel(
 			deregisterResetAllFilter,
 			firstDisplayedItem,
 			flagItemCustomization,
+			isResetting,
 			lastDisplayedItem,
 			menuItems,
 			panelId,

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -191,6 +191,19 @@ export type ToolsPanelItemProps = ToolsPanelItem & {
 	resetAllFilter?: ResetAllFilter;
 };
 
+/**
+ * The shape of an item as it is held in `ToolsPanel` state. It extends the
+ * public item props with the data the panel needs but that isn't part of the
+ * item's own API surface.
+ */
+export type RegisteredToolsPanelItem = ToolsPanelItem & {
+	/**
+	 * The item's `resetAllFilter`, collected at registration time so the panel
+	 * doesn't need a second round of effects to gather them.
+	 */
+	resetAllFilter?: ResetAllFilter;
+};
+
 export type ToolsPanelMenuItemKey = 'default' | 'optional';
 
 export type ToolsPanelMenuItems = {
@@ -201,13 +214,19 @@ export type ToolsPanelContext = {
 	panelId?: string | null;
 	menuItems: ToolsPanelMenuItems;
 	hasMenuItems: boolean;
-	registerPanelItem: ( item: ToolsPanelItem ) => void;
-	deregisterPanelItem: ( label: string ) => void;
+	registerPanelItem: ( item: RegisteredToolsPanelItem ) => void;
+	deregisterPanelItem: (
+		label: string,
+		item?: RegisteredToolsPanelItem
+	) => void;
 	registerResetAllFilter: ( filter: ResetAllFilter ) => void;
 	deregisterResetAllFilter: ( filter: ResetAllFilter ) => void;
 	flagItemCustomization: (
 		value: boolean,
 		label: string,
+		/**
+		 * Ignored. The group is derived from the item's `isShownByDefault`.
+		 */
 		group?: ToolsPanelMenuItemKey
 	) => void;
 	isResetting: boolean;
@@ -223,11 +242,4 @@ export type ToolsPanelControlsGroupProps = {
 	itemClassName?: string;
 	items: [ string, boolean ][];
 	toggleItem: ( label: string ) => void;
-};
-
-export type ToolsPanelMenuItemsConfig = {
-	panelItems: ToolsPanelItem[];
-	shouldReset: boolean;
-	currentMenuItems?: ToolsPanelMenuItems;
-	menuItemOrder: string[];
 };

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -192,8 +192,8 @@ export type ToolsPanelItemProps = ToolsPanelItem & {
 };
 
 /**
- * The shape of an item as it is held in `ToolsPanel` state. It extends the
- * public item props with the data the panel needs but that isn't part of the
+ * The shape of an item as it is held in `ToolsPanel` state. It extends
+ * `ToolsPanelItem` with the data the panel needs but that isn't part of the
  * item's own API surface.
  */
 export type RegisteredToolsPanelItem = ToolsPanelItem & {
@@ -225,7 +225,9 @@ export type ToolsPanelContext = {
 		value: boolean,
 		label: string,
 		/**
-		 * Ignored. The group is derived from the item's `isShownByDefault`.
+		 * Ignored, and kept only so that existing three argument callers
+		 * still typecheck. The group a value lands in now follows from the
+		 * registered item's `isShownByDefault` rather than from the caller.
 		 */
 		group?: ToolsPanelMenuItemKey
 	) => void;

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -17,6 +17,53 @@ test.describe( 'Global styles sidebar', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
+	test( 'should reset a block typography value through the panel menu', async ( {
+		page,
+	} ) => {
+		// Global styles panels stay mounted as their `panelId` changes, so
+		// stale ToolsPanel menu state survives here long enough to be seen.
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+
+		const settings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		await settings.getByRole( 'button', { name: 'Blocks' } ).click();
+		await settings
+			.getByRole( 'button', { name: 'Heading', exact: true } )
+			.click();
+		await settings.getByRole( 'button', { name: 'Typography' } ).click();
+
+		const typographyOptions = settings.getByRole( 'button', {
+			name: /Typography options/i,
+		} );
+		const resetAll = page.getByRole( 'menuitem', { name: 'Reset all' } );
+
+		await settings
+			.getByRole( 'group', { name: 'Letter case' } )
+			.getByRole( 'button', { name: 'Uppercase' } )
+			.click();
+
+		// The panel now has something to reset.
+		await typographyOptions.click();
+		await expect( resetAll ).toHaveAttribute( 'aria-disabled', 'false' );
+
+		await resetAll.click();
+
+		// The menu stays open, and the panel reports nothing left to reset.
+		await expect( resetAll ).toHaveAttribute( 'aria-disabled', 'true' );
+		await page.keyboard.press( 'Escape' );
+
+		await expect(
+			settings
+				.getByRole( 'group', { name: 'Letter case' } )
+				.getByRole( 'button', { name: 'Uppercase' } )
+		).toHaveAttribute( 'aria-pressed', 'false' );
+	} );
+
 	test( 'should filter blocks list results', async ( { page } ) => {
 		// Navigate to Styles -> Blocks.
 		await page

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -4886,11 +4886,6 @@
 			"count": 1
 		}
 	},
-	"packages/components/src/tools-panel/tools-panel/hook.ts": {
-		"react-hooks/refs": {
-			"count": 2
-		}
-	},
 	"packages/components/src/tree-grid/cell.tsx": {
 		"react-hooks/refs": {
 			"count": 1


### PR DESCRIPTION
## What?
Related to https://github.com/WordPress/gutenberg/pull/65564#issuecomment-2371374492.

`ToolsPanelItem` dispatched panel state from three effects across two commit phases, and `ToolsPanel` rebuilt its whole menu in the reducer on every one. This folds the item down to two layout effects, stops it re-registering when the panel's `panelId` changes, and derives `menuItems` during render.

Two user-visible fixes come with it:

- Choose Reset all in a panel holding a default control whose value the reset does not clear. The control now remains offered as resettable, rather than reading as unmodified with no way to reset it.
- A panel item's `resetAllFilter` now runs against the item's current props, not the ones captured when the panel last changed `panelId`.

Per block selection in the post editor: 70 reducer dispatches across two batches become 18 in one; `ToolsPanel` renders 16 to 12; `ToolsPanelItem` renders 68 to 42.

## Why?

React batches updates dispatched within one commit phase. The item split its dispatches across a layout effect and two passive effects, so each phase produced its own render pass, and each pass re-ran `generateMenuItems` over the whole item set. Registration was also gated on the panel's _previous_ `panelId`, so switching blocks caused every item to deregister and re-register, even when it still belonged to the panel.

The reset bug is separate and pre-existing. Reset all recorded `false` for every item, but `onDeselect` and `resetAllFilter` are both optional and a panel's `resetAll` need not know every attribute, so a default control's value can outlive the reset. Trunk recovered only if some other item happened to register afterward.

Blast radius is the panel package. The item's own `resetAllFilter` moved onto its registration, but `registerResetAllFilter` stays on the context because `block-editor`'s `inspector-controls/fill.js` registers filters directly without being a panel item.

## How?

`menuItems` is a `useMemo` over `panelItems`, `menuItemOrder` and a new `menuItemValues`. That last one contains only items that cannot report themselves: an optional item the user has shown and a default item flagged as customized. Everything else falls back to the item's `hasValue()`.

Deriving during render keeps the guarantee from [#65564](https://github.com/WordPress/gutenberg/pull/65564), which moved this state out of effects so the panel could never paint a half-built menu. It ruled out deriving in an _effect_, not during render. Registration stays in a layout effect for [#56470](https://github.com/WordPress/gutenberg/issues/56470), and the `isRegistered` check for [#45673](https://github.com/WordPress/gutenberg/pull/45673) is untouched.

- Reset all records to `false` for optional items so they hide at once, and drop default items so each falls back to the value it still holds.
- Deregistration carries the registration it belongs to, so a late cleanup cannot evict a replacement that already claimed the label.
- `resetAllFilter` uses `useEvent`. `hasValue` cannot, because the panel calls it while deriving the menu during render, which `useEvent` forbids.

## Testing Instructions

1. Open the site editor, then Styles, Blocks, Heading, Typography.
2. Under Letter case, choose Uppercase.
3. Open the Typography options menu. Reset all is enabled.
4. Choose Reset all. It becomes disabled and Uppercase is no longer selected.
5. Open a post. Select a paragraph, open the settings sidebar.
6. In Typography, open the options menu and toggle on an optional control. It appears in the panel.
7. Set a value in that control, select another block, then select the paragraph again. The control is still shown, with its value.
8. Add two Group blocks. Set Padding on the first via Dimensions. Select the second. Padding is not shown for it.

## Use of AI Tools

Assisted by Claude.
