### PR TITLE
Image block cropping: Sync image size and link destination settings

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
+-   Image: Keep the selected image size, and re-point a media file or attachment page link, when an edit in the media editor saves to a new attachment. Cropping, rotating or flipping left the block rendering the full-size file while the size control still reported the size the user had chosen, and left the link pointing at the pre-edit image ([#82316](https://github.com/WordPress/gutenberg/pull/82316)).
 
 ### Internal
 

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
@@ -474,6 +474,44 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		expect( onUrlChange ).toHaveBeenLastCalledWith( 'cropped-300x200.jpg' );
 	} );
 
+	it( 'falls back to the saved record when the refetch fails', async () => {
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original-300x200.jpg',
+				alt: '',
+				caption: '',
+				sizeSlug: 'medium',
+				href: 'original.jpg',
+				linkDestination: 'media',
+			},
+			registryOptions: {
+				// The media editor put the saved record in the store, so it
+				// is cached even though refetching it fails.
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === ORIGINAL_ATTACHMENT.id
+						? ORIGINAL_ATTACHMENT
+						: CROPPED_ATTACHMENT,
+				resolveGetEntityRecord: ( kind, name, attachmentId ) => {
+					if ( attachmentId === CROPPED_ATTACHMENT.id ) {
+						throw new Error( 'Network error' );
+					}
+					return undefined;
+				},
+			},
+			updatePayload: CROP_UPDATE,
+		} );
+
+		// The size and link still follow the edited image, rather than the
+		// block half-updating to the new file at its old settings.
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped-300x200.jpg',
+			href: 'cropped.jpg',
+		} );
+	} );
+
 	it( 'derives the size of the edited image without a metadata baseline', async () => {
 		const { setAttributes, registry } = await runModalUpdate( {
 			// Custom metadata leaves the block with no fallback baseline, and

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
@@ -1112,8 +1112,7 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ sizeSlug: 'medium' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( { url: 'cropped-300x200.jpg' } );
 	} );
@@ -1122,26 +1121,48 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ sizeSlug: 'large' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( { url: 'cropped.jpg', sizeSlug: 'full' } );
+	} );
+
+	it( 'falls back to full when the edited image is too small for any sub-size', () => {
+		// Cropping below the smallest registered size leaves
+		// `media_details.sizes` empty, so the block has to fall back to the
+		// file itself and stop reporting a size it no longer has.
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'medium' },
+				{
+					id: 2,
+					source_url: 'cropped-103x45.jpg',
+					media_details: { width: 103, height: 45, sizes: {} },
+				}
+			)
+		).toEqual( {
+			url: 'cropped-103x45.jpg',
+			sizeSlug: 'full',
+		} );
+	} );
+
+	it( 'makes no change when no full-size URL is available', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'large' },
+				{ id: 2, media_details: { sizes: { medium: {} } } }
+			)
+		).toEqual( {} );
 	} );
 
 	it( 'makes no change for the full size or an unset size', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ sizeSlug: 'full' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( {} );
 		expect(
-			getNewAttachmentImageBlockAttributes(
-				{},
-				croppedAttachment,
-				'cropped.jpg'
-			)
+			getNewAttachmentImageBlockAttributes( {}, croppedAttachment )
 		).toEqual( {} );
 	} );
 
@@ -1149,8 +1170,7 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ sizeSlug: 'medium' },
-				{ id: 2 },
-				'cropped.jpg'
+				{ id: 2 }
 			)
 		).toEqual( {} );
 	} );
@@ -1159,8 +1179,7 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ sizeSlug: 'medium' },
-				undefined,
-				'cropped.jpg'
+				undefined
 			)
 		).toBeUndefined();
 	} );
@@ -1169,8 +1188,7 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ sizeSlug: 'medium', linkDestination: 'media' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( {
 			url: 'cropped-300x200.jpg',
@@ -1182,8 +1200,7 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ linkDestination: 'attachment' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( { href: 'https://example.com/cropped/' } );
 	} );
@@ -1192,23 +1209,17 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ linkDestination: 'custom' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( {} );
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ linkDestination: 'none' },
-				croppedAttachment,
-				'cropped.jpg'
+				croppedAttachment
 			)
 		).toEqual( {} );
 		expect(
-			getNewAttachmentImageBlockAttributes(
-				{},
-				croppedAttachment,
-				'cropped.jpg'
-			)
+			getNewAttachmentImageBlockAttributes( {}, croppedAttachment )
 		).toEqual( {} );
 	} );
 
@@ -1216,15 +1227,13 @@ describe( 'getNewAttachmentImageBlockAttributes', () => {
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ linkDestination: 'media' },
-				{ id: 2 },
-				'cropped.jpg'
+				{ id: 2 }
 			)
 		).toEqual( {} );
 		expect(
 			getNewAttachmentImageBlockAttributes(
 				{ linkDestination: 'attachment' },
-				{ id: 2 },
-				'cropped.jpg'
+				{ id: 2 }
 			)
 		).toEqual( {} );
 	} );

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { useRegistry, useSelect } from '@wordpress/data';
 import {
 	getImageBlockMetadataFromAttachment,
+	getNewAttachmentImageBlockAttributes,
 	getSyncedImageBlockAttributes,
 	useOpenImageMediaEditorModal,
 } from '../use-open-image-media-editor-modal';
@@ -389,6 +390,203 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			url: 'cropped.jpg',
 			alt: 'Updated alt',
 			caption: 'Updated caption',
