### PR TITLE
Stylelint tools: Resolve test config extends from the workspace

### DIFF
--- a/tools/stylelint/test/utils/index.js
+++ b/tools/stylelint/test/utils/index.js
@@ -9,6 +9,12 @@ export const getStylelintResult = async ( filename ) => {
 	const { errored, report } = await stylelint.lint( {
 		files: path.resolve( testDirectory, filename ),
 		config,
+		/*
+		 * The config is passed inline, so point `extends` and `plugins`
+		 * resolution at the package that owns it rather than the current
+		 * working directory, which only resolves under a hoisted install.
+		 */
+		configBasedir: path.resolve( testDirectory, '../' ),
 		ignorePath: path.resolve( testDirectory, './.stylelintignore' ),
 		formatter: 'json',
 	} );


### PR DESCRIPTION
## What?

Follow up to #80738. Sets `configBasedir` when the Stylelint tools test lints a fixture, so the config's `extends` and `plugins` resolve from `tools/stylelint` instead of the current working directory.

## Why?

The config is passed to `stylelint.lint()` inline, so Stylelint falls back to `process.cwd()` (the repository root) to resolve it. That only finds `@wordpress/stylelint-config` when npm hoists it to the root `node_modules`, so the test fails with `Could not find "@wordpress/stylelint-config/scss-stylistic"` under a non-hoisting install strategy, as in [this Unit Tests run](https://github.com/WordPress/gutenberg/actions/runs/33626759227/job/100236410646?pr=75814) on #75814.

## How?

Points `configBasedir` at the package that owns the config, in [`tools/stylelint/test/utils/index.js`](https://github.com/WordPress/gutenberg/blob/trunk/tools/stylelint/test/utils/index.js). Stylelint tries `configBasedir` first and still falls back to the working directory, so hoisted installs are unaffected.

## Testing Instructions

1. Run `npm run test:unit:vitest -- --project=node tools/stylelint`.
2. Confirm the five tests pass.
3. Optionally, add `install-strategy = "linked"` to `.npmrc`, reinstall, and confirm they still pass.

## Use of AI Tools

Claude Code diagnosed the resolution failure and drafted the change and this description; I reviewed and tested both.
