### PR TITLE
Private APIs: Add back '@wordpress/dataviews' to the allowed core modules

### DIFF
--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
--   Restore `@wordpress/dataviews` in the list of core modules allowed to use private APIs. DataViews copies published to npm before the private API cleanup opt in at module load, so plugin bundles embedding them throw without the entry. [#](https://github.com/WordPress/gutenberg/pull/)
+-   Restore `@wordpress/dataviews` in the list of core modules allowed to use private APIs. DataViews copies published to npm before the private API cleanup opt in at module load, so plugin bundles embedding them throw without the entry. [#82221](https://github.com/WordPress/gutenberg/pull/82221)
 
 ## 1.54.0 (2026-08-26)
 

--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+-   Restore `@wordpress/dataviews` in the list of core modules allowed to use private APIs. DataViews copies published to npm before the private API cleanup opt in at module load, so plugin bundles embedding them throw without the entry. [#](https://github.com/WordPress/gutenberg/pull/)
+
 ## 1.54.0 (2026-08-26)
 
 ### Internal

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -41,6 +41,10 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/storybook',
 	'@wordpress/sync',
 	'@wordpress/theme',
+	// Do not remove: older `@wordpress/dataviews` versions published to npm
+	// call the opt-in at module load, so a plugin bundling one of those
+	// copies throws at load time if this entry is missing.
+	'@wordpress/dataviews',
 	'@wordpress/fields',
 	'@wordpress/lazy-editor',
 	'@wordpress/media-editor',


### PR DESCRIPTION
## What?

Follow up of: https://github.com/WordPress/gutenberg/pull/81478

Older `@wordpress/dataviews` versions published to npm call the private APIs opt-in at module load, so plugins bundling one of those copies (e.g. Jetpack Publicize, the WordPress AI plugin) throw with `23.9.0-rc.1`.

This PR adds the allowlist entry back. I'm not sure if we can define a strategy about removing such entries and when, but it feels to me as a better step to add it back for now and avoid lots of possible breakages.

This should be cherry-picked in the 23.9 release.

## Testing Instructions

1. Install a plugin that bundles an older `@wordpress/dataviews` version (Jetpack with Publicize enabled is one).
2. Open the post editor. Without this PR the Jetpack sidebar is missing and the console shows the "You tried to opt-in to unstable APIs" error. With this PR it works again.

## Use of AI Tools

Generated with Fable 5 and reviewed/adjusted manually.