### PR TITLE
Meta Boxes: Move meta box markup with moveBefore to keep classic editors alive

### DIFF
--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
--   `WelcomeGuide`: Keep the modal close icon white now that it is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
+-   `WelcomeGuide`: Keep the modal close icon white now that it is stroke-based ([#78812](https://github.com/WordPress/gutenberg/pull/78812)).
+-   Meta Boxes: Fix classic (TinyMCE) editors in meta boxes becoming unusable, by moving the meta box markup with `moveBefore` where it is available ([#82243](https://github.com/WordPress/gutenberg/pull/82243)).
 
 ### Internal
 

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/index.jsx
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef, useLayoutEffect } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -7,6 +7,24 @@ import { store as editPostStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
 const { useNativeUndo } = unlock( blockEditorPrivateApis );
+
+/**
+ * Moves `node` to the end of `parent`.
+ *
+ * `moveBefore` keeps the subtree's state, where `appendChild` reloads any
+ * iframe in it. That reload breaks a classic editor rendered by a meta box.
+ * `moveBefore` only works between connected nodes.
+ *
+ * @param {Element} parent Element to move into.
+ * @param {Element} node   Element to move.
+ */
+function move( parent, node ) {
+	if ( parent.moveBefore && parent.isConnected && node.isConnected ) {
+		parent.moveBefore( node, null );
+	} else {
+		parent.appendChild( node );
+	}
+}
 
 /**
  * Render metabox area.
@@ -19,20 +37,20 @@ function MetaBoxesArea( { location } ) {
 	const container = useRef( null );
 	const formRef = useRef( null );
 
-	useEffect( () => {
+	// A layout effect because the cleanup has to run before React detaches the
+	// meta boxes: `moveBefore` needs them connected.
+	useLayoutEffect( () => {
 		formRef.current = document.querySelector(
 			'.metabox-location-' + location
 		);
 
 		if ( formRef.current ) {
-			container.current.appendChild( formRef.current );
+			move( container.current, formRef.current );
 		}
 
 		return () => {
 			if ( formRef.current ) {
-				document
-					.querySelector( '#metaboxes' )
-					.appendChild( formRef.current );
+				move( document.querySelector( '#metaboxes' ), formRef.current );
 			}
 		};
 	}, [ location ] );


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/actions/runs/33144101877.
Related #78631.

`MetaBoxesArea` now relocates the meta box form with `moveBefore` instead of `appendChild`, from a layout effect instead of a passive one.

## Why?
Moving an `<iframe>` with `appendChild` resets its browsing context, so the document reloads. TinyMCE keeps a reference to the document it was editing, and the reload detaches it.

WordPress already anticipates a host relocating meta box markup, and defers initializing classic editors in postboxes until `document.readyState` is `complete` (`class-wp-editor.php`). Gutenberg mounts after that, so the move lands during or after `tinymce.init()`. Landing inside the init window leaves `editor.initialized` unset forever; landing after it leaves the editor bound to a document no longer in the page. Neither is recoverable, because `switchEditor()` returns early once `tinymce.get( id )` exists.

## How?

`moveBefore` performs a state-preserving move, so the iframe is not reloaded. It requires both nodes connected, which is why the effect became `useLayoutEffect`: a passive effect's cleanup runs after React has detached the subtree, and `moveBefore` then throws `HierarchyRequestError`. `parent.appendChild` remains the fallback.

This is a progressive fix. Chromium and Firefox support `moveBefore`; Safari does not yet, and falls back to the old behavior.

## Testing Instructions
1. Enable "Gutenberg Test Plugin, WP Editor Meta Box"
2. Open a post.
3. Confirm the metabox with the TinyMCE editor renders.
4. Toggle "Distraction free" mode.
5. Confirm that the editor still renders correctly. It fails on trunk.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
