### PR TITLE
Image: keep existing image when replacement upload fails

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   Image: Keep the existing image when a replacement upload fails, instead of clearing it and falling back to a broken placeholder. ([#81720](https://github.com/WordPress/gutenberg/issues/81720))
 -   Image: Fix cropped galleries rendering images at their natural height in the editor canvas. The baseline inline `height: auto` is no longer emitted for images inside a cropped gallery, so the gallery's own cropping CSS applies ([#82318](https://github.com/WordPress/gutenberg/pull/82318)).
 -   Tabs: Activate the tab that a URL hash points into, so an anchor set on a block inside a tab panel can be reached. Anchor links followed after the page has loaded are handled too, matching the Accordion block ([#81744](https://github.com/WordPress/gutenberg/pull/81744)).
 -   Accordion Panel: Reset padding-block when panel is hidden ([#81782](https://github.com/WordPress/gutenberg/pull/81782)).

--- a/packages/block-library/src/image/edit.jsx
+++ b/packages/block-library/src/image/edit.jsx
@@ -151,6 +151,15 @@ export function ImageEdit( {
 			explicitDismiss: true,
 		} );
 		setTemporaryURL();
+
+		// Keep an existing image when a replacement upload fails. Clearing the
+		// URL would drop the block into a placeholder that still carries the
+		// previous dimensions, which looks broken for small heights.
+		if ( url && ! isBlobURL( url ) ) {
+			setAttributes( { blob: undefined } );
+			return;
+		}
+
 		setAttributes( {
 			src: undefined,
 			id: undefined,


### PR DESCRIPTION
## What
Fixes #81720

When replacing an image fails (e.g. dropping an unsupported file like SVG), the existing image is now kept instead of being cleared into a broken placeholder that still carries the previous height/width.

## How
- In `onUploadError`, if the block already has a non-blob `url`, only clear temporary/blob state
- Still show the snackbar error notice
- First-time uploads that fail continue to clear attributes as before

## Test plan
- [ ] Add an Image block, upload a normal image, set height (e.g. 48px)
- [ ] Drag and drop an unsupported file (e.g. SVG) onto the image
- [ ] Confirm the original image remains and an error snackbar appears
- [ ] Confirm the placeholder does not appear in a broken/squashed state
- [ ] Confirm a successful image replace still works
- [ ] Confirm a failed first upload on an empty image still clears to the placeholder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where failed replacement uploads in the Image block could clear the existing image and show a broken placeholder.
  - Existing images now remain visible when a replacement upload fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->