### PR TITLE
CI: Port the setup-npm action to release/23.9

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -20,11 +20,8 @@ runs:
                   package-lock.json
                   patches/**
 
-        - name: Pin npm version for consistency
-          run: |
-              npm install --global npm@10
-              npm --version
-          shell: bash
+        - name: Set up npm
+          uses: ./.github/setup-npm
 
         - name: Get Node.js and npm version
           id: node-version

--- a/.github/setup-npm/action.yml
+++ b/.github/setup-npm/action.yml
@@ -1,0 +1,20 @@
+name: 'Set up npm'
+description: 'Installs the npm version required by the devEngines field of package.json, so every job resolves dependencies identically.'
+
+inputs:
+    working-directory:
+        description: 'Optional. The directory holding the package.json to read the required npm version from. Defaults to the workspace root.'
+        required: false
+        default: '.'
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Install npm
+          run: |
+              NPM_VERSION="$(jq -r '.devEngines.packageManager.version' package.json)"
+              npm install --global "npm@$NPM_VERSION"
+              echo "Required npm version: $NPM_VERSION"
+              echo "Installed npm version: $(npm --version)"
+          working-directory: ${{ inputs.working-directory }}
+          shell: bash

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -246,10 +246,8 @@ jobs:
                   node-version-file: '.nvmrc'
                   check-latest: true
 
-            - name: Pin npm version for consistency
-              run: |
-                  npm install --global npm@10
-                  npm --version
+            - name: Set up npm
+              uses: ./.github/setup-npm
 
             - name: Configure build for wordpress-develop
               if: ${{ ! matrix.IS_GUTENBERG_PLUGIN }}
@@ -569,10 +567,10 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true
 
-            - name: Pin npm version for consistency
-              run: |
-                  npm install --global npm@10
-                  npm --version
+            - name: Set up npm
+              uses: ./main/.github/setup-npm
+              with:
+                  working-directory: main
 
             - name: Publish packages to npm ("latest" dist-tag)
               run: |

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -63,10 +63,8 @@ jobs:
                   check-latest: true
                   cache: npm
 
-            - name: Pin npm version for consistency
-              run: |
-                  npm install --global npm@10
-                  npm --version
+            - name: Set up npm
+              uses: ./.github/setup-npm
 
             - uses: preactjs/compressed-size-action@f322c295dde06a1cb7ccaef105732dd8a726d1d9 # v2.10.0
               with:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -92,10 +92,10 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   check-latest: true
 
-            - name: Pin npm version for consistency
-              run: |
-                  npm install --global npm@10
-                  npm --version
+            - name: Set up npm
+              uses: ./cli/.github/setup-npm
+              with:
+                  working-directory: cli
 
             - name: Publish development packages to npm ("next" dist-tag)
               if: ${{ github.event.inputs.release_type == 'development' }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -64,10 +64,8 @@ jobs:
                   node-version: ${{ matrix.node }}
                   cache: npm
 
-            - name: Pin npm version for consistency
-              run: |
-                  npm install --global npm@10
-                  npm --version
+            - name: Set up npm
+              uses: ./.github/setup-npm
 
             - name: npm install
               # A "full" install is executed, since `npm ci` does not always exit

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		},
 		"packageManager": {
 			"name": "npm",
-			"version": ">=10.2.3"
+			"version": "^10.2.3",
+			"onFail": "warn"
 		}
 	},
 	"wpPlugin": {

--- a/tools/release/commands/performance.js
+++ b/tools/release/commands/performance.js
@@ -10,11 +10,17 @@ const {
 	getFilesFromDir,
 } = require( '../lib/utils' );
 const config = require( '../config' );
+const { devEngines } = require( '../../../package.json' );
 
 const ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
 const RAW_RESULTS_FILE_SUFFIX = '.performance-results.raw.json';
 const RESULTS_FILE_SUFFIX = '.performance-results.json';
+/*
+ * Read from the CLI's own checkout, so every branch under test builds with the
+ * npm version trunk requires rather than whichever npm the runner happens to ship.
+ */
+const NPM_VERSION = devEngines.packageManager.version;
 
 /**
  * @typedef WPPerformanceCommandOptions
@@ -400,7 +406,7 @@ async function runPerformanceTests( branches, options ) {
 
 		logAtIndent( 3, 'Installing dependencies and building' );
 		await runShellScript(
-			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@10 && npm ci && (npm run build -- --skip-types || npm run build)"`,
+			`bash -c "source $HOME/.nvm/nvm.sh && nvm install && npm install --global npm@'${ NPM_VERSION }' && npm ci && (npm run build -- --skip-types || npm run build)"`,
 			buildDir
 		);
 


### PR DESCRIPTION
## What?

Cherry-picks [#82235](https://github.com/WordPress/gutenberg/pull/82235) from trunk into `release/23.9`.

## Why?

The release workflows run from trunk but check out the release branch, so `Set up npm` resolves `./.github/setup-npm` against a branch that does not have it. [The job fails](https://github.com/WordPress/gutenberg/actions/runs/33635499864/job/100267750940) with `Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.github/setup-npm'`.

## How?

Applied with `git cherry-pick -x`. Three conflicts came from trunk-only changes and were resolved by keeping this branch's structure and taking only the npm pinning change:

- `.github/workflows/publish-npm-packages.yml`: kept the branch's `Setup Node.js (for WP major version)` step.
- `.github/workflows/static-checks.yml`: dropped the hunk targeting the `check-private-apis` job, which does not exist here.
- `tools/release/commands/performance.js`: took the `devEngines` import only; `sanitizeBranchName` is still defined locally on this branch.

The follow-up [#82320](https://github.com/WordPress/gutenberg/pull/82320) is deliberately left out, so `devEngines.packageManager` stays on `onFail: "warn"` here.

## Testing Instructions

Run the Build Gutenberg Plugin Zip workflow against `release/23.9` and confirm `Set up npm` passes in the Build Release Artifact job.

## Use of AI Tools

Claude Code performed the cherry-pick and conflict resolution. I reviewed the result.
