### PR TITLE
CI: Make the required trunk changes sweep stamp every open PR

### DIFF
--- a/.github/workflows/required-changes-from-trunk.yml
+++ b/.github/workflows/required-changes-from-trunk.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
     check-pr:
-        name: Check required changes from trunk
+        name: Report required trunk changes status
         if: github.repository == 'WordPress/gutenberg' && github.event_name == 'pull_request_target'
         runs-on: ubuntu-latest
         timeout-minutes: 15

--- a/.github/workflows/required-changes-from-trunk.yml
+++ b/.github/workflows/required-changes-from-trunk.yml
@@ -9,7 +9,11 @@ on:
     workflow_dispatch:
         inputs:
             move-baseline:
-                description: 'Move the baseline tag to current trunk HEAD and flip stale statuses'
+                description: 'Move the baseline tag to current trunk HEAD, then sweep open PRs'
+                type: boolean
+                default: false
+            sweep:
+                description: 'Sweep open PRs against the current baseline, without moving it'
                 type: boolean
                 default: false
 
@@ -54,16 +58,15 @@ jobs:
               run: npm run --workspace @wordpress/validation-tools required-trunk-changes -- check --head-sha "$HEAD_SHA"
 
     move-baseline:
-        name: Move required trunk baseline
+        name: Move the required trunk baseline or sweep
         # The baseline moves only through explicit intent: a dispatch with
         # move-baseline, or a merged PR carrying the required-update label
-        # (detected cumulatively on every trunk push). Re-dispatching when the
-        # tag is already current re-runs the fan-out, which is the retry path
-        # after an interrupted sweep.
+        # (detected cumulatively on every trunk push). An interrupted sweep is
+        # resumed with sweep, which leaves the baseline where it is.
         if: >
             github.repository == 'WordPress/gutenberg' && (
                 github.event_name == 'push' ||
-                (github.event_name == 'workflow_dispatch' && inputs.move-baseline)
+                (github.event_name == 'workflow_dispatch' && (inputs.move-baseline || inputs.sweep))
             )
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -84,5 +87,12 @@ jobs:
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 
-            - name: Move the baseline tag and fan out
+            - name: Move the baseline tag and sweep open PRs
+              if: github.event_name == 'push' || inputs.move-baseline
               run: npm run --workspace @wordpress/validation-tools required-trunk-changes -- move-baseline --force="$FORCE" --then-fanout
+
+            # Retries sweep without moving, so a baseline is not chased by
+            # trunk while a multi-run sweep is still catching up.
+            - name: Sweep open PRs against the current baseline
+              if: github.event_name == 'workflow_dispatch' && inputs.sweep && ! inputs.move-baseline
+              run: npm run --workspace @wordpress/validation-tools required-trunk-changes -- fanout

--- a/docs/contributors/code/required-changes-from-trunk.md
+++ b/docs/contributors/code/required-changes-from-trunk.md
@@ -37,7 +37,7 @@ Committers apply the `Require PR update` label to a pull request whose change in
 
 ## Maintainer runbook
 
-The `Required changes from trunk` workflow exposes two `workflow_dispatch` switches. `move-baseline` moves the baseline tag to the current `trunk` HEAD and then sweeps open pull requests. `sweep` sweeps against the baseline where it stands, which is the retry path after an interrupted run and the way to clear stale statuses if the tag is ever deleted.
+The `Required changes from trunk` workflow exposes two `workflow_dispatch` switches. `move-baseline` moves the baseline tag to the current `trunk` HEAD and then sweeps open pull requests. `sweep` sweeps against the baseline where it stands, which is the retry path after an interrupted run and the way to bring every open pull request back to passing if the tag is ever deleted.
 
 ### Initial setup
 

--- a/docs/contributors/code/required-changes-from-trunk.md
+++ b/docs/contributors/code/required-changes-from-trunk.md
@@ -4,23 +4,22 @@ The `Required changes from trunk` status check ensures open pull requests contai
 
 ## How it works
 
-A movable lightweight git tag, `required-trunk-baseline`, points at the last `trunk` commit that every open pull request must contain. The check passes when the tagged commit is an ancestor of the pull request head, and fails otherwise.
+A movable lightweight git tag, `required-trunk-baseline`, points at the last `trunk` commit that every open pull request must contain. The check passes when the tagged commit is an ancestor of the pull request head, and fails otherwise. While the tag does not exist, nothing is required and the check passes.
 
 The tag moves only through explicit maintainer intent, in one of two ways:
 
 -   Dispatching the `Required changes from trunk` workflow with `move-baseline: true`, or
 -   Merging a pull request that carries the `Require PR update` label.
 
-When the tag moves, open pull requests holding a now-outdated passing status are switched to failing, subject to the limits below.
+When the tag moves, the workflow sweeps every open pull request and posts the status each one now warrants, subject to the limits below. Pull requests already carrying the current verdict are left alone, so a repeated sweep is cheap. Drafts are swept too, so a draft is accurate the moment it is marked ready for review.
 
 ## Limits
 
 The sweep that follows a baseline move is intentionally bounded:
 
--   Draft pull requests are skipped; they cannot merge anyway and are re-checked when marked ready for review.
 -   Each run writes at most 400 statuses to stay inside API rate limits. A run that hits the cap (or any write failure) exits nonzero; dispatch the workflow again with `move-baseline: true` until a run finishes cleanly.
