### PR TITLE
Rich Text: Update useAnchor to receive ref object

### DIFF
--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -87,7 +87,7 @@ export function AutocompleterUI( {
 		autocompleter.useItems ?? getDefaultUseItems( autocompleter );
 	const [ items ] = useItems( filterValue );
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 	} );
 
 	const [ needsA11yCompat, setNeedsA11yCompat ] = useState( false );

--- a/packages/format-library/src/image/index.jsx
+++ b/packages/format-library/src/image/index.jsx
@@ -60,7 +60,7 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	const [ editedAlt, setEditedAlt ] = useState( alt );
 	const hasChanged = editedWidth !== width || editedAlt !== alt;
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 		settings: image,
 	} );
 

--- a/packages/format-library/src/language/index.jsx
+++ b/packages/format-library/src/language/index.jsx
@@ -62,7 +62,7 @@ function Edit( { isActive, value, onChange, contentRef } ) {
 
 function InlineLanguageUI( { value, contentRef, onChange, onClose } ) {
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 		settings: language,
 	} );
 

--- a/packages/format-library/src/link/inline.jsx
+++ b/packages/format-library/src/link/inline.jsx
@@ -237,7 +237,7 @@ function InlineLinkUI( {
 	}
 
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 		settings: {
 			...settings,
 			isActive,

--- a/packages/format-library/src/math/index.jsx
+++ b/packages/format-library/src/math/index.jsx
@@ -29,7 +29,7 @@ function InlineUI( {
 	const formRef = useRef();
 
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 		settings: math,
 	} );
 

--- a/packages/format-library/src/non-breaking-space/index.jsx
+++ b/packages/format-library/src/non-breaking-space/index.jsx
@@ -8,7 +8,7 @@ const title = __( 'Non breaking space' );
 
 function PopoverAnchor( { contentRef } ) {
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 		settings: nonBreakingSpace,
 	} );
 

--- a/packages/format-library/src/text-color/inline.jsx
+++ b/packages/format-library/src/text-color/inline.jsx
@@ -146,7 +146,7 @@ export default function InlineColorUI( {
 	isActive,
 } ) {
 	const popoverAnchor = useAnchor( {
-		editableContentElement: contentRef.current,
+		editableContentRef: contentRef,
 		settings: { ...settings, isActive },
 	} );
 

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `useAnchor` now expects an `editableContentRef` option holding the ref to the editable content element. The existing `editableContentElement` option keeps working, but is deprecated since 7.2.
+
 ## 7.54.0 (2026-08-26)
 
 ## 7.53.0 (2026-08-12)
-
 
 ## 7.52.0 (2026-07-29)
 

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `useAnchor` now expects an `editableContentRef` option holding the ref to the editable content element. The existing `editableContentElement` option keeps working, but is deprecated since 7.2.
+-   `useAnchor` now expects an `editableContentRef` option holding the ref to the editable content element. The existing `editableContentElement` option keeps working, but is deprecated since 7.2 ([#82191](https://github.com/WordPress/gutenberg/pull/82191)).
 
 ## 7.54.0 (2026-08-26)
 

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -464,8 +464,9 @@ This hook, to be used in a format type's Edit component, returns the active elem
 
 _Parameters_
 
--   _obj_ `{ editableContentElement: HTMLElement | null; settings?: WPFormat; }`: Named parameters.
--   _obj.editableContentElement_ `HTMLElement | null`: The element containing the editable content.
+-   _obj_ `{ editableContentRef?: RefObject< HTMLElement | null >; editableContentElement?: HTMLElement | null; settings?: WPFormat; }`: Named parameters.
+-   _obj.editableContentRef_ `RefObject< HTMLElement | null >`: Ref to the element containing the editable content.
+-   _obj.editableContentElement_ `HTMLElement | null`: The element containing the editable content. Deprecated since 7.2: pass `editableContentRef` instead.
 -   _obj.settings_ `WPFormat`: The format type's settings.
 
 _Returns_

--- a/packages/rich-text/src/hook/use-anchor.ts
+++ b/packages/rich-text/src/hook/use-anchor.ts
@@ -1,6 +1,8 @@
 import { usePrevious } from '@wordpress/compose';
-import { useState, useLayoutEffect } from '@wordpress/element';
+import { useState, useLayoutEffect, useRef, useMemo } from '@wordpress/element';
 import { getRectangleFromRange } from '@wordpress/dom';
+import deprecated from '@wordpress/deprecated';
+import type { RefObject } from 'react';
 import type { WPFormat } from '../register-format-type';
 import { ownsSelection } from '../owns-selection';
 
@@ -172,18 +174,38 @@ const DEFAULT_SETTINGS = {
  * UI, e.g. by passing it to the `Popover` component via the `anchor` prop.
  *
  * @param obj                        Named parameters.
- * @param obj.editableContentElement The element containing the editable content.
+ * @param obj.editableContentRef     Ref to the element containing the editable
+ *                                   content.
+ * @param obj.editableContentElement The element containing the editable
+ *                                   content. Deprecated since 7.2: pass
+ *                                   `editableContentRef` instead.
  * @param obj.settings               The format type's settings.
  * @return                           The active element or selection range.
  */
 export function useAnchor( {
+	editableContentRef,
 	editableContentElement,
 	settings,
 }: {
-	editableContentElement: HTMLElement | null;
+	editableContentRef?: RefObject< HTMLElement | null >;
+	editableContentElement?: HTMLElement | null;
 	settings?: WPFormat;
 } ): Element | VirtualAnchorElement | undefined | null {
 	const { tagName, className } = settings ?? DEFAULT_SETTINGS;
+
+	if ( editableContentElement !== undefined ) {
+		deprecated( '`editableContentElement` option in `useAnchor`', {
+			since: '7.2',
+			alternative: '`editableContentRef` option',
+		} );
+	}
+
+	// Normalise the deprecated element option into the ref shape, so the rest
+	// of the hook has a single code path.
+	const contentRef = useMemo(
+		() => editableContentRef ?? { current: editableContentElement ?? null },
+		[ editableContentRef, editableContentElement ]
+	);
 
 	// `isActive` is not a property of `WPFormat`, but it has made its way into
 	// `settings` in certain cases (see `core/link` format). Avoid making this
@@ -195,20 +217,25 @@ export function useAnchor( {
 		settings.isActive
 	);
 
-	const [ anchor, setAnchor ] = useState( () =>
-		getAnchor( editableContentElement, tagName, className ?? '' )
-	);
+	// The anchor is initialized in the `useLayoutEffect` below (before the
+	// browser paints) to avoid reading the ref during render.
+	const [ anchor, setAnchor ] = useState<
+		HTMLElement | VirtualAnchorElement | undefined
+	>();
 	const wasActive = usePrevious( isActive );
+	// The element the current `anchor` was computed for, so that the effect can
+	// tell a first run for an element from a re-run for the same element.
+	const anchoredElementRef = useRef< HTMLElement | null >( null );
 
 	useLayoutEffect( () => {
-		if ( ! editableContentElement ) {
+		const element = contentRef.current;
+
+		if ( ! element ) {
 			return;
 		}
 
 		function callback() {
-			setAnchor(
-				getAnchor( editableContentElement, tagName, className ?? '' )
-			);
+			setAnchor( getAnchor( element, tagName, className ?? '' ) );
 		}
 
 		function attach() {
@@ -219,33 +246,40 @@ export function useAnchor( {
 			ownerDocument.removeEventListener( 'selectionchange', callback );
 		}
 
-		const { ownerDocument } = editableContentElement;
+		const { ownerDocument } = element;
 
-		if (
-			ownsSelection( editableContentElement ) ||
+		const isNewElement = anchoredElementRef.current !== element;
+		anchoredElementRef.current = element;
+
+		const shouldAttach =
+			ownsSelection( element ) ||
 			// When a link is created, we need to attach the popover to the newly created anchor.
 			( ! wasActive && isActive ) ||
 			// Sometimes we're _removing_ an active anchor, such as the inline color popover.
 			// When we add the color, it switches from a virtual anchor to a `<mark>` element.
 			// When we _remove_ the color, it switches from a `<mark>` element to a virtual anchor.
-			( wasActive && ! isActive )
-		) {
-			setAnchor(
-				getAnchor( editableContentElement, tagName, className ?? '' )
-			);
+			( wasActive && ! isActive );
+
+		// Seed the anchor on the first run for this element, since it could not
+		// be seeded during render.
+		if ( shouldAttach || isNewElement ) {
+			callback();
+		}
+
+		if ( shouldAttach ) {
 			attach();
 		}
 
-		editableContentElement.addEventListener( 'focusin', attach );
-		editableContentElement.addEventListener( 'focusout', detach );
+		element.addEventListener( 'focusin', attach );
+		element.addEventListener( 'focusout', detach );
 
 		return () => {
 			detach();
 
-			editableContentElement.removeEventListener( 'focusin', attach );
-			editableContentElement.removeEventListener( 'focusout', detach );
+			element.removeEventListener( 'focusin', attach );
+			element.removeEventListener( 'focusout', detach );
 		};
-	}, [ editableContentElement, tagName, className, isActive, wasActive ] );
+	}, [ contentRef, tagName, className, isActive, wasActive ] );
 
 	return anchor;
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -4665,7 +4665,7 @@
 	},
 	"packages/components/src/autocomplete/autocompleter-ui.tsx": {
 		"react-hooks/refs": {
-			"count": 6
+			"count": 4
 		}
 	},
 	"packages/components/src/autocomplete/index.tsx": {
@@ -7491,9 +7491,6 @@
 		"@wordpress/use-recommended-components": {
 			"count": 1
 		},
-		"react-hooks/refs": {
-			"count": 2
-		},
 		"react/jsx-filename-extension": {
 			"count": 1
 		}
@@ -7511,9 +7508,6 @@
 	"packages/format-library/src/language/index.jsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1
-		},
-		"react-hooks/refs": {
-			"count": 2
 		},
 		"react/jsx-filename-extension": {
 			"count": 1
@@ -7533,9 +7527,6 @@
 		}
 	},
 	"packages/format-library/src/link/inline.jsx": {
-		"react-hooks/refs": {
-			"count": 2
-		},
 		"react/jsx-filename-extension": {
 			"count": 1
 		}
@@ -7546,17 +7537,11 @@
 		}
 	},
 	"packages/format-library/src/math/index.jsx": {
-		"react-hooks/refs": {
-			"count": 2
-		},
 		"react/jsx-filename-extension": {
 			"count": 1
 		}
 	},
 	"packages/format-library/src/non-breaking-space/index.jsx": {
-		"react-hooks/refs": {
-			"count": 2
-		},
 		"react/jsx-filename-extension": {
 			"count": 1
 		}
@@ -7582,9 +7567,6 @@
 		}
 	},
 	"packages/format-library/src/text-color/inline.jsx": {
-		"react-hooks/refs": {
-			"count": 2
-		},
 		"react/jsx-filename-extension": {
 			"count": 1
 		}


### PR DESCRIPTION
## What?

Updates `@wordpress/rich-text`'s `useAnchor` to receive a ref object instead of an element, with internal normalization to preserve backwards-compatibility while deprecating `editableContentElement`.

## Why?

This hook currently emits ESLint errors from [`eslint-plugin-react-hook`'s `refs` rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/refs), and those errors are currently being suppressed. To avoid perpetuating suppressions (most recently in #74040), we should fix the root issue.

The issue is legitimate, and React is clear that ref values should not be read in the render path:

> Do not write or read ref.current during rendering, except for [initialization.](https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents) This makes your component’s behavior unpredictable.

https://react.dev/reference/react/useRef#caveats

## How?

Adds new `editableContentRef` option to `useAnchor`, updates existing call sites, and normalizes internal implementation to use `ref` value instead in its own lifecycle.

## Testing Instructions

Existing test coverage would be expected to identify any regressions of these changes.

## Use of AI Tools

Used Claude Code + Opus 5 to understand change following from #74040 to fix, with changes reviewed by myself.
