### PR TITLE
Search block: opinionated mobile behavior for button-only

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 -   Navigation: Restore `flex-grow` on the menu container in the editor, where the visually hidden menu description breaks the `:only-child` selector the front end relies on, so the "Space between" and other justification settings apply in the canvas as they do on the front end ([#78447](https://github.com/WordPress/gutenberg/pull/78447)).
+-   Search: Expand button-only search over surrounding content on mobile without shifting the block's layout ([#82185](https://github.com/WordPress/gutenberg/pull/82185)).
 -   Image: Fix cropped galleries rendering images at their natural height in the editor canvas. The baseline inline `height: auto` is no longer emitted for images inside a cropped gallery, so the gallery's own cropping CSS applies ([#82318](https://github.com/WordPress/gutenberg/pull/82318)).
 -   Tabs: Activate the tab that a URL hash points into, so an anchor set on a block inside a tab panel can be reached. Anchor links followed after the page has loaded are handled too, matching the Accordion block ([#81744](https://github.com/WordPress/gutenberg/pull/81744)).
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -35,6 +35,7 @@ function render_block_core_search( $attributes ) {
 	$button_position     = $show_button ? $attributes['buttonPosition'] : null;
 	$query_params        = ( ! empty( $attributes['query'] ) ) ? $attributes['query'] : array();
 	$button              = '';
+	$mobile_button       = '';
 	$query_params_markup = '';
 	$inline_styles       = styles_for_block_core_search( $attributes );
 	$color_classes       = get_color_classes_for_block_core_search( $attributes );
@@ -45,7 +46,9 @@ function render_block_core_search( $attributes ) {
 	$border_color_classes = get_border_color_classes_for_block_core_search( $attributes );
 	// This variable is a constant and its value is always false at this moment.
 	// It is defined this way because some values depend on it, in case it changes in the future.
-	$open_by_default = false;
+	$open_by_default      = false;
+	$aria_label_expanded  = __( 'Submit Search' );
+	$aria_label_collapsed = __( 'Expand search field' );
 
 	$label_inner_html = empty( $attributes['label'] ) ? __( 'Search' ) : wp_kses_post( $attributes['label'] );
 	$label            = new WP_HTML_Tag_Processor( sprintf( '<label %1$s>%2$s</label>', $inline_styles['label'], $label_inner_html ) );
@@ -135,6 +138,11 @@ function render_block_core_search( $attributes ) {
 		if ( $button->next_tag() ) {
 			$button->add_class( implode( ' ', $button_classes ) );
 			if ( 'button-only' === $attributes['buttonPosition'] ) {
+				$mobile_button = new WP_HTML_Tag_Processor( $button->get_updated_html() );
+				$mobile_button->next_tag();
+				$mobile_button->add_class( 'wp-block-search__mobile-submit' );
+				$mobile_button->set_attribute( 'aria-label', $aria_label_expanded );
+
 				$button->set_attribute( 'data-wp-bind--aria-label', 'state.ariaLabel' );
 				$button->set_attribute( 'data-wp-bind--aria-controls', 'state.ariaControls' );
 				$button->set_attribute( 'data-wp-bind--aria-expanded', 'context.isSearchInputVisible' );
@@ -143,7 +151,7 @@ function render_block_core_search( $attributes ) {
 
 				// Adding these attributes manually is needed until the Interactivity
 				// API SSR logic is added to core.
-				$button->set_attribute( 'aria-label', __( 'Expand search field' ) );
+				$button->set_attribute( 'aria-label', $aria_label_collapsed );
 				$button->set_attribute( 'aria-controls', 'wp-block-search__input-' . $input_id );
 				$button->set_attribute( 'aria-expanded', 'false' );
 				$button->set_attribute( 'type', 'button' );
@@ -159,11 +167,16 @@ function render_block_core_search( $attributes ) {
 	if ( $is_button_inside && ! empty( $border_color_classes ) ) {
 		$field_markup_classes[] = $border_color_classes;
 	}
+	// Keep the launch button in flow while the mobile search surface overlays it.
+	$field_contents = $input . $query_params_markup;
+	if ( $is_expandable_searchfield ) {
+		$field_contents = '<div class="wp-block-search__mobile-overlay" data-wp-style--left="context.mobileOverlayLeft" data-wp-style--background-color="context.mobileOverlayBackgroundColor">' . $field_contents . $mobile_button . '</div>';
+	}
 	$field_markup       = sprintf(
 		'<div class="%s" %s>%s</div>',
 		esc_attr( implode( ' ', $field_markup_classes ) ),
 		$inline_styles['wrapper'],
-		$input . $query_params_markup . $button
+		$field_contents . $button
 	);
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => $classnames )
@@ -172,9 +185,7 @@ function render_block_core_search( $attributes ) {
 
 	// If it's interactive, add the directives.
 	if ( $is_expandable_searchfield ) {
-		$aria_label_expanded  = __( 'Submit Search' );
-		$aria_label_collapsed = __( 'Expand search field' );
-		$form_context         = wp_interactivity_data_wp_context(
+		$form_context    = wp_interactivity_data_wp_context(
 			array(
 				'isSearchInputVisible' => $open_by_default,
 				'inputId'              => $input_id,
@@ -182,12 +193,13 @@ function render_block_core_search( $attributes ) {
 				'ariaLabelCollapsed'   => $aria_label_collapsed,
 			)
 		);
-		$form_directives      = '
+		$form_directives = '
 		 data-wp-interactive="core/search"
 		 ' . $form_context . '
 		 data-wp-class--wp-block-search__searchfield-hidden="!context.isSearchInputVisible"
 		 data-wp-on--keydown="actions.handleSearchKeydown"
 		 data-wp-on--focusout="actions.handleSearchFocusout"
+		 data-wp-on-window--resize="callbacks.resizeSearch"
 		';
 	}
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/breakpoints" as *;
 @use "@wordpress/base-styles/variables" as *;
 
 $button-spacing-x: $grid-unit-10 + math.div($grid-unit-05, 2); // 10px
@@ -62,6 +63,14 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		flex-basis: 100%;
 	}
 
+	.wp-block-search__mobile-overlay {
+		display: contents;
+	}
+
+	.wp-block-search__mobile-submit {
+		display: none;
+	}
+
 	// !important here to override inline styles on button only deselected view.
 	&.wp-block-search__searchfield-hidden {
 		overflow: hidden;
@@ -80,6 +89,57 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 			flex-grow: 0;
 			margin: 0;
 			flex-basis: 0;
+		}
+	}
+}
+
+@media (max-width: #{ ($break-small) }) {
+	.wp-block-search__button-only:has(.wp-block-search__mobile-overlay) {
+		// Match the collapsed block's flex minimum when its overflow becomes visible.
+		min-width: 0;
+
+		.wp-block-search__inside-wrapper {
+			position: relative;
+			transition: none;
+		}
+
+		.wp-block-search__input {
+			transition: none;
+			min-width: 0;
+			grid-column: 1;
+		}
+
+		.wp-block-search__mobile-overlay {
+			box-sizing: border-box;
+			position: absolute;
+			top: 0;
+			width: 100vw;
+			min-height: 100%;
+			padding-left: var(--wp--style--root--padding-left, 1rem);
+			padding-right: var(--wp--style--root--padding-right, 1rem);
+			grid-template-columns: minmax(0, 1fr) auto;
+		}
+
+		.wp-block-search__mobile-submit {
+			grid-column: 2;
+		}
+
+		&:not(.wp-block-search__searchfield-hidden) {
+			position: relative;
+			z-index: 100000;
+
+			.wp-block-search__inside-wrapper > .wp-block-search__button {
+				// Preserve its layout footprint without exposing a duplicate submit button.
+				visibility: hidden;
+			}
+
+			.wp-block-search__mobile-overlay {
+				display: grid;
+			}
+
+			.wp-block-search__mobile-submit {
+				display: flex;
+			}
 		}
 	}
 }

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -5,6 +5,32 @@ import {
 	withSyncEvent,
 } from '@wordpress/interactivity';
 
+const getBackgroundColor = ( element ) => {
+	while ( element ) {
+		const { backgroundColor } = window.getComputedStyle( element );
+		if (
+			backgroundColor !== 'transparent' &&
+			backgroundColor !== 'rgba(0, 0, 0, 0)'
+		) {
+			return backgroundColor;
+		}
+		element = element.parentElement;
+	}
+	return 'Canvas';
+};
+
+const updateMobileOverlay = ( search, context ) => {
+	const overlay = search.querySelector( '.wp-block-search__mobile-overlay' );
+	if ( window.getComputedStyle( overlay ).position !== 'absolute' ) {
+		return;
+	}
+	const wrapper = overlay.parentElement;
+	context.mobileOverlayLeft = `${
+		-wrapper.getBoundingClientRect().left - wrapper.clientLeft
+	}px`;
+	context.mobileOverlayBackgroundColor = getBackgroundColor( wrapper );
+};
+
 const { actions } = store(
 	'core/search',
 	{
@@ -38,6 +64,10 @@ const { actions } = store(
 				const { ref } = getElement();
 				if ( ! ctx.isSearchInputVisible ) {
 					event.preventDefault();
+					updateMobileOverlay(
+						ref.closest( '.wp-block-search' ),
+						ctx
+					);
 					ctx.isSearchInputVisible = true;
 					ref.parentElement.querySelector( 'input' ).focus();
 				}
@@ -46,12 +76,16 @@ const { actions } = store(
 				const ctx = getContext();
 				ctx.isSearchInputVisible = false;
 			},
-			handleSearchKeydown: withSyncEvent( ( event ) => {
+			handleSearchKeydown: withSyncEvent( function* ( event ) {
 				const { ref } = getElement();
 				// If Escape close the menu.
 				if ( event?.key === 'Escape' ) {
 					actions.closeSearchInput();
-					ref.querySelector( 'button' ).focus();
+					// Make sure the button is visible before focusing it.
+					yield new Promise( window.requestAnimationFrame );
+					ref.querySelector(
+						'.wp-block-search__inside-wrapper > button'
+					).focus();
 				}
 			} ),
 			handleSearchFocusout: withSyncEvent( ( event ) => {
@@ -65,9 +99,33 @@ const { actions } = store(
 					! ref.contains( event.relatedTarget ) &&
 					event.target !== window.document.activeElement
 				) {
+					// A breakpoint change can hide the focused button. Keep focus
+					// in the open search instead of treating this as leaving it.
+					if (
+						getContext().isSearchInputVisible &&
+						! event.relatedTarget &&
+						( ! event.target.getClientRects().length ||
+							window.getComputedStyle( event.target )
+								.visibility === 'hidden' )
+					) {
+						const input = ref.querySelector( 'input' );
+						input.focus();
+						if ( ref.ownerDocument.activeElement === input ) {
+							return;
+						}
+					}
 					actions.closeSearchInput();
 				}
 			} ),
+		},
+		callbacks: {
+			resizeSearch() {
+				const { ref } = getElement();
+				const context = getContext();
+				if ( context.isSearchInputVisible ) {
+					updateMobileOverlay( ref, context );
+				}
+			},
 		},
 	},
 	{ lock: true }


### PR DESCRIPTION
## What?

Give button-only Search an opinionated mobile overlay (≤600px): 
- no animation
- cover nearby content without shifting layout

 Desktop behavior stays unchanged.

## How?

Keep the original button in flow and show a copied submit button inside an absolutely positioned full width overlay.

## Why?

When button-only search is used among other elements, it squeezes and pushes out surrounding elements. When expanded, it leads to broken, unnatural layout.

Example use case is when used in header which I consider pretty common placement for search. In this case my page name is squeezed, content on the right is pushed out of the view and search itself exceeds the screen width.

https://github.com/user-attachments/assets/d0c30ffc-382a-4cfb-8c47-afb662706a30

## Testing Instructions

1. Place button-only Search beside other blocks in a constrained Row. Test icon/text buttons and custom widths.
2. On mobile, expand it: no layout shift/overflow, and no tap-highlight flash. Scroll and resize to desktop/back.

### Keyboard

Tab to Search → Enter opens and focuses the input → Tab reaches submit. Check submission, Escape closes and restores focus, and tabbing outside closes without stealing focus. Resize while submit is focused.

Build, lint, PHP checks, and local Chrome checks passed. Automated regression tests and native-mobile coverage remain pending. Background images/gradients and translucent-background compositing are not handled.

## Videos

| Before | After |
| --- | --- |
https://github.com/user-attachments/assets/873286f1-796e-4929-bc81-66268cc6d645 | https://github.com/user-attachments/assets/48f43b81-293c-43ce-ad33-fece9e89c083



## Use of AI Tools

OpenAI Codex assisted with implementation, local checks, and this description under the author's direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile Search block behavior in button-only mode.
  - Search expansion now overlays surrounding content without shifting the page layout.
  - Enhanced focus handling when opening, closing, resizing, or changing responsive layouts.
  - Added responsive styling and positioning for the mobile search overlay.
  - Improved accessibility labeling for mobile search controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->