### PR TITLE
Try: Navigation — replace the on-canvas appenders with toolbar inserters

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/index.jsx
+++ b/packages/block-editor/src/components/block-parent-selector/index.jsx
@@ -1,9 +1,8 @@
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
-import { plus } from '@wordpress/icons';
 import useBlockDisplayInformation from '../use-block-display-information';
 import BlockIcon from '../block-icon';
 import Inserter from '../inserter';
@@ -108,37 +107,16 @@ export default function BlockParentSelector() {
 						clientId={ nextSiblingClientId }
 						isAppender={ ! nextSiblingClientId }
 						__experimentalIsQuick
-						renderToggle={ ( {
-							onToggle,
-							isOpen,
-							disabled,
-							blockTitle,
-							hasSingleBlockType,
-						} ) => (
-							<ToolbarButton
-								className="block-editor-block-parent-selector__inserter"
-								onClick={ onToggle }
-								aria-expanded={ isOpen }
-								disabled={ disabled }
-								label={
-									hasSingleBlockType
-										? sprintf(
-												// translators: %s: the name of the block when there is only one
-												_x(
-													'Add %s',
-													'directly add the only allowed block'
-												),
-												blockTitle.toLowerCase()
-										  )
-										: _x(
-												'Add block',
-												'Generic label for block inserter button'
-										  )
-								}
-								showTooltip
-								icon={ plus }
-							/>
-						) }
+						// InserterToggle supplies the icon, the disabled and
+						// aria wiring, and the label — including a block's own
+						// appender label, so the toolbar and the on-canvas
+						// appender name the same action the same way.
+						toggleProps={ {
+							as: ToolbarButton,
+							className:
+								'block-editor-inserter__toggle block-editor-block-parent-selector__inserter',
+							showTooltip: true,
+						} }
 					/>
 				</ToolbarGroup>
 			) }

--- a/packages/block-library/src/navigation-submenu/edit.jsx
+++ b/packages/block-library/src/navigation-submenu/edit.jsx
@@ -5,7 +5,7 @@ import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
-	InnerBlocks,
+	Inserter,
 	InspectorControls,
 	useInnerBlocksProps,
 	RichText,
