### PR TITLE
Revisions: render the author for users who cannot edit users

### DIFF
--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-revisions-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-revisions-controller.php
@@ -46,6 +46,15 @@ class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 			$data['author'] = (int) $post->post_author;
 		}
 
+		if ( in_array( 'author_name', $fields, true ) ) {
+			$author              = get_userdata( $post->post_author );
+			$data['author_name'] = $author ? $author->display_name : '';
+		}
+
+		if ( in_array( 'author_avatar_urls', $fields, true ) ) {
+			$data['author_avatar_urls'] = rest_get_avatar_urls( (int) $post->post_author );
+		}
+
 		if ( in_array( 'date', $fields, true ) ) {
 			$data['date'] = $this->prepare_date_response( $post->post_date_gmt, $post->post_date );
 		}
@@ -139,5 +148,57 @@ class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
 		return apply_filters( 'rest_prepare_revision', $response, $post, $request );
+	}
+
+	/**
+	 * Retrieves the revision's schema, conforming to JSON Schema.
+	 *
+	 * Adds `author_name` and `author_avatar_urls` alongside the existing numeric
+	 * `author` field, mirroring WP_REST_Comments_Controller. This lets a client
+	 * render a revision's author without a follow-up request to
+	 * `/wp/v2/users/<id>`.
+	 *
+	 * @see WP_REST_Comments_Controller::get_item_schema()
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		// Populates $this->schema with the core revision schema.
+		parent::get_item_schema();
+
+		$this->schema['properties']['author_name'] = array(
+			'description' => __( 'Display name for the revision author.', 'gutenberg' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'readonly'    => true,
+		);
+
+		if ( get_option( 'show_avatars' ) ) {
+			$avatar_properties = array();
+
+			foreach ( rest_get_avatar_sizes() as $size ) {
+				$avatar_properties[ $size ] = array(
+					/* translators: %d: Avatar image size in pixels. */
+					'description' => sprintf( __( 'Avatar URL with image size of %d pixels.', 'gutenberg' ), $size ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				);
+			}
+
+			$this->schema['properties']['author_avatar_urls'] = array(
+				'description' => __( 'Avatar URLs for the revision author.', 'gutenberg' ),
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit', 'embed' ),
+				'readonly'    => true,
+				'properties'  => $avatar_properties,
+			);
+		}
+
+		return $this->add_additional_fields_schema( $this->schema );
 	}
 }

--- a/lib/compat/wordpress-7.0/class-gutenberg-rest-revisions-controller.php
+++ b/lib/compat/wordpress-7.0/class-gutenberg-rest-revisions-controller.php
@@ -46,15 +46,6 @@ class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 			$data['author'] = (int) $post->post_author;
 		}
 
-		if ( in_array( 'author_name', $fields, true ) ) {
-			$author              = get_userdata( $post->post_author );
-			$data['author_name'] = $author ? $author->display_name : '';
-		}
-
-		if ( in_array( 'author_avatar_urls', $fields, true ) ) {
-			$data['author_avatar_urls'] = rest_get_avatar_urls( (int) $post->post_author );
-		}
-
 		if ( in_array( 'date', $fields, true ) ) {
 			$data['date'] = $this->prepare_date_response( $post->post_date_gmt, $post->post_date );
 		}
@@ -148,57 +139,5 @@ class Gutenberg_REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
 		return apply_filters( 'rest_prepare_revision', $response, $post, $request );
