### PR TITLE
DataForm: Communicate the timezone in the datetime control

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -33,6 +33,10 @@
 
     If a combined field relied on a same-id field's `isValid` rules being applied to the group, move those rules to the child fields.
 
+### Enhancements
+
+-   DataForm: Communicate the timezone a `datetime` value is edited in. When the site timezone differs from the visitor's, the control renders help text under the input naming the site timezone: the zone name (e.g. `(CEST) Europe/Madrid`) or the UTC offset for sites pinned to one ([#82291](https://github.com/WordPress/gutenberg/pull/82291)).
+
 ### Internal
 
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/dataviews/src/components/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/components/dataform-controls/datetime.tsx
@@ -12,6 +12,7 @@ import toCalendarDate from './utils/to-calendar-date';
 import useDisabledDateMatchers from './utils/use-disabled-date-matchers';
 import getCustomValidity from './utils/get-custom-validity';
 import getCalendarLocale from './utils/get-calendar-locale';
+import getTimezoneDescription from './utils/get-timezone-description';
 import parseDateTime from '../../field-types/utils/parse-date-time';
 
 const formatDateTime = ( value?: string ): string => {
@@ -179,6 +180,7 @@ function CalendarDateTimeControl< Item >( {
 					value={ formatDateTime( value ) }
 					onValueChange={ handleManualDateTimeChange }
 					disabled={ disabled }
+					description={ getTimezoneDescription() }
 					min={
 						minConstraint
 							? formatDateTime( minConstraint )

--- a/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
@@ -290,4 +290,87 @@ describe( 'DateTime control', () => {
 			} )
 		).toBeInTheDocument();
 	} );
+
+	describe( 'timezone help', () => {
+		it( 'is not rendered when the site and browser timezones match', () => {
+			render(
+				<DateTimeHarness initialValue="2026-08-15T12:30:00.000Z" />
+			);
+
+			expect(
+				screen.getByLabelText( 'Date time' )
+			).not.toHaveAccessibleDescription();
+		} );
+
+		it( 'names the timezone for a site with a named timezone', () => {
+			setSettings( {
+				...originalSettings,
+				timezone: {
+					offset: -6,
+					offsetFormatted: '-6',
+					string: 'America/Costa_Rica',
+					abbr: 'CST',
+				},
+			} );
+
+			render(
+				<DateTimeHarness initialValue="2026-08-15T12:30:00.000Z" />
+			);
+
+			// Underscores in the zone name are replaced for display.
+			expect(
+				screen.getByLabelText( 'Date time' )
+			).toHaveAccessibleDescription(
+				'Timezone: (CST) America/Costa Rica'
+			);
+		} );
+
+		it( 'falls back to the UTC offset on a site with a manual offset', () => {
+			setSiteOffset( 14 );
+
+			render(
+				<DateTimeHarness initialValue="2026-08-15T12:30:00.000Z" />
+			);
+
+			expect(
+				screen.getByLabelText( 'Date time' )
+			).toHaveAccessibleDescription( 'Timezone: UTC+14' );
+		} );
+
+		it( 'spells out a UTC site timezone for a non-UTC visitor', () => {
+			setSettings( {
+				...originalSettings,
+				timezone: {
+					offset: 0,
+					offsetFormatted: '0',
+					string: 'UTC',
+					abbr: 'UTC',
+				},
+			} );
+			// Jest pins the browser to UTC, so this mismatch is created from
+			// the browser side: UTC+1, i.e. an offset of -60 minutes.
+			const offsetSpy = jest
+				.spyOn( Date.prototype, 'getTimezoneOffset' )
+				.mockReturnValue( -60 );
+
+			try {
+				render(
+					<DateTime
+						data={ { published: '2026-08-15T12:30:00.000Z' } }
+						field={ field }
+						onChange={ noop }
+						config={ { compact: true } }
+					/>
+				);
+
+				expect(
+					screen.getByLabelText( 'Date time' )
+				).toHaveAccessibleDescription(
+					'Timezone: Coordinated Universal Time'
+				);
+			} finally {
+				offsetSpy.mockRestore();
+			}
+		} );
+	} );
 } );

--- a/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
@@ -325,16 +325,20 @@ describe( 'DateTime control', () => {
 			);
 		} );
 
