### PR TITLE
Core Data: Coalesce useEntityProp edits into a single undo level

### DIFF
--- a/packages/block-library/src/site-tagline/edit.jsx
+++ b/packages/block-library/src/site-tagline/edit.jsx
@@ -1,5 +1,5 @@
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import {
 	useBlockProps,
 	BlockControls,
@@ -15,33 +15,25 @@ export default function SiteTaglineEdit( props ) {
 
 	const { attributes, setAttributes, insertBlocksAfter } = props;
 	const { level, levelOptions } = attributes;
-	const { canUserEdit, tagline } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			tagline: canEdit
-				? settings?.description
-				: readOnlySettings?.description,
-		};
-	}, [] );
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
+	// Users who cannot edit the site settings cannot read them either, so the
+	// tagline comes from the base entity instead.
+	const [ tagline, setTagline ] = useEntityProp(
+		'root',
+		canUserEdit ? 'site' : '__unstableBase',
+		'description',
+		undefined,
+		{ coalesceEdits: true }
+	);
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
-	const { editEntityRecord } = useDispatch( coreStore );
-
-	function setTagline( newTagline ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			description: newTagline,
-		} );
-	}
-
 	const blockProps = useBlockProps( {
 		className:
 			! canUserEdit && ! tagline && 'wp-block-site-tagline__placeholder',

--- a/packages/block-library/src/site-title/edit.jsx
+++ b/packages/block-library/src/site-title/edit.jsx
@@ -1,5 +1,5 @@
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
@@ -22,31 +22,29 @@ export default function SiteTitleEdit( props ) {
 	useDeprecatedTextAlign( props );
 
 	const { attributes, setAttributes } = props;
-
 	const { level, levelOptions, isLink, linkTarget } = attributes;
-	const { canUserEdit, title } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			title: canEdit ? settings?.title : readOnlySettings?.name,
-		};
-	}, [] );
-	const { editEntityRecord } = useDispatch( coreStore );
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
+	// Users who cannot edit the site settings cannot read them either, so the
+	// title comes from the base entity instead.
+	const [ title, setSiteTitle ] = useEntityProp(
+		'root',
+		canUserEdit ? 'site' : '__unstableBase',
+		canUserEdit ? 'title' : 'name',
+		undefined,
+		{ coalesceEdits: true }
+	);
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const blockEditingMode = useBlockEditingMode();
 
 	function setTitle( newTitle ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			title: newTitle.trim(),
-		} );
+		setSiteTitle( newTitle.trim() );
 	}
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -22,6 +22,7 @@
 -   Match the Navigation embed record and current global styles ID types to their REST responses. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   Export `ContextualField` so plugins can describe context-sensitive fields when extending the entity record map. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   `PostStatus` accepts statuses registered by WordPress or plugins while preserving autocomplete for the built-in values. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
