### PR TITLE
PR meta: Move the props list into the shared comment

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -29,11 +29,13 @@ on:
         types:
             - created
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Cancels all previous runs for a pull request that have not completed.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
+    # Keyed by the pull request, which the four events carry in three different
+    # places. `github.sha` would not do: on `issue_comment` it is the default
+    # branch tip, the same value for every issue and pull request in the
+    # repository, so one comment anywhere would cancel every other run.
+    group: ${{ github.workflow }}-${{ github.event.number || github.event.issue.number || github.event.pull_request.number || github.run_id }}
     cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
@@ -134,6 +136,6 @@ jobs:
                   section: props
                   body: ${{ needs.props-bot.outputs.comment-body }}
                   # The list is gathered before this job takes the lock, so two
-                  # runs can queue out of order. Ordering by run keeps the
-                  # newer list.
-                  run-id: ${{ github.run_id }}
+                  # runs can queue out of order. `run_number` increments with
+                  # every run of this workflow, so the newer list wins.
+                  generation: ${{ github.run_number }}

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -117,10 +117,13 @@ jobs:
             queue: max
 
         steps:
-            # A `pull_request_target` job has a writable token, so it checks out
-            # the base branch it was triggered on, never the pull request's head.
+            # This job holds a writable token, and the review events check out
+            # `refs/pull/N/merge` by default, which carries the pull request's
+            # own code. Pin the action to the default branch so a pull request
+            # cannot supply the code that runs here.
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
+                  ref: ${{ github.event.repository.default_branch }}
                   sparse-checkout: tools/pr-meta
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
@@ -130,3 +133,7 @@ jobs:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   section: props
                   body: ${{ needs.props-bot.outputs.comment-body }}
+                  # The list is gathered before this job takes the lock, so two
+                  # runs can queue out of order. Ordering by run keeps the
+                  # newer list.
+                  run-id: ${{ github.run_id }}

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -44,16 +44,19 @@ jobs:
     # Compiles a list of props for a pull request.
     #
     # Performs the following steps:
-    # - Collects a list of contributor props and leaves a comment.
+    # - Collects a list of contributor props for the PR meta comment to post.
     # - Removes the props-bot label, if necessary.
     props-bot:
         name: Generate a list of props
         runs-on: 'ubuntu-24.04'
         permissions:
-            # The action needs permission `write` permission for PRs in order to add a comment.
+            # Read to gather the contributors, write to remove the label below.
+            # The action itself posts nothing, see `post-comment`.
             pull-requests: write
             contents: read
         timeout-minutes: 20
+        outputs:
+            comment-body: ${{ steps.props.outputs.comment-body }}
         # The job will run when pull requests are open, ready for review and:
         #
         # - A comment is added to the pull request.
@@ -71,7 +74,12 @@ jobs:
 
         steps:
             - name: Gather a list of contributors
+              id: props
               uses: WordPress/props-bot-action@trunk
+              with:
+                  # The PR meta comment carries the list, so the action renders
+                  # it to an output and posts nothing itself.
+                  post-comment: false
 
             - name: Remove the props-bot label
               uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -88,3 +96,37 @@ jobs:
                         issue_number: process.env.ISSUE_NUMBER,
                         name: 'props-bot'
                       });
+
+    pr-meta:
+        name: Update PR meta comment
+        needs: props-bot
+        # Only when the list was gathered: an empty body from a failed run would
+        # clear a props list nothing had disproved.
+        if: ${{ needs.props-bot.result == 'success' }}
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+            pull-requests: write
+        timeout-minutes: 5
+        # Shared with every other writer of this comment. See bundle-size.yml.
+        # This workflow runs on four events, and only some of them carry the
+        # pull request at the same place in the payload.
+        concurrency:
+            group: pr-meta-${{ github.event.number || github.event.issue.number || github.event.pull_request.number }}
+            cancel-in-progress: false
+            queue: max
+
+        steps:
+            # A `pull_request_target` job has a writable token, so it checks out
+            # the base branch it was triggered on, never the pull request's head.
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  sparse-checkout: tools/pr-meta
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - uses: ./tools/pr-meta
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  section: props
+                  body: ${{ needs.props-bot.outputs.comment-body }}

