### PR TITLE
CI: Do not immediately fail the type label check on a newly opened pull request

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -84,6 +84,9 @@ jobs:
                   section: labels
                   body-path: pr-meta/body.md
 
+            # Opening or reopening only reports the warning above, since a
+            # pull request needs time to be labelled. These are the events the
+            # workflow enforced on before it also ran on opened and reopened.
             - name: Require exactly one type label
-              if: ${{ steps.check.outputs.ok != 'true' }}
+              if: ${{ steps.check.outputs.ok != 'true' && contains( fromJSON( '["labeled", "unlabeled", "ready_for_review", "review_requested"]' ), github.event.action ) }}
               run: exit 1


### PR DESCRIPTION
## What?

Follow up to #82249.

Stop the type label check from failing a pull request on the `opened` and `reopened` events, while still reporting the missing label in the shared PR comment.

## Why?

#82249 added `opened` and `reopened` triggers so the warning reaches the shared comment right away. Before that, the workflow only ran on label events, `ready_for_review` and `review_requested`, so a contributor still setting up a draft never saw a red check.

## How?

The check and the report step still run on every event, so the warning lands in the comment on open and is cleared once a type label is added. Only the final failing step is skipped on `opened` and `reopened`. See [enforce-pr-labels.yml](https://github.com/WordPress/gutenberg/blob/fix/enforce-pr-labels-opened-events/.github/workflows/enforce-pr-labels.yml#L87-L92).

## Testing Instructions

1. Open a pull request without a `[Type]` label. The check passes and the shared comment shows the warning.
2. Add a non-type label. The check fails.
3. Add a `[Type]` label. The check passes and the warning disappears.
4. Convert to a draft, remove the type label, then mark it ready for review. The check fails.

## Use of AI Tools

Written with Claude Code, reviewed with Codex, then reviewed and tested by the author.