+-   `useEntityProp`: Add a `coalesceEdits` option that merges consecutive edits into a single undo level, so typing into a text input no longer creates an undo level per keystroke ([#82275](https://github.com/WordPress/gutenberg/pull/82275)).
 
 ### Internal
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1068,6 +1068,8 @@ _Parameters_
 -   _name_ `string`: The entity name.
 -   _prop_ `string`: The property name.
 -   _\_id_ `[number|string]`: An entity ID to use instead of the context-provided one.
+-   _options_ `[Object]`: Hook options.
+-   _options.coalesceEdits_ `[boolean]`: Whether to merge edits made less than a second apart into a single undo level. Use it for text inputs, so that typing does not create an undo level per keystroke.
 
 _Returns_
 

--- a/packages/core-data/src/hooks/test/use-entity-prop.jsdom.test.js
+++ b/packages/core-data/src/hooks/test/use-entity-prop.jsdom.test.js
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { store as coreDataStore } from '../../index';
+import useEntityProp from '../use-entity-prop';
+
+describe( 'useEntityProp', () => {
+	let registry;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		registry = createRegistry();
+		registry.register( coreDataStore );
+		// The site entity is loaded lazily in production, so register it here.
+		registry.dispatch( coreDataStore ).addEntities( [
+			{
+				kind: 'root',
+				name: 'site',
+				key: false,
+				baseURL: '/wp/v2/settings',
+			},
+		] );
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'root', 'site', { title: 'My Site' } );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	/**
+	 * Renders the hook the way the Site Title block uses it, against the
+	 * keyless `root`/`site` entity.
+	 *
+	 * @param {Object} [options] Hook options.
+	 * @return {Object} The `renderHook` result.
+	 */
+	function mountSiteTitle( options ) {
+		const wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+
+		const { result } = renderHook(
+			() => useEntityProp( 'root', 'site', 'title', undefined, options ),
+			{ wrapper }
+		);
+
+		return result;
+	}
+
+	/**
+	 * Appends the text one character at a time, as a `RichText` onChange would.
+	 *
+	 * @param {Object} result The `renderHook` result.
+	 * @param {string} text   The text to type.
+	 */
+	function type( result, text ) {
+		for ( const character of text ) {
+			act( () => {
+				const [ value, setValue ] = result.current;
+				setValue( value + character );
+			} );
+		}
+	}
+
+	const undo = () =>
+		act( () => {
+			registry.dispatch( coreDataStore ).undo();
+		} );
+
+	it( 'creates an undo level per edit by default', () => {
+		const result = mountSiteTitle();
+
+		type( result, ' Blog' );
+		expect( result.current[ 0 ] ).toBe( 'My Site Blog' );
+
+		// Each keystroke has to be undone on its own.
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site Blo' );
+	} );
+
+	it( 'merges consecutive edits into a single undo level when coalescing', () => {
+		const result = mountSiteTitle( { coalesceEdits: true } );
+
+		type( result, ' Blog' );
+		expect( result.current[ 0 ] ).toBe( 'My Site Blog' );
+
+		// A single undo discards the whole burst of typing.
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site' );
+	} );
+
+	it( 'starts a new undo level for an edit made after the timeout', () => {
+		const result = mountSiteTitle( { coalesceEdits: true } );
+
+		type( result, ' Blog' );
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		type( result, '!' );
+
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site Blog' );
+
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site' );
+	} );
+} );

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -1,19 +1,27 @@
-import { useCallback, useContext } from '@wordpress/element';
+import { useCallback, useContext, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { STORE_NAME } from '../name';
 import { DEFAULT_ENTITY_KEY } from '../entities';
 import { EntityContext } from '../entity-context';
 import useEntityId from './use-entity-id';
 
+// Matches the delay `useMarkPersistent` uses for block attributes.
+const COALESCE_TIMEOUT = 1000;
+
 /**
  * Hook that returns the value and a setter for the
  * specified property of the nearest provided
  * entity of the specified type.
  *
- * @param {string}        kind  The entity kind.
- * @param {string}        name  The entity name.
- * @param {string}        prop  The property name.
- * @param {number|string} [_id] An entity ID to use instead of the context-provided one.
+ * @param {string}        kind                    The entity kind.
+ * @param {string}        name                    The entity name.
+ * @param {string}        prop                    The property name.
+ * @param {number|string} [_id]                   An entity ID to use instead of the context-provided one.
+ * @param {Object}        [options]               Hook options.
+ * @param {boolean}       [options.coalesceEdits] Whether to merge edits made less than a second
+ *                                                apart into a single undo level. Use it for text
+ *                                                inputs, so that typing does not create an undo
+ *                                                level per keystroke.
  *
  * @return {[*, Function, *]} An array where the first item is the
  *                            property value, the second is the
@@ -22,7 +30,13 @@ import useEntityId from './use-entity-id';
  * 							  information like `raw`, `rendered` and
  * 							  `protected` props.
  */
-export default function useEntityProp( kind, name, prop, _id ) {
+export default function useEntityProp(
+	kind,
+	name,
+	prop,
+	_id,
+	{ coalesceEdits = false } = {}
+) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 	const context = useContext( EntityContext );
@@ -77,16 +91,30 @@ export default function useEntityProp( kind, name, prop, _id ) {
 		[ kind, name, id, prop, revisionId ]
 	);
 	const { editEntityRecord } = useDispatch( STORE_NAME );
+	const lastEditTimeRef = useRef( 0 );
 	const setValue = useCallback(
 		( newValue ) => {
 			if ( revisionId ) {
 				return;
 			}
-			editEntityRecord( kind, name, id, {
-				[ prop ]: newValue,
-			} );
+
+			const now = Date.now();
+			// A cached edit joins the previous edit's undo level instead of
+			// opening its own.
+			const isCached =
+				coalesceEdits &&
+				now - lastEditTimeRef.current < COALESCE_TIMEOUT;
+			lastEditTimeRef.current = now;
+
+			editEntityRecord(
+				kind,
+				name,
+				id,
+				{ [ prop ]: newValue },
+				{ isCached }
+			);
 		},
-		[ editEntityRecord, kind, name, id, prop, revisionId ]
+		[ editEntityRecord, kind, name, id, prop, revisionId, coalesceEdits ]
 	);
 
 	return [ value, setValue, fullValue ];


### PR DESCRIPTION
## What?
Alternative to #81910. Updates the existing hook instead of introducing a new one.

PR introduced as an option to coalesce edits via `useEntityProp`, which can be opted in with the `coalesceEdits` flag. When on, edits made less than a second apart merge into one undo level instead of each opening its own.

Opts in the Site Title and Site Tagline blocks. Typing in either and pressing undo used to remove one character per press. Now one press discards the whole burst of typing. Closes #37171.

## Why?
`RichText` already coalesces typing, but only for block attributes: `useMarkPersistent` dispatches `__unstableMarkLastChangeAsPersistent` into the block editor store. Entity props go through `editEntityRecord` and the core-data undo manager, which that hook never touches. So every keystroke in an entity-backed field became its own undo level.

## How?
`editEntityRecord` already accepts `isCached`, which stages an edit into the previous undo level rather than pushing a new one. The hook records the time of each edit and passes `isCached: true` when the previous edit was under a second ago. The 1s constant matches `useMarkPersistent`.

No timer. `useMarkPersistent` needs one because it has to dispatch when typing stops. Here, the level boundary is determined by the next edit, and `undoManager.undo()` flushes staged edits itself, so a timer would only set a flag that nobody reads until the next keystroke. The first edit after a pause is always uncached, so it pushes a real level for the following ones to merge into, and undo stays available immediately.

## Testing Instructions
1. Open a post or page as an admin.
2. Insert a Site Title block.
3. Type several characters into it without pausing.
4. Press undo once. The whole burst is discarded, not the last character.
5. Type again, pause more than a second, type more, then press undo. Only the text typed after the pause is discarded.
6. Press redo twice to get back to the full title.
7. Publish and reload. The title persists.
8. Repeat with a Site Tagline block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1ebedc14-4b4f-41be-87bc-2d450517c80f

## Use of AI Tools

Assisted by Claude.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Site title and tagline editing now respects the user’s editing permissions while maintaining read-only access where applicable.
  - Consecutive title or tagline edits made within one second can be grouped into a single undo step, simplifying correction of rapid changes.

- **Documentation**
  - Added guidance describing the edit-grouping option and its undo behavior.

- **Tests**
  - Added coverage for standard undo behavior, grouped edits, and creation of a new undo step after the grouping interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->