### PR TITLE
CI: Pin npm version in the private API check job

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -169,6 +169,11 @@ jobs:
                   # and the job doesn't need the install speed.
                   package-manager-cache: false
 
+            - name: Pin npm version for consistency
+              run: |
+                  npm install --global npm@10
+                  npm --version
+
             - name: npm install
               # Not the setup-node composite action: its cached node_modules
               # path skips `prepare` scripts, and bundling from source needs


### PR DESCRIPTION
## What?

Follow up to #82027.

Pins the npm version in the `check-private-apis` job of [static-checks.yml](.github/workflows/static-checks.yml), like every other job that installs dependencies. This inconsistency was caught by the [CI failure](https://github.com/WordPress/gutenberg/actions/runs/33316690587/job/99272874538?pr=75814) in #75814

## Why?

We want to use a consistent version of npm across the workflows

Like these
https://github.com/WordPress/gutenberg/blob/1addb122219043a1ac1c38f817c71255ae16d6e3/.github/setup-node/action.yml#L23-L27
https://github.com/WordPress/gutenberg/blob/1addb122219043a1ac1c38f817c71255ae16d6e3/.github/workflows/static-checks.yml#L71-L74
This matters more than usual here: the job deliberately relies on `prepare` scripts to generate sources such as the icons `src/library`, and npm's handling of workspace lifecycle scripts varies between versions.

## How?

Adds the standard "Pin npm version for consistency" step before `npm install`.

## Testing Instructions

1. Check the job log for `check-private-apis` in CI on this PR.
2. Confirm the pin step reports npm 10.x and the check passes.

## Use of AI Tools

Claude Code was used to investigate the npm behaviour and draft this description. All changes were reviewed by me.
