### PR TITLE
Editor: Refactor the View menu to use the Menu component

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/preview.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/preview.ts
@@ -18,7 +18,9 @@ export async function openPreviewPage( this: Editor ): Promise< Page > {
 
 	const [ previewPage ] = await Promise.all( [
 		this.context.waitForEvent( 'page' ),
-		this.page.click( 'role=menuitem[name="Preview in new tab"i]' ),
+		this.page
+			.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+			.click(),
 	] );
 
 	return previewPage;

--- a/packages/e2e-test-utils-playwright/src/editor/preview.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/preview.ts
@@ -19,7 +19,7 @@ export async function openPreviewPage( this: Editor ): Promise< Page > {
 	const [ previewPage ] = await Promise.all( [
 		this.context.waitForEvent( 'page' ),
 		this.page
-			.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+			.getByRole( 'menuitem', { name: 'Preview (opens in a new tab)' } )
 			.click(),
 	] );
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Deprecations
 
 -   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, `PluginPreviewMenuItem`: Deprecate the `as` prop, which reached the item only because these components forward every extra prop. The menu now renders the item itself, so the prop is ignored ([#82319](https://github.com/WordPress/gutenberg/pull/82319)).
+-   `PluginPreviewMenuItem`: The View menu renders with the `Menu` component of `@wordpress/ui`, so a link item honors only `target="_blank"`, as in the Options menu ([#82321](https://github.com/WordPress/gutenberg/pull/82321)).
 
 ### Enhancements
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -268,7 +268,7 @@
 		}
 
 		& > .editor-header__toolbar .editor-document-tools__document-overview-toggle,
-		& > .editor-header__settings > .editor-preview-dropdown,
+		& > .editor-header__settings > .editor-preview-dropdown__toggle,
 		& > .editor-header__settings > .interface-pinned-items,
 		& > .editor-header__settings > .editor-zoom-out-toggle {
 			display: none;

--- a/packages/editor/src/components/more-menu/more-menu-group.tsx
+++ b/packages/editor/src/components/more-menu/more-menu-group.tsx
@@ -6,9 +6,9 @@ import MoreMenuItem from './more-menu-item';
 
 type MoreMenuGroupProps = {
 	/**
-	 * Label of the group.
+	 * Label of the group. Omit it for a group that needs no heading.
 	 */
-	label: string;
+	label?: string;
 
 	/**
 	 * Fills of the slot.
@@ -17,7 +17,7 @@ type MoreMenuGroupProps = {
 };
 
 /**
- * Renders the fills of an action item slot as a group of the more menu.
+ * Renders the fills of an action item slot as a group of a menu.
  */
 export default function MoreMenuGroup( {
 	label,
@@ -27,7 +27,7 @@ export default function MoreMenuGroup( {
 		<>
 			<Menu.Separator />
 			<Menu.Group>
-				<Menu.GroupLabel>{ label }</Menu.GroupLabel>
+				{ label && <Menu.GroupLabel>{ label }</Menu.GroupLabel> }
 				{ toMenuItems( children ) }
 			</Menu.Group>
 		</>

--- a/packages/editor/src/components/more-menu/style.scss
+++ b/packages/editor/src/components/more-menu/style.scss
@@ -4,5 +4,5 @@
 	max-height: var(--available-height);
 	// Narrower than the default of the menu, closer to the previous menu,
 	// which sized itself to its longest label.
-	--wp-ui-menu-max-width: var(--wpds-dimension-surface-width-sm);
+	max-width: var(--wpds-dimension-surface-width-sm);
 }

--- a/packages/editor/src/components/post-preview-button/index.jsx
+++ b/packages/editor/src/components/post-preview-button/index.jsx
@@ -260,15 +260,12 @@ export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
 	}
 
 	return (
-		// The preview reuses a window of its own rather than the anonymous tab
-		// `openInNewTab` targets, so the address of that window overrides it.
 		<Menu.LinkItem
 			href={ href }
 			onClick={ onClick }
 			openInNewTab
 			closeOnClick
-			/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content -- The item supplies the address and the content. */
-			render={ <a target={ target } /> }
+			target={ target }
 		>
 			{ label }
 		</Menu.LinkItem>

--- a/packages/editor/src/components/post-preview-button/index.jsx
+++ b/packages/editor/src/components/post-preview-button/index.jsx
@@ -250,7 +250,7 @@ export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
 
 	const { disabled, href, onClick, target } = previewProps;
 	const label = (
-		<Menu.ItemLabel>{ __( 'Preview in new tab' ) }</Menu.ItemLabel>
+		<Menu.ItemLabel>{ _x( 'Preview', 'imperative verb' ) }</Menu.ItemLabel>
 	);
 
 	// There is nothing to preview until the post is saveable, so the item

--- a/packages/editor/src/components/post-preview-button/index.jsx
+++ b/packages/editor/src/components/post-preview-button/index.jsx
@@ -1,11 +1,11 @@
 import { renderToString } from '@wordpress/element';
-import { Button, MenuItem, Path, SVG } from '@wordpress/components';
+import { Button, Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import { store as coreStore } from '@wordpress/core-data';
-import { external } from '@wordpress/icons';
-import { VisuallyHidden } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Menu, VisuallyHidden } from '@wordpress/ui';
 import { store as editorStore } from '../../store';
 
 function buildInterstitialMarkup() {
@@ -248,10 +248,30 @@ export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
 		return null;
 	}
 
+	const { disabled, href, onClick, target } = previewProps;
+	const label = (
+		<Menu.ItemLabel>{ __( 'Preview in new tab' ) }</Menu.ItemLabel>
+	);
+
+	// There is nothing to preview until the post is saveable, so the item
+	// drops its address, the way the button variant does.
+	if ( disabled ) {
+		return <Menu.Item disabled>{ label }</Menu.Item>;
+	}
+
 	return (
-		<MenuItem icon={ external } { ...previewProps }>
-			{ __( 'Preview in new tab' ) }
-		</MenuItem>
+		// The preview reuses a window of its own rather than the anonymous tab
+		// `openInNewTab` targets, so the address of that window overrides it.
+		<Menu.LinkItem
+			href={ href }
+			onClick={ onClick }
+			openInNewTab
+			closeOnClick
+			/* eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content -- The item supplies the address and the content. */
+			render={ <a target={ target } /> }
+		>
+			{ label }
+		</Menu.LinkItem>
 	);
 }
 

--- a/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
+++ b/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
@@ -156,7 +156,7 @@ describe( 'PostPreviewButton', () => {
 		await openMenu( user );
 
 		const menuItem = screen.getByRole( 'menuitem', {
-			name: 'Preview in new tab (opens in a new tab)',
+			name: 'Preview (opens in a new tab)',
 		} );
 		expect( menuItem.tagName ).toBe( 'A' );
 		expect( menuItem ).toHaveAttribute( 'href', url );

--- a/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
+++ b/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
@@ -1,7 +1,23 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSelect, useDispatch } from '@wordpress/data';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Menu } from '@wordpress/ui';
 import PostPreviewButton, { PostPreviewMenuItem } from '..';
+
+function renderMenu( children ) {
+	return render(
+		<Menu.Root>
+			<Menu.Trigger>View</Menu.Trigger>
+			<Menu.Popup>{ children }</Menu.Popup>
+		</Menu.Root>
+	);
+}
+
+async function openMenu( user ) {
+	await user.click( screen.getByRole( 'button', { name: 'View' } ) );
+	await screen.findByRole( 'menu' );
+}
 
 jest.useRealTimers();
 
@@ -128,17 +144,19 @@ describe( 'PostPreviewButton', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should render the menu variant as a link with the shared menu item pattern.', () => {
+	it( 'should render the menu variant as a link with the shared menu item pattern.', async () => {
+		const user = userEvent.setup();
 		const url = 'https://wordpress.org';
 		mockUseSelect( {
 			getEditedPostPreviewLink: () => url,
 			isEditedPostSaveable: () => true,
 		} );
 
-		render( <PostPreviewMenuItem /> );
+		renderMenu( <PostPreviewMenuItem /> );
+		await openMenu( user );
 
 		const menuItem = screen.getByRole( 'menuitem', {
-			name: 'Preview in new tab',
+			name: 'Preview in new tab (opens in a new tab)',
 		} );
 		expect( menuItem.tagName ).toBe( 'A' );
 		expect( menuItem ).toHaveAttribute( 'href', url );

--- a/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
+++ b/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
@@ -8,15 +8,17 @@ import PostPreviewButton, { PostPreviewMenuItem } from '..';
 function renderMenu( children ) {
 	return render(
 		<Menu.Root>
-			<Menu.Trigger>View</Menu.Trigger>
+			<Menu.Trigger>View test menu</Menu.Trigger>
 			<Menu.Popup>{ children }</Menu.Popup>
 		</Menu.Root>
 	);
 }
 
 async function openMenu( user ) {
-	await user.click( screen.getByRole( 'button', { name: 'View' } ) );
-	await screen.findByRole( 'menu' );
+	await user.click(
+		screen.getByRole( 'button', { name: 'View test menu' } )
+	);
+	await screen.findByRole( 'menu', { name: 'View test menu' } );
 }
 
 jest.useRealTimers();

--- a/packages/editor/src/components/preview-dropdown/index.jsx
+++ b/packages/editor/src/components/preview-dropdown/index.jsx
@@ -1,21 +1,19 @@
 import clsx from 'clsx';
 import { useViewportMatch } from '@wordpress/compose';
-import {
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
-	MenuItemsChoice,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
+import { desktop, mobile, tablet } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem, store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-styles-engine';
-import { VisuallyHidden } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Menu } from '@wordpress/ui';
 import { store as editorStore } from '../../store';
+import MoreMenuGroup from '../more-menu/more-menu-group';
+import MoreMenuItem from '../more-menu/more-menu-item';
 import { PostPreviewMenuItem } from '../post-preview-button';
 import { sidebars } from '../sidebar/constants';
 import { VIEWPORT_STATE_BY_DEVICE_TYPE } from '../../utils/device-type';
@@ -23,7 +21,7 @@ import { unlock } from '../../lock-unlock';
 
 const { getViewportBreakpoints } = unlock( globalStylesEnginePrivateApis );
 
-export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
+function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 	const {
 		deviceType,
 		homeUrl,
@@ -87,8 +85,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		resetZoomLevel();
 	};
 
-	const handleResponsiveEditingChange = () => {
-		const newIsResponsiveEditing = ! isResponsiveEditing;
+	const handleResponsiveEditingChange = ( newIsResponsiveEditing ) => {
 		setResponsiveEditing( newIsResponsiveEditing );
 		setStyleStateViewport(
 			newIsResponsiveEditing
@@ -104,26 +101,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		) {
 			enableComplementaryArea( 'core', sidebars.block );
 		}
-	};
-
-	const isMobile = useViewportMatch( 'medium', '<' );
-	if ( isMobile ) {
-		return null;
-	}
-
-	const popoverProps = {
-		placement: 'bottom-end',
-	};
-	const toggleProps = {
-		className: 'editor-preview-dropdown__toggle',
-		iconPosition: 'right',
-		size: 'compact',
-		showTooltip: ! showIconLabels,
-		disabled,
-		accessibleWhenDisabled: disabled,
-	};
-	const menuProps = {
-		'aria-label': __( 'View options' ),
 	};
 
 	const deviceIcons = {
@@ -143,7 +120,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		{
 			value: 'Desktop',
 			label: __( 'Desktop' ),
-			icon: desktop,
 			info: isResponsiveEditing
 				? __( 'Style all viewports.' )
 				: __( 'Preview desktop viewport.' ),
@@ -153,7 +129,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 					{
 						value: 'Tablet',
 						label: __( 'Tablet' ),
-						icon: tablet,
 						info: isResponsiveEditing
 							? __( 'Style tablet only.' )
 							: __( 'Preview tablet viewport.' ),
@@ -165,7 +140,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 					{
 						value: 'Mobile',
 						label: __( 'Mobile' ),
-						icon: mobile,
 						info: isResponsiveEditing
 							? __( 'Style mobile only.' )
 							: __( 'Preview mobile viewport.' ),
@@ -175,69 +149,94 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	];
 
 	return (
-		<DropdownMenu
-			className={ clsx(
-				'editor-preview-dropdown',
-				`editor-preview-dropdown--${ deviceType.toLowerCase() }`,
-				{ 'is-responsive-editing': isResponsiveEditing }
-			) }
-			popoverProps={ popoverProps }
-			toggleProps={ toggleProps }
-			menuProps={ menuProps }
-			icon={ deviceIcons[ deviceType.toLowerCase() ] }
-			label={ __( 'View' ) }
-			disableOpenOnArrowDown={ disabled }
-		>
-			{ ( { onClose } ) => (
-				<>
-					<MenuGroup>
-						<MenuItemsChoice
-							choices={ choices }
-							value={ deviceType }
-							onSelect={ handleDevicePreviewChange }
-						/>
-					</MenuGroup>
-					{ isResponsiveEditingEnabled && (
-						<MenuGroup>
-							<MenuItem
-								icon={ isResponsiveEditing ? check : undefined }
-								isSelected={ isResponsiveEditing }
-								role="menuitemcheckbox"
-								onClick={ handleResponsiveEditingChange }
-								info={ __(
-									'Style changes apply only to the selected viewport.'
-								) }
+		<Menu.Root modal={ false } disabled={ disabled }>
+			<Menu.Trigger
+				render={
+					<Button
+						className={ clsx( 'editor-preview-dropdown__toggle', {
+							'is-responsive-editing': isResponsiveEditing,
+						} ) }
+						size="compact"
+						icon={ deviceIcons[ deviceType.toLowerCase() ] }
+						label={ __( 'View' ) }
+						showTooltip={ ! showIconLabels }
+						disabled={ disabled }
+						accessibleWhenDisabled={ disabled }
+					/>
+				}
+			/>
+			<Menu.Popup
+				className="editor-preview-dropdown__popup"
+				positioner={ <Menu.Positioner align="end" /> }
+			>
+				<Menu.RadioGroup
+					value={ deviceType }
+					onValueChange={ ( value ) =>
+						handleDevicePreviewChange( value )
+					}
+				>
+					<Menu.Group>
+						{ choices.map( ( choice ) => (
+							<Menu.RadioItem
+								key={ choice.value }
+								value={ choice.value }
 							>
-								{ __( 'Responsive styles' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-					{ isTemplate && (
-						<MenuGroup>
-							<MenuItem
+								<Menu.ItemLabel>
+									{ choice.label }
+								</Menu.ItemLabel>
+								<Menu.ItemDescription>
+									{ choice.info }
+								</Menu.ItemDescription>
+							</Menu.RadioItem>
+						) ) }
+					</Menu.Group>
+				</Menu.RadioGroup>
+				{ isResponsiveEditingEnabled && (
+					<>
+						<Menu.Separator />
+						<Menu.Group>
+							<Menu.CheckboxItem
+								checked={ isResponsiveEditing }
+								onCheckedChange={
+									handleResponsiveEditingChange
+								}
+							>
+								<Menu.ItemLabel>
+									{ __( 'Responsive styles' ) }
+								</Menu.ItemLabel>
+								<Menu.ItemDescription>
+									{ __(
+										'Style changes apply only to the selected viewport.'
+									) }
+								</Menu.ItemDescription>
+							</Menu.CheckboxItem>
+						</Menu.Group>
+					</>
+				) }
+				{ isTemplate && (
+					<>
+						<Menu.Separator />
+						<Menu.Group>
+							<Menu.LinkItem
 								href={ homeUrl }
-								target="_blank"
-								icon={ external }
-								onClick={ onClose }
+								openInNewTab
+								closeOnClick
 							>
-								{ __( 'View site' ) }
-								<VisuallyHidden render={ <span /> }>
-									{
-										/* translators: accessibility text */
-										__( '(opens in a new tab)' )
-									}
-								</VisuallyHidden>
-							</MenuItem>
-						</MenuGroup>
-					) }
-					{ ! isTemplate && !! templateId && (
-						<MenuGroup>
-							<MenuItem
-								icon={ ! isTemplateHidden ? check : undefined }
-								isSelected={ ! isTemplateHidden }
-								role="menuitemcheckbox"
-								onClick={ () => {
-									const newRenderingMode = isTemplateHidden
+								<Menu.ItemLabel>
+									{ __( 'View site' ) }
+								</Menu.ItemLabel>
+							</Menu.LinkItem>
+						</Menu.Group>
+					</>
+				) }
+				{ ! isTemplate && !! templateId && (
+					<>
+						<Menu.Separator />
+						<Menu.Group>
+							<Menu.CheckboxItem
+								checked={ ! isTemplateHidden }
+								onCheckedChange={ ( checked ) => {
+									const newRenderingMode = checked
 										? 'template-locked'
 										: 'post-only';
 									setRenderingMode( newRenderingMode );
@@ -245,24 +244,39 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 									resetZoomLevel();
 								} }
 							>
-								{ __( 'Show template' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-					{ isViewable && (
-						<MenuGroup>
+								<Menu.ItemLabel>
+									{ __( 'Show template' ) }
+								</Menu.ItemLabel>
+							</Menu.CheckboxItem>
+						</Menu.Group>
+					</>
+				) }
+				{ isViewable && (
+					<>
+						<Menu.Separator />
+						<Menu.Group>
 							<PostPreviewMenuItem
 								forceIsAutosaveable={ forceIsAutosaveable }
-								onPreview={ onClose }
 							/>
-						</MenuGroup>
-					) }
-					<ActionItem.Slot
-						name="core/plugin-preview-menu"
-						fillProps={ { onClick: onClose } }
-					/>
-				</>
-			) }
-		</DropdownMenu>
+						</Menu.Group>
+					</>
+				) }
+				<ActionItem.Slot
+					name="core/plugin-preview-menu"
+					fillProps={ { as: MoreMenuItem } }
+				>
+					{ ( items ) => <MoreMenuGroup>{ items }</MoreMenuGroup> }
+				</ActionItem.Slot>
+			</Menu.Popup>
+		</Menu.Root>
 	);
+}
+
+export default function PreviewDropdown( props ) {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	if ( isMobile ) {
+		return null;
+	}
+
+	return <PreviewMenu { ...props } />;
 }

--- a/packages/editor/src/components/preview-dropdown/style.scss
+++ b/packages/editor/src/components/preview-dropdown/style.scss
@@ -1,7 +1,7 @@
 // Narrower than the default of the menu, closer to the previous menu and to
 // the Options menu beside it, which sizes itself the same way.
 .editor-preview-dropdown__popup {
-	--wp-ui-menu-max-width: var(--wpds-dimension-surface-width-xs);
+	max-width: var(--wpds-dimension-surface-width-xs);
 }
 
 .editor-preview-dropdown__toggle.has-icon.has-text {

--- a/packages/editor/src/components/preview-dropdown/style.scss
+++ b/packages/editor/src/components/preview-dropdown/style.scss
@@ -1,4 +1,10 @@
-.editor-preview-dropdown .editor-preview-dropdown__toggle.has-icon.has-text {
+// Narrower than the default of the menu, closer to the previous menu and to
+// the Options menu beside it, which sizes itself the same way.
+.editor-preview-dropdown__popup {
+	--wp-ui-menu-max-width: var(--wpds-dimension-surface-width-xs);
+}
+
+.editor-preview-dropdown__toggle.has-icon.has-text {
 	padding-right: 4px;
 	padding-left: 6px;
 }
@@ -7,6 +13,6 @@
 // synced-pattern color for a consistent "special state" cue. Coloring the
 // button (rather than just the icon) also tints the "View" text label when the
 // "Show button text labels" preference is on; the icon follows via currentColor.
-.editor-preview-dropdown.is-responsive-editing .editor-preview-dropdown__toggle {
+.editor-preview-dropdown__toggle.is-responsive-editing {
 	color: var(--wp-block-synced-color);
 }

--- a/test/e2e/specs/editor/plugins/block-context.spec.js
+++ b/test/e2e/specs/editor/plugins/block-context.spec.js
@@ -65,7 +65,7 @@ test.describe( 'Block context', () => {
 			} )
 			.click();
 		await editorPage
-			.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+			.getByRole( 'menuitem', { name: 'Preview (opens in a new tab)' } )
 			.click();
 
 		// Check non-default context values are populated.

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -374,7 +374,7 @@ test.describe( 'Preview with private custom post type', () => {
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 
 		await expect(
-			page.locator( 'role=menuitem[name="Preview in new tab"i]' )
+			page.getByRole( 'menuitem', { name: 'Preview in new tab' } )
 		).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -374,7 +374,9 @@ test.describe( 'Preview with private custom post type', () => {
 		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
 
 		await expect(
-			page.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+			page.getByRole( 'menuitem', {
+				name: 'Preview (opens in a new tab)',
+			} )
 		).toBeHidden();
 	} );
 } );
@@ -394,7 +396,7 @@ class PreviewUtils {
 		}
 
 		await this.page
-			.getByRole( 'menuitem', { name: 'Preview in new tab' } )
+			.getByRole( 'menuitem', { name: 'Preview (opens in a new tab)' } )
 			.click();
 		// eslint-disable-next-line playwright/no-wait-for-navigation
 		return previewPage.waitForNavigation();


### PR DESCRIPTION
## What?
Follow-up to #81564

Renders the View menu of the editor header (the device preview dropdown) with the `Menu` component of `@wordpress/ui` instead of `DropdownMenu`, `MenuGroup`, `MenuItem`, and `MenuItemsChoice`.

* Viewport choices become a radio group.
* "Responsive styles" and "Show template" become checkbox items.
* "View site" and "Preview in new tab" become link items.


## Why?

The Options menu next to it has already been moved to `Menu`. Keeping the View menu on `DropdownMenu` leaves the two header menus on different components, with different markup, keyboard behavior and styling.

## How?

Items that plugins fill reuse the adapters introduced in the Options menu: `ActionItem.Slot` passes `MoreMenuItem` as the fill component and wraps the fills in `MoreMenuGroup`, whose `label` is now optional since this group has no heading.

`PreviewDropdown` also splits in two: the default export only matches the viewport, so nothing subscribes to the stores on a small screen where the menu does not render.

## Testing Instructions
1. Open a post, page or template.
2. Smoke test the "View" dropdown.
3. It should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="422" height="560" alt="CleanShot 2026-09-02 at 11 39 08" src="https://github.com/user-attachments/assets/8657e88d-770f-48bd-b618-d8c1aaa099da" />|<img width="422" height="526" alt="CleanShot 2026-09-02 at 13 22 42" src="https://github.com/user-attachments/assets/e7132ed4-b3bd-4976-a625-e2cea8066186" />|

## Use of AI Tools

Assisted by Claude.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the preview menu with a modern menu experience while preserving device, responsive, template, navigation, and preview options.
  - Preview links now clearly indicate that they open in a new tab.
  - Preview actions are visibly disabled when previewing is unavailable.
  - More menu groups can now appear without headings.

- **Bug Fixes**
  - Improved preview menu sizing and behavior in distraction-free mode.

- **Documentation**
  - Added an upcoming deprecation notice for `PluginPreviewMenuItem`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->