### PR TITLE
Menu: Use Text for item labels and descriptions

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Enhancements
 
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `popupWidth` prop with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087)).
--   `Menu.ItemLabel`, `Menu.ItemDescription`: Apply `text-wrap: pretty` to improve line wrapping. ([#82237](https://github.com/WordPress/gutenberg/pull/82237))
+-   `Menu`: Use `Text` for item labels and descriptions to share typography and apply `text-wrap: pretty`. ([#82237](https://github.com/WordPress/gutenberg/pull/82237))
 -   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
 
 ### Bug Fixes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Enhancements
 
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `popupWidth` prop with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087)).
+-   `Menu.ItemLabel`, `Menu.ItemDescription`: Apply `text-wrap: pretty` to improve line wrapping. ([#82237](https://github.com/WordPress/gutenberg/pull/82237))
 -   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))
 
 ### Bug Fixes

--- a/packages/ui/src/menu/item-description.tsx
+++ b/packages/ui/src/menu/item-description.tsx
@@ -1,27 +1,27 @@
-import { mergeProps, useRender } from '@base-ui/react';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { useMenuItemContentContext } from './context';
 import styles from './style.module.css';
 import type { ItemDescriptionProps } from './types';
+import { Text } from '../text';
 
 /**
  * Renders supplementary text below a menu item label. Use it as a direct child
  * alongside `Menu.ItemLabel`.
  */
 const ItemDescription = forwardRef< HTMLSpanElement, ItemDescriptionProps >(
-	function MenuItemDescription( { className, id, render, ...props }, ref ) {
+	function MenuItemDescription( { className, id, ...props }, ref ) {
 		const itemContentContext = useMenuItemContentContext();
 
-		return useRender( {
-			defaultTagName: 'span',
-			ref,
-			render,
-			props: mergeProps< 'span' >( props, {
-				id: id ?? itemContentContext?.descriptionId,
-				className: clsx( styles[ 'item-description' ], className ),
-			} ),
-		} );
+		return (
+			<Text
+				ref={ ref }
+				variant="body-sm"
+				{ ...props }
+				id={ id ?? itemContentContext?.descriptionId }
+				className={ clsx( styles[ 'item-description' ], className ) }
+			/>
+		);
 	}
 );
 

--- a/packages/ui/src/menu/item-label.tsx
+++ b/packages/ui/src/menu/item-label.tsx
@@ -1,36 +1,30 @@
-import { mergeProps, useRender } from '@base-ui/react';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { useMenuItemContentContext } from './context';
 import styles from './style.module.css';
 import type { ItemLabelProps } from './types';
+import { Text } from '../text';
 
 /**
  * Renders the primary label within a menu item. Use it as the first direct
  * child of every item.
  */
 const ItemLabel = forwardRef< HTMLSpanElement, ItemLabelProps >(
-	function MenuItemLabel(
-		{ children, className, id, render, ...props },
-		ref
-	) {
+	function MenuItemLabel( { children, className, id, ...props }, ref ) {
 		const itemContentContext = useMenuItemContentContext();
 
-		return useRender( {
-			defaultTagName: 'span',
-			ref,
-			render,
-			props: mergeProps< 'span' >( props, {
-				children: (
-					<>
-						{ children }
-						{ itemContentContext?.labelTrailing }
-					</>
-				),
-				id: id ?? itemContentContext?.labelId,
-				className: clsx( styles[ 'item-label' ], className ),
-			} ),
-		} );
+		return (
+			<Text
+				ref={ ref }
+				variant="body-md"
+				{ ...props }
+				id={ id ?? itemContentContext?.labelId }
+				className={ clsx( styles[ 'item-label' ], className ) }
+			>
+				{ children }
+				{ itemContentContext?.labelTrailing }
+			</Text>
+		);
 	}
 );
 

--- a/packages/ui/src/menu/style.module.css
+++ b/packages/ui/src/menu/style.module.css
@@ -244,12 +244,16 @@
 		}
 
 		.item-label {
+			--_gcd-heading-color: currentColor;
+
 			min-width: 0;
 			overflow-wrap: anywhere;
 			color: inherit;
 		}
 
 		.item-description {
+			--_gcd-heading-color: var(--wpds-color-foreground-content-neutral-weak);
+
 			color: var(--wpds-color-foreground-content-neutral-weak);
 			overflow-wrap: anywhere;
 			/* For better optical alignment and spacing */
@@ -323,6 +327,8 @@
 		.item[aria-disabled="true"] .item-shortcut,
 		.item[aria-disabled="true"] .item-trailing,
 		.item[aria-disabled="true"] .item-selection-indicator {
+			--_gcd-heading-color: currentColor;
+
 			color: inherit;
 		}
 	}

--- a/packages/ui/src/menu/style.module.css
+++ b/packages/ui/src/menu/style.module.css
@@ -246,6 +246,7 @@
 		.item-label {
 			min-width: 0;
 			overflow-wrap: anywhere;
+			text-wrap: pretty;
 			font-family: var(--wpds-typography-font-family-body);
 			font-size: var(--wpds-typography-font-size-md);
 			line-height: var(--wpds-typography-line-height-sm);
@@ -260,6 +261,7 @@
 			font-weight: var(--wpds-typography-font-weight-default);
 			color: var(--wpds-color-foreground-content-neutral-weak);
 			overflow-wrap: anywhere;
+			text-wrap: pretty;
 			/* For better optical alignment and spacing */
 			padding-block-end: var(--wpds-dimension-padding-xs);
 		}

--- a/packages/ui/src/menu/style.module.css
+++ b/packages/ui/src/menu/style.module.css
@@ -246,22 +246,12 @@
 		.item-label {
 			min-width: 0;
 			overflow-wrap: anywhere;
-			text-wrap: pretty;
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-md);
-			line-height: var(--wpds-typography-line-height-sm);
-			font-weight: var(--wpds-typography-font-weight-default);
 			color: inherit;
 		}
 
 		.item-description {
-			font-family: var(--wpds-typography-font-family-body);
-			font-size: var(--wpds-typography-font-size-sm);
-			line-height: var(--wpds-typography-line-height-xs);
-			font-weight: var(--wpds-typography-font-weight-default);
 			color: var(--wpds-color-foreground-content-neutral-weak);
 			overflow-wrap: anywhere;
-			text-wrap: pretty;
 			/* For better optical alignment and spacing */
 			padding-block-end: var(--wpds-dimension-padding-xs);
 		}

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -1357,10 +1357,10 @@ describe( 'Menu', () => {
 				<Menu.Trigger>Actions</Menu.Trigger>
 				<Menu.Popup>
 					<Menu.Item>
-						<Menu.ItemLabel render={ <strong /> }>
+						<Menu.ItemLabel render={ <h2 /> }>
 							Duplicate
 						</Menu.ItemLabel>
-						<Menu.ItemDescription render={ <em /> }>
+						<Menu.ItemDescription render={ <h3 /> }>
 							Create a separate copy.
 						</Menu.ItemDescription>
 					</Menu.Item>
@@ -1375,9 +1375,9 @@ describe( 'Menu', () => {
 			description: 'Create a separate copy.',
 		} );
 
-		expect( queryItemLabel( item )?.tagName ).toBe( 'STRONG' );
+		expect( queryItemLabel( item )?.tagName ).toBe( 'H2' );
 		expect( screen.getByText( 'Create a separate copy.' ).tagName ).toBe(
-			'EM'
+			'H3'
 		);
 	} );
 


### PR DESCRIPTION
## What?

Uses the shared `Text` component for `Menu.ItemLabel` and `Menu.ItemDescription`.

## Why?

These subcomponents duplicated the `body-md` and `body-sm` typography from `Text`. Reusing `Text` keeps that styling in one place and gives both components pretty line wrapping.

## How?

`Menu.ItemLabel` uses `Text` with `body-md`, while `Menu.ItemDescription` uses `body-sm`. Menu CSS keeps its layout, color, and spacing rules while removing the duplicated typography.

## Testing Instructions

1. Run Storybook with `npm run storybook:dev`.
2. Open **Design System / Components / Menu / Rich Items**.
3. Constrain the preview width until labels and descriptions wrap.
4. Confirm both retain their typography and wrap naturally.

### Testing Instructions for Keyboard

1. Open the Rich Items menu with the keyboard.
2. Move through every item with the arrow keys.
3. Confirm the wrapped text does not affect focus, highlighting, or activation.

## Screenshots

| Before | After |
|---|---|
| <img width="854" height="668" alt="Screenshot 2026-08-31 at 11 48 28" src="https://github.com/user-attachments/assets/e8f58039-1f4f-447e-a916-f5c2f32dcef1" /> | <img width="860" height="676" alt="Screenshot 2026-08-31 at 11 47 46" src="https://github.com/user-attachments/assets/b09105db-f3d0-4315-9c21-a7b0521d5b16" /> |

## Use of AI Tools

Codex was used to inspect the existing implementation, compose the Menu subcomponents with `Text`, run verification, and draft this PR description. The author reviewed the result.