### PR TITLE
Editor: Deprecate the `as` prop of the plugin menu item components

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Breaking Changes
 
--   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem`. A link item honors only `target="_blank"`, and a custom `as` has to forward its ref ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
+-   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem`. A link item honors only `target="_blank"` ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
+
+### Deprecations
+
+-   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, `PluginPreviewMenuItem`: Deprecate the `as` prop. It was never a documented part of these components, and the menu now renders the item itself. The prop is ignored ([#82319](https://github.com/WordPress/gutenberg/pull/82319)).
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
--   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, `PluginPreviewMenuItem`: Deprecate the `as` prop. It was never a documented part of these components, and the menu now renders the item itself. The prop is ignored ([#82319](https://github.com/WordPress/gutenberg/pull/82319)).
+-   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, `PluginPreviewMenuItem`: Deprecate the `as` prop, which reached the item only because these components forward every extra prop. The menu now renders the item itself, so the prop is ignored ([#82319](https://github.com/WordPress/gutenberg/pull/82319)).
 
 ### Bug Fixes
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -709,7 +709,7 @@ _Parameters_
 -   _props.href_ `[string]`: When `href` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
 -   _props.onClick_ `[Function]`: The callback function to be executed when the user clicks the menu item.
--   _props.other_ `[...*]`: Any additional props are passed through to the underlying menu item component.
+-   _props.other_ `[...*]`: Any additional props are passed through to the underlying menu item component, except for `as`, which is deprecated and ignored.
 
 _Returns_
 
@@ -861,7 +861,7 @@ _Parameters_
 -   _props.href_ `[string]`: When `href` is provided, the menu item is rendered as an anchor instead of a button. It corresponds to the `href` attribute of the anchor.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The icon to be rendered to the left of the menu item label. Can be a Dashicon slug or an SVG WP element.
 -   _props.onClick_ `[Function]`: The callback function to be executed when the user clicks the menu item.
--   _props.other_ `[...*]`: Any additional props are passed through to the underlying MenuItem component.
+-   _props.other_ `[...*]`: Any additional props are passed through to the underlying menu item component, except for `as`, which is deprecated and ignored.
 
 _Returns_
 

--- a/packages/editor/src/components/plugin-more-menu-item/index.jsx
+++ b/packages/editor/src/components/plugin-more-menu-item/index.jsx
@@ -11,7 +11,7 @@ import { ActionItem } from '@wordpress/interface';
  * @param {string}                [props.href]                          When `href` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
  * @param {Function}              [props.onClick=noop]                  The callback function to be executed when the user clicks the menu item.
- * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying menu item component.
+ * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying menu item component, except for `as`, which is deprecated and ignored.
  *
  * @example
  * ```js
@@ -61,15 +61,14 @@ import { ActionItem } from '@wordpress/interface';
  */
 export default function PluginMoreMenuItem( props ) {
 	const context = usePluginContext();
-	// `as` was never part of the contract. It is dropped so that it does not
-	// reach the item the menu renders.
+	// The menu renders the item itself, so `as` is dropped rather than
+	// forwarded.
 	const { as, ...itemProps } = props;
 
 	if ( as ) {
 		deprecated( 'The `as` prop of wp.editor.PluginMoreMenuItem', {
 			since: '7.2',
-			version: '7.4',
-			hint: 'The menu renders the item itself.',
+			hint: 'The menu renders the item itself. The prop is ignored.',
 		} );
 	}
 

--- a/packages/editor/src/components/plugin-more-menu-item/index.jsx
+++ b/packages/editor/src/components/plugin-more-menu-item/index.jsx
@@ -1,3 +1,4 @@
+import deprecated from '@wordpress/deprecated';
 import { usePluginContext } from '@wordpress/plugins';
 import { ActionItem } from '@wordpress/interface';
 
@@ -60,11 +61,23 @@ import { ActionItem } from '@wordpress/interface';
  */
 export default function PluginMoreMenuItem( props ) {
 	const context = usePluginContext();
+	// `as` was never part of the contract. It is dropped so that it does not
+	// reach the item the menu renders.
+	const { as, ...itemProps } = props;
+
+	if ( as ) {
+		deprecated( 'The `as` prop of wp.editor.PluginMoreMenuItem', {
+			since: '7.2',
+			version: '7.4',
+			hint: 'The menu renders the item itself.',
+		} );
+	}
+
 	return (
 		<ActionItem
 			name="core/plugin-more-menu"
-			icon={ props.icon || context.icon }
-			{ ...props }
+			icon={ itemProps.icon || context.icon }
+			{ ...itemProps }
 		/>
 	);
 }

--- a/packages/editor/src/components/plugin-preview-menu-item/index.jsx
+++ b/packages/editor/src/components/plugin-preview-menu-item/index.jsx
@@ -1,3 +1,4 @@
+import deprecated from '@wordpress/deprecated';
 import { usePluginContext } from '@wordpress/plugins';
 import { ActionItem } from '@wordpress/interface';
 
@@ -39,11 +40,23 @@ import { ActionItem } from '@wordpress/interface';
  */
 export default function PluginPreviewMenuItem( props ) {
 	const context = usePluginContext();
+	// `as` was never part of the contract. It is dropped so that it does not
+	// reach the item the menu renders.
+	const { as, ...itemProps } = props;
+
+	if ( as ) {
+		deprecated( 'The `as` prop of wp.editor.PluginPreviewMenuItem', {
+			since: '7.2',
+			version: '7.4',
+			hint: 'The menu renders the item itself.',
+		} );
+	}
+
 	return (
 		<ActionItem
 			name="core/plugin-preview-menu"
-			icon={ props.icon || context.icon }
-			{ ...props }
+			icon={ itemProps.icon || context.icon }
+			{ ...itemProps }
 		/>
 	);
 }

--- a/packages/editor/src/components/plugin-preview-menu-item/index.jsx
+++ b/packages/editor/src/components/plugin-preview-menu-item/index.jsx
@@ -11,7 +11,7 @@ import { ActionItem } from '@wordpress/interface';
  * @param {string}                [props.href]                          When `href` is provided, the menu item is rendered as an anchor instead of a button. It corresponds to the `href` attribute of the anchor.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The icon to be rendered to the left of the menu item label. Can be a Dashicon slug or an SVG WP element.
  * @param {Function}              [props.onClick]                       The callback function to be executed when the user clicks the menu item.
- * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying MenuItem component.
+ * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying menu item component, except for `as`, which is deprecated and ignored.
  *
  * @example
  * ```jsx
@@ -40,15 +40,14 @@ import { ActionItem } from '@wordpress/interface';
  */
 export default function PluginPreviewMenuItem( props ) {
 	const context = usePluginContext();
-	// `as` was never part of the contract. It is dropped so that it does not
-	// reach the item the menu renders.
+	// The menu renders the item itself, so `as` is dropped rather than
+	// forwarded.
 	const { as, ...itemProps } = props;
 
 	if ( as ) {
 		deprecated( 'The `as` prop of wp.editor.PluginPreviewMenuItem', {
 			since: '7.2',
-			version: '7.4',
-			hint: 'The menu renders the item itself.',
+			hint: 'The menu renders the item itself. The prop is ignored.',
 		} );
 	}
 

--- a/packages/editor/src/components/plugin-sidebar-more-menu-item/index.jsx
+++ b/packages/editor/src/components/plugin-sidebar-more-menu-item/index.jsx
@@ -50,15 +50,14 @@ import { ComplementaryAreaMoreMenuItem } from '@wordpress/interface';
  * @return {React.ReactNode} The rendered component.
  */
 export default function PluginSidebarMoreMenuItem( props ) {
-	// `as` was never part of the contract. It is dropped so that it does not
-	// reach the item the menu renders.
+	// The menu renders the item itself, so `as` is dropped rather than
+	// forwarded.
 	const { as, ...itemProps } = props;
 
 	if ( as ) {
 		deprecated( 'The `as` prop of wp.editor.PluginSidebarMoreMenuItem', {
 			since: '7.2',
-			version: '7.4',
-			hint: 'The menu renders the item itself.',
+			hint: 'The menu renders the item itself. The prop is ignored.',
 		} );
 	}
 

--- a/packages/editor/src/components/plugin-sidebar-more-menu-item/index.jsx
+++ b/packages/editor/src/components/plugin-sidebar-more-menu-item/index.jsx
@@ -1,3 +1,4 @@
+import deprecated from '@wordpress/deprecated';
 import { ComplementaryAreaMoreMenuItem } from '@wordpress/interface';
 
 /**
@@ -49,5 +50,17 @@ import { ComplementaryAreaMoreMenuItem } from '@wordpress/interface';
  * @return {React.ReactNode} The rendered component.
  */
 export default function PluginSidebarMoreMenuItem( props ) {
-	return <ComplementaryAreaMoreMenuItem scope="core" { ...props } />;
+	// `as` was never part of the contract. It is dropped so that it does not
+	// reach the item the menu renders.
+	const { as, ...itemProps } = props;
+
+	if ( as ) {
+		deprecated( 'The `as` prop of wp.editor.PluginSidebarMoreMenuItem', {
+			since: '7.2',
+			version: '7.4',
+			hint: 'The menu renders the item itself.',
+		} );
+	}
+
+	return <ComplementaryAreaMoreMenuItem scope="core" { ...itemProps } />;
 }


### PR DESCRIPTION
## What?
Follow-up to #81564.

`PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, and `PluginPreviewMenuItem` now warn when a plugin passes `as`, and no longer forward it. A plugin passing `as` has its menu item rendered by the menu's own item component, with a deprecation notice in the console, instead of its custom component.

## Why?

`as` was never a documented prop of these components. It leaked through because each one spreads the rest of its props onto `ActionItem` (or, for the sidebar item, onto `ComplementaryAreaMoreMenuItem`, whose own `as` the spread overrode). `ActionItem` treats `as` as the component to render the fill with, so plugins could swap out the menu item.

Since #81564, the Options menu renders its items with `Menu` from `@wordpress/ui`, whose items must be composed by the menu itself. A replaced component cannot participate in it, so the accidental contract has to go.

## Testing Instructions
1. Open a post or page.
2. Paste and run the test plugin snippet.
3. Confirm that the plugin menu item is rendered properly.
4. Confirm that the `as` prop logs a deprecation.

<details><summary>Test plugin snippet</summary>
<p>

```js
const el = wp.element.createElement;
const registerPlugin = wp.plugins.registerPlugin;
const PluginMoreMenuItem = wp.editor.PluginMoreMenuItem;

registerPlugin( 'my-plugin-more-menu-item', {
	render: function () {
		return el(
			PluginMoreMenuItem,
			{
				icon: 'smiley',
				onClick: () => console.log( 'Hello, world!' ),
				as: 'div'
			},
			'My Menu Item'
		);
	},
} );
```

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1334" height="404" alt="CleanShot 2026-09-02 at 10 38 59" src="https://github.com/user-attachments/assets/a0f87b36-2608-468f-b6c3-d7fb9a0c59f6" />


## Use of AI Tools

Assisted by Claude.