--- a/tools/pr-meta/README.md
+++ b/tools/pr-meta/README.md
@@ -49,6 +49,8 @@ The job also needs `actions/checkout` before `uses: ./tools/pr-meta`, since a lo
 
 Add it to `SECTIONS` in `src/sections.ts` with an id, heading, scope and character budget. Headings lead with an emoji, so a reader scanning a comment of seven sections can find theirs without reading any of them. The budgets must sum, with the headings and markers, to less than GitHub's 65536-character comment limit; a test covers that.
 
+A producer renders its markdown without knowing where it will sit, so any headings in a body are demoted to sit below the section heading, with their relative hierarchy kept. Headings inside a code fence are left alone.
+
 A `summary` collapses the section behind a fold labelled with it, for content long enough that it would otherwise push the rest of the comment out of view. Leave it out to keep the section open.
 
 `scope` decides how staleness is handled. `commit` sections describe one commit, carry its SHA, and are rejected if they arrive from a rerun of an older one. `pr-state` sections describe the pull request as it currently is and carry no SHA.

--- a/tools/pr-meta/README.md
+++ b/tools/pr-meta/README.md
@@ -49,7 +49,7 @@ The job also needs `actions/checkout` before `uses: ./tools/pr-meta`, since a lo
 
 Add it to `SECTIONS` in `src/sections.ts` with an id, heading, scope and character budget. Headings lead with an emoji, so a reader scanning a comment of seven sections can find theirs without reading any of them. The budgets must sum, with the headings and markers, to less than GitHub's 65536-character comment limit; a test covers that.
 
-A producer renders its markdown without knowing where it will sit, so any headings in a body are demoted to sit below the section heading, with their relative hierarchy kept. Headings inside a code fence are left alone.
+A producer renders its markdown without knowing where it will sit, so any headings in a body are demoted to sit below the section heading, keeping their relative hierarchy. Headings inside a code fence are left alone, and a body deep enough to need a seventh level flattens at the sixth, markdown having no more. Setext headings, the ones underlined with `=` or `-`, are not demoted.
 
 A `summary` collapses the section behind a fold labelled with it, for content long enough that it would otherwise push the rest of the comment out of view. Leave it out to keep the section open.
 

