### PR TITLE
Framework: Error on npm versions older than the required floor

### DIFF
--- a/.github/setup-npm/action.yml
+++ b/.github/setup-npm/action.yml
@@ -13,7 +13,8 @@ runs:
         - name: Install npm
           run: |
               NPM_VERSION="$(jq -r '.devEngines.packageManager.version' package.json)"
-              npm install --global "npm@$NPM_VERSION"
+              # Contributors need the floor; CI stays on that major's newest release.
+              npm install --global "npm@${NPM_VERSION/>=/^}"
               echo "Required npm version: $NPM_VERSION"
               echo "Installed npm version: $(npm --version)"
           working-directory: ${{ inputs.working-directory }}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 		},
 		"packageManager": {
 			"name": "npm",
-			"version": "^10.2.3",
-			"onFail": "warn"
+			"version": ">=10.2.3",
+			"onFail": "error"
 		}
 	},
 	"wpPlugin": {

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -18,10 +18,10 @@ const ARTIFACTS_PATH =
 const RAW_RESULTS_FILE_SUFFIX = '.performance-results.raw.json';
 const RESULTS_FILE_SUFFIX = '.performance-results.json';
 /*
- * Read from the CLI's own checkout, so every branch under test builds with the
- * npm version trunk requires rather than whichever npm the runner happens to ship.
+ * Read from the CLI's own checkout so every branch under test builds with the npm
+ * version trunk requires, narrowed to that major so a new one cannot land mid-run.
  */
-const NPM_VERSION = devEngines.packageManager.version;
+const NPM_VERSION = devEngines.packageManager.version.replace( '>=', '^' );
 
 /**
  * @typedef WPPerformanceCommandOptions


### PR DESCRIPTION
## What?

Follow up to #82235.

Turns `devEngines.packageManager` into a floor that errors below it, so a newer npm major works locally while an older one is blocked, and keeps CI reading its version from that same field.

## Why?

`^10.2.3` with `onFail: "warn"` had it backwards: npm 11 works but warns on every command, while an npm older than 10.2.3 only warns too. `engines.npm` cannot cover this, because `engine-strict` does not apply to a package's own `engines`.

## How?

The field becomes `>=10.2.3` with `onFail: "error"`. `.github/setup-npm` and the release CLI narrow that floor to its major before installing, so CI keeps getting the newest 10.x instead of following the floor into a new major.

Known limit: the narrowing rewrites a leading `>=`, so a compound range such as `>=10.2.3 || >=11.19` would not be bounded.

## Testing Instructions

1. On npm 11, run any npm command in the repo. It succeeds and prints no `EBADDEVENGINES` output.
2. Confirm a CI job's "Set up npm" step still logs `Installed npm version: 10.x.x`.

## Use of AI Tools

Authored with Claude Code, reviewed by me.
