### PR TITLE
Notes: show every thread participant on the block toolbar avatar indicator

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.jsx
+++ b/packages/editor/src/components/collab-sidebar/index.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { comment as commentIcon } from '@wordpress/icons';
@@ -20,7 +20,11 @@ import { NoteAvatarIndicator } from './note-indicator-toolbar';
 import { NoteHighlightStyles } from './note-highlight-styles';
 import { useGlobalStyles } from '../global-styles';
 import { useEnableFloatingSidebar, useNoteThreads } from './hooks';
-import { getNoteIdsFromMetadata, pickPrimaryNote } from './utils';
+import {
+	getNoteIdsFromMetadata,
+	pickIndicatorNotes,
+	pickPrimaryNote,
+} from './utils';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { unlock } from '../../lock-unlock';
 
@@ -49,7 +53,6 @@ function NotesSidebar( { postId } ) {
 		};
 	}, [] );
 
-	const blockNoteIds = getNoteIdsFromMetadata( { noteId } );
 	const { isDistractionFree } = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		return {
@@ -140,12 +143,17 @@ function NotesSidebar( { postId } ) {
 	const { merged: GlobalStyles } = useGlobalStyles();
 	const backgroundColor = GlobalStyles?.styles?.color?.background;
 
-	// Surface one thread for the avatar indicator.
-	const currentThreads =
-		blockNoteIds.length > 0
-			? notes.filter( ( thread ) => blockNoteIds.includes( thread.id ) )
-			: [];
-	const currentThread = pickPrimaryNote( currentThreads );
+	// The avatar indicator stands for every thread on the block, so it gets
+	// the whole set and aggregates their participants.
+	const indicatorThreads = useMemo( () => {
+		const noteIds = getNoteIdsFromMetadata( { noteId } );
+		if ( noteIds.length === 0 ) {
+			return [];
+		}
+		return pickIndicatorNotes(
+			notes.filter( ( thread ) => noteIds.includes( thread.id ) )
+		);
+	}, [ notes, noteId ] );
 
 	if ( isDistractionFree ) {
 		return <AddNoteMenuItem isDistractionFree />;
@@ -157,9 +165,9 @@ function NotesSidebar( { postId } ) {
 				threads={ unresolvedNotes }
 				selectedId={ selectedNoteId }
 			/>
-			{ !! currentThread && (
+			{ indicatorThreads.length > 0 && (
 				<NoteAvatarIndicator
-					note={ currentThread }
+					notes={ indicatorThreads }
 					onClick={ () => openNoteForBlock( clientId ) }
 				/>
 			) }

--- a/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.jsx
+++ b/packages/editor/src/components/collab-sidebar/note-indicator-toolbar.jsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { unlock } from '../../lock-unlock';
-import { getAvatarBorderColor } from './utils';
+import { getAvatarBorderColor, getThreadParticipants } from './utils';
 
 const { NoteIconToolbarSlotFill } = unlock( blockEditorPrivateApis );
 
@@ -63,35 +63,13 @@ function ThreadParticipants( { participants } ) {
 	);
 }
 
-export function NoteAvatarIndicator( { onClick, note } ) {
-	const threadParticipants = useMemo( () => {
-		if ( ! note ) {
-			return [];
-		}
-
-		// Track thread participants (original author + repliers), sorted by
-		// date so they appear in chronological order.
-		const participantsMap = new Map();
-		const allNotes = [ note, ...note.reply ].sort(
-			( a, b ) => new Date( a.date ) - new Date( b.date )
-		);
-
-		for ( const entry of allNotes ) {
-			if ( ! entry.author_name || participantsMap.has( entry.author ) ) {
-				continue;
-			}
-
-			participantsMap.set( entry.author, {
-				id: entry.author,
-				name: entry.author_name,
-				avatar:
-					entry.author_avatar_urls?.[ '48' ] ||
-					entry.author_avatar_urls?.[ '96' ],
-			} );
-		}
-
-		return Array.from( participantsMap.values() );
-	}, [ note ] );
+export function NoteAvatarIndicator( { onClick, notes } ) {
+	// A block can carry several threads; the indicator stands for all of them,
+	// so aggregate the participants rather than showing a single thread's.
+	const threadParticipants = useMemo(
+		() => getThreadParticipants( notes ?? [] ),
+		[ notes ]
+	);
 
 	if ( ! threadParticipants.length ) {
 		return null;

--- a/packages/editor/src/components/collab-sidebar/test/utils.jsdom.test.js
+++ b/packages/editor/src/components/collab-sidebar/test/utils.jsdom.test.js
@@ -17,6 +17,8 @@ import {
 	removeNoteIdFromMetadata,
 	calculateNotePositions,
 	pickPrimaryNote,
+	pickIndicatorNotes,
+	getThreadParticipants,
 	BLOCK_LEVEL_NOTE_START,
 	getInlineMarkerStart,
 	getNoteMarkerSelector,
@@ -327,6 +329,129 @@ describe( 'pickPrimaryNote', () => {
 			{ id: 2, status: 'approved' },
 		];
 		expect( pickPrimaryNote( threads ) ).toBe( threads[ 0 ] );
+	} );
+} );
+
+describe( 'pickIndicatorNotes', () => {
+	it( 'returns every unresolved thread when some are unresolved', () => {
+		const threads = [
+			{ id: 1, status: 'hold' },
+			{ id: 2, status: 'approved' },
+			{ id: 3, status: 'hold' },
+		];
+		expect( pickIndicatorNotes( threads ) ).toEqual( [
+			threads[ 0 ],
+			threads[ 2 ],
+		] );
+	} );
+
+	it( 'falls back to every thread when none are unresolved', () => {
+		const threads = [
+			{ id: 1, status: 'approved' },
+			{ id: 2, status: 'approved' },
+		];
+		expect( pickIndicatorNotes( threads ) ).toEqual( threads );
+	} );
+
+	it( 'returns an empty list for an empty list', () => {
+		expect( pickIndicatorNotes( [] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getThreadParticipants', () => {
+	function makeNote( { id, author, name, date, reply = [] } ) {
+		return {
+			id,
+			author,
+			author_name: name,
+			author_avatar_urls: { 48: `avatar-${ author }` },
+			date,
+			reply,
+		};
+	}
+
+	it( 'collects authors across separate threads on the same block', () => {
+		const threads = [
+			makeNote( {
+				id: 1,
+				author: 10,
+				name: 'Ann',
+				date: '2026-01-01T10:00:00',
+			} ),
+			makeNote( {
+				id: 2,
+				author: 20,
+				name: 'Bob',
+				date: '2026-01-01T11:00:00',
+			} ),
+		];
+		expect( getThreadParticipants( threads ) ).toEqual( [
+			{ id: 10, name: 'Ann', avatar: 'avatar-10' },
+			{ id: 20, name: 'Bob', avatar: 'avatar-20' },
+		] );
+	} );
+
+	it( 'includes repliers and orders participants chronologically', () => {
+		const threads = [
+			makeNote( {
+				id: 1,
+				author: 10,
+				name: 'Ann',
+				date: '2026-01-01T12:00:00',
+				reply: [
+					makeNote( {
+						id: 3,
+						author: 30,
+						name: 'Cal',
+						date: '2026-01-01T13:00:00',
+					} ),
+				],
+			} ),
+			makeNote( {
+				id: 2,
+				author: 20,
+				name: 'Bob',
+				date: '2026-01-01T09:00:00',
+			} ),
+		];
+		expect(
+			getThreadParticipants( threads ).map( ( p ) => p.name )
+		).toEqual( [ 'Bob', 'Ann', 'Cal' ] );
+	} );
+
+	it( 'lists an author once even when present in several threads', () => {
+		const threads = [
+			makeNote( {
+				id: 1,
+				author: 10,
+				name: 'Ann',
+				date: '2026-01-01T10:00:00',
+			} ),
+			makeNote( {
+				id: 2,
+				author: 10,
+				name: 'Ann',
+				date: '2026-01-01T11:00:00',
+			} ),
+		];
+		expect( getThreadParticipants( threads ) ).toHaveLength( 1 );
+	} );
+
+	it( 'skips entries without an author name', () => {
+		const threads = [ { id: 1, author: 10, date: '2026-01-01T10:00:00' } ];
+		expect( getThreadParticipants( threads ) ).toEqual( [] );
+	} );
+
+	it( 'tolerates threads with no replies', () => {
+		const threads = [
+			{
+				id: 1,
+				author: 10,
+				author_name: 'Ann',
+				date: '2026-01-01T10:00:00',
+			},
+		];
+		expect( getThreadParticipants( threads ) ).toHaveLength( 1 );
 	} );
 } );
 

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -431,6 +431,48 @@ export function pickPrimaryNote( threads ) {
 }
 
 /**
+ * Picks the threads the block toolbar indicator represents: every unresolved
+ * thread on the block, falling back to all of them when none are unresolved.
+ *
+ * @param {Array} threads Ordered list of thread objects.
+ * @return {Array} Threads the indicator should aggregate.
+ */
+export function pickIndicatorNotes( threads ) {
+	const unresolved = threads.filter( ( thread ) => thread.status === 'hold' );
+	return unresolved.length > 0 ? unresolved : threads;
+}
+
+/**
+ * Collects the distinct participants across a set of threads: each thread's
+ * author plus everyone who replied, in chronological order.
+ *
+ * @param {Array} threads Thread objects, each with an optional `reply` list.
+ * @return {Array} Participants as `{ id, name, avatar }`, first contribution first.
+ */
+export function getThreadParticipants( threads ) {
+	const entries = threads
+		.flatMap( ( thread ) => [ thread, ...( thread.reply ?? [] ) ] )
+		.sort( ( a, b ) => new Date( a.date ) - new Date( b.date ) );
+
+	const participantsMap = new Map();
+	for ( const entry of entries ) {
+		if ( ! entry.author_name || participantsMap.has( entry.author ) ) {
+			continue;
+		}
+
+		participantsMap.set( entry.author, {
+			id: entry.author,
+			name: entry.author_name,
+			avatar:
+				entry.author_avatar_urls?.[ '48' ] ||
+				entry.author_avatar_urls?.[ '96' ],
+		} );
+	}
+
+	return Array.from( participantsMap.values() );
+}
+
+/**
  * Removes a note ID from the metadata.
  *
  * @param {Object} metadata Existing block metadata


### PR DESCRIPTION

## What?

Closes https://github.com/WordPress/gutenberg/issues/82273

Makes the block toolbar avatar indicator represent all of the block's note threads instead of a single one, so every user with a note on the block shows up.

## Why?

A block can carry several threads - a block-level note plus one or more inline notes - but the indicator was wired to a single "primary" thread picked by `pickPrimaryNote()`. Block-level notes sort ahead of inline ones, so an unresolved block-level note always won and the other users who left inline notes on that block never got an avatar. Two inline threads by two different users had the same problem with no block-level note involved.

Per the discussion on the issue, the button was designed to hold multiple avatars, and with multiple inline notes per block landing in 7.1 the intent is to show everyone participating in unresolved threads (block level, inline, and replies), with the existing 3+ overflow behavior.

## How?

`NotesSidebar` now passes the whole set of the block's threads to `NoteAvatarIndicator` rather than one picked thread, and two helpers moved into `utils.js`:

- `pickIndicatorNotes()` keeps the previous resolved/unresolved preference - unresolved threads, falling back to all of them when none are unresolved.
- `getThreadParticipants()` collects the distinct authors and repliers across those threads in chronological order. This is the same dedupe the component used to do inline, just testable on its own.

The click target is unchanged: the indicator still opens the primary thread via `openNoteForBlock()`.

Unit tests cover both helpers, including the multi-thread case from the issue.

## Testing Instructions

[![Test in WordPress Playground](https://img.shields.io/badge/Test%20in%20WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/gutenberg.html?pr=82357)

Playground signs you in as a single user, so it won't show the two-user case below, but it is handy for checking a block-level note alongside an inline note and confirming replies still add avatars.

This needs two users to see the bug properly - eg. two browsers logged in as different users on the same post, with Notes enabled.

1. As user A, select a paragraph block and add a block-level note.
2. As user A, select some text in the same block and add a selection (inline) note.
3. As user B, select different text in the same block and add another selection note.
4. Select the block and look at the avatar indicator in the block toolbar.

Before: only user A's avatar shows. After: both avatars show.

Also worth checking:

- A block with a single note still shows just that author, and a thread with replies still shows the repliers.
- Resolve every note on a block - the indicator still behaves as it did before.
- Add notes from four or more users to a block and confirm the "+n" overflow still renders.

Unit tests: `npm run test:unit packages/editor/src/components/collab-sidebar/test/utils.jsdom.test.js`

### Testing Instructions for Keyboard

The toolbar button itself is unchanged - tab to the block toolbar and confirm the notes button is still reachable and activates with Enter or Space, and that its "View notes" label still reads correctly.

## Screenshots or screencast

<!-- TODO: add before/after screenshots from a two-user setup -->

## Use of AI Tools

The code, tests, and this description were written with 🤖 Claude Code. I will review and test.