--- a/tools/pr-meta/README.md
+++ b/tools/pr-meta/README.md
@@ -41,7 +41,7 @@ permissions:
     pull-requests: write
 ```
 
-**`if: ${{ !cancelled() }}`**, so a failed producer still clears its section instead of leaving a stale one behind.
+**A deliberate answer to producer failure.** Use `if: ${{ !cancelled() }}` where a missing result reliably means "nothing to report", so a failed producer clears its section rather than leaving a stale one. Where a missing result is instead indistinguishable from a failure, require the producer to have succeeded, as the props and flaky tests writers do; clearing there would erase something nothing had disproved.
 
 The job also needs `actions/checkout` before `uses: ./tools/pr-meta`, since a local action needs the repository on disk. `sparse-checkout: tools/pr-meta` is enough. Under `pull_request_target` the checkout must stay on the base ref, never the pull request's head.
 

--- a/tools/pr-meta/action.yml
+++ b/tools/pr-meta/action.yml
@@ -23,6 +23,9 @@ inputs:
     run-url:
         description: 'URL of the workflow run that produced the content.'
         required: false
+    run-id:
+        description: 'Id of the workflow run that produced the content. Orders writes to a section that has no commit to order them by, so pass `github.run_id` for one.'
+        required: false
 runs:
     # Node 24 strips the types on the fly, so the action runs straight from its
     # TypeScript sources without a build step. This requires every relative

--- a/tools/pr-meta/action.yml
+++ b/tools/pr-meta/action.yml
@@ -23,8 +23,8 @@ inputs:
     run-url:
         description: 'URL of the workflow run that produced the content.'
         required: false
-    run-id:
-        description: 'Id of the workflow run that produced the content. Orders writes to a section that has no commit to order them by, so pass `github.run_id` for one.'
+    generation:
+        description: 'Orders writes to a section that has no commit to order them by. Pass `github.run_number`, which increments with each run of a workflow, and only from the one workflow that owns the section.'
         required: false
 runs:
     # Node 24 strips the types on the fly, so the action runs straight from its

--- a/tools/pr-meta/src/__tests__/comment.test.ts
+++ b/tools/pr-meta/src/__tests__/comment.test.ts
@@ -580,13 +580,22 @@ describe( 'demoteHeadings', () => {
 	} );
 
 	it( 'keeps the hierarchy between headings', () => {
-		const body = '# Title\n\nText.\n\n### Deep\n\nText.';
+		const body = '## Title\n\nText.\n\n### Deep\n\nText.';
 
 		expect( demoteHeadings( body ) ).toBe(
-			'##### Title\n\nText.\n\n####### Deep\n\nText.'.replace(
-				'#######',
-				'######'
-			)
+			'##### Title\n\nText.\n\n###### Deep\n\nText.'
+		);
+	} );
+
+	/*
+	 * Markdown has no seventh level, so a body deep enough to need one loses
+	 * the distinction rather than the demotion.
+	 */
+	it( 'flattens levels a demotion pushes past the sixth', () => {
+		const body = '# One\n\n## Two\n\n### Three';
+
+		expect( demoteHeadings( body ) ).toBe(
+			'##### One\n\n###### Two\n\n###### Three'
 		);
 	} );
 
@@ -597,11 +606,100 @@ describe( 'demoteHeadings', () => {
 	} );
 
 	/* A stack trace can hold anything, including lines that look like headings. */
-	it( 'ignores what looks like a heading inside a code fence', () => {
-		const body = '## Real\n\n```\n# Not a heading\n```';
+	it.each( [
+		[ 'a plain fence', '```', '```' ],
+		[ 'a fence with a language', '```js', '```' ],
+		[ 'a tilde fence', '~~~', '~~~' ],
+	] )( 'ignores what looks like a heading inside %s', ( _, open, close ) => {
+		const body = `## Real\n\n${ open }\n# Not a heading\n${ close }`;
 
 		expect( demoteHeadings( body ) ).toBe(
-			'##### Real\n\n```\n# Not a heading\n```'
+			`##### Real\n\n${ open }\n# Not a heading\n${ close }`
 		);
+	} );
+
+	/* Reading the level by hunting for a space loses the first word. */
+	it( 'keeps the text of a heading separated by a tab', () => {
+		expect( demoteHeadings( '#\tTabbed' ) ).toBe( '#####\tTabbed' );
+	} );
+
+	it( 'leaves a hash that opens no heading alone', () => {
+		expect( demoteHeadings( '## Real\n\n#hashtag' ) ).toBe(
+			'##### Real\n\n#hashtag'
+		);
+	} );
+
+	it( 'caps the demotion at the deepest heading level', () => {
+		expect( demoteHeadings( '# One\n\n###### Six' ) ).toBe(
+			'##### One\n\n###### Six'
+		);
+	} );
+} );
+
+describe( 'ordering a section with no commit', () => {
+	/*
+	 * The list is gathered before its writer takes the lock, so two runs can
+	 * reach the lock in the opposite order to the views they hold.
+	 */
+	it( 'rejects a list gathered by an older run', () => {
+		const comment = bodyOf(
+			mergeSection( undefined, {
+				id: 'props',
+				body: 'Newer list.',
+				generation: 200,
+			} )
+		);
+
+		const result = mergeSection( comment, {
+			id: 'props',
+			body: 'Older list.',
+			generation: 100,
+		} );
+
+		expect( result.body ).toBeUndefined();
+		expect( result.rejected ).toContain( '100' );
+	} );
+
+	it( 'accepts a newer run, and a rerun of the same one', () => {
+		let comment = bodyOf(
+			mergeSection( undefined, {
+				id: 'props',
+				body: 'First.',
+				generation: 100,
+			} )
+		);
+		comment = bodyOf(
+			mergeSection( comment, {
+				id: 'props',
+				body: 'Retry of the same run.',
+				generation: 100,
+			} )
+		);
+		comment = bodyOf(
+			mergeSection( comment, {
+				id: 'props',
+				body: 'Newer run.',
+				generation: 200,
+			} )
+		);
+
+		expect( comment ).toContain( 'Newer run.' );
+	} );
+
+	it( 'does not order a section that a commit already orders', () => {
+		const comment = bodyOf(
+			mergeSection(
+				undefined,
+				{
+					id: 'bundle-size',
+					body: 'Size.',
+					sha: HEAD,
+					generation: 200,
+				},
+				HEAD
+			)
+		);
+
+		expect( parseSections( comment )[ 0 ].generation ).toBeUndefined();
 	} );
 } );

