### PR TITLE
DataViews: remove the rich text options from the control config type

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   Removed the rich text options (`className`, `clientId`, `allowedFormats`, `disableFormats`, `withoutInteractiveFormatting`, `preserveWhiteSpace`, `disableLineBreaks`) from the `config` prop of `DataFormControlProps`. They were added for the built-in `richtext` control ([#78471](https://github.com/WordPress/gutenberg/pull/78471)), which has since moved to `@wordpress/editor` ([#81430](https://github.com/WordPress/gutenberg/pull/81430)), so nothing in this package sets or reads them ([#82330](https://github.com/WordPress/gutenberg/pull/82330)).
 -   DataForm: a combined form field (one with `children`) is now treated purely as a layout container. Its `id` is no longer resolved against the field definitions: a field sharing that `id` no longer contributes validation rules to the group, and the `panel` layout no longer uses it for the collapsed summary or `readOnly` state, falling back to the group's first leaf child instead ([#82175](https://github.com/WordPress/gutenberg/pull/82175)).
 
     If a combined field relied on sharing its `id` with a field to pick the panel summary, declare it through `layout.summary` instead. For example, a `discussion` field whose `render` summarizes `comment_status` and `ping_status` together:

--- a/packages/dataviews/src/types/field-api.ts
+++ b/packages/dataviews/src/types/field-api.ts
@@ -777,35 +777,6 @@ export type DataFormControlProps< Item > = {
 		 * (datetime control).
 		 */
 		compact?: boolean;
-		/**
-		 * CSS class name applied to the rich text control.
-		 * Rich text control options.
-		 */
-		className?: string;
-		/**
-		 * Client id of the block the rich text control belongs to.
-		 */
-		clientId?: string;
-		/**
-		 * The formats allowed in the rich text control.
-		 */
-		allowedFormats?: string[];
-		/**
-		 * Whether to disable all rich text formats.
-		 */
-		disableFormats?: boolean;
-		/**
-		 * Whether to disallow interactive formats (e.g. links).
-		 */
-		withoutInteractiveFormatting?: boolean;
-		/**
-		 * Whether to preserve white space in the rich text value.
-		 */
-		preserveWhiteSpace?: boolean;
-		/**
-		 * Whether to prevent line breaks in the rich text control.
-		 */
-		disableLineBreaks?: boolean;
 	};
 };
 


### PR DESCRIPTION
Follow up to #81430.

## What?

Removes the rich text options (`className`, `clientId`, `allowedFormats`, `disableFormats`, `withoutInteractiveFormatting`, `preserveWhiteSpace`, `disableLineBreaks`) from the `config` prop of the `DataFormControlProps` type.

## Why?

These properties were added in #78471 for the built-in `richtext` DataForm control. That control moved to `@wordpress/editor` in #81430, so nothing in the DataViews package sets or reads them any more.

## How?

- Delete the seven rich text entries from the `config` object type in `packages/dataviews/src/types/field-api.ts`. The remaining entries (`prefix`, `suffix`, `rows`, `compact`) are the ones the text, textarea, and datetime controls read.
- Add a Breaking Changes entry to the DataViews changelog explaining the history.

## Use of AI Tools

Claude Code was used to audit the type properties for usage and to draft this PR description. The changes were reviewed by the author.