-	}
-
-	/**
-	 * Retrieves the revision's schema, conforming to JSON Schema.
-	 *
-	 * Adds `author_name` and `author_avatar_urls` alongside the existing numeric
-	 * `author` field, mirroring WP_REST_Comments_Controller. This lets a client
-	 * render a revision's author without a follow-up request to
-	 * `/wp/v2/users/<id>`.
-	 *
-	 * @see WP_REST_Comments_Controller::get_item_schema()
-	 *
-	 * @return array Item schema data.
-	 */
-	public function get_item_schema() {
-		if ( $this->schema ) {
-			return $this->add_additional_fields_schema( $this->schema );
-		}
-
-		// Populates $this->schema with the core revision schema.
-		parent::get_item_schema();
-
-		$this->schema['properties']['author_name'] = array(
-			'description' => __( 'Display name for the revision author.', 'gutenberg' ),
-			'type'        => 'string',
-			'context'     => array( 'view', 'edit', 'embed' ),
-			'readonly'    => true,
-		);
-
-		if ( get_option( 'show_avatars' ) ) {
-			$avatar_properties = array();
-
-			foreach ( rest_get_avatar_sizes() as $size ) {
-				$avatar_properties[ $size ] = array(
-					/* translators: %d: Avatar image size in pixels. */
-					'description' => sprintf( __( 'Avatar URL with image size of %d pixels.', 'gutenberg' ), $size ),
-					'type'        => 'string',
-					'format'      => 'uri',
-					'context'     => array( 'view', 'edit', 'embed' ),
-				);
-			}
-
-			$this->schema['properties']['author_avatar_urls'] = array(
-				'description' => __( 'Avatar URLs for the revision author.', 'gutenberg' ),
-				'type'        => 'object',
-				'context'     => array( 'view', 'edit', 'embed' ),
-				'readonly'    => true,
-				'properties'  => $avatar_properties,
-			);
-		}
-
-		return $this->add_additional_fields_schema( $this->schema );
 	}
 }

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-revisions-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-revisions-controller-7-2.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Revisions_Controller_7_2 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Controller which provides REST endpoint for revisions.
+ *
+ * This extends Gutenberg_REST_Revisions_Controller to supply the revision
+ * author's display name and avatar URLs alongside the numeric `author` field,
+ * mirroring WP_REST_Comments_Controller.
+ *
+ * A client can then render a revision's author without a follow-up request to
+ * `/wp/v2/users/<id>`. That request is made in the `edit` context, which
+ * WP_REST_Users_Controller::get_item_permissions_check() refuses for anyone
+ * who cannot `edit_user` the target, so every non-administrator received a
+ * 403 and no author name.
+ *
+ * @since 7.2.0
+ *
+ * @see Gutenberg_REST_Revisions_Controller
+ * @see WP_REST_Comments_Controller
+ */
+class Gutenberg_REST_Revisions_Controller_7_2 extends Gutenberg_REST_Revisions_Controller {
+
+	/**
+	 * Prepares the revision for the REST response.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param WP_Post         $item    Post revision object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		// The parent does not prepare a response body for HEAD requests.
+		if ( $request->is_method( 'HEAD' ) ) {
+			return $response;
+		}
+
+		$fields = $this->get_fields_for_response( $request );
+		$schema = $this->get_item_schema();
+		$data   = $response->get_data();
+
+		if ( in_array( 'author_name', $fields, true ) ) {
+			$author              = get_userdata( $item->post_author );
+			$data['author_name'] = $author ? $author->display_name : '';
+		}
+
+		// The schema only declares author_avatar_urls when avatars are enabled.
+		if ( ! empty( $schema['properties']['author_avatar_urls'] ) && in_array( 'author_avatar_urls', $fields, true ) ) {
+			$data['author_avatar_urls'] = rest_get_avatar_urls( (int) $item->post_author );
+		}
+
+		$response->set_data( $data );
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves the revision's schema, conforming to JSON Schema.
+	 *
+	 * Adds `author_name` and `author_avatar_urls` alongside the existing numeric
+	 * `author` field, mirroring WP_REST_Comments_Controller.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @see WP_REST_Comments_Controller::get_item_schema()
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		// Populates $this->schema with the core revision schema.
+		parent::get_item_schema();
+
+		$this->schema['properties']['author_name'] = array(
+			'description' => __( 'Display name for the revision author.', 'gutenberg' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'readonly'    => true,
+		);
+
+		if ( get_option( 'show_avatars' ) ) {
+			$avatar_properties = array();
+
+			foreach ( rest_get_avatar_sizes() as $size ) {
+				$avatar_properties[ $size ] = array(
+					/* translators: %d: Avatar image size in pixels. */
+					'description' => sprintf( __( 'Avatar URL with image size of %d pixels.', 'gutenberg' ), $size ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit', 'embed' ),
+				);
+			}
+
+			$this->schema['properties']['author_avatar_urls'] = array(
+				'description' => __( 'Avatar URLs for the revision author.', 'gutenberg' ),
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit', 'embed' ),
+				'readonly'    => true,
+				'properties'  => $avatar_properties,
+			);
+		}
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Overrides the REST controller for revisions so that a revision carries its
+ * author's display name and avatar URLs.
+ *
+ * Replaces the WordPress 7.0 override, which this controller extends. A site
+ * that has set its own controller keeps it.
+ *
+ * @since 7.2.0
+ *
+ * @param array $args Array of arguments for registering a post type.
+ * @return array Modified array of arguments.
+ */
+function gutenberg_override_revisions_rest_controller_7_2( $args ) {
+	if (
+		empty( $args['revisions_rest_controller_class'] ) ||
+		'Gutenberg_REST_Revisions_Controller' === $args['revisions_rest_controller_class']
+	) {
+		$args['revisions_rest_controller_class'] = 'Gutenberg_REST_Revisions_Controller_7_2';
+	}
+
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_override_revisions_rest_controller_7_2', 11, 1 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -72,6 +72,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.1/block-comments.php';
 
 	// WordPress 7.2 compat.
+	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-revisions-controller-7-2.php';
+	require __DIR__ . '/compat/wordpress-7.2/rest-api.php';
 	require __DIR__ . '/compat/wordpress-7.2/view-config-api.php';
 
 	// Real-time collaboration.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Revisions: Request `author_name` and `author_avatar_urls` alongside the numeric `author`, so a revision's author renders for everyone who can open the revisions view rather than only for administrators.
 -   Attach media an Image or Gallery block displays to the post on save, when it is not already attached to another post, matching what uploading into that post has always done ([#81977](https://github.com/WordPress/gutenberg/pull/81977)).
 -   Color the welcome guide's hovered button icon with `color` rather than `fill`, so stroke-based icons follow it. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -352,6 +352,8 @@ export function buildRevisionsPageQuery( revisionKey, page ) {
 				'date',
 				'modified',
 				'author',
+				'author_name',
+				'author_avatar_urls',
 				'slug',
 				'meta',
 				'title.raw',

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `AuthorView`: Prefer author details supplied on the record itself over a separate user fetch. The `root/user` entity is fixed to `context=edit`, which `WP_REST_Users_Controller` refuses for anyone who cannot `edit_user` the target, so the author's name and avatar were missing for every non-administrator.
 -   Normalize special characters in exported pattern filenames to prevent broken or unreadable files. ([#77033](https://github.com/WordPress/gutenberg/pull/77033))
 
 ### Internal

--- a/packages/fields/src/fields/author/author-view.tsx
+++ b/packages/fields/src/fields/author/author-view.tsx
@@ -11,13 +11,21 @@ import { store as coreStore } from '@wordpress/core-data';
 import type { BasePostWithEmbeddedAuthor } from '../../types';
 
 function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
-	// Fetch the author record from the store when _embedded data is unavailable
+	// Prefer author details supplied on the record itself. Revisions include
+	// them, which avoids a follow-up request the viewer may not be permitted to
+	// make: the `root/user` entity is fixed to `context=edit`, and
+	// WP_REST_Users_Controller only allows that context for users who can
+	// `edit_user` the target, so everyone else receives a 403 and no name.
+	const authorId = item?.author;
+	const inlineAuthorName = item?.author_name;
+	const embeddedAuthorId = item?._embedded?.author?.[ 0 ]?.id;
+	// Otherwise fetch the author record when _embedded data is unavailable
 	// (e.g. in the post editor inspector) or when the author has been changed
 	// during editing (item.author differs from _embedded.author).
-	const authorId = item?.author;
-	const embeddedAuthorId = item?._embedded?.author?.[ 0 ]?.id;
 	const shouldFetch = Boolean(
-		authorId && ( ! embeddedAuthorId || authorId !== embeddedAuthorId )
+		! inlineAuthorName &&
+			authorId &&
+			( ! embeddedAuthorId || authorId !== embeddedAuthorId )
 	);
 	const author = useSelect(
 		( select ) => {
@@ -25,17 +33,19 @@ function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
 				return null;
 			}
 			const { getEntityRecord } = select( coreStore );
-			// This doesn't make extra REST requests because the records are
-			// already in the store from the field's getElements function.
 			return authorId
 				? getEntityRecord( 'root', 'user', authorId )
 				: null;
 		},
 		[ authorId, shouldFetch ]
 	);
-	// Use fetched author if available, otherwise use _embedded.
-	const text = author?.name || item?._embedded?.author?.[ 0 ]?.name;
+	// Use inline author details if present, then the fetched author, then _embedded.
+	const text =
+		inlineAuthorName ||
+		author?.name ||
+		item?._embedded?.author?.[ 0 ]?.name;
 	const imageUrl =
+		item?.author_avatar_urls?.[ 48 ] ||
 		author?.avatar_urls?.[ 48 ] ||
 		item?._embedded?.author?.[ 0 ]?.avatar_urls?.[ 48 ];
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -39,6 +39,8 @@ interface EmbeddedAuthor {
  * BasePost interface used for all post types.
  */
 export interface BasePost extends CommonPost {
+	author_name?: string;
+	author_avatar_urls?: Record< number, string >;
 	comment_status?: 'open' | 'closed';
 	excerpt?: string | { raw: string; rendered: string };
 	meta?: Record< string, any >;


### PR DESCRIPTION
## What?

Closes #82305

Renders a revision's author for users who cannot `edit_users`, by supplying the author's display name and avatars with the revision instead of resolving them through a separate user request.

## Why?

`AuthorView` resolves a revision's author with `getEntityRecord( 'root', 'user', authorId )`. The `root/user` entity is fixed to `context: 'edit'`, and `WP_REST_Users_Controller::get_item_permissions_check()` refuses that context unless the caller can `edit_user` the target, which maps to the administrator-only `edit_users` capability.

Every other role therefore gets a `403 rest_forbidden_context` and the row renders as an empty name next to the fallback person icon. Viewers still see their own row, because the controller short-circuits when the caller is the target. Captured as an editor-role user on one page load:

```
200  /wp/v2/users/2?context=view&_fields=id,name   <- post author panel, fine
403  /wp/v2/users/2?context=edit                   <- revisions sidebar, blocked
200  /wp/v2/users/3?context=edit                   <- self, allowed
```

The obvious fix is to pass `{ context: 'view' }` at the call site, and it does work for the common case. I did not take that route, because a second gate in the same permission check (`count_user_posts()`) still refuses a user who has never published, even in `view` context. Any approach that resolves the author through `/wp/v2/users/<id>` hits that gate, `_embed` included, since `context=embed` only skips the first one. That leaves a blank name for a revision authored by someone with no published posts.

## How?

Supplies the author with the revision, mirroring `WP_REST_Comments_Controller`, which has exposed `author_name` and `author_avatar_urls` directly for exactly this reason since 4.7. The server decides what to expose, the client never asks about a user, and the permission question does not arise.

- `Gutenberg_REST_Revisions_Controller_7_2` (new, in `lib/compat/wordpress-7.2/`) extends `Gutenberg_REST_Revisions_Controller` and exposes `author_name` and `author_avatar_urls` alongside the existing numeric `author`, plus a `get_item_schema()` override declaring them. It calls the parent's `prepare_item_for_response()` and adds the two fields to the response rather than duplicating the method, so the 7.0 nested `_fields` handling stays in one place. The avatar block follows the comments controller, including the `show_avatars` guard and the `rest_get_avatar_sizes()` loop.
- `lib/compat/wordpress-7.2/rest-api.php` points `revisions_rest_controller_class` at the new class at priority 11, superseding the 7.0 override while leaving a controller a site set itself alone.
- `buildRevisionsPageQuery` requests the two new fields.
- `AuthorView` prefers them and skips the fetch when they are present, falling back to the existing fetch and `_embedded` paths otherwise, so it behaves unchanged wherever the fields are absent.

This also removes one REST request per distinct revision author. In the repro below, the revisions sidebar goes from 3 user requests to 0.

Two incidental fixes:

- Drops a comment claiming the fetch is free because `getElements` already populated the store. Records are keyed by the query's context: `getElements` uses `getEntityRecords` with `context: 'view'` and writes the `"view"` bucket, while `AuthorView` reads the `"default"` bucket. They never share an entry, so the request always happened. `getElements` also does not run in the revisions inspector at all.
- Adds `author_name` and `author_avatar_urls` to `BasePost`.

## Testing Instructions

1. Fresh WordPress with this branch active.
2. Create an administrator (`alice`) and an editor (`bob`).
3. Publish a post as `alice`, then edit and save it twice more as `alice`.
4. Edit and save the same post once as `bob`.
5. As `bob`, open the post, enter the revisions view, and open the settings sidebar.
6. Every revision should show its author's name and avatar. On `trunk`, `alice`'s two revisions show an empty name and a generic person icon.
7. Repeat as `alice` to confirm no regression for administrators.
8. Optionally add a user with no published posts, have them save a revision, and confirm their name renders too. That case is not fixed by switching the call site to `context: 'view'`.

Verified against WordPress 7.2-alpha with an editor-role viewer, four revisions by three authors, one of whom has no published posts:

| | Author names rendered | `/wp/v2/users` requests |
| - | - | - |
| Before | `["", "Bob Editor", "", ""]` | `403` alice, `403` carol, `200` self |
| After | `["Carol NoPosts", "Bob Editor", "Alice Admin", "Alice Admin"]` | none |

Also checked: `view`/`edit`/`embed` contexts, `_fields` still honoured when the new fields are not requested, `title.raw` sub-field filtering unaffected, `show_avatars = 0` omits `author_avatar_urls` from both the response and the schema, and `HEAD` still returns an empty body.

### Testing Instructions for Keyboard

No UI or interaction changes. The revision list is reachable and operable exactly as before; only the rendered author text and avatar differ.

## Screenshots or screencast

Before 
<img width="1440" height="900" alt="before" src="https://github.com/user-attachments/assets/cf967ca3-019d-437b-8118-ad8700eb4f02" />

After
<img width="1440" height="900" alt="after" src="https://github.com/user-attachments/assets/161d4a89-57d6-45ca-be87-4f1873da24f2" />