--- a/tools/pr-meta/src/__tests__/comment.test.ts
+++ b/tools/pr-meta/src/__tests__/comment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	COMMENT_MARKER,
+	demoteHeadings,
 	isParseable,
 	isPrMetaComment,
 	mergeSection,
@@ -561,5 +562,46 @@ describe( 'rendering other sections', () => {
 		);
 
 		expect( merged ).toContain( 'not the current head' );
+	} );
+} );
+
+describe( 'demoteHeadings', () => {
+	it( 'pushes a props body below its own section heading', () => {
+		const props =
+			'## Unlinked Accounts\n\nSome text.\n\n## Core SVN\n\nMore text.';
+
+		const merged = bodyOf(
+			mergeSection( undefined, { id: 'props', body: props } )
+		);
+
+		expect( merged ).toContain( '##### Unlinked Accounts' );
+		expect( merged ).toContain( '##### Core SVN' );
+		expect( merged ).not.toMatch( /^## Unlinked/m );
+	} );
+
+	it( 'keeps the hierarchy between headings', () => {
+		const body = '# Title\n\nText.\n\n### Deep\n\nText.';
+
+		expect( demoteHeadings( body ) ).toBe(
+			'##### Title\n\nText.\n\n####### Deep\n\nText.'.replace(
+				'#######',
+				'######'
+			)
+		);
+	} );
+
+	it( 'leaves a body that has no headings alone', () => {
+		const body = 'Just text, and a # that is not a heading.';
+
+		expect( demoteHeadings( body ) ).toBe( body );
+	} );
+
+	/* A stack trace can hold anything, including lines that look like headings. */
+	it( 'ignores what looks like a heading inside a code fence', () => {
+		const body = '## Real\n\n```\n# Not a heading\n```';
+
+		expect( demoteHeadings( body ) ).toBe(
+			'##### Real\n\n```\n# Not a heading\n```'
+		);
 	} );
 } );

--- a/tools/pr-meta/src/__tests__/comment.test.ts
+++ b/tools/pr-meta/src/__tests__/comment.test.ts
@@ -623,6 +623,37 @@ describe( 'demoteHeadings', () => {
 		expect( demoteHeadings( '#\tTabbed' ) ).toBe( '#####\tTabbed' );
 	} );
 
+	/*
+	 * A `.` stops at a carriage return, so a CRLF body would match on its last
+	 * line only, demoting that one and leaving every fence untracked.
+	 */
+	it( 'handles a body with carriage returns', () => {
+		const body = '## Real\r\n\r\n```\r\n# inner\r\n```\r\n\r\n## After';
+
+		expect( demoteHeadings( body ) ).toBe(
+			'##### Real\r\n\r\n```\r\n# inner\r\n```\r\n\r\n##### After'
+		);
+	} );
+
+	it( 'demotes a heading indented up to three spaces, keeping the indent', () => {
+		expect( demoteHeadings( '   ## Indented' ) ).toBe(
+			'   ##### Indented'
+		);
+	} );
+
+	/* Four spaces makes it indented code rather than a heading. */
+	it( 'leaves a heading indented four spaces alone', () => {
+		expect( demoteHeadings( '    ## Code\n\n## Plain' ) ).toBe(
+			'    ## Code\n\n##### Plain'
+		);
+	} );
+
+	it( 'demotes a heading with no text', () => {
+		expect( demoteHeadings( '#\n\n## Plain' ) ).toBe(
+			'#####\n\n###### Plain'
+		);
+	} );
+
 	it( 'leaves a hash that opens no heading alone', () => {
 		expect( demoteHeadings( '## Real\n\n#hashtag' ) ).toBe(
 			'##### Real\n\n#hashtag'
@@ -701,5 +732,81 @@ describe( 'ordering a section with no commit', () => {
 		);
 
 		expect( parseSections( comment )[ 0 ].generation ).toBeUndefined();
+	} );
+} );
+
+describe( 'clearing a section that has an order', () => {
+	/*
+	 * Dropping the entry on clear would drop its generation with it, letting a
+	 * run gathered earlier put the old content back.
+	 */
+	it( 'still rejects an older run after the section was cleared', () => {
+		let comment = bodyOf(
+			mergeSection( undefined, { id: 'labels', body: 'Warning.' } )
+		);
+		comment = bodyOf(
+			mergeSection( comment, {
+				id: 'props',
+				body: 'Newer list.',
+				generation: 200,
+			} )
+		);
+		comment = bodyOf(
+			mergeSection( comment, {
+				id: 'props',
+				body: '',
+				generation: 200,
+			} )
+		);
+
+		expect( comment ).not.toContain( 'Newer list.' );
+
+		const result = mergeSection( comment, {
+			id: 'props',
+			body: 'Older list.',
+			generation: 100,
+		} );
+
+		expect( result.body ).toBeUndefined();
+		expect( result.rejected ).toContain( '100' );
+	} );
+
+	it( 'renders a cleared section as nothing at all', () => {
+		let comment = bodyOf(
+			mergeSection( undefined, { id: 'labels', body: 'Warning.' } )
+		);
+		comment = bodyOf(
+			mergeSection( comment, {
+				id: 'props',
+				body: 'A list.',
+				generation: 200,
+			} )
+		);
+		comment = bodyOf(
+			mergeSection( comment, { id: 'props', body: '', generation: 200 } )
+		);
+
+		expect( comment ).not.toContain( getSection( 'props' )!.heading );
+
+		// Invisible, but still present and still carrying its generation.
+		const props = parseSections( comment ).find(
+			( section ) => section.id === 'props'
+		);
+		expect( props ).toBeDefined();
+		expect( props?.generation ).toBe( 200 );
+	} );
+
+	it( 'removes the comment once nothing visible is left', () => {
+		const comment = bodyOf(
+			mergeSection( undefined, {
+				id: 'props',
+				body: 'A list.',
+				generation: 200,
+			} )
+		);
+
+		expect(
+			mergeSection( comment, { id: 'props', body: '', generation: 200 } )
+		).toEqual( { remove: true } );
 	} );
 } );

--- a/tools/pr-meta/src/comment.ts
+++ b/tools/pr-meta/src/comment.ts
@@ -40,6 +40,63 @@ export function sanitizeBody( body: string ): string {
 	return body.replace( /<!--(\s*\/?\s*)pr-meta:/g, '&lt;!--$1pr-meta:' );
 }
 
+/** Section headings are `####`, so a body's own headings start below them. */
+const BODY_HEADING_LEVEL = 5;
+const MAX_HEADING_LEVEL = 6;
+
+/**
+ * Pushes a body's own headings below the heading of its section.
+ *
+ * A producer renders its markdown without knowing where it will sit, so props
+ * opens with `## Unlinked Accounts` and would outrank the `#### Props` above
+ * it. Shifting them all by the same amount keeps their hierarchy intact.
+ *
+ * @param body Markdown that may carry its own headings.
+ * @return The same markdown, its headings demoted.
+ */
+export function demoteHeadings( body: string ): string {
+	const lines = body.split( '\n' );
+	const isHeading = ( line: string, fenced: boolean ) =>
+		! fenced && /^#{1,6}\s/.test( line );
+
+	let fenced = false;
+	let shallowest = MAX_HEADING_LEVEL;
+
+	for ( const line of lines ) {
+		if ( /^\s*```/.test( line ) ) {
+			fenced = ! fenced;
+		} else if ( isHeading( line, fenced ) ) {
+			shallowest = Math.min( shallowest, line.indexOf( ' ' ) );
+		}
+	}
+
+	const shift = Math.max( 0, BODY_HEADING_LEVEL - shallowest );
+
+	if ( shift === 0 ) {
+		return body;
+	}
+
+	fenced = false;
+
+	return lines
+		.map( ( line ) => {
+			if ( /^\s*```/.test( line ) ) {
+				fenced = ! fenced;
+			} else if ( isHeading( line, fenced ) ) {
+				const level = Math.min(
+					line.indexOf( ' ' ) + shift,
+					MAX_HEADING_LEVEL
+				);
+				return `${ '#'.repeat( level ) }${ line.slice(
+					line.indexOf( ' ' )
+				) }`;
+			}
+
+			return line;
+		} )
+		.join( '\n' );
+}
+
 function parseAttributes( raw: string ): { sha?: string; runUrl?: string } {
 	const attributes: { sha?: string; runUrl?: string } = {};
 
@@ -302,7 +359,7 @@ export function mergeSection(
 		}
 	}
 