--   Pull requests that never received a status show as "Expected", which also blocks merging; they get a real status on their next update.
 -   A pull request checked at the exact moment the baseline moves can briefly keep an outdated status; it converges on the pull request's next event or the next dispatch.
+-   A pull request opened while the workflow is broken carries no status at all, and shows as "Expected", which also blocks merging. The next sweep or its own next update gives it a real one.
 
 ## My pull request has a red "Required changes from trunk" status. What do I do?
 
@@ -37,16 +36,16 @@ Committers apply the `Require PR update` label to a pull request whose change in
 
 ## Maintainer runbook
 
-The `Required changes from trunk` workflow exposes one `workflow_dispatch` switch, `move-baseline`: it moves the baseline tag to the current `trunk` HEAD and flips stale passing statuses. Re-dispatching when the baseline is already current re-runs only the flip sweep, which is the retry path after an interrupted run.
+The `Required changes from trunk` workflow exposes one `workflow_dispatch` switch, `move-baseline`: it moves the baseline tag to the current `trunk` HEAD and sweeps open pull requests. Re-dispatching when the baseline is already current re-runs only the sweep, which is the retry path after an interrupted run.
 
 ### Initial setup
 
 The workflow blocks nothing until these one-time steps are completed, in order:
 
 1. Create the `Require PR update` label.
-2. Seed the baseline: dispatch the workflow with `move-baseline: true`.
-3. Let the check run unenforced for a while; active pull requests get stamped by their own events.
-4. Ask a repository admin to add `Required changes from trunk` (source: GitHub Actions) to the trunk ruleset's required status checks, and to add a tag ruleset for `required-trunk-baseline` restricting creation, update, and deletion to the GitHub Actions app.
+2. Seed the baseline: dispatch the workflow with `move-baseline: true`. Every open pull request is stamped in the same run, or across repeated dispatches when the write cap is hit.
+3. Re-dispatch until a run reports no writes, so that no pull request is left unstamped.
+4. Ask a repository admin to add the `Required changes from trunk` commit status to the trunk ruleset's required status checks, not the `Report required trunk changes status` job that posts it, and to add a tag ruleset for `required-trunk-baseline` restricting creation, update, and deletion to the GitHub Actions app.
 
 To roll the check back, remove `Required changes from trunk` from the required status checks; existing statuses become informational immediately. The tag can stay for a later re-enable.
 

--- a/docs/contributors/code/required-changes-from-trunk.md
+++ b/docs/contributors/code/required-changes-from-trunk.md
@@ -17,7 +17,8 @@ When the tag moves, the workflow sweeps every open pull request and posts the st
 
 The sweep that follows a baseline move is intentionally bounded:
 
--   Each run writes at most 400 statuses to stay inside API rate limits. A run that hits the cap (or any write failure) exits nonzero; dispatch the workflow again with `move-baseline: true` until a run finishes cleanly.
+-   Each run writes at most 400 statuses. Evaluating and stamping one pull request costs two REST requests, so a full run uses about 800 of the 1,000 per hour the workflow token is allowed. A run that hits the cap, is rate limited, or fails a write exits nonzero; dispatch again with `sweep: true` about an hour later, and repeat until a run finishes cleanly.
+-   Retries use `sweep: true`, never `move-baseline: true`. Moving the baseline again would re-invalidate everything the previous runs stamped, and a sweep that takes several hours would never catch up with a moving `trunk`.
 -   A pull request checked at the exact moment the baseline moves can briefly keep an outdated status; it converges on the pull request's next event or the next dispatch.
 -   A pull request opened while the workflow is broken carries no status at all, and shows as "Expected", which also blocks merging. The next sweep or its own next update gives it a real one.
 
@@ -36,7 +37,7 @@ Committers apply the `Require PR update` label to a pull request whose change in
 
 ## Maintainer runbook
 
-The `Required changes from trunk` workflow exposes one `workflow_dispatch` switch, `move-baseline`: it moves the baseline tag to the current `trunk` HEAD and sweeps open pull requests. Re-dispatching when the baseline is already current re-runs only the sweep, which is the retry path after an interrupted run.
+The `Required changes from trunk` workflow exposes two `workflow_dispatch` switches. `move-baseline` moves the baseline tag to the current `trunk` HEAD and then sweeps open pull requests. `sweep` sweeps against the baseline where it stands, which is the retry path after an interrupted run and the way to clear stale statuses if the tag is ever deleted.
 
 ### Initial setup
 
@@ -44,7 +45,7 @@ The workflow blocks nothing until these one-time steps are completed, in order:
 
 1. Create the `Require PR update` label.
 2. Seed the baseline: dispatch the workflow with `move-baseline: true`. Every open pull request is stamped in the same run, or across repeated dispatches when the write cap is hit.
-3. Re-dispatch until a run reports no writes, so that no pull request is left unstamped.
+3. Re-dispatch with `sweep: true`, roughly hourly, until a run reports no writes, so that no pull request is left unstamped.
 4. Ask a repository admin to add the `Required changes from trunk` commit status to the trunk ruleset's required status checks, not the `Report required trunk changes status` job that posts it, and to add a tag ruleset for `required-trunk-baseline` restricting creation, update, and deletion to the GitHub Actions app.
 
 To roll the check back, remove `Required changes from trunk` from the required status checks; existing statuses become informational immediately. The tag can stay for a later re-enable.

