### PR TITLE
Try: Buttons — replace the on-canvas appender with a toolbar inserter

### DIFF
--- a/packages/block-library/src/buttons/edit.jsx
+++ b/packages/block-library/src/buttons/edit.jsx
@@ -1,11 +1,18 @@
 import clsx from 'clsx';
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	Inserter,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const DEFAULT_BLOCK = {
 	name: 'core/button',
 };
 
-function ButtonsEdit( { attributes, className } ) {
+function ButtonsEdit( { attributes, className, clientId } ) {
 	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
@@ -16,9 +23,33 @@ function ButtonsEdit( { attributes, className } ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
 		orientation: layout?.orientation ?? 'horizontal',
+
+		// No on-canvas appender: adding a button goes through the toolbar.
+		renderAppender: false,
 	} );
 
-	return <div { ...innerBlocksProps } />;
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					{ /* `core/button` is the only allowed child, so Inserter
+					     renders a one-click button and names it from the block
+					     title rather than a hardcoded string. */ }
+					<Inserter
+						rootClientId={ clientId }
+						isAppender
+						toggleProps={ {
+							as: ToolbarButton,
+							name: 'add-button',
+							icon: undefined,
+							children: __( 'Add button' ),
+						} }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+			<div { ...innerBlocksProps } />
+		</>
+	);
 }
 
 export default ButtonsEdit;

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -449,7 +449,7 @@ test.describe( 'Buttons', () => {
 		);
 	} );
 
-	test( 'copies attributes when inserting a sibling via the appender', async ( {
+	test( 'copies attributes when inserting a sibling via the toolbar', async ( {
 		editor,
 		page,
 	} ) => {
@@ -479,13 +479,14 @@ test.describe( 'Buttons', () => {
 			.click();
 		await page.getByRole( 'option', { name: 'Vivid red' } ).click();
 
-		// Select the parent Buttons block so the appender is visible.
+		// Select the parent Buttons block so its toolbar is shown.
 		await editor.selectBlocks(
 			editor.canvas.getByRole( 'document', { name: 'Block: Buttons' } )
 		);
 
-		// Insert a sibling via the appender; should auto-insert a button.
-		await editor.canvas
+		// Insert a sibling from the toolbar; should auto-insert a button.
+		await page
+			.getByRole( 'toolbar', { name: 'Block tools' } )
 			.getByRole( 'button', { name: 'Add button' } )
 			.click();
 


### PR DESCRIPTION
## What?

**A prototype, opened as a draft to look at rather than to merge.** It applies the same idea as #82270 (Navigation) to the Buttons block: no on-canvas appender, and "Add button" in the block toolbar when the Buttons block is selected.

## Why?

Same question as #82270 — whether "add an item" reads better in the toolbar than as a `+` on the canvas. Buttons is a good second case because it is the simple version of the pattern: one allowed child, no submenu nesting, no entity loading. If the idea does not hold up here it is unlikely to hold up anywhere.

## How?

The button is `<Inserter isAppender>` rather than a hand-rolled insert.

`core/button` is the only entry in the Buttons block's `allowedBlocks` and defines no inserter variations, so `Inserter` resolves a single block type. That means it renders as a one-click button instead of a popover, and `InserterToggle` derives the label from the block title — so "Add button" is not hardcoded, and no `directInsert` declaration is needed.

Going through `Inserter` rather than around it also preserves adjacent-sibling attribute inheritance (`getSiblingBlockAttributes`, #37904), which the on-canvas appender provided. That is not an assumption: `buttons.spec.js` already covered it, and the existing test passes unchanged apart from clicking the toolbar instead of the canvas. It is renamed from "…via the appender" to "…via the toolbar" to match.

## Testing Instructions

1. Insert a Buttons block and select the parent → "Add button" in the toolbar, no `+` on canvas.
2. Click it → a Button is appended.
3. Give the first button a text and background colour, select the parent, then "Add button" → the new button inherits both.
4. Select a child Button → the inserter beside the parent selector still works as before.
5. Empty the Buttons block, select it → "Add button" is still the way to add one.

## Status

`buttons.spec.js` and `navigable-toolbar.spec.js`: 27 passing. `inserting-blocks.spec.js`: 47 passing.

Unlike #82270, there is no outstanding focus-management work here — the Buttons block has none of the custom focus handling the Navigation block built around its appender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkuJuaK9Vo54v3FmifLFt8
