### PR TITLE
Performance tests: Reuse the plugin an earlier trunk run already built

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -109,9 +109,16 @@ jobs:
                   BUILD_KEY: ${{ needs.prepare.outputs.build-key }}
                   BUILD_SHA: ${{ matrix.branch.sha }}
               run: |
+                  # The revision matters, not just the family: GitHub updates the hosted
+                  # image regularly. A runner that does not name both is unidentifiable, so
+                  # it keys on this attempt instead, which nothing else can match.
+                  image="run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+                  if [[ -n "${ImageOS:-}" && -n "${ImageVersion:-}" ]]; then
+                    image="$ImageOS-$ImageVersion"
+                  fi
                   jq -n --arg sha "$BUILD_SHA" --arg buildKey "$BUILD_KEY" \
-                    --arg node "$(node -v)" --arg npm "$(npm -v)" \
-                    --arg image "${ImageOS:-}" '$ARGS.named' | tee "$MANIFEST"
+                    --arg node "$(node -v)" --arg npm "$(npm -v)" --arg image "$image" \
+                    '$ARGS.named' | tee "$MANIFEST"
 
             # Downloads into a staging directory: a partial download must not survive into
             # the plugin a fresh build packages.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -34,13 +34,16 @@ jobs:
         runs-on: ${{ vars.RUNNERS_NAME || 'ubuntu-24.04' }}
         permissions:
             contents: read
+            actions: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}
         outputs:
             # See tools/release/resolve-performance-branches.mjs for the shapes.
-            branches: ${{ steps.branches.outputs.branches }}
+            # Falls back to the unresolved branches when the reuse lookup fails.
+            branches: ${{ steps.reuse.outputs.branches || steps.branches.outputs.branches }}
             shards: ${{ steps.branches.outputs.shards }}
             wp-version: ${{ steps.branches.outputs.wp-version }}
             plugin-files: ${{ steps.branches.outputs.plugin-files }}
+            build-key: ${{ steps.branches.outputs.build-key }}
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -63,6 +66,16 @@ jobs:
                   INPUT_WP_VERSION: ${{ github.event.inputs.wpversion }}
               run: node tools/release/resolve-performance-branches.mjs
 