@@ -109,7 +109,6 @@ export default function NavigationSubmenuEdit( {
 	const {
 		parentCount,
 		isParentOfSelectedBlock,
-		isImmediateParentOfSelectedBlock,
 		hasChildren,
 		selectedBlockHasChildren,
 		onlyDescendantIsEmptyLink,
@@ -149,10 +148,6 @@ export default function NavigationSubmenuEdit( {
 				isParentOfSelectedBlock: hasSelectedInnerBlock(
 					clientId,
 					true
-				),
-				isImmediateParentOfSelectedBlock: hasSelectedInnerBlock(
-					clientId,
-					false
 				),
 				hasChildren: !! getBlockCount( clientId ),
 				selectedBlockHasChildren: !! selectedBlockChildren?.length,
@@ -271,14 +266,9 @@ export default function NavigationSubmenuEdit( {
 		// see: https://github.com/WordPress/gutenberg/pull/34615.
 		__experimentalCaptureToolbars: true,
 
-		renderAppender:
-			isSelected ||
-			( isImmediateParentOfSelectedBlock &&
-				! selectedBlockHasChildren ) ||
-			// Show the appender while dragging to allow inserting element between item and the appender.
-			hasChildren
-				? InnerBlocks.ButtonBlockAppender
-				: false,
+		// No on-canvas appender: the toolbar's "Add submenu page" adds items
+		// to this submenu.
+		renderAppender: false,
 	} );
 
 	const ParentElement = openSubmenusOnClick ? 'button' : 'a';
@@ -324,6 +314,22 @@ export default function NavigationSubmenuEdit( {
 						onClick={ transformToLink }
 						className="wp-block-navigation__submenu__revert"
 						disabled={ ! canConvertToLink }
+					/>
+				</ToolbarGroup>
+				<ToolbarGroup>
+					{ /* `defaultBlock` + `directInsert` below make this a
+					     one-click append into this submenu, rather than the
+					     Navigation block that the parent selector targets. */ }
+					<Inserter
+						rootClientId={ clientId }
+						isAppender
+						toggleProps={ {
+							as: ToolbarButton,
+							name: 'add-submenu-page',
+							icon: undefined,
+							label: __( 'Add submenu page' ),
+							children: __( 'Add submenu page' ),
+						} }
 					/>
 				</ToolbarGroup>
 			</BlockControls>

--- a/packages/block-library/src/navigation/edit/index.jsx
+++ b/packages/block-library/src/navigation/edit/index.jsx
@@ -14,6 +14,7 @@ import {
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
+	Inserter,
 	BlockControls,
 } from '@wordpress/block-editor';
 import {
@@ -35,8 +36,6 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { page } from '@wordpress/icons';
-import { createBlock } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import useNavigationMenu from '../use-navigation-menu';
 import Placeholder from './placeholder';
@@ -65,10 +64,7 @@ import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { isWithinNavigationOverlay } from '../../utils/is-within-overlay';
 import useLayoutCustomProperties from './use-layout-custom-properties';
-import {
-	DEFAULT_BLOCK,
-	NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
-} from '../constants';
+import { NAVIGATION_OVERLAY_TEMPLATE_PART_AREA } from '../constants';
 
 const { isNavigationPostEditorKey } = unlock( blockEditorPrivateApis );
 
@@ -77,36 +73,33 @@ const { isNavigationPostEditorKey } = unlock( blockEditorPrivateApis );
  *
  * @param {Object} props          Component props.
  * @param {string} props.clientId Block client ID.
- * @return {React.JSX.Element} The Add page button component or null if not applicable.
+ * @return {React.JSX.Element|null} The Add page button, or null when editing is disabled.
  */
 function NavigationAddPageButton( { clientId } ) {
-	const { insertBlock } = useDispatch( blockEditorStore );
-	const { getBlockCount } = useSelect( blockEditorStore );
+	const blockEditingMode = useBlockEditingMode();
 
-	const onAddPage = useCallback( () => {
-		// Get the current number of blocks to insert at the end
-		const blockCount = getBlockCount( clientId );
+	if ( blockEditingMode === 'disabled' ) {
+		return null;
+	}
 
-		// Create a new navigation link block (default block)
-		const newBlock = createBlock( DEFAULT_BLOCK.name, {
-			kind: DEFAULT_BLOCK.attributes.kind,
-			type: DEFAULT_BLOCK.attributes.type,
-		} );
-
-		// Insert the block at the end of the navigation
-		insertBlock( newBlock, blockCount, clientId );
-	}, [ clientId, insertBlock, getBlockCount ] );
-
+	// The inner blocks declare `defaultBlock` + `directInsert`, so `Inserter`
+	// renders as a one-click button that appends that block — no popover — and
+	// brings the screen-reader announcement, the allowed-blocks/lock check and
+	// adjacent-attribute inheritance with it.
 	return (
 		<BlockControls>
 			<ToolbarGroup>
-				<ToolbarButton
-					name="add-page"
-					icon={ page }
-					onClick={ onAddPage }
-				>
-					{ __( 'Add page' ) }
-				</ToolbarButton>
+				<Inserter
+					rootClientId={ clientId }
+					isAppender
+					toggleProps={ {
+						as: ToolbarButton,
+						name: 'add-page',
+						icon: undefined,
+						label: __( 'Add page' ),
+						children: __( 'Add page' ),
+					} }
+				/>
 			</ToolbarGroup>
 		</BlockControls>
 	);
@@ -976,6 +969,7 @@ function Navigation( {
 					blockEditingMode={ blockEditingMode }
 				/>
 				{ blockEditingMode === 'default' && stylingInspectorControls }
+				<NavigationAddPageButton clientId={ clientId } />
 				<TagName
 					{ ...blockProps }
 					aria-describedby={
@@ -1001,7 +995,9 @@ function Navigation( {
 						<UnsavedInnerBlocks
 							createNavigationMenu={ createNavigationMenu }
 							blocks={ uncontrolledInnerBlocks }
-							hasSelection={ isSelected || isInnerBlockSelected }
+							shouldAutoSave={
+								isSelected || isInnerBlockSelected
+							}
 						/>
 					</ResponsiveWrapper>
 				</TagName>
@@ -1101,10 +1097,7 @@ function Navigation( {
 			{ blockEditingMode === 'default' && stylingInspectorControls }
 			<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
 				<RecursionProvider uniqueId={ recursionId }>
-					{ blockEditingMode === 'contentOnly' &&
-						isEntityAvailable && (
-							<NavigationAddPageButton clientId={ clientId } />
-						) }
+					<NavigationAddPageButton clientId={ clientId } />
 					{ blockEditingMode === 'default' && isEntityAvailable && (
 						<InspectorControls group="advanced">
 							{ hasResolvedCanUserUpdateNavigationMenu &&
@@ -1169,7 +1162,7 @@ function Navigation( {
 								>
 									{ isEntityAvailable && (
 										<NavigationInnerBlocks
-											clientId={ clientId }
+											isSelected={ isSelected }
 											hasCustomPlaceholder={
 												!! CustomPlaceholder
 											}

--- a/packages/block-library/src/navigation/edit/inner-blocks.jsx
+++ b/packages/block-library/src/navigation/edit/inner-blocks.jsx
@@ -1,61 +1,19 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
-import {
-	useInnerBlocksProps,
-	InnerBlocks,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 import PlaceholderPreview from './placeholder/placeholder-preview';
 import { DEFAULT_BLOCK, PRIORITIZED_INSERTER_BLOCKS } from '../constants';
 
 export default function NavigationInnerBlocks( {
-	clientId,
 	hasCustomPlaceholder,
+	isSelected,
 	orientation,
 	templateLock,
 } ) {
-	const {
-		isImmediateParentOfSelectedBlock,
-		selectedBlockHasChildren,
-		isSelected,
-		hasSelectedDescendant,
-	} = useSelect(
-		( select ) => {
-			const {
-				getBlockCount,
-				hasSelectedInnerBlock,
-				getSelectedBlockClientId,
-			} = select( blockEditorStore );
-			const selectedBlockId = getSelectedBlockClientId();
-
-			return {
-				isImmediateParentOfSelectedBlock: hasSelectedInnerBlock(
-					clientId,
-					false
-				),
-				selectedBlockHasChildren: !! getBlockCount( selectedBlockId ),
-				hasSelectedDescendant: hasSelectedInnerBlock( clientId, true ),
-
-				// This prop is already available but computing it here ensures it's
-				// fresh compared to isImmediateParentOfSelectedBlock.
-				isSelected: selectedBlockId === clientId,
-			};
-		},
-		[ clientId ]
-	);
-
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'wp_navigation'
 	);
-
-	// When the block is selected itself or has a top level item selected that
-	// doesn't itself have children, show the standard appender. Else show no
-	// appender.
-	const parentOrChildHasSelection =
-		isSelected ||
-		( isImmediateParentOfSelectedBlock && ! selectedBlockHasChildren );
 
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
@@ -63,8 +21,8 @@ export default function NavigationInnerBlocks( {
 
 	// If there is a `ref` attribute pointing to a `wp_navigation` but
 	// that menu has no **items** (i.e. empty) then show a placeholder.
-	// The block must also be selected else the placeholder will display
-	// alongside the appender.
+	// While the block is selected the toolbar offers "Add page", so the
+	// placeholder would only be telling the user what to do next.
 	const showPlaceholder =
 		! hasCustomPlaceholder && ! hasMenuItems && ! isSelected;
 
@@ -82,20 +40,10 @@ export default function NavigationInnerBlocks( {
 			orientation,
 			templateLock,
 
-			// As an exception to other blocks which feature nesting, show
-			// the block appender even when a child block is selected.
-			// This should be a temporary fix, to be replaced by improvements to
-			// the sibling inserter.
-			// See https://github.com/WordPress/gutenberg/issues/37572.
-			renderAppender:
-				isSelected ||
-				( isImmediateParentOfSelectedBlock &&
-					! selectedBlockHasChildren ) ||
-				hasSelectedDescendant ||
-				// Show the appender while dragging to allow inserting element between item and the appender.
-				parentOrChildHasSelection
-					? InnerBlocks.ButtonBlockAppender
-					: false,
+			// No on-canvas appender: `defaultBlock` and `directInsert` above
+			// are what the toolbar's "Add page" inserts, and what pressing
+			// Enter at the end of an item adds.
+			renderAppender: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
 			__unstableDisableLayoutClassNames: true,

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.jsx
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.jsx
@@ -11,7 +11,7 @@ const EMPTY_OBJECT = {};
 export default function UnsavedInnerBlocks( {
 	blocks,
 	createNavigationMenu,
-	hasSelection,
+	shouldAutoSave,
 } ) {
 	const originalBlocksRef = useRef();
 
@@ -44,7 +44,9 @@ export default function UnsavedInnerBlocks( {
 			className: 'wp-block-navigation__container',
 		},
 		{
-			renderAppender: hasSelection ? undefined : false,
+			// No on-canvas appender, matching a menu backed by a
+			// wp_navigation entity.
+			renderAppender: false,
 			defaultBlock: DEFAULT_BLOCK,
 			directInsert: true,
 		}
@@ -88,7 +90,7 @@ export default function UnsavedInnerBlocks( {
 			isDisabled ||
 			isSaving ||
 			! hasResolvedAllNavigationMenus ||
-			! hasSelection ||
+			! shouldAutoSave ||
 			! innerBlocksAreDirty
 		) {
 			return;
@@ -102,7 +104,7 @@ export default function UnsavedInnerBlocks( {
 		isSaving,
 		hasResolvedAllNavigationMenus,
 		innerBlocksAreDirty,
-		hasSelection,
+		shouldAutoSave,
 	] );
 
 	const Wrapper = isSaving ? Disabled : 'div';


### PR DESCRIPTION
## What?

**This is a prototype, opened as a draft to look at, not to merge.** The point is to see whether moving "add an item" out of the canvas and into the block toolbar feels better before committing to it. Focus management is deliberately unfinished (see Status below).

Removes the on-canvas appenders from the Navigation and Submenu blocks, so adding an item goes through the toolbar:

| Selection | How you add |
| --- | --- |
| Navigation block | "Add page" in the toolbar |
| A child link | the inserter beside the parent selector, added in #81532 |
| Submenu block | "Add submenu page", appending into that submenu |

## Why?

The condition being deleted said so itself:

> As an exception to other blocks which feature nesting, show the block appender even when a child block is selected. This should be a temporary fix, to be replaced by improvements to the sibling inserter. See #37572.

The parent-selector inserter from #81532 is that improvement, so the exception has something to hand off to. Removing it takes the selection plumbing that only existed to drive it: `isImmediateParentOfSelectedBlock`, `selectedBlockHasChildren`, `hasSelectedDescendant`, `parentOrChildHasSelection`, and a store subscription in `inner-blocks.jsx` that recomputed a value the parent already had as a prop.

Net **−146/+73**.

## How?

Both toolbar buttons are `<Inserter isAppender>` rather than hand-rolled inserts. The inner blocks already declare `defaultBlock` + `directInsert`, which is exactly the contract `Inserter` consumes — with it set, `Inserter` renders as a one-click button rather than a popover. Going through it rather than around it keeps the `%s block added` announcement the on-canvas appender used to provide, the allowed-blocks and template-lock checks that hide the affordance when insertion isn't possible, and adjacent-sibling attribute inheritance.

`BlockParentSelector` now passes `toggleProps` instead of a hand-written `renderToggle`, so `InserterToggle` supplies the label, icon, and aria wiring. That includes a block's own appender label, which is why the toolbar inserter reads "Add page" for Navigation: the block already declares it via `__experimentalLabel` in the `appender` context, and the parent selector was the one inserter ignoring it.

`defaultBlock` and `directInsert` stay in place, so pressing Enter at the end of an item still adds one — the on-canvas insert path is narrowed, not removed.

## Testing Instructions

1. Insert a Navigation block, select it → "Add page" in the toolbar, no `+` on canvas.
2. Select a child link → the inserter beside the parent selector, reading "Add page".
3. Add a Submenu, select it → "Add submenu page", which adds inside the submenu.
4. Paste a ref-less menu and repeat — both the saved and unsaved paths behave the same.
5. Put the caret at the end of an item and press Enter — still adds an item.
6. Select a non-Navigation nested block (a Paragraph in a Column) — the parent selector still reads "Add block", unchanged.

## Status

**Focus management is not done.** `navigation-link/edit.jsx` still walks the DOM for `.block-editor-button-block-appender`, which nothing renders any more, and the mount effect that selects the parent "to keep the appender visible" now reveals an appender that isn't there. Escaping out of a new link needs to return focus to the toolbar button instead. That is the main open question, and it is why this is a draft.

**12 e2e tests in `navigation.spec.js` fail**, all of them asserting the on-canvas appender is visible or focused — 9 reference it directly, and the other 3 fail in the `Focus management` `beforeEach`, which asserts `getNavBlockInserter()` is visible. They need rewriting against the toolbar once the focus behaviour is settled, which is work deliberately deferred until the approach is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkuJuaK9Vo54v3FmifLFt8
