### PR TITLE
Automated Testing: Fix failing categories test on trunk

### DIFF
--- a/phpunit/blocks/render-block-categories-test.php
+++ b/phpunit/blocks/render-block-categories-test.php
@@ -27,7 +27,7 @@ class Tests_Blocks_Render_Categories extends WP_UnitTestCase {
 			)
 		);
 
-		$output = gutenberg_render_block_core_categories( $attributes, '', $block );
+		$output = $block->render();
 
 		$this->assertSame( '', $output );
 	}
@@ -50,18 +50,17 @@ class Tests_Blocks_Render_Categories extends WP_UnitTestCase {
 			)
 		);
 
-		$attributes = array(
-			'taxonomy'          => 'category',
-			'displayAsDropdown' => false,
-		);
-		$block      = new WP_Block(
+		$block = new WP_Block(
 			array(
 				'blockName' => 'core/categories',
-				'attrs'     => $attributes,
+				'attrs'     => array(
+					'taxonomy'          => 'category',
+					'displayAsDropdown' => false,
+				),
 			)
 		);
 
-		$output = gutenberg_render_block_core_categories( $attributes, '', $block );
+		$output = $block->render();
 
 		$this->assertStringContainsString( 'wp-block-categories-list', $output );
 		$this->assertStringContainsString( 'Categories block test term', $output );


### PR DESCRIPTION
## What?

Updates categories block test added in #82153 to avoid failing in `trunk`.

Example: https://github.com/WordPress/gutenberg/actions/runs/33169165961/job/98842206190

## Why?

`trunk` should pass.

## How?

Uses `$block->render` to render block rather than call `gutenberg_render_block_core_categories` directly.

Explanation of issue: https://github.com/WordPress/gutenberg/pull/82182#issuecomment-5453854738

## Testing Instructions

Repeat Testing Instructions from #82153

## Use of AI Tools

Used Cursor IDE + Auto (likely Composer) model to diagnose and implement fix, verified test results locally.