-	const body = sanitizeBody( update.body ).trim();
+	const body = demoteHeadings( sanitizeBody( update.body ) ).trim();
 	const remaining = sections.filter(
 		( section ) => section.id !== update.id
 	);

--- a/tools/pr-meta/src/comment.ts
+++ b/tools/pr-meta/src/comment.ts
@@ -9,6 +9,7 @@ export type ParsedSection = {
 	body: string;
 	sha?: string;
 	runUrl?: string;
+	generation?: number;
 };
 
 export type SectionUpdate = {
@@ -16,6 +17,8 @@ export type SectionUpdate = {
 	body: string;
 	sha?: string;
 	runUrl?: string;
+	/** Run that produced this, to order writes a commit cannot order. */
+	generation?: number;
 };
 
 const SECTION_PATTERN =
@@ -44,6 +47,52 @@ export function sanitizeBody( body: string ): string {
 const BODY_HEADING_LEVEL = 5;
 const MAX_HEADING_LEVEL = 6;
 
+/* The hashes and the rest of the line, so neither is reconstructed by hand. */
+const HEADING = /^(#{1,6})(\s.*)$/;
+/* A fence opens on three or more backticks or tildes, indented at most three. */
+const FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+
+/**
+ * Tracks whether a line falls inside a fenced code block.
+ *
+ * Toggling on every fence-looking line is not enough: a fence closes only on
+ * the character it opened with, repeated at least as many times, and a
+ * backtick fence's info string may not itself contain a backtick.
+ *
+ * @return A function reporting whether each line handed to it is fenced.
+ */
+function fenceTracker() {
+	let open: string | undefined;
+
+	return ( line: string ): boolean => {
+		const match = line.match( FENCE );
+
+		if ( ! match ) {
+			return open !== undefined;
+		}
+
+		const [ , marker, info ] = match;
+
+		if ( open === undefined ) {
+			if ( marker.startsWith( '`' ) && info.includes( '`' ) ) {
+				return false;
+			}
+			open = marker;
+			return true;
+		}
+
+		if (
+			marker[ 0 ] === open[ 0 ] &&
+			marker.length >= open.length &&
+			info.trim() === ''
+		) {
+			open = undefined;
+		}
+
+		return true;
+	};
+}
+
 /**
  * Pushes a body's own headings below the heading of its section.
  *
@@ -56,17 +105,17 @@ const MAX_HEADING_LEVEL = 6;
  */
 export function demoteHeadings( body: string ): string {
 	const lines = body.split( '\n' );
-	const isHeading = ( line: string, fenced: boolean ) =>
-		! fenced && /^#{1,6}\s/.test( line );
 
-	let fenced = false;
+	let isFenced = fenceTracker();
 	let shallowest = MAX_HEADING_LEVEL;
 
 	for ( const line of lines ) {
-		if ( /^\s*```/.test( line ) ) {
-			fenced = ! fenced;
-		} else if ( isHeading( line, fenced ) ) {
-			shallowest = Math.min( shallowest, line.indexOf( ' ' ) );
+		const level = isFenced( line )
+			? undefined
+			: line.match( HEADING )?.[ 1 ].length;
+
+		if ( level !== undefined ) {
+			shallowest = Math.min( shallowest, level );
 		}
 	}
 
@@ -76,29 +125,30 @@ export function demoteHeadings( body: string ): string {
 		return body;
 	}
 
-	fenced = false;
+	isFenced = fenceTracker();
 
 	return lines
 		.map( ( line ) => {
-			if ( /^\s*```/.test( line ) ) {
-				fenced = ! fenced;
-			} else if ( isHeading( line, fenced ) ) {
-				const level = Math.min(
-					line.indexOf( ' ' ) + shift,
-					MAX_HEADING_LEVEL
-				);
-				return `${ '#'.repeat( level ) }${ line.slice(
-					line.indexOf( ' ' )
-				) }`;
+			if ( isFenced( line ) ) {
+				return line;
 			}
 
-			return line;
+			return line.replace(
+				HEADING,
+				( _, hashes, rest ) =>
+					`${ '#'.repeat(
+						Math.min( hashes.length + shift, MAX_HEADING_LEVEL )
+					) }${ rest }`
+			);
 		} )
 		.join( '\n' );
 }
 
-function parseAttributes( raw: string ): { sha?: string; runUrl?: string } {
-	const attributes: { sha?: string; runUrl?: string } = {};
+function parseAttributes(
+	raw: string
+): Pick< ParsedSection, 'sha' | 'runUrl' | 'generation' > {
+	const attributes: Pick< ParsedSection, 'sha' | 'runUrl' | 'generation' > =
+		{};
 
 	for ( const pair of raw.trim().split( /\s+/ ).filter( Boolean ) ) {
 		const [ key, value ] = pair.split( '=' );
@@ -106,6 +156,11 @@ function parseAttributes( raw: string ): { sha?: string; runUrl?: string } {
 			attributes.sha = value;
 		} else if ( key === 'run' ) {
 			attributes.runUrl = value;
+		} else if ( key === 'gen' ) {
+			const generation = Number.parseInt( value, 10 );
+			attributes.generation = Number.isNaN( generation )
+				? undefined
+				: generation;
 		}
 	}
 
@@ -216,6 +271,7 @@ function renderSection(
 	const attributes = [
 		section.sha && `sha=${ section.sha }`,
 		section.runUrl && `run=${ section.runUrl }`,
+		section.generation !== undefined && `gen=${ section.generation }`,
 	]
 		.filter( Boolean )
 		.join( ' ' );
@@ -344,6 +400,23 @@ export function mergeSection(
 	 * optional, since without either one the two cases are indistinguishable
 	 * and guessing lets the stale run through.
 	 */
+	/*
+	 * A section describing the pull request rather than a commit has no SHA to
+	 * order writes by. Two runs can gather their view, queue behind each other
+	 * on the shared lock, and land out of order, so the later-numbered run
+	 * wins regardless of which reaches the lock first.
+	 */
+	if (
+		definition.scope === 'pr-state' &&
+		update.generation !== undefined &&
+		current?.generation !== undefined &&
+		update.generation < current.generation
+	) {
+		return {
+			rejected: `Result is from run ${ update.generation }, older than the run ${ current.generation } already reported.`,
+		};
+	}
+
 	if ( definition.scope === 'commit' && ( update.body || current ) ) {
 		if ( ! update.sha || ! headSha ) {
 			return {
@@ -373,6 +446,10 @@ export function mergeSection(
 					runUrl:
 						definition.scope === 'commit'
 							? update.runUrl
+							: undefined,
+					generation:
+						definition.scope === 'pr-state'
+							? update.generation
 							: undefined,
 				},
 		  ]

--- a/tools/pr-meta/src/comment.ts
+++ b/tools/pr-meta/src/comment.ts
@@ -47,10 +47,14 @@ export function sanitizeBody( body: string ): string {
 const BODY_HEADING_LEVEL = 5;
 const MAX_HEADING_LEVEL = 6;
 
-/* The hashes and the rest of the line, so neither is reconstructed by hand. */
-const HEADING = /^(#{1,6})(\s.*)$/;
+/*
+ * The hashes and the rest of the line, so neither is reconstructed by hand.
+ * `s` matters: without it a `.` stops at the carriage return of a CRLF body,
+ * so no line would match and the body would be left half demoted.
+ */
+const HEADING = /^( {0,3})(#{1,6})(\s.*|)$/s;
 /* A fence opens on three or more backticks or tildes, indented at most three. */
-const FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+const FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/s;
 
 /**
  * Tracks whether a line falls inside a fenced code block.
@@ -112,7 +116,7 @@ export function demoteHeadings( body: string ): string {
 	for ( const line of lines ) {
 		const level = isFenced( line )
 			? undefined
-			: line.match( HEADING )?.[ 1 ].length;
+			: line.match( HEADING )?.[ 2 ].length;
 
 		if ( level !== undefined ) {
 			shallowest = Math.min( shallowest, level );
@@ -135,8 +139,8 @@ export function demoteHeadings( body: string ): string {
 
 			return line.replace(
 				HEADING,
-				( _, hashes, rest ) =>
-					`${ '#'.repeat(
+				( _, indent, hashes, rest ) =>
+					`${ indent }${ '#'.repeat(
 						Math.min( hashes.length + shift, MAX_HEADING_LEVEL )
 					) }${ rest }`
 			);
@@ -285,6 +289,15 @@ function renderSection(
 		definition ?? UNKNOWN_SECTION,
 		section.runUrl
 	);
+
+	/*
+	 * A cleared section stays as a bare pair of markers, invisible in the
+	 * rendered comment but still carrying its generation, so a run that was
+	 * gathered earlier cannot bring the old content back.
+	 */
+	if ( body === '' ) {
+		return `${ open }\n\n${ close }`;
+	}
 
 	const delimited = `${ open }\n${ body }\n${ close }`;
 
@@ -436,26 +449,37 @@ export function mergeSection(
 	const remaining = sections.filter(
 		( section ) => section.id !== update.id
 	);
-	const next = body
-		? [
-				...remaining,
-				{
-					id: update.id,
-					body,
-					sha: definition.scope === 'commit' ? update.sha : undefined,
-					runUrl:
-						definition.scope === 'commit'
-							? update.runUrl
-							: undefined,
-					generation:
-						definition.scope === 'pr-state'
-							? update.generation
-							: undefined,
-				},
-		  ]
-		: remaining;
+	/*
+	 * Clearing keeps the entry when it has a generation to remember, so a
+	 * later, older write is still ordered against it.
+	 */
+	const cleared =
+		definition.scope === 'pr-state' && update.generation !== undefined;
+	const next =
+		body || cleared
+			? [
+					...remaining,
+					{
+						id: update.id,
+						body,
+						sha:
+							definition.scope === 'commit'
+								? update.sha
+								: undefined,
+						runUrl:
+							definition.scope === 'commit'
+								? update.runUrl
+								: undefined,
+						generation:
+							definition.scope === 'pr-state'
+								? update.generation
+								: undefined,
+					},
+			  ]
+			: remaining;
 
-	if ( next.length === 0 ) {
+	/* Markers alone render as nothing, so a comment of them is worth no comment. */
+	if ( next.every( ( section ) => section.body === '' ) ) {
 		return { remove: Boolean( existing ) };
 	}
 

--- a/tools/pr-meta/src/run.ts
+++ b/tools/pr-meta/src/run.ts
@@ -101,7 +101,7 @@ async function run() {
 			sha: getInput( 'commit-sha' ) || undefined,
 			runUrl: getInput( 'run-url' ) || undefined,
 			generation:
-				Number.parseInt( getInput( 'run-id' ), 10 ) || undefined,
+				Number.parseInt( getInput( 'generation' ), 10 ) || undefined,
 		},
 		headSha
 	);

--- a/tools/pr-meta/src/run.ts
+++ b/tools/pr-meta/src/run.ts
@@ -14,11 +14,14 @@ function resolvePrNumber(): number | undefined {
 
 	/*
 	 * `number` covers pull_request and pull_request_target, `issue` covers
-	 * issue_comment. A push carries no pull request, so those callers have to
-	 * pass `pr-number` themselves.
+	 * issue_comment, and `pull_request` covers the review events, which carry
+	 * no number of their own. A push has no pull request at all, so those
+	 * callers have to pass `pr-number` themselves.
 	 */
 	const payload = getEventPayload();
-	return payload.number ?? payload.issue?.number;
+	return (
+		payload.number ?? payload.issue?.number ?? payload.pull_request?.number
+	);
 }
 
 export function resolveBody(): string {

--- a/tools/pr-meta/src/run.ts
+++ b/tools/pr-meta/src/run.ts
@@ -100,6 +100,8 @@ async function run() {
 			body,
 			sha: getInput( 'commit-sha' ) || undefined,
 			runUrl: getInput( 'run-url' ) || undefined,
+			generation:
+				Number.parseInt( getInput( 'run-id' ), 10 ) || undefined,
 		},
 		headSha
 	);


### PR DESCRIPTION
## What?

Follow up to #82249

Moves the props list into the single automation comment, leaving no bot posting a comment of its own.

> [!IMPORTANT]
> Depends on [WordPress/props-bot-action#287](https://github.com/WordPress/props-bot-action/pull/287). Draft until that lands, since `@trunk` has neither the input nor the output this uses.

## Why?

Props was the last producer that could neither expose its body nor be told to stay quiet.

## How?

Upstream now takes `post-comment: false` and returns `comment-body`, so it renders the list and the writer posts it.

-   Section bodies are demoted below their section heading, code fences aside. Props opens with `## Unlinked Accounts`, which would outrank the `#### Props` above it.
-   The writer pins its checkout to the default branch, since the review events check out `refs/pull/N/merge`.
-   Props is gathered before its writer takes the lock, so writes are ordered by `run_number`. A cleared section keeps an invisible marker carrying that order.
-   The workflow cancelled by a group falling back to `github.sha`, the default branch tip on `issue_comment`.

## Testing Instructions

1. Comment on a pull request and confirm one comment appears, props first.
2. Confirm no separate props comment is posted.
