### PR TITLE
Writing flow: fix keyboard trap in preview mode when focus capture elements are absent

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Writing flow: Guard `preventScrollOnTab` against the focus capture elements being absent, matching the existing bail in the Tab keydown handler. In preview mode (e.g. the Visual revisions view) those elements are omitted, so Shift+Tab out of the first tabbable element in the canvas threw and was cancelled, trapping keyboard focus inside the iframe.
 -   Block List Appender: Show the appender button as a drop target when dragging a block over an empty container such as a Column, restoring the reveal that the `visibility`-to-`opacity` migration left behind ([#77852](https://github.com/WordPress/gutenberg/pull/77852)).
 -   Inserter: Keep the hovered block preview inside the viewport, so a tall preview in a short window is no longer clipped ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   Element styles: Register each block's element-style CSS override with the block's `clientId`, so the editor orders them by block position instead of registration order. A parent's link color re-registered after a child's (e.g. by resetting and re-picking it) no longer overrides the child's own link color in the canvas ([#77833](https://github.com/WordPress/gutenberg/pull/77833)).

--- a/packages/block-editor/src/components/writing-flow/test/index.jsdom.test.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.jsdom.test.js
@@ -1,5 +1,16 @@
-import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { UP, DOWN, LEFT, RIGHT, TAB } from '@wordpress/keycodes';
 import { isNavigationCandidate } from '../use-arrow-nav';
+import useTabNav from '../use-tab-nav';
+import { lock } from '../../../lock-unlock';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: jest.fn(),
+} ) );
 
 describe( 'isNavigationCandidate', () => {
 	let elements;
@@ -89,5 +100,78 @@ describe( 'isNavigationCandidate', () => {
 
 			expect( result ).toBe( true );
 		} );
+	} );
+} );
+
+describe( 'useTabNav', () => {
+	// `useTabNav` reads the block editor store selectors and actions through
+	// `unlock()`, so the mocked hook return values have to be locked objects.
+	const toLocked = ( privateData ) => {
+		const object = {};
+		lock( object, privateData );
+		return object;
+	};
+
+	const defaultUseSelectValues = {
+		hasMultiSelection: () => false,
+		getSelectedBlockClientId: () => null,
+		getBlockCount: () => 0,
+		getBlockOrder: () => [],
+		getLastFocus: () => null,
+		getSectionRootClientId: () => null,
+		isZoomOut: () => false,
+	};
+
+	beforeEach( () => {
+		useSelect.mockImplementation( () =>
+			toLocked( defaultUseSelectValues )
+		);
+		useDispatch.mockImplementation( () =>
+			toLocked( { setLastFocus: () => {} } )
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// The focus capture elements (`before`/`after`) are omitted in preview mode
+	// to avoid silent tab stops, so both refs are undefined. Rendering only the
+	// writing flow container (without `before`/`after`) reproduces that state.
+	// `createElement` rather than JSX keeps this a `.js` test file.
+	function PreviewModeWritingFlow() {
+		const [ , ref ] = useTabNav();
+		return createElement(
+			'div',
+			{ ref },
+			createElement( 'button', { type: 'button' }, 'First tabbable' )
+		);
+	}
+
+	it( 'does not trap focus when the focus capture elements are absent', () => {
+		render( createElement( PreviewModeWritingFlow ) );
+
+		const button = screen.getByRole( 'button', { name: 'First tabbable' } );
+		button.focus();
+
+		const errorListener = jest.fn();
+		window.addEventListener( 'error', errorListener );
+
+		// Shift+Tab from the first (and only) tabbable element: `findPrevious`
+		// returns `undefined`, which previously matched the undefined capture
+		// refs, cancelling the event and throwing on `undefined.focus()`.
+		let notCancelled;
+		expect( () => {
+			notCancelled = fireEvent.keyDown( button, {
+				keyCode: TAB,
+				shiftKey: true,
+			} );
+		} ).not.toThrow();
+
+		window.removeEventListener( 'error', errorListener );
+
+		expect( errorListener ).not.toHaveBeenCalled();
+		// `preventDefault` was not called, so focus is free to leave the canvas.
+		expect( notCancelled ).toBe( true );
 	} );
 } );

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.jsx
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.jsx
@@ -204,6 +204,15 @@ export default function useTabNav() {
 				return;
 			}
 
+			if (
+				// Bails in case the focus capture elements aren’t present. They
+				// may be omitted to avoid silent tab stops in preview mode.
+				! focusCaptureAfterRef.current ||
+				! focusCaptureBeforeRef.current
+			) {
+				return;
+			}
+
 			if ( event.target?.getAttribute( 'role' ) === 'region' ) {
 				return;
 			}


### PR DESCRIPTION
## What?

Fixes a keyboard trap in the writing flow in the Visual revisions view.

`preventScrollOnTab` in `use-tab-nav.jsx` now bails out when either focus
capture ref is missing, matching the guard the `onKeyDown` handler in the same
file already has.

## Why?

In the Visual revisions view, Tab moves forward into the editor canvas but
Shift+Tab cannot move back out. Focus stays inside the iframe and this is thrown
on every attempt:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'focus')
    at preventScrollOnTab (use-tab-nav.jsx)
```

This is a keyboard trap — WCAG 2.1.2 (No Keyboard Trap, Level A). Keyboard-only
and screen reader users cannot leave the revisions region without a pointer.

### Root cause

Revisions mode sets `isPreviewMode: true`
(`packages/editor/src/components/provider/use-block-editor-settings.js`), and
`packages/block-editor/src/components/iframe/index.jsx` omits the `before` /
`after` focus capture elements in that mode:

```js
const shouldRenderFocusCaptureElements = tabIndex >= 0 && ! isPreviewMode;
```

So `focusCaptureBeforeRef.current` and `focusCaptureAfterRef.current` are both
`undefined`. On Shift+Tab from the first tabbable element in the canvas,
`focus.tabbable.findPrevious()` also returns `undefined` (it is
`Array.prototype.find` under the hood). The condition

```js
if (
    target === focusCaptureBeforeRef.current ||
    target === focusCaptureAfterRef.current
) {
```

then passes as `undefined === undefined`, `event.preventDefault()` cancels the
Tab, and `target.focus( { preventScroll: true } )` throws. Focus never moves.

The `onKeyDown` handler in the same file already guards against this;
`preventScrollOnTab` was missed.

## How?

Add the same early return to `preventScrollOnTab`, with the same explanatory
comment. No other change to the file.

## Testing Instructions

1. `npm run test:unit -- packages/block-editor/src/components/writing-flow`
   — the new regression test in `test/index.jsdom.test.js` covers the case
   where both capture refs and `findPrevious` are `undefined`: the handler must
   not throw and must not call `preventDefault`.

## Testing Instructions for Keyboard

1. On a default theme with only Gutenberg active, create a post with several
   blocks, publish, then save two or three revisions.
2. In the post editor, open **Status & visibility** and click **Revisions (N)**
   to open the Visual revisions view.
3. Press <kbd>Tab</kbd> until focus is on the first block inside the editor
   canvas.
4. Press <kbd>Shift</kbd> + <kbd>Tab</kbd>.
5. Focus moves back to the previous control outside the canvas. No error is
   logged in the console.
6. Press <kbd>Tab</kbd> repeatedly to the last tabbable element in the canvas,
   then <kbd>Tab</kbd> once more — focus leaves the canvas forward, again with
   no error.

Before this change, steps 4 and 6 leave focus stuck inside the iframe and log
the `TypeError` above.

## Screenshots Before
<img width="1478" height="954" alt="Screenshot 2026-09-01 at 3 35 48 PM" src="https://github.com/user-attachments/assets/1b1c8b3b-254c-4708-b750-a403480401fe" />

## Screenshots After
<img width="1489" height="951" alt="Screenshot 2026-09-01 at 4 33 54 PM" src="https://github.com/user-attachments/assets/128360a8-df1f-4561-ace2-1e85433053cc" />


<!-- Add before/after screen recording and console screenshot here. -->

## Screencast before

https://github.com/user-attachments/assets/8a8dd77c-e9ac-43b2-a3d6-e64c4a18a656


## Screencast After

https://github.com/user-attachments/assets/325c1399-edd7-45ac-b056-3378ac30f68a



