### PR TITLE
Icon block: Apply block supports to the wrapper instead of the SVG

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,10 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 
+### Enhancements
+
+-   Icon: Apply block supports such as color, border, spacing, and dimensions to the `.wp-block-icon` wrapper instead of the inner SVG, so rounded, padded icons render correctly ([#82190](https://github.com/WordPress/gutenberg/pull/82190)).
+
 ### Internal
 
 -   Remove unused dependencies `@wordpress/keyboard-shortcuts`, `@wordpress/reusable-blocks` and `@wordpress/viewport` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/block-library/src/icon/README.md
+++ b/packages/block-library/src/icon/README.md
@@ -41,10 +41,8 @@ _Defined via the [`supports`](https://developer.wordpress.org/block-editor/refer
 
 _Defined via the [`selectors`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/) property in block.json._
 
-- **root**: `.wp-block-icon svg`
+- **root**: `.wp-block-icon`
 - **css**: `.wp-block-icon`
-- **spacing**:
-  - margin: `.wp-block-icon`
 
 ## Block Markup
 

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -33,7 +33,6 @@
 		"align": [ "left", "center", "right" ],
 		"html": false,
 		"color": {
-			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
@@ -47,7 +46,6 @@
 			"radius": true,
 			"style": true,
 			"width": true,
-			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"color": false,
 				"radius": false,
@@ -58,7 +56,6 @@
 		"spacing": {
 			"padding": true,
 			"margin": true,
-			"__experimentalSkipSerialization": [ "padding" ],
 			"__experimentalDefaultControls": {
 				"margin": false,
 				"padding": false
@@ -66,18 +63,14 @@
 		},
 		"dimensions": {
 			"width": true,
-			"__experimentalSkipSerialization": [ "width" ],
 			"__experimentalDefaultControls": {
 				"width": true
 			}
 		}
 	},
 	"selectors": {
-		"root": ".wp-block-icon svg",
-		"css": ".wp-block-icon",
-		"spacing": {
-			"margin": ".wp-block-icon"
-		}
+		"root": ".wp-block-icon",
+		"css": ".wp-block-icon"
 	},
 	"style": "wp-block-icon",
 	"editorStyle": "wp-block-icon-editor"

--- a/packages/block-library/src/icon/edit.jsx
+++ b/packages/block-library/src/icon/edit.jsx
@@ -17,10 +17,6 @@ import {
 	InspectorControls,
 	useBlockProps,
 	useBlockEditingMode,
-	__experimentalUseColorProps as useColorProps,
-	__experimentalUseBorderProps as useBorderProps,
-	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
-	getDimensionsClassesAndStyles as useDimensionsProps,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { SVG, Rect, Path } from '@wordpress/primitives';
@@ -57,19 +53,6 @@ export function Edit( { attributes, setAttributes } ) {
 	const [ isInserterOpen, setInserterOpen ] = useState( false );
 
 	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
-
-	const colorProps = useColorProps( attributes );
-	// Only padding is applied to the inner SVG element, matching the front
-	// end. The margin support is serialized to the block wrapper instead.
-	const spacingProps = useSpacingProps( {
-		style: {
-			spacing: {
-				padding: attributes.style?.spacing?.padding,
-			},
-		},
-	} );
-	const borderProps = useBorderProps( attributes );
-	const dimensionsProps = useDimensionsProps( attributes );
 
 	const selectedIcon = useSelect(
 		( select ) => {
@@ -211,37 +194,14 @@ export function Edit( { attributes, setAttributes } ) {
 					<HtmlRenderer
 						html={ iconToDisplay }
 						wrapperProps={ {
-							className: clsx(
-								colorProps.className,
-								borderProps.className,
-								spacingProps.className,
-								dimensionsProps.className,
-								flipClasses
-							),
-							style: {
-								...colorProps.style,
-								...borderProps.style,
-								...spacingProps.style,
-								...dimensionsProps.style,
-								...rotationStyle,
-							},
+							className: clsx( flipClasses ),
+							style: rotationStyle,
 						} }
 					/>
 				) : (
 					<IconPlaceholder
-						className={ clsx(
-							borderProps.className,
-							spacingProps.className,
-							dimensionsProps.className,
-							flipClasses
-						) }
-						style={ {
-							...borderProps.style,
-							...spacingProps.style,
-							...dimensionsProps.style,
-							...rotationStyle,
-							height: 'auto',
-						} }
+						className={ clsx( flipClasses ) }
+						style={ rotationStyle }
 					/>
 				) }
 			</div>

--- a/packages/block-library/src/icon/editor.scss
+++ b/packages/block-library/src/icon/editor.scss
@@ -3,8 +3,8 @@
 @use "@wordpress/base-styles/mixins" as *;
 
 .wp-block[data-align="center"] > .wp-block-icon {
-	display: flex;
-	justify-content: center;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .wp-block-icon__inserter-sidebar {

--- a/packages/block-library/src/icon/index.php
+++ b/packages/block-library/src/icon/index.php
@@ -19,72 +19,11 @@ function render_block_core_icon( $attributes ) {
 		return;
 	}
 
-	// Text color and background color.
-	$color_styles = array();
-
-	$preset_text_color    = array_key_exists( 'textColor', $attributes ) ? "var:preset|color|{$attributes['textColor']}" : null;
-	$custom_text_color    = $attributes['style']['color']['text'] ?? null;
-	$color_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
-
-	$preset_background_color    = array_key_exists( 'backgroundColor', $attributes ) ? "var:preset|color|{$attributes['backgroundColor']}" : null;
-	$custom_background_color    = $attributes['style']['color']['background'] ?? null;
-	$color_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
-
-	// Border.
-	$border_styles = array();
-	$sides         = array( 'top', 'right', 'bottom', 'left' );
-
-	if ( isset( $attributes['style']['border']['radius'] ) ) {
-		$border_styles['radius'] = $attributes['style']['border']['radius'];
-	}
-	if ( isset( $attributes['style']['border']['style'] ) ) {
-		$border_styles['style'] = $attributes['style']['border']['style'];
-	}
-	if ( isset( $attributes['style']['border']['width'] ) ) {
-		$border_styles['width'] = $attributes['style']['border']['width'];
-	}
-
-	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
-	$custom_color           = $attributes['style']['border']['color'] ?? null;
-	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
-
-	foreach ( $sides as $side ) {
-		$border                 = $attributes['style']['border'][ $side ] ?? null;
-		$border_styles[ $side ] = array(
-			'color' => $border['color'] ?? null,
-			'style' => $border['style'] ?? null,
-			'width' => $border['width'] ?? null,
-		);
-	}
-
-	// Spacing (Padding).
-	$spacing_styles = array();
-	if ( isset( $attributes['style']['spacing']['padding'] ) ) {
-		$spacing_styles['padding'] = $attributes['style']['spacing']['padding'];
-	}
-
-	// Dimensions (Width).
-	$dimensions_styles = array();
-	if ( isset( $attributes['style']['dimensions']['width'] ) ) {
-		$dimensions_styles['width'] = $attributes['style']['dimensions']['width'];
-	}
-
-	// Generate styles and classes.
-	$styles = wp_style_engine_get_styles(
-		array(
-			'color'      => $color_styles,
-			'border'     => $border_styles,
-			'spacing'    => $spacing_styles,
-			'dimensions' => $dimensions_styles,
-		),
-	);
-
 	$svg = wp_get_icon(
 		$attributes['icon'],
 		array(
-			// Width is applied via the dimensions block support styles below.
+			// Width is applied via the dimensions block support on the wrapper.
 			'size'  => null,
-			'class' => $styles['classnames'] ?? '',
 			'label' => $attributes['ariaLabel'] ?? '',
 		)
 	);
@@ -95,10 +34,6 @@ function render_block_core_icon( $attributes ) {
 
 	$processor = new WP_HTML_Tag_Processor( $svg );
 	if ( $processor->next_tag( 'svg' ) ) {
-		if ( ! empty( $styles['css'] ) ) {
-			$processor->set_attribute( 'style', $styles['css'] );
-		}
-
 		// Apply flip classes to the SVG.
 		$flip_horizontal = $attributes['flipHorizontal'] ?? false;
 		$flip_vertical   = $attributes['flipVertical'] ?? false;

--- a/packages/block-library/src/icon/style.scss
+++ b/packages/block-library/src/icon/style.scss
@@ -4,11 +4,13 @@
 
 /* Icon Block styles. */
 .wp-block-icon {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 	line-height: 0;
 
 	&.aligncenter {
-		display: flex;
-		justify-content: center;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	svg {
@@ -30,7 +32,8 @@
 }
 
 // Use :where() so these defaults have zero specificity and can be overridden
-// by global styles, which target `.wp-block-icon svg` at higher specificity.
+// by global styles. The SVG fills the wrapper, preserving its aspect ratio via
+// the viewBox.
 :where(.wp-block-icon) svg {
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #82165

Applies the `core/icon` block supports — color, border, spacing (padding/margin), and dimensions (width) — to the `.wp-block-icon` wrapper instead of the inner `<svg>` element.

## Why?
Currently the Icon block serializes background, border, spacing, and color styles onto the `<svg>` element itself. Inline styles such as `padding: 1rem` and `border-radius: 999px` are applied to the SVG, which can make the icon/background bleed outside the intended rounded shape and cause spacing to behave unexpectedly.

Applying box-model and color styles to the wrapper makes the Icon block behave like a normal styled container, so rounded, padded icons render correctly without custom CSS.

## How?
- Removed `__experimentalSkipSerialization` from the `color`, `border`, `spacing`, and `dimensions` supports in `block.json` so these styles are serialized onto the block wrapper by the standard block supports mechanism.
- Changed `selectors.root` from `.wp-block-icon svg` to `.wp-block-icon` (and removed the now-redundant `spacing.margin` selector override).
- Removed the manual style generation in `index.php` (`wp_style_engine_get_styles`) and in `edit.jsx` (`useColorProps` / `useBorderProps` / `useSpacingProps` / `useDimensionsProps`), delegating entirely to block supports via `get_block_wrapper_attributes()` and `useBlockProps()`.
- The SVG keeps `width: 100%; height: 100%` so it fills the wrapper while preserving its aspect ratio via the `viewBox`.
- Updated `.aligncenter` to use auto margins (matching a normal container) and added `box-sizing: border-box` to the wrapper for predictable padding/border.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an Icon block and pick an icon.
3. In the block inspector, set a background color, text color, border radius, border width, padding, and a custom width.
4. Confirm the background, border, padding, and width are applied to the `.wp-block-icon` wrapper (not the `<svg>`), and the icon scales inside while preserving its aspect ratio.
5. Confirm the same result on the front end.
6. Confirm the flip and rotate controls still apply to the SVG as before.

### Testing Instructions for Keyboard
N/A — this change does not alter the user interface or keyboard interaction.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
This pull request was authored with the assistance of an AI coding assistant; the resulting changes were reviewed manually.
