### PR TITLE
Span the writing flow focus capture elements over the canvas

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.jsx
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.jsx
@@ -7,6 +7,15 @@ import { store as blockEditorStore } from '../../store';
 import { isInSameBlock, isInsideRootBlock } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
 
+/**
+ * Keeps the element positioned within the viewport, so focussing it never
+ * scrolls the page. Fixed positioning once made Safari build an oversized
+ * compositing layer for the scrollable canvas, which is why keydown handlers
+ * prevented the scrolling instead, but current Safari sizes the layer
+ * correctly.
+ */
+const PREVENT_SCROLL_ON_FOCUS = { position: 'fixed' };
+
 export default function useTabNav() {
 	const containerRef = /** @type {typeof useRef<HTMLElement>} */ ( useRef )();
 	const focusCaptureBeforeRef = useRef();
@@ -90,6 +99,7 @@ export default function useTabNav() {
 			ref={ focusCaptureBeforeRef }
 			tabIndex="0"
 			onFocus={ onFocusCapture }
+			style={ PREVENT_SCROLL_ON_FOCUS }
 		/>
 	);
 
@@ -98,6 +108,7 @@ export default function useTabNav() {
 			ref={ focusCaptureAfterRef }
 			tabIndex="0"
 			onFocus={ onFocusCapture }
+			style={ PREVENT_SCROLL_ON_FOCUS }
 		/>
 	);
 
@@ -162,10 +173,7 @@ export default function useTabNav() {
 			// (moving focus to the next tabbable element).
 			noCaptureRef.current = true;
 
-			// Focusing the focus capture element, which is located above and
-			// below the editor, should not scroll the page all the way up or
-			// down.
-			next.current.focus( { preventScroll: true } );
+			next.current.focus();
 		}
 
 		function onFocusOut( event ) {
@@ -191,47 +199,9 @@ export default function useTabNav() {
 			}
 		}
 
-		// When tabbing back to an element in block list, this event handler prevents scrolling if the
-		// focus capture divs (before/after) are outside of the viewport. (For example shift+tab back to a paragraph
-		// when focus is on a sidebar element. This prevents the scrollable writing area from jumping either to the
-		// top or bottom of the document.
-		//
-		// Note that it isn't possible to disable scrolling in the onFocus event. We need to intercept this
-		// earlier in the keypress handler, and call focus( { preventScroll: true } ) instead.
-		// https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus#parameters
-		function preventScrollOnTab( event ) {
-			if ( event.keyCode !== TAB ) {
-				return;
-			}
-
-			if ( event.target?.getAttribute( 'role' ) === 'region' ) {
-				return;
-			}
-
-			if ( containerRef.current === event.target ) {
-				return;
-			}
-
-			const isShift = event.shiftKey;
-			const direction = isShift ? 'findPrevious' : 'findNext';
-			const target = focus.tabbable[ direction ]( event.target );
-			// Only do something when the next tabbable is a focus capture div (before/after)
-			if (
-				target === focusCaptureBeforeRef.current ||
-				target === focusCaptureAfterRef.current
-			) {
-				event.preventDefault();
-				target.focus( { preventScroll: true } );
-			}
-		}
-
-		const { ownerDocument } = node;
-		const { defaultView } = ownerDocument;
-		defaultView.addEventListener( 'keydown', preventScrollOnTab );
 		node.addEventListener( 'keydown', onKeyDown );
 		node.addEventListener( 'focusout', onFocusOut );
 		return () => {
-			defaultView.removeEventListener( 'keydown', preventScrollOnTab );
 			node.removeEventListener( 'keydown', onKeyDown );
 			node.removeEventListener( 'focusout', onFocusOut );
 		};

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.jsx
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.jsx
@@ -8,13 +8,16 @@ import { isInSameBlock, isInsideRootBlock } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
 
 /**
- * Keeps the element positioned within the viewport, so focussing it never
- * scrolls the page. Fixed positioning once made Safari build an oversized
- * compositing layer for the scrollable canvas, which is why keydown handlers
- * prevented the scrolling instead, but current Safari sizes the layer
- * correctly.
+ * Spans the element over the canvas, so it is always at least partially in
+ * view and focussing it never scrolls the content. Fixed positioning would
+ * achieve that too, but makes Safari composite the scrollable canvas on a
+ * layer sized to the whole document instead of the visible pane.
  */
-const PREVENT_SCROLL_ON_FOCUS = { position: 'fixed' };
+const PREVENT_SCROLL_ON_FOCUS = {
+	position: 'absolute',
+	inset: 0,
+	pointerEvents: 'none',
+};
 
 export default function useTabNav() {
 	const containerRef = /** @type {typeof useRef<HTMLElement>} */ ( useRef )();


### PR DESCRIPTION
## What?

Spans the focus capture elements before and after the editor canvas over the whole canvas (`position: absolute; inset: 0; pointer-events: none;`), and removes the keydown scroll prevention that guarded their old zero height geometry: the `preventScrollOnTab` window listener and the `preventScroll: true` focus option in the tab navigation.

## Why?

Preparation for #82314, and removes a hack. Browsers only scroll on focus to reveal an element that is out of view. An element spanning the canvas is always at least partially in view, so focusing it never scrolls, and no keydown interception is needed. The elements stay invisible and click through.

Some history:

1. **The elements were `position: fixed` from their introduction in #19235**, for the same always-in-view reason.
2. **#32824 removed the fixed positioning** because a fixed element inside the scrollable canvas made Safari composite it on a layer sized to the whole document (text flickering on scroll, roughly 30% more memory), and added the keydown prevention as the replacement.
3. **That Safari behaviour still exists in Safari 26.6.2**: rerunning the reduced case from #32824 with 150,000px of content shows a 455,101px tall composited layer in the Layers inspector, with the fixed element as the trigger. Process memory looks normal because tiles are allocated lazily, but the layer bounds and the flicker risk remain, so fixed positioning stays off the table.
4. **Spanned elements avoid both problems**: they scroll with the content like any other element, so Safari composites nothing extra (verified in the Layers inspector on the same reduced case), and they never trigger reveal scrolling in Chromium, Firefox, or WebKit, whether focused natively via Tab or programmatically.

Alternatively we could always make sure the block editor is either iframed or scrollable within.

## Testing Instructions

1. In the post editor with a long document scrolled midway, Tab and Shift+Tab out of and back into the canvas: the canvas must not jump.
2. Repeat on the widgets screen, where the capture elements sit inside the scrollable pane.
3. In Safari, open the reduced case from #32824 with the fixed style replaced by `position: absolute; inset: 0; pointer-events: none;` and confirm the Layers inspector shows no document sized layer.

Written with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard Tab navigation within the editor canvas.
  - Focus transitions now preserve the canvas view more reliably and reduce unwanted scrolling.
  - The canvas remains partially visible while focus moves between navigation points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->