+		} );
+	} );
+
+	it( 'keeps the selected image size when the edit created a new attachment', async () => {
+		const originalAttachment = {
+			id: 1,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const croppedAttachment = {
+			id: 2,
+			alt_text: '',
+			caption: { raw: '' },
+			media_details: {
+				sizes: {
+					medium: { source_url: 'cropped-300x200.jpg' },
+					full: { source_url: 'cropped.jpg' },
+				},
+			},
+		};
+		const onUrlChange = jest.fn();
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original-300x200.jpg',
+				alt: '',
+				caption: '',
+				sizeSlug: 'medium',
+			},
+			registryOptions: {
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 1 ? originalAttachment : croppedAttachment,
+				resolveGetEntityRecord: () => croppedAttachment,
+			},
+			updatePayload: { id: 2, url: 'cropped.jpg' },
+			hookOptions: { onUrlChange },
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped-300x200.jpg',
+		} );
+		expect( onUrlChange ).toHaveBeenCalledWith( 'cropped-300x200.jpg' );
+	} );
+
+	it( 'resolves the selected image size when the new attachment is not cached', async () => {
+		const originalAttachment = {
+			id: 1,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const croppedAttachment = {
+			id: 2,
+			alt_text: '',
+			caption: { raw: '' },
+			media_details: {
+				sizes: {
+					medium: { source_url: 'cropped-300x200.jpg' },
+					full: { source_url: 'cropped.jpg' },
+				},
+			},
+		};
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original-300x200.jpg',
+				alt: '',
+				caption: '',
+				sizeSlug: 'medium',
+			},
+			registryOptions: {
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 1 ? originalAttachment : undefined,
+				resolveGetEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 2 ? croppedAttachment : undefined,
+			},
+			updatePayload: { id: 2, url: 'cropped.jpg' },
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped-300x200.jpg',
+		} );
+	} );
+
+	it( 'falls back to the full size when the edited image has no such size', async () => {
+		const originalAttachment = {
+			id: 1,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const croppedAttachment = {
+			id: 2,
+			alt_text: '',
+			caption: { raw: '' },
+			media_details: {
+				sizes: {
+					full: { source_url: 'cropped.jpg' },
+				},
+			},
+		};
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original-300x200.jpg',
+				alt: '',
+				caption: '',
+				sizeSlug: 'medium',
+			},
+			registryOptions: {
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 1 ? originalAttachment : croppedAttachment,
+				resolveGetEntityRecord: () => croppedAttachment,
+			},
+			updatePayload: { id: 2, url: 'cropped.jpg' },
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped.jpg',
+			sizeSlug: 'full',
+		} );
+	} );
+
+	it( 'points a media file link at the edited image', async () => {
+		const originalAttachment = {
+			id: 1,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const croppedAttachment = {
+			id: 2,
+			alt_text: '',
+			caption: { raw: '' },
+			source_url: 'cropped.jpg',
+		};
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original.jpg',
+				alt: '',
+				caption: '',
+				href: 'original.jpg',
+				linkDestination: 'media',
+			},
+			registryOptions: {
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 1 ? originalAttachment : croppedAttachment,
+				resolveGetEntityRecord: () => croppedAttachment,
+			},
+			updatePayload: { id: 2, url: 'cropped.jpg' },
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped.jpg',
+			href: 'cropped.jpg',
+		} );
+	} );
+
+	it( 'leaves a custom link alone after an edit', async () => {
+		const originalAttachment = {
+			id: 1,
+			alt_text: '',
+			caption: { raw: '' },
+		};
+		const croppedAttachment = {
+			id: 2,
+			alt_text: '',
+			caption: { raw: '' },
+			source_url: 'cropped.jpg',
+		};
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original.jpg',
+				alt: '',
+				caption: '',
+				href: 'https://example.com/somewhere/',
+				linkDestination: 'custom',
+			},
+			registryOptions: {
+				getEditedEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 1 ? originalAttachment : croppedAttachment,
+				resolveGetEntityRecord: () => croppedAttachment,
+			},
+			updatePayload: { id: 2, url: 'cropped.jpg' },
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped.jpg',
 		} );
 	} );
 
@@ -920,6 +1118,141 @@ describe( 'getSyncedImageBlockAttributes', () => {
 					alt_text: 'Updated alt',
 					caption: { raw: 'Updated caption' },
 				}
+			)
+		).toEqual( {} );
+	} );
+} );
+
+describe( 'getNewAttachmentImageBlockAttributes', () => {
+	const croppedAttachment = {
+		id: 2,
+		source_url: 'cropped.jpg',
+		link: 'https://example.com/cropped/',
+		media_details: {
+			sizes: {
+				medium: { source_url: 'cropped-300x200.jpg' },
+				full: { source_url: 'cropped.jpg' },
+			},
+		},
+	};
+
+	it( 'points the URL at the selected size on the new attachment', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'medium' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( { url: 'cropped-300x200.jpg' } );
+	} );
+
+	it( 'falls back to full when the new attachment lacks the selected size', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'large' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( { url: 'cropped.jpg', sizeSlug: 'full' } );
+	} );
+
+	it( 'makes no change for the full size or an unset size', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'full' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{},
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'makes no change when the attachment sizes are unknown', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'medium' },
+				{ id: 2 },
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'makes no change when the attachment record is unknown', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'medium' },
+				undefined,
+				'cropped.jpg'
+			)
+		).toBeUndefined();
+	} );
+
+	it( 'points a media file link at the new attachment file', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ sizeSlug: 'medium', linkDestination: 'media' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( {
+			url: 'cropped-300x200.jpg',
+			href: 'cropped.jpg',
+		} );
+	} );
+
+	it( 'points an attachment page link at the new attachment page', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ linkDestination: 'attachment' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( { href: 'https://example.com/cropped/' } );
+	} );
+
+	it( 'leaves custom and absent links alone', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ linkDestination: 'custom' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ linkDestination: 'none' },
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{},
+				croppedAttachment,
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'keeps the existing link when the new attachment record lacks it', () => {
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ linkDestination: 'media' },
+				{ id: 2 },
+				'cropped.jpg'
+			)
+		).toEqual( {} );
+		expect(
+			getNewAttachmentImageBlockAttributes(
+				{ linkDestination: 'attachment' },
+				{ id: 2 },
+				'cropped.jpg'
 			)
 		).toEqual( {} );
 	} );

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
@@ -120,40 +120,33 @@ const CROPPED_ATTACHMENT = {
 	},
 };
 
