### PR TITLE
Revisions: Meet AA contrast for the inline del diff without an opacity filter

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 -   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.
 -   `StylesCanvas`: In preview mode, render edge to edge without the close button and Escape handler. There the canvas is the whole surface rather than a frame opened over an editing session, and whatever opened it owns closing it.
--   Visual History: Render the inline removed-text diff (`<del>`) at the theme's body color over a red-tinted background instead of recoloring it with a translucent color-matrix filter, so it keeps the theme's WCAG AA contrast on any background ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
+-   Visual History: Render the inline removed-text diff (`<del>`) at the theme's body color over a red-tinted background instead of recoloring it with a translucent color-matrix filter, so it keeps the theme's WCAG AA contrast on any background ([#82258](https://github.com/WordPress/gutenberg/pull/82258)).
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.
 -   `StylesCanvas`: In preview mode, render edge to edge without the close button and Escape handler. There the canvas is the whole surface rather than a frame opened over an editing session, and whatever opened it owns closing it.
+-   Visual History: Render the inline removed-text diff (`<del>`) at the theme's body color over a red-tinted background instead of recoloring it with a translucent color-matrix filter, so it keeps the theme's WCAG AA contrast on any background ([#PRNUM](https://github.com/WordPress/gutenberg/pull/PRNUM)).
 
 ### Bug Fixes
 

--- a/packages/editor/src/components/post-revisions-preview/revisions-canvas.jsx
+++ b/packages/editor/src/components/post-revisions-preview/revisions-canvas.jsx
@@ -59,11 +59,19 @@ const REVISION_DIFF_STYLES = `
 	.is-revision-removed,
 	.revision-diff-removed {
 		text-decoration: line-through;
-		filter: url(#revision-removed-filter);
 	}
 	.is-revision-removed {
 		outline: 3px dashed #d63638;
 		outline-offset: 2px;
+		filter: url(#revision-removed-filter);
+	}
+	.revision-diff-removed {
+		/* Mirror .revision-diff-added so the ins/del pair reads symmetrically.
+		   Leaving the text at currentColor (rather than recolouring it with an
+		   opacity + color-matrix filter) keeps the theme's own AA-compliant body
+		   contrast on any background. */
+		background-color: color-mix(in srgb, currentColor 5%, #d63638 15%);
+		text-decoration-color: #d63638;
 	}
 	.is-revision-modified {
 		outline: 3px dotted #9a7000 !important;

--- a/packages/editor/src/components/revision-diff-panel/style.scss
+++ b/packages/editor/src/components/revision-diff-panel/style.scss
@@ -8,6 +8,7 @@
 }
 
 .editor-revision-fields-diff__removed {
+	background-color: color-mix(in srgb, currentColor 5%, #d63638 15%);
 	text-decoration: line-through;
-	color: #d63638;
+	text-decoration-color: #d63638;
 }


### PR DESCRIPTION
## What?

Inline removed text in Visual History no longer goes through the SVG colour matrix. It keeps the theme's body colour and gets a red-tinted background plus a red strike, matching how `.revision-diff-added` already renders `<ins>`.

Part of #77530 — the "Color contrast of marked `del`" item.

## Why?

`filter: url(#revision-removed-filter)` applied to inline `<del>` transforms whatever colour the theme set: it desaturates, adds a red offset, and multiplies alpha by 0.8. Because its input is arbitrary theme content, its output contrast can't be guaranteed by the rule.

Inline `<ins>` never had this — it uses a background tint and leaves the text colour alone. Removed text was the only inline treatment recolouring the text itself, so this is also an inconsistency between the two halves of the diff.

## How?

- `revisions-canvas.jsx`: `filter` moves from the shared rule onto `.is-revision-removed` only. Block-level and image treatment is unchanged. `.revision-diff-removed` gets the tint plus `text-decoration-color`.
- `revision-diff-panel/style.scss`: the sidebar `del` drops `color: #d63638` for the same treatment, so both surfaces read the same.

## Testing Instructions

1. Create a post, publish, then save several revisions, changing a sentence each time so there is both deleted and added text.
2. Open the revisions view and compare a modified paragraph.
3. Deleted words keep the body text colour with a red tint and red strike; added words are unchanged.
4. Select a block whose attributes changed and check the sidebar "Changed attributes" panel renders the same way.
5. Confirm removed *blocks* and removed *images* still render as before — the outline and the desaturating filter are unchanged for those.

## Screenshots

Left: before. Right: after. Rows: sidebar "Changed attributes" panel, an inline paragraph diff, and a set of removed/added block rows.
<img width="2710" height="2016" alt="before-after-comparison" src="https://github.com/user-attachments/assets/a3a5b353-2522-40bb-a20a-9695f00697c4" />



