### PR TITLE
Format Library: Preserve inline images in Link UI title editing.

### DIFF
--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Link UI: hide inline image placeholders from the editable link title and preserve inline images when updating link text. ([#64031](https://github.com/WordPress/gutenberg/issues/64031))
+
 ### Internal
 
 -   Use the `.jsx` extension for JavaScript source files that contain JSX ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).

--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Link UI: hide inline image placeholders from the editable link title and preserve inline images when updating link text. ([#64031](https://github.com/WordPress/gutenberg/issues/64031))
+-   Link UI: hide inline image placeholders from the editable link title and preserve inline images when updating link text. ([#82206](https://github.com/WordPress/gutenberg/pull/82206))
 
 ### Internal
 

--- a/packages/format-library/src/link/inline.jsx
+++ b/packages/format-library/src/link/inline.jsx
@@ -14,13 +14,20 @@ import {
 	split,
 	concat,
 	useAnchor,
+	getTextContent,
 } from '@wordpress/rich-text';
 import {
 	LinkControl,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
+import {
+	createLinkFormat,
+	isValidHref,
+	getFormatBoundary,
+	hasInlineReplacements,
+	createLinkTextValueFromDisplayTitle,
+} from './utils';
 import { link as settings } from './index';
 import CSSClassesSettingComponent from './css-classes-setting';
 
@@ -57,7 +64,8 @@ function InlineLinkUI( {
 } ) {
 	const richLinkTextValue = getRichTextValueFromSelection( value, isActive );
 
-	// Get the text content minus any HTML tags.
+	// Omit object replacement characters from the editable link title.
+	const linkDisplayTitle = getTextContent( richLinkTextValue );
 	const richTextText = richLinkTextValue.text;
 
 	const { selectionChange } = useDispatch( blockEditorStore );
@@ -84,7 +92,7 @@ function InlineLinkUI( {
 			id: activeAttributes.id,
 			opensInNewTab: activeAttributes.target === '_blank',
 			nofollow: activeAttributes.rel?.includes( 'nofollow' ),
-			title: richTextText,
+			title: linkDisplayTitle,
 			cssClasses: activeAttributes.class,
 		} ),
 		[
@@ -94,7 +102,7 @@ function InlineLinkUI( {
 			activeAttributes.target,
 			activeAttributes.type,
 			activeAttributes.url,
-			richTextText,
+			linkDisplayTitle,
 		]
 	);
 
@@ -128,7 +136,8 @@ function InlineLinkUI( {
 			cssClasses: nextValue.cssClasses,
 		} );
 
-		const newText = nextValue.title || newUrl;
+		const submittedDisplayTitle = nextValue.title ?? linkDisplayTitle;
+		const newText = submittedDisplayTitle || newUrl;
 
 		// Scenario: we have any active text selection or an active format.
 		let newValue;
@@ -157,7 +166,7 @@ function InlineLinkUI( {
 			} );
 
 			return;
-		} else if ( newText === richTextText ) {
+		} else if ( submittedDisplayTitle === linkDisplayTitle ) {
 			// Use explicit format boundaries rather than relying on
 			// the current selection which may be collapsed or
 			// misaligned after external value changes.
@@ -173,11 +182,20 @@ function InlineLinkUI( {
 		} else {
 			// Scenario: Editing an existing link.
 
-			// Create new RichText value for the new text in order that we
-			// can apply formats to it.
-			newValue = create( { text: newText } );
-			// Apply the new Link format to this new text value.
-			newValue = applyFormat( newValue, linkFormat, 0, newText.length );
+			const newTextValue = hasInlineReplacements( richLinkTextValue )
+				? createLinkTextValueFromDisplayTitle(
+						richLinkTextValue,
+						submittedDisplayTitle
+				  )
+				: create( { text: submittedDisplayTitle } );
+
+			// Apply the new Link format to the updated text value.
+			newValue = applyFormat(
+				newTextValue,
+				linkFormat,
+				0,
+				newTextValue.text.length
+			);
 
 			// Get the boundaries of the active link format.
 			const boundary = getFormatBoundary( value, {

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -1,4 +1,11 @@
-import { isValidHref, getFormatBoundary } from '../utils';
+import {
+	isValidHref,
+	getFormatBoundary,
+	hasInlineReplacements,
+	createLinkTextValueFromDisplayTitle,
+} from '../utils';
+
+const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
 
 describe( 'isValidHref', () => {
 	it( 'returns true if the href cannot be recognised as a url or an anchor link', () => {
@@ -451,6 +458,115 @@ describe( 'getFormatBoundary', () => {
 		).toEqual( {
 			start: 0,
 			end: 5,
+		} );
+	} );
+} );
+
+describe( 'hasInlineReplacements', () => {
+	it( 'returns true when the value includes inline replacements', () => {
+		expect(
+			hasInlineReplacements( {
+				text: `a${ OBJECT_REPLACEMENT_CHARACTER }b`,
+				replacements: [ undefined, { type: 'core/image' } ],
+			} )
+		).toBe( true );
+	} );
+
+	it( 'returns false when the value has no inline replacements', () => {
+		expect(
+			hasInlineReplacements( {
+				text: 'abc',
+				replacements: [],
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'createLinkTextValueFromDisplayTitle', () => {
+	const imageReplacement = {
+		type: 'core/image',
+		attributes: {
+			url: 'https://example.com/image.jpg',
+		},
+	};
+
+	it( 'returns plain text when there are no inline replacements', () => {
+		expect(
+			createLinkTextValueFromDisplayTitle(
+				{
+					text: 'Hello',
+					formats: [],
+					replacements: [],
+				},
+				'Hi'
+			)
+		).toEqual( {
+			text: 'Hi',
+			formats: [],
+			replacements: [],
+		} );
+	} );
+
+	it( 'prepends display text for image-only links', () => {
+		expect(
+			createLinkTextValueFromDisplayTitle(
+				{
+					text: OBJECT_REPLACEMENT_CHARACTER,
+					formats: [ [] ],
+					replacements: [ imageReplacement ],
+				},
+				'Click here'
+			)
+		).toEqual( {
+			text: `Click here${ OBJECT_REPLACEMENT_CHARACTER }`,
+			formats: [ ...Array( 'Click here'.length ).fill( undefined ), [] ],
+			replacements: [
+				...Array( 'Click here'.length ).fill( undefined ),
+				imageReplacement,
+			],
+		} );
+	} );
+
+	it( 'preserves inline replacements when editing mixed link text', () => {
+		expect(
+			createLinkTextValueFromDisplayTitle(
+				{
+					text: `Hello${ OBJECT_REPLACEMENT_CHARACTER } world`,
+					formats: [],
+					replacements: [
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						imageReplacement,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+					],
+				},
+				'Hi world'
+			)
+		).toEqual( {
+			text: `Hi${ OBJECT_REPLACEMENT_CHARACTER } world`,
+			formats: Array(
+				`Hi${ OBJECT_REPLACEMENT_CHARACTER } world`.length
+			).fill( undefined ),
+			replacements: [
+				undefined,
+				undefined,
+				imageReplacement,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+			],
 		} );
 	} );
 } );

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -268,3 +268,154 @@ const partialRight =
 const walkToStart = partialRight( walkToBoundary, 'backwards' );
 
 const walkToEnd = partialRight( walkToBoundary, 'forwards' );
+
+/**
+ * @typedef {import('@wordpress/rich-text').RichTextValue} RichTextValue
+ */
+
+/**
+ * Whether the value includes inline object replacements such as images.
+ *
+ * @param {RichTextValue} value The value to check.
+ * @return {boolean} True when inline replacements exist.
+ */
+export function hasInlineReplacements( value ) {
+	return value.replacements?.some( Boolean ) ?? false;
+}
+
+/**
+ * @param {RichTextValue} value The rich text value to parse.
+ * @return {Array<{ type: 'text', content: string } | { type: 'replacement', replacement: *, format: * }>} Segments.
+ */
+function getLinkContentSegments( value ) {
+	const { text, formats, replacements } = value;
+	const segments = [];
+	let textBuffer = '';
+
+	for ( let index = 0; index < text.length; index++ ) {
+		if ( replacements[ index ] ) {
+			if ( textBuffer ) {
+				segments.push( { type: 'text', content: textBuffer } );
+				textBuffer = '';
+			}
+
+			segments.push( {
+				type: 'replacement',
+				replacement: replacements[ index ],
+				format: formats[ index ],
+				character: text[ index ],
+			} );
+			continue;
+		}
+
+		textBuffer += text[ index ];
+	}
+
+	if ( textBuffer ) {
+		segments.push( { type: 'text', content: textBuffer } );
+	}
+
+	return segments;
+}
+
+/**
+ * Builds a RichTextValue from editable link title text while preserving inline
+ * object replacements within the original linked content.
+ *
+ * @param {RichTextValue} sourceValue  The linked rich text slice.
+ * @param {string}        displayTitle The title shown in the Link UI.
+ * @return {Pick<RichTextValue, 'text' | 'formats' | 'replacements'>} The rebuilt value.
+ */
+export function createLinkTextValueFromDisplayTitle(
+	sourceValue,
+	displayTitle
+) {
+	const { formats, replacements, text } = sourceValue;
+
+	if ( ! hasInlineReplacements( sourceValue ) ) {
+		return {
+			text: displayTitle,
+			formats: [],
+			replacements: [],
+		};
+	}
+
+	const segments = getLinkContentSegments( sourceValue );
+	const textSegments = segments.filter(
+		( segment ) => segment.type === 'text'
+	);
+	const originalDisplay = textSegments
+		.map( ( segment ) => segment.content )
+		.join( '' );
+
+	if ( displayTitle === originalDisplay ) {
+		return {
+			text,
+			formats,
+			replacements,
+		};
+	}
+
+	if ( originalDisplay.length === 0 && displayTitle.length > 0 ) {
+		const prependFormats = Array( displayTitle.length );
+		const prependReplacements = Array( displayTitle.length );
+
+		return {
+			text: displayTitle + text,
+			formats: prependFormats.concat( formats ),
+			replacements: prependReplacements.concat( replacements ),
+		};
+	}
+
+	const firstSegment = segments[ 0 ];
+	const trailingText = textSegments.at( -1 )?.content ?? '';
+	let updatedLeadingText = displayTitle;
+	let updatedTrailingText = '';
+
+	if ( textSegments.length > 1 ) {
+		updatedTrailingText = trailingText;
+		updatedLeadingText = displayTitle.slice(
+			0,
+			displayTitle.length - trailingText.length
+		);
+	} else if ( firstSegment.type === 'replacement' ) {
+		updatedLeadingText = '';
+		updatedTrailingText = displayTitle;
+	}
+
+	let textSegmentIndex = 0;
+	let newText = '';
+	const newFormats = [];
+	const newReplacements = [];
+
+	for ( const segment of segments ) {
+		if ( segment.type === 'text' ) {
+			let updatedText = segment.content;
+
+			if ( textSegmentIndex === 0 ) {
+				updatedText = updatedLeadingText;
+			} else if ( textSegmentIndex === textSegments.length - 1 ) {
+				updatedText = updatedTrailingText;
+			}
+
+			for ( let index = 0; index < updatedText.length; index++ ) {
+				newText += updatedText[ index ];
+				newFormats.push( undefined );
+				newReplacements.push( undefined );
+			}
+
+			textSegmentIndex++;
+			continue;
+		}
+
+		newText += segment.character;
+		newFormats.push( segment.format );
+		newReplacements.push( segment.replacement );
+	}
+
+	return {
+		text: newText,
+		formats: newFormats,
+		replacements: newReplacements,
+	};
+}


### PR DESCRIPTION
Fixes #64031

## What?
Link UI no longer shows the object replacement character (`￼`) when linked content includes an inline image. Updating the URL or link title preserves inline image replacements.

## How?
- Use `getTextContent()` for the editable link title shown in LinkControl.
- Compare submitted title against display text (not raw rich text with ORCs).
- Rebuild linked rich text from display title while preserving inline replacements.

## Test plan
- [ ] Insert paragraph, add inline image, apply link, open Link UI,  no `￼` in title field
- [ ] Change URL only — image remains linked
- [ ] Edit link title text — image remains in place
- [ ] `npm run test:unit -- --testPathPatterns=packages/format-library/src/link/test/utils.js`