### PR TITLE
Theme JSON: Avoid rebuilding identical block schemas during sanitization

### DIFF
--- a/backport-changelog/7.2/13337.md
+++ b/backport-changelog/7.2/13337.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13337
+
+* https://github.com/WordPress/gutenberg/pull/82203

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1298,6 +1298,13 @@ class WP_Theme_JSON_Gutenberg {
 		$schema_settings_blocks = array();
 		$breakpoint_states      = array_keys( $responsive_media_queries );
 
+		$common_block_settings = static::VALID_SETTINGS;
+		// `viewport` and `blockVisibility` are global-only settings and cannot be set per block for now.
+		unset(
+			$common_block_settings['viewport'],
+			$common_block_settings['blockVisibility']
+		);
+
 		/*
 		 * Generate a schema for blocks.
 		 * - Block styles can contain `elements`, `variations`, and responsive breakpoint state definitions.
@@ -1322,12 +1329,8 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		foreach ( $valid_block_names as $block ) {
-			$schema_settings_blocks[ $block ] = static::VALID_SETTINGS;
-			// `viewport` and `blockVisibility` are global-only settings and cannot be set per block for now.
-			unset( $schema_settings_blocks[ $block ]['viewport'] );
-			unset( $schema_settings_blocks[ $block ]['blockVisibility'] );
-
-			$schema_styles_blocks[ $block ] = $common_block_schema;
+			$schema_settings_blocks[ $block ] = $common_block_settings;
+			$schema_styles_blocks[ $block ]   = $common_block_schema;
 
 			// Add responsive pseudo-selectors only to blocks that support them.
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1296,6 +1296,7 @@ class WP_Theme_JSON_Gutenberg {
 
 		$schema_styles_blocks   = array();
 		$schema_settings_blocks = array();
+		$breakpoint_states      = array_keys( $responsive_media_queries );
 
 		/*
 		 * Generate a schema for blocks.
@@ -1306,21 +1307,31 @@ class WP_Theme_JSON_Gutenberg {
 		 *
 		 * As each variation needs both a `blocks` schema and responsive `blocks` schemas
 		 * for further nested inner `blocks`, the overall schema is generated in multiple passes.
+		 *
+		 * All blocks start with the same style schema. Build that common schema
+		 * once, then add block-specific pseudo and custom states below.
 		 */
+		$responsive_block_schema             = $styles_non_top_level;
+		$responsive_block_schema['elements'] = $schema_styles_elements;
+
+		$common_block_schema             = $styles_non_top_level;
+		$common_block_schema['elements'] = $schema_styles_elements;
+
+		foreach ( $breakpoint_states as $breakpoint_state ) {
+			$common_block_schema[ $breakpoint_state ] = $responsive_block_schema;
+		}
+
 		foreach ( $valid_block_names as $block ) {
 			$schema_settings_blocks[ $block ] = static::VALID_SETTINGS;
 			// `viewport` and `blockVisibility` are global-only settings and cannot be set per block for now.
 			unset( $schema_settings_blocks[ $block ]['viewport'] );
 			unset( $schema_settings_blocks[ $block ]['blockVisibility'] );
-			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
-			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
 
-			// Add responsive breakpoint states for all blocks.
-			foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
-				$schema_styles_blocks[ $block ][ $breakpoint_state ]             = $styles_non_top_level;
-				$schema_styles_blocks[ $block ][ $breakpoint_state ]['elements'] = $schema_styles_elements;
+			$schema_styles_blocks[ $block ] = $common_block_schema;
 
-				if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
+			// Add responsive pseudo-selectors only to blocks that support them.
+			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
+				foreach ( $breakpoint_states as $breakpoint_state ) {
 					foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
 						$schema_styles_blocks[ $block ][ $breakpoint_state ][ $pseudo_selector ] = $styles_non_top_level;
 					}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -8146,6 +8146,92 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that responsive pseudo-states are kept only for supported blocks.
+	 *
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 */
+	public function test_sanitize_keeps_responsive_pseudo_states_on_supported_blocks_only() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/button'          => array(
+							'@mobile' => array(
+								':hover' => array(
+									'color' => array(
+										'text' => 'blue',
+									),
+								),
+							),
+						),
+						'core/paragraph'       => array(
+							'color'   => array(
+								'text' => 'black',
+							),
+							'@mobile' => array(
+								'color'  => array(
+									'text' => 'green',
+								),
+								':hover' => array(
+									'color' => array(
+										'text' => 'red',
+									),
+								),
+							),
+						),
+						'core/navigation-link' => array(
+							'-current' => array(
+								'color' => array(
+									'text' => 'purple',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$actual = $theme_json->get_raw_data();
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/button'          => array(
+						'@mobile' => array(
+							':hover' => array(
+								'color' => array(
+									'text' => 'blue',
+								),
+							),
+						),
+					),
+					'core/paragraph'       => array(
+						'color'   => array(
+							'text' => 'black',
+						),
+						'@mobile' => array(
+							'color' => array(
+								'text' => 'green',
+							),
+						),
+					),
+					'core/navigation-link' => array(
+						'-current' => array(
+							'color' => array(
+								'text' => 'purple',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
 	 * Test that block pseudo selectors work with elements within blocks.
 	 */
 	public function test_block_pseudo_selectors_with_elements() {


### PR DESCRIPTION
## What?

In `sanitize()`, build the common base schema only once instead of recreating it for each registered block.

## Why?

Performance. The base schema doesn't change with the block name, so we should only need to build it once. In the old loop, we modify arrays inside the loop crossing every registered block. This triggers PHP's copy-on-write, causing it to copy large data structures in memory (one time for each block).

```php
foreach ( $valid_block_names as $block ) {
	$schema_styles_blocks[ $block ]             = $styles_non_top_level;   // Cheap assign to existing data
	$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements; // Modifying --> PHP has to make a new copy of the data structure.

    // And once again //

	foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
		$schema_styles_blocks[ $block ][ $breakpoint_state ]             = $styles_non_top_level;   // Cheap
		$schema_styles_blocks[ $block ][ $breakpoint_state ]['elements'] = $schema_styles_elements; // Modify --> Copying entire datastructure
```

## How?

Put `elements` and `@mobile`/`@tablet` on two templates before the block loop. Inside the loop, most blocks just get those templates.

By moving the array mutations outside of the block loop, we significantly reduce the amount of data being copied around while we are building the sanitize schema. 

## Testing Instructions

`npm run test:unit:php`

A test shows that when attempting to assign `@mobile -> :hover -> color` to both a core/button and core/paragraph, sanitize() removes it from the paragraph but keeps it on the button.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Performance

To test if the improvement was visible on actual requests, I looked at a WordPress.com sandbox site using Twenty Twenty and its default homepage content. Note that this is an environment specific measurement rather than a core benchmark.

I ran four interleaved control and path runs, with 600 requests each, equalling 4,800 requests in total. The average of the 4 run level percentiles were:

| Metric   |   Control | With patch |       Difference |
| -------- | --------: | ---------: | ---------------: |
| p50 TTFB | 252.22 ms |  243.09 ms | −9.13 ms (−3.6%) |
| p75 TTFB | 258.94 ms |  251.57 ms | −7.38 ms (−2.8%) |

The size of the improvement will be different depending on the environment.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

After manually discovering a performance regression in Gutenberg, and manually narrowing it down to WP_Theme_JSON_Gutenberg, GPT-5.6 Sol Pro brainstormed possible reasons for the regression. I measured this one to be impactful and went with it. It created the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Responsive pseudo-state styles are now retained for supported blocks, including buttons and navigation links.
  * Unsupported blocks no longer retain responsive pseudo-state styles, while regular responsive styles continue to work.
  * Custom current-state styles for navigation links remain preserved.

* **Performance**
  * Theme style sanitization now avoids repeating shared processing, improving efficiency without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->