### PR TITLE
Project Management: Remove empty entries from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,53 +2,24 @@
 /docs                                           @juanmaguitar @fabiankaegy
 /packages/interactivity/docs                    @juanmaguitar
 
-# Schemas
-/schemas/json
-
 # Data
 /packages/api-fetch
 /packages/core-data                             @Mamaduka
 /packages/data                                  @Mamaduka
-/packages/redux-routine
-/packages/data-controls
 
 # Blocks
 /packages/block-library                         @fabiankaegy
-/packages/block-library/src/gallery
-
-# Duotone
-/lib/block-supports/duotone.php
-/packages/block-editor/src/components/duotone-control
-/packages/block-editor/src/hooks/duotone.jsx
-/packages/components/src/duotone-picker
 
 # Editor
-/packages/annotations
-/packages/autop
 /packages/block-editor                          @ellatrix
 /packages/block-editor/src/hooks                @tellthemachines
 /packages/block-editor/src/layouts              @tellthemachines
 /packages/block-serialization-spec-parser       @dmsnell
 /packages/block-serialization-default-parser    @dmsnell
-/packages/blocks
-/packages/edit-post
-/packages/editor
-/packages/list-reusable-blocks
-/packages/shortcode
-/packages/block-directory
-/packages/interface
-/packages/media-utils
-/packages/server-side-render
 /packages/block-editor/src/components/link-control  @getdave
 
 # Widgets
-/packages/edit-widgets
-/packages/customize-widgets
-/packages/widgets
 /packages/widget-primitives                     @retrofox
-
-# Full Site Editing
-/packages/edit-site
 
 # Interactivity API
 /packages/interactivity                         @luisherranz @darerodz
@@ -56,39 +27,12 @@
 # Tooling
 /bin                                            @manzoorwanijk
 /tools                                          @manzoorwanijk
-/tools/eslint/suppressions.json
-/tools/stylelint/stylelint-suppressions.json
-/packages/babel-plugin-import-jsx-pragma
-/packages/babel-plugin-makepot
-/packages/babel-preset-default
-/packages/browserslist-config
-/packages/create-block
-/packages/create-block-tutorial-template
-/packages/dependency-extraction-webpack-plugin
-/packages/docgen
-/packages/e2e-tests
-/packages/e2e-test-utils-playwright
-/packages/eslint-plugin
-/packages/jest-console
-/packages/jest-preset-default
-/packages/npm-package-json-lint-config
-/packages/postcss-themes
-/packages/prettier-config
-/packages/scripts
-/packages/stylelint-config
 /test/php/gutenberg-coding-standards            @anton-vlasenko
 
 # UI Components
 /packages/components                            @WordPress/gutenberg-components
-/packages/compose
 /packages/design-system-mcp                     @WordPress/gutenberg-components
-/packages/element
-/packages/notices
 /packages/nux                                   @peterwilsoncc
-/packages/viewport
-/packages/base-styles
-/packages/icons
-/packages/primitives
 /packages/dataviews                             @oandregal @gigitux @ntsekouras
 /packages/theme                                 @WordPress/gutenberg-components
 /packages/ui                                    @WordPress/gutenberg-components
@@ -96,28 +40,11 @@
 /packages/grid                                  @retrofox
 
 # Utilities
-/packages/a11y
-/packages/blob
-/packages/date
-/packages/deprecated
 /packages/dom                                   @ellatrix
-/packages/dom-ready
-/packages/escape-html
-/packages/html-entities
 /packages/i18n                                  @swissspidy
-/packages/is-shallow-equal
-/packages/keyboard-shortcuts
-/packages/keycodes
-/packages/preferences
-/packages/priority-queue
-/packages/token-list
-/packages/url
-/packages/wordcount
-/packages/warning
 
 # Extensibility
 /packages/hooks                                 @adamsilverstein
-/packages/plugins
 
 # Rich Text
 /packages/format-library                        @ellatrix
@@ -126,8 +53,6 @@
 
 # Project Management
 /.github                                        @desrosj
-/packages/project-management-automation
-/packages/report-flaky-tests
 
 # wp-env
 /packages/env                                   @t-hamano
@@ -141,6 +66,3 @@
 /lib/block-supports/layout.php                  @tellthemachines
 /lib/class-wp-theme-json-gutenberg.php          @tellthemachines
 /lib/compat/*/html-api                          @dmsnell
-/lib/experimental/rest-api.php
-/lib/experimental/class-wp-rest-*
-/lib/experimental/class-wp-rest-block-editor-settings-controller.php


### PR DESCRIPTION
## What?

Updates CODEOWNERS to remove path entries which have no associated code owners.

Related discussion: https://github.com/WordPress/gutenberg/pull/82262#pullrequestreview-5069046098

## Why?

Helps keep the file clear to where ownership is assigned.

As discussed in https://github.com/WordPress/gutenberg/pull/82262#issuecomment-5481740724, we may have previously kept empty path entries as an indicator where there is a gap in coverage, but this is also misleading because the list is not exhaustive. And we can expect that will always be the case without rigor to keep the path entries in sync with available packages, and that the value derived from having a full list of paths is not worth the complexity of keeping it in sync.

## Testing Instructions

Review updated `CODEOWNERS` for accuracy. Only entries which have no associated code owner should be removed.

Confirm also that there are no lingering path entries without associated code owners.

## Use of AI Tools

No AI was used.