### PR TITLE
Fix: Page List in a Navigation must not bring a list of its own

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -334,7 +334,15 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$show_submenu_icons = array_key_exists( 'showSubmenuIcon', $block->context ) ? $block->context['showSubmenuIcon'] : false;
 
-	$wrapper_markup = $is_nested ? '%2$s' : '<ul %1$s>%2$s</ul>';
+	/*
+	 * A Page List inside a Navigation contributes items to that navigation's list; it does not
+	 * bring a list of its own. Wrapping them would place a `<ul>` among the navigation's `<li>`
+	 * children, which no `<ul>` may contain.
+	 *
+	 * `$is_nested` is not widened to cover this, because it also decides whether first-level
+	 * submenus receive the overlay colors below.
+	 */
+	$wrapper_markup = ( $is_nested || $is_navigation_child ) ? '%2$s' : '<ul %1$s>%2$s</ul>';
 
 	$items_markup = block_core_page_list_render_nested_page_list( $submenu_visibility, $show_submenu_icons, $is_navigation_child, $nested_pages, $is_nested, $active_page_ancestor_ids, $colors );
 

--- a/phpunit/blocks/render-block-page-list-test.php
+++ b/phpunit/blocks/render-block-page-list-test.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Page List block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Page List block.
+ *
+ * @group blocks
+ */
+class Render_Block_Page_List_Test extends WP_UnitTestCase {
+
+	/**
+	 * Pages the block lists.
+	 *
+	 * @var int[]
+	 */
+	private static $page_ids = array();
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		foreach ( array( 'Alpha', 'Beta' ) as $index => $title ) {
+			self::$page_ids[] = $factory->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_title'  => $title,
+					'post_status' => 'publish',
+					'menu_order'  => $index,
+				)
+			);
+		}
+	}
+
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$page_ids as $page_id ) {
+			wp_delete_post( $page_id, true );
+		}
+		self::$page_ids = array();
+	}
+
+	/**
+	 * Render a Page List with the context a parent would provide.
+	 *
+	 * @param array $context Block context.
+	 * @return string Rendered markup.
+	 */
+	private function render_page_list( $context = array() ) {
+		$parsed = parse_blocks( '<!-- wp:page-list /-->' );
+		$block  = new WP_Block( $parsed[0], $context );
+
+		return $block->render();
+	}
+
+	/**
+	 * On its own the block is a list, so it brings the list element with it.
+	 *
+	 * @covers ::gutenberg_render_block_core_page_list
+	 */
+	public function test_standalone_page_list_is_wrapped_in_a_list() {
+		$markup = $this->render_page_list();
+
+		$this->assertStringContainsString( '<ul class="wp-block-page-list"', $markup );
+	}
+
+	/**
+	 * Inside a Navigation the block contributes items to that navigation's list.
+	 *
+	 * A list of its own would be placed among the navigation's list items, and a `<ul>` may
+	 * contain only `<li>` and script-supporting elements.
+	 *
+	 * @covers ::gutenberg_render_block_core_page_list
+	 */
+	public function test_page_list_in_navigation_contributes_items_without_a_list() {
+		$markup = $this->render_page_list(
+			array(
+				'showSubmenuIcon'   => true,
+				'submenuVisibility' => 'hover',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<ul class="wp-block-page-list"', $markup );
+		$this->assertStringStartsWith( '<li ', $markup );
+	}
+
+	/**
+	 * The same is already true inside a submenu, and stays true.
+	 *
+	 * @covers ::gutenberg_render_block_core_page_list
+	 */
+	public function test_page_list_inside_a_submenu_still_contributes_items_only() {
+		$markup = $this->render_page_list(
+			array(
+				'core/isInsideSubmenu' => true,
+				'showSubmenuIcon'      => true,
+				'submenuVisibility'    => 'hover',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<ul class="wp-block-page-list"', $markup );
+		$this->assertStringStartsWith( '<li ', $markup );
+	}
+
+	/**
+	 * A Navigation containing a Page List renders one list of sibling items.
+	 *
+	 * Every child of the navigation's container is a list item, whether it was authored as a
+	 * Navigation Link or generated from a page, so the two participate in the same layout.
+	 *
+	 * @covers ::gutenberg_render_block_core_page_list
+	 */
+	public function test_navigation_with_a_page_list_has_only_list_items_as_children() {
+		$markup = do_blocks(
+			'<!-- wp:navigation {"overlayMenu":"never"} -->
+				<!-- wp:navigation-link {"label":"First","url":"/first"} /-->
+				<!-- wp:page-list /-->
+				<!-- wp:navigation-link {"label":"Last","url":"/last"} /-->
+			<!-- /wp:navigation -->'
+		);
+
+		$document               = new DOMDocument();
+		$previous_libxml_errors = libxml_use_internal_errors( true );
+		try {
+			$this->assertTrue( $document->loadHTML( '<!doctype html><html><body>' . $markup . '</body></html>' ) );
+		} finally {
+			libxml_clear_errors();
+			libxml_use_internal_errors( $previous_libxml_errors );
+		}
+		$xpath = new DOMXPath( $document );
+
+		$this->assertSame(
+			0,
+			$xpath->query( '//ul/ul' )->length,
+			'A list may not be a direct child of another list.'
+		);
+
+		$container = '//ul[contains(@class,"wp-block-navigation__container")]';
+		$this->assertSame(
+			$xpath->query( $container . '/*' )->length,
+			$xpath->query( $container . '/li' )->length,
+			'Every child of the navigation container is a list item.'
+		);
+
+		// The two authored links and the two published pages, as peers.
+		$this->assertSame( 4, $xpath->query( $container . '/li' )->length );
+	}
+}

--- a/test/e2e/specs/editor/plugins/block-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/block-hooks.spec.js
@@ -343,7 +343,7 @@ test.describe( 'Block Hooks API', () => {
 			).toHaveClass( [
 				'wp-block-navigation-item wp-block-home-link',
 				'wp-block-navigation-item wp-block-navigation-link',
-				'wp-block-page-list',
+				'wp-block-pages-list__item current-menu-item wp-block-navigation-item open-on-hover-click',
 			] );
 		} );
 
@@ -422,7 +422,7 @@ test.describe( 'Block Hooks API', () => {
 			).toHaveClass( [
 				'wp-block-navigation-item wp-block-navigation-link',
 				'wp-block-navigation-item wp-block-home-link',
-				'wp-block-page-list',
+				'wp-block-pages-list__item current-menu-item wp-block-navigation-item open-on-hover-click',
 			] );
 		} );
 	} );


