### PR TITLE
Icons: Convert Search icon to strokes

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internal
 
+-   Search: Keep the editor's button icon fill-based and separate from `@wordpress/icons` so it matches the PHP renderer and existing theme `fill` styles. ([#82338](https://github.com/WordPress/gutenberg/pull/82338))
 -   Remove unused dependencies `@wordpress/keyboard-shortcuts`, `@wordpress/reusable-blocks` and `@wordpress/viewport` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Use the `.jsx` extension for JavaScript source files that contain JSX ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).

--- a/packages/block-library/src/search/edit.jsx
+++ b/packages/block-library/src/search/edit.jsx
@@ -25,10 +25,11 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { Icon, search } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { speak } from '@wordpress/a11y';
+import { Path, SVG } from '@wordpress/primitives';
 import {
 	PC_WIDTH_DEFAULT,
 	PX_WIDTH_DEFAULT,
@@ -55,6 +56,19 @@ const TAG_NAME_MESSAGES = {
 // button is placed inside wrapper.
 const DEFAULT_INNER_PADDING = '4px';
 const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
+
+// Keep this block-specific icon aligned with the PHP renderer. Unlike the
+// Search icon from @wordpress/icons, it remains fill-based so existing theme
+// styles continue to work in both the editor and the front end.
+const searchBlockIcon = (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		className="search-icon"
+	>
+		<Path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z" />
+	</SVG>
+);
 
 export default function SearchEdit( {
 	className,
@@ -294,7 +308,7 @@ export default function SearchEdit( {
 						}
 						ref={ buttonRef }
 					>
-						<Icon icon={ search } />
+						<Icon icon={ searchBlockIcon } />
 					</button>
 				) }
 

--- a/packages/block-library/src/search/edit.jsx
+++ b/packages/block-library/src/search/edit.jsx
@@ -61,11 +61,7 @@ const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
 // Search icon from @wordpress/icons, it remains fill-based so existing theme
 // styles continue to work in both the editor and the front end.
 const searchBlockIcon = (
-	<SVG
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 24 24"
-		className="search-icon"
-	>
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z" />
 	</SVG>
 );

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   The `search` icon is now stroke-based. Use CSS `color` rather than `fill` to recolor it. ([#82338](https://github.com/WordPress/gutenberg/pull/82338))
 -   Stroke-based icons now declare `fill: none` via inline `style` on the outer `<svg>` instead of the `fill` attribute, so the source's intent survives ordinary third-party CSS overrides like `.foo svg { fill: currentColor }` without using `!important`. Consumers should use CSS `color` to recolor icons. A `fill` prop or ordinary CSS `fill` declaration no longer overrides the intrinsic `fill: none`; pass `style={ { fill: value } }` to deliberately replace it. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   Stroke-based icons use `vector-effect="non-scaling-stroke"`, so their stroke width stays constant when rendered outside the Icon block at sizes other than 24px. The Icon block deliberately restores the previous proportional stroke scaling. When new bundled icon elements run with an older externalized `wp.components.Icon`, supplying an unrelated `style` prop can replace the icon's intrinsic style; update the paired packages together to retain merged styles. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 

--- a/packages/icons/src/library/search.svg
+++ b/packages/icons/src/library/search.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-	<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="fill: none" stroke="currentColor" stroke-width="1.5">
+	<path d="M5 19L9.28769 14.7123M18.25 11C18.25 13.8995 15.8995 16.25 13 16.25C10.1005 16.25 7.75 13.8995 7.75 11C7.75 8.10051 10.1005 5.75 13 5.75C15.8995 5.75 18.25 8.10051 18.25 11Z" vector-effect="non-scaling-stroke" />
 </svg>


### PR DESCRIPTION
Follow-up to #78812.

## What?

Converts the public `@wordpress/icons` Search icon to the stroke-based version prepared in #78812.

The Search block now keeps its fill-based button icon separate from `@wordpress/icons`, so the editor continues to match the PHP-rendered front end.

## Why?

The WordPress UI icon should follow the stroke conventions established in #78808. The Search block icon has a different compatibility constraint: existing themes style its front-end SVG with `fill`, so changing that icon would alter published sites.

## How?

- Updates the Search source SVG in `@wordpress/icons` to use `stroke="currentColor"`, `fill: none`, and a non-scaling stroke.
- Gives the Search block editor a block-owned copy of the legacy filled icon used by its PHP renderer.
- Leaves the PHP-rendered icon unchanged.

## Testing Instructions

1. Run `npm run storybook:dev` and open **Icons > Library**.
2. Find the Search icon and verify that it uses the new stroke design at 16px, 24px, and 32px.
3. Open the post editor and insert a Search block.
4. In the block settings, enable **Use button with icon**.
5. Verify that the button uses the legacy filled icon in the editor.
6. Preview the post and verify that the front-end button matches the editor.
7. Apply a `fill` color to `.wp-block-search__button svg` and verify that it colors the button icon in both contexts.

### Testing Instructions for Keyboard

Use the keyboard to insert the Search block and enable **Use button with icon**. Focus order, activation, and visible focus should work as before.

## Use of AI Tools

OpenAI Codex helped inspect the prior discussion, implement the changes, run verification, and draft this description.
