### PR TITLE
Menu: Default popovers to non-modal for accessible labeling.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   `Menu`: Default popovers to non-modal behaviour so menus no longer trap interaction behind a transparent overlay or expose an invalid ARIA dismiss control. Modal menus keep their trigger in the accessibility tree for correct labelling ([#67078](https://github.com/WordPress/gutenberg/issues/67078)).
 -   `Snackbar`: Restart the auto-dismiss timer when a notice is recreated with the same ID during removal ([#81764](https://github.com/WordPress/gutenberg/pull/81764)).
 -   `ToolsPanel`: Stop a panel item whose `panelId` doesn't match the panel from writing its value into that panel's menu, which could leave an orphaned entry in the dropdown ([#82127](https://github.com/WordPress/gutenberg/pull/82127)).
 

--- a/packages/components/src/menu/README.md
+++ b/packages/components/src/menu/README.md
@@ -175,7 +175,7 @@ keyboard event or a React synthetic event.
 
  - Type: `boolean`
  - Required: No
- - Default: `true`
+ - Default: `false`
 
 The modality of the menu popover. When set to true, interaction with
 outside elements will be disabled and only menu content will be visible to

--- a/packages/components/src/menu/popover.tsx
+++ b/packages/components/src/menu/popover.tsx
@@ -13,8 +13,25 @@ import { Context } from './context';
 export const Popover = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< PopoverProps, 'div', false >
->( function Popover( { gutter, shift, modal = true, ...otherProps }, ref ) {
+>( function Popover(
+	{ gutter, shift, modal = false, children, ...otherProps },
+	ref
+) {
 	const menuContext = useContext( Context );
+
+	const getPersistentElements = useCallback( () => {
+		if ( ! menuContext?.store ) {
+			return [];
+		}
+
+		const { disclosureElement } = menuContext.store.getState();
+
+		if ( ! disclosureElement ) {
+			return [];
+		}
+
+		return [ disclosureElement ];
+	}, [ menuContext?.store ] );
 
 	// Extract the side from the applied placement — useful for animations.
 	// Using `currentPlacement` instead of `placement` to make sure that we
@@ -73,6 +90,7 @@ export const Popover = forwardRef<
 			{ ...otherProps }
 			ref={ ref }
 			modal={ modal }
+			getPersistentElements={ modal ? getPersistentElements : undefined }
 			store={ menuContext.store }
 			// Root menu has an 8px distance from its trigger,
 			// otherwise 0 (which causes the submenu to slightly overlap)
@@ -87,6 +105,9 @@ export const Popover = forwardRef<
 			hideOnEscape={ hideOnEscape }
 			unmountOnHide
 			render={ renderMenu }
-		/>
+		>
+			{ modal && <Ariakit.MenuDismiss hidden /> }
+			{ children }
+		</Styled.Menu>
 	);
 } );

--- a/packages/components/src/menu/test/index.tsx
+++ b/packages/components/src/menu/test/index.tsx
@@ -1176,7 +1176,7 @@ describe( 'Menu', () => {
 	} );
 
 	describe( 'modality', () => {
-		it( 'should be modal by default', async () => {
+		it( 'should not be modal by default', async () => {
 			render(
 				<>
 					<Menu>
@@ -1199,10 +1199,72 @@ describe( 'Menu', () => {
 			// Menu open, focus is on the menu wrapper
 			await waitForFocusedMenu();
 
+			// Menu is not modal, therefore the outer button is part of the
+			// accessibility tree and can be found.
+			const outerButton = screen.getByRole( 'button', {
+				name: 'Button outside of dropdown',
+			} );
+			expect( outerButton ).toBeVisible();
+
+			// The outer button can be focused by pressing tab. Doing so will cause
+			// the Menu to close.
+			await user.tab();
+			expect( outerButton ).toHaveFocus();
+			await waitFor( () =>
+				expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument()
+			);
+		} );
+
+		it( 'should be modal when the `modal` prop is set to `true`', async () => {
+			render(
+				<>
+					<Menu>
+						<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+						<Menu.Popover modal>
+							<Menu.Item>Menu item</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+					<button>Button outside of dropdown</button>
+				</>
+			);
+
+			// Click to open the menu
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+
+			// Menu open, focus is on the menu wrapper
+			await waitForFocusedMenu();
+
 			expect(
 				screen.queryByRole( 'button', {
 					name: 'Button outside of dropdown',
 				} )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should not render a dismiss button inside modal menus', async () => {
+			render(
+				<Menu>
+					<Menu.TriggerButton>Open dropdown</Menu.TriggerButton>
+					<Menu.Popover modal>
+						<Menu.Item>Menu item</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Open dropdown',
+				} )
+			);
+
+			await waitForFocusedMenu();
+
+			expect(
+				screen.queryByRole( 'button', { name: 'Dismiss popup' } )
 			).not.toBeInTheDocument();
 		} );
 

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -65,7 +65,7 @@ export interface PopoverProps {
 	 *   still be manually set to `false`.
 	 * - When the dialog is open, element tree outside it will be inert.
 	 *
-	 * @default true
+	 * @default false
 	 */
 	modal?: Ariakit.MenuProps[ 'modal' ];
 	/**


### PR DESCRIPTION
Fixes #67078

## What?

Menus default to non-modal popovers so they no longer trap interaction behind a transparent overlay or expose an invalid ARIA dismiss control.

## Why?

Modal menus marked the page inert, which broke `aria-labelledby` labelling in Chrome and inserted a hidden "Dismiss popup" button into the menu ARIA tree.

## How?

- Change `Menu.Popover` default `modal` to `false`.
- For explicit modal menus, keep the trigger in the modal context via `getPersistentElements` and suppress Ariakit's auto dismiss button.

## Test plan

- [ ] Open Site Editor > Styles > Preview menu — menu should label correctly in Chrome accessibility tree
- [ ] Open a dropdown — page controls remain clickable without double-click
- [ ] `npm run test:unit -- packages/components/src/menu/test/index.tsx --testNamePattern=modality`