+            - name: Find reusable plugin builds
+              id: reuse
+              continue-on-error: true
+              env:
+                  BRANCHES: ${{ steps.branches.outputs.branches }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  node tools/release/find-reusable-plugin-artifacts.mjs \
+                    --branches "$BRANCHES" --repository "$GITHUB_REPOSITORY"
+
     build:
         timeout-minutes: 30
         name: Build plugin (${{ matrix.branch.name }})
@@ -70,30 +83,71 @@ jobs:
         needs: prepare
         permissions:
             contents: read
+            actions: read
         strategy:
             fail-fast: false
             matrix:
                 branch: ${{ fromJSON( needs.prepare.outputs.branches ) }}
 
         steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            # Downloads into a staging directory: a partial download must not survive into
+            # the plugin a fresh build packages.
+            - name: Download the plugin an earlier run built
+              id: download
+              if: matrix.branch.reuseRunId
+              continue-on-error: true
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
-                  ref: ${{ matrix.branch.ref }}
+                  name: plugin-${{ matrix.branch.sha }}
+                  run-id: ${{ matrix.branch.reuseRunId }}
+                  repository: ${{ github.repository }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  path: ${{ runner.temp }}/download
+
+            - name: Validate the downloaded plugin
+              id: reused
+              if: steps.download.outcome == 'success'
+              env:
+                  DOWNLOAD_DIR: ${{ runner.temp }}/download
+                  PLUGIN_DIR: ${{ runner.temp }}/plugin
+                  BUILD_KEY: ${{ needs.prepare.outputs.build-key }}
+                  BUILD_SHA: ${{ matrix.branch.sha }}
+              run: |
+                  # A missing or malformed manifest has to build, not fail the job.
+                  key=$( jq -r '.buildKey // empty' "$DOWNLOAD_DIR/perf-build.json" 2>/dev/null || true )
+                  sha=$( jq -r '.sha // empty' "$DOWNLOAD_DIR/perf-build.json" 2>/dev/null || true )
+                  if [[ -f "$DOWNLOAD_DIR/gutenberg.php" && "$key" == "$BUILD_KEY" && "$sha" == "$BUILD_SHA" ]]; then
+                    mv "$DOWNLOAD_DIR" "$PLUGIN_DIR"
+                    echo "ok=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "::notice::Building $BUILD_SHA; the downloaded plugin did not match this run."
+                  fi
+
+            # The resolved commit, so a moving branch cannot change under the run.
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              if: steps.reused.outputs.ok != 'true'
+              with:
+                  ref: ${{ matrix.branch.sha || matrix.branch.ref }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
             - name: Setup Node.js and install dependencies
+              if: steps.reused.outputs.ok != 'true'
               uses: ./.github/setup-node
 
             - name: Build
+              if: steps.reused.outputs.ok != 'true'
               run: npm run build -- --skip-types || npm run build
 
             # The list comes from bin/plugin-files.txt on the tested commit, so older refs
             # are packaged the same way. They may lack some of the files.
             - name: Package plugin
+              if: steps.reused.outputs.ok != 'true'
               env:
                   PLUGIN_DIR: ${{ runner.temp }}/plugin
                   PLUGIN_FILES: ${{ needs.prepare.outputs.plugin-files }}
+                  BUILD_KEY: ${{ needs.prepare.outputs.build-key }}
+                  BUILD_SHA: ${{ matrix.branch.sha }}
               run: |
                   mkdir -p "$PLUGIN_DIR"
                   # post-content.php is gone from trunk but refs up to WP 6.x still require it from lib/demo.php.
@@ -101,6 +155,10 @@ jobs:
                   tar --ignore-failed-read -cf - $PLUGIN_FILES post-content.php \
                     | tar -xf - -C "$PLUGIN_DIR"
                   test -f "$PLUGIN_DIR/gutenberg.php"
+                  # Travels with the plugin so a later run can tell what it is downloading.
+                  jq -n --arg sha "$BUILD_SHA" --arg buildKey "$BUILD_KEY" \
+                    --arg node "$(node -v)" --arg npm "$(npm -v)" --arg image "${ImageOS:-}" \
+                    '$ARGS.named' > "$PLUGIN_DIR/perf-build.json"
 
             - name: Upload plugin
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -108,6 +166,8 @@ jobs:
                   name: ${{ matrix.branch.artifact }}
                   path: ${{ runner.temp }}/plugin
                   compression-level: 1
+                  # Long enough to serve the pull requests based on this commit.
+                  retention-days: 14
 
             # Lets the trace artifacts be resolved with tools/build-scripts/packages/resolve-trace-source-maps.cjs
             # after extracting both next to each other. Only the first branch records traces.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -90,6 +90,29 @@ jobs:
                 branch: ${{ fromJSON( needs.prepare.outputs.branches ) }}
 
         steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  ref: ${{ matrix.branch.ref }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            # Runs before the plugin is reused so the toolchain it would have been built
+            # with is known, and so a rejected download still has everything to build.
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
+            # Describes the plugin this job would produce. It travels with the artifact, and
+            # a downloaded plugin is only reused when its own manifest is identical.
+            - name: Describe this build
+              env:
+                  MANIFEST: ${{ runner.temp }}/perf-build.json
+                  BUILD_KEY: ${{ needs.prepare.outputs.build-key }}
+                  BUILD_SHA: ${{ matrix.branch.sha }}
+              run: |
+                  jq -n --arg sha "$BUILD_SHA" --arg buildKey "$BUILD_KEY" \
+                    --arg node "$(node -v)" --arg npm "$(npm -v)" \
+                    --arg image "${ImageOS:-}" '$ARGS.named' | tee "$MANIFEST"
+
             # Downloads into a staging directory: a partial download must not survive into
             # the plugin a fresh build packages.
             - name: Download the plugin an earlier run built
@@ -110,30 +133,18 @@ jobs:
               env:
                   DOWNLOAD_DIR: ${{ runner.temp }}/download
                   PLUGIN_DIR: ${{ runner.temp }}/plugin
-                  BUILD_KEY: ${{ needs.prepare.outputs.build-key }}
+                  MANIFEST: ${{ runner.temp }}/perf-build.json
                   BUILD_SHA: ${{ matrix.branch.sha }}
               run: |
                   # A missing or malformed manifest has to build, not fail the job.
-                  key=$( jq -r '.buildKey // empty' "$DOWNLOAD_DIR/perf-build.json" 2>/dev/null || true )
-                  sha=$( jq -r '.sha // empty' "$DOWNLOAD_DIR/perf-build.json" 2>/dev/null || true )
-                  if [[ -f "$DOWNLOAD_DIR/gutenberg.php" && "$key" == "$BUILD_KEY" && "$sha" == "$BUILD_SHA" ]]; then
+                  downloaded=$( jq -S . "$DOWNLOAD_DIR/perf-build.json" 2>/dev/null || echo '{}' )
+                  if [[ -f "$DOWNLOAD_DIR/gutenberg.php" ]] &&
+                     diff <( echo "$downloaded" ) <( jq -S . "$MANIFEST" ); then
                     mv "$DOWNLOAD_DIR" "$PLUGIN_DIR"
                     echo "ok=true" >> "$GITHUB_OUTPUT"
                   else
-                    echo "::notice::Building $BUILD_SHA; the downloaded plugin did not match this run."
+                    echo "::notice::Building $BUILD_SHA; the downloaded plugin does not match this run."
                   fi
-
-            # The resolved commit, so a moving branch cannot change under the run.
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-              if: steps.reused.outputs.ok != 'true'
-              with:
-                  ref: ${{ matrix.branch.sha || matrix.branch.ref }}
-                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-                  persist-credentials: false
-
-            - name: Setup Node.js and install dependencies
-              if: steps.reused.outputs.ok != 'true'
-              uses: ./.github/setup-node
 
             - name: Build
               if: steps.reused.outputs.ok != 'true'
@@ -146,8 +157,7 @@ jobs:
               env:
                   PLUGIN_DIR: ${{ runner.temp }}/plugin
                   PLUGIN_FILES: ${{ needs.prepare.outputs.plugin-files }}
-                  BUILD_KEY: ${{ needs.prepare.outputs.build-key }}
-                  BUILD_SHA: ${{ matrix.branch.sha }}
+                  MANIFEST: ${{ runner.temp }}/perf-build.json
               run: |
                   mkdir -p "$PLUGIN_DIR"
                   # post-content.php is gone from trunk but refs up to WP 6.x still require it from lib/demo.php.
@@ -155,10 +165,7 @@ jobs:
                   tar --ignore-failed-read -cf - $PLUGIN_FILES post-content.php \
                     | tar -xf - -C "$PLUGIN_DIR"
                   test -f "$PLUGIN_DIR/gutenberg.php"
-                  # Travels with the plugin so a later run can tell what it is downloading.
-                  jq -n --arg sha "$BUILD_SHA" --arg buildKey "$BUILD_KEY" \
-                    --arg node "$(node -v)" --arg npm "$(npm -v)" --arg image "${ImageOS:-}" \
-                    '$ARGS.named' > "$PLUGIN_DIR/perf-build.json"
+                  cp "$MANIFEST" "$PLUGIN_DIR/perf-build.json"
 
             - name: Upload plugin
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tools/release/find-reusable-plugin-artifacts.mjs
+++ b/tools/release/find-reusable-plugin-artifacts.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Finds plugin builds an earlier run already published, so a commit is not built twice.
+ * Takes the `branches` output of resolve-performance-branches.mjs and writes it back with
+ * `reuseRunId` set. Every failure falls through to a normal build.
+ */
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+/*
+ * Only builds published by a push to trunk are reused: a pull request, a release or a
+ * manual run can build an arbitrary ref under a name that says nothing about it.
+ */
+const TRUSTED_EVENT = 'push';
+const TRUSTED_BRANCH = 'trunk';
+const WORKFLOW = 'performance.yml';
+
+// How many recent trunk runs to scan when the artifact is looked up by name.
+const RUNS_SCANNED = 10;
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/*
+ * Cheaper to build a commit again than to hold up every other job waiting for the API,
+ * so the whole lookup gives up at this point.
+ */
+const LOOKUP_BUDGET_MS = 60_000;
+
+/**
+ * @typedef {{ id: number, event: string, head_branch: string }} Run
+ * @typedef {{ name: string, expired: boolean, workflow_run?: { id: number } }} Artifact
+ * @typedef {{ name: string, sha?: string, reuse?: string, reuseRunId?: number }} Branch
+ * @typedef {( path: string ) => Promise<any>} Request
+ */
+
+/**
+ * @param {Run} run
+ * @return {boolean} Whether the run may serve a plugin to another run.
+ */
+export function isTrustedRun( run ) {
+	return (
+		!! run &&
+		run.event === TRUSTED_EVENT &&
+		run.head_branch === TRUSTED_BRANCH
+	);
+}
+
+/**
+ * @param {Array<{ run: Run, artifacts: Artifact[] }>} candidates   Runs newest first.
+ * @param {string}                                     artifactName Name to look for.
+ * @return {number|undefined} Id of the run to download from.
+ */
+export function selectReusableArtifact( candidates, artifactName ) {
+	for ( const { run, artifacts } of candidates ) {
+		if ( ! isTrustedRun( run ) ) {
+			continue;
+		}
+		const artifact = ( artifacts || [] ).find(
+			( candidate ) =>
+				candidate.name === artifactName &&
+				! candidate.expired &&
+				// Guards against an artifact listed under a run it does not belong to.
+				( candidate.workflow_run?.id ?? run.id ) === run.id
+		);
+		if ( artifact ) {
+			return run.id;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * @param {string} repository Owner and name of the repository.
+ * @param {string} token      Token to authenticate with.
+ * @return {Request} Reads a path from the GitHub API of that repository.
+ */
+export function createRequest( repository, token ) {
+	return async ( path ) => {
+		const response = await fetch(
+			`https://api.github.com/repos/${ repository }${ path }`,
+			{
+				headers: {
+					accept: 'application/vnd.github+json',
+					authorization: `Bearer ${ token }`,
+					'x-github-api-version': '2022-11-28',
+				},
+				signal: AbortSignal.timeout( REQUEST_TIMEOUT_MS ),
+			}
+		);
+		if ( ! response.ok ) {
+			throw new Error(
+				`GitHub API responded ${ response.status }: ${ path }`
+			);
+		}
+		return response.json();
+	};
+}
+
+/**
+ * @param {Branch}  branch  Branch to find an earlier build for.
+ * @param {Request} request Reads the GitHub API.
+ * @return {Promise<number|undefined>} Id of the run holding a reusable plugin.
+ */
+async function findRun( branch, request ) {
+	if ( ! branch.sha || ! branch.reuse ) {
+		return undefined;
+	}
+	const artifactName = `plugin-${ branch.sha }`;
+	const query = new URLSearchParams( {
+		event: TRUSTED_EVENT,
+		branch: TRUSTED_BRANCH,
+		per_page: String( branch.reuse === 'sha' ? 5 : RUNS_SCANNED ),
+	} );
+	// The reference commit heads no run of its own; recent runs republish its plugin.
+	if ( branch.reuse === 'sha' ) {
+		query.set( 'head_sha', branch.sha );
+	}
+	const { workflow_runs: runs = [] } = await request(
+		`/actions/workflows/${ WORKFLOW }/runs?${ query }`
+	);
+
+	for ( const run of runs.filter( isTrustedRun ) ) {
+		// Asking for one name keeps the response small and avoids paginating.
+		const { artifacts = [] } = await request(
+			`/actions/runs/${ run.id }/artifacts?name=${ artifactName }`
+		);
+		const runId = selectReusableArtifact(
+			[ { run, artifacts } ],
+			artifactName
+		);
+		if ( runId ) {
+			return runId;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * @param {Branch[]} branches Branches from resolve-performance-branches.mjs.
+ * @param {Request}  request  Reads the GitHub API.
+ * @param {number}   deadline When to give up, as a `Date.now()` value.
+ * @return {Promise<Branch[]>} The branches, with `reuseRunId` where one was found.
+ */
+export async function findReusableRuns(
+	branches,
+	request,
+	deadline = Date.now() + LOOKUP_BUDGET_MS
+) {
+	// Guards every request, not just the first of a branch.
+	const withinBudget = ( path ) => {
+		if ( Date.now() > deadline ) {
+			throw new Error( 'the lookup ran out of time' );
+		}
+		return request( path );
+	};
+
+	for ( const branch of branches ) {
+		try {
+			branch.reuseRunId = await findRun( branch, withinBudget );
+		} catch ( error ) {
+			// Reuse is an optimization; a lookup that fails just means building.
+			console.log(
+				`::warning::Could not look up a reusable build for ${ branch.name }: ${ error.message }`
+			);
+		}
+		console.log(
+			branch.reuseRunId
+				? `${ branch.name }: reusing the plugin from run ${ branch.reuseRunId }`
+				: `${ branch.name }: building`
+		);
+	}
+	return branches;
+}
+
+async function main() {
+	const { values } = parseArgs( {
+		options: {
+			branches: { type: 'string', default: '[]' },
+			repository: { type: 'string', default: '' },
+		},
+	} );
+	const { GITHUB_OUTPUT, GITHUB_TOKEN } = process.env;
+	if ( ! GITHUB_OUTPUT ) {
+		throw new Error(
+			'GITHUB_OUTPUT is not set; this script runs in GitHub Actions.'
+		);
+	}
+	const branches = await findReusableRuns(
+		JSON.parse( values.branches ),
+		createRequest( values.repository, GITHUB_TOKEN || '' )
+	);
+	fs.appendFileSync(
+		GITHUB_OUTPUT,
+		`branches=${ JSON.stringify( branches ) }\n`
+	);
+}
+
+if (
+	process.argv[ 1 ] &&
+	import.meta.url === pathToFileURL( process.argv[ 1 ] ).href
+) {
+	main();
+}

--- a/tools/release/find-reusable-plugin-artifacts.mjs
+++ b/tools/release/find-reusable-plugin-artifacts.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 /**
- * Finds plugin builds an earlier run already published, so a commit is not built twice.
- * Takes the `branches` output of resolve-performance-branches.mjs and writes it back with
- * `reuseRunId` set. Every failure falls through to a normal build.
+ * Takes the `branches` of resolve-performance-branches.mjs and writes them back with the
+ * `reuseRunId` that already holds a build for them. Any failure falls through to a build.
  */
 import fs from 'node:fs';
 import { parseArgs } from 'node:util';
@@ -16,9 +15,6 @@ const TRUSTED_EVENT = 'push';
 const TRUSTED_BRANCH = 'trunk';
 const WORKFLOW = 'performance.yml';
 
-// How many recent trunk runs to scan when the artifact is looked up by name.
-const RUNS_SCANNED = 10;
-
 const REQUEST_TIMEOUT_MS = 10_000;
 
 /*
@@ -30,45 +26,9 @@ const LOOKUP_BUDGET_MS = 60_000;
 /**
  * @typedef {{ id: number, event: string, head_branch: string }} Run
  * @typedef {{ name: string, expired: boolean, workflow_run?: { id: number } }} Artifact
- * @typedef {{ name: string, sha?: string, reuse?: string, reuseRunId?: number }} Branch
+ * @typedef {{ name: string, sha?: string, reusable?: boolean, reuseRunId?: number }} Branch
  * @typedef {( path: string ) => Promise<any>} Request
  */
-
-/**
- * @param {Run} run
- * @return {boolean} Whether the run may serve a plugin to another run.
- */
-export function isTrustedRun( run ) {
-	return (
-		!! run &&
-		run.event === TRUSTED_EVENT &&
-		run.head_branch === TRUSTED_BRANCH
-	);
-}
-
-/**
- * @param {Array<{ run: Run, artifacts: Artifact[] }>} candidates   Runs newest first.
- * @param {string}                                     artifactName Name to look for.
- * @return {number|undefined} Id of the run to download from.
- */
-export function selectReusableArtifact( candidates, artifactName ) {
-	for ( const { run, artifacts } of candidates ) {
-		if ( ! isTrustedRun( run ) ) {
-			continue;
-		}
-		const artifact = ( artifacts || [] ).find(
-			( candidate ) =>
-				candidate.name === artifactName &&
-				! candidate.expired &&
-				// Guards against an artifact listed under a run it does not belong to.
-				( candidate.workflow_run?.id ?? run.id ) === run.id
-		);
-		if ( artifact ) {
-			return run.id;
-		}
-	}
-	return undefined;
-}
 
 /**
  * @param {string} repository Owner and name of the repository.
@@ -103,34 +63,41 @@ export function createRequest( repository, token ) {
  * @return {Promise<number|undefined>} Id of the run holding a reusable plugin.
  */
 async function findRun( branch, request ) {
-	if ( ! branch.sha || ! branch.reuse ) {
+	if ( ! branch.sha || ! branch.reusable ) {
 		return undefined;
 	}
-	const artifactName = `plugin-${ branch.sha }`;
+	const name = `plugin-${ branch.sha }`;
 	const query = new URLSearchParams( {
 		event: TRUSTED_EVENT,
 		branch: TRUSTED_BRANCH,
-		per_page: String( branch.reuse === 'sha' ? 5 : RUNS_SCANNED ),
+		head_sha: branch.sha,
+		per_page: '5',
 	} );
-	// The reference commit heads no run of its own; recent runs republish its plugin.
-	if ( branch.reuse === 'sha' ) {
-		query.set( 'head_sha', branch.sha );
-	}
 	const { workflow_runs: runs = [] } = await request(
 		`/actions/workflows/${ WORKFLOW }/runs?${ query }`
 	);
 
-	for ( const run of runs.filter( isTrustedRun ) ) {
+	for ( const run of runs ) {
+		// The query filters already, but the answer decides what the tests measure.
+		if (
+			run.event !== TRUSTED_EVENT ||
+			run.head_branch !== TRUSTED_BRANCH
+		) {
+			continue;
+		}
 		// Asking for one name keeps the response small and avoids paginating.
 		const { artifacts = [] } = await request(
-			`/actions/runs/${ run.id }/artifacts?name=${ artifactName }`
+			`/actions/runs/${ run.id }/artifacts?name=${ name }`
 		);
-		const runId = selectReusableArtifact(
-			[ { run, artifacts } ],
-			artifactName
+		const found = artifacts.some(
+			( artifact ) =>
+				artifact.name === name &&
+				! artifact.expired &&
+				// Guards against an artifact listed under a run it does not belong to.
+				( artifact.workflow_run?.id ?? run.id ) === run.id
 		);
-		if ( runId ) {
-			return runId;
+		if ( found ) {
+			return run.id;
 		}
 	}
 	return undefined;

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Resolves the branches and the suite shards the performance workflow runs for a GitHub event.
- * Writes `branches` (`{ name, ref, artifact, sha?, reuse? }[]`), `shards` (`{ shard, suites }[]`),
+ * Writes `branches` (`{ name, ref, artifact, sha?, reusable? }[]`), `shards` (`{ shard, suites }[]`),
  * `wp-version`, `plugin-files` (space separated globs from bin/plugin-files.txt) and `build-key`
  * to `$GITHUB_OUTPUT`.
  */
@@ -19,9 +19,6 @@ import { sanitizeBranchName } from './lib/sanitize-branch-name.js';
 export const REFERENCE_COMMIT = '28d414f1327652e2b49e784ddc12098768991c62';
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
-
-// A ref that origin will not resolve promptly is built by name, as it was before.
-const LS_REMOTE_TIMEOUT_MS = 30_000;
 
 /*
  * Suites grouped into CI jobs that run in parallel, balanced by their duration.
@@ -64,21 +61,18 @@ export function resolveShards( suites ) {
 }
 
 /**
- * @param {string}        name  Branch label shown in the results.
- * @param {string}        ref   Git ref to build.
- * @param {'sha'|'name'=} reuse How to find a plugin an earlier run built for `ref`: `sha` looks
- *                              up the trunk push run for that commit, `name` scans recent trunk
- *                              push runs for the artifact. Omitted when the build is not reusable.
- * @param {string=}       sha   Commit `ref` points at, when it is not a commit itself.
+ * @param {string}   name     Branch label shown in the results.
+ * @param {string}   ref      Git ref to build.
+ * @param {boolean=} reusable Whether a trunk push run may have built this commit already.
  */
-function branch( name, ref = name, reuse = undefined, sha = ref ) {
+function branch( name, ref = name, reusable = undefined ) {
 	return {
 		name,
 		ref,
 		artifact: `plugin-${ sanitizeBranchName( name ) }`,
-		// What actually gets built, so a moving ref cannot change under the run.
-		sha: SHA_PATTERN.test( sha ) ? sha : undefined,
-		reuse,
+		// Only a commit can be reused; a branch or a tag moves.
+		sha: SHA_PATTERN.test( ref ) ? ref : undefined,
+		reusable,
 	};
 }
 
@@ -110,22 +104,22 @@ export function getTestedUpToMajor( readme ) {
 }
 
 /**
- * @typedef {'tag' | 'head' | 'any'} RefKind
- * @typedef {(ref: string, kind: RefKind) => string} RefResolver
+ * @typedef {'tag' | 'head'} RefKind
+ * @typedef {(ref: string, kind: RefKind) => boolean} RefExists
  */
 
 /**
  * @typedef ResolveOptions
  *
- * @property {string}      event          GitHub event name.
- * @property {string}      sha            Commit that triggered the workflow.
- * @property {string}      wpMajor        The `Tested up to` version from readme.txt.
- * @property {RefResolver} resolveRef     Commit a ref points at on origin, empty when there is none.
- * @property {string=}     baseSha        Pull request base commit.
- * @property {string=}     baseRef        Pull request base branch name.
- * @property {string=}     releaseTag     Release tag name.
- * @property {string=}     inputBranches  `workflow_dispatch` branches input.
- * @property {string=}     inputWpVersion `workflow_dispatch` WP version input.
+ * @property {string}    event          GitHub event name.
+ * @property {string}    sha            Commit that triggered the workflow.
+ * @property {string}    wpMajor        The `Tested up to` version from readme.txt.
+ * @property {RefExists} refExists      Whether a tag or branch exists on origin.
+ * @property {string=}   baseSha        Pull request base commit.
+ * @property {string=}   baseRef        Pull request base branch name.
+ * @property {string=}   releaseTag     Release tag name.
+ * @property {string=}   inputBranches  `workflow_dispatch` branches input.
+ * @property {string=}   inputWpVersion `workflow_dispatch` WP version input.
  */
 
 /**
@@ -150,7 +144,7 @@ export function resolveBranches( options ) {
  * @param {ResolveOptions} options
  */
 function resolveBranchesForEvent( options ) {
-	const { event, sha, wpMajor, resolveRef } = options;
+	const { event, sha, wpMajor, refExists } = options;
 
 	switch ( event ) {
 		case 'pull_request':
@@ -167,7 +161,7 @@ function resolveBranchesForEvent( options ) {
 						 * trunk PR has usually been built already. Other base branches
 						 * are never built by a push run.
 						 */
-						options.baseRef === 'trunk' ? 'sha' : undefined
+						options.baseRef === 'trunk' || undefined
 					),
 				],
 				wpVersion: '',
@@ -175,14 +169,7 @@ function resolveBranchesForEvent( options ) {
 
 		case 'push':
 			return {
-				branches: [
-					branch( sha ),
-					/*
-					 * The reference commit is not the head of any run, so it is found by
-					 * artifact name among recent trunk runs, each of which republishes it.
-					 */
-					branch( REFERENCE_COMMIT, REFERENCE_COMMIT, 'name' ),
-				],
+				branches: [ branch( sha ), branch( REFERENCE_COMMIT ) ],
 				wpVersion: wpMajor,
 			};
 
@@ -201,25 +188,24 @@ function resolveBranchesForEvent( options ) {
 				previousBase10 % 10
 			}`;
 			const wp = `wp/${ wpMajor }`;
-			/** @type {Record<string, string>} */
-			const commits = {};
 			for ( const [ ref, kind, description ] of [
 				[ tag, 'tag', 'release tag' ],
 				[ current, 'head', 'current release branch' ],
 				[ previous, 'head', 'previous release branch' ],
 				[ wp, 'head', 'WordPress branch' ],
 			] ) {
-				commits[ ref ] = resolveRef( ref, kind );
-				if ( ! commits[ ref ] ) {
+				if ( ! refExists( ref, kind ) ) {
 					throw new Error(
 						`Expected ${ description } '${ ref }' to exist in the Gutenberg repository.`
 					);
 				}
 			}
 			return {
-				branches: [ wp, previous, current ].map( ( ref ) =>
-					branch( ref, ref, undefined, commits[ ref ] )
-				),
+				branches: [
+					branch( wp ),
+					branch( previous ),
+					branch( current ),
+				],
 				wpVersion: wpMajor,
 			};
 		}
@@ -233,9 +219,7 @@ function resolveBranchesForEvent( options ) {
 				throw new Error( 'Need at least two branches to compare.' );
 			}
 			return {
-				branches: names.map( ( name ) =>
-					branch( name, name, undefined, resolveRef( name, 'any' ) )
-				),
+				branches: names.map( ( name ) => branch( name ) ),
 				wpVersion: options.inputWpVersion || '',
 			};
 		}
@@ -256,36 +240,24 @@ function main() {
 		event: env.GITHUB_EVENT_NAME || '',
 		sha: env.GITHUB_SHA || '',
 		wpMajor: getTestedUpToMajor( fs.readFileSync( 'readme.txt', 'utf8' ) ),
-		resolveRef: ( ref, kind ) => {
-			if ( SHA_PATTERN.test( ref ) ) {
-				return ref;
-			}
-			const filter = { tag: [ '--tags' ], head: [ '--heads' ], any: [] }[
-				kind
-			];
+		refExists: ( ref, kind ) => {
 			try {
-				const lines = execFileSync(
+				execFileSync(
 					'git',
 					[
 						'ls-remote',
 						'--exit-code',
-						...filter,
+						kind === 'tag' ? '--tags' : '--heads',
 						'origin',
 						ref,
-						// An annotated tag needs peeling to the commit it points at.
-						`${ ref }^{}`,
 					],
-					{ encoding: 'utf8', timeout: LS_REMOTE_TIMEOUT_MS }
-				)
-					.trim()
-					.split( '\n' );
-				const line =
-					lines.find( ( candidate ) =>
-						candidate.endsWith( '^{}' )
-					) || lines[ 0 ];
-				return line.split( /\s/ )[ 0 ] || '';
+					{
+						stdio: 'ignore',
+					}
+				);
+				return true;
 			} catch {
-				return '';
+				return false;
 			}
 		},
 		baseSha: env.BASE_SHA,

--- a/tools/release/resolve-performance-branches.mjs
+++ b/tools/release/resolve-performance-branches.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
  * Resolves the branches and the suite shards the performance workflow runs for a GitHub event.
- * Writes `branches` (`{ name, ref, artifact }[]`), `shards` (`{ shard, suites }[]`), `wp-version`
- * and `plugin-files` (space separated globs from bin/plugin-files.txt) to `$GITHUB_OUTPUT`.
+ * Writes `branches` (`{ name, ref, artifact, sha?, reuse? }[]`), `shards` (`{ shard, suites }[]`),
+ * `wp-version`, `plugin-files` (space separated globs from bin/plugin-files.txt) and `build-key`
+ * to `$GITHUB_OUTPUT`.
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { sanitizeBranchName } from './lib/sanitize-branch-name.js';
@@ -15,6 +17,11 @@ import { sanitizeBranchName } from './lib/sanitize-branch-name.js';
  * https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
  */
 export const REFERENCE_COMMIT = '28d414f1327652e2b49e784ddc12098768991c62';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+// A ref that origin will not resolve promptly is built by name, as it was before.
+const LS_REMOTE_TIMEOUT_MS = 30_000;
 
 /*
  * Suites grouped into CI jobs that run in parallel, balanced by their duration.
@@ -57,11 +64,37 @@ export function resolveShards( suites ) {
 }
 
 /**
- * @param {string} name Branch label shown in the results.
- * @param {string} ref  Git ref to build.
+ * @param {string}        name  Branch label shown in the results.
+ * @param {string}        ref   Git ref to build.
+ * @param {'sha'|'name'=} reuse How to find a plugin an earlier run built for `ref`: `sha` looks
+ *                              up the trunk push run for that commit, `name` scans recent trunk
+ *                              push runs for the artifact. Omitted when the build is not reusable.
+ * @param {string=}       sha   Commit `ref` points at, when it is not a commit itself.
  */
-function branch( name, ref = name ) {
-	return { name, ref, artifact: `plugin-${ sanitizeBranchName( name ) }` };
+function branch( name, ref = name, reuse = undefined, sha = ref ) {
+	return {
+		name,
+		ref,
+		artifact: `plugin-${ sanitizeBranchName( name ) }`,
+		// What actually gets built, so a moving ref cannot change under the run.
+		sha: SHA_PATTERN.test( sha ) ? sha : undefined,
+		reuse,
+	};
+}
+
+/**
+ * Identifies the recipe that turns a commit into a packaged plugin: a build is reused
+ * only by a run that would produce it the same way. Hashing the whole workflow rebuilds
+ * more often than strictly needed, but it never needs anyone to remember to invalidate.
+ *
+ * @param {string} pluginFiles Space separated globs the plugin is packaged from.
+ * @param {string} workflow    Contents of the performance workflow.
+ * @return {string} Key a reusable build must match to be interchangeable with a fresh one.
+ */
+export function computeBuildKey( pluginFiles, workflow ) {
+	return createHash( 'sha256' )
+		.update( [ pluginFiles, workflow ].join( '\n' ) )
+		.digest( 'hex' );
 }
 
 /**
@@ -77,17 +110,22 @@ export function getTestedUpToMajor( readme ) {
 }
 
 /**
+ * @typedef {'tag' | 'head' | 'any'} RefKind
+ * @typedef {(ref: string, kind: RefKind) => string} RefResolver
+ */
+
+/**
  * @typedef ResolveOptions
  *
- * @property {string}                                         event          GitHub event name.
- * @property {string}                                         sha            Commit that triggered the workflow.
- * @property {string}                                         wpMajor        The `Tested up to` version from readme.txt.
- * @property {(ref: string, kind: 'tag' | 'head') => boolean} refExists      Whether a tag or branch exists on origin.
- * @property {string=}                                        baseSha        Pull request base commit.
- * @property {string=}                                        baseRef        Pull request base branch name.
- * @property {string=}                                        releaseTag     Release tag name.
- * @property {string=}                                        inputBranches  `workflow_dispatch` branches input.
- * @property {string=}                                        inputWpVersion `workflow_dispatch` WP version input.
+ * @property {string}      event          GitHub event name.
+ * @property {string}      sha            Commit that triggered the workflow.
+ * @property {string}      wpMajor        The `Tested up to` version from readme.txt.
+ * @property {RefResolver} resolveRef     Commit a ref points at on origin, empty when there is none.
+ * @property {string=}     baseSha        Pull request base commit.
+ * @property {string=}     baseRef        Pull request base branch name.
+ * @property {string=}     releaseTag     Release tag name.
+ * @property {string=}     inputBranches  `workflow_dispatch` branches input.
+ * @property {string=}     inputWpVersion `workflow_dispatch` WP version input.
  */
 
 /**
@@ -112,7 +150,7 @@ export function resolveBranches( options ) {
  * @param {ResolveOptions} options
  */
 function resolveBranchesForEvent( options ) {
-	const { event, sha, wpMajor, refExists } = options;
+	const { event, sha, wpMajor, resolveRef } = options;
 
 	switch ( event ) {
 		case 'pull_request':
@@ -121,14 +159,30 @@ function resolveBranchesForEvent( options ) {
 			return {
 				branches: [
 					branch( sha ),
-					branch( options.baseRef || '', options.baseSha ),
+					branch(
+						options.baseRef || '',
+						options.baseSha,
+						/*
+						 * Every push to trunk builds its own commit, so the base of a
+						 * trunk PR has usually been built already. Other base branches
+						 * are never built by a push run.
+						 */
+						options.baseRef === 'trunk' ? 'sha' : undefined
+					),
 				],
 				wpVersion: '',
 			};
 
 		case 'push':
 			return {
-				branches: [ branch( sha ), branch( REFERENCE_COMMIT ) ],
+				branches: [
+					branch( sha ),
+					/*
+					 * The reference commit is not the head of any run, so it is found by
+					 * artifact name among recent trunk runs, each of which republishes it.
+					 */
+					branch( REFERENCE_COMMIT, REFERENCE_COMMIT, 'name' ),
+				],
 				wpVersion: wpMajor,
 			};
 
@@ -147,24 +201,25 @@ function resolveBranchesForEvent( options ) {
 				previousBase10 % 10
 			}`;
 			const wp = `wp/${ wpMajor }`;
+			/** @type {Record<string, string>} */
+			const commits = {};
 			for ( const [ ref, kind, description ] of [
 				[ tag, 'tag', 'release tag' ],
 				[ current, 'head', 'current release branch' ],
 				[ previous, 'head', 'previous release branch' ],
 				[ wp, 'head', 'WordPress branch' ],
 			] ) {
-				if ( ! refExists( ref, kind ) ) {
+				commits[ ref ] = resolveRef( ref, kind );
+				if ( ! commits[ ref ] ) {
 					throw new Error(
 						`Expected ${ description } '${ ref }' to exist in the Gutenberg repository.`
 					);
 				}
 			}
 			return {
-				branches: [
-					branch( wp ),
-					branch( previous ),
-					branch( current ),
-				],
+				branches: [ wp, previous, current ].map( ( ref ) =>
+					branch( ref, ref, undefined, commits[ ref ] )
+				),
 				wpVersion: wpMajor,
 			};
 		}
@@ -178,7 +233,9 @@ function resolveBranchesForEvent( options ) {
 				throw new Error( 'Need at least two branches to compare.' );
 			}
 			return {
-				branches: names.map( ( name ) => branch( name ) ),
+				branches: names.map( ( name ) =>
+					branch( name, name, undefined, resolveRef( name, 'any' ) )
+				),
 				wpVersion: options.inputWpVersion || '',
 			};
 		}
@@ -199,24 +256,36 @@ function main() {
 		event: env.GITHUB_EVENT_NAME || '',
 		sha: env.GITHUB_SHA || '',
 		wpMajor: getTestedUpToMajor( fs.readFileSync( 'readme.txt', 'utf8' ) ),
-		refExists: ( ref, kind ) => {
+		resolveRef: ( ref, kind ) => {
+			if ( SHA_PATTERN.test( ref ) ) {
+				return ref;
+			}
+			const filter = { tag: [ '--tags' ], head: [ '--heads' ], any: [] }[
+				kind
+			];
 			try {
-				execFileSync(
+				const lines = execFileSync(
 					'git',
 					[
 						'ls-remote',
 						'--exit-code',
-						kind === 'tag' ? '--tags' : '--heads',
+						...filter,
 						'origin',
 						ref,
+						// An annotated tag needs peeling to the commit it points at.
+						`${ ref }^{}`,
 					],
-					{
-						stdio: 'ignore',
-					}
-				);
-				return true;
+					{ encoding: 'utf8', timeout: LS_REMOTE_TIMEOUT_MS }
+				)
+					.trim()
+					.split( '\n' );
+				const line =
+					lines.find( ( candidate ) =>
+						candidate.endsWith( '^{}' )
+					) || lines[ 0 ];
+				return line.split( /\s/ )[ 0 ] || '';
 			} catch {
-				return false;
+				return '';
 			}
 		},
 		baseSha: env.BASE_SHA,
@@ -240,8 +309,20 @@ function main() {
 		.filter( ( line ) => line && ! line.startsWith( '#' ) )
 		.join( ' ' );
 
+	const buildKey = computeBuildKey(
+		pluginFiles,
+		fs.readFileSync(
+			path.join( '.github', 'workflows', 'performance.yml' ),
+			'utf8'
+		)
+	);
+
 	console.log(
-		JSON.stringify( { branches, shards, wpVersion, pluginFiles }, null, 2 )
+		JSON.stringify(
+			{ branches, shards, wpVersion, pluginFiles, buildKey },
+			null,
+			2
+		)
 	);
 	fs.appendFileSync(
 		env.GITHUB_OUTPUT,
@@ -250,6 +331,7 @@ function main() {
 			`shards=${ JSON.stringify( shards ) }`,
 			`wp-version=${ wpVersion }`,
 			`plugin-files=${ pluginFiles }`,
+			`build-key=${ buildKey }`,
 			'',
 		].join( '\n' )
 	);

--- a/tools/release/test/find-reusable-plugin-artifacts.js
+++ b/tools/release/test/find-reusable-plugin-artifacts.js
@@ -1,8 +1,9 @@
-const {
-	isTrustedRun,
-	selectReusableArtifact,
-	findReusableRuns,
-} = require( '../find-reusable-plugin-artifacts.mjs' );
+const { findReusableRuns } = require( '../find-reusable-plugin-artifacts.mjs' );
+
+const sha = 'a'.repeat( 40 );
+const runsPath = `/actions/workflows/performance.yml/runs?event=push&branch=trunk&head_sha=${ sha }&per_page=5`;
+const artifactsPath = ( id ) =>
+	`/actions/runs/${ id }/artifacts?name=plugin-${ sha }`;
 
 const run = ( overrides = {} ) => ( {
 	id: 1,
@@ -11,143 +12,101 @@ const run = ( overrides = {} ) => ( {
 	...overrides,
 } );
 const artifact = ( overrides = {} ) => ( {
-	name: 'plugin-abc',
+	name: `plugin-${ sha }`,
 	expired: false,
 	workflow_run: { id: 1 },
 	...overrides,
 } );
 
-describe( 'isTrustedRun', () => {
-	it( 'trusts a push to trunk', () => {
-		expect( isTrustedRun( run() ) ).toBe( true );
-	} );
+const request = ( responses ) => {
+	const paths = [];
+	const fake = ( path ) => {
+		paths.push( path );
+		return responses[ path ]
+			? Promise.resolve( responses[ path ] )
+			: Promise.reject( new Error( `Unexpected ${ path }` ) );
+	};
+	fake.paths = paths;
+	return fake;
+};
 
-	it( 'does not trust another event or another branch', () => {
-		expect( isTrustedRun( run( { event: 'pull_request' } ) ) ).toBe(
-			false
-		);
-		expect( isTrustedRun( run( { head_branch: 'release/24.0' } ) ) ).toBe(
-			false
-		);
-		expect( isTrustedRun( undefined ) ).toBe( false );
-	} );
-} );
-
-describe( 'selectReusableArtifact', () => {
-	it( 'returns the run holding the artifact', () => {
-		expect(
-			selectReusableArtifact(
-				[ { run: run(), artifacts: [ artifact() ] } ],
-				'plugin-abc'
-			)
-		).toBe( 1 );
-	} );
-
-	it( 'takes the first run that has it', () => {
-		expect(
-			selectReusableArtifact(
-				[
-					{ run: run( { id: 2 } ), artifacts: [] },
-					{
-						run: run( { id: 3 } ),
-						artifacts: [ artifact( { workflow_run: { id: 3 } } ) ],
-					},
-				],
-				'plugin-abc'
-			)
-		).toBe( 3 );
-	} );
-
-	it( 'skips untrusted runs even when they have the artifact', () => {
-		expect(
-			selectReusableArtifact(
-				[
-					{
-						run: run( { event: 'workflow_dispatch' } ),
-						artifacts: [ artifact() ],
-					},
-				],
-				'plugin-abc'
-			)
-		).toBeUndefined();
-	} );
-
-	it( 'skips expired artifacts, other names and other runs', () => {
-		const candidates = [
-			{
-				run: run(),
-				artifacts: [
-					artifact( { expired: true } ),
-					artifact( { name: 'plugin-def' } ),
-					artifact( { workflow_run: { id: 99 } } ),
-				],
-			},
-		];
-		expect(
-			selectReusableArtifact( candidates, 'plugin-abc' )
-		).toBeUndefined();
-	} );
-
-	it( 'handles runs without an artifact list', () => {
-		expect(
-			selectReusableArtifact(
-				[ { run: run(), artifacts: undefined } ],
-				'plugin-abc'
-			)
-		).toBeUndefined();
-	} );
+const base = ( overrides = {} ) => ( {
+	name: 'trunk',
+	sha,
+	reusable: true,
+	...overrides,
 } );
 
 describe( 'findReusableRuns', () => {
-	const sha = 'a'.repeat( 40 );
-	const request = ( responses ) => {
-		const paths = [];
-		const fake = ( path ) => {
-			paths.push( path );
-			const response = responses[ path ];
-			if ( ! response ) {
-				return Promise.reject( new Error( `Unexpected ${ path }` ) );
-			}
-			return Promise.resolve( response );
-		};
-		fake.paths = paths;
-		return fake;
-	};
-
 	it( 'finds the run that built the commit', async () => {
 		const fake = request( {
-			[ `/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=5&head_sha=${ sha }` ]:
-				{ workflow_runs: [ run() ] },
-			[ `/actions/runs/1/artifacts?name=plugin-${ sha }` ]: {
-				artifacts: [ artifact( { name: `plugin-${ sha }` } ) ],
-			},
+			[ runsPath ]: { workflow_runs: [ run() ] },
+			[ artifactsPath( 1 ) ]: { artifacts: [ artifact() ] },
 		} );
-		const [ branch ] = await findReusableRuns(
-			[ { name: 'trunk', sha, reuse: 'sha' } ],
-			fake
-		);
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
 		expect( branch.reuseRunId ).toBe( 1 );
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'scans recent runs when it looks the artifact up by name', async () => {
+	it( 'takes the first run that has the artifact', async () => {
 		const fake = request( {
-			'/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=10':
-				{ workflow_runs: [ run( { id: 7 } ) ] },
-			[ `/actions/runs/7/artifacts?name=plugin-${ sha }` ]: {
+			[ runsPath ]: { workflow_runs: [ run(), run( { id: 2 } ) ] },
+			[ artifactsPath( 1 ) ]: { artifacts: [] },
+			[ artifactsPath( 2 ) ]: {
+				artifacts: [ artifact( { workflow_run: { id: 2 } } ) ],
+			},
+		} );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
+		expect( branch.reuseRunId ).toBe( 2 );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'skips a run that was not a push', async () => {
+		const fake = request( {
+			[ runsPath ]: {
+				workflow_runs: [ run( { event: 'workflow_dispatch' } ) ],
+			},
+		} );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
+		expect( branch.reuseRunId ).toBeUndefined();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'skips a run that was not on trunk', async () => {
+		const fake = request( {
+			[ runsPath ]: {
+				workflow_runs: [ run( { head_branch: 'release/24.0' } ) ],
+			},
+		} );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
+		expect( branch.reuseRunId ).toBeUndefined();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'skips an artifact with another name', async () => {
+		const fake = request( {
+			[ runsPath ]: { workflow_runs: [ run() ] },
+			[ artifactsPath( 1 ) ]: {
+				artifacts: [ artifact( { name: 'plugin-trunk' } ) ],
+			},
+		} );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
+		expect( branch.reuseRunId ).toBeUndefined();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'skips an expired artifact and one belonging to another run', async () => {
+		const fake = request( {
+			[ runsPath ]: { workflow_runs: [ run() ] },
+			[ artifactsPath( 1 ) ]: {
 				artifacts: [
-					artifact( {
-						name: `plugin-${ sha }`,
-						workflow_run: { id: 7 },
-					} ),
+					artifact( { expired: true } ),
+					artifact( { workflow_run: { id: 99 } } ),
 				],
 			},
 		} );
-		const [ branch ] = await findReusableRuns(
-			[ { name: 'reference', sha, reuse: 'name' } ],
-			fake
-		);
-		expect( branch.reuseRunId ).toBe( 7 );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
+		expect( branch.reuseRunId ).toBeUndefined();
 		expect( console ).toHaveLogged();
 	} );
 
@@ -156,7 +115,7 @@ describe( 'findReusableRuns', () => {
 		const branches = await findReusableRuns(
 			[
 				{ name: 'head', sha },
-				{ name: 'wp/7.1', reuse: 'sha' },
+				{ name: 'wp/7.1', reusable: true },
 			],
 			fake
 		);
@@ -167,62 +126,41 @@ describe( 'findReusableRuns', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'builds when the API fails, without failing the other branches', async () => {
-		const fake = request( {
-			'/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=10':
-				{ workflow_runs: [] },
-		} );
-		const branches = await findReusableRuns(
-			[
-				{ name: 'trunk', sha, reuse: 'sha' },
-				{ name: 'reference', sha, reuse: 'name' },
-			],
-			fake
-		);
-		expect( branches.map( ( { reuseRunId } ) => reuseRunId ) ).toEqual( [
-			undefined,
-			undefined,
-		] );
+	it( 'builds when the API fails', async () => {
+		const fake = request( {} );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
+		expect( branch.reuseRunId ).toBeUndefined();
 		expect( console ).toHaveLogged();
 	} );
 
 	it( 'builds when a response is malformed', async () => {
-		const fake = request( {
-			[ `/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=5&head_sha=${ sha }` ]:
-				{},
-		} );
-		const [ branch ] = await findReusableRuns(
-			[ { name: 'trunk', sha, reuse: 'sha' } ],
-			fake
-		);
+		const fake = request( { [ runsPath ]: {} } );
+		const [ branch ] = await findReusableRuns( [ base() ], fake );
 		expect( branch.reuseRunId ).toBeUndefined();
 		expect( console ).toHaveLogged();
 	} );
 
 	it( 'stops mid branch once it runs out of time', async () => {
-		const fake = request( {
-			[ `/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=5&head_sha=${ sha }` ]:
-				{ workflow_runs: [ run() ] },
-		} );
+		const fake = request( { [ runsPath ]: { workflow_runs: [ run() ] } } );
 		const slow = ( path ) =>
 			new Promise( ( resolve ) => setTimeout( resolve, 20 ) ).then( () =>
 				fake( path )
 			);
 		const [ branch ] = await findReusableRuns(
-			[ { name: 'trunk', sha, reuse: 'sha' } ],
+			[ base() ],
 			slow,
 			Date.now() + 10
 		);
 		expect( branch.reuseRunId ).toBeUndefined();
 		// The first request went out, the artifact lookup did not.
-		expect( fake.paths ).toHaveLength( 1 );
+		expect( fake.paths ).toEqual( [ runsPath ] );
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'stops looking once it runs out of time', async () => {
+	it( 'does not look anything up once the budget is gone', async () => {
 		const fake = request( {} );
 		const [ branch ] = await findReusableRuns(
-			[ { name: 'trunk', sha, reuse: 'sha' } ],
+			[ base() ],
 			fake,
 			Date.now() - 1
 		);

--- a/tools/release/test/find-reusable-plugin-artifacts.js
+++ b/tools/release/test/find-reusable-plugin-artifacts.js
@@ -1,0 +1,233 @@
+const {
+	isTrustedRun,
+	selectReusableArtifact,
+	findReusableRuns,
+} = require( '../find-reusable-plugin-artifacts.mjs' );
+
+const run = ( overrides = {} ) => ( {
+	id: 1,
+	event: 'push',
+	head_branch: 'trunk',
+	...overrides,
+} );
+const artifact = ( overrides = {} ) => ( {
+	name: 'plugin-abc',
+	expired: false,
+	workflow_run: { id: 1 },
+	...overrides,
+} );
+
+describe( 'isTrustedRun', () => {
+	it( 'trusts a push to trunk', () => {
+		expect( isTrustedRun( run() ) ).toBe( true );
+	} );
+
+	it( 'does not trust another event or another branch', () => {
+		expect( isTrustedRun( run( { event: 'pull_request' } ) ) ).toBe(
+			false
+		);
+		expect( isTrustedRun( run( { head_branch: 'release/24.0' } ) ) ).toBe(
+			false
+		);
+		expect( isTrustedRun( undefined ) ).toBe( false );
+	} );
+} );
+
+describe( 'selectReusableArtifact', () => {
+	it( 'returns the run holding the artifact', () => {
+		expect(
+			selectReusableArtifact(
+				[ { run: run(), artifacts: [ artifact() ] } ],
+				'plugin-abc'
+			)
+		).toBe( 1 );
+	} );
+
+	it( 'takes the first run that has it', () => {
+		expect(
+			selectReusableArtifact(
+				[
+					{ run: run( { id: 2 } ), artifacts: [] },
+					{
+						run: run( { id: 3 } ),
+						artifacts: [ artifact( { workflow_run: { id: 3 } } ) ],
+					},
+				],
+				'plugin-abc'
+			)
+		).toBe( 3 );
+	} );
+
+	it( 'skips untrusted runs even when they have the artifact', () => {
+		expect(
+			selectReusableArtifact(
+				[
+					{
+						run: run( { event: 'workflow_dispatch' } ),
+						artifacts: [ artifact() ],
+					},
+				],
+				'plugin-abc'
+			)
+		).toBeUndefined();
+	} );
+
+	it( 'skips expired artifacts, other names and other runs', () => {
+		const candidates = [
+			{
+				run: run(),
+				artifacts: [
+					artifact( { expired: true } ),
+					artifact( { name: 'plugin-def' } ),
+					artifact( { workflow_run: { id: 99 } } ),
+				],
+			},
+		];
+		expect(
+			selectReusableArtifact( candidates, 'plugin-abc' )
+		).toBeUndefined();
+	} );
+
+	it( 'handles runs without an artifact list', () => {
+		expect(
+			selectReusableArtifact(
+				[ { run: run(), artifacts: undefined } ],
+				'plugin-abc'
+			)
+		).toBeUndefined();
+	} );
+} );
+
+describe( 'findReusableRuns', () => {
+	const sha = 'a'.repeat( 40 );
+	const request = ( responses ) => {
+		const paths = [];
+		const fake = ( path ) => {
+			paths.push( path );
+			const response = responses[ path ];
+			if ( ! response ) {
+				return Promise.reject( new Error( `Unexpected ${ path }` ) );
+			}
+			return Promise.resolve( response );
+		};
+		fake.paths = paths;
+		return fake;
+	};
+
+	it( 'finds the run that built the commit', async () => {
+		const fake = request( {
+			[ `/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=5&head_sha=${ sha }` ]:
+				{ workflow_runs: [ run() ] },
+			[ `/actions/runs/1/artifacts?name=plugin-${ sha }` ]: {
+				artifacts: [ artifact( { name: `plugin-${ sha }` } ) ],
+			},
+		} );
+		const [ branch ] = await findReusableRuns(
+			[ { name: 'trunk', sha, reuse: 'sha' } ],
+			fake
+		);
+		expect( branch.reuseRunId ).toBe( 1 );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'scans recent runs when it looks the artifact up by name', async () => {
+		const fake = request( {
+			'/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=10':
+				{ workflow_runs: [ run( { id: 7 } ) ] },
+			[ `/actions/runs/7/artifacts?name=plugin-${ sha }` ]: {
+				artifacts: [
+					artifact( {
+						name: `plugin-${ sha }`,
+						workflow_run: { id: 7 },
+					} ),
+				],
+			},
+		} );
+		const [ branch ] = await findReusableRuns(
+			[ { name: 'reference', sha, reuse: 'name' } ],
+			fake
+		);
+		expect( branch.reuseRunId ).toBe( 7 );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'leaves branches that cannot be reused alone', async () => {
+		const fake = request( {} );
+		const branches = await findReusableRuns(
+			[
+				{ name: 'head', sha },
+				{ name: 'wp/7.1', reuse: 'sha' },
+			],
+			fake
+		);
+		expect( branches.every( ( { reuseRunId } ) => ! reuseRunId ) ).toBe(
+			true
+		);
+		expect( fake.paths ).toEqual( [] );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'builds when the API fails, without failing the other branches', async () => {
+		const fake = request( {
+			'/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=10':
+				{ workflow_runs: [] },
+		} );
+		const branches = await findReusableRuns(
+			[
+				{ name: 'trunk', sha, reuse: 'sha' },
+				{ name: 'reference', sha, reuse: 'name' },
+			],
+			fake
+		);
+		expect( branches.map( ( { reuseRunId } ) => reuseRunId ) ).toEqual( [
+			undefined,
+			undefined,
+		] );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'builds when a response is malformed', async () => {
+		const fake = request( {
+			[ `/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=5&head_sha=${ sha }` ]:
+				{},
+		} );
+		const [ branch ] = await findReusableRuns(
+			[ { name: 'trunk', sha, reuse: 'sha' } ],
+			fake
+		);
+		expect( branch.reuseRunId ).toBeUndefined();
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'stops mid branch once it runs out of time', async () => {
+		const fake = request( {
+			[ `/actions/workflows/performance.yml/runs?event=push&branch=trunk&per_page=5&head_sha=${ sha }` ]:
+				{ workflow_runs: [ run() ] },
+		} );
+		const slow = ( path ) =>
+			new Promise( ( resolve ) => setTimeout( resolve, 20 ) ).then( () =>
+				fake( path )
+			);
+		const [ branch ] = await findReusableRuns(
+			[ { name: 'trunk', sha, reuse: 'sha' } ],
+			slow,
+			Date.now() + 10
+		);
+		expect( branch.reuseRunId ).toBeUndefined();
+		// The first request went out, the artifact lookup did not.
+		expect( fake.paths ).toHaveLength( 1 );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'stops looking once it runs out of time', async () => {
+		const fake = request( {} );
+		const [ branch ] = await findReusableRuns(
+			[ { name: 'trunk', sha, reuse: 'sha' } ],
+			fake,
+			Date.now() - 1
+		);
+		expect( branch.reuseRunId ).toBeUndefined();
+		expect( fake.paths ).toEqual( [] );
+		expect( console ).toHaveLogged();
+	} );
+} );

--- a/tools/release/test/resolve-performance-branches.js
+++ b/tools/release/test/resolve-performance-branches.js
@@ -3,13 +3,15 @@ const path = require( 'node:path' );
 const {
 	resolveBranches,
 	resolveShards,
+	computeBuildKey,
 	getTestedUpToMajor,
 	REFERENCE_COMMIT,
 } = require( '../resolve-performance-branches.mjs' );
 
 const sha = 'a'.repeat( 40 );
 const baseSha = 'b'.repeat( 40 );
-const refExists = () => true;
+const releaseSha = 'c'.repeat( 40 );
+const resolveRef = () => releaseSha;
 
 describe( 'getTestedUpToMajor', () => {
 	it( 'returns major.minor', () => {
@@ -28,29 +30,54 @@ describe( 'resolveBranches', () => {
 				event: 'pull_request',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 				baseSha,
 				baseRef: 'trunk',
 			} )
 		).toEqual( {
 			branches: [
-				{ name: sha, ref: sha, artifact: `plugin-${ sha }` },
-				{ name: 'trunk', ref: baseSha, artifact: 'plugin-trunk' },
+				{ name: sha, ref: sha, artifact: `plugin-${ sha }`, sha },
+				{
+					name: 'trunk',
+					ref: baseSha,
+					artifact: 'plugin-trunk',
+					sha: baseSha,
+					reuse: 'sha',
+				},
 			],
 			wpVersion: '',
 		} );
 	} );
 
+	it( 'does not reuse a build for a base branch that is not trunk', () => {
+		const { branches } = resolveBranches( {
+			event: 'pull_request',
+			sha,
+			wpMajor: '7.1',
+			resolveRef,
+			baseSha,
+			baseRef: 'release/24.0',
+		} );
+		expect( branches[ 1 ].reuse ).toBeUndefined();
+	} );
+
 	it( 'compares a push with the reference commit on the tested WP version', () => {
 		expect(
-			resolveBranches( { event: 'push', sha, wpMajor: '7.1', refExists } )
+			resolveBranches( {
+				event: 'push',
+				sha,
+				wpMajor: '7.1',
+				resolveRef,
+			} )
 		).toEqual( {
 			branches: [
-				{ name: sha, ref: sha, artifact: `plugin-${ sha }` },
+				{ name: sha, ref: sha, artifact: `plugin-${ sha }`, sha },
 				{
 					name: REFERENCE_COMMIT,
 					ref: REFERENCE_COMMIT,
 					artifact: `plugin-${ REFERENCE_COMMIT }`,
+					sha: REFERENCE_COMMIT,
+					reuse: 'name',
 				},
 			],
 			wpVersion: '7.1',
@@ -63,21 +90,28 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 				releaseTag: 'v24.0.0-rc.1',
 			} )
 		).toEqual( {
 			branches: [
-				{ name: 'wp/7.1', ref: 'wp/7.1', artifact: 'plugin-wp-7-1' },
+				{
+					name: 'wp/7.1',
+					ref: 'wp/7.1',
+					artifact: 'plugin-wp-7-1',
+					sha: releaseSha,
+				},
 				{
 					name: 'release/23.9',
 					ref: 'release/23.9',
 					artifact: 'plugin-release-23-9',
+					sha: releaseSha,
 				},
 				{
 					name: 'release/24.0',
 					ref: 'release/24.0',
 					artifact: 'plugin-release-24-0',
+					sha: releaseSha,
 				},
 			],
 			wpVersion: '7.1',
@@ -90,7 +124,7 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 				releaseTag: 'v24.0',
 			} )
 		).toThrow( "Release tag 'v24.0' does not resolve" );
@@ -102,9 +136,9 @@ describe( 'resolveBranches', () => {
 			event: 'release',
 			sha,
 			wpMajor: '7.1',
-			refExists: ( ref, kind ) => {
+			resolveRef: ( ref, kind ) => {
 				seen.push( `${ kind }:${ ref }` );
-				return true;
+				return releaseSha;
 			},
 			releaseTag: 'v24.0.0',
 		} );
@@ -122,7 +156,8 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				refExists: ( ref ) => ref !== 'release/23.9',
+				resolveRef: ( ref ) =>
+					ref === 'release/23.9' ? '' : releaseSha,
 				releaseTag: 'v24.0.0',
 			} )
 		).toThrow( "previous release branch 'release/23.9'" );
@@ -134,17 +169,45 @@ describe( 'resolveBranches', () => {
 				event: 'workflow_dispatch',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 				inputBranches: ' trunk, v23.8.0 ,,',
 				inputWpVersion: '7.0',
 			} )
 		).toEqual( {
 			branches: [
-				{ name: 'trunk', ref: 'trunk', artifact: 'plugin-trunk' },
-				{ name: 'v23.8.0', ref: 'v23.8.0', artifact: 'plugin-v23-8-0' },
+				{
+					name: 'trunk',
+					ref: 'trunk',
+					artifact: 'plugin-trunk',
+					sha: releaseSha,
+				},
+				{
+					name: 'v23.8.0',
+					ref: 'v23.8.0',
+					artifact: 'plugin-v23-8-0',
+					sha: releaseSha,
+				},
 			],
 			wpVersion: '7.0',
 		} );
+	} );
+
+	it( 'builds a manual ref that does not resolve, without reusing it', () => {
+		const { branches } = resolveBranches( {
+			event: 'workflow_dispatch',
+			sha,
+			wpMajor: '7.1',
+			resolveRef: () => '',
+			inputBranches: 'trunk,my-branch',
+		} );
+		expect( branches.map( ( item ) => item.sha ) ).toEqual( [
+			undefined,
+			undefined,
+		] );
+		expect( branches.map( ( item ) => item.ref ) ).toEqual( [
+			'trunk',
+			'my-branch',
+		] );
 	} );
 
 	it( 'rejects manual runs with fewer than two branches', () => {
@@ -153,7 +216,7 @@ describe( 'resolveBranches', () => {
 				event: 'workflow_dispatch',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 				inputBranches: 'trunk,',
 			} )
 		).toThrow( 'at least two branches' );
@@ -165,7 +228,7 @@ describe( 'resolveBranches', () => {
 				event: 'workflow_dispatch',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 				inputBranches: 'wp/6.9,wp-6.9',
 			} )
 		).toThrow( 'plugin-wp-6-9' );
@@ -177,7 +240,7 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				refExists: ( ref ) => ref !== 'wp/7.1',
+				resolveRef: ( ref ) => ( ref === 'wp/7.1' ? '' : releaseSha ),
 				releaseTag: 'v24.0.0',
 			} )
 		).toThrow( "WordPress branch 'wp/7.1'" );
@@ -189,9 +252,29 @@ describe( 'resolveBranches', () => {
 				event: 'schedule',
 				sha,
 				wpMajor: '7.1',
-				refExists,
+				resolveRef,
 			} )
 		).toThrow( 'Unsupported event' );
+	} );
+} );
+
+describe( 'computeBuildKey', () => {
+	it( 'changes with the packaged files', () => {
+		expect( computeBuildKey( 'lib build', 'workflow' ) ).not.toBe(
+			computeBuildKey( 'lib build readme.txt', 'workflow' )
+		);
+	} );
+
+	it( 'changes with the workflow that builds and packages', () => {
+		expect( computeBuildKey( 'lib build', 'workflow' ) ).not.toBe(
+			computeBuildKey( 'lib build', 'workflow with a new step' )
+		);
+	} );
+
+	it( 'is stable for the same inputs', () => {
+		expect( computeBuildKey( 'lib build', 'workflow' ) ).toBe(
+			computeBuildKey( 'lib build', 'workflow' )
+		);
 	} );
 } );
 

--- a/tools/release/test/resolve-performance-branches.js
+++ b/tools/release/test/resolve-performance-branches.js
@@ -10,8 +10,7 @@ const {
 
 const sha = 'a'.repeat( 40 );
 const baseSha = 'b'.repeat( 40 );
-const releaseSha = 'c'.repeat( 40 );
-const resolveRef = () => releaseSha;
+const refExists = () => true;
 
 describe( 'getTestedUpToMajor', () => {
 	it( 'returns major.minor', () => {
@@ -30,7 +29,7 @@ describe( 'resolveBranches', () => {
 				event: 'pull_request',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 				baseSha,
 				baseRef: 'trunk',
 			} )
@@ -42,7 +41,7 @@ describe( 'resolveBranches', () => {
 					ref: baseSha,
 					artifact: 'plugin-trunk',
 					sha: baseSha,
-					reuse: 'sha',
+					reusable: true,
 				},
 			],
 			wpVersion: '',
@@ -54,11 +53,11 @@ describe( 'resolveBranches', () => {
 			event: 'pull_request',
 			sha,
 			wpMajor: '7.1',
-			resolveRef,
+			refExists,
 			baseSha,
 			baseRef: 'release/24.0',
 		} );
-		expect( branches[ 1 ].reuse ).toBeUndefined();
+		expect( branches[ 1 ].reusable ).toBeUndefined();
 	} );
 
 	it( 'compares a push with the reference commit on the tested WP version', () => {
@@ -67,7 +66,7 @@ describe( 'resolveBranches', () => {
 				event: 'push',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 			} )
 		).toEqual( {
 			branches: [
@@ -77,7 +76,6 @@ describe( 'resolveBranches', () => {
 					ref: REFERENCE_COMMIT,
 					artifact: `plugin-${ REFERENCE_COMMIT }`,
 					sha: REFERENCE_COMMIT,
-					reuse: 'name',
 				},
 			],
 			wpVersion: '7.1',
@@ -90,7 +88,7 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 				releaseTag: 'v24.0.0-rc.1',
 			} )
 		).toEqual( {
@@ -99,19 +97,16 @@ describe( 'resolveBranches', () => {
 					name: 'wp/7.1',
 					ref: 'wp/7.1',
 					artifact: 'plugin-wp-7-1',
-					sha: releaseSha,
 				},
 				{
 					name: 'release/23.9',
 					ref: 'release/23.9',
 					artifact: 'plugin-release-23-9',
-					sha: releaseSha,
 				},
 				{
 					name: 'release/24.0',
 					ref: 'release/24.0',
 					artifact: 'plugin-release-24-0',
-					sha: releaseSha,
 				},
 			],
 			wpVersion: '7.1',
@@ -124,7 +119,7 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 				releaseTag: 'v24.0',
 			} )
 		).toThrow( "Release tag 'v24.0' does not resolve" );
@@ -136,9 +131,9 @@ describe( 'resolveBranches', () => {
 			event: 'release',
 			sha,
 			wpMajor: '7.1',
-			resolveRef: ( ref, kind ) => {
+			refExists: ( ref, kind ) => {
 				seen.push( `${ kind }:${ ref }` );
-				return releaseSha;
+				return true;
 			},
 			releaseTag: 'v24.0.0',
 		} );
@@ -156,8 +151,7 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				resolveRef: ( ref ) =>
-					ref === 'release/23.9' ? '' : releaseSha,
+				refExists: ( ref ) => ref !== 'release/23.9',
 				releaseTag: 'v24.0.0',
 			} )
 		).toThrow( "previous release branch 'release/23.9'" );
@@ -169,7 +163,7 @@ describe( 'resolveBranches', () => {
 				event: 'workflow_dispatch',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 				inputBranches: ' trunk, v23.8.0 ,,',
 				inputWpVersion: '7.0',
 			} )
@@ -179,35 +173,15 @@ describe( 'resolveBranches', () => {
 					name: 'trunk',
 					ref: 'trunk',
 					artifact: 'plugin-trunk',
-					sha: releaseSha,
 				},
 				{
 					name: 'v23.8.0',
 					ref: 'v23.8.0',
 					artifact: 'plugin-v23-8-0',
-					sha: releaseSha,
 				},
 			],
 			wpVersion: '7.0',
 		} );
-	} );
-
-	it( 'builds a manual ref that does not resolve, without reusing it', () => {
-		const { branches } = resolveBranches( {
-			event: 'workflow_dispatch',
-			sha,
-			wpMajor: '7.1',
-			resolveRef: () => '',
-			inputBranches: 'trunk,my-branch',
-		} );
-		expect( branches.map( ( item ) => item.sha ) ).toEqual( [
-			undefined,
-			undefined,
-		] );
-		expect( branches.map( ( item ) => item.ref ) ).toEqual( [
-			'trunk',
-			'my-branch',
-		] );
 	} );
 
 	it( 'rejects manual runs with fewer than two branches', () => {
@@ -216,7 +190,7 @@ describe( 'resolveBranches', () => {
 				event: 'workflow_dispatch',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 				inputBranches: 'trunk,',
 			} )
 		).toThrow( 'at least two branches' );
@@ -228,7 +202,7 @@ describe( 'resolveBranches', () => {
 				event: 'workflow_dispatch',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 				inputBranches: 'wp/6.9,wp-6.9',
 			} )
 		).toThrow( 'plugin-wp-6-9' );
@@ -240,7 +214,7 @@ describe( 'resolveBranches', () => {
 				event: 'release',
 				sha,
 				wpMajor: '7.1',
-				resolveRef: ( ref ) => ( ref === 'wp/7.1' ? '' : releaseSha ),
+				refExists: ( ref ) => ref !== 'wp/7.1',
 				releaseTag: 'v24.0.0',
 			} )
 		).toThrow( "WordPress branch 'wp/7.1'" );
@@ -252,7 +226,7 @@ describe( 'resolveBranches', () => {
 				event: 'schedule',
 				sha,
 				wpMajor: '7.1',
-				resolveRef,
+				refExists,
 			} )
 		).toThrow( 'Unsupported event' );
 	} );


### PR DESCRIPTION
## What?

Follow up to #82160. The performance workflow downloads the plugin an earlier trunk run built for the base commit instead of rebuilding it.

## Why?

Every pull request run rebuilds its base, which a trunk push run already built ([comment](https://github.com/WordPress/gutenberg/pull/82160#issuecomment-5453274680)). That job is 2m13 of a 41 runner-minute run.

## How?

`prepare` finds the trunk `push` run that published `plugin-<sha>`; the build job stages the download and promotes it only once the artifact's own `perf-build.json` is identical to the one this job would write.

- The manifest holds the commit, build key, `node -v`, `npm -v` and `ImageOS`, so a plugin is reused only when this job would have built it the same way.
- The build key hashes `bin/plugin-files.txt` and [performance.yml](.github/workflows/performance.yml).
- Only push-to-trunk artifacts are trusted. Any mismatch, missing artifact, API failure or timeout builds.

## Testing Instructions

Validation cannot pass here: no artifact carries a manifest yet, and the build key covers this PR's own workflow change. Demonstrated with two throwaway commits, since reverted, in [run 33399810596](https://github.com/WordPress/gutenberg/actions/runs/33399810596):

```
7e2d710d3c95: reusing the plugin from run 33399542079
Validate the downloaded plugin  success
Build                           skipped
Package plugin                  skipped
```

55s against 2m13. Two builds of the same commit were also byte identical across 2181 files.

## Use of AI Tools

Authored with Claude Code, reviewed with Codex.
