### PR TITLE
Fields: Hide the slug field for posts without a permalink

### DIFF
--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -259,7 +259,10 @@ export const registerPostTypeSchema =
 				! isDesignPostType && dateField,
 				! isDesignPostType && scheduledDateField,
 				lastEditedDateField,
-				! isDesignPostType && slugField,
+				// There is no post type support flag for permalinks, and
+				// `viewable` alone is not the full condition (the type must
+				// also be public), so the field also checks each post.
+				! isDesignPostType && postTypeConfig.viewable && slugField,
 				! isDesignPostType &&
 					postTypeConfig.supports?.excerpt &&
 					excerptField,

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Hide the slug field for posts without a permalink, such as posts of non-public post types, matching the classic post URL panel ([#82341](https://github.com/WordPress/gutenberg/pull/82341)).
 -   Normalize special characters in exported pattern filenames to prevent broken or unreadable files. ([#77033](https://github.com/WordPress/gutenberg/pull/77033))
 
 ### Internal

--- a/packages/fields/src/fields/slug/index.ts
+++ b/packages/fields/src/fields/slug/index.ts
@@ -11,6 +11,9 @@ const slugField: Field< BasePost > = {
 	Edit: SlugEdit,
 	render: SlugView,
 	filterBy: false,
+	// The REST API only exposes `permalink_template` for viewable public
+	// post types, so posts without a permalink hide the field.
+	isVisible: ( item ) => !! item.link && !! item.permalink_template,
 };
 
 /**

--- a/test/e2e/specs/editor/various/post-summary-dataform/sidebar-permalink.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/sidebar-permalink.spec.js
@@ -1,0 +1,100 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, openPostSummary } = require( './utils' );
+
+/*
+ * Mirrors `test/e2e/specs/editor/various/sidebar-permalink.spec.js` with the
+ * DataForm inspector experiment enabled; delete that spec when the experiment
+ * graduates.
+ */
+// This tests are not together with the remaining sidebar tests,
+// because we need to publish/save a post, to correctly test the permalink row.
+// The sidebar test suit enforces that focus is never lost, but during save operations
+// the focus is lost and a new element is focused once the save is completed.
+test.describe( 'Sidebar Permalink (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( 'gutenberg-test-custom-post-types' );
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-custom-post-types'
+		);
+	} );
+
+	test( 'should not render URL when post is publicly queryable but not public', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost( { postType: 'public_q_not_public' } );
+		const summary = await openPostSummary( { editor, page } );
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'aaaaa' );
+		await editor.publishPost();
+		// Start editing again.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'aaaa (Updated)' );
+		// A hidden check passes on an empty sidebar, so wait for the summary first.
+		await expect(
+			summary.getByRole( 'button', { name: 'Edit Status' } )
+		).toBeVisible();
+		await expect(
+			summary.getByRole( 'button', { name: 'Edit Slug' } )
+		).toBeHidden();
+	} );
+
+	test( 'should not render URL when post is public but not publicly queryable', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost( { postType: 'not_public_q_public' } );
+		const summary = await openPostSummary( { editor, page } );
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'aaaaa' );
+		await editor.publishPost();
+		// Start editing again.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'aaaa (Updated)' );
+		// A hidden check passes on an empty sidebar, so wait for the summary first.
+		await expect(
+			summary.getByRole( 'button', { name: 'Edit Status' } )
+		).toBeVisible();
+		await expect(
+			summary.getByRole( 'button', { name: 'Edit Slug' } )
+		).toBeHidden();
+	} );
+
+	test( 'should render URL when post is public and publicly queryable', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost( { postType: 'public_q_public' } );
+		const summary = await openPostSummary( { editor, page } );
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'aaaaa' );
+		await editor.publishPost();
+
+		// Start editing again.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'aaaa (Updated)' );
+		await expect(
+			summary.getByRole( 'button', { name: 'Edit Slug' } )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
## What?

The e2e testing task in #76076 for the editor inspector consolidation experiment surfaced a bug we had in `slug` field and kept it visible in post types that are not public, unlike the classic post URL panel.

This PR fixes that and also mirrors the respective Sidebar Permalink e2e tests as part of #76076.


## Testing Instructions

1. CI should be 🟢
2. Enable the editor inspector consolidation experiment.
3. Add the snippet below (e.g. in an mu-plugin) to make pages non-public.
4. Edit a page and check the summary has no Slug row. Posts still have it.
5. Remove the snippet and check the Slug row is back for pages.

```php
add_filter(
      'register_post_type_args',
      function ( $args, $post_type ) {
              if ( 'page' === $post_type ) {
                      $args['public']             = false;
                      $args['publicly_queryable'] = true;
                      $args['show_ui']            = true;
              }
              return $args;
      },
      10,
      2
);
```


## Use of AI Tools

Generated with Fable 5.1 and adjusted/reviewed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The slug and permalink controls are now hidden for posts that don’t have a valid public permalink.
  * Permalink fields now appear only when posts are both public and publicly queryable.
* **Tests**
  * Added coverage for permalink visibility across different post type configurations.
* **Documentation**
  * Added a changelog entry describing the permalink visibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->