--- a/tools/validation/required-trunk-changes/check.mjs
+++ b/tools/validation/required-trunk-changes/check.mjs
@@ -7,6 +7,7 @@ import {
 	fail,
 	getBaseline,
 	isAncestor,
+	NO_BASELINE_STATUS,
 	statusFor,
 	latestStatus,
 	postStatus,
@@ -25,7 +26,7 @@ import {
 async function evaluate( baseline, headSha ) {
 	/* No baseline means nothing is required of open PRs yet. */
 	if ( baseline === null ) {
-		return { state: 'success', description: 'No required trunk changes.' };
+		return NO_BASELINE_STATUS;
 	}
 	return statusFor( await isAncestor( baseline, headSha ), baseline );
 }

--- a/tools/validation/required-trunk-changes/check.mjs
+++ b/tools/validation/required-trunk-changes/check.mjs
@@ -13,6 +13,22 @@ import {
 } from './utils.mjs';
 
 /** @typedef {import('./types.mjs').CommandOptions} CommandOptions */
+/** @typedef {import('./types.mjs').StatusPayload} StatusPayload */
+
+/**
+ * Builds the status payload for a head commit against the baseline.
+ *
+ * @param {string | null} baseline Baseline commit SHA, if any.
+ * @param {string}        headSha  Head commit SHA.
+ * @return {Promise<StatusPayload>} Status state and description.
+ */
+async function evaluate( baseline, headSha ) {
+	/* No baseline means nothing is required of open PRs yet. */
+	if ( baseline === null ) {
+		return { state: 'success', description: 'No required trunk changes.' };
+	}
+	return statusFor( await isAncestor( baseline, headSha ), baseline );
+}
 
 /**
  * Checks one PR head against the baseline and stamps its status.
@@ -23,17 +39,17 @@ export async function check( { headSha, dryRun } ) {
 	if ( ! headSha ) {
 		return fail( 'The check subcommand requires --head-sha.' );
 	}
-	let baseline = /** @type {string} */ ( await getBaseline() );
-	let includesBaseline = await isAncestor( baseline, headSha );
+	let baseline = await getBaseline();
+	let payload = await evaluate( baseline, headSha );
 
 	// Re-read the baseline just before posting to shrink the move race window.
-	const latest = /** @type {string} */ ( await getBaseline() );
+	const latest = await getBaseline();
 	if ( latest !== baseline ) {
 		baseline = latest;
-		includesBaseline = await isAncestor( baseline, headSha );
+		payload = await evaluate( baseline, headSha );
 	}
 
-	const { state, description } = statusFor( includesBaseline, baseline );
+	const { state, description } = payload;
 
 	/* Statuses are append-only and capped per SHA/context; skip no-op writes. */
 	const current = await latestStatus( headSha );
@@ -47,6 +63,8 @@ export async function check( { headSha, dryRun } ) {
 	}
 	await postStatus( headSha, state, description, dryRun );
 	console.log(
-		`Posted ${ state } for ${ headSha } against baseline ${ baseline }.`
+		`Posted ${ state } for ${ headSha } against baseline ${
+			baseline ?? 'none'
+		}.`
 	);
 }

--- a/tools/validation/required-trunk-changes/fanout.mjs
+++ b/tools/validation/required-trunk-changes/fanout.mjs
@@ -10,6 +10,7 @@ import {
 	graphql,
 	getBaseline,
 	isAncestor,
+	NO_BASELINE_STATUS,
 	statusFor,
 	postStatus,
 } from './utils.mjs';
@@ -42,7 +43,6 @@ const PAGE_QUERY = `
 					commits(last: 1) {
 						nodes {
 							commit {
-								committedDate
 								status {
 									context(name: $context) {
 										state
@@ -81,7 +81,6 @@ async function listOpenPRs() {
 			prs.push( {
 				number: node.number,
 				headRefOid: node.headRefOid,
-				committedDate: commit?.committedDate ?? null,
 				status: commit?.status?.context ?? null,
 			} );
 		}
@@ -94,46 +93,25 @@ async function listOpenPRs() {
 }
 
 /**
- * Reads a commit's date, used as a cheap ancestry bound.
- *
- * @param {string} oid Commit SHA.
- * @return {Promise<string>} Commit date, ISO 8601.
- */
-async function commitDate( oid ) {
-	const [ owner, name ] = REPO.split( '/' );
-	const data = await graphql(
-		`
-			query ($owner: String!, $name: String!, $oid: GitObjectID!) {
-				repository(owner: $owner, name: $name) {
-					object(oid: $oid) {
-						... on Commit {
-							committedDate
-						}
-					}
-				}
-			}
-		`,
-		{ owner, name, oid }
-	);
-	return data.repository.object.committedDate;
-}
-
-/**
  * Brings every open PR's status in line with the current baseline.
  *
  * @param {CommandOptions} options Command options.
  */
 export async function fanout( { dryRun } ) {
 	const baseline = await getBaseline();
-	if ( baseline === null ) {
-		console.log( 'No baseline tag; nothing to fan out.' );
-		return;
-	}
-	const short = baseline.slice( 0, 7 );
-	const baselineDate = await commitDate( baseline );
+	/* A description names its baseline, so it identifies the current verdict. */
+	const current =
+		baseline === null
+			? [ NO_BASELINE_STATUS.description ]
+			: [
+					statusFor( true, baseline ).description,
+					statusFor( false, baseline ).description,
+			  ];
 
 	const prs = await listOpenPRs();
-	console.log( `Baseline ${ baseline }; ${ prs.length } open PRs.` );
+	console.log(
+		`Baseline ${ baseline ?? 'none' }; ${ prs.length } open PRs.`
+	);
 
 	let written = 0;
 	let skipped = 0;
@@ -141,20 +119,22 @@ export async function fanout( { dryRun } ) {
 	let budgetExhausted = false;
 
 	for ( const pr of prs ) {
-		/* Both descriptions embed the baseline; anything else needs a stamp. */
-		if ( pr.status?.description?.includes( short ) ) {
+		if ( pr.status && current.includes( pr.status.description ) ) {
 			skipped++;
 			continue;
 		}
-		/*
-		 * A head committed before the baseline cannot contain it, which spares
-		 * a compare call for all but the PRs updated since the baseline moved.
-		 */
-		const includesBaseline =
-			pr.committedDate && pr.committedDate < baselineDate
-				? false
-				: await isAncestor( baseline, pr.headRefOid );
-		const { state, description } = statusFor( includesBaseline, baseline );
+		/* With no baseline nothing is required, so only clear stale verdicts. */
+		if ( baseline === null && ! pr.status ) {
+			skipped++;
+			continue;
+		}
+		const { state, description } =
+			baseline === null
+				? NO_BASELINE_STATUS
+				: statusFor(
+						await isAncestor( baseline, pr.headRefOid ),
+						baseline
+				  );
 		try {
 			if (
 				! ( await postStatus(

--- a/tools/validation/required-trunk-changes/fanout.mjs
+++ b/tools/validation/required-trunk-changes/fanout.mjs
@@ -21,6 +21,9 @@ import {
 /** @typedef {import('./types.mjs').PullRequest} PullRequest */
 /** @typedef {import('./types.mjs').ContextStatus} ContextStatus */
 
+const RETRY_HINT =
+	'Dispatch the workflow with sweep: true in about an hour to continue.';
+
 const PAGE_QUERY = `
 	query (
 		$owner: String!
@@ -101,7 +104,21 @@ async function listOpenPRs() {
  * @param {CommandOptions} options Command options.
  */
 export async function fanout( { dryRun } ) {
-	const baseline = await getBaseline();
+	/* A limit hit while reading still owes the operator the retry guidance. */
+	let baseline;
+	let prs;
+	try {
+		baseline = await getBaseline();
+		prs = await listOpenPRs();
+	} catch ( error ) {
+		if ( error instanceof Error && error.name === RATE_LIMIT_ERROR ) {
+			console.error( `${ error.message } ${ RETRY_HINT }` );
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+
 	/* A description names its baseline, so it identifies the current verdict. */
 	const current =
 		baseline === null
@@ -114,7 +131,6 @@ export async function fanout( { dryRun } ) {
 				payload.description === status.description
 		);
 
-	const prs = await listOpenPRs();
 	console.log(
 		`Baseline ${ baseline ?? 'none' }; ${ prs.length } open PRs.`
 	);
@@ -169,9 +185,7 @@ export async function fanout( { dryRun } ) {
 		`Sweep done: ${ written } written, ${ skipped } skipped, ${ failed } failed.` +
 			( rateLimited ? ' Rate limited.' : '' ) +
 			( budgetExhausted ? ' Write budget exhausted.' : '' ) +
-			( incomplete
-				? ' Dispatch the workflow with sweep: true in about an hour to continue.'
-				: '' )
+			( incomplete ? ` ${ RETRY_HINT }` : '' )
 	);
 	// Nonzero exit makes an incomplete or lossy sweep visible in the run list.
 	if ( failed > 0 || incomplete ) {

--- a/tools/validation/required-trunk-changes/fanout.mjs
+++ b/tools/validation/required-trunk-changes/fanout.mjs
@@ -9,14 +9,17 @@ import {
 	REPO,
 	graphql,
 	getBaseline,
+	hasWriteBudget,
 	isAncestor,
 	NO_BASELINE_STATUS,
+	RATE_LIMIT_ERROR,
 	statusFor,
 	postStatus,
 } from './utils.mjs';
 
 /** @typedef {import('./types.mjs').CommandOptions} CommandOptions */
 /** @typedef {import('./types.mjs').PullRequest} PullRequest */
+/** @typedef {import('./types.mjs').ContextStatus} ContextStatus */
 
 const PAGE_QUERY = `
 	query (
@@ -102,11 +105,14 @@ export async function fanout( { dryRun } ) {
 	/* A description names its baseline, so it identifies the current verdict. */
 	const current =
 		baseline === null
-			? [ NO_BASELINE_STATUS.description ]
-			: [
-					statusFor( true, baseline ).description,
-					statusFor( false, baseline ).description,
-			  ];
+			? [ NO_BASELINE_STATUS ]
+			: [ statusFor( true, baseline ), statusFor( false, baseline ) ];
+	const isCurrent = ( /** @type {ContextStatus} */ status ) =>
+		current.some(
+			( payload ) =>
+				payload.state.toUpperCase() === status.state &&
+				payload.description === status.description
+		);
 
 	const prs = await listOpenPRs();
 	console.log(
@@ -117,9 +123,10 @@ export async function fanout( { dryRun } ) {
 	let skipped = 0;
 	let failed = 0;
 	let budgetExhausted = false;
+	let rateLimited = false;
 
 	for ( const pr of prs ) {
-		if ( pr.status && current.includes( pr.status.description ) ) {
+		if ( pr.status && isCurrent( pr.status ) ) {
 			skipped++;
 			continue;
 		}
@@ -128,25 +135,20 @@ export async function fanout( { dryRun } ) {
 			skipped++;
 			continue;
 		}
-		const { state, description } =
-			baseline === null
-				? NO_BASELINE_STATUS
-				: statusFor(
-						await isAncestor( baseline, pr.headRefOid ),
-						baseline
-				  );
+		/* Probed first so an unwritable PR costs no ancestry request. */
+		if ( ! hasWriteBudget() ) {
+			budgetExhausted = true;
+			break;
+		}
 		try {
-			if (
-				! ( await postStatus(
-					pr.headRefOid,
-					state,
-					description,
-					dryRun
-				) )
-			) {
-				budgetExhausted = true;
-				break;
-			}
+			const { state, description } =
+				baseline === null
+					? NO_BASELINE_STATUS
+					: statusFor(
+							await isAncestor( baseline, pr.headRefOid ),
+							baseline
+					  );
+			await postStatus( pr.headRefOid, state, description, dryRun );
 			written++;
 		} catch ( error ) {
 			failed++;
@@ -155,17 +157,24 @@ export async function fanout( { dryRun } ) {
 					error instanceof Error ? error.message : error
 				}`
 			);
+			if ( error instanceof Error && error.name === RATE_LIMIT_ERROR ) {
+				rateLimited = true;
+				break;
+			}
 		}
 	}
 
+	const incomplete = budgetExhausted || rateLimited;
 	console.log(
-		`Fan-out done: ${ written } written, ${ skipped } skipped, ${ failed } failed.` +
-			( budgetExhausted
-				? ' Write budget exhausted; dispatch the workflow again to continue.'
+		`Sweep done: ${ written } written, ${ skipped } skipped, ${ failed } failed.` +
+			( rateLimited ? ' Rate limited.' : '' ) +
+			( budgetExhausted ? ' Write budget exhausted.' : '' ) +
+			( incomplete
+				? ' Dispatch the workflow with sweep: true in about an hour to continue.'
 				: '' )
 	);
 	// Nonzero exit makes an incomplete or lossy sweep visible in the run list.
-	if ( failed > 0 || budgetExhausted ) {
+	if ( failed > 0 || incomplete ) {
 		process.exitCode = 1;
 	}
 }

--- a/tools/validation/required-trunk-changes/fanout.mjs
+++ b/tools/validation/required-trunk-changes/fanout.mjs
@@ -146,11 +146,6 @@ export async function fanout( { dryRun } ) {
 			skipped++;
 			continue;
 		}
-		/* With no baseline nothing is required, so only clear stale verdicts. */
-		if ( baseline === null && ! pr.status ) {
-			skipped++;
-			continue;
-		}
 		/* Probed first so an unwritable PR costs no ancestry request. */
 		if ( ! hasWriteBudget() ) {
 			budgetExhausted = true;

--- a/tools/validation/required-trunk-changes/fanout.mjs
+++ b/tools/validation/required-trunk-changes/fanout.mjs
@@ -1,14 +1,15 @@
 // @ts-check
 
 /**
- * The `fanout` subcommand: after a baseline move, flips open PRs whose
- * passing required changes status references an older baseline to failing.
+ * The `fanout` subcommand: brings every open PR's required changes status up
+ * to date with the current baseline, stamping PRs that carry no status yet.
  */
 import {
 	CONTEXT,
 	REPO,
 	graphql,
 	getBaseline,
+	isAncestor,
 	statusFor,
 	postStatus,
 } from './utils.mjs';
@@ -38,10 +39,10 @@ const PAGE_QUERY = `
 				nodes {
 					number
 					headRefOid
-					isDraft
 					commits(last: 1) {
 						nodes {
 							commit {
+								committedDate
 								status {
 									context(name: $context) {
 										state
@@ -76,12 +77,12 @@ async function listOpenPRs() {
 		} );
 		const page = data.repository.pullRequests;
 		for ( const node of page.nodes ) {
+			const commit = node.commits.nodes[ 0 ]?.commit;
 			prs.push( {
 				number: node.number,
 				headRefOid: node.headRefOid,
-				isDraft: node.isDraft,
-				status:
-					node.commits.nodes[ 0 ]?.commit?.status?.context ?? null,
+				committedDate: commit?.committedDate ?? null,
+				status: commit?.status?.context ?? null,
 			} );
 		}
 		if ( ! page.pageInfo.hasNextPage ) {
@@ -93,13 +94,43 @@ async function listOpenPRs() {
 }
 
 /**
- * Flips stale passing statuses to failing against the current baseline.
+ * Reads a commit's date, used as a cheap ancestry bound.
+ *
+ * @param {string} oid Commit SHA.
+ * @return {Promise<string>} Commit date, ISO 8601.
+ */
+async function commitDate( oid ) {
+	const [ owner, name ] = REPO.split( '/' );
+	const data = await graphql(
+		`
+			query ($owner: String!, $name: String!, $oid: GitObjectID!) {
+				repository(owner: $owner, name: $name) {
+					object(oid: $oid) {
+						... on Commit {
+							committedDate
+						}
+					}
+				}
+			}
+		`,
+		{ owner, name, oid }
+	);
+	return data.repository.object.committedDate;
+}
+
+/**
+ * Brings every open PR's status in line with the current baseline.
  *
  * @param {CommandOptions} options Command options.
  */
 export async function fanout( { dryRun } ) {
-	const baseline = /** @type {string} */ ( await getBaseline() );
+	const baseline = await getBaseline();
+	if ( baseline === null ) {
+		console.log( 'No baseline tag; nothing to fan out.' );
+		return;
+	}
 	const short = baseline.slice( 0, 7 );
+	const baselineDate = await commitDate( baseline );
 
 	const prs = await listOpenPRs();
 	console.log( `Baseline ${ baseline }; ${ prs.length } open PRs.` );
@@ -110,19 +141,20 @@ export async function fanout( { dryRun } ) {
 	let budgetExhausted = false;
 
 	for ( const pr of prs ) {
-		/* Drafts cannot merge, and ready_for_review re-stamps them. */
-		if ( pr.isDraft ) {
+		/* Both descriptions embed the baseline; anything else needs a stamp. */
+		if ( pr.status?.description?.includes( short ) ) {
 			skipped++;
 			continue;
 		}
-		const stale =
-			pr.status?.state === 'SUCCESS' &&
-			! pr.status.description?.includes( short );
-		if ( ! stale ) {
-			skipped++;
-			continue;
-		}
-		const { state, description } = statusFor( false, baseline );
+		/*
+		 * A head committed before the baseline cannot contain it, which spares
+		 * a compare call for all but the PRs updated since the baseline moved.
+		 */
+		const includesBaseline =
+			pr.committedDate && pr.committedDate < baselineDate
+				? false
+				: await isAncestor( baseline, pr.headRefOid );
+		const { state, description } = statusFor( includesBaseline, baseline );
 		try {
 			if (
 				! ( await postStatus(

--- a/tools/validation/required-trunk-changes/move-baseline.mjs
+++ b/tools/validation/required-trunk-changes/move-baseline.mjs
@@ -89,7 +89,7 @@ async function hasLabeledMergeSince( baseline, head ) {
  */
 export async function moveBaseline( options ) {
 	const { force, thenFanout, dryRun } = options;
-	const baseline = await getBaseline( false );
+	const baseline = await getBaseline();
 
 	if ( baseline === null ) {
 		if ( force !== 'true' ) {

--- a/tools/validation/required-trunk-changes/types.mjs
+++ b/tools/validation/required-trunk-changes/types.mjs
@@ -7,10 +7,9 @@
 
 /**
  * @typedef PullRequest
- * @property {number}               number        PR number.
- * @property {string}               headRefOid    Head commit SHA.
- * @property {string | null}        committedDate Head commit date, ISO 8601.
- * @property {ContextStatus | null} status        Latest required changes status, if any.
+ * @property {number}               number     PR number.
+ * @property {string}               headRefOid Head commit SHA.
+ * @property {ContextStatus | null} status     Latest required changes status, if any.
  */
 
 /**

--- a/tools/validation/required-trunk-changes/types.mjs
+++ b/tools/validation/required-trunk-changes/types.mjs
@@ -7,10 +7,10 @@
 
 /**
  * @typedef PullRequest
- * @property {number}               number     PR number.
- * @property {string}               headRefOid Head commit SHA.
- * @property {boolean}              isDraft    Whether the PR is a draft.
- * @property {ContextStatus | null} status     Latest required changes status, if any.
+ * @property {number}               number        PR number.
+ * @property {string}               headRefOid    Head commit SHA.
+ * @property {string | null}        committedDate Head commit date, ISO 8601.
+ * @property {ContextStatus | null} status        Latest required changes status, if any.
  */
 
 /**

--- a/tools/validation/required-trunk-changes/utils.mjs
+++ b/tools/validation/required-trunk-changes/utils.mjs
@@ -36,6 +36,39 @@ export function fail( message ) {
 	process.exit( 1 );
 }
 
+export const RATE_LIMIT_ERROR = 'RateLimitError';
+
+/**
+ * Detects a primary or secondary rate limit response. A secondary limit can
+ * arrive with neither header set, leaving the body as the only signal.
+ *
+ * @param {Response} response Fetch response.
+ * @param {string}   body     Response body.
+ * @return {boolean} Whether the request was rate limited.
+ */
+function isRateLimited( response, body ) {
+	if ( response.status !== 403 && response.status !== 429 ) {
+		return false;
+	}
+	return (
+		response.headers.get( 'x-ratelimit-remaining' ) === '0' ||
+		response.headers.has( 'retry-after' ) ||
+		/rate limit/i.test( body )
+	);
+}
+
+/**
+ * Builds a rate limit error the sweep can recognize and stop on.
+ *
+ * @param {string} path Request path.
+ * @return {Error} Named rate limit error.
+ */
+function rateLimitError( path ) {
+	const error = new Error( `GitHub API rate limit reached on ${ path }.` );
+	error.name = RATE_LIMIT_ERROR;
+	return error;
+}
+
 /**
  * Performs an authenticated GitHub API request.
  *
@@ -43,24 +76,6 @@ export function fail( message ) {
  * @param {{ method?: string, body?: string, headers?: Record<string, string>, allow404?: boolean }} [options] Fetch options.
  * @return {Promise<unknown>} Parsed JSON response.
  */
-export const RATE_LIMIT_ERROR = 'RateLimitError';
-
-/**
- * Detects a primary or secondary rate limit response.
- *
- * @param {Response} response Fetch response.
- * @return {boolean} Whether the request was rate limited.
- */
-function isRateLimited( response ) {
-	if ( response.status !== 403 && response.status !== 429 ) {
-		return false;
-	}
-	return (
-		response.headers.get( 'x-ratelimit-remaining' ) === '0' ||
-		response.headers.has( 'retry-after' )
-	);
-}
-
 async function api( path, options = {} ) {
 	const RETRYABLE_STATUS = [ 502, 503, 504 ];
 	const MAX_ATTEMPTS = 3;
@@ -79,23 +94,18 @@ async function api( path, options = {} ) {
 				if ( response.status === 404 && options.allow404 ) {
 					return null;
 				}
-				if ( isRateLimited( response ) ) {
-					const error = new Error(
-						`GitHub API rate limit reached on ${ path }.`
-					);
-					error.name = RATE_LIMIT_ERROR;
-					throw error;
-				}
 				if (
 					RETRYABLE_STATUS.includes( response.status ) &&
 					attempt < MAX_ATTEMPTS
 				) {
 					throw new TypeError( `retryable ${ response.status }` );
 				}
+				const body = await response.text();
+				if ( isRateLimited( response, body ) ) {
+					throw rateLimitError( path );
+				}
 				throw new Error(
-					`GitHub API ${ path } failed: ${
-						response.status
-					} ${ await response.text() }`
+					`GitHub API ${ path } failed: ${ response.status } ${ body }`
 				);
 			}
 			return response.json();
@@ -126,6 +136,14 @@ export async function graphql( query, variables ) {
 		} )
 	);
 	if ( result.errors ) {
+		/* A GraphQL rate limit is a 200 carrying a RATE_LIMITED error. */
+		if (
+			result.errors.some(
+				( /** @type {any} */ error ) => error?.type === 'RATE_LIMITED'
+			)
+		) {
+			throw rateLimitError( 'the GraphQL endpoint' );
+		}
 		throw new Error(
 			`GraphQL request failed: ${ JSON.stringify( result.errors ) }`
 		);
@@ -296,7 +314,8 @@ export function hasWriteBudget() {
  * @param {string}  state       Status state: success or failure.
  * @param {string}  description Status description embedding the baseline.
  * @param {boolean} dryRun      Log the write instead of performing it.
- * @return {Promise<boolean>} False when the per-run budget is exhausted.
+ * @return {Promise<boolean>} False when the per-run budget is exhausted. Callers
+ *                            preflight with `hasWriteBudget`; this is a backstop.
  */
 export async function postStatus( sha, state, description, dryRun ) {
 	/* Budgeted before the dry-run exit, so a dry run models one real run. */

--- a/tools/validation/required-trunk-changes/utils.mjs
+++ b/tools/validation/required-trunk-changes/utils.mjs
@@ -109,23 +109,18 @@ export async function graphql( query, variables ) {
 }
 
 /**
- * Resolves the baseline commit SHA from the tag ref via the API.
+ * Resolves the baseline commit SHA from the tag ref via the API. A missing tag
+ * is not an error: it means nothing is required of open PRs yet.
  *
- * @param {boolean} [required] Throw when the tag does not exist.
  * @return {Promise<string | null>} Baseline commit SHA, or null when absent.
  */
-export async function getBaseline( required = true ) {
+export async function getBaseline() {
 	const ref = /** @type {any} */ (
 		await api( `/repos/${ REPO }/git/ref/tags/${ TAG }`, {
 			allow404: true,
 		} )
 	);
 	if ( ! ref ) {
-		if ( required ) {
-			throw new Error(
-				`The ${ TAG } tag does not exist; seed it via workflow dispatch.`
-			);
-		}
 		return null;
 	}
 	// Peel defensively; the tag should always be lightweight.

--- a/tools/validation/required-trunk-changes/utils.mjs
+++ b/tools/validation/required-trunk-changes/utils.mjs
@@ -162,6 +162,18 @@ export async function getTrunkHead() {
 	return commit.sha;
 }
 
+/** @type {StatusPayload} */
+export const NO_BASELINE_STATUS = {
+	state: 'success',
+	description: 'No required trunk changes.',
+};
+
+/*
+ * A sweep recognizes its own verdict by the abbreviated baseline in the
+ * description; this history has dozens of colliding 7-character prefixes.
+ */
+const SHORT_SHA_LENGTH = 12;
+
 /**
  * Builds the status payload for a required changes result.
  *
@@ -170,7 +182,7 @@ export async function getTrunkHead() {
  * @return {StatusPayload} Status state and description.
  */
 export function statusFor( includesBaseline, baseline ) {
-	const short = baseline.slice( 0, 7 );
+	const short = baseline.slice( 0, SHORT_SHA_LENGTH );
 	return includesBaseline
 		? {
 				state: 'success',
@@ -252,12 +264,14 @@ let minuteWindowStart = Date.now();
  * @return {Promise<boolean>} False when the per-run budget is exhausted.
  */
 export async function postStatus( sha, state, description, dryRun ) {
-	if ( dryRun ) {
-		console.log( `[dry-run] ${ sha }: ${ state } (${ description })` );
-		return true;
-	}
+	/* Budgeted before the dry-run exit, so a dry run models one real run. */
 	if ( writesThisRun >= MAX_WRITES_PER_RUN ) {
 		return false;
+	}
+	if ( dryRun ) {
+		console.log( `[dry-run] ${ sha }: ${ state } (${ description })` );
+		writesThisRun++;
+		return true;
 	}
 	if ( writesThisMinute >= MAX_WRITES_PER_MINUTE ) {
 		const waitMs = 60_000 - ( Date.now() - minuteWindowStart );

--- a/tools/validation/required-trunk-changes/utils.mjs
+++ b/tools/validation/required-trunk-changes/utils.mjs
@@ -43,6 +43,24 @@ export function fail( message ) {
  * @param {{ method?: string, body?: string, headers?: Record<string, string>, allow404?: boolean }} [options] Fetch options.
  * @return {Promise<unknown>} Parsed JSON response.
  */
+export const RATE_LIMIT_ERROR = 'RateLimitError';
+
+/**
+ * Detects a primary or secondary rate limit response.
+ *
+ * @param {Response} response Fetch response.
+ * @return {boolean} Whether the request was rate limited.
+ */
+function isRateLimited( response ) {
+	if ( response.status !== 403 && response.status !== 429 ) {
+		return false;
+	}
+	return (
+		response.headers.get( 'x-ratelimit-remaining' ) === '0' ||
+		response.headers.has( 'retry-after' )
+	);
+}
+
 async function api( path, options = {} ) {
 	const RETRYABLE_STATUS = [ 502, 503, 504 ];
 	const MAX_ATTEMPTS = 3;
@@ -60,6 +78,13 @@ async function api( path, options = {} ) {
 			if ( ! response.ok ) {
 				if ( response.status === 404 && options.allow404 ) {
 					return null;
+				}
+				if ( isRateLimited( response ) ) {
+					const error = new Error(
+						`GitHub API rate limit reached on ${ path }.`
+					);
+					error.name = RATE_LIMIT_ERROR;
+					throw error;
 				}
 				if (
 					RETRYABLE_STATUS.includes( response.status ) &&
@@ -253,6 +278,16 @@ export async function updateTagRef( sha, create ) {
 let writesThisRun = 0;
 let writesThisMinute = 0;
 let minuteWindowStart = Date.now();
+
+/**
+ * Reports whether the run can still write, so a caller can stop before
+ * spending an ancestry request it cannot act on.
+ *
+ * @return {boolean} Whether the per-run budget has room.
+ */
+export function hasWriteBudget() {
+	return writesThisRun < MAX_WRITES_PER_RUN;
+}
 
 /**
  * Posts a commit status, honoring the per-minute and per-run write budgets.


### PR DESCRIPTION
## What?

Follow up to #82272. Fixes the sweep that runs after the required trunk baseline moves, so it actually invalidates open pull requests.

## Why?

The baseline moved for the first time when #80395 merged, and the sweep wrote 8 statuses out of 2,469 open pull requests. It only rewrote a status that already existed, so a pull request never stamped before was skipped and never learned it was outdated.

## How?

- The sweep posts the verdict each open pull request warrants, drafts included, and skips only those already carrying it.
- Skipping compares state and full description; the baseline is abbreviated to 12 characters, since `trunk` has 34 colliding 7-character prefixes.
- Ancestry always goes through the compare API. The commit-date shortcut was wrong: committer dates are not monotonic.
- A new `sweep` dispatch input retries without moving the baseline. Retrying with `move-baseline` re-invalidated earlier runs, so a long sweep never converged.
- A missing tag now means nothing is required, instead of an error that posts no status at all.
- REST and GraphQL rate limits stop the sweep with a summary.

## Testing Instructions

1. `npm run --workspace @wordpress/validation-tools required-trunk-changes -- fanout --dry-run`, with `GITHUB_REPOSITORY` and `GITHUB_TOKEN` set. It writes nothing and stops at the 400 per run budget.
2. `npm run test:unit:vitest -- tools/validation/required-trunk-changes`

## Use of AI Tools

Authored with Claude Code, reviewed across four rounds with Codex. All changes reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate options to move the baseline or sweep open pull requests without moving it.
  * Baseline updates now sweep all open pull requests, including drafts.
  * Added support for resumable sweeps and retry guidance.
* **Bug Fixes**
  * Systems without an initial baseline now receive a clear status instead of failing ancestry checks.
  * Sweeps now detect stale and missing statuses more accurately.
  * Improved handling of API rate limits and status write limits.
* **Documentation**
  * Updated contributor guidance for baseline setup, sweep behavior, retries, and status configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->