### PR TITLE
DataViews: clamp page after delete

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch.
+-   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 
 ### Internal
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch.
+
 ### Internal
 
 -   Remove the template activation (`active_templates`) experiment: drop the `registeredTemplate` entity and the experiment-only `wp_template` endpoint rewrites and query params ([#82241](https://github.com/WordPress/gutenberg/pull/82241)).

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -257,6 +257,41 @@ const receiveQueries = compose( [
 } );
 
 /**
+ * Removes items from a query's item IDs, keeping the pagination metadata in
+ * sync. Every removed item the query listed was counted by the endpoint in
+ * `totalItems`, so the total shrinks by that many. Nothing else refreshes the
+ * totals until the next fetch, and a consumer whose page has just emptied
+ * would otherwise keep requesting a page that no longer exists.
+ *
+ * @param {Object} queryItems   Query state, with `itemIds` and optional `meta`.
+ * @param {Object} removedItems Removed item IDs, as object keys.
+ *
+ * @return {Object} Updated query state.
+ */
+function removeQueryItems( queryItems, removedItems ) {
+	const itemIds = queryItems.itemIds.filter(
+		( itemId ) => ! removedItems[ itemId ]
+	);
+	const removedCount = queryItems.itemIds.length - itemIds.length;
+	if ( removedCount === 0 ) {
+		return queryItems;
+	}
+
+	const nextQueryItems = { ...queryItems, itemIds };
+	if ( Number.isFinite( queryItems.meta?.totalItems ) ) {
+		nextQueryItems.meta = {
+			...queryItems.meta,
+			totalItems: Math.max(
+				0,
+				queryItems.meta.totalItems - removedCount
+			),
+		};
+	}
+
+	return nextQueryItems;
+}
+
+/**
  * Reducer tracking queries state.
  *
  * @param {Object} state  Current state.
@@ -282,13 +317,10 @@ const queries = ( state = {}, action ) => {
 							Object.entries( contextQueries ).map(
 								( [ query, queryItems ] ) => [
 									query,
-									{
-										...queryItems,
-										itemIds: queryItems.itemIds.filter(
-											( queryId ) =>
-												! removedItems[ queryId ]
-										),
-									},
+									removeQueryItems(
+										queryItems,
+										removedItems
+									),
 								]
 							)
 						),

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -263,6 +263,12 @@ const receiveQueries = compose( [
  * totals until the next fetch, and a consumer whose page has just emptied
  * would otherwise keep requesting a page that no longer exists.
  *
+ * `totalPages` can't be recomputed here — the page size that produced the
+ * `X-WP-TotalPages` header isn't known to the reducer — so it is reset to
+ * `null` ("unknown") rather than left next to a fresh `totalItems` it no
+ * longer matches. Queries that set `per_page` are unaffected: the selectors
+ * derive their page count from `totalItems` and never read the header value.
+ *
  * @param {Object} queryItems   Query state, with `itemIds` and optional `meta`.
  * @param {Object} removedItems Removed item IDs, as object keys.
  *
@@ -285,6 +291,7 @@ function removeQueryItems( queryItems, removedItems ) {
 				0,
 				queryItems.meta.totalItems - removedCount
 			),
+			totalPages: null,
 		};
 	}
 

--- a/packages/core-data/src/queried-data/test/reducer.jsdom.test.js
+++ b/packages/core-data/src/queried-data/test/reducer.jsdom.test.js
@@ -306,6 +306,46 @@ describe( 'reducer', () => {
 		} );
 	} );
 
+	it( 'keeps the pagination totals in sync when deleting an item', () => {
+		const kind = 'postType';
+		const name = 'page';
+		const original = deepFreeze( {
+			items: {
+				default: {
+					1: { id: 1 },
+					2: { id: 2 },
+					3: { id: 3 },
+				},
+			},
+			queries: {
+				default: {
+					'': {
+						itemIds: [ 1, 2, 3 ],
+						meta: { totalItems: 3, totalPages: 2 },
+					},
+					's=a': {
+						itemIds: [ 1, 2 ],
+						meta: { totalItems: 2, totalPages: 1 },
+					},
+				},
+			},
+		} );
+		const state = reducer( original, removeItems( kind, name, 3 ) );
+
+		expect( state.queries ).toEqual( {
+			default: {
+				'': {
+					itemIds: [ 1, 2 ],
+					meta: { totalItems: 2, totalPages: 2 },
+				},
+				's=a': {
+					itemIds: [ 1, 2 ],
+					meta: { totalItems: 2, totalPages: 1 },
+				},
+			},
+		} );
+	} );
+
 	it( 'deletes an item with string ID', () => {
 		const kind = 'postType';
 		const name = 'wp_template';

--- a/packages/core-data/src/queried-data/test/reducer.jsdom.test.js
+++ b/packages/core-data/src/queried-data/test/reducer.jsdom.test.js
@@ -336,7 +336,7 @@ describe( 'reducer', () => {
 			default: {
 				'': {
 					itemIds: [ 1, 2 ],
-					meta: { totalItems: 2, totalPages: 2 },
+					meta: { totalItems: 2, totalPages: null },
 				},
 				's=a': {
 					itemIds: [ 1, 2 ],

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### Bug Fixes
 
--   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page.
+-   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 
 ### Internal
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -40,6 +40,10 @@
 -   Export the `DataViewsProps` and `ItemWithId` types ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).
 -   Export the `DataViewsProps` and `ItemWithId` types and document every type property ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).
 
+### Bug Fixes
+
+-   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page.
+
 ### Internal
 
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/dataviews/src/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/dataviews-picker/index.tsx
@@ -31,6 +31,7 @@ import DataViewsViewConfig, {
 import normalizeFields from '../field-types';
 import useData from '../hooks/use-data';
 import { useInfiniteScroll } from '../hooks/use-infinite-scroll';
+import usePageClamp from '../hooks/use-page-clamp';
 import type { ActionButton, Field, View, SupportedLayouts } from '../types';
 import type { SelectionOrUpdater } from '../types/private';
 type ItemWithId = { id: string };
@@ -293,6 +294,13 @@ function DataViewsPicker< Item >( {
 		paginationInfo,
 		containerRef,
 		setVisibleEntries,
+	} );
+
+	usePageClamp( {
+		view,
+		onChangeView,
+		isLoading,
+		totalPages: paginationInfo.totalPages,
 	} );
 
 	useEffect( () => {

--- a/packages/dataviews/src/dataviews/index.tsx
+++ b/packages/dataviews/src/dataviews/index.tsx
@@ -28,6 +28,7 @@ import DataViewsViewConfig, {
 import normalizeFields from '../field-types';
 import useData from '../hooks/use-data';
 import { useInfiniteScroll } from '../hooks/use-infinite-scroll';
+import usePageClamp from '../hooks/use-page-clamp';
 import type { SupportedLayouts, DataViewsProps, ItemWithId } from '../types';
 import type { SelectionOrUpdater } from '../types/private';
 
@@ -186,6 +187,13 @@ function DataViews< Item >( {
 		paginationInfo,
 		containerRef,
 		setVisibleEntries,
+	} );
+
+	usePageClamp( {
+		view,
+		onChangeView,
+		isLoading,
+		totalPages: paginationInfo.totalPages,
 	} );
 
 	useEffect( () => {

--- a/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
@@ -282,6 +282,83 @@ describe( 'DataViews component', () => {
 		} );
 	} );
 
+	describe( 'page clamping', () => {
+		it( 'moves the view to the last page when it points past the end of the collection', async () => {
+			const onChangeView = jest.fn();
+			// Three items, one per page: page 5 doesn't exist.
+			render(
+				<DataViewWrapper
+					view={ { type: LAYOUT_TABLE, page: 5, perPage: 1 } }
+					onChangeView={ onChangeView }
+				/>
+			);
+
+			await waitFor( () => {
+				expect( onChangeView ).toHaveBeenCalledWith(
+					expect.objectContaining( { page: 3, perPage: 1 } )
+				);
+			} );
+		} );
+
+		it( 'falls back to the first page when the collection is empty', async () => {
+			const onChangeView = jest.fn();
+			render(
+				<DataViewWrapper
+					view={ { type: LAYOUT_TABLE, page: 2 } }
+					data={ [] }
+					paginationInfo={ { totalItems: 0, totalPages: 0 } }
+					onChangeView={ onChangeView }
+				/>
+			);
+
+			await waitFor( () => {
+				expect( onChangeView ).toHaveBeenCalledWith(
+					expect.objectContaining( { page: 1 } )
+				);
+			} );
+		} );
+
+		it( 'leaves the page alone while loading', () => {
+			const onChangeView = jest.fn();
+			render(
+				<DataViewWrapper
+					view={ { type: LAYOUT_TABLE, page: 5, perPage: 1 } }
+					isLoading
+					onChangeView={ onChangeView }
+				/>
+			);
+
+			expect( onChangeView ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves the page alone when the total is unknown', () => {
+			const onChangeView = jest.fn();
+			render(
+				<DataViewWrapper
+					view={ { type: LAYOUT_TABLE, page: 5, perPage: 1 } }
+					paginationInfo={
+						{ totalItems: null, totalPages: null } as any
+					}
+					onChangeView={ onChangeView }
+				/>
+			);
+
+			expect( onChangeView ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves a valid page alone', () => {
+			const onChangeView = jest.fn();
+			render(
+				<DataViewWrapper
+					view={ { type: LAYOUT_TABLE, page: 3, perPage: 1 } }
+					onChangeView={ onChangeView }
+				/>
+			);
+
+			expect( onChangeView ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( 'in table view', () => {
 		it( 'should display columns for each field', () => {
 			render( <DataViewWrapper /> );

--- a/packages/dataviews/src/hooks/index.ts
+++ b/packages/dataviews/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useFormValidity } from './use-form-validity';
 export { default as useData } from './use-data';
 export { useInfiniteScroll } from './use-infinite-scroll';
+export { default as usePageClamp } from './use-page-clamp';
 export { default as useSelectedItems } from './use-selected-items';

--- a/packages/dataviews/src/hooks/use-page-clamp.ts
+++ b/packages/dataviews/src/hooks/use-page-clamp.ts
@@ -1,0 +1,50 @@
+import { useEffect } from '@wordpress/element';
+import { useEvent } from '@wordpress/compose';
+import type { View } from '../types';
+
+interface UsePageClampParams {
+	view: View;
+	onChangeView: ( view: View ) => void;
+	isLoading: boolean;
+	totalPages: number | null | undefined;
+}
+
+/**
+ * Moves the view back to the last available page whenever it points past the
+ * end of the collection — for instance after deleting the only item of the
+ * last page — so the consumer isn't left requesting a page that no longer
+ * exists.
+ *
+ * The page is left alone while data is loading and when the total is unknown
+ * (a consumer that hasn't resolved its totals yet reports `null`).
+ *
+ * @param params              Hook parameters.
+ * @param params.view         Current view.
+ * @param params.onChangeView Callback to update the view.
+ * @param params.isLoading    Whether data is currently loading.
+ * @param params.totalPages   Number of available pages, if known.
+ */
+export default function usePageClamp( {
+	view,
+	onChangeView,
+	isLoading,
+	totalPages,
+}: UsePageClampParams ) {
+	const lastPage =
+		typeof totalPages === 'number' && Number.isFinite( totalPages )
+			? Math.max( totalPages, 1 )
+			: null;
+	const page = view.page;
+	const goToLastPage = useEvent( () => {
+		if ( lastPage !== null ) {
+			onChangeView( { ...view, page: lastPage } );
+		}
+	} );
+
+	useEffect( () => {
+		if ( isLoading || lastPage === null || ! page || page <= lastPage ) {
+			return;
+		}
+		goToLastPage();
+	}, [ isLoading, lastPage, page, goToLastPage ] );
+}

--- a/routes/guidelines/components/block-guidelines.tsx
+++ b/routes/guidelines/components/block-guidelines.tsx
@@ -176,21 +176,6 @@ export default function BlockGuidelines( {
 	);
 
 	useEffect( () => {
-		const lastPage = Math.max( paginationInfo.totalPages, 1 );
-
-		if ( view.page && view.page > lastPage ) {
-			setView( ( currentView ) =>
-				currentView.page && currentView.page > lastPage
-					? {
-							...currentView,
-							page: lastPage,
-					  }
-					: currentView
-			);
-		}
-	}, [ paginationInfo.totalPages, view.page ] );
-
-	useEffect( () => {
 		if ( shouldFocusAddButton ) {
 			addButtonRef.current?.focus();
 			setShouldFocusAddButton( false );


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/80840

## What?

After removing the last item of a page, redirect to the last existing page.

Before:

https://github.com/user-attachments/assets/1a0d5250-b771-4054-bf04-8feeaae7e107

After:


https://github.com/user-attachments/assets/fe31f45c-a780-42d0-bda3-dbd806630131


## Why?

So that users aren't left hanging in a page that does not exist.

## How?

- Core Data: Keep a query's totalItems in sync when records are removed.
- DataViews: Move the view back to the last available page.
- Guidelines: Drop the local page clamp now handled by DataViews

## Testing Instructions

1. Create enough pages to fill more than two pages of the list — e.g. with 20 per page, 41 pages; or set the list to 10 per page and create 21. `wp post generate --post_type=page --count=21` via `npm run wp-env run cli -- wp …` is the quickest way.
2. Go to **Site Editor → Pages** (both with and without the `gutenberg-extensible-site-editor` experiment, to cover both site editors).
3. Set the view to 10 items per page and navigate to the **last page**, which shows a single item.
4. Trash that item.
5. Expected: the list moves to the new last page (page 2 of 2), showing 10 items, and the footer count and page selector reflect the new totals.
6. Bulk variant: go to a page with several items, select all of them, and trash them. Expected: same behavior, the view lands on the new last page.
7. Regression check: on **trunk**, step 4 leaves you on an empty "page 3 of 3" with a `400` for `/wp/v2/pages?page=3…` in the network tab.
8. Unit tests: `npm run test:unit -- packages/core-data/src/queried-data packages/dataviews/src/dataviews`.

## Use of AI Tools

Claude Code was used to trace the data flow, implement the changes, write the tests, and draft this description. All of it was reviewed by the author.
