### PR TITLE
Navigation: Keep the flex layout on a block inserted into an overlay

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
--   Navigation: Keep the flex layout on a Navigation block inserted into a navigation overlay, so block spacing applies to it.
+-   Navigation: Keep the flex layout on a Navigation block inserted into a navigation overlay, so block spacing applies to it ([#82232](https://github.com/WordPress/gutenberg/pull/82232)).
 
 ### Internal
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
+-   Navigation: Keep the flex layout on a Navigation block inserted into a navigation overlay, so block spacing applies to it.
 
 ### Internal
 

--- a/packages/block-library/src/navigation/edit/index.jsx
+++ b/packages/block-library/src/navigation/edit/index.jsx
@@ -36,7 +36,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { page } from '@wordpress/icons';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockSupport } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import useNavigationMenu from '../use-navigation-menu';
 import Placeholder from './placeholder';
@@ -592,6 +592,7 @@ function Navigation( {
 			setAttributes( {
 				submenuVisibility: 'always',
 				layout: {
+					...getBlockSupport( 'core/navigation', 'layout' )?.default,
 					...attributes.layout,
 					orientation: 'vertical',
 				},

--- a/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
+++ b/test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js
@@ -106,6 +106,33 @@ test.describe( 'Navigation Overlay Template Part', () => {
 			await expect( overlayMenuItem ).toBeHidden();
 			await expect( openMenuButton ).toBeFocused();
 		} );
+
+		test( 'As a user I want a navigation block inserted into an overlay to keep the flex layout so block spacing applies', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await createNavigationOverlay( {
+				admin,
+				editor,
+				page,
+				requestUtils,
+			} );
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			const navigationBlock = editor.canvas
+				.locator( '[data-type="core/navigation"]' )
+				.last();
+
+			// The block mounts with the flex layout already applied, so wait for
+			// the overlay defaults to land before asserting it survived them.
+			await expect( navigationBlock ).toHaveClass( /is-vertical/ );
+			await expect( navigationBlock ).toHaveClass(
+				/wp-block-navigation-is-layout-flex/
+			);
+		} );
 	} );
 
 	test.describe( 'Customization', () => {


### PR DESCRIPTION
## What?
Closes #82094

A Navigation block inserted into a navigation overlay loses its flex layout, so Block spacing has no effect on it.

## Why?
The overlay defaults effect spreads `attributes.layout`, which is `undefined` on a freshly inserted block, so it writes a layout attribute with no `type`. `useLayoutClasses` then stops falling back to `supports.layout.default` and renders the block as flow, where the gap becomes a margin on the single Page List child and never reaches the items.

## How?
Seed the layout with the block's registered layout default before spreading the saved attribute.

This fixes newly inserted blocks only. Overlays already saved with the typeless layout stay broken until someone toggles orientation; I've asked in the issue whether you'd want a deprecation that restores `type: "flex"` on parse, and can add it here if so.

## Testing Instructions
1. Site editor → Header → select the Navigation block → Settings → **Create overlay**.
2. In the overlay, delete the Navigation block and insert a new one.
3. Select it and set **Block spacing** to Large.
4. The items space out. On trunk nothing happens.

`npm run test:e2e -- test/e2e/specs/site-editor/navigation-overlay-template-part.spec.js`

- [x] New e2e test fails on trunk (3/3) and passes with the fix
- [x] `npm run test:unit -- packages/block-library/src/navigation` — 282 passed
- [x] `navigation`, `navigation-submenu-visibility`, `navigation-colors`, `navigation-list-view` e2e — 42 passed

### Testing Instructions for Keyboard
No UI change; the steps above are reachable with List View and the sidebar in keyboard order.

## Screenshots or screencast

### Before
<img width="1568" height="740" alt="82094-bug-blockgap-ignored" src="https://github.com/user-attachments/assets/c37b44c1-a037-4ca6-b0ca-bc6e63402936" />

### After
<img width="1568" height="740" alt="82094-with-type-flex-blockgap-applies" src="https://github.com/user-attachments/assets/9a417693-fe92-42c3-8cdb-92c264c5acb3" />

## Use of AI Tools
Investigation, fix and e2e test written with Claude Code; I reviewed and tested the change.