### PR DESCRIPTION
## What?

Fixes #82207.

A Page List placed at the top level of a Navigation rendered its own `<ul>`, which
the navigation then appended among its `<li>` children. `<ul>` permits only `<li>`
and script-supporting elements as children, so the output was invalid, and the
generated pages were not siblings of the links beside them.

```html
<!-- before -->
<ul class="wp-block-navigation__container">
  <li class="wp-block-navigation-item">…First…</li>
  <ul class="wp-block-page-list">
    <li class="wp-block-pages-list__item">…</li>
  </ul>
  <li class="wp-block-navigation-item">…Last…</li>
</ul>

<!-- after -->
<ul class="wp-block-navigation__container">
  <li class="wp-block-navigation-item">…First…</li>
  <li class="wp-block-pages-list__item">…</li>
  <li class="wp-block-navigation-item">…Last…</li>
</ul>
```

## Why?

Beyond the invalid markup, this is why `justify-content` behaves oddly on a
navigation containing a Page List: the whole list is one flex child holding many
items, so the items a visitor sees are not the items being distributed.

Inside a submenu the block already omits its wrapper and contributes items
directly. It knows it is a navigation child at the top level too — it derives
`$is_navigation_child` from the `showSubmenuIcon` context a few lines above. So
this makes the two paths agree rather than introducing a new behaviour.

## How?

One condition:

```php
$wrapper_markup = ( $is_nested || $is_navigation_child ) ? '%2$s' : '<ul %1$s>%2$s</ul>';
```

`$is_nested` is deliberately not widened to cover this, because it also decides
whether first-level submenus receive the overlay colors further down.

### Why not fix this in the Navigation renderer?

That was the first thing I tried, since #78793 fixed an adjacent `<ul>`-splitting
problem in the same loop five days ago. The navigation decides whether a child
belongs in the list by searching the rendered string for an `<li>`:

```php
$p            = new WP_HTML_Tag_Processor( $inner_block_markup );
$is_list_item = $p->next_tag( 'LI' );
```

Page List's markup contains `<li>` elements inside its own `<ul>`, so the test
passes and the nested list is appended whole. Tightening it to look at the root
tag instead removes the invalid nesting — and produces this:

```
lists directly inside <nav> : 3
ul inside ul                : 0
  list 1: wp-block-navigation__container   li children=1
  list 2: wp-block-page-list               li children=1
  list 3: wp-block-navigation__container   li children=1
```

The navigation's own list is split in two with the Page List's list between them,
which is the condition #78793 set out to prevent, and the items are still not
siblings. The peering problem is not the navigation's to solve: a block that
contributes items to a list must not bring a list.

## Testing Instructions

1. In a site with a few published pages, add a Navigation containing a Navigation
   Link, a Page List, and another Navigation Link, in that order.
2. View the front end and inspect the navigation markup.
3. Every child of `ul.wp-block-navigation__container` is an `<li>`, and no `<ul>`
   is a direct child of another `<ul>`.
