### PR TITLE
Private APIs: Deprecate the '@wordpress/dataviews' opt-in, scheduling removal for WordPress 7.4

### DIFF
--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
--   Deprecate the `@wordpress/dataviews` opt-in: it still works so that copies published to npm before v18 keep loading, but logs a warning when `SCRIPT_DEBUG` is enabled. Scheduled for removal in WordPress 7.4. [#82231](https://github.com/WordPress/gutenberg/pull/82231)
+-   Deprecate the `@wordpress/dataviews` opt-in: it still works so that copies published to npm before v18.1 keep loading, but logs a warning when `SCRIPT_DEBUG` is enabled. Scheduled for removal in WordPress 7.4. [#82231](https://github.com/WordPress/gutenberg/pull/82231)
 
 ### Bug fixes
 

--- a/packages/private-apis/CHANGELOG.md
+++ b/packages/private-apis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Deprecate the `@wordpress/dataviews` opt-in: it still works so that copies published to npm before v18 keep loading, but logs a warning when `SCRIPT_DEBUG` is enabled. Scheduled for removal in WordPress 7.4. [#82231](https://github.com/WordPress/gutenberg/pull/82231)
+
 ### Bug fixes
 
 -   Restore `@wordpress/dataviews` in the list of core modules allowed to use private APIs. DataViews copies published to npm before the private API cleanup opt in at module load, so plugin bundles embedding them throw without the entry. [#82221](https://github.com/WordPress/gutenberg/pull/82221)

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -71,7 +71,7 @@ const DEPRECATED_CORE_MODULES: Record<
 	'@wordpress/dataviews': {
 		since: '7.2',
 		removal: '7.4',
-		note: 'Update the `@wordpress/dataviews` npm dependency to version 18 or newer, which no longer uses the private APIs.',
+		note: 'Update the `@wordpress/dataviews` npm dependency to version 18.1 or newer, which no longer uses the private APIs.',
 	},
 };
 

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -41,10 +41,6 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/storybook',
 	'@wordpress/sync',
 	'@wordpress/theme',
-	// Do not remove: older `@wordpress/dataviews` versions published to npm
-	// call the opt-in at module load, so a plugin bundling one of those
-	// copies throws at load time if this entry is missing.
-	'@wordpress/dataviews',
 	'@wordpress/fields',
 	'@wordpress/lazy-editor',
 	'@wordpress/media-editor',
@@ -56,6 +52,57 @@ const CORE_MODULES_USING_PRIVATE_APIS = [
 	'@wordpress/views',
 	'@wordpress/widget-dashboard',
 ];
+
+/**
+ * Core modules that no longer use the private APIs but must remain allowed
+ * to opt-in: copies of them published to npm before they stopped using the
+ * private APIs call the opt-in at module load, so a plugin bundling one of
+ * those copies would throw at load time if the module was not allowed.
+ *
+ * Opting in as one of these modules still works, but logs a deprecation
+ * warning when `SCRIPT_DEBUG` is enabled. Each entry documents the WordPress
+ * version scheduled for its removal; a unit test starts failing when the
+ * release cycle of that version begins.
+ */
+const DEPRECATED_CORE_MODULES: Record<
+	string,
+	{ since: string; removal: string; note: string }
+> = {
+	'@wordpress/dataviews': {
+		since: '7.2',
+		removal: '7.4',
+		note: 'Update the `@wordpress/dataviews` npm dependency to version 18 or newer, which no longer uses the private APIs.',
+	},
+};
+
+/**
+ * The deprecated modules that already logged a warning, to avoid logging
+ * the same warning more than once.
+ */
+const warnedDeprecatedModules = new Set< string >();
+
+/**
+ * Logs a deprecation warning for a module in `DEPRECATED_CORE_MODULES`,
+ * once per module and only when `SCRIPT_DEBUG` is enabled.
+ *
+ * @param moduleName The name of the deprecated module that opted in.
+ */
+function warnDeprecatedModule( moduleName: string ) {
+	// eslint-disable-next-line @wordpress/wp-global-usage
+	if ( globalThis.SCRIPT_DEBUG !== true ) {
+		return;
+	}
+	if ( warnedDeprecatedModules.has( moduleName ) ) {
+		return;
+	}
+	warnedDeprecatedModules.add( moduleName );
+	const { since, removal, note } = DEPRECATED_CORE_MODULES[ moduleName ];
+	// eslint-disable-next-line no-console
+	console.warn(
+		`The private APIs opt-in of the module "${ moduleName }" is deprecated since WordPress ${ since } ` +
+			`and will stop working in WordPress ${ removal }. ${ note }`
+	);
+}
 
 /*
  * Warning for theme and plugin developers.
@@ -86,7 +133,10 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 	consent: string,
 	moduleName: string
 ) => {
-	if ( ! CORE_MODULES_USING_PRIVATE_APIS.includes( moduleName ) ) {
+	if (
+		! CORE_MODULES_USING_PRIVATE_APIS.includes( moduleName ) &&
+		! ( moduleName in DEPRECATED_CORE_MODULES )
+	) {
 		throw new Error(
 			`You tried to opt-in to unstable APIs as module "${ moduleName }". ` +
 				'This feature is only for JavaScript modules shipped with WordPress core. ' +
@@ -103,6 +153,10 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 				'without a warning. If you ignore this error and depend on unstable features, ' +
 				'your product will inevitably break on the next WordPress release.'
 		);
+	}
+
+	if ( moduleName in DEPRECATED_CORE_MODULES ) {
+		warnDeprecatedModule( moduleName );
 	}
 
 	return {
@@ -214,3 +268,13 @@ export function resetAllowedCoreModules() {
 		CORE_MODULES_USING_PRIVATE_APIS.pop();
 	}
 }
+
+/**
+ * Private function to allow the unit tests to trigger
+ * the deprecation warnings again.
+ */
+export function resetWarnedDeprecatedModules() {
+	warnedDeprecatedModules.clear();
+}
+
+export { DEPRECATED_CORE_MODULES };

--- a/packages/private-apis/src/test/index.jsx
+++ b/packages/private-apis/src/test/index.jsx
@@ -1,5 +1,15 @@
+import fs from 'fs';
+import path from 'path';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '../';
-import { resetAllowedCoreModules, allowCoreModule } from '../implementation';
+import {
+	resetAllowedCoreModules,
+	allowCoreModule,
+	resetWarnedDeprecatedModules,
+	DEPRECATED_CORE_MODULES,
+} from '../implementation';
+
+// eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair
+/* eslint-disable @wordpress/wp-global-usage */
 
 beforeEach( () => {
 	resetAllowedCoreModules();
@@ -285,5 +295,94 @@ describe( 'Specific use-cases of sharing private APIs', () => {
 		 * ```
 		 */
 		expect( unlock( DataTable ) ).toBe( PrivateDataTable );
+	} );
+} );
+
+describe( 'Deprecated core modules', () => {
+	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
+
+	beforeEach( () => {
+		globalThis.SCRIPT_DEBUG = true;
+		resetWarnedDeprecatedModules();
+	} );
+
+	afterEach( () => {
+		globalThis.SCRIPT_DEBUG = initialScriptDebug;
+	} );
+
+	it( 'Should grant access to unstable APIs and log a deprecation warning', () => {
+		const unstableAPIs = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			requiredConsent,
+			'@wordpress/dataviews'
+		);
+		expect( console ).toHaveWarned();
+		expect( unstableAPIs.lock ).toEqual( expect.any( Function ) );
+		expect( unstableAPIs.unlock ).toEqual( expect.any( Function ) );
+	} );
+
+	it( 'Should still require the consent string', () => {
+		expect( () => {
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				'',
+				'@wordpress/dataviews'
+			);
+		} ).toThrow( /without confirming you know the consequences/ );
+	} );
+
+	it( 'Should log the deprecation warning only once per module', () => {
+		__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			requiredConsent,
+			'@wordpress/dataviews'
+		);
+		__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			requiredConsent,
+			'@wordpress/dataviews'
+		);
+		expect( console ).toHaveWarned();
+		// eslint-disable-next-line no-console
+		expect( console.warn ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'Should not log a deprecation warning when SCRIPT_DEBUG is disabled', () => {
+		globalThis.SCRIPT_DEBUG = false;
+		const unstableAPIs = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			requiredConsent,
+			'@wordpress/dataviews'
+		);
+		expect( unstableAPIs.lock ).toEqual( expect.any( Function ) );
+	} );
+
+	it( 'Should be removed when the WordPress version scheduled for their removal is reached', () => {
+		// The newest lib/compat/wordpress-X.Y directory marks the WordPress
+		// release Gutenberg is currently targeting.
+		const compatDir = path.join( __dirname, '../../../../lib/compat' );
+		const targetedVersion = fs
+			.readdirSync( compatDir )
+			.map( ( name ) => name.match( /^wordpress-(\d+)\.(\d+)$/ ) )
+			.filter( Boolean )
+			.map( ( match ) => [ Number( match[ 1 ] ), Number( match[ 2 ] ) ] )
+			.sort( ( a, b ) => a[ 0 ] - b[ 0 ] || a[ 1 ] - b[ 1 ] )
+			.pop();
+
+		const dueForRemoval = [];
+		for ( const [ moduleName, { removal } ] of Object.entries(
+			DEPRECATED_CORE_MODULES
+		) ) {
+			const [ major, minor ] = removal.split( '.' ).map( Number );
+			const isReached =
+				targetedVersion[ 0 ] > major ||
+				( targetedVersion[ 0 ] === major &&
+					targetedVersion[ 1 ] >= minor );
+			if ( isReached ) {
+				dueForRemoval.push(
+					`The "${ moduleName }" entry in DEPRECATED_CORE_MODULES was scheduled ` +
+						`for removal in WordPress ${ removal }, and the ` +
+						`${ targetedVersion[ 0 ] }.${ targetedVersion[ 1 ] } release cycle has started. ` +
+						`Remove the entry and its deprecation warning, unless old copies of the ` +
+						`module are still in significant use by plugins.`
+				);
+			}
+		}
+		expect( dueForRemoval ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
## What?

Follow up to #82221 (see [this discussion](https://github.com/WordPress/gutenberg/pull/82221#discussion_r3892130244)). Moves `@wordpress/dataviews` from the list of core modules allowed to use private APIs to a new list of deprecated modules. Opting in as a deprecated module still works, but logs a deprecation warning, and its removal is scheduled for WordPress 7.4.

## Why?

`@wordpress/dataviews` copies published to npm before v18 call the private APIs opt-in when they load, so a plugin bundling one of them would break the moment we remove the entry. We still want to remove it eventually, and developers need a heads-up on how to prepare (update the npm dependency to v18 or newer).

## How?

Adds a `DEPRECATED_CORE_MODULES` list to `@wordpress/private-apis`. Modules on it still get `lock`/`unlock`, but a warning is logged once per module when `SCRIPT_DEBUG` is enabled, naming the removal version and the fix. A new unit test starts failing as soon as a `lib/compat/wordpress-7.4` directory appears, so the removal cannot be forgotten; actual usage of old copies in the plugin directory should still be checked before removing.

## Testing Instructions

Run `npm run test:unit -- packages/private-apis`. To see the warning in a browser, open the editor in a dev environment with `SCRIPT_DEBUG` enabled and run `wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules( 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.', '@wordpress/dataviews' )` in the console: it returns the lock/unlock utilities and logs the deprecation warning once.

## Use of AI Tools

This PR was written with the help of Claude Code, based on the discussion linked above. The changes were reviewed, tested, and are owned by the author.
