### PR TITLE
Fix expand-on-click animation for bordered images

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Image: Fix expand-on-click animation when the image has a border. ([#63567](https://github.com/WordPress/gutenberg/issues/63567))
 -   Tabs: Activate the tab that a URL hash points into, so an anchor set on a block inside a tab panel can be reached. Anchor links followed after the page has loaded are handled too, matching the Accordion block ([#81744](https://github.com/WordPress/gutenberg/pull/81744)).
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -15,12 +15,16 @@
 		box-sizing: border-box;
 
 		@media not (prefers-reduced-motion) {
+			& {
+				transition: opacity 0.4s ease;
+			}
+
 			&.hide {
-				visibility: hidden;
+				opacity: 0;
 			}
 
 			&.show {
-				animation: show-content-image 0.4s;
+				opacity: 1;
 			}
 		}
 	}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -167,13 +167,21 @@ const { state, actions, callbacks } = store(
 				);
 			},
 			get imgStyles() {
-				return (
-					state.overlayOpened &&
-					`${ state.selectedImage.imgStyles?.replace(
-						/;$/,
-						''
-					) }; object-fit:cover;`
-				);
+				if ( ! state.overlayOpened ) {
+					return;
+				}
+
+				const styles = ( state.selectedImage.imgStyles || '' )
+					.split( ';' )
+					.filter( ( style ) => !! style )
+					.map( ( style ) =>
+						style.startsWith( 'border-width:' )
+							? 'border-width: 0'
+							: style
+					)
+					.join( ';' );
+
+				return `${ styles }; object-fit:cover;`;
 			},
 			get isContentHidden() {
 				const ctx = getContext();
@@ -421,11 +429,20 @@ const { state, actions, callbacks } = store(
 				let {
 					naturalWidth,
 					naturalHeight,
-					offsetWidth: originalWidth,
-					offsetHeight: originalHeight,
+					clientWidth: originalWidth,
+					clientHeight: originalHeight,
 				} = state.selectedImage.imageRef;
 				let { x: screenPosX, y: screenPosY } =
 					state.selectedImage.imageRef.getBoundingClientRect();
+				const computedStyle = window.getComputedStyle(
+					state.selectedImage.imageRef
+				);
+				screenPosX +=
+					parseFloat( computedStyle.borderLeftWidth ) +
+					parseFloat( computedStyle.paddingLeft );
+				screenPosY +=
+					parseFloat( computedStyle.borderTopWidth ) +
+					parseFloat( computedStyle.paddingTop );
 
 				// Natural ratio of the image clicked to open the lightbox.
 				const naturalRatio = naturalWidth / naturalHeight;


### PR DESCRIPTION
## What
Fixes #63567

When an image has a border and expand-on-click is enabled, the lightbox zoom animation now accounts for border/padding dimensions and fades the original image with opacity instead of toggling visibility. This prevents the border from jumping at the end of the close animation.

## How
- Use `clientWidth`/`clientHeight` and adjust position for border/padding in zoom calculations
- Zero out border width in the lightbox overlay image styles during animation
- Replace visibility-based hide/show with opacity transition on the original image

## Test plan
- [ ] Add an image with a thick border and border radius
- [ ] Enable expand on click, publish, and open/close the lightbox
- [ ] Confirm zoom in/out is smooth with no border jump at the end
- [ ] Test with custom aspect ratio images
- [ ] Test images without borders still work correctly