### PR TITLE
Post Title: Coalesce typing into a single undo level

### DIFF
--- a/packages/block-library/src/site-tagline/edit.jsx
+++ b/packages/block-library/src/site-tagline/edit.jsx
@@ -1,5 +1,5 @@
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import {
 	useBlockProps,
 	BlockControls,
@@ -15,33 +15,25 @@ export default function SiteTaglineEdit( props ) {
 
 	const { attributes, setAttributes, insertBlocksAfter } = props;
 	const { level, levelOptions } = attributes;
-	const { canUserEdit, tagline } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			tagline: canEdit
-				? settings?.description
-				: readOnlySettings?.description,
-		};
-	}, [] );
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
+	// Users who cannot edit the site settings cannot read them either, so the
+	// tagline comes from the base entity instead.
+	const [ tagline, setTagline ] = useEntityProp(
+		'root',
+		canUserEdit ? 'site' : '__unstableBase',
+		'description',
+		undefined,
+		{ coalesceEdits: true }
+	);
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
-	const { editEntityRecord } = useDispatch( coreStore );
-
-	function setTagline( newTagline ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			description: newTagline,
-		} );
-	}
-
 	const blockProps = useBlockProps( {
 		className:
 			! canUserEdit && ! tagline && 'wp-block-site-tagline__placeholder',

--- a/packages/block-library/src/site-title/edit.jsx
+++ b/packages/block-library/src/site-title/edit.jsx
@@ -1,5 +1,5 @@
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
@@ -22,31 +22,29 @@ export default function SiteTitleEdit( props ) {
 	useDeprecatedTextAlign( props );
 
 	const { attributes, setAttributes } = props;
-
 	const { level, levelOptions, isLink, linkTarget } = attributes;
-	const { canUserEdit, title } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			title: canEdit ? settings?.title : readOnlySettings?.name,
-		};
-	}, [] );
-	const { editEntityRecord } = useDispatch( coreStore );
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
+	// Users who cannot edit the site settings cannot read them either, so the
+	// title comes from the base entity instead.
+	const [ title, setSiteTitle ] = useEntityProp(
+		'root',
+		canUserEdit ? 'site' : '__unstableBase',
+		canUserEdit ? 'title' : 'name',
+		undefined,
+		{ coalesceEdits: true }
+	);
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const blockEditingMode = useBlockEditingMode();
 
 	function setTitle( newTitle ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			title: newTitle.trim(),
-		} );
+		setSiteTitle( newTitle.trim() );
 	}
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `useEntityProp`: Add a `coalesceEdits` option that merges consecutive edits into a single undo level, so typing into a text input no longer creates an undo level per keystroke ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+
 ### Internal
 
 -   Remove the template activation (`active_templates`) experiment: drop the `registeredTemplate` entity and the experiment-only `wp_template` endpoint rewrites and query params ([#82241](https://github.com/WordPress/gutenberg/pull/82241)).

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `useEntityProp`: Add a `coalesceEdits` option that merges consecutive edits into a single undo level, so typing into a text input no longer creates an undo level per keystroke ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `useEntityProp`: Add a `coalesceEdits` option that merges consecutive edits into a single undo level, so typing into a text input no longer creates an undo level per keystroke ([#82275](https://github.com/WordPress/gutenberg/pull/82275)).
 
 ### Internal
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1064,6 +1064,8 @@ _Parameters_
 -   _name_ `string`: The entity name.
 -   _prop_ `string`: The property name.
 -   _\_id_ `[number|string]`: An entity ID to use instead of the context-provided one.
+-   _options_ `[Object]`: Hook options.
+-   _options.coalesceEdits_ `[boolean]`: Whether to merge edits made less than a second apart into a single undo level. Use it for text inputs, so that typing does not create an undo level per keystroke.
 
 _Returns_
 

--- a/packages/core-data/src/hooks/test/use-entity-prop.jsdom.test.js
+++ b/packages/core-data/src/hooks/test/use-entity-prop.jsdom.test.js
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { store as coreDataStore } from '../../index';
+import useEntityProp from '../use-entity-prop';
+
+describe( 'useEntityProp', () => {
+	let registry;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		registry = createRegistry();
+		registry.register( coreDataStore );
+		// The site entity is loaded lazily in production, so register it here.
+		registry.dispatch( coreDataStore ).addEntities( [
+			{
+				kind: 'root',
+				name: 'site',
+				key: false,
+				baseURL: '/wp/v2/settings',
+			},
+		] );
+		registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'root', 'site', { title: 'My Site' } );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	/**
+	 * Renders the hook the way the Site Title block uses it, against the
+	 * keyless `root`/`site` entity.
+	 *
+	 * @param {Object} [options] Hook options.
+	 * @return {Object} The `renderHook` result.
+	 */
+	function mountSiteTitle( options ) {
+		const wrapper = ( { children } ) =>
+			createElement( RegistryProvider, { value: registry }, children );
+
+		const { result } = renderHook(
+			() => useEntityProp( 'root', 'site', 'title', undefined, options ),
+			{ wrapper }
+		);
+
+		return result;
+	}
+
+	/**
+	 * Appends the text one character at a time, as a `RichText` onChange would.
+	 *
+	 * @param {Object} result The `renderHook` result.
+	 * @param {string} text   The text to type.
+	 */
+	function type( result, text ) {
+		for ( const character of text ) {
+			act( () => {
+				const [ value, setValue ] = result.current;
+				setValue( value + character );
+			} );
+		}
+	}
+
+	const undo = () =>
+		act( () => {
+			registry.dispatch( coreDataStore ).undo();
+		} );
+
+	it( 'creates an undo level per edit by default', () => {
+		const result = mountSiteTitle();
+
+		type( result, ' Blog' );
+		expect( result.current[ 0 ] ).toBe( 'My Site Blog' );
+
+		// Each keystroke has to be undone on its own.
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site Blo' );
+	} );
+
+	it( 'merges consecutive edits into a single undo level when coalescing', () => {
+		const result = mountSiteTitle( { coalesceEdits: true } );
+
+		type( result, ' Blog' );
+		expect( result.current[ 0 ] ).toBe( 'My Site Blog' );
+
+		// A single undo discards the whole burst of typing.
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site' );
+	} );
+
+	it( 'starts a new undo level for an edit made after the timeout', () => {
+		const result = mountSiteTitle( { coalesceEdits: true } );
+
+		type( result, ' Blog' );
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		type( result, '!' );
+
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site Blog' );
+
+		undo();
+		expect( result.current[ 0 ] ).toBe( 'My Site' );
+	} );
+} );

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -1,19 +1,27 @@
-import { useCallback, useContext } from '@wordpress/element';
+import { useCallback, useContext, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { STORE_NAME } from '../name';
 import { DEFAULT_ENTITY_KEY } from '../entities';
 import { EntityContext } from '../entity-context';
 import useEntityId from './use-entity-id';
 
+// Matches the delay `useMarkPersistent` uses for block attributes.
+const COALESCE_TIMEOUT = 1000;
+
 /**
  * Hook that returns the value and a setter for the
  * specified property of the nearest provided
  * entity of the specified type.
  *
- * @param {string}        kind  The entity kind.
- * @param {string}        name  The entity name.
- * @param {string}        prop  The property name.
- * @param {number|string} [_id] An entity ID to use instead of the context-provided one.
+ * @param {string}        kind                    The entity kind.
+ * @param {string}        name                    The entity name.
+ * @param {string}        prop                    The property name.
+ * @param {number|string} [_id]                   An entity ID to use instead of the context-provided one.
+ * @param {Object}        [options]               Hook options.
+ * @param {boolean}       [options.coalesceEdits] Whether to merge edits made less than a second
+ *                                                apart into a single undo level. Use it for text
+ *                                                inputs, so that typing does not create an undo
+ *                                                level per keystroke.
  *
  * @return {[*, Function, *]} An array where the first item is the
  *                            property value, the second is the
@@ -22,7 +30,13 @@ import useEntityId from './use-entity-id';
  * 							  information like `raw`, `rendered` and
  * 							  `protected` props.
  */
-export default function useEntityProp( kind, name, prop, _id ) {
+export default function useEntityProp(
+	kind,
+	name,
+	prop,
+	_id,
+	{ coalesceEdits = false } = {}
+) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 	const context = useContext( EntityContext );
@@ -77,16 +91,30 @@ export default function useEntityProp( kind, name, prop, _id ) {
 		[ kind, name, id, prop, revisionId ]
 	);
 	const { editEntityRecord } = useDispatch( STORE_NAME );
+	const lastEditTimeRef = useRef( 0 );
 	const setValue = useCallback(
 		( newValue ) => {
 			if ( revisionId ) {
 				return;
 			}
-			editEntityRecord( kind, name, id, {
-				[ prop ]: newValue,
-			} );
+
+			const now = Date.now();
+			// A cached edit joins the previous edit's undo level instead of
+			// opening its own.
+			const isCached =
+				coalesceEdits &&
+				now - lastEditTimeRef.current < COALESCE_TIMEOUT;
+			lastEditTimeRef.current = now;
+
+			editEntityRecord(
+				kind,
+				name,
+				id,
+				{ [ prop ]: newValue },
+				{ isCached }
+			);
 		},
-		[ editEntityRecord, kind, name, id, prop, revisionId ]
+		[ editEntityRecord, kind, name, id, prop, revisionId, coalesceEdits ]
 	);
 
 	return [ value, setValue, fullValue ];

--- a/packages/editor/src/components/post-title/use-post-title.js
+++ b/packages/editor/src/components/post-title/use-post-title.js
@@ -1,4 +1,5 @@
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 
 /**
@@ -7,18 +8,22 @@ import { store as editorStore } from '../../store';
  * @return {Object} An object containing the current title and a function to update the title.
  */
 export default function usePostTitle() {
-	const { editPost } = useDispatch( editorStore );
-	const { title } = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( editorStore );
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
 
 		return {
-			title: getEditedPostAttribute( 'title' ),
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
 		};
 	}, [] );
 
-	function updateTitle( newTitle ) {
-		editPost( { title: newTitle } );
-	}
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		postType,
+		'title',
+		postId,
+		{ coalesceEdits: true }
+	);
 
-	return { title, setTitle: updateTitle };
+	return { title, setTitle };
 }

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -493,6 +493,9 @@ test.describe( 'undo', () => {
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.type( 'a' ); // First step.
+		// Title edits made less than a second apart share an undo level, so
+		// pause to give the backspace its own.
+		await editor.page.waitForTimeout( 1000 );
 		await page.keyboard.press( 'Backspace' ); // Second step.
 		await editor.canvas
 			.getByRole( 'document', { name: 'Add default block' } )


### PR DESCRIPTION
## What?
Alternative to #52375.
Builds on #82275.

PR refactors the editor's Post Title component to use `useEntityProp` with coalescing edits enabled, which improves how changes are undone, similar to Paragraph or Heading blocks.

## Testing Instructions
1. Open a post or page.
2. Type in the title field a couple of characters, then pause (at least 2s); repeat the step.
3. Undoing changes should undo them in chunks, instead of one character at a time.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.