### PR TITLE
Global styles: resolve theme-relative background image URLs for display

### DIFF
--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Background panels: Resolve theme-relative (`file:./…`) background image URLs and `ref` pointers before rendering thumbnails and the focal point picker. The screens render inside the package's own `BlockEditorProvider`, which cannot carry the private settings the panels previously resolved these against ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+
 ### Internal
 
 -   Remove unused dependency `change-case` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Background panels: Resolve theme-relative (`file:./…`) background image URLs and `ref` pointers before rendering thumbnails and the focal point picker. The screens render inside the package's own `BlockEditorProvider`, which cannot carry the private settings the panels previously resolved these against ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Background panels: Resolve theme-relative (`file:./…`) background image URLs and `ref` pointers before rendering thumbnails and the focal point picker. The screens render inside the package's own `BlockEditorProvider`, which cannot carry the private settings the panels previously resolved these against ([#82242](https://github.com/WordPress/gutenberg/pull/82242)).
 
 ### Internal
 

--- a/packages/global-styles-ui/src/background-panel.tsx
+++ b/packages/global-styles-ui/src/background-panel.tsx
@@ -1,6 +1,6 @@
 // @ts-expect-error: Not typed yet.
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { useStyle, useSetting } from './hooks';
+import { useStyle, useSetting, useStyleWithResolvedBackground } from './hooks';
 import { unlock } from './lock-unlock';
 
 // Initial control values where no block style is set.
@@ -35,11 +35,13 @@ export default function BackgroundPanel() {
 		'merged',
 		false
 	);
+	const resolvedInheritedStyle =
+		useStyleWithResolvedBackground( inheritedStyle );
 	const [ settings ] = useSetting( '' );
 
 	return (
 		<StylesBackgroundPanel
-			inheritedValue={ inheritedStyle }
+			inheritedValue={ resolvedInheritedStyle }
 			value={ style }
 			onChange={ setStyle }
 			settings={ settings }

--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -12,7 +12,11 @@ import {
 	setSetting,
 	mergeGlobalStyles,
 } from '@wordpress/global-styles-engine';
-import type { StyleVariation, Color } from '@wordpress/global-styles-engine';
+import type {
+	GlobalStylesConfig,
+	StyleVariation,
+	Color,
+} from '@wordpress/global-styles-engine';
 import { GlobalStylesContext } from './context';
 import { removePropertiesFromObject, isVariationWithProperties } from './utils';
 
@@ -297,7 +301,9 @@ export function useColorRandomizer( blockName?: string ): [ () => void ] | [] {
  *              pointers or theme-relative URLs.
  * @return The style object with its `background` values resolved.
  */
-export function useStyleWithResolvedBackground( style: any ) {
+export function useStyleWithResolvedBackground(
+	style: GlobalStylesConfig[ 'styles' ]
+) {
 	const { merged } = useContext( GlobalStylesContext );
 	return useMemo( () => {
 		if ( ! style?.background ) {

--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
+	getResolvedValue,
 	getStyle,
 	setStyle,
 	getSetting,
@@ -283,4 +284,38 @@ export function useColorRandomizer( blockName?: string ): [ () => void ] | [] {
 	return ( window as any ).__experimentalEnableColorRandomizer
 		? [ randomizeColors ]
 		: [];
+}
+
+/**
+ * Resolves `ref` pointers and theme-relative (`file:./…`) URLs in a style
+ * object's `background` sub-tree, for display. The Global Styles screens
+ * render inside the package's own public `BlockEditorProvider`, which strips
+ * the Symbol-keyed settings the background panel would otherwise resolve
+ * these against, so the screens resolve them before passing styles down.
+ *
+ * @param style A style object whose `background` values may contain `ref`
+ *              pointers or theme-relative URLs.
+ * @return The style object with its `background` values resolved.
+ */
+export function useStyleWithResolvedBackground( style: any ) {
+	const { merged } = useContext( GlobalStylesContext );
+	return useMemo( () => {
+		if ( ! style?.background ) {
+			return style;
+		}
+		const tree = { styles: merged?.styles, _links: merged?._links };
+		const background: Record< string, any > = {};
+		for ( const [ key, value ] of Object.entries(
+			style.background as Record< string, any >
+		) ) {
+			// getResolvedValue writes the resolved URL onto the object it is
+			// given: pass a copy so the context config keeps its
+			// theme-relative path.
+			background[ key ] = getResolvedValue(
+				value && typeof value === 'object' ? { ...value } : value,
+				tree
+			);
+		}
+		return { ...style, background };
+	}, [ style, merged ] );
 }

--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -22,7 +22,7 @@ import {
 	useBlockVariations,
 	VariationsPanel,
 } from './variations/variations-panel';
-import { useStyle, useSetting } from './hooks';
+import { useStyle, useSetting, useStyleWithResolvedBackground } from './hooks';
 import { GlobalStylesContext } from './context';
 import { unlock } from './lock-unlock';
 import { getValidPseudoStates, getValidViewportStates } from './utils';
@@ -156,6 +156,8 @@ function ScreenBlock( {
 		false,
 		hasSelectedState ? stateParam : undefined
 	);
+	const inheritedStyleWithResolvedBackground =
+		useStyleWithResolvedBackground( inheritedStyle );
 
 	const [ userSettings ] = useSetting( '', name, 'user' );
 	const [ rawSettings, setSettings ] = useSetting( '', name );
@@ -404,7 +406,7 @@ function ScreenBlock( {
 			) }
 			{ hasBackgroundPanel && (
 				<StylesBackgroundPanel
-					inheritedValue={ inheritedStyle }
+					inheritedValue={ inheritedStyleWithResolvedBackground }
 					value={ style }
 					onChange={ setStyle }
 					settings={ settings }


### PR DESCRIPTION
## What?

Theme-relative background image URLs (`file:./…`) in theme.json now render in the Global Styles background controls. 

Previously the thumbnail, filename label, and focal point picker received the raw unresolved path, e.g. `file:./img/image.jpg`.

## Why?

Regression from the Global Styles UI package refactor (#72599). 

The background panels resolve `file:` URLs and `ref` pointers against Symbol-keyed block editor settings, but the Global Styles screens render inside the package's own public `BlockEditorProvider`, whose settings strip drops Symbol keys. 

Before the refactor the screens rendered inside the editor's provider and could read those settings.

The the strip was probably deliberate so this PR respects that and adds its own hook that calls `getResolvedValue`.

## How?

A `useStyleWithResolvedBackground` hook resolves the `background` sub-tree against the merged config from `GlobalStylesContext`, which carries the theme-file links, before styles reach the panels. Each value is copied first so the stored config keeps its theme-relative path.

We resolve at the data layer rather than letting Symbol keys through the provider's settings strip: stripping private settings from the public `BlockEditorProvider` is intentional, and this package cannot use the private-API provider because it is bundled.

## Testing Instructions

1. Give a theme a theme-relative background image in theme.json, for example in `test/emptytheme/theme.json`:

```json
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "file:./img/1024x768_emptytheme_test_image.jpg"
			}
		},
		"blocks": {
			"core/group": {
				"background": {
					"backgroundImage": {
						"url": "file:./img/1024x768_emptytheme_test_image.jpg"
					}
				}
			}
		}
	},
```

2. Site Editor → Styles → Blocks → Group: the Image control should show the thumbnail and filename, and the size/position dropdown's focal point picker should show the image.
3. Repeat at the root: Styles → Background.
4. This only affects the site editor - block inspector in the post editor is unchanged.


| Before | After |
|--------|--------|
| <img width="661" height="507" alt="Screenshot 2026-08-31 at 8 17 22 pm" src="https://github.com/user-attachments/assets/630cb3d2-d69a-4b6f-9db1-aa8eef3dbae2" /> | <img width="713" height="606" alt="Screenshot 2026-08-31 at 8 40 08 pm" src="https://github.com/user-attachments/assets/70c8e01d-2189-427d-955f-6f01fb8e6e3b" /> | 





