### PR TITLE
Test: Prepare TypeScript test graphs for Vitest

### DIFF
--- a/packages/compose/src/higher-order/pipe.ts
+++ b/packages/compose/src/higher-order/pipe.ts
@@ -49,7 +49,7 @@
  */
 const basePipe =
 	( reverse: boolean = false ) =>
-	( ...funcs: Function[] ) =>
+	( ...funcs: ( Function | Function[] )[] ) =>
 	( ...args: unknown[] ) => {
 		const functions = funcs.flat();
 		if ( reverse ) {


### PR DESCRIPTION
## What?

Part of #80855.

Type `compose` and `pipe` array inputs to match their existing runtime behavior and the downstream Vitest test graph.

No tests move runners in this PR.

## Why?

The migrated Compose tests pass functions both separately and in arrays. `basePipe` already flattens those inputs at runtime, but its parameter type accepted only separate functions.

## How?

Allow each rest argument to be a function or an array of functions. This does not change runtime behavior.

## Testing Instructions

1. Run `npm run typecheck`.
2. Run `npm run test:unit:conventions`.
3. Run `npm run test:unit packages/compose/src/higher-order/test/pipe.ts`.

<details>
<summary>Downstream verification</summary>

On #82212, the convention validator checked 1,038 routed Vitest tests and 426 TypeScript tests. Removing this type change produced four array-input errors in the migrated Compose tests; restoring it made the full check pass.

</details>

### Testing Instructions for Keyboard

Not applicable; this PR does not change the UI.

## Use of AI Tools

Codex helped rebase, review, verify, and document the change. I reviewed the result.
