### PR TITLE
UI: Drop Status and Empty live region test assertions

### DIFF
--- a/packages/ui/src/form/primitives/autocomplete/test/index.jsdom.test.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/test/index.jsdom.test.tsx
@@ -82,13 +82,7 @@ describe( 'Autocomplete', () => {
 		expect( itemRef.current ).toBeInstanceOf( HTMLDivElement );
 		expect( clearRef.current ).toBeInstanceOf( HTMLButtonElement );
 		expect( emptyRef.current ).toBeInstanceOf( HTMLDivElement );
-		expect( emptyRef.current ).toHaveAttribute( 'role', 'status' );
-		expect( emptyRef.current ).toHaveAttribute( 'aria-live', 'polite' );
-		expect( emptyRef.current ).toHaveAttribute( 'aria-atomic', 'true' );
 		expect( statusRef.current ).toBeInstanceOf( HTMLDivElement );
-		expect( statusRef.current ).toHaveAttribute( 'role', 'status' );
-		expect( statusRef.current ).toHaveAttribute( 'aria-live', 'polite' );
-		expect( statusRef.current ).toHaveAttribute( 'aria-atomic', 'true' );
 	} );
 
 	describe( 'portal', () => {

--- a/packages/ui/src/form/primitives/combobox/test/index.jsdom.test.tsx
+++ b/packages/ui/src/form/primitives/combobox/test/index.jsdom.test.tsx
@@ -139,13 +139,7 @@ describe( 'Combobox', () => {
 		expect( chipWithRemoveRef.current ).toBeInstanceOf( HTMLDivElement );
 		expect( clearRef.current ).toBeInstanceOf( HTMLButtonElement );
 		expect( emptyRef.current ).toBeInstanceOf( HTMLDivElement );
-		expect( emptyRef.current ).toHaveAttribute( 'role', 'status' );
-		expect( emptyRef.current ).toHaveAttribute( 'aria-live', 'polite' );
-		expect( emptyRef.current ).toHaveAttribute( 'aria-atomic', 'true' );
 		expect( statusRef.current ).toBeInstanceOf( HTMLDivElement );
-		expect( statusRef.current ).toHaveAttribute( 'role', 'status' );
-		expect( statusRef.current ).toHaveAttribute( 'aria-live', 'polite' );
-		expect( statusRef.current ).toHaveAttribute( 'aria-atomic', 'true' );
 	} );
 
 	it( 'uses a custom positioner', async () => {


### PR DESCRIPTION
## What?
Follow up to [#82195](https://github.com/WordPress/gutenberg/pull/82195). Removes the `role`, `aria-live`, and `aria-atomic` assertions on `Autocomplete`/`Combobox` `Status` and `Empty`.

## Why?
Those attributes are Base UI's. The wrappers do not change them, so the extra checks only pin an upstream implementation detail.

## How?
Keep the existing ref assertions. Drop the live-region attribute checks.

## Testing Instructions
1. Run `npm run test:unit -- packages/ui/src/form/primitives/autocomplete/test/index.jsdom.test.tsx packages/ui/src/form/primitives/combobox/test/index.jsdom.test.tsx --testNamePattern="forwards ref"`.
1. Confirm the `forwards ref` tests still pass.