### PR TITLE
Tests: Fix Vitest setup and stale jest types under non-hoisting installs

### DIFF
--- a/packages/design-system-mcp/tsconfig.json
+++ b/packages/design-system-mcp/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.dev.base.json",
 	"compilerOptions": {
-		"types": [ "jest", "node" ]
+		"types": [ "node" ]
 	},
 	"references": [ { "path": "./tsconfig.build.json" } ]
 }

--- a/packages/global-styles-engine/tsconfig.json
+++ b/packages/global-styles-engine/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.dev.base.json",
 	"compilerOptions": {
-		"types": [ "jest", "gutenberg-env" ]
+		"types": [ "gutenberg-env" ]
 	},
 	"references": [
 		{ "path": "./tsconfig.build.json" },

--- a/packages/priority-queue/tsconfig.json
+++ b/packages/priority-queue/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.dev.base.json",
 	"compilerOptions": {
-		"types": [ "jest", "requestidlecallback" ]
+		"types": [ "requestidlecallback" ]
 	},
 	"references": [ { "path": "./tsconfig.build.json" } ]
 }

--- a/packages/report-flaky-tests/tsconfig.json
+++ b/packages/report-flaky-tests/tsconfig.json
@@ -2,7 +2,9 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.dev.base.json",
 	"compilerOptions": {
-		"allowImportingTsExtensions": true
+		"allowImportingTsExtensions": true,
+		// Tests run on Vitest and import their globals, so no jest types.
+		"types": []
 	},
 	"references": [ { "path": "./tsconfig.build.json" } ]
 }

--- a/packages/server-side-render/tsconfig.json
+++ b/packages/server-side-render/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.dev.base.json",
 	"compilerOptions": {
-		"types": [ "jest", "gutenberg-env" ]
+		"types": [ "gutenberg-env" ]
 	},
 	"references": [
 		{ "path": "./tsconfig.build.json" },

--- a/test/unit/config/testing-library.vitest.js
+++ b/test/unit/config/testing-library.vitest.js
@@ -1,9 +1,15 @@
-import '@testing-library/jest-dom/vitest';
+/*
+ * The `/vitest` entry point resolves `vitest` from jest-dom's own location,
+ * which non-hoisting installs do not provide. Extend the matchers manually.
+ */
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 // eslint-disable-next-line testing-library/no-manual-cleanup -- Vitest globals are disabled, so Testing Library cannot register cleanup automatically.
 import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, expect } from 'vitest';
 import './matchers/to-match-diff-snapshot.vitest';
 import './matchers/to-be-positioned-popover.vitest';
+
+expect.extend( jestDomMatchers );
 
 let previousIsReactActEnvironment;
 

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -6,7 +6,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from 'node:fs';
-import { isBuiltin } from 'node:module';
+import { createRequire, isBuiltin } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { globSync } from 'glob';
@@ -174,6 +174,34 @@ const commonTypes = [
 	'style-imports',
 ];
 
+const require = createRequire( import.meta.url );
+
+/**
+ * Resolve the directories holding the given `@types` packages.
+ *
+ * Non-hoisting installs keep them in the workspace that declares the
+ * dependency, so the repository root is not a reliable type root.
+ *
+ * @param {string[]} typeNames Type package names, without the `@types/` scope.
+ * @return {string[]} Absolute `@types` directories, without duplicates.
+ */
+function resolveTypeRoots( typeNames ) {
+	const typeRoots = new Set();
+
+	for ( const typeName of typeNames ) {
+		try {
+			const packageJsonPath = require.resolve(
+				`@types/${ typeName }/package.json`
+			);
+			typeRoots.add( path.dirname( path.dirname( packageJsonPath ) ) );
+		} catch {
+			// Declared under `typings` rather than by a `@types` package.
+		}
+	}
+
+	return [ ...typeRoots ];
+}
+
 function importsNodeBuiltin( file ) {
 	const source =
 		sourcesByFile.get( file ) ??
@@ -262,7 +290,8 @@ for ( const projectName of VITEST_PROJECT_NAMES ) {
 				rootDir: ROOT_DIR,
 				typeRoots: [
 					path.join( ROOT_DIR, 'typings' ),
-					path.join( ROOT_DIR, 'node_modules/@types' ),
+					path.join( ROOT_DIR, 'test/unit/typings' ),
+					...resolveTypeRoots( [ ...commonTypes, 'node' ] ),
 				],
 				types:
 					projectName === 'jsdom'

--- a/test/unit/typings/gutenberg-vitest-test-env/index.d.ts
+++ b/test/unit/typings/gutenberg-vitest-test-env/index.d.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- The owning test workspaces declare Vitest.
 import 'vitest';
 
 interface GutenbergVitestMatchers {

--- a/tools/pr-meta/tsconfig.json
+++ b/tools/pr-meta/tsconfig.json
@@ -6,7 +6,7 @@
 		// what Node's type stripping resolves when the action runs.
 		"allowImportingTsExtensions": true,
 		// The action talks to Node and the runner directly, with no dependencies.
-		"types": [ "jest", "node" ]
+		"types": [ "node" ]
 	},
 	"include": [ "src" ]
 }


### PR DESCRIPTION
## What?

Follow up to #82211.

Fixes the Vitest jsdom setup, the leftover `jest` tsconfig `types` entries, and the convention check's type roots, all left behind by the Vitest migration. They only surface when npm does not hoist dependencies to the root `node_modules` in #75814

See the failed runs on #75814

- https://github.com/WordPress/gutenberg/actions/runs/33508096158/job/99856886720?pr=75814.
- https://github.com/WordPress/gutenberg/actions/runs/33510953595/job/99866182188?pr=75814

## Why?

`@testing-library/jest-dom/vitest` imports `vitest` from jest-dom's own location, where it is an optional peer that npm never installs. Six migrated packages still list `"jest"` in their tsconfig `types` without declaring `@types/jest`. The convention check points at the root `node_modules/@types`, and `typings/gutenberg-vitest-test-env` augments a `vitest` the root cannot resolve, which drops the custom matchers from type checking silently rather than erroring.

## How?

Extend the matchers manually in [testing-library.vitest.js](test/unit/config/testing-library.vitest.js), as jest-dom documents. Drop the stale `"jest"` entry from the affected tsconfigs; [report-flaky-tests](packages/report-flaky-tests/tsconfig.json) inherits it from `tsconfig.dev.base.json`, so it overrides `types` instead. Resolve the `@types` directories through Node in [validate-vitest-conventions.mjs](test/unit/scripts/validate-vitest-conventions.mjs), and move the Vitest typings next to the `vitest` they augment.

## Testing Instructions

1. `npm run typecheck` passes.
2. `npm run test:unit:vitest` passes.
3. `npm run --workspace @wordpress/unit-tests test:unit:conventions` passes.

## Use of AI Tools

Authored with Claude Code, reviewed by me.
