### PR TITLE
Menu: Use the external icon for new-tab links

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `AlertDialog`, `Dialog`, `Drawer`, `Popover`, and `Tooltip`: Derive Trigger props from the corresponding Base UI components. ([#81824](https://github.com/WordPress/gutenberg/pull/81824))
 -   `Autocomplete.Status`, `Combobox.Status`: Add a `Status` subcomponent that announces async list status to screen readers. Item popups give Status its own collapsing grid row so a visible result count sits above the list without overlaying items ([#82195](https://github.com/WordPress/gutenberg/pull/82195)).
 -   `Autocomplete.Popup`, `Combobox.Popup`, `SearchableChipSelect`, `SearchableChipSelectControl`, `Select.Popup`, and `SelectControl`: Add `width` on Popups and `popupWidth` on composites, with preset width constraints (`anchor`, `content`, `sm`, `md`, `lg`, and `available`) for the item popup. `SelectControl` defaults to `content` to preserve prior popup sizing ([#82087](https://github.com/WordPress/gutenberg/pull/82087), [#82193](https://github.com/WordPress/gutenberg/pull/82193)).
+-   `Menu`: Use the external icon instead of an arrow glyph for links that open in a new tab. ([#82345](https://github.com/WordPress/gutenberg/pull/82345))
 -   `Menu`: Support multiple item descriptions. ([#81825](https://github.com/WordPress/gutenberg/pull/81825))
 -   `Menu`: Use `Text` for item labels and descriptions to share typography and apply `text-wrap: pretty`. ([#82237](https://github.com/WordPress/gutenberg/pull/82237))
 -   `Text`: Apply `text-wrap: pretty` by default to improve line wrapping. ([#82133](https://github.com/WordPress/gutenberg/pull/82133))

--- a/packages/ui/src/menu/link-item.tsx
+++ b/packages/ui/src/menu/link-item.tsx
@@ -2,6 +2,8 @@ import { Menu as _Menu } from '@base-ui/react/menu';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { Icon } from '../icon';
 import defenseStyles from '../utils/css/global-css-defense.module.css';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
@@ -37,7 +39,9 @@ const LinkItem = forwardRef< Element, LinkItemProps >( function MenuLinkItem(
 				/* translators: accessibility text appended to link text */
 				__( '(opens in a new tab)' )
 			}
-		/>
+		>
+			<Icon icon={ external } size={ 16 } aria-hidden="true" />
+		</span>
 	) : null;
 	const {
 		contentChildren,

--- a/packages/ui/src/menu/style.module.css
+++ b/packages/ui/src/menu/style.module.css
@@ -300,19 +300,11 @@
 		}
 
 		.external-link-indicator {
-			display: inline-block;
-			line-height: 1;
+			display: inline-flex;
+			align-items: center;
 			margin-inline-start: var(--wpds-dimension-gap-xs);
-			font-weight: var(--wpds-typography-font-weight-default);
 			text-decoration: none;
-		}
-
-		.external-link-indicator::after {
-			content: "\2197";
-		}
-
-		.external-link-indicator:dir(rtl)::after {
-			content: "\2196";
+			vertical-align: middle;
 		}
 
 		.item[data-highlighted]:not([aria-disabled="true"]) .item-prefix,


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/82321#issuecomment-5506883240

## What?

Replaces the arrow glyph shown by `Menu.LinkItem` for new-tab links with the 16px `external` icon from `@wordpress/icons`. The icon remains inline after the item label.

## Why?

The text arrow suits links in prose, while menu items generally use the icon treatment. This PR tries the alternative proposed in the linked discussion.

## How?

Renders `Icon` inside the existing accessible new-tab indicator and removes the glyph-specific pseudo-element styles. The link target and accessible name do not change.

## Testing Instructions

1. Open **Design System > Components > Menu > Link Item** in Storybook.
2. Open the menu.
3. Confirm that the external-link icon appears inline after the first two item labels.
4. Confirm that the in-page link has no icon.

### Testing Instructions for Keyboard

1. Press Tab to focus **Open menu**, then press Enter.
2. Use the arrow keys to move through every item.
3. Confirm that focus and activation work as before.

### Screenshots

| Before | After |
|---|---|
| <img width="828" height="386" alt="Screenshot 2026-09-02 at 18 37 55" src="https://github.com/user-attachments/assets/da389d3b-5ac2-4783-8568-c727e4793bba" /> | <img width="838" height="390" alt="Screenshot 2026-09-02 at 18 39 45" src="https://github.com/user-attachments/assets/00c6eb7f-2554-45ef-8722-22ac465b3b15" /> |

For reference, `Link` and `LinkButton` components:

<img width="292" height="130" alt="Screenshot 2026-09-02 at 18 40 27" src="https://github.com/user-attachments/assets/1fbb9210-d240-42be-9a82-e602d175b349" />

<img width="260" height="112" alt="Screenshot 2026-09-02 at 18 40 40" src="https://github.com/user-attachments/assets/29c984fd-8cbe-444f-a09e-e09e9272483e" />


## Use of AI Tools

Assisted by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated menu links that open in a new tab to display an external-link icon instead of an arrow.
  - Improved the icon’s alignment and presentation within the link indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->