### PR TITLE
Hide Highlight control when theme colors are disabled

### DIFF
--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   Prevent Highlight format toolbar from crashing when switching to Edit as HTML with background-only formatting active. ([#82215](https://github.com/WordPress/gutenberg/pull/82215))
--   Hide the Highlight format control when theme color palettes and custom colors are disabled. ([#82268](https://github.com/WordPress/gutenberg/pull/82268))
+-   Highlight: Toggle native `<mark>` styling when theme colors are disabled instead of hiding the control or opening an empty color picker. ([#82268](https://github.com/WordPress/gutenberg/pull/82268))
 
 ### Internal
 

--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Prevent Highlight format toolbar from crashing when switching to Edit as HTML with background-only formatting active. ([#82215](https://github.com/WordPress/gutenberg/pull/82215))
+-   Hide the Highlight format control when theme color palettes and custom colors are disabled. ([#82268](https://github.com/WordPress/gutenberg/pull/82268))
 
 ### Internal
 

--- a/packages/format-library/src/text-color/index.jsx
+++ b/packages/format-library/src/text-color/index.jsx
@@ -6,7 +6,7 @@ import {
 	color as colorIcon,
 	textColor as textColorIcon,
 } from '@wordpress/icons';
-import { removeFormat } from '@wordpress/rich-text';
+import { toggleFormat } from '@wordpress/rich-text';
 import { default as InlineColorUI, getActiveColors } from './inline';
 import { getAvailableHighlightColors } from './utils';
 
@@ -87,10 +87,6 @@ function TextColorEdit( {
 		[ contentRef, value, colors ]
 	);
 
-	if ( ! hasColorsToChoose && ! isActive ) {
-		return null;
-	}
-
 	return (
 		<>
 			<RichTextToolbarButton
@@ -107,11 +103,16 @@ function TextColorEdit( {
 					/>
 				}
 				title={ title }
-				// If has no colors to choose but a color is active remove the color onClick.
 				onClick={
 					hasColorsToChoose
 						? () => setIsAddingColor( true )
-						: () => onChange( removeFormat( value, name ) )
+						: () =>
+								onChange(
+									toggleFormat( value, {
+										type: name,
+										title,
+									} )
+								)
 				}
 				role="menuitemcheckbox"
 			/>

--- a/packages/format-library/src/text-color/index.jsx
+++ b/packages/format-library/src/text-color/index.jsx
@@ -8,13 +8,12 @@ import {
 } from '@wordpress/icons';
 import { removeFormat } from '@wordpress/rich-text';
 import { default as InlineColorUI, getActiveColors } from './inline';
+import { getAvailableHighlightColors } from './utils';
 
 export const transparentValue = 'rgba(0, 0, 0, 0)';
 
 const name = 'core/text-color';
 const title = __( 'Highlight' );
-
-const EMPTY_ARRAY = [];
 
 function getComputedStyleProperty( element, property ) {
 	if ( ! element ) {
@@ -58,10 +57,26 @@ function TextColorEdit( {
 	activeAttributes,
 	contentRef,
 } ) {
-	const [ allowCustomControl, colors = EMPTY_ARRAY ] = useSettings(
+	const [
+		defaultColors,
+		themeColors,
+		customColors,
+		enableCustomColors,
+		enableDefaultColors,
+	] = useSettings(
+		'color.palette.default',
+		'color.palette.theme',
+		'color.palette.custom',
 		'color.custom',
-		'color.palette'
+		'color.defaultPalette'
 	);
+	const { colors, hasColorsToChoose } = getAvailableHighlightColors( {
+		themeColors,
+		defaultColors,
+		customColors,
+		enableCustomColors,
+		enableDefaultColors,
+	} );
 	const [ isAddingColor, setIsAddingColor ] = useState( false );
 	const colorIndicatorStyle = useMemo(
 		() =>
@@ -72,7 +87,6 @@ function TextColorEdit( {
 		[ contentRef, value, colors ]
 	);
 
-	const hasColorsToChoose = !! colors.length || allowCustomControl;
 	if ( ! hasColorsToChoose && ! isActive ) {
 		return null;
 	}

--- a/packages/format-library/src/text-color/test/utils.js
+++ b/packages/format-library/src/text-color/test/utils.js
@@ -1,7 +1,7 @@
 import { getAvailableHighlightColors } from '../utils';
 
 describe( 'getAvailableHighlightColors', () => {
-	it( 'hides Highlight when palette is empty and custom colors are disabled', () => {
+	it( 'returns no colors when palette is empty and custom colors are disabled', () => {
 		const result = getAvailableHighlightColors( {
 			themeColors: [],
 			defaultColors: [ { slug: 'black', color: '#000' } ],
@@ -28,7 +28,7 @@ describe( 'getAvailableHighlightColors', () => {
 		expect( result.colors ).toEqual( defaults );
 	} );
 
-	it( 'keeps Highlight available when custom colors are enabled', () => {
+	it( 'keeps Highlight available for custom colors when the palette is empty', () => {
 		const result = getAvailableHighlightColors( {
 			themeColors: [],
 			defaultColors: [],

--- a/packages/format-library/src/text-color/test/utils.js
+++ b/packages/format-library/src/text-color/test/utils.js
@@ -1,0 +1,42 @@
+import { getAvailableHighlightColors } from '../utils';
+
+describe( 'getAvailableHighlightColors', () => {
+	it( 'hides Highlight when palette is empty and custom colors are disabled', () => {
+		const result = getAvailableHighlightColors( {
+			themeColors: [],
+			defaultColors: [ { slug: 'black', color: '#000' } ],
+			customColors: [],
+			enableCustomColors: false,
+			enableDefaultColors: false,
+		} );
+
+		expect( result.hasColorsToChoose ).toBe( false );
+		expect( result.colors ).toEqual( [] );
+	} );
+
+	it( 'includes default colors when defaultPalette is enabled', () => {
+		const defaults = [ { slug: 'black', color: '#000' } ];
+		const result = getAvailableHighlightColors( {
+			themeColors: [],
+			defaultColors: defaults,
+			customColors: [],
+			enableCustomColors: false,
+			enableDefaultColors: true,
+		} );
+
+		expect( result.hasColorsToChoose ).toBe( true );
+		expect( result.colors ).toEqual( defaults );
+	} );
+
+	it( 'keeps Highlight available when custom colors are enabled', () => {
+		const result = getAvailableHighlightColors( {
+			themeColors: [],
+			defaultColors: [],
+			customColors: [],
+			enableCustomColors: true,
+			enableDefaultColors: false,
+		} );
+
+		expect( result.hasColorsToChoose ).toBe( true );
+	} );
+} );

--- a/packages/format-library/src/text-color/utils.js
+++ b/packages/format-library/src/text-color/utils.js
@@ -1,0 +1,32 @@
+/**
+ * Builds the effective highlight color palette and whether the Highlight
+ * toolbar control should be available, matching ColorPalette's origin rules.
+ *
+ * @param {Object}  settings
+ * @param {Array}   [settings.themeColors]
+ * @param {Array}   [settings.defaultColors]
+ * @param {Array}   [settings.customColors]
+ * @param {boolean} [settings.enableCustomColors]
+ * @param {boolean} [settings.enableDefaultColors]
+ * @return {{ colors: Array, hasColorsToChoose: boolean }} Available colors and visibility.
+ */
+export function getAvailableHighlightColors( {
+	themeColors,
+	defaultColors,
+	customColors,
+	enableCustomColors,
+	enableDefaultColors,
+} = {} ) {
+	const colors = enableDefaultColors
+		? [
+				...( themeColors || [] ),
+				...( defaultColors || [] ),
+				...( customColors || [] ),
+		  ]
+		: [ ...( themeColors || [] ), ...( customColors || [] ) ];
+
+	return {
+		colors,
+		hasColorsToChoose: colors.length > 0 || !! enableCustomColors,
+	};
+}

--- a/packages/format-library/src/text-color/utils.js
+++ b/packages/format-library/src/text-color/utils.js
@@ -1,6 +1,6 @@
 /**
  * Builds the effective highlight color palette and whether the Highlight
- * toolbar control should be available, matching ColorPalette's origin rules.
+ * control should be available, matching ColorPalette's origin rules.
  *
  * @param {Object}  settings
  * @param {Array}   [settings.themeColors]
@@ -8,7 +8,7 @@
  * @param {Array}   [settings.customColors]
  * @param {boolean} [settings.enableCustomColors]
  * @param {boolean} [settings.enableDefaultColors]
- * @return {{ colors: Array, hasColorsToChoose: boolean }} Available colors and visibility.
+ * @return {{ colors: Array, hasColorsToChoose: boolean }} Available colors and whether the color picker should open.
  */
 export function getAvailableHighlightColors( {
 	themeColors,


### PR DESCRIPTION
## What
Fixes #26386

Hides the Highlight format toolbar when the theme disables color palettes and custom colors, including when `defaultPalette` is false.

## Why
`useSettings( 'color.palette' )` did not follow the same origin rules as `ColorPalette`, so Highlight could still appear (with an empty popover) after colors were turned off in `theme.json`.

## How
Build the available palette from theme/default/custom origins and respect `color.defaultPalette` + `color.custom`, matching `@wordpress/components` ColorPalette behavior.

## Test plan
- [ ] In a theme `theme.json`, set:
  ```json
  "settings": {
    "color": {
      "palette": [],
      "custom": false,
      "defaultPalette": false
    }
  }