### PR TITLE
Global styles engine: return a copy from getResolvedValue instead of mutating

### DIFF
--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `getResolvedValue`: Return a copy when resolving a theme-relative (`file:./…`) URL instead of writing the resolved URL onto the given object, which could be the caller's own value or, via a `ref`, an object aliased by the user or theme config ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `getResolvedValue`: Return a copy when resolving a theme-relative (`file:./…`) URL instead of writing the resolved URL onto the given object, which could be the caller's own value or, via a `ref`, an object aliased by the user or theme config ([#82278](https://github.com/WordPress/gutenberg/pull/82278)).
 
 ## 1.21.0 (2026-08-26)
 

--- a/packages/global-styles-engine/CHANGELOG.md
+++ b/packages/global-styles-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `getResolvedValue`: Return a copy when resolving a theme-relative (`file:./…`) URL instead of writing the resolved URL onto the given object, which could be the caller's own value or, via a `ref`, an object aliased by the user or theme config ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+
 ## 1.21.0 (2026-08-26)
 
 ### Bug Fixes

--- a/packages/global-styles-engine/src/test/utils.test.ts
+++ b/packages/global-styles-engine/src/test/utils.test.ts
@@ -482,5 +482,28 @@ describe( 'editor utils', () => {
 				).toEqual( returnedValue );
 			}
 		);
+
+		it( 'returns a copy instead of writing the resolved URL onto the given value', () => {
+			const ruleValue = { url: 'file:./assets/image.jpg' };
+			expect( getResolvedValue( ruleValue, themeJson ) ).toEqual( {
+				url: 'https://wordpress.org/assets/image.jpg',
+			} );
+			expect( ruleValue.url ).toBe( 'file:./assets/image.jpg' );
+		} );
+
+		it( 'does not write the resolved URL into the tree when resolving a ref', () => {
+			const tree = JSON.parse(
+				JSON.stringify( themeJson )
+			) as GlobalStylesConfig;
+			expect(
+				getResolvedValue(
+					{ ref: 'styles.background.backgroundImage' },
+					tree
+				)
+			).toEqual( { url: 'https://wordpress.org/assets/image.jpg' } );
+			expect( tree.styles?.background?.backgroundImage ).toEqual( {
+				url: 'file:./assets/image.jpg',
+			} );
+		} );
 	} );
 } );

--- a/packages/global-styles-engine/src/utils/common.ts
+++ b/packages/global-styles-engine/src/utils/common.ts
@@ -469,10 +469,18 @@ export function getResolvedValue(
 		'url' in resolvedValue &&
 		resolvedValue?.url
 	) {
-		resolvedValue.url = getResolvedThemeFilePath(
-			resolvedValue.url,
-			tree?._links?.[ 'wp:theme-file' ]
-		);
+		/*
+		 * Copy rather than write in place: `resolvedValue` is the caller's
+		 * own object or, when a `ref` was just resolved, the tree's — which
+		 * aliases the user or theme config.
+		 */
+		return {
+			...resolvedValue,
+			url: getResolvedThemeFilePath(
+				resolvedValue.url,
+				tree?._links?.[ 'wp:theme-file' ]
+			),
+		};
 	}
 
 	return resolvedValue;


### PR DESCRIPTION
## What?

`getResolvedValue` in `@wordpress/global-styles-engine` no longer writes the resolved theme-relative (`file:./…`) URL onto the object it resolved. It returns a copy instead.

## Why?

The object it writes to can be shared data. In the plain case it is the caller's own value. When a `ref` is resolved first, it is the tree's own object, and `mergeGlobalStyles` keeps `backgroundImage` leaves atomic (`userConfig ?? baseConfig`), so the merged tree aliases the user or theme config object. Writing the resolved absolute URL in place can turn a portable theme-relative pointer into a hardcoded site URL in data that gets saved.

The existing tests only passed in their current order for this reason: resolving a `ref` through `getResolvedValue` rewrote the shared fixture that the `getResolvedRefValue` tests assert against.

## How?

Build a new object for the resolved URL instead of assigning to `resolvedValue.url`. All callers use the return value; none depend on the argument being mutated.

## Testing Instructions

Covered by unit tests: resolving a plain `{ url }` value and a `ref` to one now leaves the input object and the tree untouched while returning the resolved URL.

```
npm run test:unit -- packages/global-styles-engine/src/test/utils.test.ts
```
