### PR TITLE
Gallery block: Fix 'Crop images to fit' broken in editor

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Image: Fix cropped galleries rendering images at their natural height in the editor canvas. The baseline inline `height: auto` is no longer emitted for images inside a cropped gallery, so the gallery's own cropping CSS applies ([#82318](https://github.com/WordPress/gutenberg/pull/82318)).
 -   Tabs: Activate the tab that a URL hash points into, so an anchor set on a block inside a tab panel can be reached. Anchor links followed after the page has loaded are handled too, matching the Accordion block ([#81744](https://github.com/WordPress/gutenberg/pull/81744)).
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).

--- a/packages/block-library/src/gallery/dynamic-gallery.jsx
+++ b/packages/block-library/src/gallery/dynamic-gallery.jsx
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import {
 	Button,
 	Notice,
@@ -19,6 +19,7 @@ import {
 	__experimentalUseBlockPreview as useBlockPreview,
 } from '@wordpress/block-editor';
 import { sharedIcon } from './shared-icon';
+import { isGalleryFlexLayout } from './shared';
 import { Caption } from '../utils/caption';
 import { DEFAULT_ORDERBY, DEFAULT_ORDER, MAX_IMAGES } from './dynamic-source';
 
@@ -282,12 +283,21 @@ export function GallerySourcePanel( {
  * stays editable. This relies on the gallery's image styles using descendant
  * (not direct-child) selectors, which the box-less wrapper leaves intact.
  *
+ * The gallery's layout is passed through so the previewed images see the same
+ * parent layout that real inner blocks would (`useBlockPreview` provides it to
+ * their layout context). Without it they resolve to the default flow layout and
+ * behave as if they weren't in a gallery — most visibly, an image inside a
+ * cropped gallery would keep its baseline `height: auto` and defeat the
+ * gallery's cropping CSS.
+ *
  * @param {Object}   props
  * @param {Object[]} props.imageBlocks Non-persisted `core/image` blocks to preview.
+ * @param {Object}   props.layout      The gallery's layout, for the preview's layout context.
  */
-function GalleryImagesPreview( { imageBlocks } ) {
+function GalleryImagesPreview( { imageBlocks, layout } ) {
 	const { children, ref, className } = useBlockPreview( {
 		blocks: imageBlocks,
+		layout,
 	} );
 	return (
 		<div
@@ -353,6 +363,19 @@ export function GalleryDynamicView( {
 
 	const [ isConfirmingDetach, setIsConfirmingDetach ] = useState( false );
 
+	// The layout the previewed images sit in. Normalized the same way the
+	// gallery's own classes are (`isGalleryFlexLayout`), so a layout that the
+	// wrapper treats as flex — including a missing or typeless one — is reported
+	// as flex to the images rather than resolving to the default flow layout.
+	// Memoized because it becomes the preview's layout context value.
+	const previewLayout = useMemo(
+		() =>
+			isGalleryFlexLayout( attributes.layout )
+				? { ...attributes.layout, type: 'flex' }
+				: attributes.layout,
+		[ attributes.layout ]
+	);
+
 	// Empty-state copy for the preview. Framed as forward-looking ("… will appear
 	// here") rather than as an error, since the same empty result covers both a
 	// post with no matching images and a template with no post in context yet —
@@ -396,6 +419,7 @@ export function GalleryDynamicView( {
 					<BlockContextProvider value={ galleryContext }>
 						<GalleryImagesPreview
 							imageBlocks={ dynamicImageBlocks }
+							layout={ previewLayout }
 						/>
 					</BlockContextProvider>
 				) : (

--- a/packages/block-library/src/image/image.jsx
+++ b/packages/block-library/src/image/image.jsx
@@ -317,6 +317,10 @@ export default function Image( {
 	}, [ imageElement ] );
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
 	const { allowResize = true, imageCrop = false } = context;
+	// Only a cropped gallery (flex layout) controls the image height via its
+	// own CSS. Grid galleries and standalone images keep the baseline
+	// `height: auto` so a theme can't squish them.
+	const isCroppedGalleryImage = imageCrop && parentLayoutType === 'flex';
 
 	const { image, attachmentResolutionError } = useSelect(
 		( select ) => {
@@ -1232,7 +1236,7 @@ export default function Image( {
 												typeof height === 'number'
 													? `${ height }px`
 													: height;
-										} else if ( ! imageCrop ) {
+										} else if ( ! isCroppedGalleryImage ) {
 											// Default to `height: auto` so a
 											// theme that sets an explicit height
 											// on images can't squish them. Inside

--- a/packages/block-library/src/image/image.jsx
+++ b/packages/block-library/src/image/image.jsx
@@ -316,7 +316,7 @@ export default function Image( {
 		setOffsetTop( imageElement?.offsetTop ?? 0 );
 	}, [ imageElement ] );
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
-	const { allowResize = true } = context;
+	const { allowResize = true, imageCrop = false } = context;
 
 	const { image, attachmentResolutionError } = useSelect(
 		( select ) => {
@@ -1222,17 +1222,23 @@ export default function Image( {
 													? `${ width }px`
 													: width;
 										}
-										if (
-											height === 'auto' ||
-											height === undefined ||
-											height === null
-										) {
+										if ( height === 'auto' ) {
 											style.height = 'auto';
-										} else {
+										} else if (
+											height !== undefined &&
+											height !== null
+										) {
 											style.height =
 												typeof height === 'number'
 													? `${ height }px`
 													: height;
+										} else if ( ! imageCrop ) {
+											// Default to `height: auto` so a
+											// theme that sets an explicit height
+											// on images can't squish them. Inside
+											// a cropped gallery the gallery's own
+											// CSS controls the height instead.
+											style.height = 'auto';
 										}
 										return style;
 								  } )() ),

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -463,6 +463,64 @@ test.describe( 'Gallery', () => {
 			} )
 			.toBeLessThanOrEqual( 1 );
 	} );
+
+	test( 'does not crop images to a uniform height when cropping is disabled', async ( {
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		const landscapeMedia = await requestUtils.uploadMedia(
+			'./assets/200x150_e2e_test_image_opaque.png'
+		);
+		const squareMedia = await requestUtils.uploadMedia(
+			'./assets/10x10_e2e_test_image_z9T8jK.png'
+		);
+
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				imageCrop: false,
+			},
+			innerBlocks: [
+				{
+					name: 'core/image',
+					attributes: {
+						id: landscapeMedia.id,
+						url: landscapeMedia.source_url,
+						sizeSlug: 'full',
+					},
+				},
+				{
+					name: 'core/image',
+					attributes: {
+						id: squareMedia.id,
+						url: squareMedia.source_url,
+						sizeSlug: 'full',
+					},
+				},
+			],
+		} );
+
+		const images = editor.canvas.locator(
+			'role=document[name="Block: Gallery"i] >> role=img'
+		);
+		await expect( images ).toHaveCount( 2 );
+
+		// With cropping disabled, each image renders at its natural aspect
+		// ratio, so the two images have different heights. Poll so the
+		// assertion waits for both images to finish loading.
+		await expect
+			.poll( async () => {
+				const landscapeBox = await images.nth( 0 ).boundingBox();
+				const squareBox = await images.nth( 1 ).boundingBox();
+				if ( ! landscapeBox || ! squareBox ) {
+					return 0;
+				}
+				return Math.abs( landscapeBox.height - squareBox.height );
+			} )
+			.toBeGreaterThan( 10 );
+	} );
 } );
 
 class GalleryBlockUtils {

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -12,12 +12,16 @@ test.use( {
 
 test.describe( 'Gallery', () => {
 	let uploadedMedia;
+	let landscapeMedia;
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllMedia();
 
 		uploadedMedia = await requestUtils.uploadMedia(
 			'./assets/10x10_e2e_test_image_z9T8jK.png'
+		);
+		landscapeMedia = await requestUtils.uploadMedia(
+			'./assets/200x150_e2e_test_image_opaque.png'
 		);
 	} );
 
@@ -405,15 +409,7 @@ test.describe( 'Gallery', () => {
 	test( 'crops linked images to a uniform height in the editor canvas', async ( {
 		admin,
 		editor,
-		requestUtils,
 	} ) => {
-		const landscapeMedia = await requestUtils.uploadMedia(
-			'./assets/200x150_e2e_test_image_opaque.png'
-		);
-		const squareMedia = await requestUtils.uploadMedia(
-			'./assets/10x10_e2e_test_image_z9T8jK.png'
-		);
-
 		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'core/gallery',
@@ -434,11 +430,11 @@ test.describe( 'Gallery', () => {
 				{
 					name: 'core/image',
 					attributes: {
-						id: squareMedia.id,
-						url: squareMedia.source_url,
+						id: uploadedMedia.id,
+						url: uploadedMedia.source_url,
 						sizeSlug: 'full',
 						linkDestination: 'media',
-						href: squareMedia.source_url,
+						href: uploadedMedia.source_url,
 					},
 				},
 			],
@@ -467,15 +463,7 @@ test.describe( 'Gallery', () => {
 	test( 'does not crop images to a uniform height when cropping is disabled', async ( {
 		admin,
 		editor,
-		requestUtils,
 	} ) => {
-		const landscapeMedia = await requestUtils.uploadMedia(
-			'./assets/200x150_e2e_test_image_opaque.png'
-		);
-		const squareMedia = await requestUtils.uploadMedia(
-			'./assets/10x10_e2e_test_image_z9T8jK.png'
-		);
-
 		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'core/gallery',
@@ -494,8 +482,8 @@ test.describe( 'Gallery', () => {
 				{
 					name: 'core/image',
 					attributes: {
-						id: squareMedia.id,
-						url: squareMedia.source_url,
+						id: uploadedMedia.id,
+						url: uploadedMedia.source_url,
 						sizeSlug: 'full',
 					},
 				},
@@ -520,6 +508,62 @@ test.describe( 'Gallery', () => {
 				return Math.abs( landscapeBox.height - squareBox.height );
 			} )
 			.toBeGreaterThan( 10 );
+	} );
+
+	// Regression test for the dynamic gallery preview, where the gallery's
+	// layout must be passed to `useBlockPreview` for the crop to apply.
+	test( 'crops images to a uniform height in a dynamic gallery', async ( {
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		// A dynamic gallery resolves the images attached to the post being
+		// edited, so create a post and attach two different-aspect-ratio
+		// images to it.
+		const post = await requestUtils.createPost( {
+			title: 'Dynamic gallery',
+			status: 'draft',
+		} );
+		for ( const file of [
+			'./assets/200x150_e2e_test_image_opaque.png',
+			'./assets/10x10_e2e_test_image_z9T8jK.png',
+		] ) {
+			const media = await requestUtils.uploadMedia( file );
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/media/${ media.id }`,
+				data: { post: post.id },
+			} );
+		}
+
+		await admin.editPost( post.id );
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				dynamicContent: { source: 'core/attached-media' },
+				linkTo: 'media',
+			},
+		} );
+
+		const images = editor.canvas.locator(
+			'[data-type="core/gallery"] img'
+		);
+		// Wait for the dynamic source to resolve and preview both images.
+		await expect( images ).toHaveCount( 2 );
+
+		// With cropping enabled, both previewed images render at the same
+		// height. Poll so the assertion waits for the images to load and the
+		// layout to settle.
+		await expect
+			.poll( async () => {
+				const firstBox = await images.nth( 0 ).boundingBox();
+				const secondBox = await images.nth( 1 ).boundingBox();
+				if ( ! firstBox || ! secondBox ) {
+					return Number.POSITIVE_INFINITY;
+				}
+				return Math.abs( firstBox.height - secondBox.height );
+			} )
+			.toBeLessThanOrEqual( 1 );
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -400,6 +400,69 @@ test.describe( 'Gallery', () => {
 		);
 		expect( numbers ).not.toEqual( imageAltTexts );
 	} );
+
+	// Regression test for https://github.com/WordPress/gutenberg/issues/82252.
+	test( 'crops linked images to a uniform height in the editor canvas', async ( {
+		admin,
+		editor,
+		requestUtils,
+	} ) => {
+		const landscapeMedia = await requestUtils.uploadMedia(
+			'./assets/200x150_e2e_test_image_opaque.png'
+		);
+		const squareMedia = await requestUtils.uploadMedia(
+			'./assets/10x10_e2e_test_image_z9T8jK.png'
+		);
+
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				linkTo: 'media',
+			},
+			innerBlocks: [
+				{
+					name: 'core/image',
+					attributes: {
+						id: landscapeMedia.id,
+						url: landscapeMedia.source_url,
+						sizeSlug: 'full',
+						linkDestination: 'media',
+						href: landscapeMedia.source_url,
+					},
+				},
+				{
+					name: 'core/image',
+					attributes: {
+						id: squareMedia.id,
+						url: squareMedia.source_url,
+						sizeSlug: 'full',
+						linkDestination: 'media',
+						href: squareMedia.source_url,
+					},
+				},
+			],
+		} );
+
+		const images = editor.canvas.locator(
+			'role=document[name="Block: Gallery"i] >> role=img'
+		);
+		await expect( images ).toHaveCount( 2 );
+
+		// With cropping enabled, both images in the row render at the same
+		// height. Poll so the assertion waits for both images to finish
+		// loading and for the layout to settle.
+		await expect
+			.poll( async () => {
+				const landscapeBox = await images.nth( 0 ).boundingBox();
+				const squareBox = await images.nth( 1 ).boundingBox();
+				if ( ! landscapeBox || ! squareBox ) {
+					return Number.POSITIVE_INFINITY;
+				}
+				return Math.abs( landscapeBox.height - squareBox.height );
+			} )
+			.toBeLessThanOrEqual( 1 );
+	} );
 } );
 
 class GalleryBlockUtils {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -1068,9 +1068,10 @@ test.describe( 'Image - dimensions forced by global styles', () => {
 			'./assets/200x150_e2e_test_image_opaque.png'
 		);
 
-		// Mimic a theme that forces a fixed height on image blocks. The
-		// top-level custom CSS is prefixed with `:root :where(body)`, giving
-		// it higher specificity than the block's own `height: auto` rule.
+		// Mimic a theme that forces a fixed height on image blocks. User
+		// global styles load after the block's own stylesheet, so this rule
+		// wins the equal-specificity cascade against the block's `height: auto`
+		// unless the block sets an inline `height: auto` (which always wins).
 		const stylesPostId =
 			await requestUtils.getCurrentThemeGlobalStylesPostId();
 		await requestUtils.rest( {
@@ -1116,6 +1117,46 @@ test.describe( 'Image - dimensions forced by global styles', () => {
 		// ratio (150px tall) instead of being squished to the 100px height
 		// forced by global styles.
 		expect( box.width / box.height ).toBeCloseTo( 4 / 3, 1 );
+	} );
+
+	test( 'preserves the aspect ratio for images in a grid gallery', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				layout: { type: 'grid' },
+			},
+			innerBlocks: [
+				{
+					name: 'core/image',
+					attributes: {
+						id: uploadedMedia.id,
+						url: uploadedMedia.source_url,
+						sizeSlug: 'full',
+					},
+				},
+			],
+		} );
+
+		// The grid variation relabels the block to "Gallery Grid", so select
+		// by data-type rather than by the block's accessible name.
+		const image = editor.canvas.locator(
+			'[data-type="core/gallery"] [data-type="core/image"] img'
+		);
+		await expect( image ).toBeVisible();
+
+		// Grid galleries do not crop images, so the image keeps its baseline
+		// `height: auto` and is not squished by the global styles. Poll so the
+		// assertion waits for the image to load and the layout to settle.
+		await expect
+			.poll( async () => {
+				const box = await image.boundingBox();
+				return box ? box.width / box.height : 0;
+			} )
+			.toBeCloseTo( 4 / 3, 1 );
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -1089,6 +1089,7 @@ test.describe( 'Image - dimensions forced by global styles', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.resetThemeGlobalStyles();
 		await requestUtils.deleteAllMedia();
+		await requestUtils.deleteAllPosts();
 	} );
 
 	test( 'preserves the aspect ratio when only the width is set', async ( {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -1058,6 +1058,67 @@ test.describe( 'Image - Site editor', () => {
 	} );
 } );
 
+// Regression test for https://github.com/WordPress/gutenberg/pull/70575.
+test.describe( 'Image - dimensions forced by global styles', () => {
+	let uploadedMedia;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllMedia();
+		uploadedMedia = await requestUtils.uploadMedia(
+			'./assets/200x150_e2e_test_image_opaque.png'
+		);
+
+		// Mimic a theme that forces a fixed height on image blocks. The
+		// top-level custom CSS is prefixed with `:root :where(body)`, giving
+		// it higher specificity than the block's own `height: auto` rule.
+		const stylesPostId =
+			await requestUtils.getCurrentThemeGlobalStylesPostId();
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/global-styles/${ stylesPostId }`,
+			data: {
+				id: stylesPostId,
+				styles: {
+					css: '.wp-block-image img { height: 100px; }',
+				},
+			},
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.resetThemeGlobalStyles();
+		await requestUtils.deleteAllMedia();
+	} );
+
+	test( 'preserves the aspect ratio when only the width is set', async ( {
+		admin,
+		editor,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/image',
+			attributes: {
+				id: uploadedMedia.id,
+				url: uploadedMedia.source_url,
+				sizeSlug: 'full',
+				width: '200px',
+			},
+		} );
+
+		const image = editor.canvas.locator(
+			'role=document[name="Block: Image"i] >> role=img'
+		);
+		await expect( image ).toBeVisible();
+		await image.evaluate( ( img ) => img.decode() );
+
+		const box = await image.boundingBox();
+		// The 200x150 image displayed at 200px wide keeps its 4:3 aspect
+		// ratio (150px tall) instead of being squished to the 100px height
+		// forced by global styles.
+		expect( box.width / box.height ).toBeCloseTo( 4 / 3, 1 );
+	} );
+} );
+
 class ImageBlockUtils {
 	constructor( { page } ) {
 		/** @type {Page} */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #82252

As mentioned in that issue discussion, when a gallery image had a link (either to attachment page or directly to the media), the `object-fit: cover` rule ('Crop images to fit' option) no longer worked in the editor in trunk.

## Why?
This looks to be a regression after https://github.com/WordPress/gutenberg/pull/70575, so it's a bug in WordPress 7.1.

That PR adds a `height: auto` inline style that prevents `object-fit: cover` from working when the image is wrapped in a `<a>` link rule.

## How?
The fix is to only conditionally apply `height: auto` when the image is not in a gallery.

Added e2e tests to cover #70575 and #82252

## Testing Instructions
1. Add a gallery with some images (you likely need some landscape images to reproduce the bug).
2. From the gallery block toolbar set 'Link images to attachment pages'

In trunk: Observe that landscape images no longer apply the 'cover' rule
In this PR: Observe that the images fit correctly

Other things to check:
- Gallery Grid still works correctly ('Crop images to fit' is permanently switched off and non-turn-on-able)
- 'Crop images to fit' switched off still works correctly

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="968" height="753" alt="Screenshot 2026-09-01 at 4 57 22 pm" src="https://github.com/user-attachments/assets/4fc03467-46f7-4f6e-b124-838dda67ebde" /> | <img width="981" height="651" alt="Screenshot 2026-09-02 at 2 11 11 pm" src="https://github.com/user-attachments/assets/6b008f36-8734-4d4b-b4f1-9dfbe80b9a81" /> |

## Use of AI Tools
OpenCode / Kimi K3, Kimi K2.7 for code edits