### PR TITLE
Widget Dashboard: make the column count a host decision

### DIFF
--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -23,7 +23,7 @@
 -   `gridSettings.columns` now lowers the column cap on wide containers, from
     `1` to `WIDGET_DASHBOARD_COLUMN_COUNT`; the responsive steps scale from
     the cap. Defaults are unchanged: `DEFAULT_GRID` keeps four columns
-    ([#82173](https://github.com/WordPress/gutenberg/issues/82173)).
+    ([#82204](https://github.com/WordPress/gutenberg/pull/82204)).
 
 ### Internal
 

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -20,10 +20,12 @@
 
 ### Enhancements
 
--   `gridSettings.columns` now lowers the column cap on wide containers, from
-    `1` to `WIDGET_DASHBOARD_COLUMN_COUNT`; the responsive steps scale from
-    the cap. Defaults are unchanged: `DEFAULT_GRID` keeps four columns
-    ([#82204](https://github.com/WordPress/gutenberg/pull/82204)).
+-   `gridSettings.columns` now sets the wide-container column count (floored,
+    with a floor of one); the responsive steps scale from it.
+    `WIDGET_DASHBOARD_COLUMN_COUNT` is the default when the host sets
+    nothing, and the wp-admin dashboard pins it where it reads its stored
+    settings, so preferences persisted by the removed Columns control stay
+    inert ([#82204](https://github.com/WordPress/gutenberg/pull/82204)).
 
 ### Internal
 

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -18,6 +18,13 @@
     registered type be inserted
     ([#81967](https://github.com/WordPress/gutenberg/pull/81967)).
 
+### Enhancements
+
+-   `gridSettings.columns` now lowers the column cap on wide containers, from
+    `1` to `WIDGET_DASHBOARD_COLUMN_COUNT`; the responsive steps scale from
+    the cap. Defaults are unchanged: `DEFAULT_GRID` keeps four columns
+    ([#82173](https://github.com/WordPress/gutenberg/issues/82173)).
+
 ### Internal
 
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -252,7 +252,7 @@ The exported kit for handling them:
 -   `DEFAULT_GRID` — canonical default settings, applied when `gridSettings` is omitted.
 -   `normalizeGridSettings( settings, defaultRowHeight )` — coerces legacy freeform row heights to the nearest preset. Run it over stored payloads before passing them in.
 -   `ROW_HEIGHT_PRESETS` / `DEFAULT_ROW_HEIGHT` — the row-height presets (`small`, `medium`, `large`) that `rowHeight` values normalize to.
--   `WIDGET_DASHBOARD_COLUMN_COUNT` — default and maximum column count on wide containers. `gridSettings.columns` lowers it: a finite value is floored and clamped between `1` and the constant, anything else resolves to the constant. The effective count steps down from container width: the cap at `960px` and above, `min( 2, cap )` below that, one column below `600px`.
+-   `WIDGET_DASHBOARD_COLUMN_COUNT` — column count used on wide containers when the host sets no `gridSettings.columns`. A default, not a ceiling: a finite `columns` is floored, with a floor of `1`, and rendered as asked. The effective count steps down from container width: the count at `960px` and above, `min( 2, count )` below that, one column below `600px`.
 
 ```tsx
 <WidgetDashboard

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -252,7 +252,7 @@ The exported kit for handling them:
 -   `DEFAULT_GRID` — canonical default settings, applied when `gridSettings` is omitted.
 -   `normalizeGridSettings( settings, defaultRowHeight )` — coerces legacy freeform row heights to the nearest preset. Run it over stored payloads before passing them in.
 -   `ROW_HEIGHT_PRESETS` / `DEFAULT_ROW_HEIGHT` — the row-height presets (`small`, `medium`, `large`) that `rowHeight` values normalize to.
--   `WIDGET_DASHBOARD_COLUMN_COUNT` — maximum column count on wide containers. The effective count steps down from container width; persisted `columns` values are ignored.
+-   `WIDGET_DASHBOARD_COLUMN_COUNT` — default and maximum column count on wide containers. `gridSettings.columns` lowers it (`1` to the constant; anything else resolves to the constant). The effective count steps down from container width: the cap at `960px` and above, two below that, one below `600px`.
 
 ```tsx
 <WidgetDashboard

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -252,7 +252,7 @@ The exported kit for handling them:
 -   `DEFAULT_GRID` — canonical default settings, applied when `gridSettings` is omitted.
 -   `normalizeGridSettings( settings, defaultRowHeight )` — coerces legacy freeform row heights to the nearest preset. Run it over stored payloads before passing them in.
 -   `ROW_HEIGHT_PRESETS` / `DEFAULT_ROW_HEIGHT` — the row-height presets (`small`, `medium`, `large`) that `rowHeight` values normalize to.
--   `WIDGET_DASHBOARD_COLUMN_COUNT` — default and maximum column count on wide containers. `gridSettings.columns` lowers it (`1` to the constant; anything else resolves to the constant). The effective count steps down from container width: the cap at `960px` and above, two below that, one below `600px`.
+-   `WIDGET_DASHBOARD_COLUMN_COUNT` — default and maximum column count on wide containers. `gridSettings.columns` lowers it: a finite value is floored and clamped between `1` and the constant, anything else resolves to the constant. The effective count steps down from container width: the cap at `960px` and above, `min( 2, cap )` below that, one column below `600px`.
 
 ```tsx
 <WidgetDashboard

--- a/packages/widget-dashboard/src/components/widgets/widgets.tsx
+++ b/packages/widget-dashboard/src/components/widgets/widgets.tsx
@@ -131,8 +131,10 @@ export const Widgets = forwardRef< HTMLDivElement, WidgetsProps >(
 			widgetTypes,
 			canPerform,
 		} = useDashboardInternalContext();
-		const { containerRef, columnCount } =
-			useDashboardContainerColumnCount( ref );
+		const { containerRef, columnCount } = useDashboardContainerColumnCount(
+			ref,
+			gridSettings.columns
+		);
 		const isMasonry = gridSettings.model === 'masonry';
 
 		const permissionsFor = useCallback< TilePermissionsFor >(

--- a/packages/widget-dashboard/src/context/dashboard-context.tsx
+++ b/packages/widget-dashboard/src/context/dashboard-context.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@wordpress/widget-primitives';
 import { DEFAULT_GRID } from '../utils/default-grid';
 import { normalizeGridSettings } from '../utils/normalize-grid-settings';
+import { resolveDashboardColumnCap } from '../utils/resolve-dashboard-column-count/resolve-dashboard-column-count';
 import { DEFAULT_ROW_HEIGHT } from '../utils/row-height-presets';
 import { useDashboardPolicy } from '../components/dashboard-policy';
 import type {
@@ -22,7 +23,6 @@ import type {
 	WidgetGridSettings,
 	DashboardWidget,
 } from '../types';
-import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../types';
 
 type GridSettingsWithColumns = WidgetGridSettings & { columns: number };
 
@@ -32,7 +32,7 @@ function resolveGridSettings(
 	const normalized = normalizeGridSettings( settings, DEFAULT_ROW_HEIGHT );
 	return {
 		...normalized,
-		columns: WIDGET_DASHBOARD_COLUMN_COUNT,
+		columns: resolveDashboardColumnCap( normalized.columns ),
 	};
 }
 

--- a/packages/widget-dashboard/src/hooks/use-dashboard-container-column-count.ts
+++ b/packages/widget-dashboard/src/hooks/use-dashboard-container-column-count.ts
@@ -14,13 +14,15 @@ interface UseDashboardContainerColumnCountResult {
 
 /**
  * Tracks the dashboard grid container width and maps it to an opinionated
- * column count (4 → 2 → 1). Measurement is container-based via
+ * column count (cap → 2 → 1). Measurement is container-based via
  * `ResizeObserver`, not viewport media queries.
  *
  * @param {Ref< HTMLDivElement >} [forwardedRef] Ref forwarded from the grid wrapper.
+ * @param {number}                [maxColumns]   Column cap for wide containers.
  */
 export function useDashboardContainerColumnCount(
-	forwardedRef?: Ref< HTMLDivElement >
+	forwardedRef?: Ref< HTMLDivElement >,
+	maxColumns?: number
 ): UseDashboardContainerColumnCountResult {
 	const [ container, setContainer ] = useState< HTMLDivElement | null >(
 		null
@@ -48,8 +50,8 @@ export function useDashboardContainerColumnCount(
 	}, [ container ] );
 
 	const columnCount = useMemo(
-		() => resolveDashboardColumnCount( containerWidth ),
-		[ containerWidth ]
+		() => resolveDashboardColumnCount( containerWidth, maxColumns ),
+		[ containerWidth, maxColumns ]
 	);
 
 	return { containerRef, columnCount };

--- a/packages/widget-dashboard/src/stories/index.story.tsx
+++ b/packages/widget-dashboard/src/stories/index.story.tsx
@@ -27,6 +27,8 @@ import type {
 	WidgetRenderProps,
 	WidgetType,
 } from '@wordpress/widget-primitives';
+import { ROW_HEIGHT_PRESETS } from '../utils/row-height-presets';
+import type { RowHeightPreset } from '../utils/row-height-presets';
 import { WidgetDashboard } from '../widget-dashboard';
 import type { CanPerformDashboardOperation, DashboardWidget } from '../types';
 
@@ -782,6 +784,127 @@ Switch the \`profile\` control. A Viewer gets no Customize button, no attribute 
 Switch the section, then open "Add widget": the listing follows the section, even while open; the excluded types keep rendering where already placed because the \`widgetTypes\` registry never changes.
 
 Nested policies compose restrictively; without a policy, every operation is allowed. See the **Policy** page for the contract.
+`,
+			},
+		},
+	},
+};
+
+// A fuller board than INITIAL_LAYOUT: a hero spanning the whole first row at
+// any column count (the grid clamps the span), then a rank of small tiles so
+// the columns control visibly repacks them.
+const GRID_SETTINGS_LAYOUT: DashboardWidget[] = [
+	{
+		uuid: 'grid-settings-traffic-week',
+		type: 'demo/traffic-snapshot',
+		attributes: { metric: 'views', period: 'week', label: 'Traffic' },
+		placement: { width: 2, height: 1, order: 1 },
+	},
+	{
+		uuid: 'grid-settings-goal-revenue',
+		type: 'demo/goal-progress',
+		attributes: { metric: 'revenue', target: '5000' },
+		placement: { width: 1, height: 1, order: 2 },
+	},
+	{
+		uuid: 'grid-settings-audience-tall',
+		type: 'demo/traffic-snapshot',
+		attributes: { metric: 'visitors', period: 'month', label: 'Audience' },
+		placement: { width: 1, height: 2, order: 3 },
+	},
+	{
+		uuid: 'grid-settings-goal-orders',
+		type: 'demo/goal-progress',
+		attributes: { metric: 'orders', target: '1000' },
+		placement: { width: 2, height: 1, order: 4 },
+	},
+	{
+		uuid: 'grid-settings-traffic-day',
+		type: 'demo/traffic-snapshot',
+		attributes: { metric: 'views', period: 'day', label: 'Today' },
+		placement: { width: 1, height: 1, order: 5 },
+	},
+	{
+		uuid: 'grid-settings-goal-stretch',
+		type: 'demo/goal-progress',
+		attributes: { metric: 'revenue', target: '10000' },
+		placement: { width: 1, height: 1, order: 6 },
+	},
+];
+
+type GridSettingsStoryProps = {
+	columns: number;
+	model: 'grid' | 'masonry';
+	rowHeight: RowHeightPreset;
+};
+
+function GridSettingsStory( {
+	columns,
+	model,
+	rowHeight,
+}: GridSettingsStoryProps ) {
+	const [ layout, setLayout ] =
+		useState< DashboardWidget[] >( GRID_SETTINGS_LAYOUT );
+	const [ editMode, setEditMode ] = useState( false );
+
+	return (
+		<WidgetDashboard
+			widgetTypes={ [
+				trafficSnapshotWidgetType,
+				goalProgressWidgetType,
+			] }
+			layout={ layout }
+			onLayoutChange={ setLayout }
+			editMode={ editMode }
+			onEditChange={ setEditMode }
+			resolveWidgetModule={ resolveDemoModule }
+			gridSettings={ {
+				model,
+				columns,
+				rowHeight: ROW_HEIGHT_PRESETS[ rowHeight ],
+			} }
+		>
+			<Page
+				title="Dashboard"
+				subTitle={ `Standard grid, ${ columns } columns on a wide container, stepping down to 2 and then one as it narrows.` }
+				actions={ <WidgetDashboard.Actions /> }
+				showSidebarToggle={ false }
+				hasPadding
+			>
+				<WidgetDashboard.Widgets />
+			</Page>
+		</WidgetDashboard>
+	);
+}
+
+export const GridSettings: StoryObj< GridSettingsStoryProps > = {
+	render: ( args ) => <GridSettingsStory { ...args } />,
+	args: {
+		columns: 4,
+		model: 'grid',
+		rowHeight: 'medium',
+	},
+	argTypes: {
+		columns: {
+			control: { type: 'range', min: 1, max: 12, step: 1 },
+			description:
+				'Wide-container column count. The host decides; the package only floors it at one.',
+		},
+		model: {
+			control: 'radio',
+			options: [ 'grid', 'masonry' ],
+		},
+		rowHeight: {
+			control: 'radio',
+			options: Object.keys( ROW_HEIGHT_PRESETS ),
+		},
+	},
+	parameters: {
+		controls: { include: [ 'columns', 'model', 'rowHeight' ] },
+		docs: {
+			description: {
+				story: `
+The \`gridSettings\` prop carries the host's layout decisions. \`columns\` sets the wide-container count — \`WIDGET_DASHBOARD_COLUMN_COUNT\` is only the default when the host sets nothing — and container width steps the effective count down to \`min( 2, count )\` and then one as it narrows. Drag the columns control; resize the canvas to watch the steps.
 `,
 			},
 		},

--- a/packages/widget-dashboard/src/stories/index.story.tsx
+++ b/packages/widget-dashboard/src/stories/index.story.tsx
@@ -30,7 +30,12 @@ import type {
 import { ROW_HEIGHT_PRESETS } from '../utils/row-height-presets';
 import type { RowHeightPreset } from '../utils/row-height-presets';
 import { WidgetDashboard } from '../widget-dashboard';
-import type { CanPerformDashboardOperation, DashboardWidget } from '../types';
+import type {
+	CanPerformDashboardOperation,
+	DashboardWidget,
+	WidgetGridModel,
+	WidgetGridSettings,
+} from '../types';
 
 /*
  * Stories run without WordPress, so both halves of the demo widget are
@@ -834,18 +839,49 @@ const GRID_SETTINGS_LAYOUT: DashboardWidget[] = [
 
 type GridSettingsStoryProps = {
 	columns: number;
-	model: 'grid' | 'masonry';
+	model: WidgetGridModel;
 	rowHeight: RowHeightPreset;
+	flowTolerance: number;
 };
+
+// The ladder in words, so the caption tracks the count the story asked for
+// rather than describing the four-column default.
+function describeColumnSteps( columns: number ): string {
+	if ( columns === 1 ) {
+		return 'one column at every width';
+	}
+
+	const middle = Math.min( 2, columns );
+	if ( middle === columns ) {
+		return `${ columns } columns until the container narrows to one`;
+	}
+
+	return `${ columns } columns on a wide container, ${ middle } as it narrows, then one`;
+}
 
 function GridSettingsStory( {
 	columns,
 	model,
 	rowHeight,
+	flowTolerance,
 }: GridSettingsStoryProps ) {
 	const [ layout, setLayout ] =
 		useState< DashboardWidget[] >( GRID_SETTINGS_LAYOUT );
 	const [ editMode, setEditMode ] = useState( false );
+
+	// The settings union is per model: `rowHeight` belongs to the grid and
+	// `flowTolerance` to masonry, so only the active model's field travels.
+	const gridSettings = useMemo< WidgetGridSettings >(
+		() =>
+			model === 'masonry'
+				? { model, columns, flowTolerance }
+				: {
+						model,
+						columns,
+						rowHeight: ROW_HEIGHT_PRESETS[ rowHeight ],
+				  },
+		[ model, columns, flowTolerance, rowHeight ]
+	);
 
 	return (
 		<WidgetDashboard
@@ -858,15 +894,13 @@ function GridSettingsStory( {
 			editMode={ editMode }
 			onEditChange={ setEditMode }
 			resolveWidgetModule={ resolveDemoModule }
-			gridSettings={ {
-				model,
-				columns,
-				rowHeight: ROW_HEIGHT_PRESETS[ rowHeight ],
-			} }
+			gridSettings={ gridSettings }
 		>
 			<Page
 				title="Dashboard"
-				subTitle={ `Standard grid, ${ columns } columns on a wide container, stepping down to 2 and then one as it narrows.` }
+				subTitle={ `${
+					model === 'masonry' ? 'Masonry' : 'Standard grid'
+				}: ${ describeColumnSteps( columns ) }.` }
 				actions={ <WidgetDashboard.Actions /> }
 				showSidebarToggle={ false }
 				hasPadding
@@ -883,6 +917,7 @@ export const GridSettings: StoryObj< GridSettingsStoryProps > = {
 		columns: 4,
 		model: 'grid',
 		rowHeight: 'medium',
+		flowTolerance: 16,
 	},
 	argTypes: {
 		columns: {
@@ -893,18 +928,34 @@ export const GridSettings: StoryObj< GridSettingsStoryProps > = {
 		model: {
 			control: 'radio',
 			options: [ 'grid', 'masonry' ],
+			description:
+				'The grid model. `grid` gives uniform rows and two-axis spans; `masonry` drives heights from content.',
 		},
 		rowHeight: {
 			control: 'radio',
 			options: Object.keys( ROW_HEIGHT_PRESETS ),
+			description: 'Height of each grid row. Grid model only.',
+			if: { arg: 'model', eq: 'grid' },
+		},
+		flowTolerance: {
+			control: { type: 'range', min: 0, max: 200, step: 4 },
+			description:
+				'Pixel tolerance for source-order tiebreaking between lanes. Masonry model only.',
+			if: { arg: 'model', eq: 'masonry' },
 		},
 	},
 	parameters: {
-		controls: { include: [ 'columns', 'model', 'rowHeight' ] },
+		controls: {
+			include: [ 'columns', 'model', 'rowHeight', 'flowTolerance' ],
+		},
 		docs: {
 			description: {
 				story: `
-The \`gridSettings\` prop carries the host's layout decisions. \`columns\` sets the wide-container count — \`WIDGET_DASHBOARD_COLUMN_COUNT\` is only the default when the host sets nothing — and container width steps the effective count down to \`min( 2, count )\` and then one as it narrows. Drag the columns control; resize the canvas to watch the steps.
+The \`gridSettings\` prop carries the host's layout decisions. \`columns\` sets the wide-container count (\`WIDGET_DASHBOARD_COLUMN_COUNT\` is only the default when the host sets nothing), and container width steps the effective count down to \`min( 2, count )\` and then one as it narrows. Drag the columns control; resize the canvas to watch the steps.
+
+\`model\` picks the surface, and the per-model field follows it: \`rowHeight\` belongs to \`grid\`, \`flowTolerance\` to \`masonry\`. Only the active one is passed in \`gridSettings\`, and only its control is shown.
+
+Tile spans are stored per widget and do not scale with the count. Raise \`columns\` and every track narrows, so the same spans cover less of the surface. Enter Customize and resize a tile to see it take the new count.
 `,
 			},
 		},

--- a/packages/widget-dashboard/src/types.ts
+++ b/packages/widget-dashboard/src/types.ts
@@ -114,8 +114,8 @@ export type WidgetGridModel = 'grid' | 'masonry';
 /**
  * Default and maximum column count for the widget dashboard on wide
  * containers. A host may lower it through `gridSettings.columns`; container
- * width then steps the count down to two and one column at fixed
- * breakpoints. Not a user-facing setting.
+ * width then steps the effective count down at fixed breakpoints: the cap,
+ * then `min( 2, cap )`, then one column. Not a user-facing setting.
  */
 export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
 
@@ -133,10 +133,11 @@ export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
  */
 interface BaseWidgetGridSettings {
 	/**
-	 * Column cap on wide containers, `1` to
-	 * {@link WIDGET_DASHBOARD_COLUMN_COUNT}. Values outside that range, or
-	 * absent, resolve to the constant. Container width steps the effective
-	 * count down from the cap.
+	 * Column cap on wide containers. A finite value is floored and clamped
+	 * between `1` and {@link WIDGET_DASHBOARD_COLUMN_COUNT}; an absent or
+	 * non-finite value resolves to the constant. Container width steps the
+	 * effective count down from the cap: `min( 2, cap )` in the middle band,
+	 * one column below it.
 	 */
 	columns?: number;
 

--- a/packages/widget-dashboard/src/types.ts
+++ b/packages/widget-dashboard/src/types.ts
@@ -112,10 +112,10 @@ export interface WidgetContextValue {
 export type WidgetGridModel = 'grid' | 'masonry';
 
 /**
- * Default and maximum column count for the widget dashboard on wide
- * containers. A host may lower it through `gridSettings.columns`; container
- * width then steps the effective count down at fixed breakpoints: the cap,
- * then `min( 2, cap )`, then one column. Not a user-facing setting.
+ * Column count used on wide containers when the host sets no
+ * `gridSettings.columns`. A default, not a ceiling: the package renders
+ * whatever count the host asks for. The four-column wp-admin dashboard is
+ * that page's own decision, pinned where it reads its stored settings.
  */
 export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
 
@@ -133,11 +133,11 @@ export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
  */
 interface BaseWidgetGridSettings {
 	/**
-	 * Column cap on wide containers. A finite value is floored and clamped
-	 * between `1` and {@link WIDGET_DASHBOARD_COLUMN_COUNT}; an absent or
-	 * non-finite value resolves to the constant. Container width steps the
-	 * effective count down from the cap: `min( 2, cap )` in the middle band,
-	 * one column below it.
+	 * Column count on wide containers. A finite value is floored, with a
+	 * floor of one and no ceiling; an absent or non-finite value resolves to
+	 * {@link WIDGET_DASHBOARD_COLUMN_COUNT}. Container width steps the
+	 * effective count down: `min( 2, count )` in the middle band, one
+	 * column below it.
 	 */
 	columns?: number;
 

--- a/packages/widget-dashboard/src/types.ts
+++ b/packages/widget-dashboard/src/types.ts
@@ -112,18 +112,19 @@ export interface WidgetContextValue {
 export type WidgetGridModel = 'grid' | 'masonry';
 
 /**
- * Maximum column count for the widget dashboard on wide containers.
- * Not user-configurable; container width steps the count down to two
- * and one column at fixed breakpoints.
+ * Default and maximum column count for the widget dashboard on wide
+ * containers. A host may lower it through `gridSettings.columns`; container
+ * width then steps the count down to two and one column at fixed
+ * breakpoints. Not a user-facing setting.
  */
 export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
 
 /**
  * Settings common to every grid model. Column count is resolved from
- * the dashboard container width (see
- * `utils/resolve-dashboard-column-count`). `columns` and `minColumnWidth`
- * on this type remain for persisted payloads and `@wordpress/grid`
- * compatibility; the dashboard ignores user-facing values for both.
+ * the host's cap and the dashboard container width (see
+ * `utils/resolve-dashboard-column-count`). `minColumnWidth` remains for
+ * persisted payloads and `@wordpress/grid` compatibility; the dashboard
+ * ignores it.
  *
  * `spacing` is intentionally absent: the gap between tiles is
  * presentational and lives with the design-system theme/density, not
@@ -132,8 +133,10 @@ export const WIDGET_DASHBOARD_COLUMN_COUNT = 4;
  */
 interface BaseWidgetGridSettings {
 	/**
-	 * Target column count (cap). The dashboard always uses
-	 * {@link WIDGET_DASHBOARD_COLUMN_COUNT}; persisted values are ignored.
+	 * Column cap on wide containers, `1` to
+	 * {@link WIDGET_DASHBOARD_COLUMN_COUNT}. Values outside that range, or
+	 * absent, resolve to the constant. Container width steps the effective
+	 * count down from the cap.
 	 */
 	columns?: number;
 

--- a/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
+++ b/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
@@ -13,22 +13,20 @@ export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN = 600;
 export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS = 960;
 
 /**
- * Resolves the column cap a host asked for. A finite value is floored and
- * clamped between one and {@link WIDGET_DASHBOARD_COLUMN_COUNT}; an absent
- * or non-finite value resolves to the package default.
+ * Resolves the wide-container column count a host asked for. A finite value
+ * is floored, with a floor of one and no ceiling: how many columns a surface
+ * can carry is the host's decision, not the package's. An absent or
+ * non-finite value resolves to {@link WIDGET_DASHBOARD_COLUMN_COUNT}.
  *
  * @param columns Host-provided `gridSettings.columns`, if any.
- * @return Column cap for wide containers.
+ * @return Column count for wide containers.
  */
 export function resolveDashboardColumnCap( columns?: number ): number {
 	if ( typeof columns !== 'number' || ! Number.isFinite( columns ) ) {
 		return WIDGET_DASHBOARD_COLUMN_COUNT;
 	}
 
-	return Math.min(
-		WIDGET_DASHBOARD_COLUMN_COUNT,
-		Math.max( 1, Math.floor( columns ) )
-	);
+	return Math.max( 1, Math.floor( columns ) );
 }
 
 /**

--- a/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
+++ b/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
@@ -7,23 +7,46 @@ import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../../types';
 export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN = 600;
 
 /**
- * Container width (px) below which the dashboard drops from four columns
- * to two. Above this threshold (and below the four-column cap) the
- * grid uses {@link WIDGET_DASHBOARD_COLUMN_COUNT}.
+ * Container width (px) below which the dashboard drops from the column
+ * cap to two. Above this threshold the grid uses the cap itself.
  */
 export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS = 960;
 
 /**
+ * Resolves the column cap a host asked for. The cap can only lower the
+ * count: anything above {@link WIDGET_DASHBOARD_COLUMN_COUNT}, below one,
+ * or not a finite number falls back to the package default.
+ *
+ * @param columns Host-provided `gridSettings.columns`, if any.
+ * @return Column cap for wide containers.
+ */
+export function resolveDashboardColumnCap( columns?: number ): number {
+	if ( typeof columns !== 'number' || ! Number.isFinite( columns ) ) {
+		return WIDGET_DASHBOARD_COLUMN_COUNT;
+	}
+
+	return Math.min(
+		WIDGET_DASHBOARD_COLUMN_COUNT,
+		Math.max( 1, Math.floor( columns ) )
+	);
+}
+
+/**
  * Resolves the dashboard grid column count from the widget surface
- * container width. Uses discrete steps (4 → 2 → 1), not viewport
+ * container width. Uses discrete steps (cap → 2 → 1), not viewport
  * media queries.
  *
  * @param containerWidth Measured inline size of the dashboard grid container.
+ * @param maxColumns     Column cap for wide containers; see
+ *                       {@link resolveDashboardColumnCap}.
  * @return Column count for {@link @wordpress/grid} surfaces.
  */
-export function resolveDashboardColumnCount( containerWidth: number ): number {
+export function resolveDashboardColumnCount(
+	containerWidth: number,
+	maxColumns: number = WIDGET_DASHBOARD_COLUMN_COUNT
+): number {
 	if ( containerWidth <= 0 ) {
-		return WIDGET_DASHBOARD_COLUMN_COUNT;
+		return maxColumns;
 	}
 
 	if ( containerWidth < WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN ) {
@@ -31,8 +54,9 @@ export function resolveDashboardColumnCount( containerWidth: number ): number {
 	}
 
 	if ( containerWidth < WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS ) {
-		return 2;
+		// A cap of one must not step up to two in the middle band.
+		return Math.min( 2, maxColumns );
 	}
 
-	return WIDGET_DASHBOARD_COLUMN_COUNT;
+	return maxColumns;
 }

--- a/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
+++ b/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/resolve-dashboard-column-count.ts
@@ -13,9 +13,9 @@ export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN = 600;
 export const WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS = 960;
 
 /**
- * Resolves the column cap a host asked for. The cap can only lower the
- * count: anything above {@link WIDGET_DASHBOARD_COLUMN_COUNT}, below one,
- * or not a finite number falls back to the package default.
+ * Resolves the column cap a host asked for. A finite value is floored and
+ * clamped between one and {@link WIDGET_DASHBOARD_COLUMN_COUNT}; an absent
+ * or non-finite value resolves to the package default.
  *
  * @param columns Host-provided `gridSettings.columns`, if any.
  * @return Column cap for wide containers.

--- a/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
+++ b/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
@@ -1,8 +1,50 @@
 import {
+	resolveDashboardColumnCap,
 	resolveDashboardColumnCount,
 	WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN,
 	WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS,
 } from '../resolve-dashboard-column-count';
+import { WIDGET_DASHBOARD_COLUMN_COUNT } from '../../../types';
+
+describe( 'resolveDashboardColumnCap', () => {
+	it( 'falls back to the package default when the host sets nothing', () => {
+		expect( resolveDashboardColumnCap( undefined ) ).toBe(
+			WIDGET_DASHBOARD_COLUMN_COUNT
+		);
+	} );
+
+	it( 'keeps a cap within range', () => {
+		expect( resolveDashboardColumnCap( 3 ) ).toBe( 3 );
+		expect( resolveDashboardColumnCap( 1 ) ).toBe( 1 );
+		expect(
+			resolveDashboardColumnCap( WIDGET_DASHBOARD_COLUMN_COUNT )
+		).toBe( WIDGET_DASHBOARD_COLUMN_COUNT );
+	} );
+
+	it( 'never raises the count above the package default', () => {
+		expect(
+			resolveDashboardColumnCap( WIDGET_DASHBOARD_COLUMN_COUNT + 2 )
+		).toBe( WIDGET_DASHBOARD_COLUMN_COUNT );
+	} );
+
+	it( 'never drops below one column', () => {
+		expect( resolveDashboardColumnCap( 0 ) ).toBe( 1 );
+		expect( resolveDashboardColumnCap( -3 ) ).toBe( 1 );
+	} );
+
+	it( 'floors a fractional cap', () => {
+		expect( resolveDashboardColumnCap( 2.9 ) ).toBe( 2 );
+	} );
+
+	it( 'treats a non-numeric cap as unset', () => {
+		expect( resolveDashboardColumnCap( Number.NaN ) ).toBe(
+			WIDGET_DASHBOARD_COLUMN_COUNT
+		);
+		expect( resolveDashboardColumnCap( Number.POSITIVE_INFINITY ) ).toBe(
+			WIDGET_DASHBOARD_COLUMN_COUNT
+		);
+	} );
+} );
 
 describe( 'resolveDashboardColumnCount', () => {
 	it( 'defaults to four columns before measurement', () => {
@@ -37,5 +79,53 @@ describe( 'resolveDashboardColumnCount', () => {
 				WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN - 1
 			)
 		).toBe( 1 );
+	} );
+
+	describe( 'with a host cap', () => {
+		it( 'uses the cap before measurement and on wide containers', () => {
+			expect( resolveDashboardColumnCount( 0, 3 ) ).toBe( 3 );
+			expect(
+				resolveDashboardColumnCount(
+					WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS,
+					3
+				)
+			).toBe( 3 );
+			expect( resolveDashboardColumnCount( 1200, 3 ) ).toBe( 3 );
+		} );
+
+		it( 'keeps the two- and one-column steps below the cap', () => {
+			expect(
+				resolveDashboardColumnCount(
+					WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS - 1,
+					3
+				)
+			).toBe( 2 );
+			expect(
+				resolveDashboardColumnCount(
+					WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_ONE_COLUMN - 1,
+					3
+				)
+			).toBe( 1 );
+		} );
+
+		it( 'never steps above a cap of one in the middle band', () => {
+			expect(
+				resolveDashboardColumnCount(
+					WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS - 1,
+					1
+				)
+			).toBe( 1 );
+			expect( resolveDashboardColumnCount( 1200, 1 ) ).toBe( 1 );
+		} );
+
+		it( 'keeps a cap of two flat across the middle and wide bands', () => {
+			expect(
+				resolveDashboardColumnCount(
+					WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS - 1,
+					2
+				)
+			).toBe( 2 );
+			expect( resolveDashboardColumnCount( 1200, 2 ) ).toBe( 2 );
+		} );
 	} );
 } );

--- a/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
+++ b/packages/widget-dashboard/src/utils/resolve-dashboard-column-count/test/resolve-dashboard-column-count.test.ts
@@ -21,10 +21,10 @@ describe( 'resolveDashboardColumnCap', () => {
 		).toBe( WIDGET_DASHBOARD_COLUMN_COUNT );
 	} );
 
-	it( 'never raises the count above the package default', () => {
+	it( 'renders counts above the package default as asked', () => {
 		expect(
 			resolveDashboardColumnCap( WIDGET_DASHBOARD_COLUMN_COUNT + 2 )
-		).toBe( WIDGET_DASHBOARD_COLUMN_COUNT );
+		).toBe( WIDGET_DASHBOARD_COLUMN_COUNT + 2 );
 	} );
 
 	it( 'never drops below one column', () => {
@@ -116,6 +116,16 @@ describe( 'resolveDashboardColumnCount', () => {
 				)
 			).toBe( 1 );
 			expect( resolveDashboardColumnCount( 1200, 1 ) ).toBe( 1 );
+		} );
+
+		it( 'uses a count above the default on wide containers', () => {
+			expect( resolveDashboardColumnCount( 1200, 6 ) ).toBe( 6 );
+			expect(
+				resolveDashboardColumnCount(
+					WIDGET_DASHBOARD_CONTAINER_BREAKPOINT_TWO_COLUMNS - 1,
+					6
+				)
+			).toBe( 2 );
 		} );
 
 		it( 'keeps a cap of two flat across the middle and wide bands', () => {

--- a/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_GRID,
 	DEFAULT_ROW_HEIGHT,
 	normalizeGridSettings,
+	WIDGET_DASHBOARD_COLUMN_COUNT,
 } from '@wordpress/widget-dashboard';
 import type { WidgetGridSettings } from '@wordpress/widget-dashboard';
 
@@ -23,9 +24,14 @@ export function useDashboardGridSettings(): WidgetGridSettings {
 		const stored = select( preferencesStore ).get( SCOPE, KEY ) as
 			| WidgetGridSettings
 			| undefined;
-		return normalizeGridSettings(
-			stored ?? DEFAULT_GRID,
-			DEFAULT_ROW_HEIGHT
-		);
+		return {
+			...normalizeGridSettings(
+				stored ?? DEFAULT_GRID,
+				DEFAULT_ROW_HEIGHT
+			),
+			// The removed Columns control persisted other counts into this
+			// preference; pinning on read keeps those stale values inert.
+			columns: WIDGET_DASHBOARD_COLUMN_COUNT,
+		};
 	}, [] );
 }


### PR DESCRIPTION
## What?

Closes #82173

Makes the wide-container column count a host decision: `gridSettings.columns` sets it, floored at one with no ceiling. `WIDGET_DASHBOARD_COLUMN_COUNT` becomes the value used when the host sets nothing. The four-column wp-admin dashboard is unchanged — that decision now lives in the page, pinned where it reads its stored settings.

## Why?

The count is fixed at four in the package: `resolveGridSettings()` overwrites whatever `columns` a host passes with the constant, so the `columns` field on `WidgetGridSettings` has no effect. How many columns a surface can carry depends on how wide the surface is and what the application is, and the package knows neither — first-party hosts already want 3 (Jetpack Stats) and 12 (the customizable dashboard grid). A CSS override doesn't work because drag and resize read the same `columns` value.

Per the review discussion below: the ceiling belongs to the page, not the rendering engine. The four-column decision from #78732 is a wp-admin product decision, stated in wp-admin.

## How?

- `resolveDashboardColumnCap( columns )` floors a finite value at one; anything absent or non-finite resolves to `WIDGET_DASHBOARD_COLUMN_COUNT`. No upper clamp.
- `resolveGridSettings()` in the dashboard context uses that instead of overwriting `columns`.
- `resolveDashboardColumnCount( containerWidth, maxColumns )` scales the responsive steps from the count: `count → min( 2, count ) → 1`.
- `useDashboardContainerColumnCount()` and `Widgets` thread `gridSettings.columns` through.
- `useDashboardGridSettings()` in the wp-admin dashboard route pins `columns: WIDGET_DASHBOARD_COLUMN_COUNT` after reading the stored preference. The removed Columns control (#78732) persisted counts of 1–12 into that key; pinning on read keeps those stale values inert, so the page renders 4 → 2 → 1 exactly as today.
- A **Grid Settings** playground story: a `Page`-wrapped board with a columns slider (1–12), model, and row height controls.
- Docs on the constant, the `columns` field, the README, and the changelog updated to the same contract.

## Testing Instructions

1. `npm run storybook:dev`, open **Widget Dashboard → Playground → Grid Settings**. Drag the columns control from 1 to 12: the board repacks at every count; narrow the canvas to watch the steps down to `min( 2, count )` and one.
2. Enable the `gutenberg-dashboard-widgets` experiment and open **Dashboard (Beta)** on a wide window: four columns, unchanged.
3. Simulate a stale preference from the removed Columns control:
   ```js
   wp.data.dispatch( 'core/preferences' ).set( 'core/dashboard', 'dashboardGridSettings', { model: 'grid', columns: 2, rowHeight: 200 } );
   ```
   The page stays at four columns. Same with `columns: 12`.
4. `npm run test:unit -- packages/widget-dashboard/src/utils/resolve-dashboard-column-count` — 15 tests pass.

### Testing Instructions for Keyboard

No new interface in wp-admin. In the story and in Customize mode, keyboard move and resize snap to the active column count.

## Screenshots or screencast

Resolved count by container width — unit-tested, and verified live in the story and on the wp-admin dashboard:

| host count | ≥960px | 750px | 500px |
|-|-|-|-|
| unset (default 4) | 4 | 2 | 1 |
| 3 | 3 | 2 | 1 |
| 12 | 12 | 2 | 1 |
| 1 | 1 | 1 | 1 |

## Use of AI Tools

Implementation, tests, and this description were drafted with Claude Code (Anthropic). I reviewed every change, and verified the behavior above by hand in a local wp-admin build and Storybook.
