### PR TITLE
Add more e2e tests for the editor inspector consolidation experiment

### DIFF
--- a/test/e2e/specs/editor/various/post-summary-dataform/plugins-api.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/plugins-api.spec.js
@@ -1,0 +1,47 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS } = require( './utils' );
+
+/*
+ * Mirrors the 'Post Status Info' test of
+ * `test/e2e/specs/editor/plugins/plugins-api.spec.js` with the DataForm
+ * inspector experiment enabled; delete that test there when the experiment
+ * graduates. The other tests of that classic file don't drive the summary and
+ * stay where they are.
+ */
+test.describe( 'Plugins API (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-plugins-api'
+		);
+	} );
+
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-plugins-api'
+		);
+	} );
+
+	test.describe( 'Post Status Info', () => {
+		test( 'Should render post status info inside Document Setting sidebar', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.openDocumentSettingsSidebar();
+
+			await expect(
+				page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.locator( '.my-post-status-info-plugin' )
+			).toHaveText( 'My post status info' );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
@@ -561,4 +561,183 @@ test.describe( 'Post Summary', () => {
 				.toBe( 'image' );
 		} );
 	} );
+
+	test.describe( 'panel preferences', () => {
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.resetPreferences();
+		} );
+
+		test( 'hides the rows of panels disabled in Preferences', async ( {
+			admin,
+			editor,
+			page,
+		} ) => {
+			await admin.createNewPost();
+			const summary = await openPostSummary( { editor, page } );
+			const excerptButton = summary.getByRole( 'button', {
+				name: 'Edit Excerpt',
+			} );
+			const discussionButton = summary.getByRole( 'button', {
+				name: 'Edit Discussion',
+			} );
+			await expect( excerptButton ).toBeVisible();
+			await expect( discussionButton ).toBeVisible();
+
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Options' } )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Preferences' } ).click();
+			const preferences = page.getByRole( 'dialog', {
+				name: 'Preferences',
+			} );
+			await preferences
+				.getByRole( 'checkbox', { name: 'Excerpt' } )
+				.uncheck();
+			await preferences
+				.getByRole( 'checkbox', { name: 'Discussion' } )
+				.uncheck();
+			await preferences.getByRole( 'button', { name: 'Close' } ).click();
+
+			await expect( excerptButton ).toBeHidden();
+			await expect( discussionButton ).toBeHidden();
+		} );
+	} );
+
+	test.describe( 'wp_template summary', () => {
+		let blogPage;
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'emptytheme' );
+			await requestUtils.deleteAllPages();
+			blogPage = await requestUtils.createPage( {
+				title: 'Blog',
+				status: 'publish',
+			} );
+			await requestUtils.updateSiteSettings( {
+				show_on_front: 'page',
+				page_for_posts: blogPage.id,
+				posts_per_page: 10,
+				default_comment_status: 'open',
+			} );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.updateSiteSettings( {
+				show_on_front: 'posts',
+				page_for_posts: 0,
+				posts_per_page: 10,
+				default_comment_status: 'open',
+			} );
+			await requestUtils.deleteAllPages();
+			await requestUtils.activateTheme( 'twentytwentyone' );
+		} );
+
+		test( 'edits the posts page and the site settings from the index template', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//index',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+			const summary = await openPostSummary( { editor, page } );
+			const blogTitleButton = summary.getByRole( 'button', {
+				name: 'Edit Blog title',
+			} );
+			const postsPerPageButton = summary.getByRole( 'button', {
+				name: 'Edit Posts per page',
+			} );
+			const discussionButton = summary.getByRole( 'button', {
+				name: 'Edit Discussion',
+			} );
+			await expect( blogTitleButton ).toHaveAccessibleDescription(
+				'Blog'
+			);
+			await expect( postsPerPageButton ).toHaveAccessibleDescription(
+				'10'
+			);
+			await expect( discussionButton ).toHaveAccessibleDescription(
+				'Comments open'
+			);
+
+			await blogTitleButton.click();
+			await page
+				.getByRole( 'textbox', { name: 'Blog title' } )
+				.fill( 'Latest news' );
+			await page.keyboard.press( 'Escape' );
+			await postsPerPageButton.click();
+			await page
+				.getByRole( 'spinbutton', { name: 'Posts per page' } )
+				.fill( '5' );
+			await page.keyboard.press( 'Escape' );
+			await discussionButton.click();
+			await page
+				.getByRole( 'radiogroup', { name: 'Discussion' } )
+				.getByRole( 'radio', { name: 'Closed' } )
+				.click();
+			await page.keyboard.press( 'Escape' );
+
+			await expect( blogTitleButton ).toHaveAccessibleDescription(
+				'Latest news'
+			);
+			await expect( postsPerPageButton ).toHaveAccessibleDescription(
+				'5'
+			);
+			await expect( discussionButton ).toHaveAccessibleDescription(
+				'Comments closed'
+			);
+
+			// The edits target the posts page and the site settings rather
+			// than the template, so they go through the multi-entity save panel.
+			await editor.saveSiteEditorEntities();
+			await page.reload();
+
+			const reloadedSummary = await openPostSummary( { editor, page } );
+			await expect(
+				reloadedSummary.getByRole( 'button', {
+					name: 'Edit Blog title',
+				} )
+			).toHaveAccessibleDescription( 'Latest news' );
+			await expect(
+				reloadedSummary.getByRole( 'button', {
+					name: 'Edit Posts per page',
+				} )
+			).toHaveAccessibleDescription( '5' );
+			await expect(
+				reloadedSummary.getByRole( 'button', {
+					name: 'Edit Discussion',
+				} )
+			).toHaveAccessibleDescription( 'Comments closed' );
+
+			const settings = await requestUtils.getSiteSettings();
+			expect( settings.posts_per_page ).toBe( 5 );
+			const savedPage = await requestUtils.rest( {
+				path: `/wp/v2/pages/${ blogPage.id }`,
+			} );
+			expect( savedPage.title.rendered ).toBe( 'Latest news' );
+		} );
+
+		test( 'hides the posts page and site settings rows for other templates', async ( {
+			admin,
+			editor,
+			page,
+		} ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//singular',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+			const summary = await openPostSummary( { editor, page } );
+
+			await expect(
+				summary.getByRole( 'button', {
+					name: /^Edit (Blog title|Posts per page|Discussion)$/,
+				} )
+			).toHaveCount( 0 );
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/various/post-summary-dataform/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/sidebar.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS } = require( './utils' );
+
+/*
+ * Mirrors the 'should be possible to programmatically remove Document Settings
+ * panels' test of `test/e2e/specs/editor/various/sidebar.spec.js` with the
+ * DataForm inspector experiment enabled; delete that test there when the
+ * experiment graduates. The other tests of that classic file don't drive the
+ * summary and stay where they are.
+ */
+test.describe( 'Sidebar (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// The test expects clean user preferences.
+		await requestUtils.resetPreferences();
+	} );
+
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test( 'should be possible to programmatically remove Document Settings panels', async ( {
+		page,
+	} ) => {
+		const documentSettingsPanels = page
+			.getByRole( 'tabpanel', { name: 'Post' } )
+			.getByRole( 'heading', { level: 2 } );
+
+		await expect( documentSettingsPanels ).toHaveText( [
+			'No title',
+			'Categories',
+			'Tags',
+		] );
+		// Also check 'panels' that are not rendered as TabPanels.
+		const postExcerptPanel = page.getByRole( 'button', {
+			name: 'Edit Excerpt',
+		} );
+		const postFeaturedImagePanel = page.getByRole( 'button', {
+			name: 'Set featured image',
+		} );
+		const postDiscussionPanel = page.getByRole( 'button', {
+			name: 'Edit Discussion',
+		} );
+		const postAuthorPanel = page.getByRole( 'button', {
+			name: 'Edit Author',
+		} );
+
+		await expect( postExcerptPanel ).toBeVisible();
+		await expect( postFeaturedImagePanel ).toBeVisible();
+		await expect( postAuthorPanel ).toBeVisible();
+		// The description also carries the alt text of the author's avatar.
+		await expect( postAuthorPanel ).toHaveAccessibleDescription( /admin$/ );
+		await expect( postDiscussionPanel ).toHaveCount( 1 );
+
+		await page.evaluate( () => {
+			const { removeEditorPanel } =
+				window.wp.data.dispatch( 'core/editor' );
+
+			removeEditorPanel( 'taxonomy-panel-category' );
+			removeEditorPanel( 'taxonomy-panel-post_tag' );
+			removeEditorPanel( 'featured-image' );
+			removeEditorPanel( 'post-excerpt' );
+			removeEditorPanel( 'discussion-panel' );
+			removeEditorPanel( 'post-status' );
+		} );
+
+		await expect( documentSettingsPanels ).toHaveCount( 1 );
+		await expect( postExcerptPanel ).toBeHidden();
+		await expect( postFeaturedImagePanel ).toBeHidden();
+		await expect( postAuthorPanel ).toBeHidden();
+		await expect( postDiscussionPanel ).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
## What?

Part of the e2e testing task in #76076. Follow up of #82239.

Adds tests for removing document settings panels and `PluginPostStatusInfo` (mirrors), and for the Preferences panel toggles and the template summary rows that edit the site settings and the posts page (new).

## Testing Instructions

1. CI should be 🟢

## Use of AI Tools

Generated with Fable 5.1 and adjusted/reviewed manually.
