### PR TITLE
Navigation: Scale overlay menu icons with the block's font size

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -11,7 +11,11 @@
 // - .wp-block-navigation__submenu-icon targets the chevron icon indicating submenus.
 
 // Size of burger and close icons.
-$navigation-icon-size: 24px;
+// The icons scale with the navigation's font size so a large menu doesn't get a
+// small hamburger, but they never render below the previous fixed size so the
+// toggle stays a large enough target.
+$navigation-icon-min-size: 24px;
+$navigation-icon-size: max(#{$navigation-icon-min-size}, 1.5em);
 
 .wp-block-navigation {
 	position: relative;


### PR DESCRIPTION
## What?
Closes #58517

Makes the Navigation block's hamburger and close icons scale with the block's font size, instead of being pinned at 24px.

## Why?
A Navigation block set to a large font size still rendered a 24px hamburger, so the toggle looked undersized next to the menu it opens.

The block already treats icons this way elsewhere, the submenu chevron is sized in `em` (`width: 0.6em`) precisely so it stays in proportion with the text. The overlay toggle was the one icon left at a fixed pixel size.

## Testing Instructions
1. Create or edit a page/template and insert a **Navigation** block.
2. In the block's settings, set **Overlay Menu** to **Always**, so the toggle is visible at desktop widths.
3. In the Styles tab, set the block's **Typography → Size** to a large value (e.g. 40px, or the "XX Large" preset).
4. **Expected:** the hamburger icon grows in proportion with the font size, rather than staying small.
5. Click the toggle to open the overlay. **Expected:** the close (×) icon is the same scaled size, and the menu items still clear it, no overlap with the close button.
6. Set the font size back to the default (or a small preset such as 13–14px). **Expected:** the icon renders at 24px, exactly as it does on `trunk`.
7. Repeat on the front end and confirm it matches the editor.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/87627227-b18b-461e-92f4-a9155cfa7db0

## Use of AI Tools
NA