+// What the media editor reports after a crop, rotate or flip: it saved to a
+// new attachment, and reports that attachment's full-size file.
+const CROP_UPDATE = {
+	id: CROPPED_ATTACHMENT.id,
+	url: CROPPED_ATTACHMENT.source_url,
+};
+
 /**
- * Runs an edit that saved to a new attachment, as a crop, rotate or flip does.
+ * Registry options for an edit that saved to a new attachment: the pre-edit
+ * record is cached, and the edited one is only reachable by resolving it.
  *
  * @param {Object}  options             Options.
- * @param {Object}  options.attributes  Block attributes, merged over an image
- *                                      pointing at the original attachment.
  * @param {boolean} options.hasOriginal Whether the pre-edit attachment is
- *                                      known; without it there is no metadata
- *                                      baseline.
+ *                                      known at all; without it there is no
+ *                                      metadata baseline.
  */
-function runCropUpdate( { attributes, hasOriginal = true, ...options } ) {
-	return runModalUpdate( {
-		attributes: {
-			id: ORIGINAL_ATTACHMENT.id,
-			alt: '',
-			caption: '',
-			...attributes,
-		},
-		registryOptions: {
-			getEditedEntityRecord: ( kind, name, attachmentId ) =>
-				hasOriginal && attachmentId === ORIGINAL_ATTACHMENT.id
-					? ORIGINAL_ATTACHMENT
-					: undefined,
-			resolveGetEntityRecord: ( kind, name, attachmentId ) =>
-				attachmentId === CROPPED_ATTACHMENT.id
-					? CROPPED_ATTACHMENT
-					: undefined,
-		},
-		updatePayload: {
-			id: CROPPED_ATTACHMENT.id,
-			url: CROPPED_ATTACHMENT.source_url,
-		},
-		...options,
-	} );
+function croppedAttachmentRecords( { hasOriginal = true } = {} ) {
+	return {
+		getEditedEntityRecord: ( kind, name, attachmentId ) =>
+			hasOriginal && attachmentId === ORIGINAL_ATTACHMENT.id
+				? ORIGINAL_ATTACHMENT
+				: undefined,
+		resolveGetEntityRecord: ( kind, name, attachmentId ) =>
+			attachmentId === CROPPED_ATTACHMENT.id
+				? CROPPED_ATTACHMENT
+				: undefined,
+	};
 }
 
 describe( 'useOpenImageMediaEditorModal', () => {
@@ -456,8 +449,16 @@ describe( 'useOpenImageMediaEditorModal', () => {
 
 	it( 'keeps the selected image size when the edit created a new attachment', async () => {
 		const onUrlChange = jest.fn();
-		const { setAttributes } = await runCropUpdate( {
-			attributes: { url: 'original-300x200.jpg', sizeSlug: 'medium' },
+		const { setAttributes } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original-300x200.jpg',
+				alt: '',
+				caption: '',
+				sizeSlug: 'medium',
+			},
+			registryOptions: croppedAttachmentRecords(),
+			updatePayload: CROP_UPDATE,
 			hookOptions: { onUrlChange },
 		} );
 
@@ -474,16 +475,18 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'derives the size of the edited image without a metadata baseline', async () => {
-		const { setAttributes, registry } = await runCropUpdate( {
+		const { setAttributes, registry } = await runModalUpdate( {
 			// Custom metadata leaves the block with no fallback baseline, and
 			// the original attachment is unknown, so no metadata is synced.
 			attributes: {
+				id: 1,
 				url: 'original-300x200.jpg',
 				alt: 'Custom alt',
 				caption: 'Custom caption',
 				sizeSlug: 'medium',
 			},
-			hasOriginal: false,
+			registryOptions: croppedAttachmentRecords( { hasOriginal: false } ),
+			updatePayload: CROP_UPDATE,
 		} );
 
 		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
@@ -500,12 +503,17 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'points a media file link at the edited image', async () => {
-		const { setAttributes } = await runCropUpdate( {
+		const { setAttributes } = await runModalUpdate( {
 			attributes: {
+				id: 1,
 				url: 'original.jpg',
+				alt: '',
+				caption: '',
 				href: 'original.jpg',
 				linkDestination: 'media',
 			},
+			registryOptions: croppedAttachmentRecords(),
+			updatePayload: CROP_UPDATE,
 		} );
 
 		expect( setAttributes ).toHaveBeenCalledTimes( 1 );

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
@@ -517,6 +517,49 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		} );
 	} );
 
+	it( 'resolves the selected image size without an attachment metadata baseline', async () => {
+		const croppedAttachment = {
+			id: 2,
+			media_details: {
+				sizes: {
+					medium: { source_url: 'cropped-300x200.jpg' },
+					full: { source_url: 'cropped.jpg' },
+				},
+			},
+		};
+		const { setAttributes, registry } = await runModalUpdate( {
+			attributes: {
+				id: 1,
+				url: 'original-300x200.jpg',
+				alt: 'Custom alt',
+				caption: 'Custom caption',
+				sizeSlug: 'medium',
+			},
+			registryOptions: {
+				// Nothing is cached, and the original attachment never
+				// resolves, so there is no baseline to sync metadata against.
+				resolveGetEntityRecord: ( kind, name, attachmentId ) =>
+					attachmentId === 2 ? croppedAttachment : undefined,
+			},
+			updatePayload: { id: 2, url: 'cropped.jpg' },
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			id: 2,
+			url: 'cropped-300x200.jpg',
+		} );
+		// The size is derived from a freshly resolved record for the edited
+		// attachment, not a stale cached one.
+		expect( registry.actions.invalidateResolution ).toHaveBeenCalledTimes(
+			1
+		);
+		expect( registry.actions.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecord',
+			[ 'postType', 'attachment', 2 ]
+		);
+	} );
+
 	it( 'points a media file link at the edited image', async () => {
 		const originalAttachment = {
 			id: 1,

--- a/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
+++ b/packages/block-library/src/image/test/use-open-image-media-editor-modal.jsdom.test.js
@@ -95,6 +95,67 @@ async function runModalUpdate( {
 	return { setAttributes, registry, openMediaEditorModal };
 }
 
+// The attachment as it was before the edit. Its metadata matches the blocks
+// used below, so the metadata sync never contributes attributes and the
+// assertions stay about the ones derived from the edited attachment.
+const ORIGINAL_ATTACHMENT = {
+	id: 1,
+	alt_text: '',
+	caption: { raw: '' },
+};
+
+// Editing media saves to a new attachment, with its own sub-sizes, file and
+// attachment page.
+const CROPPED_ATTACHMENT = {
+	id: 2,
+	alt_text: '',
+	caption: { raw: '' },
+	source_url: 'cropped.jpg',
+	link: 'https://example.com/cropped/',
+	media_details: {
+		sizes: {
+			medium: { source_url: 'cropped-300x200.jpg' },
+			full: { source_url: 'cropped.jpg' },
+		},
+	},
+};
+
+/**
+ * Runs an edit that saved to a new attachment, as a crop, rotate or flip does.
+ *
+ * @param {Object}  options             Options.
+ * @param {Object}  options.attributes  Block attributes, merged over an image
+ *                                      pointing at the original attachment.
+ * @param {boolean} options.hasOriginal Whether the pre-edit attachment is
+ *                                      known; without it there is no metadata
+ *                                      baseline.
+ */
+function runCropUpdate( { attributes, hasOriginal = true, ...options } ) {
+	return runModalUpdate( {
+		attributes: {
+			id: ORIGINAL_ATTACHMENT.id,
+			alt: '',
+			caption: '',
+			...attributes,
+		},
+		registryOptions: {
+			getEditedEntityRecord: ( kind, name, attachmentId ) =>
+				hasOriginal && attachmentId === ORIGINAL_ATTACHMENT.id
+					? ORIGINAL_ATTACHMENT
+					: undefined,
+			resolveGetEntityRecord: ( kind, name, attachmentId ) =>
+				attachmentId === CROPPED_ATTACHMENT.id
+					? CROPPED_ATTACHMENT
+					: undefined,
+		},
+		updatePayload: {
+			id: CROPPED_ATTACHMENT.id,
+			url: CROPPED_ATTACHMENT.source_url,
+		},
+		...options,
+	} );
+}
+
 describe( 'useOpenImageMediaEditorModal', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -394,154 +455,35 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'keeps the selected image size when the edit created a new attachment', async () => {
-		const originalAttachment = {
-			id: 1,
-			alt_text: '',
-			caption: { raw: '' },
-		};
-		const croppedAttachment = {
-			id: 2,
-			alt_text: '',
-			caption: { raw: '' },
-			media_details: {
-				sizes: {
-					medium: { source_url: 'cropped-300x200.jpg' },
-					full: { source_url: 'cropped.jpg' },
-				},
-			},
-		};
 		const onUrlChange = jest.fn();
-		const { setAttributes } = await runModalUpdate( {
-			attributes: {
-				id: 1,
-				url: 'original-300x200.jpg',
-				alt: '',
-				caption: '',
-				sizeSlug: 'medium',
-			},
-			registryOptions: {
-				getEditedEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 1 ? originalAttachment : croppedAttachment,
-				resolveGetEntityRecord: () => croppedAttachment,
-			},
-			updatePayload: { id: 2, url: 'cropped.jpg' },
+		const { setAttributes } = await runCropUpdate( {
+			attributes: { url: 'original-300x200.jpg', sizeSlug: 'medium' },
 			hookOptions: { onUrlChange },
 		} );
 
+		// Everything lands in one update, so the block never renders against
+		// half-updated settings.
 		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			id: 2,
 			url: 'cropped-300x200.jpg',
 		} );
-		expect( onUrlChange ).toHaveBeenCalledWith( 'cropped-300x200.jpg' );
+		// The loading state settles against the file the block will render,
+		// not the full-size file the media editor reported.
+		expect( onUrlChange ).toHaveBeenLastCalledWith( 'cropped-300x200.jpg' );
 	} );
 
-	it( 'resolves the selected image size when the new attachment is not cached', async () => {
-		const originalAttachment = {
-			id: 1,
-			alt_text: '',
-			caption: { raw: '' },
-		};
-		const croppedAttachment = {
-			id: 2,
-			alt_text: '',
-			caption: { raw: '' },
-			media_details: {
-				sizes: {
-					medium: { source_url: 'cropped-300x200.jpg' },
-					full: { source_url: 'cropped.jpg' },
-				},
-			},
-		};
-		const { setAttributes } = await runModalUpdate( {
+	it( 'derives the size of the edited image without a metadata baseline', async () => {
+		const { setAttributes, registry } = await runCropUpdate( {
+			// Custom metadata leaves the block with no fallback baseline, and
+			// the original attachment is unknown, so no metadata is synced.
 			attributes: {
-				id: 1,
-				url: 'original-300x200.jpg',
-				alt: '',
-				caption: '',
-				sizeSlug: 'medium',
-			},
-			registryOptions: {
-				getEditedEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 1 ? originalAttachment : undefined,
-				resolveGetEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 2 ? croppedAttachment : undefined,
-			},
-			updatePayload: { id: 2, url: 'cropped.jpg' },
-		} );
-
-		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			id: 2,
-			url: 'cropped-300x200.jpg',
-		} );
-	} );
-
-	it( 'falls back to the full size when the edited image has no such size', async () => {
-		const originalAttachment = {
-			id: 1,
-			alt_text: '',
-			caption: { raw: '' },
-		};
-		const croppedAttachment = {
-			id: 2,
-			alt_text: '',
-			caption: { raw: '' },
-			media_details: {
-				sizes: {
-					full: { source_url: 'cropped.jpg' },
-				},
-			},
-		};
-		const { setAttributes } = await runModalUpdate( {
-			attributes: {
-				id: 1,
-				url: 'original-300x200.jpg',
-				alt: '',
-				caption: '',
-				sizeSlug: 'medium',
-			},
-			registryOptions: {
-				getEditedEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 1 ? originalAttachment : croppedAttachment,
-				resolveGetEntityRecord: () => croppedAttachment,
-			},
-			updatePayload: { id: 2, url: 'cropped.jpg' },
-		} );
-
-		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			id: 2,
-			url: 'cropped.jpg',
-			sizeSlug: 'full',
-		} );
-	} );
-
-	it( 'resolves the selected image size without an attachment metadata baseline', async () => {
-		const croppedAttachment = {
-			id: 2,
-			media_details: {
-				sizes: {
-					medium: { source_url: 'cropped-300x200.jpg' },
-					full: { source_url: 'cropped.jpg' },
-				},
-			},
-		};
-		const { setAttributes, registry } = await runModalUpdate( {
-			attributes: {
-				id: 1,
 				url: 'original-300x200.jpg',
 				alt: 'Custom alt',
 				caption: 'Custom caption',
 				sizeSlug: 'medium',
 			},
-			registryOptions: {
-				// Nothing is cached, and the original attachment never
-				// resolves, so there is no baseline to sync metadata against.
-				resolveGetEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 2 ? croppedAttachment : undefined,
-			},
-			updatePayload: { id: 2, url: 'cropped.jpg' },
+			hasOriginal: false,
 		} );
 
 		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
@@ -551,9 +493,6 @@ describe( 'useOpenImageMediaEditorModal', () => {
 		} );
 		// The size is derived from a freshly resolved record for the edited
 		// attachment, not a stale cached one.
-		expect( registry.actions.invalidateResolution ).toHaveBeenCalledTimes(
-			1
-		);
 		expect( registry.actions.invalidateResolution ).toHaveBeenCalledWith(
 			'getEntityRecord',
 			[ 'postType', 'attachment', 2 ]
@@ -561,32 +500,12 @@ describe( 'useOpenImageMediaEditorModal', () => {
 	} );
 
 	it( 'points a media file link at the edited image', async () => {
-		const originalAttachment = {
-			id: 1,
-			alt_text: '',
-			caption: { raw: '' },
-		};
-		const croppedAttachment = {
-			id: 2,
-			alt_text: '',
-			caption: { raw: '' },
-			source_url: 'cropped.jpg',
-		};
-		const { setAttributes } = await runModalUpdate( {
+		const { setAttributes } = await runCropUpdate( {
 			attributes: {
-				id: 1,
 				url: 'original.jpg',
-				alt: '',
-				caption: '',
 				href: 'original.jpg',
 				linkDestination: 'media',
 			},
-			registryOptions: {
-				getEditedEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 1 ? originalAttachment : croppedAttachment,
-				resolveGetEntityRecord: () => croppedAttachment,
-			},
-			updatePayload: { id: 2, url: 'cropped.jpg' },
 		} );
 
 		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
@@ -594,42 +513,6 @@ describe( 'useOpenImageMediaEditorModal', () => {
 			id: 2,
 			url: 'cropped.jpg',
 			href: 'cropped.jpg',
-		} );
-	} );
-
-	it( 'leaves a custom link alone after an edit', async () => {
-		const originalAttachment = {
-			id: 1,
-			alt_text: '',
-			caption: { raw: '' },
-		};
-		const croppedAttachment = {
-			id: 2,
-			alt_text: '',
-			caption: { raw: '' },
-			source_url: 'cropped.jpg',
-		};
-		const { setAttributes } = await runModalUpdate( {
-			attributes: {
-				id: 1,
-				url: 'original.jpg',
-				alt: '',
-				caption: '',
-				href: 'https://example.com/somewhere/',
-				linkDestination: 'custom',
-			},
-			registryOptions: {
-				getEditedEntityRecord: ( kind, name, attachmentId ) =>
-					attachmentId === 1 ? originalAttachment : croppedAttachment,
-				resolveGetEntityRecord: () => croppedAttachment,
-			},
-			updatePayload: { id: 2, url: 'cropped.jpg' },
-		} );
-
-		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			id: 2,
-			url: 'cropped.jpg',
 		} );
 	} );
 

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -383,6 +383,14 @@ export function useOpenImageMediaEditorModal( {
 					return;
 				}
 
+				// A failed refetch returns nothing, which would leave the
+				// block pointing at the new file while its size and link
+				// still describe the old one. The record the media editor
+				// received when it saved is already in the store, so fall
+				// back to that rather than half-updating the block.
+				const attachmentRecord =
+					resolvedAttachment ?? getCachedAttachmentRecord( newId );
+
 				const latestBlockAttributes = blockAttributesRef.current;
 
 				// Sync alt text and caption back to the block only when
@@ -396,7 +404,7 @@ export function useOpenImageMediaEditorModal( {
 						getSyncedImageBlockAttributes(
 							latestBlockAttributes,
 							originalAttachment,
-							resolvedAttachment
+							attachmentRecord
 						);
 
 					if ( Object.keys( resolvedMetadataAttributes ).length ) {
@@ -411,7 +419,7 @@ export function useOpenImageMediaEditorModal( {
 					const derivedAttributes =
 						getNewAttachmentImageBlockAttributes(
 							latestBlockAttributes,
-							resolvedAttachment,
+							attachmentRecord,
 							nextAttributes.url
 						);
 
@@ -444,7 +452,12 @@ export function useOpenImageMediaEditorModal( {
 				setAttributes( nextAttributes );
 			}
 		},
-		[ onUrlChange, resolveFreshAttachmentRecord, setAttributes ]
+		[
+			getCachedAttachmentRecord,
+			onUrlChange,
+			resolveFreshAttachmentRecord,
+			setAttributes,
+		]
 	);
 
 	const openImageMediaEditorModal = useCallback( async () => {

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -7,6 +7,11 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { unlock } from '../lock-unlock';
+import {
+	DEFAULT_MEDIA_SIZE_SLUG,
+	LINK_DESTINATION_ATTACHMENT,
+	LINK_DESTINATION_MEDIA,
+} from './constants';
 
 function normalizeImageBlockCaption( caption ) {
 	if ( typeof caption !== 'string' ) {
@@ -96,6 +101,106 @@ export function getSyncedImageBlockAttributes(
 	return syncedAttributes;
 }
 
+/**
+ * Resolves the attributes needed to keep the selected image size on a new
+ * attachment.
+ *
+ * WordPress skips generating a sub-size larger than the file itself, so the
+ * selected size may not exist on the edited image; fall back to full when it
+ * doesn't, as selecting a new image does.
+ *
+ * @param {string|undefined} sizeSlug   The block's currently selected size.
+ * @param {Object}           attachment The new attachment record.
+ * @param {string|undefined} fullUrl    URL of the new attachment's full size.
+ *
+ * @return {Object|undefined} Attributes to apply, if any.
+ */
+function getNewAttachmentSizeAttributes( sizeSlug, attachment, fullUrl ) {
+	const sizes = attachment.media_details?.sizes;
+
+	if ( ! sizeSlug || sizeSlug === DEFAULT_MEDIA_SIZE_SLUG || ! sizes ) {
+		return undefined;
+	}
+
+	const sizeUrl = sizes[ sizeSlug ]?.source_url;
+
+	return sizeUrl
+		? { url: sizeUrl }
+		: { url: fullUrl, sizeSlug: DEFAULT_MEDIA_SIZE_SLUG };
+}
+
+/**
+ * Resolves the link attributes needed to keep the block's link pointing at the
+ * new attachment.
+ *
+ * Only the destinations derived from the attachment follow the edited image. A
+ * `custom` link is the user's own URL and a `none` link has nothing to point
+ * at, so both are left alone. When the record doesn't carry the field, the
+ * existing link is kept rather than cleared.
+ *
+ * @param {string|undefined} linkDestination The block's link destination.
+ * @param {Object}           attachment      The new attachment record.
+ *
+ * @return {Object|undefined} Attributes to apply, if any.
+ */
+function getNewAttachmentLinkAttributes( linkDestination, attachment ) {
+	// Media file links point at the full-size file, independently of the size
+	// the block renders.
+	if ( linkDestination === LINK_DESTINATION_MEDIA ) {
+		return attachment.source_url
+			? { href: attachment.source_url }
+			: undefined;
+	}
+
+	if ( linkDestination === LINK_DESTINATION_ATTACHMENT ) {
+		return attachment.link ? { href: attachment.link } : undefined;
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolves the block attributes that are derived from the attachment, for an
+ * edit that saved to a different one.
+ *
+ * Editing media (crop, rotate, flip) creates a new attachment with its own
+ * generated sub-sizes and its own attachment page, and the media editor
+ * reports the full-size file. Without re-deriving these, the size control
+ * keeps reporting e.g. "Medium" while the block renders the full-size image,
+ * and a "Media file" or "Attachment page" link still points at the image as it
+ * was before the edit. Everything else the user set on the block — dimensions,
+ * lightbox, title, custom links — is left untouched.
+ *
+ * @param {Object}           blockAttributes The block's current attributes.
+ * @param {Object|undefined} attachment      The new attachment record.
+ * @param {string|undefined} fullUrl         URL of the new attachment's full
+ *                                           size.
+ *
+ * @return {Object|undefined} Attributes to apply, or undefined when the
+ *                            attachment record isn't known yet.
+ */
+export function getNewAttachmentImageBlockAttributes(
+	blockAttributes,
+	attachment,
+	fullUrl
+) {
+	if ( ! attachment ) {
+		return undefined;
+	}
+
+	return {
+		...getNewAttachmentSizeAttributes(
+			blockAttributes.sizeSlug,
+			attachment,
+			fullUrl
+		),
+		...getNewAttachmentLinkAttributes(
+			blockAttributes.linkDestination,
+			attachment
+		),
+	};
+}
+
 const { openMediaEditorModalKey } = unlock( blockEditorPrivateApis );
 
 function getAttachmentFallbackForEmptyBlockMetadata( { alt, caption } ) {
@@ -134,8 +239,10 @@ export function useOpenImageMediaEditorModal( {
 } ) {
 	// Keep this hook private to the Image block and pass the block attributes
 	// object so the callsite stays compact. Destructure only the attributes
-	// currently used for metadata sync; add more here if the sync policy grows.
-	const { id, url, alt, caption } = attributes;
+	// the update needs to read — those synced from the attachment's metadata,
+	// and those derived from which attachment the block points at; add more
+	// here if the sync policy grows.
+	const { id, url, alt, caption, sizeSlug, linkDestination } = attributes;
 	const registry = useRegistry();
 	const openMediaEditorModal = useSelect(
 		( select ) =>
@@ -151,6 +258,8 @@ export function useOpenImageMediaEditorModal( {
 		url,
 		alt,
 		caption: caption?.toString(),
+		sizeSlug,
+		linkDestination,
 	} );
 	// Snapshot of the attachment's metadata taken just before the modal opens,
 	// used as the baseline for detecting what changed during the editing session.
@@ -165,8 +274,10 @@ export function useOpenImageMediaEditorModal( {
 			url,
 			alt,
 			caption: caption?.toString(),
+			sizeSlug,
+			linkDestination,
 		};
-	}, [ alt, caption, id, url ] );
+	}, [ alt, caption, id, linkDestination, sizeSlug, url ] );
 
 	// Reads the cached attachment record. The `attachment` postType entity
 	// fetches with `context: 'edit'` by default, so `getEditedEntityRecord`
@@ -237,9 +348,29 @@ export function useOpenImageMediaEditorModal( {
 
 			const currentBlockAttributes = blockAttributesRef.current;
 
-			if ( newId !== currentBlockAttributes.id ) {
+			const isNewAttachment = newId !== currentBlockAttributes.id;
+			// Whether the attachment-derived attributes were re-resolved from
+			// the cached record; when they weren't, the freshly resolved
+			// record below gets a second chance.
+			let hasResolvedNewAttachment = false;
+
+			if ( isNewAttachment ) {
+				const fullUrl = newUrl ?? currentBlockAttributes.url;
+
 				nextAttributes.id = newId;
-				nextAttributes.url = newUrl ?? currentBlockAttributes.url;
+				nextAttributes.url = fullUrl;
+
+				const derivedAttributes = getNewAttachmentImageBlockAttributes(
+					currentBlockAttributes,
+					getCachedAttachmentRecord( newId ),
+					fullUrl
+				);
+
+				if ( derivedAttributes ) {
+					Object.assign( nextAttributes, derivedAttributes );
+					hasResolvedNewAttachment = true;
+				}
+
 				if ( nextAttributes.url !== currentBlockAttributes.url ) {
 					// The block is about to point at a freshly generated file
 					// the browser hasn't loaded yet; let the caller show a
@@ -248,8 +379,7 @@ export function useOpenImageMediaEditorModal( {
 				}
 				blockAttributesRef.current = {
 					...blockAttributesRef.current,
-					id: nextAttributes.id,
-					url: nextAttributes.url,
+					...nextAttributes,
 				};
 			}
 
@@ -284,6 +414,28 @@ export function useOpenImageMediaEditorModal( {
 				if ( Object.keys( resolvedMetadataAttributes ).length ) {
 					Object.assign( nextAttributes, resolvedMetadataAttributes );
 				}
+
+				// The new attachment wasn't cached yet when the update came
+				// in, so its size and link couldn't be derived from it then.
+				if ( isNewAttachment && ! hasResolvedNewAttachment ) {
+					const derivedAttributes =
+						getNewAttachmentImageBlockAttributes(
+							latestBlockAttributes,
+							resolvedAttachment,
+							nextAttributes.url
+						);
+
+					if ( derivedAttributes ) {
+						Object.assign( nextAttributes, derivedAttributes );
+
+						if (
+							derivedAttributes.url &&
+							derivedAttributes.url !== latestBlockAttributes.url
+						) {
+							onUrlChange?.( derivedAttributes.url );
+						}
+					}
+				}
 			}
 
 			if ( Object.keys( nextAttributes ).length ) {
@@ -294,7 +446,12 @@ export function useOpenImageMediaEditorModal( {
 				setAttributes( nextAttributes );
 			}
 		},
-		[ onUrlChange, resolveFreshAttachmentRecord, setAttributes ]
+		[
+			getCachedAttachmentRecord,
+			onUrlChange,
+			resolveFreshAttachmentRecord,
+			setAttributes,
+		]
 	);
 
 	const openImageMediaEditorModal = useCallback( async () => {

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -107,15 +107,14 @@ export function getSyncedImageBlockAttributes(
  *
  * WordPress skips generating a sub-size larger than the file itself, so the
  * selected size may not exist on the edited image; fall back to full when it
- * doesn't, as selecting a new image does.
+ * doesn't.
  *
  * @param {string|undefined} sizeSlug   The block's currently selected size.
  * @param {Object}           attachment The new attachment record.
- * @param {string|undefined} fullUrl    URL of the new attachment's full size.
  *
  * @return {Object|undefined} Attributes to apply, if any.
  */
-function getNewAttachmentSizeAttributes( sizeSlug, attachment, fullUrl ) {
+function getNewAttachmentSizeAttributes( sizeSlug, attachment ) {
 	const sizes = attachment.media_details?.sizes;
 
 	if ( ! sizeSlug || sizeSlug === DEFAULT_MEDIA_SIZE_SLUG || ! sizes ) {
@@ -124,9 +123,15 @@ function getNewAttachmentSizeAttributes( sizeSlug, attachment, fullUrl ) {
 
 	const sizeUrl = sizes[ sizeSlug ]?.source_url;
 
-	return sizeUrl
-		? { url: sizeUrl }
-		: { url: fullUrl, sizeSlug: DEFAULT_MEDIA_SIZE_SLUG };
+	if ( sizeUrl ) {
+		return { url: sizeUrl };
+	}
+
+	const fullUrl = attachment.source_url ?? sizes.full?.source_url;
+
+	return fullUrl
+		? { url: fullUrl, sizeSlug: DEFAULT_MEDIA_SIZE_SLUG }
+		: undefined;
 }
 
 /**
@@ -173,16 +178,13 @@ function getNewAttachmentLinkAttributes( linkDestination, attachment ) {
  *
  * @param {Object}           blockAttributes The block's current attributes.
  * @param {Object|undefined} attachment      The new attachment record.
- * @param {string|undefined} fullUrl         URL of the new attachment's full
- *                                           size.
  *
  * @return {Object|undefined} Attributes to apply, or undefined when the
  *                            attachment record isn't known yet.
  */
 export function getNewAttachmentImageBlockAttributes(
 	blockAttributes,
-	attachment,
-	fullUrl
+	attachment
 ) {
 	if ( ! attachment ) {
 		return undefined;
@@ -191,8 +193,7 @@ export function getNewAttachmentImageBlockAttributes(
 	return {
 		...getNewAttachmentSizeAttributes(
 			blockAttributes.sizeSlug,
-			attachment,
-			fullUrl
+			attachment
 		),
 		...getNewAttachmentLinkAttributes(
 			blockAttributes.linkDestination,
@@ -419,8 +420,7 @@ export function useOpenImageMediaEditorModal( {
 					const derivedAttributes =
 						getNewAttachmentImageBlockAttributes(
 							latestBlockAttributes,
-							attachmentRecord,
-							nextAttributes.url
+							attachmentRecord
 						);
 
 					if ( derivedAttributes ) {

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -418,9 +418,14 @@ export function useOpenImageMediaEditorModal( {
 					if ( derivedAttributes ) {
 						Object.assign( nextAttributes, derivedAttributes );
 
-						// Point the pending swap at the file the block will
-						// actually render, so the loading state settles
-						// against the right URL.
+						// The URL announced before the resolve was the
+						// full-size file the media editor reported, and
+						// deriving the selected size can change it.
+						// Re-announce so the pending swap names the file
+						// that actually lands: an update that is undone or
+						// superseded never changes the <img> src, and the
+						// block then clears its loading state by matching
+						// the pending URL against the rendered one.
 						if (
 							derivedAttributes.url &&
 							derivedAttributes.url !== latestBlockAttributes.url

--- a/packages/block-library/src/image/use-open-image-media-editor-modal.js
+++ b/packages/block-library/src/image/use-open-image-media-editor-modal.js
@@ -347,46 +347,31 @@ export function useOpenImageMediaEditorModal( {
 			const nextAttributes = {};
 
 			const currentBlockAttributes = blockAttributesRef.current;
-
 			const isNewAttachment = newId !== currentBlockAttributes.id;
-			// Whether the attachment-derived attributes were re-resolved from
-			// the cached record; when they weren't, the freshly resolved
-			// record below gets a second chance.
-			let hasResolvedNewAttachment = false;
 
 			if ( isNewAttachment ) {
-				const fullUrl = newUrl ?? currentBlockAttributes.url;
-
 				nextAttributes.id = newId;
-				nextAttributes.url = fullUrl;
-
-				const derivedAttributes = getNewAttachmentImageBlockAttributes(
-					currentBlockAttributes,
-					getCachedAttachmentRecord( newId ),
-					fullUrl
-				);
-
-				if ( derivedAttributes ) {
-					Object.assign( nextAttributes, derivedAttributes );
-					hasResolvedNewAttachment = true;
-				}
-
+				nextAttributes.url = newUrl ?? currentBlockAttributes.url;
 				if ( nextAttributes.url !== currentBlockAttributes.url ) {
 					// The block is about to point at a freshly generated file
 					// the browser hasn't loaded yet; let the caller show a
-					// loading state until its <img> fires load/error.
+					// loading state until its <img> fires load/error. Raising
+					// it here, before anything is awaited, keeps the rest of
+					// this update behind that loading state: the attributes
+					// land in a single `setAttributes` at the end, so the
+					// image never renders against half-updated settings.
 					onUrlChange?.( nextAttributes.url );
 				}
 				blockAttributesRef.current = {
 					...blockAttributesRef.current,
-					...nextAttributes,
+					id: nextAttributes.id,
+					url: nextAttributes.url,
 				};
 			}
 
-			if ( originalAttachment ) {
-				// Fetch fresh server state so the comparison reflects what
-				// the media editor actually saved, not a potentially stale
-				// cache.
+			if ( originalAttachment || isNewAttachment ) {
+				// Fetch fresh server state so this reflects what the media
+				// editor actually saved, not a potentially stale cache.
 				const resolvedAttachment =
 					await resolveFreshAttachmentRecord( newId );
 
@@ -398,26 +383,31 @@ export function useOpenImageMediaEditorModal( {
 					return;
 				}
 
+				const latestBlockAttributes = blockAttributesRef.current;
+
 				// Sync alt text and caption back to the block only when
 				// they were changed in the media editor. Fields the user
 				// has independently customised on the block (i.e. values
 				// that don't match the pre-session attachment metadata)
-				// are left untouched.
-				const latestBlockAttributes = blockAttributesRef.current;
-				const resolvedMetadataAttributes =
-					getSyncedImageBlockAttributes(
-						latestBlockAttributes,
-						originalAttachment,
-						resolvedAttachment
-					);
+				// are left untouched. Without a baseline there's no way to
+				// tell the two apart, so nothing is synced.
+				if ( originalAttachment ) {
+					const resolvedMetadataAttributes =
+						getSyncedImageBlockAttributes(
+							latestBlockAttributes,
+							originalAttachment,
+							resolvedAttachment
+						);
 
-				if ( Object.keys( resolvedMetadataAttributes ).length ) {
-					Object.assign( nextAttributes, resolvedMetadataAttributes );
+					if ( Object.keys( resolvedMetadataAttributes ).length ) {
+						Object.assign(
+							nextAttributes,
+							resolvedMetadataAttributes
+						);
+					}
 				}
 
-				// The new attachment wasn't cached yet when the update came
-				// in, so its size and link couldn't be derived from it then.
-				if ( isNewAttachment && ! hasResolvedNewAttachment ) {
+				if ( isNewAttachment ) {
 					const derivedAttributes =
 						getNewAttachmentImageBlockAttributes(
 							latestBlockAttributes,
@@ -428,6 +418,9 @@ export function useOpenImageMediaEditorModal( {
 					if ( derivedAttributes ) {
 						Object.assign( nextAttributes, derivedAttributes );
 
+						// Point the pending swap at the file the block will
+						// actually render, so the loading state settles
+						// against the right URL.
 						if (
 							derivedAttributes.url &&
 							derivedAttributes.url !== latestBlockAttributes.url
@@ -446,12 +439,7 @@ export function useOpenImageMediaEditorModal( {
 				setAttributes( nextAttributes );
 			}
 		},
-		[
-			getCachedAttachmentRecord,
-			onUrlChange,
-			resolveFreshAttachmentRecord,
-			setAttributes,
-		]
+		[ onUrlChange, resolveFreshAttachmentRecord, setAttributes ]
 	);
 
 	const openImageMediaEditorModal = useCallback( async () => {


### PR DESCRIPTION
## What?

Fixes #82296 

This fixes a subtle bug in the Image block when cropping an image:

In the image block's handling of media after a crop is performed, attempt to sync across the selected image size that a user has set for the particular block. So, if a block is set to "medium" or "large" size, then once the crop has been performed and the new attachment refetched, assign that particular image size.

While we're here, also ensure that the new url for the cropped attachment is the one that gets used for a wrapper `a` tag if the user has selected to have the image block link to the image file.

## Why?

Prior to this change, as described in #82296, if you'd selected anything other than `full` size for the image, then after performing a crop, the image block would revert back to being at full size, but the UI would be stuck on whatever you chose. This change makes the image resolution settings a user selects independent from cropping the image. The cropping _modal_ continues to use the full source image.

Additionally, while testing out #82296, I stumbled across another subtle bug where if you're using the "Link to image file" setting on the image block, then the _previous_ crop would be the image that gets linked to, rather than the full source url of the new crop. It should be the latter, as that's now the "real" attachment.

## How?

* In `useOpenImageMediaEditorModal` add a couple of helper functions to manage pulling in the right url depending on the `sizeSlug` being used, and using the right url when the image is set to link to the image file or attachment

## Testing Instructions

* Add an image to a post or page
* Click the link button button in the block toolbar and set it to "Link to image file"

<img width="506" height="290" alt="image" src="https://github.com/user-attachments/assets/fe87824f-3a67-4808-ab9c-b69ebe8d0a54" />

* In the settings sidebar, set the image to a size other than Full, e.g. Large or Medium
* Open up the cropper for the image
* Crop the image
* In the editor, the image size you selected should still be selected, and the image rendered in the editor should be that size (i.e. the smaller medium or full image, not the full sized image)
* Save the post
* View the post on the site frontend, and it should still be the medium/large image size depending on what you chose
* Click on the image, and it should take you to the full sized version of the _cropped_ image and not the original uncropped attachment

## Screenshots or screencast <!-- if applicable -->

This shows selecting "Link to image file", a lower image resolution, performing a crop, and the smaller image size (cropped) in the editor and site frontend, with the link on the site frontend going to the full size version of the _cropped_ image:

https://github.com/user-attachments/assets/9ce19833-ff2f-435f-bea6-94652386911b

## Use of AI Tools

Claude Code (Opus 5)