### PR TITLE
Widget Dashboard: govern Reset to default through the policy

### DIFF
--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -17,6 +17,10 @@
 -   The Add widget button and command show only while the policy lets some
     registered type be inserted
     ([#81967](https://github.com/WordPress/gutenberg/pull/81967)).
+-   `WidgetDashboard.Policy` governs `reset`: the Reset to default entry in
+    the overflow menu, the `core/dashboard/reset-to-default` command, and
+    the confirmation prompt are hidden while the policy denies it
+    ([#82007](https://github.com/WordPress/gutenberg/issues/82007)).
 
 ### Internal
 

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -20,7 +20,7 @@
 -   `WidgetDashboard.Policy` governs `reset`: the Reset to default entry in
     the overflow menu, the `core/dashboard/reset-to-default` command, and
     the confirmation prompt are hidden while the policy denies it
-    ([#82007](https://github.com/WordPress/gutenberg/issues/82007)).
+    ([#82255](https://github.com/WordPress/gutenberg/pull/82255)).
 
 ### Internal
 

--- a/packages/widget-dashboard/README.md
+++ b/packages/widget-dashboard/README.md
@@ -193,6 +193,7 @@ type CanPerformDashboardOperation = (
 
 type DashboardOperationRequest =
 	| { operation: 'customize' }
+	| { operation: 'reset' }
 	| { operation: 'insert'; widgetType: WidgetType }
 	| {
 			operation: 'remove' | 'move' | 'resize' | 'edit';
@@ -225,6 +226,7 @@ Each request names the operation and carries its subject, so a branch on `reques
 | Operation   | Subject                 | What it gates                                                                                                                                                                                     |
 | ----------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `customize` | none                    | The Customize button, the `core/dashboard/customize` command, the `core/dashboard/add-widgets` command outside edit mode, and the automatic entry into customize mode on an empty layout.         |
+| `reset`     | none                    | The Reset to default entry in the overflow menu, the `core/dashboard/reset-to-default` command, and the confirmation prompt they open. A denied reset is hidden, not disabled.                    |
 | `insert`    | `widgetType`            | Whether the inserter offers the type; a rejected type keeps rendering where already placed. The Add widget button and command show only while some registered type is insertable.                 |
 | `remove`    | `widget`, `widgetType?` | The Remove control in customize mode. The staging layer re-asserts, in place, a locked instance dropped by any trigger.                                                                           |
 | `move`      | `widget`, `widgetType?` | Dragging the tile in customize mode. A denied tile is pinned: it holds its index while the other tiles reorder around it; a change ahead of it can still reflow the cell it lands in.             |

--- a/packages/widget-dashboard/src/components/actions/actions.tsx
+++ b/packages/widget-dashboard/src/components/actions/actions.tsx
@@ -19,7 +19,8 @@ import styles from './actions.module.css';
  *
  * Returns `null` when mounted without `onEditChange`, so hosts that don't
  * expose edit mode can keep `Actions` in their tree unconditionally. The
- * Customize button also needs the policy in effect to allow `customize`.
+ * Customize button also needs the policy in effect to allow `customize`,
+ * and the Reset to default item needs it to allow `reset`.
  */
 export function Actions(): React.ReactNode {
 	const {
@@ -90,13 +91,16 @@ export function Actions(): React.ReactNode {
 		commit();
 	}, [ commit ] );
 
-	const menuItems: ActionsMenuItem[] = [
-		{
-			label: __( 'Reset to default' ),
-			onClick: () => setResetDialogOpen( true ),
-			disabled: ! onLayoutReset,
-		},
-	];
+	// A denied reset is hidden; a missing handler is disabled.
+	const menuItems: ActionsMenuItem[] = canPerform( { operation: 'reset' } )
+		? [
+				{
+					label: __( 'Reset to default' ),
+					onClick: () => setResetDialogOpen( true ),
+					disabled: ! onLayoutReset,
+				},
+		  ]
+		: [];
 
 	if ( ! onEditChange ) {
 		return null;

--- a/packages/widget-dashboard/src/components/commands/commands.tsx
+++ b/packages/widget-dashboard/src/components/commands/commands.tsx
@@ -25,6 +25,7 @@ export function Commands() {
 		useDashboardInternalContext();
 
 	const canCustomize = canPerform( { operation: 'customize' } );
+	const canReset = canPerform( { operation: 'reset' } );
 	const canInsertAny = useMemo(
 		() =>
 			widgetTypes.some( ( widgetType ) =>
@@ -101,7 +102,7 @@ export function Commands() {
 				category: 'command',
 				context: DASHBOARD_COMMAND_CONTEXT,
 				keywords: [ __( 'reset' ), __( 'default' ) ],
-				disabled: ! onLayoutReset,
+				disabled: ! onLayoutReset || ! canReset,
 				callback: resetToDefault,
 			},
 		],
@@ -109,6 +110,7 @@ export function Commands() {
 			onEditChange,
 			editMode,
 			canCustomize,
+			canReset,
 			canInsertAny,
 			customize,
 			addWidgets,

--- a/packages/widget-dashboard/src/components/reset-confirmation/reset-confirmation.tsx
+++ b/packages/widget-dashboard/src/components/reset-confirmation/reset-confirmation.tsx
@@ -8,11 +8,17 @@ import { useDashboardUIContext } from '../../context/ui-context';
  * Confirmation prompt for resetting the dashboard to its default layout,
  * mounted by the engine and shown while `resetDialogOpen` is set in the
  * shared UI context. Confirming runs `onLayoutReset` and leaves customize
- * mode.
+ * mode. Renders nothing while the policy denies `reset`, so no trigger can
+ * reach the handler around the hidden entry points.
  */
 export function ResetConfirmation(): React.ReactNode {
-	const { onLayoutReset, onEditChange } = useDashboardInternalContext();
+	const { onLayoutReset, onEditChange, canPerform } =
+		useDashboardInternalContext();
 	const { resetDialogOpen, setResetDialogOpen } = useDashboardUIContext();
+
+	if ( ! canPerform( { operation: 'reset' } ) ) {
+		return null;
+	}
 
 	return (
 		<AlertDialog.Root

--- a/packages/widget-dashboard/src/stories/assets/policy-seam.svg
+++ b/packages/widget-dashboard/src/stories/assets/policy-seam.svg
@@ -31,7 +31,7 @@
 
   <rect x="84" y="236" width="113" height="52" rx="5" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.2"/>
   <text x="140" y="257" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="10.5" font-weight="700" fill="#334155">Customize</text>
-  <text x="140" y="274" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, monospace" font-size="8.5" fill="#64748b">customize</text>
+  <text x="140" y="274" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, monospace" font-size="8.5" fill="#64748b">customize · reset</text>
 
   <rect x="202" y="236" width="113" height="52" rx="5" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.2"/>
   <text x="258" y="257" text-anchor="middle" font-family="-apple-system, system-ui, sans-serif" font-size="10.5" font-weight="700" fill="#334155">inserter</text>

--- a/packages/widget-dashboard/src/stories/index.story.tsx
+++ b/packages/widget-dashboard/src/stories/index.story.tsx
@@ -653,7 +653,7 @@ const PROFILES = {
 	arranger: {
 		label: 'Arranger',
 		summary:
-			'may customize, move, and resize; never adds, removes, or edits',
+			'may customize, move, and resize; never adds, removes, edits, or resets',
 		operations: [ 'customize', 'move', 'resize' ] as readonly string[],
 	},
 	owner: {
@@ -728,6 +728,7 @@ function PolicyStory( { profile }: PolicyStoryProps ) {
 				] }
 				layout={ layout }
 				onLayoutChange={ setLayout }
+				onLayoutReset={ () => setLayout( INITIAL_LAYOUT ) }
 				editMode={ editMode }
 				onEditChange={ setEditMode }
 				resolveWidgetModule={ resolveDemoModule }
@@ -768,7 +769,7 @@ export const Policy: StoryObj< PolicyStoryProps > = {
 			control: 'select',
 			options: Object.keys( PROFILES ),
 			description:
-				'The user profile the application maps to a policy. Viewer: nothing. Arranger: customize, move, resize. Owner: everything.',
+				'The user profile the application maps to a policy. Viewer: nothing. Arranger: customize, move, resize. Owner: everything, including reset.',
 		},
 	},
 	parameters: {
@@ -777,7 +778,7 @@ export const Policy: StoryObj< PolicyStoryProps > = {
 				story: `
 The application governs the dashboard; the widget types stay untouched. This story mounts \`WidgetDashboard.Policy\` around the dashboard with a \`canPerform\` closing over the signed-in profile and the active section, and composes the dashboard inside an admin \`Page\`: the section links in its navigation, the dashboard actions in its actions slot.
 
-Switch the \`profile\` control. A Viewer gets no Customize button, no attribute controls, and read-only widgets (no \`setAttributes\`). An Arranger enters customize mode and drags or resizes tiles, but has no Add widget trigger, no Remove control, and no attribute editing. An Owner does everything.
+Switch the \`profile\` control. A Viewer gets no Customize button, no Reset to default entry, no attribute controls, and read-only widgets (no \`setAttributes\`). An Arranger enters customize mode and drags or resizes tiles, but has no Add widget trigger, no Reset to default entry, no Remove control, and no attribute editing. An Owner does everything.
 
 Switch the section, then open "Add widget": the listing follows the section, even while open; the excluded types keep rendering where already placed because the \`widgetTypes\` registry never changes.
 

--- a/packages/widget-dashboard/src/stories/index.story.tsx
+++ b/packages/widget-dashboard/src/stories/index.story.tsx
@@ -4,12 +4,16 @@ import type {
 	ComponentPropsWithoutRef,
 	ComponentType,
 } from 'react';
-// Form controls read these stylesheets, normally enqueued by WordPress.
+// Form controls and the command palette read these stylesheets, normally
+// enqueued by WordPress.
+// eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
+import '@wordpress/commands/build-style/style.css';
 // eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
 import '@wordpress/components/build-style/style.css';
 // eslint-disable-next-line @wordpress/no-non-module-stylesheet-imports
 import '@wordpress/dataviews/build-style/style.css';
 import { Page } from '@wordpress/admin-ui';
+import { CommandMenu } from '@wordpress/commands';
 import {
 	forwardRef,
 	useCallback,
@@ -717,6 +721,27 @@ function PolicyStory( { profile }: PolicyStoryProps ) {
 		[]
 	);
 
+	// Storybook forwards every keydown to its manager (`window.onkeydown`)
+	// without honoring `defaultPrevented`, so its own search would answer
+	// the palette combination too. Stop the event before it leaves the
+	// document; the palette's global shortcut listens on the document as
+	// well, and `stopPropagation` never affects same-target listeners.
+	useEffect( () => {
+		const containPaletteShortcut = ( event: KeyboardEvent ) => {
+			if (
+				( event.metaKey || event.ctrlKey ) &&
+				! event.shiftKey &&
+				! event.altKey &&
+				event.key.toLowerCase() === 'k'
+			) {
+				event.stopPropagation();
+			}
+		};
+		document.addEventListener( 'keydown', containPaletteShortcut );
+		return () =>
+			document.removeEventListener( 'keydown', containPaletteShortcut );
+	}, [] );
+
 	const { label, summary } = PROFILES[ profile ];
 
 	return (
@@ -753,6 +778,8 @@ function PolicyStory( { profile }: PolicyStoryProps ) {
 					hasPadding
 				>
 					<WidgetDashboard.Widgets />
+					<WidgetDashboard.Commands />
+					<CommandMenu />
 				</Page>
 			</WidgetDashboard>
 		</WidgetDashboard.Policy>
@@ -779,6 +806,8 @@ export const Policy: StoryObj< PolicyStoryProps > = {
 The application governs the dashboard; the widget types stay untouched. This story mounts \`WidgetDashboard.Policy\` around the dashboard with a \`canPerform\` closing over the signed-in profile and the active section, and composes the dashboard inside an admin \`Page\`: the section links in its navigation, the dashboard actions in its actions slot.
 
 Switch the \`profile\` control. A Viewer gets no Customize button, no Reset to default entry, no attribute controls, and read-only widgets (no \`setAttributes\`). An Arranger enters customize mode and drags or resizes tiles, but has no Add widget trigger, no Reset to default entry, no Remove control, and no attribute editing. An Owner does everything.
+
+The command palette is mounted too: press ⌘K (Ctrl+K outside macOS) and the commands follow the same policy. An Owner sees Customize dashboard, Add dashboard widgets, and Reset dashboard widgets to default; an Arranger keeps Customize dashboard only; a Viewer gets no dashboard commands.
 
 Switch the section, then open "Add widget": the listing follows the section, even while open; the excluded types keep rendering where already placed because the \`widgetTypes\` registry never changes.
 

--- a/packages/widget-dashboard/src/stories/policy.md
+++ b/packages/widget-dashboard/src/stories/policy.md
@@ -4,7 +4,7 @@
 This package is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-The engine knows which operations a user can perform on a dashboard: enter customize mode, insert a widget type, remove, move, resize, or edit an instance. It does not know who the user is or what the application allows. `WidgetDashboard.Policy` is the seam through which the application answers.
+The engine knows which operations a user can perform on a dashboard: enter customize mode, reset the layout to default, insert a widget type, remove, move, resize, or edit an instance. It does not know who the user is or what the application allows. `WidgetDashboard.Policy` is the seam through which the application answers.
 
 ![The engine asks one question per operation via a request that names the operation and its subject. The application, which owns the permission model, answers via the policy seam with a single callback. The engine resolves that answer once, and every surface follows it: the Customize button and the command palette, the inserter, the tile controls, the drag and resize gestures. Widgets are never asked; without edit they render read-only. Without a policy, every operation is allowed.](./assets/policy-seam.svg)
 
@@ -15,6 +15,7 @@ The engine knows which operations a user can perform on a dashboard: enter custo
 ```ts
 type DashboardOperationRequest =
 	| { operation: 'customize' }
+	| { operation: 'reset' }
 	| { operation: 'insert'; widgetType: WidgetType }
 	| {
 			operation: 'remove' | 'move' | 'resize' | 'edit';
@@ -32,6 +33,7 @@ The Customize button, the command palette entries, the tile controls, and the in
 | Operation   | Subject                 | What it gates                                                                                                                                                                                     |
 | ----------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `customize` | none                    | The Customize button, the `core/dashboard/customize` command, the `core/dashboard/add-widgets` command outside edit mode, and the automatic entry into customize mode on an empty layout.         |
+| `reset`     | none                    | The Reset to default entry in the overflow menu, the `core/dashboard/reset-to-default` command, and the confirmation prompt they open. A denied reset is hidden, not disabled.                    |
 | `insert`    | `widgetType`            | Whether the inserter offers the type; a rejected type keeps rendering where already placed. The Add widget button and command show only while some registered type is insertable.                 |
 | `remove`    | `widget`, `widgetType?` | The Remove control in customize mode. The staging layer re-asserts, in place, a locked instance dropped by any trigger.                                                                           |
 | `move`      | `widget`, `widgetType?` | Dragging the tile in customize mode. A denied tile is pinned: it holds its index while the other tiles reorder around it; a change ahead of it can still reflow the cell it lands in.             |

--- a/packages/widget-dashboard/src/stories/policy.md
+++ b/packages/widget-dashboard/src/stories/policy.md
@@ -85,4 +85,4 @@ const canPerform = useMemo< CanPerformDashboardOperation >(
 </WidgetDashboard.Policy>;
 ```
 
-See the _Policy_ story in the Playground: three user profiles (Viewer, Arranger, Owner) and a section-scoped inserter, composed inside an admin `Page`.
+See the _Policy_ story in the Playground: three user profiles (Viewer, Arranger, Owner) and a section-scoped inserter, composed inside an admin `Page`. The command palette is mounted there as well; press ⌘K to check which commands each profile keeps.

--- a/packages/widget-dashboard/src/test/actions.jsdom.test.tsx
+++ b/packages/widget-dashboard/src/test/actions.jsdom.test.tsx
@@ -20,6 +20,7 @@ interface HarnessProps {
 	onLayoutChange?: ( next: DashboardWidget[] ) => void;
 	canPerform?: CanPerformDashboardOperation;
 	layout?: DashboardWidget[];
+	onLayoutReset?: () => Promise< void >;
 }
 
 function Harness( {
@@ -28,6 +29,7 @@ function Harness( {
 	onLayoutChange = () => {},
 	canPerform,
 	layout: initialLayout = layout,
+	onLayoutReset,
 }: HarnessProps ) {
 	const [ editMode, setEditMode ] = useState( initialEditMode );
 
@@ -41,6 +43,7 @@ function Harness( {
 				setEditMode( next );
 				onEditChange?.( next );
 			} }
+			onLayoutReset={ onLayoutReset }
 		>
 			<WidgetDashboard.Actions />
 		</WidgetDashboard>
@@ -57,6 +60,9 @@ function Harness( {
 
 const denyCustomize: CanPerformDashboardOperation = ( request ) =>
 	request.operation !== 'customize';
+
+const denyReset: CanPerformDashboardOperation = ( request ) =>
+	request.operation !== 'reset';
 
 describe( 'WidgetDashboard.Actions', () => {
 	let user: ReturnType< typeof userEvent.setup >;
@@ -187,6 +193,34 @@ describe( 'WidgetDashboard.Actions', () => {
 			/>
 		);
 		expect( onEditChange ).not.toHaveBeenCalled();
+	} );
+
+	it( 'offers Reset to default when the policy allows it', async () => {
+		render( <Harness onLayoutReset={ async () => {} } /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'More options' } )
+		);
+
+		expect(
+			await screen.findByRole( 'menuitem', { name: 'Reset to default' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'hides Reset to default and its menu when the policy denies reset', () => {
+		render(
+			<Harness
+				onLayoutReset={ async () => {} }
+				canPerform={ denyReset }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Customize' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'More options' } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'throws when used outside a WidgetDashboard subtree', () => {

--- a/packages/widget-dashboard/src/test/commands.jsdom.test.tsx
+++ b/packages/widget-dashboard/src/test/commands.jsdom.test.tsx
@@ -101,6 +101,9 @@ function Harness( {
 const denyCustomize: CanPerformDashboardOperation = ( request ) =>
 	request.operation !== 'customize';
 
+const denyReset: CanPerformDashboardOperation = ( request ) =>
+	request.operation !== 'reset';
+
 function getRegistered( probe: HTMLElement ): Record< string, boolean > {
 	return JSON.parse( probe.getAttribute( 'data-registered' ) ?? '{}' );
 }
@@ -147,6 +150,17 @@ describe( 'WidgetDashboard.Commands', () => {
 		const registered = getRegistered(
 			screen.getByTestId( 'commands-probe' )
 		);
+		expect( registered[ 'core/dashboard/add-widgets' ] ).toBe( true );
+	} );
+
+	it( 'unregisters Reset to default when the policy denies reset', () => {
+		render( <Harness withLayoutReset canPerform={ denyReset } /> );
+
+		const registered = getRegistered(
+			screen.getByTestId( 'commands-probe' )
+		);
+		expect( registered[ 'core/dashboard/reset-to-default' ] ).toBe( false );
+		expect( registered[ 'core/dashboard/customize' ] ).toBe( true );
 		expect( registered[ 'core/dashboard/add-widgets' ] ).toBe( true );
 	} );
 

--- a/packages/widget-dashboard/src/types.ts
+++ b/packages/widget-dashboard/src/types.ts
@@ -201,12 +201,13 @@ export interface DashboardInstanceOperationRequest {
 
 /**
  * An operation the dashboard asks permission for, with its subject.
- * `customize` is entering customize mode; `insert` is offering a widget
- * type in the inserter; `remove`, `move`, `resize`, and `edit` act on a
- * placed widget.
+ * `customize` is entering customize mode; `reset` is restoring the default
+ * layout; `insert` is offering a widget type in the inserter; `remove`,
+ * `move`, `resize`, and `edit` act on a placed widget.
  */
 export type DashboardOperationRequest =
 	| { operation: 'customize' }
+	| { operation: 'reset' }
 	| { operation: 'insert'; widgetType: WidgetType }
 	| DashboardInstanceOperationRequest;
 


### PR DESCRIPTION
Closes #82007. Part of #79231.

## What?

`WidgetDashboard.Policy` now governs `reset`.

The operation joins the request union as `{ operation: 'reset' }`, and the three surfaces that reach the handler follow the resolved answer: the Reset to default entry in the overflow menu, the `core/dashboard/reset-to-default` command, and the confirmation prompt they open. A denied reset is hidden, not disabled.

## Why?

Reset was the one destructive dashboard operation the policy could not govern: any profile that could see the dashboard could restore the default layout.

#81967 shipped the vocabulary deliberately without it; this follow-up completes the surface so applications can reserve reset for the profiles that own the layout.

## How?

### packages/widget-dashboard/src/types.ts

`{ operation: 'reset' }` joins `DashboardOperationRequest`. Like `customize`, it carries no subject: it acts on the dashboard, not on an instance.

### packages/widget-dashboard/src/components/actions/actions.tsx

The overflow menu builds its items from the resolved policy: a denied reset contributes no entry, and since Reset to default is the only item today, the menu trigger disappears with it. A missing `onLayoutReset` handler still renders the entry disabled; absence of the handler is a host ability, not policy.

### packages/widget-dashboard/src/components/commands/commands.tsx

The `core/dashboard/reset-to-default` command is unregistered while the policy denies `reset`, composing with the existing `onLayoutReset` presence check.

### packages/widget-dashboard/src/components/reset-confirmation/reset-confirmation.tsx

The confirmation prompt renders nothing while `reset` is denied, so no composed trigger can reach `onLayoutReset` around the hidden entry points. This is the engine-consistency backstop: the prompt is engine-mounted, and hiding the triggers alone would leave the shared `resetDialogOpen` state able to open it.

### packages/widget-dashboard/src/stories/index.story.tsx, src/stories/policy.md, src/stories/assets/policy-seam.svg

The Policy story wires a working `onLayoutReset` (restores the initial layout) and updates the profile copy: Viewer and Arranger deny `reset` through the profile mapping, Owner allows it. The Policy page and the seam diagram add the operation to the vocabulary.

### packages/widget-dashboard/src/test/actions.jsdom.test.tsx, src/test/commands.jsdom.test.tsx

Three tests: the entry offered when allowed; the entry and its menu hidden when denied (with Customize still present); and the command unregistered when denied (with the other commands still registered).

### packages/widget-dashboard/README.md, CHANGELOG.md

The `reset` row in the Governance operations table, and a New Features entry linking #82007.

## Testing

```
npx jest --config test/unit/jest.config.js packages/widget-dashboard/
```

All 107 tests pass, including the three new ones.

Manual check through the Policy story:

```
npm run storybook:dev
```

Open Widget Dashboard → Policy.

As **Owner**: drag a tile, Done, open the actions overflow menu, Reset to default, confirm, and the layout returns to the initial one; the command palette offers Reset to default as well.

Switch to **Arranger**: the Customize button remains, but the overflow menu is gone, and the command palette no longer lists the reset command.

As **Viewer**, no dashboard action renders at all.

https://github.com/user-attachments/assets/63a7aab2-de4b-4a98-9928-5f4d5f83071c

You can test against the Command palette as well.

https://github.com/user-attachments/assets/604e731e-1d30-4cb4-be62-a0ca82aeaf97

