### PR TITLE
Preserve inline image attributes when editing width

### DIFF
--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Preserve unregistered attributes when editing an inline image's width or alt text. ([#38490](https://github.com/WordPress/gutenberg/issues/38490))
+
 ### Internal
 
 -   Use the `.jsx` extension for JavaScript source files that contain JSX ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).

--- a/packages/format-library/src/image/index.jsx
+++ b/packages/format-library/src/image/index.jsx
@@ -14,6 +14,7 @@ import {
 	RichTextToolbarButton,
 	MediaUploadCheck,
 } from '@wordpress/block-editor';
+import { updateActiveInlineImage } from './utils';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -73,25 +74,13 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 			<form
 				className="block-editor-format-toolbar__image-container-content"
 				onSubmit={ ( event ) => {
-					const newReplacements = value.replacements.slice();
-
-					newReplacements[ value.start ] = {
-						type: name,
-						attributes: {
-							...activeObjectAttributes,
-							style: editedWidth
-								? `width: ${ editedWidth }px;`
-								: '',
-							alt: editedAlt,
-						},
-					};
-
-					onChange( {
-						...value,
-						replacements: newReplacements,
-					} );
-
 					event.preventDefault();
+					onChange(
+						updateActiveInlineImage( value, {
+							width: editedWidth,
+							alt: editedAlt,
+						} )
+					);
 				} }
 			>
 				<Stack direction="column" gap="lg">
@@ -160,6 +149,10 @@ function Edit( {
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ getCurrentImageId( activeObjectAttributes ) }
 				onSelect={ ( { id, url, alt, width: imgWidth } ) => {
+					const current = isObjectActive
+						? value.replacements[ value.start ]
+						: undefined;
+
 					onChange(
 						insertObject( value, {
 							type: name,
@@ -172,6 +165,10 @@ function Edit( {
 								url,
 								alt,
 							},
+							...( current?.unregisteredAttributes && {
+								unregisteredAttributes:
+									current.unregisteredAttributes,
+							} ),
 						} )
 					);
 					onFocus();

--- a/packages/format-library/src/image/test/utils.js
+++ b/packages/format-library/src/image/test/utils.js
@@ -1,0 +1,105 @@
+import { updateActiveInlineImage } from '../utils';
+
+const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
+
+describe( 'updateActiveInlineImage', () => {
+	it( 'updates width and alt while preserving registered attributes', () => {
+		const value = {
+			text: OBJECT_REPLACEMENT_CHARACTER,
+			start: 0,
+			end: 1,
+			formats: [ , ],
+			replacements: [
+				{
+					type: 'core/image',
+					attributes: {
+						className: 'wp-image-12',
+						url: 'https://example.com/a.jpg',
+						style: 'width: 100px;',
+						alt: 'Before',
+					},
+				},
+			],
+		};
+
+		const result = updateActiveInlineImage( value, {
+			width: 200,
+			alt: 'After',
+		} );
+
+		expect( result.replacements[ 0 ] ).toEqual( {
+			type: 'core/image',
+			attributes: {
+				className: 'wp-image-12',
+				url: 'https://example.com/a.jpg',
+				style: 'width: 200px;',
+				alt: 'After',
+			},
+		} );
+	} );
+
+	it( 'preserves unregistered attributes when editing width', () => {
+		const value = {
+			text: OBJECT_REPLACEMENT_CHARACTER,
+			start: 0,
+			end: 1,
+			formats: [ , ],
+			replacements: [
+				{
+					type: 'core/image',
+					attributes: {
+						className: 'wp-image-12',
+						url: 'https://example.com/a.jpg',
+						style: 'width: 100px;',
+						alt: 'Photo',
+					},
+					unregisteredAttributes: {
+						loading: 'lazy',
+						srcset: 'https://example.com/a-2x.jpg 2x',
+						'data-custom-id': 'abc',
+					},
+				},
+			],
+		};
+
+		const result = updateActiveInlineImage( value, {
+			width: 80,
+			alt: 'Photo',
+		} );
+
+		expect( result.replacements[ 0 ].unregisteredAttributes ).toEqual( {
+			loading: 'lazy',
+			srcset: 'https://example.com/a-2x.jpg 2x',
+			'data-custom-id': 'abc',
+		} );
+		expect( result.replacements[ 0 ].attributes.style ).toBe(
+			'width: 80px;'
+		);
+	} );
+
+	it( 'clears style when width is empty', () => {
+		const value = {
+			text: OBJECT_REPLACEMENT_CHARACTER,
+			start: 0,
+			end: 1,
+			formats: [ , ],
+			replacements: [
+				{
+					type: 'core/image',
+					attributes: {
+						url: 'https://example.com/a.jpg',
+						style: 'width: 100px;',
+						alt: '',
+					},
+				},
+			],
+		};
+
+		const result = updateActiveInlineImage( value, {
+			width: '',
+			alt: '',
+		} );
+
+		expect( result.replacements[ 0 ].attributes.style ).toBe( '' );
+	} );
+} );

--- a/packages/format-library/src/image/utils.js
+++ b/packages/format-library/src/image/utils.js
@@ -1,0 +1,29 @@
+/**
+ * Updates the active inline image object's width and alt text while preserving
+ * any other registered or unregistered attributes on the replacement.
+ *
+ * @param {Object}                  value       Value with an active image object.
+ * @param {Object}                  edits       Width and alt edits.
+ * @param {string|number|undefined} edits.width Edited width in pixels.
+ * @param {string|undefined}        edits.alt   Edited alt text.
+ * @return {Object} Updated rich text value.
+ */
+export function updateActiveInlineImage( value, { width, alt } ) {
+	const current = value.replacements[ value.start ];
+	const newReplacements = value.replacements.slice();
+
+	newReplacements[ value.start ] = {
+		...current,
+		type: 'core/image',
+		attributes: {
+			...current?.attributes,
+			style: width ? `width: ${ width }px;` : '',
+			alt,
+		},
+	};
+
+	return {
+		...value,
+		replacements: newReplacements,
+	};
+}


### PR DESCRIPTION
## What
Fixes #38490

Editing an inline image's width or alt text no longer drops unregistered attributes such as `loading`, `srcset`, or custom data attributes.

## How
- Preserve the full replacement object (including `unregisteredAttributes`) when applying width/alt edits
- Preserve `unregisteredAttributes` when replacing inline image media

## Test plan
- [ ] Add inline image with custom attributes in RichText
- [ ] Edit width via inline image popover -> custom attrs remain
- [ ] Replace image -> custom attrs remain
- [ ] `npm run test:unit -- --testPathPatterns=packages/format-library/src/image/test/utils`