### PR TITLE
Core Data: Convert hooks tests to renderHook and drop JSX

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.jsdom.test.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.jsdom.test.js
@@ -1,7 +1,8 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 jest.mock( '@wordpress/api-fetch' );
-import { act, render, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
 import { store as coreDataStore } from '../../index';
 import useEntityRecord from '../use-entity-record';
 
@@ -14,6 +15,12 @@ describe( 'useEntityRecord', () => {
 		triggerFetch.mockReset();
 	} );
 
+	function renderHookWithRegistry( hook, options = {} ) {
+		const Wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+		return renderHook( hook, { wrapper: Wrapper, ...options } );
+	}
+
 	const TEST_RECORD = { id: 1, hello: 'world' };
 	const TEST_RECORD_RESPONSE = { json: () => Promise.resolve( TEST_RECORD ) };
 
@@ -21,18 +28,11 @@ describe( 'useEntityRecord', () => {
 		// Provide response
 		triggerFetch.mockImplementation( () => TEST_RECORD_RESPONSE );
 
-		let data;
-		const TestComponent = () => {
-			data = useEntityRecord( 'root', 'widget', 1 );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		const { result } = renderHookWithRegistry( () =>
+			useEntityRecord( 'root', 'widget', 1 )
 		);
 
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			edit: expect.any( Function ),
 			editedRecord: false,
 			hasEdits: false,
@@ -53,7 +53,7 @@ describe( 'useEntityRecord', () => {
 			} )
 		);
 
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			edit: expect.any( Function ),
 			editedRecord: { hello: 'world', id: 1 },
 			hasEdits: false,
@@ -71,19 +71,12 @@ describe( 'useEntityRecord', () => {
 		// Provide response
 		triggerFetch.mockImplementation( () => TEST_RECORD_RESPONSE );
 
-		let widget;
-		const TestComponent = () => {
-			widget = useEntityRecord( 'root', 'widget', 1 );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		const { result } = renderHookWithRegistry( () =>
+			useEntityRecord( 'root', 'widget', 1 )
 		);
 
 		await waitFor( () =>
-			expect( widget ).toEqual( {
+			expect( result.current ).toEqual( {
 				edit: expect.any( Function ),
 				editedRecord: { hello: 'world', id: 1 },
 				hasEdits: false,
@@ -98,31 +91,29 @@ describe( 'useEntityRecord', () => {
 		);
 
 		await act( async () => {
-			widget.edit( { hello: 'foo' } );
+			result.current.edit( { hello: 'foo' } );
 		} );
 
-		await waitFor( () => expect( widget.hasEdits ).toEqual( true ) );
+		await waitFor( () =>
+			expect( result.current.hasEdits ).toEqual( true )
+		);
 
-		expect( widget.record ).toEqual( { hello: 'world', id: 1 } );
-		expect( widget.editedRecord ).toEqual( { hello: 'foo', id: 1 } );
-		expect( widget.edits ).toEqual( { hello: 'foo' } );
+		expect( result.current.record ).toEqual( { hello: 'world', id: 1 } );
+		expect( result.current.editedRecord ).toEqual( {
+			hello: 'foo',
+			id: 1,
+		} );
+		expect( result.current.edits ).toEqual( { hello: 'foo' } );
 	} );
 
 	it( 'does not resolve entity record when disabled via options', async () => {
 		triggerFetch.mockImplementation( () => TEST_RECORD_RESPONSE );
 
-		let data;
-		const TestComponent = ( { enabled } ) => {
-			data = useEntityRecord( 'root', 'widget', 1, { enabled } );
-			return <div />;
-		};
-		const UI = ( { enabled } ) => (
-			<RegistryProvider value={ registry }>
-				<TestComponent enabled={ enabled } />
-			</RegistryProvider>
+		const { result, rerender } = renderHookWithRegistry(
+			( { enabled } ) =>
+				useEntityRecord( 'root', 'widget', 1, { enabled } ),
+			{ initialProps: { enabled: true } }
 		);
-
-		const { rerender } = render( <UI enabled /> );
 
 		// A minimum delay for a fetch request. The same delay is used again as a control.
 		await act(
@@ -137,9 +128,9 @@ describe( 'useEntityRecord', () => {
 		// Clear the fetch call history.
 		triggerFetch.mockReset();
 
-		rerender( <UI enabled={ false } /> );
+		rerender( { enabled: false } );
 
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			edit: expect.any( Function ),
 			editedRecord: {},
 			hasEdits: false,

--- a/packages/core-data/src/hooks/test/use-entity-records.jsdom.test.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.jsdom.test.js
@@ -1,7 +1,8 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 jest.mock( '@wordpress/api-fetch' );
-import { render, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
 import { store as coreDataStore } from '../../index';
 import useEntityRecords, {
 	useEntityRecordsWithPermissions,
@@ -15,6 +16,12 @@ describe( 'useEntityRecords', () => {
 		registry.register( coreDataStore );
 	} );
 
+	function renderHookWithRegistry( hook, options = {} ) {
+		const Wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+		return renderHook( hook, { wrapper: Wrapper, ...options } );
+	}
+
 	const TEST_RECORDS = [
 		{ id: 1, hello: 'world1' },
 		{ id: 2, hello: 'world2' },
@@ -25,18 +32,11 @@ describe( 'useEntityRecords', () => {
 		// Provide response
 		triggerFetch.mockImplementation( () => TEST_RECORDS );
 
-		let data;
-		const TestComponent = () => {
-			data = useEntityRecords( 'root', 'widget', { status: 'draft' } );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		const { result } = renderHookWithRegistry( () =>
+			useEntityRecords( 'root', 'widget', { status: 'draft' } )
 		);
 
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			records: null,
 			hasResolved: false,
 			hasStarted: false,
@@ -53,7 +53,7 @@ describe( 'useEntityRecords', () => {
 			} )
 		);
 
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			records: TEST_RECORDS,
 			hasResolved: true,
 			hasStarted: true,
@@ -83,6 +83,12 @@ describe( 'useEntityRecordsWithPermissions', () => {
 		] );
 	} );
 
+	function renderHookWithRegistry( hook, options = {} ) {
+		const Wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+		return renderHook( hook, { wrapper: Wrapper, ...options } );
+	}
+
 	const TEST_RECORDS = [
 		{ id: 1, title: 'Post 1', slug: 'post-1' },
 		{ id: 2, title: 'Post 2', slug: 'post-2' },
@@ -94,16 +100,10 @@ describe( 'useEntityRecordsWithPermissions', () => {
 		// Mock the API response
 		triggerFetch.mockImplementation( () => TEST_RECORDS );
 
-		const TestComponent = () => {
+		renderHookWithRegistry( () =>
 			useEntityRecordsWithPermissions( 'postType', 'post', {
 				_fields: fieldsFromMock,
-			} );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+			} )
 		);
 
 		// Should inject _links into the _fields parameter
@@ -120,14 +120,8 @@ describe( 'useEntityRecordsWithPermissions', () => {
 		// Mock the API response
 		triggerFetch.mockImplementation( () => TEST_RECORDS );
 
-		const TestComponent = () => {
-			useEntityRecordsWithPermissions( 'postType', 'post', {} );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		renderHookWithRegistry( () =>
+			useEntityRecordsWithPermissions( 'postType', 'post', {} )
 		);
 
 		// Should not add _fields when not originally provided
@@ -143,16 +137,10 @@ describe( 'useEntityRecordsWithPermissions', () => {
 		triggerFetch.mockImplementation( () => TEST_RECORDS );
 
 		const fieldsWithLinks = fieldsFromMock + ',_links';
-		const TestComponent = () => {
+		renderHookWithRegistry( () =>
 			useEntityRecordsWithPermissions( 'postType', 'post', {
 				_fields: fieldsWithLinks,
-			} );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+			} )
 		);
 
 		// Should not duplicate _links (deduplication working correctly)

--- a/packages/core-data/src/hooks/test/use-query-select.jsdom.test.js
+++ b/packages/core-data/src/hooks/test/use-query-select.jsdom.test.js
@@ -3,7 +3,8 @@ import {
 	createRegistry,
 	RegistryProvider,
 } from '@wordpress/data';
-import { render, screen, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
 import useQuerySelect from '../use-query-select';
 
 /* eslint-disable @wordpress/wp-global-usage */
@@ -31,51 +32,42 @@ describe( 'useQuerySelect', () => {
 		globalThis.SCRIPT_DEBUG = initialScriptDebug;
 	} );
 
-	const getTestComponent = ( mapSelectSpy, dependencyKey ) => ( props ) => {
-		const dependencies = props[ dependencyKey ];
-		mapSelectSpy.mockImplementation( ( select ) => ( {
-			results: select( 'testStore' ).testSelector( props.keyName ),
-		} ) );
-		const data = useQuerySelect( mapSelectSpy, [ dependencies ] );
-		return <div>{ data.results.data }</div>;
-	};
+	function renderHookWithRegistry( hook, options = {} ) {
+		const Wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+		return renderHook( hook, { wrapper: Wrapper, ...options } );
+	}
 
-	it( 'passes the relevant data to the component', () => {
+	it( 'passes the relevant data to the hook', () => {
+		const renderSpy = jest.fn();
 		const selectSpy = jest.fn();
-		const TestComponent = jest
-			.fn()
-			.mockImplementation( getTestComponent( selectSpy, 'keyName' ) );
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent keyName="foo" />
-			</RegistryProvider>
-		);
+
+		const { result } = renderHookWithRegistry( () => {
+			renderSpy();
+			selectSpy.mockImplementation( ( select ) => ( {
+				results: select( 'testStore' ).testSelector( 'foo' ),
+			} ) );
+			return useQuerySelect( selectSpy, [ 'foo' ] );
+		} );
 
 		expect( selectSpy ).toHaveBeenCalledTimes( 1 );
-		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
+		expect( renderSpy ).toHaveBeenCalledTimes( 1 );
 
-		// ensure expected state was rendered
-		expect( screen.getByText( 'bar' ) ).toBeInTheDocument();
+		// ensure the expected state was returned
+		expect( result.current.results.data ).toBe( 'bar' );
 	} );
 
 	it( 'uses memoized selectors', () => {
 		const selectors = [];
-		const TestComponent = jest.fn().mockImplementation( ( props ) => {
-			useQuerySelect(
-				function ( query ) {
-					selectors.push( query( 'testStore' ) );
-					selectors.push( query( 'testStore' ) );
-					return null;
-				},
-				[ props.keyName ]
-			);
-			return <div />;
-		} );
+		const mapSelect = ( query ) => {
+			selectors.push( query( 'testStore' ) );
+			selectors.push( query( 'testStore' ) );
+			return null;
+		};
 
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent keyName="foo" />
-			</RegistryProvider>
+		renderHookWithRegistry(
+			( { keyName } ) => useQuerySelect( mapSelect, [ keyName ] ),
+			{ initialProps: { keyName: 'foo' } }
 		);
 
 		// ensure the selectors were properly memoized
@@ -84,10 +76,9 @@ describe( 'useQuerySelect', () => {
 		expect( selectors[ 0 ] ).toBe( selectors[ 1 ] );
 
 		// Re-render
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent keyName="bar" />
-			</RegistryProvider>
+		renderHookWithRegistry(
+			( { keyName } ) => useQuerySelect( mapSelect, [ keyName ] ),
+			{ initialProps: { keyName: 'bar' } }
 		);
 
 		// ensure we still got the memoized results after re-rendering
@@ -98,21 +89,11 @@ describe( 'useQuerySelect', () => {
 	} );
 
 	it( 'returns the expected "response" details – no resolvers and arguments', () => {
-		let querySelectData;
-		const TestComponent = jest.fn().mockImplementation( () => {
-			querySelectData = useQuerySelect( function ( query ) {
-				return query( 'testStore' ).getFoo();
-			}, [] );
-			return <div />;
-		} );
-
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		const { result } = renderHookWithRegistry( () =>
+			useQuerySelect( ( query ) => query( 'testStore' ).getFoo(), [] )
 		);
 
-		expect( querySelectData ).toEqual( {
+		expect( result.current ).toEqual( {
 			data: 'bar',
 			isResolving: false,
 			hasResolved: false,
@@ -148,21 +129,16 @@ describe( 'useQuerySelect', () => {
 			} )
 		);
 
-		let querySelectData;
-		const TestComponent = jest.fn().mockImplementation( () => {
-			querySelectData = useQuerySelect( function ( query ) {
-				return query( 'resolverStore' ).getResolvedFoo( 10 );
-			}, [] );
-			return <div />;
-		} );
+		const renderResolvedFoo = () =>
+			renderHookWithRegistry( () =>
+				useQuerySelect(
+					( query ) => query( 'resolverStore' ).getResolvedFoo( 10 ),
+					[]
+				)
+			);
 
 		// Initial render, expect default values
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
-		);
-		expect( querySelectData ).toEqual( {
+		expect( renderResolvedFoo().result.current ).toEqual( {
 			data: 10,
 			isResolving: false,
 			hasResolved: false,
@@ -171,14 +147,10 @@ describe( 'useQuerySelect', () => {
 		} );
 
 		// Re-render, expect resolved data
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
-		);
+		const { result } = renderResolvedFoo();
 
 		await waitFor( () =>
-			expect( querySelectData ).toEqual( {
+			expect( result.current ).toEqual( {
 				data: 15,
 				isResolving: false,
 				hasResolved: true,

--- a/packages/core-data/src/hooks/test/use-resource-permissions.jsdom.test.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.jsdom.test.js
@@ -1,7 +1,8 @@
 import triggerFetch from '@wordpress/api-fetch';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 jest.mock( '@wordpress/api-fetch' );
-import { render, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
 import { store as coreDataStore } from '../../index';
 import useResourcePermissions from '../use-resource-permissions';
 
@@ -18,18 +19,17 @@ describe( 'useResourcePermissions', () => {
 		} ) );
 	} );
 
+	function renderHookWithRegistry( hook, options = {} ) {
+		const Wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+		return renderHook( hook, { wrapper: Wrapper, ...options } );
+	}
+
 	it( 'retrieves the relevant permissions for a key-less resource', async () => {
-		let data;
-		const TestComponent = () => {
-			data = useResourcePermissions( 'widgets' );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		const { result } = renderHookWithRegistry( () =>
+			useResourcePermissions( 'widgets' )
 		);
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			status: 'IDLE',
 			isResolving: false,
 			hasResolved: false,
@@ -38,7 +38,7 @@ describe( 'useResourcePermissions', () => {
 		} );
 
 		await waitFor( () =>
-			expect( data ).toEqual( {
+			expect( result.current ).toEqual( {
 				status: 'SUCCESS',
 				isResolving: false,
 				hasResolved: true,
@@ -49,17 +49,10 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'retrieves the relevant permissions for a resource with a key', async () => {
-		let data;
-		const TestComponent = () => {
-			data = useResourcePermissions( 'widgets', 1 );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+		const { result } = renderHookWithRegistry( () =>
+			useResourcePermissions( 'widgets', 1 )
 		);
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			status: 'IDLE',
 			isResolving: false,
 			hasResolved: false,
@@ -70,7 +63,7 @@ describe( 'useResourcePermissions', () => {
 		} );
 
 		await waitFor( () =>
-			expect( data ).toEqual( {
+			expect( result.current ).toEqual( {
 				status: 'SUCCESS',
 				isResolving: false,
 				hasResolved: true,
@@ -83,20 +76,13 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'retrieves the relevant permissions for a id-less entity', async () => {
-		let data;
-		const TestComponent = () => {
-			data = useResourcePermissions( {
+		const { result } = renderHookWithRegistry( () =>
+			useResourcePermissions( {
 				kind: 'root',
 				name: 'user',
-			} );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+			} )
 		);
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			status: 'IDLE',
 			isResolving: false,
 			hasResolved: false,
@@ -105,7 +91,7 @@ describe( 'useResourcePermissions', () => {
 		} );
 
 		await waitFor( () =>
-			expect( data ).toEqual( {
+			expect( result.current ).toEqual( {
 				status: 'SUCCESS',
 				isResolving: false,
 				hasResolved: true,
@@ -116,7 +102,6 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'normalizes id-less entity resources before resolving permissions', async () => {
-		let data;
 		triggerFetch.mockImplementation( ( options ) => {
 			if ( options.path === '/wp/v2/types?context=view' ) {
 				return {
@@ -141,22 +126,16 @@ describe( 'useResourcePermissions', () => {
 			);
 		} );
 
-		const TestComponent = () => {
-			data = useResourcePermissions( {
+		const { result } = renderHookWithRegistry( () =>
+			useResourcePermissions( {
 				kind: 'postType',
 				name: 'wp_navigation',
 				id: undefined,
-			} );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+			} )
 		);
 
 		await waitFor( () =>
-			expect( data ).toEqual( {
+			expect( result.current ).toEqual( {
 				status: 'SUCCESS',
 				isResolving: false,
 				hasResolved: true,
@@ -173,21 +152,14 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'retrieves the relevant permissions for an entity', async () => {
-		let data;
-		const TestComponent = () => {
-			data = useResourcePermissions( {
+		const { result } = renderHookWithRegistry( () =>
+			useResourcePermissions( {
 				kind: 'root',
 				name: 'user',
 				id: 1,
-			} );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+			} )
 		);
-		expect( data ).toEqual( {
+		expect( result.current ).toEqual( {
 			status: 'IDLE',
 			isResolving: false,
 			hasResolved: false,
@@ -198,7 +170,7 @@ describe( 'useResourcePermissions', () => {
 		} );
 
 		await waitFor( () =>
-			expect( data ).toEqual( {
+			expect( result.current ).toEqual( {
 				status: 'SUCCESS',
 				isResolving: false,
 				hasResolved: true,
@@ -211,20 +183,14 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'should warn when called with incorrect arguments signature', () => {
-		const TestComponent = () => {
+		renderHookWithRegistry( () =>
 			useResourcePermissions(
 				{
 					kind: 'root',
 					name: 'user',
 				},
 				1
-			);
-			return null;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
+			)
 		);
 
 		expect( console ).toHaveWarnedWith(

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -5064,26 +5064,6 @@
 			"count": 1
 		}
 	},
-	"packages/core-data/src/hooks/test/use-entity-record.jsdom.test.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/hooks/test/use-entity-records.jsdom.test.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/hooks/test/use-query-select.jsdom.test.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
-	"packages/core-data/src/hooks/test/use-resource-permissions.jsdom.test.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
 	"packages/core-data/src/test/entity-provider.jsdom.test.jsx": {
 		"react/jsx-filename-extension": {
 			"count": 1


### PR DESCRIPTION
## What?

Rewrites the four `packages/core-data/src/hooks/test` suites to use `renderHook` instead of wrapper `TestComponent`s, and renames them from `.jsx` to `.js`. This also fixes suppressed `react/jsx-filename-extension` errors.

## Testing Instructions
CI checks are green.

### Testing Instructions for Keyboard
None, no UI change.

## Use of AI Tools
Assisted by Claude.
