### PR TITLE
Dropdown: Close popover for unrelated dialog-like overlays

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+-   `Dropdown`: Close the popover when focus moves to a dialog opened outside the dropdown ([#82284](https://github.com/WordPress/gutenberg/pull/82284)).
 -   `Snackbar`: Restart the auto-dismiss timer when a notice is recreated with the same ID during removal ([#81764](https://github.com/WordPress/gutenberg/pull/81764)).
 -   `ToolsPanel`: Stop a panel item whose `panelId` doesn't match the panel from writing its value into that panel's menu, which could leave an orphaned entry in the dropdown ([#82127](https://github.com/WordPress/gutenberg/pull/82127)).
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
--   `Dropdown`: Close the popover when focus moves to a dialog opened outside the dropdown ([#82284](https://github.com/WordPress/gutenberg/pull/82284)).
+-   `Dropdown`: Close the popover when focus moves to a dialog-like overlay opened outside the dropdown ([#82284](https://github.com/WordPress/gutenberg/pull/82284)).
 -   `Snackbar`: Restart the auto-dismiss timer when a notice is recreated with the same ID during removal ([#81764](https://github.com/WordPress/gutenberg/pull/81764)).
 -   `ToolsPanel`: Stop a panel item whose `panelId` doesn't match the panel from writing its value into that panel's menu, which could leave an orphaned entry in the dropdown ([#82127](https://github.com/WordPress/gutenberg/pull/82127)).
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -51,7 +51,10 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
-	const lastActivationWasInsideRef = useRef( false );
+	const activationWasInsideRef = useRef( false );
+	const dialogBeforeActivationRef = useRef< Element | null >( null );
+	const dialogOpenedByActivationRef = useRef< Element | null >( null );
+	const activationSequenceRef = useRef( 0 );
 
 	const [ isOpen, setIsOpen ] = useControlledValue( {
 		defaultValue: defaultOpen,
@@ -66,34 +69,80 @@ const UnconnectedDropdown = (
 
 		const { ownerDocument } = containerRef.current;
 		const activationEvents = [ 'pointerdown', 'keydown', 'click' ] as const;
-		const resetActivationOrigin = () => {
-			lastActivationWasInsideRef.current = false;
+		const getActiveDialog = () =>
+			ownerDocument.activeElement?.closest( '[role="dialog"]' ) ?? null;
+		const startActivation = () => {
+			activationSequenceRef.current += 1;
+			activationWasInsideRef.current = false;
+			dialogBeforeActivationRef.current = getActiveDialog();
+
+			if (
+				dialogOpenedByActivationRef.current !==
+				dialogBeforeActivationRef.current
+			) {
+				dialogOpenedByActivationRef.current = null;
+			}
+		};
+		const finishActivation = () => {
+			const sequence = activationSequenceRef.current;
+			const activationWasInside = activationWasInsideRef.current;
+			const dialogBeforeActivation = dialogBeforeActivationRef.current;
+			const recordOpenedDialog = () => {
+				if ( sequence !== activationSequenceRef.current ) {
+					return;
+				}
+
+				const activeDialog = getActiveDialog();
+				if ( ! activationWasInside ) {
+					dialogOpenedByActivationRef.current = null;
+				} else if ( activeDialog !== dialogBeforeActivation ) {
+					dialogOpenedByActivationRef.current = activeDialog;
+				} else if (
+					dialogOpenedByActivationRef.current !== activeDialog
+				) {
+					dialogOpenedByActivationRef.current = null;
+				}
+			};
+
+			recordOpenedDialog();
+
+			// Some dialogs move focus in a timer. Check once more on the next
+			// task, before Popover's delayed focus-outside check runs.
+			if (
+				activationWasInside &&
+				! dialogOpenedByActivationRef.current
+			) {
+				ownerDocument.defaultView?.setTimeout( recordOpenedDialog, 0 );
+			}
 		};
 
-		// Native document capture runs before the React capture handlers below.
-		// Events from portaled Popover content still follow the React tree, so
-		// those handlers can mark an activation as internal again.
+		// Native document capture runs before the React capture handlers below,
+		// while document bubble runs after them. Events from portaled Popover
+		// content still follow the React tree, so this records only dialogs that
+		// open during an activation from this Dropdown.
 		for ( const eventName of activationEvents ) {
-			ownerDocument.addEventListener(
-				eventName,
-				resetActivationOrigin,
-				true
-			);
+			ownerDocument.addEventListener( eventName, startActivation, true );
+			ownerDocument.addEventListener( eventName, finishActivation );
 		}
 
 		return () => {
+			activationSequenceRef.current += 1;
 			for ( const eventName of activationEvents ) {
 				ownerDocument.removeEventListener(
 					eventName,
-					resetActivationOrigin,
+					startActivation,
 					true
+				);
+				ownerDocument.removeEventListener(
+					eventName,
+					finishActivation
 				);
 			}
 		};
 	}, [ isOpen ] );
 
 	function recordActivationInside() {
-		lastActivationWasInsideRef.current = true;
+		activationWasInsideRef.current = true;
 	}
 
 	function recordKeyboardActivationInside(
@@ -119,11 +168,13 @@ const UnconnectedDropdown = (
 		const activeElement = ownerDocument?.activeElement;
 		const dialog = activeElement?.closest( '[role="dialog"]' );
 		const isParentDialog = dialog?.contains( containerRef.current );
+		const dialogOpenedByActivation = dialogOpenedByActivationRef.current;
+		dialogOpenedByActivationRef.current = null;
 		if (
 			! containerRef.current.contains( activeElement ) &&
 			( ! dialog ||
 				isParentDialog ||
-				! lastActivationWasInsideRef.current )
+				dialog !== dialogOpenedByActivation )
 		) {
 			close();
 		}

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -8,6 +8,14 @@ import { useControlledValue } from '../utils/hooks';
 import Popover from '../popover';
 import type { DropdownProps, DropdownInternalContext } from './types';
 
+type InternalActivation = {
+	sequence: number;
+	dialogsBefore: Map< Document, Element | null >;
+};
+
+const getActiveDialog = ( ownerDocument: Document ) =>
+	ownerDocument.activeElement?.closest( '[role="dialog"]' ) ?? null;
+
 const UnconnectedDropdown = (
 	props: DropdownProps,
 	forwardedRef: ForwardedRef< any >
@@ -51,9 +59,8 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
-	const activationWasInsideRef = useRef( false );
-	const dialogBeforeActivationRef = useRef< Element | null >( null );
 	const dialogOpenedByActivationRef = useRef< Element | null >( null );
+	const internalActivationRef = useRef< InternalActivation | null >( null );
 	const activationSequenceRef = useRef( 0 );
 
 	const [ isOpen, setIsOpen ] = useControlledValue( {
@@ -69,60 +76,21 @@ const UnconnectedDropdown = (
 
 		const { ownerDocument } = containerRef.current;
 		const activationEvents = [ 'pointerdown', 'keydown', 'click' ] as const;
-		const getActiveDialog = () =>
-			ownerDocument.activeElement?.closest( '[role="dialog"]' ) ?? null;
 		const startActivation = () => {
 			activationSequenceRef.current += 1;
-			activationWasInsideRef.current = false;
-			dialogBeforeActivationRef.current = getActiveDialog();
-
 			if (
 				dialogOpenedByActivationRef.current !==
-				dialogBeforeActivationRef.current
+				getActiveDialog( ownerDocument )
 			) {
 				dialogOpenedByActivationRef.current = null;
 			}
 		};
-		const finishActivation = () => {
-			const sequence = activationSequenceRef.current;
-			const activationWasInside = activationWasInsideRef.current;
-			const dialogBeforeActivation = dialogBeforeActivationRef.current;
-			const recordOpenedDialog = () => {
-				if ( sequence !== activationSequenceRef.current ) {
-					return;
-				}
 
-				const activeDialog = getActiveDialog();
-				if ( ! activationWasInside ) {
-					dialogOpenedByActivationRef.current = null;
-				} else if ( activeDialog !== dialogBeforeActivation ) {
-					dialogOpenedByActivationRef.current = activeDialog;
-				} else if (
-					dialogOpenedByActivationRef.current !== activeDialog
-				) {
-					dialogOpenedByActivationRef.current = null;
-				}
-			};
-
-			recordOpenedDialog();
-
-			// Some dialogs move focus in a timer. Check once more on the next
-			// task, before Popover's delayed focus-outside check runs.
-			if (
-				activationWasInside &&
-				! dialogOpenedByActivationRef.current
-			) {
-				ownerDocument.defaultView?.setTimeout( recordOpenedDialog, 0 );
-			}
-		};
-
-		// Native document capture runs before the React capture handlers below,
-		// while document bubble runs after them. Events from portaled Popover
-		// content still follow the React tree, so this records only dialogs that
-		// open during an activation from this Dropdown.
+		// Native document capture clears stale provenance before the React
+		// capture handlers below record an internal activation. Events from
+		// portaled Popover content still follow the React tree.
 		for ( const eventName of activationEvents ) {
 			ownerDocument.addEventListener( eventName, startActivation, true );
-			ownerDocument.addEventListener( eventName, finishActivation );
 		}
 
 		return () => {
@@ -133,24 +101,99 @@ const UnconnectedDropdown = (
 					startActivation,
 					true
 				);
-				ownerDocument.removeEventListener(
-					eventName,
-					finishActivation
-				);
 			}
 		};
 	}, [ isOpen ] );
 
-	function recordActivationInside() {
-		activationWasInsideRef.current = true;
+	function startInternalActivation(
+		event: React.SyntheticEvent< HTMLDivElement >
+	) {
+		if ( ! containerRef.current ) {
+			return;
+		}
+
+		const containerDocument = containerRef.current.ownerDocument;
+		const eventDocument = ( event.target as Node | null )?.ownerDocument;
+		const ownerDocuments = [ containerDocument ];
+		if ( eventDocument && eventDocument !== containerDocument ) {
+			ownerDocuments.push( eventDocument );
+		}
+
+		const sequence = ++activationSequenceRef.current;
+		internalActivationRef.current = {
+			sequence,
+			dialogsBefore: new Map(
+				ownerDocuments.map(
+					( ownerDocument ) =>
+						[
+							ownerDocument,
+							getActiveDialog( ownerDocument ),
+						] as const
+				)
+			),
+		};
+
+		const activeDialogIsKnown = ownerDocuments.some(
+			( ownerDocument ) =>
+				getActiveDialog( ownerDocument ) ===
+				dialogOpenedByActivationRef.current
+		);
+		if ( ! activeDialogIsKnown ) {
+			dialogOpenedByActivationRef.current = null;
+		}
+
+		// A target can stop propagation, so do not rely on the React bubble
+		// handler to finalize the activation. The second check supports dialogs
+		// that move focus in a timer before Popover checks focus outside.
+		containerDocument.defaultView?.setTimeout( () => {
+			if ( ! finishInternalActivation() ) {
+				containerDocument.defaultView?.setTimeout(
+					finishInternalActivation,
+					0
+				);
+			}
+		}, 0 );
 	}
 
-	function recordKeyboardActivationInside(
+	function startInternalKeyboardActivation(
 		event: React.KeyboardEvent< HTMLDivElement >
 	) {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
-			recordActivationInside();
+			startInternalActivation( event );
 		}
+	}
+
+	function finishInternalActivation() {
+		const activation = internalActivationRef.current;
+		if (
+			! activation ||
+			activation.sequence !== activationSequenceRef.current
+		) {
+			return false;
+		}
+
+		for ( const [
+			ownerDocument,
+			dialogBefore,
+		] of activation.dialogsBefore ) {
+			const activeDialog = getActiveDialog( ownerDocument );
+			if ( activeDialog && activeDialog !== dialogBefore ) {
+				dialogOpenedByActivationRef.current = activeDialog;
+				return true;
+			}
+		}
+
+		const knownDialogIsStillActive = [
+			...activation.dialogsBefore.keys(),
+		].some(
+			( ownerDocument ) =>
+				getActiveDialog( ownerDocument ) ===
+				dialogOpenedByActivationRef.current
+		);
+		if ( ! knownDialogIsStillActive ) {
+			dialogOpenedByActivationRef.current = null;
+		}
+		return knownDialogIsStillActive;
 	}
 
 	/**
@@ -170,11 +213,14 @@ const UnconnectedDropdown = (
 		const isParentDialog = dialog?.contains( containerRef.current );
 		const dialogOpenedByActivation = dialogOpenedByActivationRef.current;
 		dialogOpenedByActivationRef.current = null;
+		activationSequenceRef.current += 1;
+		const relatedDialogIsActive =
+			!! dialogOpenedByActivation &&
+			getActiveDialog( dialogOpenedByActivation.ownerDocument ) ===
+				dialogOpenedByActivation;
 		if (
 			! containerRef.current.contains( activeElement ) &&
-			( ! dialog ||
-				isParentDialog ||
-				dialog !== dialogOpenedByActivation )
+			( isParentDialog || ! relatedDialogIsActive )
 		) {
 			close();
 		}
@@ -201,9 +247,9 @@ const UnconnectedDropdown = (
 	return (
 		<div
 			className={ className }
-			onClickCapture={ recordActivationInside }
-			onPointerDownCapture={ recordActivationInside }
-			onKeyDownCapture={ recordKeyboardActivationInside }
+			onClickCapture={ startInternalActivation }
+			onPointerDownCapture={ startInternalActivation }
+			onKeyDownCapture={ startInternalKeyboardActivation }
 			ref={ useMergeRefs( [
 				containerRef,
 				forwardedRef,

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -8,8 +8,16 @@ import { useControlledValue } from '../utils/hooks';
 import Popover from '../popover';
 import type { DropdownProps, DropdownInternalContext } from './types';
 
-const getActiveDialog = ( ownerDocument: Document ) =>
-	ownerDocument.activeElement?.closest( '[role="dialog"]' ) ?? null;
+const OVERLAY_SELECTOR = [
+	'dialog',
+	'[role~="dialog" i]',
+	'[role~="alertdialog" i]',
+	'[aria-modal="true" i]',
+	'[popover]',
+].join( ',' );
+
+const getActiveOverlay = ( ownerDocument: Document ) =>
+	ownerDocument.activeElement?.closest( OVERLAY_SELECTOR ) ?? null;
 
 const UnconnectedDropdown = (
 	props: DropdownProps,
@@ -54,7 +62,7 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
-	const dialogOpenedByActivationRef = useRef< Element | null >( null );
+	const overlayOpenedByActivationRef = useRef< Element | null >( null );
 	const activationSequenceRef = useRef( 0 );
 
 	const [ isOpen, setIsOpen ] = useControlledValue( {
@@ -76,18 +84,18 @@ const UnconnectedDropdown = (
 		if ( eventDocument && eventDocument !== containerDocument ) {
 			ownerDocuments.push( eventDocument );
 		}
-		const dialogsBefore = ownerDocuments.map( getActiveDialog );
+		const overlaysBefore = ownerDocuments.map( getActiveOverlay );
 
 		const sequence = ++activationSequenceRef.current;
-		const recordOpenedDialog = () => {
+		const recordOpenedOverlay = () => {
 			if ( sequence !== activationSequenceRef.current ) {
 				return false;
 			}
 
 			for ( const [ index, ownerDocument ] of ownerDocuments.entries() ) {
-				const dialog = getActiveDialog( ownerDocument );
-				if ( dialog && dialog !== dialogsBefore[ index ] ) {
-					dialogOpenedByActivationRef.current = dialog;
+				const overlay = getActiveOverlay( ownerDocument );
+				if ( overlay && overlay !== overlaysBefore[ index ] ) {
+					overlayOpenedByActivationRef.current = overlay;
 					return true;
 				}
 			}
@@ -95,13 +103,14 @@ const UnconnectedDropdown = (
 			return false;
 		};
 
-		// Modal can move focus in a timer. Check once after the activation and
-		// once more after a deferred focus handoff. An unrelated dialog focused
-		// during this bounded window is indistinguishable and treated as related.
+		// An overlay can move focus in a timer. Check once after the activation
+		// and once more after a deferred focus handoff. An unrelated overlay
+		// focused during this bounded window is indistinguishable and treated as
+		// related.
 		containerDocument.defaultView?.setTimeout( () => {
-			if ( ! recordOpenedDialog() ) {
+			if ( ! recordOpenedOverlay() ) {
 				containerDocument.defaultView?.setTimeout(
-					recordOpenedDialog,
+					recordOpenedOverlay,
 					0
 				);
 			}
@@ -118,9 +127,9 @@ const UnconnectedDropdown = (
 
 	/**
 	 * Closes the popover when focus leaves it unless the toggle was pressed or
-	 * focus has moved to a dialog opened from the dropdown. The former lets the
-	 * toggle handle closing the popover. The latter preserves presence so focus
-	 * can return when the dialog is dismissed.
+	 * focus has moved to a dialog-like overlay opened from the dropdown. The
+	 * former lets the toggle handle closing the popover. The latter preserves
+	 * presence so focus can return when the overlay is dismissed.
 	 */
 	function closeIfFocusOutside() {
 		if ( ! containerRef.current ) {
@@ -129,19 +138,18 @@ const UnconnectedDropdown = (
 
 		const { ownerDocument } = containerRef.current;
 		const activeElement = ownerDocument?.activeElement;
-		const dialog = activeElement?.closest( '[role="dialog"]' );
-		const isParentDialog = dialog?.contains( containerRef.current );
-		const dialogOpenedByActivation = dialogOpenedByActivationRef.current;
-		dialogOpenedByActivationRef.current = null;
+		const overlay = activeElement?.closest( OVERLAY_SELECTOR );
+		const isParentOverlay = overlay?.contains( containerRef.current );
+		const overlayOpenedByActivation = overlayOpenedByActivationRef.current;
+		overlayOpenedByActivationRef.current = null;
 		activationSequenceRef.current += 1;
-		const relatedDialogIsActive =
-			!! dialogOpenedByActivation &&
-			dialogOpenedByActivation.ownerDocument.activeElement?.closest(
-				'[role="dialog"]'
-			) === dialogOpenedByActivation;
+		const relatedOverlayIsActive =
+			!! overlayOpenedByActivation &&
+			getActiveOverlay( overlayOpenedByActivation.ownerDocument ) ===
+				overlayOpenedByActivation;
 		if (
 			! containerRef.current.contains( activeElement ) &&
-			( isParentDialog || ! relatedDialogIsActive )
+			( isParentOverlay || ! relatedOverlayIsActive )
 		) {
 			close();
 		}

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -1,17 +1,12 @@
 import clsx from 'clsx';
 import type { ForwardedRef } from 'react';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
 import { contextConnect, useContextSystem } from '../context';
 import { useControlledValue } from '../utils/hooks';
 import Popover from '../popover';
 import type { DropdownProps, DropdownInternalContext } from './types';
-
-type InternalActivation = {
-	sequence: number;
-	dialogsBefore: Map< Document, Element | null >;
-};
 
 const getActiveDialog = ( ownerDocument: Document ) =>
 	ownerDocument.activeElement?.closest( '[role="dialog"]' ) ?? null;
@@ -60,7 +55,6 @@ const UnconnectedDropdown = (
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const dialogOpenedByActivationRef = useRef< Element | null >( null );
-	const internalActivationRef = useRef< InternalActivation | null >( null );
 	const activationSequenceRef = useRef( 0 );
 
 	const [ isOpen, setIsOpen ] = useControlledValue( {
@@ -69,43 +63,7 @@ const UnconnectedDropdown = (
 		onChange: onToggle,
 	} );
 
-	useEffect( () => {
-		if ( ! isOpen || ! containerRef.current ) {
-			return;
-		}
-
-		const { ownerDocument } = containerRef.current;
-		const activationEvents = [ 'pointerdown', 'keydown', 'click' ] as const;
-		const startActivation = () => {
-			activationSequenceRef.current += 1;
-			if (
-				dialogOpenedByActivationRef.current !==
-				getActiveDialog( ownerDocument )
-			) {
-				dialogOpenedByActivationRef.current = null;
-			}
-		};
-
-		// Native document capture clears stale provenance before the React
-		// capture handlers below record an internal activation. Events from
-		// portaled Popover content still follow the React tree.
-		for ( const eventName of activationEvents ) {
-			ownerDocument.addEventListener( eventName, startActivation, true );
-		}
-
-		return () => {
-			activationSequenceRef.current += 1;
-			for ( const eventName of activationEvents ) {
-				ownerDocument.removeEventListener(
-					eventName,
-					startActivation,
-					true
-				);
-			}
-		};
-	}, [ isOpen ] );
-
-	function startInternalActivation(
+	function recordActivationInside(
 		event: React.SyntheticEvent< HTMLDivElement >
 	) {
 		if ( ! containerRef.current ) {
@@ -118,82 +76,44 @@ const UnconnectedDropdown = (
 		if ( eventDocument && eventDocument !== containerDocument ) {
 			ownerDocuments.push( eventDocument );
 		}
+		const dialogsBefore = ownerDocuments.map( getActiveDialog );
 
 		const sequence = ++activationSequenceRef.current;
-		internalActivationRef.current = {
-			sequence,
-			dialogsBefore: new Map(
-				ownerDocuments.map(
-					( ownerDocument ) =>
-						[
-							ownerDocument,
-							getActiveDialog( ownerDocument ),
-						] as const
-				)
-			),
+		const recordOpenedDialog = () => {
+			if ( sequence !== activationSequenceRef.current ) {
+				return false;
+			}
+
+			for ( const [ index, ownerDocument ] of ownerDocuments.entries() ) {
+				const dialog = getActiveDialog( ownerDocument );
+				if ( dialog && dialog !== dialogsBefore[ index ] ) {
+					dialogOpenedByActivationRef.current = dialog;
+					return true;
+				}
+			}
+
+			return false;
 		};
 
-		const activeDialogIsKnown = ownerDocuments.some(
-			( ownerDocument ) =>
-				getActiveDialog( ownerDocument ) ===
-				dialogOpenedByActivationRef.current
-		);
-		if ( ! activeDialogIsKnown ) {
-			dialogOpenedByActivationRef.current = null;
-		}
-
-		// A target can stop propagation, so do not rely on the React bubble
-		// handler to finalize the activation. The second check supports dialogs
-		// that move focus in a timer before Popover checks focus outside.
+		// Modal can move focus in a timer. Check once after the activation and
+		// once more after a deferred focus handoff. An unrelated dialog focused
+		// during this bounded window is indistinguishable and treated as related.
 		containerDocument.defaultView?.setTimeout( () => {
-			if ( ! finishInternalActivation() ) {
+			if ( ! recordOpenedDialog() ) {
 				containerDocument.defaultView?.setTimeout(
-					finishInternalActivation,
+					recordOpenedDialog,
 					0
 				);
 			}
 		}, 0 );
 	}
 
-	function startInternalKeyboardActivation(
+	function recordKeyboardActivationInside(
 		event: React.KeyboardEvent< HTMLDivElement >
 	) {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
-			startInternalActivation( event );
+			recordActivationInside( event );
 		}
-	}
-
-	function finishInternalActivation() {
-		const activation = internalActivationRef.current;
-		if (
-			! activation ||
-			activation.sequence !== activationSequenceRef.current
-		) {
-			return false;
-		}
-
-		for ( const [
-			ownerDocument,
-			dialogBefore,
-		] of activation.dialogsBefore ) {
-			const activeDialog = getActiveDialog( ownerDocument );
-			if ( activeDialog && activeDialog !== dialogBefore ) {
-				dialogOpenedByActivationRef.current = activeDialog;
-				return true;
-			}
-		}
-
-		const knownDialogIsStillActive = [
-			...activation.dialogsBefore.keys(),
-		].some(
-			( ownerDocument ) =>
-				getActiveDialog( ownerDocument ) ===
-				dialogOpenedByActivationRef.current
-		);
-		if ( ! knownDialogIsStillActive ) {
-			dialogOpenedByActivationRef.current = null;
-		}
-		return knownDialogIsStillActive;
 	}
 
 	/**
@@ -216,8 +136,9 @@ const UnconnectedDropdown = (
 		activationSequenceRef.current += 1;
 		const relatedDialogIsActive =
 			!! dialogOpenedByActivation &&
-			getActiveDialog( dialogOpenedByActivation.ownerDocument ) ===
-				dialogOpenedByActivation;
+			dialogOpenedByActivation.ownerDocument.activeElement?.closest(
+				'[role="dialog"]'
+			) === dialogOpenedByActivation;
 		if (
 			! containerRef.current.contains( activeElement ) &&
 			( isParentDialog || ! relatedDialogIsActive )
@@ -247,9 +168,9 @@ const UnconnectedDropdown = (
 	return (
 		<div
 			className={ className }
-			onClickCapture={ startInternalActivation }
-			onPointerDownCapture={ startInternalActivation }
-			onKeyDownCapture={ startInternalKeyboardActivation }
+			onClickCapture={ recordActivationInside }
+			onPointerDownCapture={ recordActivationInside }
+			onKeyDownCapture={ recordKeyboardActivationInside }
 			ref={ useMergeRefs( [
 				containerRef,
 				forwardedRef,

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import type { ForwardedRef } from 'react';
-import { useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
 import { contextConnect, useContextSystem } from '../context';
@@ -51,6 +51,7 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
+	const lastActivationWasInsideRef = useRef( false );
 
 	const [ isOpen, setIsOpen ] = useControlledValue( {
 		defaultValue: defaultOpen,
@@ -58,11 +59,56 @@ const UnconnectedDropdown = (
 		onChange: onToggle,
 	} );
 
+	useEffect( () => {
+		if ( ! isOpen || ! containerRef.current ) {
+			return;
+		}
+
+		const { ownerDocument } = containerRef.current;
+		const activationEvents = [ 'pointerdown', 'keydown', 'click' ] as const;
+		const resetActivationOrigin = () => {
+			lastActivationWasInsideRef.current = false;
+		};
+
+		// Native document capture runs before the React capture handlers below.
+		// Events from portaled Popover content still follow the React tree, so
+		// those handlers can mark an activation as internal again.
+		for ( const eventName of activationEvents ) {
+			ownerDocument.addEventListener(
+				eventName,
+				resetActivationOrigin,
+				true
+			);
+		}
+
+		return () => {
+			for ( const eventName of activationEvents ) {
+				ownerDocument.removeEventListener(
+					eventName,
+					resetActivationOrigin,
+					true
+				);
+			}
+		};
+	}, [ isOpen ] );
+
+	function recordActivationInside() {
+		lastActivationWasInsideRef.current = true;
+	}
+
+	function recordKeyboardActivationInside(
+		event: React.KeyboardEvent< HTMLDivElement >
+	) {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			recordActivationInside();
+		}
+	}
+
 	/**
 	 * Closes the popover when focus leaves it unless the toggle was pressed or
-	 * focus has moved to a separate dialog. The former is to let the toggle
-	 * handle closing the popover and the latter is to preserve presence in
-	 * case a dialog has opened, allowing focus to return when it's dismissed.
+	 * focus has moved to a dialog opened from the dropdown. The former lets the
+	 * toggle handle closing the popover. The latter preserves presence so focus
+	 * can return when the dialog is dismissed.
 	 */
 	function closeIfFocusOutside() {
 		if ( ! containerRef.current ) {
@@ -70,11 +116,14 @@ const UnconnectedDropdown = (
 		}
 
 		const { ownerDocument } = containerRef.current;
-		const dialog =
-			ownerDocument?.activeElement?.closest( '[role="dialog"]' );
+		const activeElement = ownerDocument?.activeElement;
+		const dialog = activeElement?.closest( '[role="dialog"]' );
+		const isParentDialog = dialog?.contains( containerRef.current );
 		if (
-			! containerRef.current.contains( ownerDocument.activeElement ) &&
-			( ! dialog || dialog.contains( containerRef.current ) )
+			! containerRef.current.contains( activeElement ) &&
+			( ! dialog ||
+				isParentDialog ||
+				! lastActivationWasInsideRef.current )
 		) {
 			close();
 		}
@@ -101,6 +150,9 @@ const UnconnectedDropdown = (
 	return (
 		<div
 			className={ className }
+			onClickCapture={ recordActivationInside }
+			onPointerDownCapture={ recordActivationInside }
+			onKeyDownCapture={ recordKeyboardActivationInside }
 			ref={ useMergeRefs( [
 				containerRef,
 				forwardedRef,

--- a/packages/components/src/dropdown/test/index.jsdom.test.tsx
+++ b/packages/components/src/dropdown/test/index.jsdom.test.tsx
@@ -354,6 +354,48 @@ describe( 'Dropdown', () => {
 		}
 	} );
 
+	it( 'should stay open when an iframe dropdown opens a dialog in the parent document', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const mountNode = iframe.contentDocument!.createElement( 'div' );
+		iframe.contentDocument!.body.appendChild( mountNode );
+		let unmount: () => void = () => undefined;
+
+		try {
+			( { unmount } = render(
+				<DropdownWithModal
+					dialogTriggerLocation="inside"
+					onClose={ onClose }
+				/>,
+				{ container: mountNode }
+			) );
+			await user.click(
+				within( iframe.contentDocument!.body ).getByRole( 'button', {
+					name: 'Toggle',
+				} )
+			);
+			await user.click(
+				await screen.findByRole( 'button', {
+					name: 'Open dialog',
+				} )
+			);
+
+			await screen.findByRole( 'dialog', { name: 'Dialog' } );
+			await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+			expect(
+				within( iframe.contentDocument!.body ).getByRole( 'button', {
+					name: 'Toggle',
+					hidden: true,
+				} )
+			).toHaveAttribute( 'aria-expanded', 'true' );
+		} finally {
+			unmount();
+			iframe.remove();
+		}
+	} );
+
 	it( 'should not reuse a stale internal activation for an unrelated dialog', async () => {
 		const user = userEvent.setup();
 		const onClose = jest.fn();

--- a/packages/components/src/dropdown/test/index.jsdom.test.tsx
+++ b/packages/components/src/dropdown/test/index.jsdom.test.tsx
@@ -1,6 +1,12 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useState } from '@wordpress/element';
+import { createPortal, useState } from '@wordpress/element';
 import Dropdown from '..';
 import Modal from '../../modal';
 import { DropdownContentWrapper } from '../dropdown-content-wrapper';
@@ -9,13 +15,24 @@ import styles from '../style.module.scss';
 const DropdownWithModal = ( {
 	dialogTriggerLocation,
 	onClose,
+	stopDialogTriggerPropagation = false,
 }: {
 	dialogTriggerLocation: 'inside' | 'outside';
 	onClose?: () => void;
+	stopDialogTriggerPropagation?: boolean;
 } ) => {
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 	const dialogTrigger = (
-		<button onClick={ () => setIsDialogOpen( true ) }>Open dialog</button>
+		<button
+			onClick={ ( event ) => {
+				if ( stopDialogTriggerPropagation ) {
+					event.stopPropagation();
+				}
+				setIsDialogOpen( true );
+			} }
+		>
+			Open dialog
+		</button>
 	);
 
 	return (
@@ -74,6 +91,45 @@ const DropdownWithProgrammaticModal = ( {
 		) }
 	</>
 );
+
+const DropdownWithPortaledModalTrigger = ( {
+	portalContainer,
+	onClose,
+}: {
+	portalContainer: Element;
+	onClose: () => void;
+} ) => {
+	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
+
+	return (
+		<>
+			<Dropdown
+				onClose={ onClose }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<button aria-expanded={ isOpen } onClick={ onToggle }>
+						Toggle
+					</button>
+				) }
+				renderContent={ () =>
+					createPortal(
+						<button onClick={ () => setIsDialogOpen( true ) }>
+							Open portaled dialog
+						</button>,
+						portalContainer
+					)
+				}
+			/>
+			{ isDialogOpen && (
+				<Modal
+					title="Portaled dialog"
+					onRequestClose={ () => setIsDialogOpen( false ) }
+				>
+					<p>Portaled dialog content</p>
+				</Modal>
+			) }
+		</>
+	);
+};
 
 describe( 'DropdownContentWrapper', () => {
 	it( 'should apply the small padding class by default', () => {
@@ -235,6 +291,67 @@ describe( 'Dropdown', () => {
 		);
 		expect( dialogTrigger ).toHaveFocus();
 		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should stay open when a propagation-stopping trigger opens its dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render(
+			<DropdownWithModal
+				dialogTriggerLocation="inside"
+				onClose={ onClose }
+				stopDialogTriggerPropagation
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dialogTrigger = await screen.findByRole( 'button', {
+			name: 'Open dialog',
+		} );
+		await user.click( dialogTrigger );
+
+		await screen.findByRole( 'dialog', { name: 'Dialog' } );
+		await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+		expect(
+			screen.getByRole( 'button', { name: 'Toggle', hidden: true } )
+		).toHaveAttribute( 'aria-expanded', 'true' );
+	} );
+
+	it( 'should stay open when a portaled trigger opens its dialog from another document', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		let unmount: () => void = () => undefined;
+
+		try {
+			( { unmount } = render(
+				<DropdownWithPortaledModalTrigger
+					portalContainer={ iframe.contentDocument!.body }
+					onClose={ onClose }
+				/>
+			) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle' } )
+			);
+			await user.click(
+				within( iframe.contentDocument!.body ).getByRole( 'button', {
+					name: 'Open portaled dialog',
+				} )
+			);
+
+			await screen.findByRole( 'dialog', { name: 'Portaled dialog' } );
+			await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Toggle',
+					hidden: true,
+				} )
+			).toHaveAttribute( 'aria-expanded', 'true' );
+		} finally {
+			unmount();
+			iframe.remove();
+		}
 	} );
 
 	it( 'should not reuse a stale internal activation for an unrelated dialog', async () => {

--- a/packages/components/src/dropdown/test/index.jsdom.test.tsx
+++ b/packages/components/src/dropdown/test/index.jsdom.test.tsx
@@ -13,10 +13,12 @@ import { DropdownContentWrapper } from '../dropdown-content-wrapper';
 import styles from '../style.module.scss';
 
 const DropdownWithModal = ( {
+	dialogRole = 'dialog',
 	dialogTriggerLocation,
 	onClose,
 	stopDialogTriggerPropagation = false,
 }: {
+	dialogRole?: 'dialog' | 'alertdialog';
 	dialogTriggerLocation: 'inside' | 'outside';
 	onClose?: () => void;
 	stopDialogTriggerPropagation?: boolean;
@@ -54,11 +56,61 @@ const DropdownWithModal = ( {
 			{ dialogTriggerLocation === 'outside' && dialogTrigger }
 			{ isDialogOpen && (
 				<Modal
+					role={ dialogRole }
 					title="Dialog"
 					onRequestClose={ () => setIsDialogOpen( false ) }
 				>
 					<p>Dialog content</p>
 				</Modal>
+			) }
+		</>
+	);
+};
+
+const DropdownWithSemanticOverlay = ( {
+	overlayType,
+	onClose,
+}: {
+	overlayType: 'native-dialog' | 'native-popover' | 'aria-modal';
+	onClose: () => void;
+} ) => {
+	const [ isOverlayOpen, setIsOverlayOpen ] = useState( false );
+	const overlayContent = (
+		<button ref={ ( element ) => element?.focus() }>Overlay item</button>
+	);
+
+	return (
+		<>
+			<Dropdown
+				onClose={ onClose }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<button aria-expanded={ isOpen } onClick={ onToggle }>
+						Toggle
+					</button>
+				) }
+				renderContent={ () => (
+					<>
+						<button>Dropdown item</button>
+						<button onClick={ () => setIsOverlayOpen( true ) }>
+							Open overlay
+						</button>
+					</>
+				) }
+			/>
+			{ isOverlayOpen && overlayType === 'native-dialog' && (
+				<dialog open>{ overlayContent }</dialog>
+			) }
+			{ isOverlayOpen && overlayType === 'native-popover' && (
+				<div
+					ref={ ( element ) =>
+						element?.setAttribute( 'popover', 'manual' )
+					}
+				>
+					{ overlayContent }
+				</div>
+			) }
+			{ isOverlayOpen && overlayType === 'aria-modal' && (
+				<div aria-modal="true">{ overlayContent }</div>
 			) }
 		</>
 	);
@@ -292,6 +344,66 @@ describe( 'Dropdown', () => {
 		expect( dialogTrigger ).toHaveFocus();
 		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
 	} );
+
+	it( 'should stay open and restore focus when its alert dialog closes', async () => {
+		const user = userEvent.setup();
+		render(
+			<DropdownWithModal
+				dialogRole="alertdialog"
+				dialogTriggerLocation="inside"
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dialogTrigger = await screen.findByRole( 'button', {
+			name: 'Open dialog',
+		} );
+		await user.click( dialogTrigger );
+
+		await screen.findByRole( 'alertdialog' );
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'alertdialog' )
+			).not.toBeInTheDocument()
+		);
+		expect( dialogTrigger ).toHaveFocus();
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+	} );
+
+	it.each( [
+		[ 'native dialog', 'native-dialog' ],
+		[ 'native popover', 'native-popover' ],
+		[ 'ARIA modal', 'aria-modal' ],
+	] as const )(
+		'should stay open when its %s receives focus',
+		async ( _label, overlayType ) => {
+			const user = userEvent.setup();
+			const onClose = jest.fn();
+			render(
+				<DropdownWithSemanticOverlay
+					overlayType={ overlayType }
+					onClose={ onClose }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle' } )
+			);
+			await user.click(
+				await screen.findByRole( 'button', {
+					name: 'Open overlay',
+				} )
+			);
+
+			await screen.findByRole( 'button', { name: 'Overlay item' } );
+			await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+			expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+		}
+	);
 
 	it( 'should stay open when a propagation-stopping trigger opens its dialog', async () => {
 		const user = userEvent.setup();

--- a/packages/components/src/dropdown/test/index.jsdom.test.tsx
+++ b/packages/components/src/dropdown/test/index.jsdom.test.tsx
@@ -47,6 +47,34 @@ const DropdownWithModal = ( {
 	);
 };
 
+const DropdownWithProgrammaticModal = ( {
+	isDialogOpen,
+	onClose,
+}: {
+	isDialogOpen: boolean;
+	onClose: () => void;
+} ) => (
+	<>
+		<Dropdown
+			onClose={ onClose }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<button aria-expanded={ isOpen } onClick={ onToggle }>
+					Toggle
+				</button>
+			) }
+			renderContent={ () => <button>Dropdown item</button> }
+		/>
+		{ isDialogOpen && (
+			<Modal
+				title="Programmatic dialog"
+				onRequestClose={ () => undefined }
+			>
+				<p>Programmatic dialog content</p>
+			</Modal>
+		) }
+	</>
+);
+
 describe( 'DropdownContentWrapper', () => {
 	it( 'should apply the small padding class by default', () => {
 		render(
@@ -207,6 +235,74 @@ describe( 'Dropdown', () => {
 		);
 		expect( dialogTrigger ).toHaveFocus();
 		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not reuse a stale internal activation for an unrelated dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const { rerender } = render(
+			<DropdownWithProgrammaticModal
+				isDialogOpen={ false }
+				onClose={ onClose }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		await user.click(
+			await screen.findByRole( 'button', { name: 'Dropdown item' } )
+		);
+		rerender(
+			<DropdownWithProgrammaticModal isDialogOpen onClose={ onClose } />
+		);
+
+		await screen.findByRole( 'dialog', { name: 'Programmatic dialog' } );
+		await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.queryByText( 'Dropdown item' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should close when an iframe activation opens an unrelated dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const { rerender } = render(
+			<DropdownWithProgrammaticModal
+				isDialogOpen={ false }
+				onClose={ onClose }
+			/>
+		);
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+
+		try {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle' } )
+			);
+			await user.click(
+				await screen.findByRole( 'button', { name: 'Dropdown item' } )
+			);
+
+			const iframeButton =
+				iframe.contentDocument!.createElement( 'button' );
+			iframeButton.addEventListener( 'click', () => {
+				rerender(
+					<DropdownWithProgrammaticModal
+						isDialogOpen
+						onClose={ onClose }
+					/>
+				);
+			} );
+			iframe.contentDocument!.body.appendChild( iframeButton );
+			fireEvent.click( iframeButton );
+
+			await screen.findByRole( 'dialog', {
+				name: 'Programmatic dialog',
+			} );
+			await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+			expect(
+				screen.queryByText( 'Dropdown item' )
+			).not.toBeInTheDocument();
+		} finally {
+			iframe.remove();
+		}
 	} );
 
 	it( 'should close when focus moves into an unrelated dialog', async () => {

--- a/packages/components/src/dropdown/test/index.jsdom.test.tsx
+++ b/packages/components/src/dropdown/test/index.jsdom.test.tsx
@@ -1,8 +1,51 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from '@wordpress/element';
 import Dropdown from '..';
+import Modal from '../../modal';
 import { DropdownContentWrapper } from '../dropdown-content-wrapper';
 import styles from '../style.module.scss';
+
+const DropdownWithModal = ( {
+	dialogTriggerLocation,
+	onClose,
+}: {
+	dialogTriggerLocation: 'inside' | 'outside';
+	onClose?: () => void;
+} ) => {
+	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
+	const dialogTrigger = (
+		<button onClick={ () => setIsDialogOpen( true ) }>Open dialog</button>
+	);
+
+	return (
+		<>
+			<Dropdown
+				onClose={ onClose }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<button aria-expanded={ isOpen } onClick={ onToggle }>
+						Toggle
+					</button>
+				) }
+				renderContent={ () => (
+					<>
+						<button>Dropdown item</button>
+						{ dialogTriggerLocation === 'inside' && dialogTrigger }
+					</>
+				) }
+			/>
+			{ dialogTriggerLocation === 'outside' && dialogTrigger }
+			{ isDialogOpen && (
+				<Modal
+					title="Dialog"
+					onRequestClose={ () => setIsDialogOpen( false ) }
+				>
+					<p>Dialog content</p>
+				</Modal>
+			) }
+		</>
+	);
+};
 
 describe( 'DropdownContentWrapper', () => {
 	it( 'should apply the small padding class by default', () => {
@@ -122,5 +165,85 @@ describe( 'Dropdown', () => {
 		await user.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( screen.queryByText( 'test' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should close when a dialog opens after an outside activation', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render(
+			<DropdownWithModal
+				dialogTriggerLocation="outside"
+				onClose={ onClose }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		await screen.findByRole( 'button', { name: 'Dropdown item' } );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open dialog' } )
+		);
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.queryByText( 'Dropdown item' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should stay open and restore focus when its dialog closes', async () => {
+		const user = userEvent.setup();
+		render( <DropdownWithModal dialogTriggerLocation="inside" /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dialogTrigger = await screen.findByRole( 'button', {
+			name: 'Open dialog',
+		} );
+		await user.click( dialogTrigger );
+
+		await screen.findByRole( 'dialog' );
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await waitFor( () =>
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+		);
+		expect( dialogTrigger ).toHaveFocus();
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should close when focus moves into an unrelated dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render(
+			<>
+				<div role="dialog" aria-label="Existing dialog">
+					<button>Existing dialog item</button>
+				</div>
+				<Dropdown
+					onClose={ onClose }
+					popoverProps={ { constrainTabbing: false } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<button aria-expanded={ isOpen } onClick={ onToggle }>
+							Toggle
+						</button>
+					) }
+					renderContent={ () => <button>Dropdown item</button> }
+				/>
+			</>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dropdownItem = await screen.findByRole( 'button', {
+			name: 'Dropdown item',
+		} );
+		dropdownItem.focus();
+		expect( dropdownItem ).toHaveFocus();
+		fireEvent.keyDown( dropdownItem, { key: 'Tab' } );
+		const existingDialogItem = screen.getByRole( 'button', {
+			name: 'Existing dialog item',
+		} );
+		existingDialogItem.focus();
+
+		expect( existingDialogItem ).toHaveFocus();
+		await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.queryByText( 'Dropdown item' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Closes #82124.

Continues #82170. Thanks to @wprashed for the original investigation and implementation.

## What?

Closes a `Dropdown` when focus moves into a dialog-like overlay opened from outside that dropdown. Overlays opened from the dropdown still preserve it so focus can return after the overlay closes.

## Why?

`Dropdown` delays its focus-outside check. If an unrelated action opens and focuses an overlay before that check runs, the dropdown treated the overlay as related and stayed mounted behind it.

## How?

Captures the active overlays in both the dropdown container's document and the activation target's document. It recognizes native `<dialog>` and popover elements, ARIA `dialog` and `alertdialog` roles, and `aria-modal="true"`, without relying on library-specific attributes.

<details>
<summary>Implementation trade-off</summary>

An unrelated overlay that gains focus during the same bounded handoff window is indistinguishable from one opened by the dropdown and would be treated as related. Attribution ends after two checks, so later unrelated overlays still close the dropdown.

The overlay must move focus into an element with one of the recognized platform or ARIA markers during that window. Other popup patterns continue to use `Popover`'s normal nested-overlay handling.

</details>

## Testing Instructions

1. Insert a Custom HTML block with content such as `<h1>Test</h1>`.
2. Open the block switcher in the block toolbar.
3. While the "Transform to" popover is open, click "Edit code".
4. Confirm that the modal opens and the "Transform to" popover closes.
5. Open the editor Options menu and select "Preferences".
6. Close the Preferences modal and confirm that the Options menu returns with focus on the control that opened the modal.

### Testing Instructions for Keyboard

1. Use the keyboard to open the editor Options menu.
2. Move to "Preferences" and press Enter.
3. Press Escape to close the modal.
4. Confirm that the Options menu returns and focus returns to "Preferences".

### Screencast

https://github.com/user-attachments/assets/e48c9af6-a22c-4f28-a3d5-4815af12be34

## Use of AI Tools

Codex was used to port the original change, address the existing review feedback, simplify the implementation, run adversarial self-review, and add regression tests. I reviewed the final diff and test results.
