### PR TITLE
Fix: alert dialog box cancel button color

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+-   `AlertDialog`: Use a neutral tone for the cancel button. ([#82261](https://github.com/WordPress/gutenberg/pull/82261))
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 
 ## 0.21.0 (2026-08-26)

--- a/packages/ui/src/alert-dialog/popup.tsx
+++ b/packages/ui/src/alert-dialog/popup.tsx
@@ -96,7 +96,7 @@ const Popup = forwardRef< HTMLDivElement, PopupProps >(
 					align="center"
 				>
 					<_AlertDialog.Close
-						render={ <Button variant="minimal" /> }
+						render={ <Button variant="minimal" tone="neutral" /> }
 						disabled={ buttonsDisabled }
 					>
 						{ cancelButtonText }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #81934.

Supersedes #82236. This change was originally contributed by @Kallyan01 in that PR. This replacement keeps their implementation and corrects the changelog entry.

Makes `AlertDialog.Popup` render its built-in Cancel button with `tone="neutral"` instead of the `Button` component's default brand tone.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Cancel is the less prominent action next to Confirm or Delete. The internal Cancel button did not set a tone, so it inherited the brand styling.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Passes `tone="neutral"` to the minimal `Button` rendered by `_AlertDialog.Close` and records the fix in the `@wordpress/ui` unreleased changelog.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Run `npm run storybook:dev`.
2. Open Design System -> Components -> AlertDialog.
3. Open the Default story and trigger the dialog.
4. Confirm that Cancel uses the neutral gray style and the confirm button keeps its brand style.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Use Tab to focus the AlertDialog trigger and press Enter to open it.
2. Tab through the dialog actions and confirm that Cancel and Confirm remain keyboard operable.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="596" height="214" alt="image" src="https://github.com/user-attachments/assets/09605c9d-3d99-4f8e-8d20-10f71c8fe68b" />|<img width="618" height="222" alt="image" src="https://github.com/user-attachments/assets/ceadb63c-c404-4886-8110-b6f7b1210162" />|

## Use of AI Tools

Codex recreated the original change on current trunk, ran the focused verification, and drafted this PR description. I reviewed the resulting diff and description.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
