### PR TITLE
Documentation: Add recommended bulk suppressions configuration for ESLint VSCode

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -239,6 +239,9 @@ You can start with this workspace settings file:
 		"editor.formatOnSave": true,
 		"editor.defaultFormatter": "obliviousharmony.vscode-php-codesniffer"
 	},
+	"eslint.bulkSuppression.enable": true,
+	"eslint.bulkSuppression.location": "tools/eslint/suppressions.json",
+	"eslint.bulkSuppression.severity": "hint",
 	"intelephense.environment.phpVersion": "7.4.0",
 	"intelephense.files.exclude": [
 		"**/.cache/**",


### PR DESCRIPTION
## What?

Updates the ["Getting Started With Code Contribution" documentation](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md) to include recommended ESLint plugin settings around [bulk suppressions](https://eslint.org/docs/latest/use/suppressions), based on the discussion stemming from https://github.com/WordPress/gutenberg/pull/80123#issuecomment-5497606411.

## Why?

Currently, a default VSCode environment using the ESLint plugin will display bulk suppressions as errors, which can be very distracting (see "Before" screenshot below). 

Since we're already recommending the ESLint plugin _and_ a recommended configuration for VSCode (and have established a precedent for other plugin-specific recommended configuration), it's natural that this documentation would be the logical entry point for improving this experience.

## Testing Instructions

Review settings for accuracy, referring to [extension settings options](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#settings-options) as a resource.

## Screenshots or screencast <!-- if applicable -->

The following screenshots show the difference after the settings take effect in VSCode. Observe that the "hint" is highlighted as three dots under the opening tag for `DropdownMenu`.

Also worth noting that my editor is [Cursor](https://cursor.com/), but since Cursor is a derivative of VSCode, support for the settings configuration extends to these editors as well.

|Before|After|
|-|-|
<img width="1145" height="1522" alt="image" src="https://github.com/user-attachments/assets/d60307b7-60b2-499a-b487-17c5352003c0" />|<img width="1145" height="1522" alt="image" src="https://github.com/user-attachments/assets/92726374-e693-467a-816d-741b0f493e24" />

## Use of AI Tools

Claude Code + Opus 5 was used in the course of researching solutions following the discussion of https://github.com/WordPress/gutenberg/pull/80123#issuecomment-5497606411, but the actual content changes here were applied manually.