4. Set `justify-content: space-between` on the navigation. The items distribute
   individually rather than as one group.
5. A Page List inside a submenu, and a Page List outside a Navigation, are
   unchanged.

`phpunit/blocks/render-block-page-list-test.php` covers the four cases: standalone,
navigation child, submenu child, and the whole navigation having only list items as
children.

## Screenshots or screencast

On a Navigation with `justify-content: space-between` holding a Navigation Link, a
Page List, and another Navigation Link, the layout consequence is visible directly.

**Before**, the container's children are `li`, `ul.wp-block-page-list`, `li`. The
list takes a row to itself, so there is nothing for `space-between` to distribute
and the three children stack:

<img width="1265" height="712" alt="download" src="https://github.com/user-attachments/assets/cf6bba8d-9d91-48ba-b062-6e0d5ed637f9" />

**After**, all nine children are `li`; they distribute across the row and
`Last link` reaches the far edge:

<img width="1265" height="712" alt="download" src="https://github.com/user-attachments/assets/cde24583-f649-4241-a1d4-9876c6d174c3" />


### On a real menu

A saved menu that uses all three positions at once — a Page List at the top level,
a submenu holding links and a Page List, and a nested submenu holding a link and
another Page List — renders like this after the change:

```
ul   wp-block-navigation__container
  li   wp-block-pages-list__item              <- generated
  li   wp-block-pages-list__item
  li   wp-block-pages-list__item
  li   wp-block-pages-list__item has-child
    ul   wp-block-navigation__submenu-container   <- page hierarchy, still nested
      li   wp-block-pages-list__item
      li   wp-block-pages-list__item has-child
        ul   wp-block-navigation__submenu-container
          li   wp-block-pages-list__item           <- three levels deep
  li   wp-block-pages-list__item
  li   wp-block-navigation-item wp-block-navigation-link   <- authored
  li   wp-block-navigation-item wp-block-navigation-link
  li   wp-block-navigation-item has-child
    ul   wp-block-navigation__submenu-container
      li   wp-block-navigation-item wp-block-navigation-link
      li   wp-block-navigation-item wp-block-navigation-link
      li   wp-block-pages-list__item            <- generated, peer of the links
      li   wp-block-pages-list__item
```

Generated items and authored items sit at the same level, in the order the menu
was written; page hierarchies still nest through
`wp-block-navigation__submenu-container`; and a Page List inside a submenu becomes
a peer of the links in that submenu rather than a group beside them. The items are
placed correctly, not flattened.

Across the whole page — three Navigation instances, since the responsive overlay
renders its own — `//ul/ul` matches nothing, every child of every
`wp-block-navigation__container` is an `<li>`, and no `wp-block-page-list` wrapper
is emitted.

### Case matrix

Measured on Twenty Twenty-Five with no plugins other than Gutenberg:

| case | before | after |
| --- | --- | --- |
| standalone Page List | own `<ul>`, no `ul > ul` | unchanged |
| Page List at navigation top level | `ul > ul` = 1, container has 2 `<li>` of 3 children | `ul > ul` = 0, all children are `<li>` |
| Page List inside a submenu | items only, no wrapper | unchanged |
| navigation without a Page List | valid | unchanged |

Reproduced identically on WordPress 7.1 core without the Gutenberg plugin, so this
is not trunk-only.

## What this does not change: the editor

The editor does not have the invalid markup, because its navigation container is a
`<div>` rather than a `<ul>`. Measured in the site editor on the same menu:

```
container       : <div class="wp-block-navigation__container">   display: flex
container children : 5  ->  [ ul.wp-block-page-list, div, div, div, div ]
ul > ul         : 0
```

So there is nothing to fix there, and this patch — being PHP — does not touch it.

It does open a presentational gap that was not there before, and I would rather
name it than have it found. Before this change the two agreed that a Page List is
one child of the navigation. After it, the front end lays the generated pages out
as siblings while the editor still shows them grouped inside one flex child, so a
navigation with `justify-content: space-between` will not look the same in both.

Closing that gap is not a matter of dropping the `<ul>` in `edit.jsx`. The editor's
navigation children are already `<div>`s carrying block-list wrappers, and its
container is a `<div>` — the editor DOM is not the front-end DOM here, starting at
the container. Making the two agree means changing how the navigation editor
renders its children, which is a good deal larger than this defect and belongs in
its own change. I am happy to open an issue for it.

## Note on a markup change

Omitting the wrapper also omits its block wrapper attributes, including the
`wp-block-page-list` class, when the block is a navigation child. That is already
what happens inside a submenu, so the change makes the two consistent; the
generated items keep `wp-block-pages-list__item`. Themes styling
`.wp-block-page-list` **inside a navigation** would need to target the items
instead. Worth a mention in the release note.