-		it( 'falls back to the UTC offset on a site with a manual offset', () => {
-			setSiteOffset( 14 );
+		// The manual offset reaches Calendar as a raw offset identifier,
+		// which Node 20 rejects — see `supportsOffsetTimeZones`.
+		describeWithOffsetTimeZones( 'on a site with a manual offset', () => {
+			it( 'falls back to the UTC offset', () => {
+				setSiteOffset( 14 );
 
-			render(
-				<DateTimeHarness initialValue="2026-08-15T12:30:00.000Z" />
-			);
+				render(
+					<DateTimeHarness initialValue="2026-08-15T12:30:00.000Z" />
+				);
 
-			expect(
-				screen.getByLabelText( 'Date time' )
-			).toHaveAccessibleDescription( 'Timezone: UTC+14' );
+				expect(
+					screen.getByLabelText( 'Date time' )
+				).toHaveAccessibleDescription( 'Timezone: UTC+14' );
+			} );
 		} );
 
 		it( 'spells out a UTC site timezone for a non-UTC visitor', () => {

--- a/packages/dataviews/src/components/dataform-controls/utils/get-timezone-description.ts
+++ b/packages/dataviews/src/components/dataform-controls/utils/get-timezone-description.ts
@@ -1,0 +1,41 @@
+import { getSettings } from '@wordpress/date';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Help text communicating the timezone a datetime value is edited in.
+ * Returns `undefined` when the site timezone matches the visitor's, where
+ * spelling out the frame would be noise.
+ */
+export default function getTimezoneDescription(): string | undefined {
+	const { timezone } = getSettings();
+
+	const userTimezoneOffset = -1 * ( new Date().getTimezoneOffset() / 60 );
+	// Compare as numbers because the site offset comes over as a string.
+	if ( Number( timezone.offset ) === userTimezoneOffset ) {
+		return undefined;
+	}
+
+	const offsetSymbol = Number( timezone.offset ) >= 0 ? '+' : '';
+	const zoneAbbr =
+		'' !== timezone.abbr && isNaN( Number( timezone.abbr ) )
+			? timezone.abbr
+			: `UTC${ offsetSymbol }${ timezone.offsetFormatted }`;
+
+	// Replace underscores with spaces in strings like `America/Costa_Rica`.
+	// A site set to a manual UTC offset has no zone name, and is described by
+	// the offset alone.
+	const prettyTimezoneString = timezone.string.replaceAll( '_', ' ' );
+
+	let timezoneDetail = zoneAbbr;
+	if ( 'UTC' === timezone.string ) {
+		timezoneDetail = __( 'Coordinated Universal Time' );
+	} else if ( prettyTimezoneString.trim().length > 0 ) {
+		timezoneDetail = `(${ zoneAbbr }) ${ prettyTimezoneString }`;
+	}
+
+	return sprintf(
+		/* translators: %s: timezone detail, e.g. "(CEST) Europe/Madrid" or "UTC+3". */
+		__( 'Timezone: %s' ),
+		timezoneDetail
+	);
+}


### PR DESCRIPTION
## What?

Resolves: https://github.com/WordPress/gutenberg/issues/76194

The datetime DataForm control does not communicate the timezone, which may lead to confusion. This PR fixes that.

When the site timezone is different from the user's, the `datetime` control now renders help text under the input with the site timezone, like `Timezone: (CEST) Europe/Copenhagen` (or the UTC offset if the site uses a manual one). Nothing is rendered when the timezones match.



### Notes

1. Initially I tried to add this info as a suffix of the input. This doesn't work well though in narrower containers like the filter dialog. I couldn't find a better solution than truncating something or extending the `max-width` of the dialog, but both don't seem good approaches. For reference this is a screenshot with the inline approach:

<img width="959" height="706" alt="Screenshot 2026-09-01 at 3 54 49 PM" src="https://github.com/user-attachments/assets/01548271-ca16-44c6-8b90-00de74a738bc" />

2. If a field has a description, it's still rendered below the calendar and with the `compact` variant it has two lines. Check the `compact` variant below:
<img width="959" height="706" alt="Screenshot 2026-09-01 at 4 28 14 PM" src="https://github.com/user-attachments/assets/b468054e-19d4-4fa4-9d95-88f5a8082a1b" />

3. In the current approach with a named timezone the text can wrap to two lines in the filter popover. We could drop the abbreviation and show just the zone name, or only the offset. For reference I'm attaching the three cases:




| 'Big' named tz | Smaller named tz | Manual offset |
| --- | --- | --- |
|<img width="398" height="501" alt="Screenshot 2026-09-01 at 4 28 32 PM" src="https://github.com/user-attachments/assets/c1275e1c-28f5-4636-8887-ebb822b1eb63" />|<img width="398" height="501" alt="Screenshot 2026-09-01 at 4 28 59 PM" src="https://github.com/user-attachments/assets/5f595ff0-2312-4d0b-b685-5aef45a10f81" />|<img width="398" height="501" alt="Screenshot 2026-09-01 at 4 29 43 PM" src="https://github.com/user-attachments/assets/6cadb17d-08c9-455d-828a-b1e2bb21f98c" />|

## Testing Instructions

1. In Settings > General set a timezone different from your machine's.
2. In the site editor open Pages and add a Date filter. The timezone help should render below the input.
5.  In Quick Edit, edit the Date field and check the help shows there too.
6. Set the timezone to match your machine's and verify the help is not rendered.
7. Everything else should work as before.


## Use of AI Tools

Generated with Fable 5 and adjusted/reviewed manually.