### PR TITLE
Notes: reveal the add-reaction trigger on hover instead of reserving a row

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Notes: allow reacting to a note with an emoji. Reactions display as pill buttons on the note with per-emoji counts, backed by a new `reaction` comment type ([#76767](https://github.com/WordPress/gutenberg/pull/76767)). The add-reaction trigger sits among the note's other icon actions and fades in on hover or focus, so a note with no reactions costs no vertical space for the option ([#82313](https://github.com/WordPress/gutenberg/pull/82313)).
+-   Notes: allow reacting to a note with an emoji. Reactions display as pill buttons on the note with per-emoji counts, backed by a new `reaction` comment type ([#76767](https://github.com/WordPress/gutenberg/pull/76767)). The add-reaction trigger fades in on hover or focus at the end of the note, where the reactions themselves appear, so a note with no reactions costs no vertical space for the option ([#82313](https://github.com/WordPress/gutenberg/pull/82313)).
 -   Notes: the add-reaction popover now offers a full searchable emoji picker with a per-user skin tone preference, powered by a self-hosted Emojibase dataset configured via the `noteEmojibaseUrl` editor setting (with optional `noteEmojiLabelOverrides`) ([#78176](https://github.com/WordPress/gutenberg/pull/78176)).
 
 ### Bug Fixes

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Notes: allow reacting to a note with an emoji. Reactions display as pill buttons on the note with per-emoji counts, backed by a new `reaction` comment type ([#76767](https://github.com/WordPress/gutenberg/pull/76767)).
+-   Notes: allow reacting to a note with an emoji. Reactions display as pill buttons on the note with per-emoji counts, backed by a new `reaction` comment type ([#76767](https://github.com/WordPress/gutenberg/pull/76767)). The add-reaction trigger sits among the note's other icon actions and fades in on hover or focus, so a note with no reactions costs no vertical space for the option ([#82313](https://github.com/WordPress/gutenberg/pull/82313)).
 -   Notes: the add-reaction popover now offers a full searchable emoji picker with a per-user skin tone preference, powered by a self-hosted Emojibase dataset configured via the `noteEmojibaseUrl` editor setting (with optional `noteEmojiLabelOverrides`) ([#78176](https://github.com/WordPress/gutenberg/pull/78176)).
 
 ### Bug Fixes

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Notes: allow reacting to a note with an emoji. Reactions display as pill buttons on the note with per-emoji counts, backed by a new `reaction` comment type ([#76767](https://github.com/WordPress/gutenberg/pull/76767)). The add-reaction trigger fades in on hover or focus at the end of the note, where the reactions themselves appear, so a note with no reactions costs no vertical space for the option ([#82313](https://github.com/WordPress/gutenberg/pull/82313)).
+-   Notes: allow reacting to a note with an emoji. Reactions display as pill buttons on the note with per-emoji counts, backed by a new `reaction` comment type ([#76767](https://github.com/WordPress/gutenberg/pull/76767)). The add-reaction trigger fades in on hover or focus in the note's top corner, in line with its other actions, so a note with no reactions costs no vertical space for the option ([#82313](https://github.com/WordPress/gutenberg/pull/82313)).
 -   Notes: the add-reaction popover now offers a full searchable emoji picker with a per-user skin tone preference, powered by a self-hosted Emojibase dataset configured via the `noteEmojibaseUrl` editor setting (with optional `noteEmojiLabelOverrides`) ([#78176](https://github.com/WordPress/gutenberg/pull/78176)).
 
 ### Bug Fixes

--- a/packages/editor/src/components/collab-sidebar/add-reaction-picker.tsx
+++ b/packages/editor/src/components/collab-sidebar/add-reaction-picker.tsx
@@ -129,12 +129,6 @@ class PickerErrorBoundary extends Component< PickerErrorBoundaryProps > {
 interface AddReactionButtonProps {
 	noteId: number;
 	disabled?: boolean;
-	/**
-	 * Chrome for the trigger. `outline` reads as a control of its own beside
-	 * the reaction pills; `minimal` lets it sit quietly among the note's other
-	 * icon actions.
-	 */
-	variant?: 'outline' | 'minimal';
 	onToggleReaction: ( slug: string ) => void;
 }
 
@@ -150,15 +144,11 @@ interface AddReactionButtonProps {
  * @param props.noteId           The parent note comment ID.
  * @param props.disabled         Whether the button is disabled (e.g. on a
  *                               resolved note thread).
- * @param props.variant          Trigger chrome: `outline` to read as a control
- *                               of its own, `minimal` to sit among the note's
- *                               other icon actions.
  * @param props.onToggleReaction Callback to toggle a reaction.
  */
 export function AddReactionButton( {
 	noteId,
 	disabled = false,
-	variant = 'outline',
 	onToggleReaction,
 }: AddReactionButtonProps ) {
 	const { recordUse } = useFrequentEmojis();
@@ -218,7 +208,7 @@ export function AddReactionButton( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<IconButton
 					size="small"
-					variant={ variant }
+					variant="outline"
 					tone="neutral"
 					className="editor-collab-sidebar-panel__add-reaction-button"
 					icon={ smileyIcon }

--- a/packages/editor/src/components/collab-sidebar/add-reaction-picker.tsx
+++ b/packages/editor/src/components/collab-sidebar/add-reaction-picker.tsx
@@ -129,6 +129,12 @@ class PickerErrorBoundary extends Component< PickerErrorBoundaryProps > {
 interface AddReactionButtonProps {
 	noteId: number;
 	disabled?: boolean;
+	/**
+	 * Chrome for the trigger. `outline` reads as a control of its own beside
+	 * the reaction pills; `minimal` lets it sit quietly among the note's other
+	 * icon actions.
+	 */
+	variant?: 'outline' | 'minimal';
 	onToggleReaction: ( slug: string ) => void;
 }
 
@@ -144,11 +150,15 @@ interface AddReactionButtonProps {
  * @param props.noteId           The parent note comment ID.
  * @param props.disabled         Whether the button is disabled (e.g. on a
  *                               resolved note thread).
+ * @param props.variant          Trigger chrome: `outline` to read as a control
+ *                               of its own, `minimal` to sit among the note's
+ *                               other icon actions.
  * @param props.onToggleReaction Callback to toggle a reaction.
  */
 export function AddReactionButton( {
 	noteId,
 	disabled = false,
+	variant = 'outline',
 	onToggleReaction,
 }: AddReactionButtonProps ) {
 	const { recordUse } = useFrequentEmojis();
@@ -208,7 +218,7 @@ export function AddReactionButton( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<IconButton
 					size="small"
-					variant="outline"
+					variant={ variant }
 					tone="neutral"
 					className="editor-collab-sidebar-panel__add-reaction-button"
 					icon={ smileyIcon }

--- a/packages/editor/src/components/collab-sidebar/note.jsx
+++ b/packages/editor/src/components/collab-sidebar/note.jsx
@@ -87,8 +87,8 @@ export function Note( {
 
 	const canResolve = note.parent === 0;
 	const hasReactions = getReactedSlugs( reactions ).length > 0;
-	// Not while editing: the trigger floats over the end of the note, which
-	// during an edit is the form's own buttons.
+	// Not while editing: the trigger floats over the note's corner, which
+	// during an edit is the form's own text field.
 	const canReact =
 		isSelected && !! onToggleReaction && actionState !== 'edit';
 	const isResolutionNote =
@@ -234,25 +234,13 @@ export function Note( {
 								'editor-collab-sidebar-panel__reactions',
 								{
 									// Nothing to sit beside yet, so the
-									// trigger floats over the end of the note
+									// trigger floats in the note's top corner
 									// rather than making the card taller for
 									// an option nobody has taken up.
 									'is-floating': ! hasReactions,
 								}
 							) }
 						>
-							{ canReact && (
-								<AddReactionButton
-									noteId={ note.id }
-									disabled={ isThreadResolved }
-									onToggleReaction={ ( emoji ) =>
-										onToggleReaction( {
-											commentId: note.id,
-											emoji,
-										} )
-									}
-								/>
-							) }
 							{ /*
 							 * Reactions are information about the note, so
 							 * unlike its actions they stay visible once the
@@ -268,7 +256,27 @@ export function Note( {
 										emoji,
 									} )
 								}
-							/>
+							>
+								{ /*
+								 * Trails the pills, in the same tree position
+								 * whether or not there are any: a different
+								 * position once the first reaction lands would
+								 * remount the open picker's trigger and drop
+								 * focus to the body.
+								 */ }
+								{ canReact && (
+									<AddReactionButton
+										noteId={ note.id }
+										disabled={ isThreadResolved }
+										onToggleReaction={ ( emoji ) =>
+											onToggleReaction( {
+												commentId: note.id,
+												emoji,
+											} )
+										}
+									/>
+								) }
+							</ReactionDisplay>
 						</div>
 					</ThemeProvider>
 				) }

--- a/packages/editor/src/components/collab-sidebar/note.jsx
+++ b/packages/editor/src/components/collab-sidebar/note.jsx
@@ -6,13 +6,13 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 // eslint-disable-next-line @wordpress/use-recommended-components
-import { Stack, Button as UIButton } from '@wordpress/ui';
+import { Button as UIButton } from '@wordpress/ui';
 import { ThemeProvider } from '@wordpress/theme';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { moreVertical, published } from '@wordpress/icons';
 import { NoteCard } from './note-card';
 import { NoteForm } from './note-form';
-import ReactionDisplay from './reaction-display';
+import ReactionDisplay, { getReactedSlugs } from './reaction-display';
 import { AddReactionButton } from './add-reaction-picker';
 import { unlock } from '../../lock-unlock';
 
@@ -86,6 +86,7 @@ export function Note( {
 	}, [ rawContent ] );
 
 	const canResolve = note.parent === 0;
+	const hasReactions = getReactedSlugs( reactions ).length > 0;
 	const isResolutionNote =
 		note.type === 'note' &&
 		note.meta &&
@@ -193,6 +194,25 @@ export function Note( {
 
 	const actions = isSelected ? (
 		<>
+			{ /*
+			 * The trigger joins the note's other icon actions rather than
+			 * sitting on a row of its own, so a note nobody has reacted to
+			 * costs no vertical space at all. The stylesheet then keeps it
+			 * faded until the thread is hovered or reached by keyboard.
+			 */ }
+			{ onToggleReaction && (
+				<AddReactionButton
+					noteId={ note.id }
+					disabled={ isThreadResolved }
+					variant="minimal"
+					onToggleReaction={ ( emoji ) =>
+						onToggleReaction( {
+							commentId: note.id,
+							emoji,
+						} )
+					}
+				/>
+			) }
 			{ canResolve && onResolve && (
 				<Button
 					label={ _x( 'Resolve', 'Mark note as resolved' ) }
@@ -217,42 +237,26 @@ export function Note( {
 			role={ note.parent !== 0 ? 'treeitem' : undefined }
 		>
 			{ body }
-			{ isSelected && (
+			{ hasReactions && (
 				// The editor sets `cornerRadius="none"`, but reactions read
 				// as badges rather than controls, so the row opts into the
 				// pill shape the Design System's `pronounced` preset gives a
 				// small Button.
+				//
+				// Reactions are information about the note, so unlike the
+				// other actions they stay visible on an unselected thread.
 				<ThemeProvider cornerRadius="pronounced">
-					<Stack
-						direction="row"
-						gap="sm"
-						justify="flex-start"
-						// The pills wrap onto further rows; without this the
-						// trigger stretches to the full wrapped height.
-						align="flex-start"
-					>
-						<AddReactionButton
-							noteId={ note.id }
-							disabled={ isThreadResolved }
-							onToggleReaction={ ( emoji ) =>
-								onToggleReaction?.( {
-									commentId: note.id,
-									emoji,
-								} )
-							}
-						/>
-						<ReactionDisplay
-							noteId={ note.id }
-							reactions={ reactions }
-							disabled={ isThreadResolved }
-							onToggleReaction={ ( emoji ) =>
-								onToggleReaction?.( {
-									commentId: note.id,
-									emoji,
-								} )
-							}
-						/>
-					</Stack>
+					<ReactionDisplay
+						noteId={ note.id }
+						reactions={ reactions }
+						disabled={ isThreadResolved }
+						onToggleReaction={ ( emoji ) =>
+							onToggleReaction?.( {
+								commentId: note.id,
+								emoji,
+							} )
+						}
+					/>
 				</ThemeProvider>
 			) }
 			{ actionState === 'delete' && (

--- a/packages/editor/src/components/collab-sidebar/note.jsx
+++ b/packages/editor/src/components/collab-sidebar/note.jsx
@@ -87,6 +87,10 @@ export function Note( {
 
 	const canResolve = note.parent === 0;
 	const hasReactions = getReactedSlugs( reactions ).length > 0;
+	// Not while editing: the trigger floats over the end of the note, which
+	// during an edit is the form's own buttons.
+	const canReact =
+		isSelected && !! onToggleReaction && actionState !== 'edit';
 	const isResolutionNote =
 		note.type === 'note' &&
 		note.meta &&
@@ -194,25 +198,6 @@ export function Note( {
 
 	const actions = isSelected ? (
 		<>
-			{ /*
-			 * The trigger joins the note's other icon actions rather than
-			 * sitting on a row of its own, so a note nobody has reacted to
-			 * costs no vertical space at all. The stylesheet then keeps it
-			 * faded until the thread is hovered or reached by keyboard.
-			 */ }
-			{ onToggleReaction && (
-				<AddReactionButton
-					noteId={ note.id }
-					disabled={ isThreadResolved }
-					variant="minimal"
-					onToggleReaction={ ( emoji ) =>
-						onToggleReaction( {
-							commentId: note.id,
-							emoji,
-						} )
-					}
-				/>
-			) }
 			{ canResolve && onResolve && (
 				<Button
 					label={ _x( 'Resolve', 'Mark note as resolved' ) }
@@ -236,29 +221,58 @@ export function Note( {
 			actions={ actions }
 			role={ note.parent !== 0 ? 'treeitem' : undefined }
 		>
-			{ body }
-			{ hasReactions && (
-				// The editor sets `cornerRadius="none"`, but reactions read
-				// as badges rather than controls, so the row opts into the
-				// pill shape the Design System's `pronounced` preset gives a
-				// small Button.
-				//
-				// Reactions are information about the note, so unlike the
-				// other actions they stay visible on an unselected thread.
-				<ThemeProvider cornerRadius="pronounced">
-					<ReactionDisplay
-						noteId={ note.id }
-						reactions={ reactions }
-						disabled={ isThreadResolved }
-						onToggleReaction={ ( emoji ) =>
-							onToggleReaction?.( {
-								commentId: note.id,
-								emoji,
-							} )
-						}
-					/>
-				</ThemeProvider>
-			) }
+			<div className="editor-collab-sidebar-panel__note-body">
+				{ body }
+				{ ( hasReactions || canReact ) && (
+					// The editor sets `cornerRadius="none"`, but reactions
+					// read as badges rather than controls, so the row opts
+					// into the pill shape the Design System's `pronounced`
+					// preset gives a small Button.
+					<ThemeProvider cornerRadius="pronounced">
+						<div
+							className={ clsx(
+								'editor-collab-sidebar-panel__reactions',
+								{
+									// Nothing to sit beside yet, so the
+									// trigger floats over the end of the note
+									// rather than making the card taller for
+									// an option nobody has taken up.
+									'is-floating': ! hasReactions,
+								}
+							) }
+						>
+							{ canReact && (
+								<AddReactionButton
+									noteId={ note.id }
+									disabled={ isThreadResolved }
+									onToggleReaction={ ( emoji ) =>
+										onToggleReaction( {
+											commentId: note.id,
+											emoji,
+										} )
+									}
+								/>
+							) }
+							{ /*
+							 * Reactions are information about the note, so
+							 * unlike its actions they stay visible once the
+							 * thread is deselected.
+							 */ }
+							<ReactionDisplay
+								noteId={ note.id }
+								reactions={ reactions }
+								disabled={ isThreadResolved }
+								onToggleReaction={ ( emoji ) =>
+									onToggleReaction?.( {
+										commentId: note.id,
+										emoji,
+									} )
+								}
+							/>
+						</div>
+					</ThemeProvider>
+				) }
+			</div>
 			{ actionState === 'delete' && (
 				<ConfirmDialog
 					isOpen

--- a/packages/editor/src/components/collab-sidebar/reaction-display.tsx
+++ b/packages/editor/src/components/collab-sidebar/reaction-display.tsx
@@ -70,7 +70,7 @@ function hasUserReacted(
  * @param reactions The reactions summary (keyed by slug).
  * @return Array of slugs with reactions.
  */
-function getReactedSlugs(
+export function getReactedSlugs(
 	reactions: ReactionSummary | null | undefined
 ): string[] {
 	if ( ! reactions ) {

--- a/packages/editor/src/components/collab-sidebar/reaction-display.tsx
+++ b/packages/editor/src/components/collab-sidebar/reaction-display.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { __, sprintf, _n } from '@wordpress/i18n';
 /*
  * `Button` is pending Design System review (WordPress/gutenberg#76135);
@@ -351,6 +351,7 @@ interface ReactionDisplayProps {
 	reactions: ReactionSummary | null | undefined;
 	disabled?: boolean;
 	onToggleReaction: ( slug: string ) => void;
+	children?: ReactNode;
 }
 
 /**
@@ -362,12 +363,16 @@ interface ReactionDisplayProps {
  * @param props.disabled         Whether reactions can no longer be toggled
  *                               (the thread is resolved).
  * @param props.onToggleReaction Callback to toggle a reaction.
+ * @param props.children         Rendered after the last pill, inside the same
+ *                               wrapping row, so a trailing control follows
+ *                               the pills onto whichever line they end on.
  */
 export default function ReactionDisplay( {
 	noteId,
 	reactions,
 	disabled = false,
 	onToggleReaction,
+	children,
 }: ReactionDisplayProps ) {
 	// The list is filterable server-side (and static per page load),
 	// so index it once per list identity.
@@ -378,13 +383,19 @@ export default function ReactionDisplay( {
 	);
 	const reactedSlugs = getReactedSlugs( reactions );
 
-	if ( reactedSlugs.length === 0 ) {
+	if ( reactedSlugs.length === 0 && ! children ) {
 		return null;
 	}
 
 	return (
 		// `sm`: at `xs` two adjacent pressed pills read as one solid bar.
-		<Stack direction="row" gap="sm" justify="flex-start" wrap="wrap">
+		<Stack
+			direction="row"
+			gap="sm"
+			align="flex-start"
+			justify="flex-start"
+			wrap="wrap"
+		>
 			{ reactedSlugs.map( ( slug ) => {
 				const count = getReactionCount( reactions, slug );
 				const isActive = hasUserReacted( reactions, slug );
@@ -404,6 +415,7 @@ export default function ReactionDisplay( {
 					/>
 				);
 			} ) }
+			{ children }
 		</Stack>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -96,6 +96,11 @@
 
 .editor-collab-sidebar-panel__note-content {
 	overflow-wrap: break-word;
+	// Keep clear of the add-reaction trigger floating in the note's top
+	// corner. Reserved on every note, selected or not, so the text does not
+	// rewrap under the reader as a note is selected or gains its first
+	// reaction.
+	padding-right: $button-size-small + $grid-unit-10;
 
 	p:last-child {
 		margin-bottom: 0;
@@ -270,8 +275,8 @@ mark.wp-note {
 }
 
 // The note's text and, below it, the reaction row. Anchors the trigger while
-// it floats, so it lands on the end of the note itself rather than on
-// whatever else the card carries underneath.
+// it floats, so it lands on the note itself rather than on whatever else the
+// card carries underneath.
 .editor-collab-sidebar-panel__note-body {
 	position: relative;
 	display: flex;
@@ -280,31 +285,23 @@ mark.wp-note {
 }
 
 .editor-collab-sidebar-panel__reactions {
-	display: flex;
-	align-items: flex-start;
-	gap: $grid-unit-10;
-
 	// Until the note has a reaction to show, the trigger is the whole row, and
-	// it floats over the note's last line rather than making every note taller
+	// it floats in the note's top corner rather than making every note taller
 	// for an option nobody has taken up. Once a reaction lands, the row drops
-	// into the flow and the trigger takes its place at the head of it.
+	// into the flow and the trigger trails the pills.
 	//
-	// Against the right edge rather than the left, where the row itself sits:
-	// a paragraph's last line rarely reaches the right edge, so the trigger
-	// lands on the run-out instead of on the words.
+	// The top corner lines up with the Resolve and Actions buttons in the
+	// header above, so the trigger reads as one more action in that column
+	// rather than a control parked wherever the text happened to end. The
+	// note's text keeps a safe area on that side (see `__note-content`), so
+	// nothing runs underneath it.
 	&.is-floating {
 		position: absolute;
-		bottom: 0;
 		right: 0;
-
-		// A short last line still leaves it over text, so it needs its own
-		// ground. On the trigger rather than the row: the row is always
-		// opaque, and a white patch would blank out the text under a trigger
-		// at rest.
-		.editor-collab-sidebar-panel__add-reaction {
-			background-color: $white;
-			border-radius: $radius-full;
-		}
+		// Centered on the first line of text, so a one-line note reads as a
+		// single row with its trigger. The row shares the text's font and
+		// line height, so its own `lh` is the text's line box.
+		top: calc((1lh - #{$button-size-small}) / 2);
 	}
 }
 

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -269,6 +269,36 @@ mark.wp-note {
 	display: flex;
 }
 
+// The trigger sits among the note's other icon actions and stays out of the
+// way until the note is hovered, so reacting costs no standing real estate.
+//
+// Only where a pointer can hover: a touch device would otherwise be left
+// with a control it has no way to reveal.
+@media (hover: hover) {
+	.editor-collab-sidebar-panel__add-reaction {
+		// Fading rather than removing keeps the button in the tab order and
+		// keeps the action row from reflowing as the pointer moves over it.
+		opacity: 0;
+		transition: opacity 0.1s ease-out;
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+	}
+
+	.editor-collab-sidebar-panel__thread:hover
+	.editor-collab-sidebar-panel__add-reaction,
+	// Reveal on the trigger itself rather than on the thread: the thread is
+	// `tabIndex={ 0 }`, so a thread-level `:focus-within` would hold for as
+	// long as the note is selected and the fade would never take effect.
+	.editor-collab-sidebar-panel__add-reaction:focus-within,
+	// While the picker is open the pointer is over the popover, not the
+	// thread, and focus has moved into the popover's own portal.
+	.editor-collab-sidebar-panel__add-reaction:has([aria-expanded="true"]) {
+		opacity: 1;
+	}
+}
+
 .editor-collab-sidebar-panel__reaction-button {
 	// The glyph and its count are one unit, closer than the Button's
 	// default gap between an icon and a label.

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -287,15 +287,20 @@ mark.wp-note {
 	// Until the note has a reaction to show, the trigger is the whole row, and
 	// it floats over the note's last line rather than making every note taller
 	// for an option nobody has taken up. Once a reaction lands, the row drops
-	// into the flow and the trigger keeps its place at the head of it.
+	// into the flow and the trigger takes its place at the head of it.
+	//
+	// Against the right edge rather than the left, where the row itself sits:
+	// a paragraph's last line rarely reaches the right edge, so the trigger
+	// lands on the run-out instead of on the words.
 	&.is-floating {
 		position: absolute;
 		bottom: 0;
-		left: 0;
+		right: 0;
 
-		// It sits on top of the note's own text, so it needs its own ground.
-		// On the trigger rather than the row: the row is always opaque, and a
-		// white patch would blank out the text under a trigger at rest.
+		// A short last line still leaves it over text, so it needs its own
+		// ground. On the trigger rather than the row: the row is always
+		// opaque, and a white patch would blank out the text under a trigger
+		// at rest.
 		.editor-collab-sidebar-panel__add-reaction {
 			background-color: $white;
 			border-radius: $radius-full;

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -269,8 +269,42 @@ mark.wp-note {
 	display: flex;
 }
 
-// The trigger sits among the note's other icon actions and stays out of the
-// way until the note is hovered, so reacting costs no standing real estate.
+// The note's text and, below it, the reaction row. Anchors the trigger while
+// it floats, so it lands on the end of the note itself rather than on
+// whatever else the card carries underneath.
+.editor-collab-sidebar-panel__note-body {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+}
+
+.editor-collab-sidebar-panel__reactions {
+	display: flex;
+	align-items: flex-start;
+	gap: $grid-unit-10;
+
+	// Until the note has a reaction to show, the trigger is the whole row, and
+	// it floats over the note's last line rather than making every note taller
+	// for an option nobody has taken up. Once a reaction lands, the row drops
+	// into the flow and the trigger keeps its place at the head of it.
+	&.is-floating {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+
+		// It sits on top of the note's own text, so it needs its own ground.
+		// On the trigger rather than the row: the row is always opaque, and a
+		// white patch would blank out the text under a trigger at rest.
+		.editor-collab-sidebar-panel__add-reaction {
+			background-color: $white;
+			border-radius: $radius-full;
+		}
+	}
+}
+
+// The trigger stays out of the way until the note is hovered, so reacting
+// costs no standing real estate.
 //
 // Only where a pointer can hover: a touch device would otherwise be left
 // with a control it has no way to reveal.

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1220,16 +1220,26 @@ test.describe( 'Block Notes', () => {
 				'.editor-collab-sidebar-panel__thread'
 			);
 
-			// The trigger lives among the note's other icon actions, so a
-			// note nobody has reacted to has no reaction row at all.
-			await expect(
-				page
-					.locator( '.editor-collab-sidebar-panel__note-actions' )
-					.getByRole( 'button', { name: 'Add reaction' } )
-			).toHaveCount( 1 );
+			// The trigger sits where the reactions will, at the end of the
+			// note, and floats over it rather than claiming a row: the note
+			// is no taller for carrying it.
+			const reactionRow = page.locator(
+				'.editor-collab-sidebar-panel__reactions'
+			);
+			await expect( reactionRow ).toHaveClass( /is-floating/ );
 			await expect(
 				page.locator( '.editor-collab-sidebar-panel__reaction-button' )
 			).toHaveCount( 0 );
+
+			const noteBody = page.locator(
+				'.editor-collab-sidebar-panel__note-body'
+			);
+			const noteText = page.locator(
+				'.editor-collab-sidebar-panel__note-content'
+			);
+			expect( ( await noteBody.boundingBox() ).height ).toBe(
+				( await noteText.boundingBox() ).height
+			);
 
 			// Park the pointer outside the sidebar: adding the note leaves it
 			// over the thread, which would hold the trigger open.

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1203,6 +1203,79 @@ test.describe( 'Block Notes', () => {
 			).toBeVisible();
 		} );
 
+		test( 'the add-reaction trigger stays out of the way until hovered', async ( {
+			page,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing the hover trigger' },
+				comment: 'Test comment for the hover trigger',
+			} );
+
+			const trigger = page.locator(
+				'.editor-collab-sidebar-panel__add-reaction'
+			);
+			const thread = page.locator(
+				'.editor-collab-sidebar-panel__thread'
+			);
+
+			// The trigger lives among the note's other icon actions, so a
+			// note nobody has reacted to has no reaction row at all.
+			await expect(
+				page
+					.locator( '.editor-collab-sidebar-panel__note-actions' )
+					.getByRole( 'button', { name: 'Add reaction' } )
+			).toHaveCount( 1 );
+			await expect(
+				page.locator( '.editor-collab-sidebar-panel__reaction-button' )
+			).toHaveCount( 0 );
+
+			// Park the pointer outside the sidebar: adding the note leaves it
+			// over the thread, which would hold the trigger open.
+			await page.mouse.move( 0, 0 );
+			await expect( trigger ).toHaveCSS( 'opacity', '0' );
+
+			await thread.hover();
+			await expect( trigger ).toHaveCSS( 'opacity', '1' );
+
+			// Keyboard reaches it too: the reveal hangs off the trigger, not
+			// the thread, which stays focused for as long as it is selected.
+			await page.mouse.move( 0, 0 );
+			await expect( trigger ).toHaveCSS( 'opacity', '0' );
+			await page.getByRole( 'button', { name: 'Add reaction' } ).focus();
+			await expect( trigger ).toHaveCSS( 'opacity', '1' );
+		} );
+
+		test( 'reactions stay visible once the thread is deselected', async ( {
+			page,
+			editor,
+			blockNoteUtils,
+		} ) => {
+			await blockNoteUtils.addBlockWithNote( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing deselected reactions' },
+				comment: 'Test comment for deselected reactions',
+			} );
+
+			await blockNoteUtils.addReactionToComment( 'Heart' );
+			const reactionButton = page.getByRole( 'button', {
+				name: /Heart/,
+			} );
+			await expect( reactionButton ).toBeVisible();
+
+			// Focus the title to deselect the block and the note. The pills
+			// carry information about the note, so unlike its actions they
+			// survive being deselected.
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.focus();
+			await expect(
+				page.getByRole( 'button', { name: 'Add reaction' } )
+			).toHaveCount( 0 );
+			await expect( reactionButton ).toBeVisible();
+		} );
+
 		test.describe( 'Emojibase dataset unavailable', () => {
 			test.beforeAll( async ( { requestUtils } ) => {
 				await requestUtils.activatePlugin(

--- a/test/e2e/specs/editor/various/block-notes.spec.js
+++ b/test/e2e/specs/editor/various/block-notes.spec.js
@@ -1220,9 +1220,8 @@ test.describe( 'Block Notes', () => {
 				'.editor-collab-sidebar-panel__thread'
 			);
 
-			// The trigger sits where the reactions will, at the end of the
-			// note, and floats over it rather than claiming a row: the note
-			// is no taller for carrying it.
+			// The trigger floats in the note's top corner rather than
+			// claiming a row: the note is no taller for carrying it.
 			const reactionRow = page.locator(
 				'.editor-collab-sidebar-panel__reactions'
 			);
@@ -1240,6 +1239,20 @@ test.describe( 'Block Notes', () => {
 			expect( ( await noteBody.boundingBox() ).height ).toBe(
 				( await noteText.boundingBox() ).height
 			);
+
+			// It lines up under the note's other actions, and the text keeps
+			// clear of it rather than running underneath.
+			const triggerBox = await trigger.boundingBox();
+			const actionsBox = await page
+				.getByRole( 'button', { name: 'Actions' } )
+				.boundingBox();
+			expect( triggerBox.x ).toBe( actionsBox.x );
+			const textRight = await noteText.evaluate( ( element ) => {
+				const range = document.createRange();
+				range.selectNodeContents( element );
+				return range.getBoundingClientRect().right;
+			} );
+			expect( textRight ).toBeLessThanOrEqual( triggerBox.x );
 
 			// Park the pointer outside the sidebar: adding the note leaves it
 			// over the thread, which would hold the trigger open.


### PR DESCRIPTION
Stacked on #78176.

In https://github.com/WordPress/gutenberg/pull/78176#issuecomment-5481602877 @annezazu pointed out that the add-reaction button takes up a lot of real estate, and asked whether it could appear on hover the way Google Docs does. This is a try at that, now following @fcoveram's exploration in https://github.com/WordPress/gutenberg/issues/82324#issuecomment-5538776739.

The trigger floats in the note's top corner, in the same column as Resolve and the actions menu, and stays faded until the note is hovered or the trigger itself is focused. A note nobody has reacted to costs no vertical space for the option. The note text keeps a safe area on that side so it never runs under the button. Once a reaction lands, the trigger trails the reaction pills and wraps with them.

Two things fell out of the change that are worth calling out:

- The reveal hangs off the trigger, not the thread. The thread is `tabIndex={ 0 }`, so a thread-level `:focus-within` holds for as long as the note is selected and the fade would never take effect.
- The whole treatment sits inside `@media (hover: hover)`. A touch device has no hover, so there it keeps a trigger it can actually see.

The pills also no longer disappear when you deselect a note. Reactions are information about the note rather than one of its actions, so they now stay put - otherwise you could react on hover and watch the reaction vanish.

## Screenshots

| At rest | Hovered | Long note, hovered |
| --- | --- | --- |
| <img width="248" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82313-corner-v2-1-at-rest.png" /> | <img width="248" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82313-corner-v2-2-hovered.png" /> | <img width="248" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82313-corner-v2-3-long-hovered.png" /> |

| One reaction | Several reactions |
| --- | --- |
| <img width="248" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82313-corner-v2-4-one-reaction.png" /> | <img width="248" src="https://raw.githubusercontent.com/adamsilverstein/gutenberg/issue-assets/issue-assets/82313-corner-v2-5-many-reactions.png" /> |

## How has this been tested

[![Test in WordPress Playground](https://img.shields.io/badge/Test_in-WP_Playground-blue?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/gutenberg.html?pr=82313)

1. Enable the Notes experiment and add a note to a block.
2. With the note selected, move the pointer away from the sidebar. The smiley should be gone, and the note should be one row shorter than on #78176.
3. Hover the note. The smiley fades in at the note's top right corner, under the actions menu, and the text stays clear of it.
4. Tab to it with the keyboard - it should appear as focus lands on it, and open the picker on Enter.
5. Add a reaction. The smiley moves in after the pill; add enough reactions to wrap and it follows them onto the next line.
6. Click the post title to deselect. The pills should stay; the smiley should go.

Existing `Emoji Reactions` e2e specs all pass, plus two new ones covering the fade, the placement, and the deselected pills.

## Types of changes

- Float the add-reaction trigger in the note's top corner, in line with the other note actions, and reserve a safe area beside the note text so it never overlaps.
- Fade the trigger in on hover / focus, scoped to pointer devices.
- Render the reaction pill row only when the note has reactions, and independently of selection; the trigger trails the pills once there are any.
- Add e2e coverage for the fade, the placement, and the deselected pills.

## Open questions

- Google Docs reveals the emoji option on hovering *any* comment, selected or not. This only does it on the selected one, because rendering the trigger on every note would add a tab stop per note in the sidebar. Is the narrower version enough, or is the unselected-hover behavior the point?
- The safe area is reserved on every note so the text does not rewrap on selection. It costs about 32px of line width; reserving it only on the selected note would get that back at the cost of a rewrap on every click. Which is the better trade?

## AI Use

Claude Code did the typing here, I did the asking. I will review and test.

