### PR TITLE
Image: measure the lightbox container, not the image's parent

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
+-   Image: Position the lightbox trigger button against the `.wp-lightbox-container` figure instead of the image's parent element, so the button stays over the image when a plugin wraps the `img` in a `picture` element ([#82312](https://github.com/WordPress/gutenberg/pull/82312)).
 
 ### Internal
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -618,14 +618,17 @@ const { state, actions, callbacks } = store(
 					return;
 				}
 
-				const figure = ref.parentElement;
-				const figureWidth = ref.parentElement.clientWidth;
+				// The image is not necessarily a direct child of the figure, as
+				// plugins can wrap it, so it uses the container the button is
+				// positioned against rather than the image's parent element.
+				const figure = ref.closest( '.wp-lightbox-container' );
+				const figureWidth = figure.clientWidth;
 
 				// It needs special handling for the height because a caption will cause
 				// the figure to be taller than the image, which means it needs to
 				// account for that when calculating the placement of the button in the
 				// top right corner of the image.
-				let figureHeight = ref.parentElement.clientHeight;
+				let figureHeight = figure.clientHeight;
 				const caption = figure.querySelector( 'figcaption' );
 				if ( caption ) {
 					const captionComputedStyle =

--- a/packages/e2e-tests/plugins/image-picture-wrapper.php
+++ b/packages/e2e-tests/plugins/image-picture-wrapper.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Image Picture Wrapper
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-image-picture-wrapper
+ */
+
+/**
+ * Wraps the `img` of an Image block in a `picture` element, the way the Modern
+ * Image Formats plugin does when its picture element setting is enabled.
+ *
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Parsed block.
+ * @return string Filtered block content.
+ */
+function gutenberg_test_wrap_image_in_picture( $block_content, $block ) {
+	if ( 'core/image' !== $block['blockName'] || ! str_contains( $block_content, '<img' ) ) {
+		return $block_content;
+	}
+
+	return preg_replace(
+		'/<img[^>]+>/',
+		'<picture style="display: contents;">$0</picture>',
+		$block_content,
+		1
+	);
+}
+add_filter( 'render_block', 'gutenberg_test_wrap_image_in_picture', 10, 2 );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -996,6 +996,74 @@ test.describe( 'Image - lightbox', () => {
 			} );
 			expect( margin ).toBe( '0px' );
 		} );
+
+		// Regression test for https://github.com/WordPress/gutenberg/issues/82283.
+		test.describe( 'when a plugin wraps the image', () => {
+			let largeMedia;
+
+			test.beforeAll( async ( { requestUtils } ) => {
+				largeMedia = await requestUtils.uploadMedia(
+					'./assets/1024x768_e2e_test_image_size.jpeg'
+				);
+				await requestUtils.activatePlugin(
+					'gutenberg-test-image-picture-wrapper'
+				);
+			} );
+
+			test.afterAll( async ( { requestUtils } ) => {
+				await requestUtils.deactivatePlugin(
+					'gutenberg-test-image-picture-wrapper'
+				);
+			} );
+
+			test( 'Trigger button should still be placed inside the figure', async ( {
+				editor,
+				page,
+			} ) => {
+				await editor.setContent( `<!-- wp:image {"id":${ largeMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+				<figure class="wp-block-image size-full"><img src="${ largeMedia.source_url }" alt="" class="wp-image-${ largeMedia.id }"/><figcaption class="wp-element-caption">A caption.</figcaption></figure>
+				<!-- /wp:image -->` );
+
+				const postId = await editor.publishPost();
+				await page.setViewportSize( { width: 500, height: 800 } );
+				await page.goto( `/?p=${ postId }` );
+
+				const image = page.locator( '.wp-lightbox-container img' );
+				await expect( image ).toBeVisible();
+				// The button is only positioned once the image has loaded.
+				await expect
+					.poll( () =>
+						page.evaluate(
+							() =>
+								document.querySelector(
+									'button.lightbox-trigger'
+								).style.top
+						)
+					)
+					.not.toBe( '' );
+
+				const figureBox = await page
+					.locator( '.wp-lightbox-container' )
+					.boundingBox();
+				const buttonBox = await page
+					.locator( 'button.lightbox-trigger' )
+					.boundingBox();
+
+				expect( buttonBox.y ).toBeGreaterThanOrEqual( figureBox.y );
+				expect( buttonBox.x + buttonBox.width ).toBeLessThanOrEqual(
+					figureBox.x + figureBox.width
+				);
+
+				// A mispositioned button pushes the page sideways.
+				const { scrollWidth, clientWidth } = await page.evaluate(
+					() => ( {
+						scrollWidth: document.documentElement.scrollWidth,
+						clientWidth: document.documentElement.clientWidth,
+					} )
+				);
+				expect( scrollWidth ).toBe( clientWidth );
+			} );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/82283

Places the Image block's lightbox trigger button against the `.wp-lightbox-container` figure instead of the image's parent element, so the button stays in the corner of the image when a plugin wraps the `img`.

## Why?

`setButtonStyles` measured `ref.parentElement`, which assumes the `img` is a direct child of the figure. Plugins can wrap it: Modern Image Formats wraps it in a `<picture style="display: contents">` when its picture element setting is on. That wrapper generates no box, so `clientWidth` and `clientHeight` both read `0`.

The button then gets `right: -offsetWidth + 16` and `top: -offsetHeight + 16`, which lands it outside the figure and adds horizontal scrolling to the page. `figure.querySelector( 'figcaption' )` on the next line also returns `null`, so a caption's height is never subtracted.

Reported downstream at https://github.com/WordPress/performance/issues/1918

Follow up to https://github.com/WordPress/gutenberg/pull/57089, which made the trigger button ref resilient to the same wrapping.

## How?

Measures `ref.closest( '.wp-lightbox-container' )`. That is the element the button is actually positioned against - `.wp-lightbox-container` is `position: relative` and the button is `position: absolute` - and it is always present, since `block_core_image_render_lightbox()` adds the class. For an unwrapped image it resolves to the same node as `parentElement`, so nothing changes there.

## Testing Instructions

[![Test in WordPress Playground](https://img.shields.io/badge/Test_in-WP_Playground-blue?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=82312)

1. Install Modern Image Formats. Under Settings > Media, enable "Generate JPEG and WebP" and the picture element setting.
2. Upload a reasonably large JPEG, add it to an Image block, and turn on "Expand on click".
3. Publish and view the post at a narrow viewport, around 500px.
4. Hover the image. The enlarge button should sit in the top right corner of the image, and the page should not scroll sideways.

On trunk the button lands well outside the figure and the page picks up horizontal scroll.

The automated regression test covers the same thing without the plugin, using a small e2e plugin that wraps the `img` the same way:

```
npm run test:e2e -- specs/editor/blocks/image.spec.js --grep "Trigger button should still be placed inside the figure"
```

### Testing Instructions for Keyboard

Tab to the enlarge button on the published post. Focus should land on the button over the image rather than somewhere off to the side, and pressing Enter should open the lightbox.

## Screenshots or screencast

Both shots are the full scrollable width of the page in a 500px viewport, with the `img` wrapped in a `picture` element.

Before - the button is 364px to the right of the figure, up beside the post title, and the page is 834px wide instead of 500px:

<img width="834" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82283-before-wrapped-button-mispositioned.png">

After - the button is back in the corner of the image and the page is 500px wide again:

<img width="500" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82283-after-wrapped-button-fixed.png">

## Use of AI Tools

Claude Code did the typing here, I did the asking. I will review and test.
