### PR TITLE
DateTime tests: freeze the clock in the empty-value calendar test

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
@@ -221,7 +221,13 @@ describe( 'DateTime control', () => {
 
 		it( 'should start a datetime selected from the calendar at midnight', async () => {
 			setSiteOffset( -8 );
-			const user = userEvent.setup();
+			// Freeze the clock: with no value the calendar opens on the
+			// current month, and the day clicked below must be in it.
+			jest.useFakeTimers();
+			jest.setSystemTime( new Date( '2026-08-15T12:00:00.000Z' ) );
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 
 			render( <DateTimeHarness initialValue="" /> );
 


### PR DESCRIPTION
## What?

Freezes the clock in the DateTime control test that clicks a hardcoded calendar day with no initial value.

## Why?

With no value the calendar opens on the current month, so clicking "August 25, 2026" only worked while the real month was August 2026. The test fails on trunk since September 1, on every branch. Not a code regression.

## How?

`jest.useFakeTimers()` + `setSystemTime`, with the `advanceTimers` option user-event needs under fake timers. Same pattern as the neighboring "site's today" test.

## Testing Instructions

On Node 22+ (the suite skips on Node 20):

```
npm run test:unit -- packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
```
