### PR TITLE
Editor: Build the View menu with radio items for the viewport options

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Breaking Changes
 
 -   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem`. A link item honors only `target="_blank"` ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
+-   `PluginPreviewMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem`. A link item honors only `target="_blank"` ([#81226](https://github.com/WordPress/gutenberg/issues/81226)).
+
+### Enhancements
+
+-   View menu: Offer the viewport to preview as radio menu items rather than a list of checkmarks, so the menu shows that only one viewport can be selected at a time, and reads differently from the "Responsive styles" checkbox below it. The menu is rebuilt with the `Menu` component of `@wordpress/ui`; it is now named "View" after its trigger rather than "View options", and "Preview in new tab" carries the menu's own link styling rather than an external-link icon ([#81226](https://github.com/WordPress/gutenberg/issues/81226)).
 
 ### Deprecations
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -165,10 +165,6 @@
 		}
 	}
 
-	// Don't hide MenuItemsChoice check icons
-	.components-menu-items-choice .components-menu-items__item-icon.components-menu-items__item-icon {
-		display: block;
-	}
 	.editor-document-tools__inserter-toggle.editor-document-tools__inserter-toggle,
 	.interface-pinned-items .components-button {
 		padding-left: $grid-unit;
@@ -268,7 +264,7 @@
 		}
 
 		& > .editor-header__toolbar .editor-document-tools__document-overview-toggle,
-		& > .editor-header__settings > .editor-preview-dropdown,
+		& > .editor-header__settings > .editor-preview-dropdown__toggle,
 		& > .editor-header__settings > .interface-pinned-items,
 		& > .editor-header__settings > .editor-zoom-out-toggle {
 			display: none;

--- a/packages/editor/src/components/more-menu/more-menu-item.tsx
+++ b/packages/editor/src/components/more-menu/more-menu-item.tsx
@@ -199,7 +199,8 @@ function UnforwardedMoreMenuItem(
 }
 
 /**
- * Renders an item of the more menu. Fills use it instead of the menu parts,
- * which only share their context within the package they are bundled into.
+ * Renders an item of the more menu, or of the View menu. Fills use it instead
+ * of the menu parts, which only share their context within the package they
+ * are bundled into.
  */
 export default forwardRef( UnforwardedMoreMenuItem );

--- a/packages/editor/src/components/post-preview-button/index.jsx
+++ b/packages/editor/src/components/post-preview-button/index.jsx
@@ -1,11 +1,11 @@
 import { renderToString } from '@wordpress/element';
-import { Button, MenuItem, Path, SVG } from '@wordpress/components';
+import { Button, Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import { store as coreStore } from '@wordpress/core-data';
-import { external } from '@wordpress/icons';
-import { VisuallyHidden } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Menu, VisuallyHidden } from '@wordpress/ui';
 import { store as editorStore } from '../../store';
 
 function buildInterstitialMarkup() {
@@ -248,10 +248,33 @@ export function PostPreviewMenuItem( { forceIsAutosaveable, onPreview } ) {
 		return null;
 	}
 
+	const { disabled, href, onClick, target } = previewProps;
+	const label = (
+		<Menu.ItemLabel>{ __( 'Preview in new tab' ) }</Menu.ItemLabel>
+	);
+
+	// A link item has no disabled state, and a link that cannot be followed is
+	// not a link. An unsaveable post falls back to a disabled plain item.
+	if ( disabled ) {
+		return <Menu.Item disabled>{ label }</Menu.Item>;
+	}
+
 	return (
-		<MenuItem icon={ external } { ...previewProps }>
-			{ __( 'Preview in new tab' ) }
-		</MenuItem>
+		<Menu.LinkItem
+			href={ href }
+			onClick={ onClick }
+			closeOnClick
+			// The click handler opens, and reuses, a preview window named after
+			// the post, which the link item drops along with any other target.
+			// `openInNewTab` would replace it with `_blank`, and append an
+			// "(opens in a new tab)" that only repeats the label.
+			render={
+				/* eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid -- Menu.LinkItem clones this template with the required href and accessible content. */
+				<a target={ target } />
+			}
+		>
+			{ label }
+		</Menu.LinkItem>
 	);
 }
 

--- a/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
+++ b/packages/editor/src/components/post-preview-button/test/index.jsdom.test.jsx
@@ -1,7 +1,23 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSelect, useDispatch } from '@wordpress/data';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Menu } from '@wordpress/ui';
 import PostPreviewButton, { PostPreviewMenuItem } from '..';
+
+function renderMenu( children ) {
+	return render(
+		<Menu.Root>
+			<Menu.Trigger>Options</Menu.Trigger>
+			<Menu.Popup>{ children }</Menu.Popup>
+		</Menu.Root>
+	);
+}
+
+async function openMenu( user ) {
+	await user.click( screen.getByRole( 'button', { name: 'Options' } ) );
+	await screen.findByRole( 'menu' );
+}
 
 jest.useRealTimers();
 
@@ -128,21 +144,39 @@ describe( 'PostPreviewButton', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should render the menu variant as a link with the shared menu item pattern.', () => {
+	it( 'should render the menu variant as a link with the shared menu item pattern.', async () => {
+		const user = userEvent.setup();
 		const url = 'https://wordpress.org';
 		mockUseSelect( {
 			getEditedPostPreviewLink: () => url,
 			isEditedPostSaveable: () => true,
 		} );
 
-		render( <PostPreviewMenuItem /> );
+		renderMenu( <PostPreviewMenuItem /> );
+		await openMenu( user );
 
 		const menuItem = screen.getByRole( 'menuitem', {
 			name: 'Preview in new tab',
 		} );
 		expect( menuItem.tagName ).toBe( 'A' );
 		expect( menuItem ).toHaveAttribute( 'href', url );
+		// The named window the click handler reuses, rather than the `_blank`
+		// of a link that opens in a new tab.
 		expect( menuItem ).toHaveAttribute( 'target', 'wp-preview-123' );
+	} );
+
+	it( 'should render the menu variant as a disabled item if post is not saveable.', async () => {
+		const user = userEvent.setup();
+		mockUseSelect( { isEditedPostSaveable: () => false } );
+
+		renderMenu( <PostPreviewMenuItem /> );
+		await openMenu( user );
+
+		const menuItem = screen.getByRole( 'menuitem', {
+			name: 'Preview in new tab',
+		} );
+		expect( menuItem.tagName ).not.toBe( 'A' );
+		expect( menuItem ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	it( 'should be accessibly disabled if post is not saveable.', () => {

--- a/packages/editor/src/components/preview-dropdown/index.jsx
+++ b/packages/editor/src/components/preview-dropdown/index.jsx
@@ -1,22 +1,19 @@
 import clsx from 'clsx';
 import { useViewportMatch } from '@wordpress/compose';
-import {
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
-	MenuItemsChoice,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
+import { desktop, mobile, tablet } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem, store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { privateApis as globalStylesEnginePrivateApis } from '@wordpress/global-styles-engine';
-import { VisuallyHidden } from '@wordpress/ui';
+// eslint-disable-next-line @wordpress/use-recommended-components
+import { Menu } from '@wordpress/ui';
 import { store as editorStore } from '../../store';
 import { PostPreviewMenuItem } from '../post-preview-button';
+import MoreMenuItem from '../more-menu/more-menu-item';
 import { sidebars } from '../sidebar/constants';
 import { VIEWPORT_STATE_BY_DEVICE_TYPE } from '../../utils/device-type';
 import { unlock } from '../../lock-unlock';
@@ -111,21 +108,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		return null;
 	}
 
-	const popoverProps = {
-		placement: 'bottom-end',
-	};
-	const toggleProps = {
-		className: 'editor-preview-dropdown__toggle',
-		iconPosition: 'right',
-		size: 'compact',
-		showTooltip: ! showIconLabels,
-		disabled,
-		accessibleWhenDisabled: disabled,
-	};
-	const menuProps = {
-		'aria-label': __( 'View options' ),
-	};
-
 	const deviceIcons = {
 		desktop,
 		mobile,
@@ -143,7 +125,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		{
 			value: 'Desktop',
 			label: __( 'Desktop' ),
-			icon: desktop,
 			info: isResponsiveEditing
 				? __( 'Style all viewports.' )
 				: __( 'Preview desktop viewport.' ),
@@ -153,7 +134,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 					{
 						value: 'Tablet',
 						label: __( 'Tablet' ),
-						icon: tablet,
 						info: isResponsiveEditing
 							? __( 'Style tablet only.' )
 							: __( 'Preview tablet viewport.' ),
@@ -165,7 +145,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 					{
 						value: 'Mobile',
 						label: __( 'Mobile' ),
-						icon: mobile,
 						info: isResponsiveEditing
 							? __( 'Style mobile only.' )
 							: __( 'Preview mobile viewport.' ),
@@ -175,94 +154,123 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	];
 
 	return (
-		<DropdownMenu
-			className={ clsx(
-				'editor-preview-dropdown',
-				`editor-preview-dropdown--${ deviceType.toLowerCase() }`,
-				{ 'is-responsive-editing': isResponsiveEditing }
-			) }
-			popoverProps={ popoverProps }
-			toggleProps={ toggleProps }
-			menuProps={ menuProps }
-			icon={ deviceIcons[ deviceType.toLowerCase() ] }
-			label={ __( 'View' ) }
-			disableOpenOnArrowDown={ disabled }
-		>
-			{ ( { onClose } ) => (
-				<>
-					<MenuGroup>
-						<MenuItemsChoice
-							choices={ choices }
-							value={ deviceType }
-							onSelect={ handleDevicePreviewChange }
-						/>
-					</MenuGroup>
-					{ isResponsiveEditingEnabled && (
-						<MenuGroup>
-							<MenuItem
-								icon={ isResponsiveEditing ? check : undefined }
-								isSelected={ isResponsiveEditing }
-								role="menuitemcheckbox"
-								onClick={ handleResponsiveEditingChange }
-								info={ __(
+		// The `disabled` prop on `Menu.Root` (rather than on the trigger) keeps
+		// the menu from opening while letting the trigger button stay focusable
+		// via its own `accessibleWhenDisabled`.
+		<Menu.Root modal={ false } disabled={ disabled }>
+			<Menu.Trigger
+				render={
+					<Button
+						className={ clsx( 'editor-preview-dropdown__toggle', {
+							'is-responsive-editing': isResponsiveEditing,
+						} ) }
+						size="compact"
+						icon={ deviceIcons[ deviceType.toLowerCase() ] }
+						label={ __( 'View' ) }
+						showTooltip={ ! showIconLabels }
+						disabled={ disabled }
+						accessibleWhenDisabled={ disabled }
+					/>
+				}
+			/>
+			{ /* The menu is named "View" after its trigger. An `aria-label` of
+			its own would be ignored, the trigger naming it takes precedence. */ }
+			<Menu.Popup
+				className="editor-preview-dropdown__popup"
+				positioner={ <Menu.Positioner align="end" /> }
+			>
+				<Menu.RadioGroup
+					value={ deviceType }
+					onValueChange={ handleDevicePreviewChange }
+				>
+					<Menu.Group>
+						{ choices.map( ( choice ) => (
+							<Menu.RadioItem
+								key={ choice.value }
+								value={ choice.value }
+							>
+								<Menu.ItemLabel>
+									{ choice.label }
+								</Menu.ItemLabel>
+								<Menu.ItemDescription>
+									{ choice.info }
+								</Menu.ItemDescription>
+							</Menu.RadioItem>
+						) ) }
+					</Menu.Group>
+				</Menu.RadioGroup>
+				{ isResponsiveEditingEnabled && (
+					<>
+						<Menu.Separator />
+						<Menu.CheckboxItem
+							checked={ isResponsiveEditing }
+							onClick={ handleResponsiveEditingChange }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Responsive styles' ) }
+							</Menu.ItemLabel>
+							<Menu.ItemDescription>
+								{ __(
 									'Style changes apply only to the selected viewport.'
 								) }
-							>
-								{ __( 'Responsive styles' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-					{ isTemplate && (
-						<MenuGroup>
-							<MenuItem
-								href={ homeUrl }
-								target="_blank"
-								icon={ external }
-								onClick={ onClose }
-							>
+							</Menu.ItemDescription>
+						</Menu.CheckboxItem>
+					</>
+				) }
+				{ isTemplate && (
+					<>
+						<Menu.Separator />
+						<Menu.LinkItem
+							href={ homeUrl }
+							openInNewTab
+							closeOnClick
+						>
+							<Menu.ItemLabel>
 								{ __( 'View site' ) }
-								<VisuallyHidden render={ <span /> }>
-									{
-										/* translators: accessibility text */
-										__( '(opens in a new tab)' )
-									}
-								</VisuallyHidden>
-							</MenuItem>
-						</MenuGroup>
-					) }
-					{ ! isTemplate && !! templateId && (
-						<MenuGroup>
-							<MenuItem
-								icon={ ! isTemplateHidden ? check : undefined }
-								isSelected={ ! isTemplateHidden }
-								role="menuitemcheckbox"
-								onClick={ () => {
-									const newRenderingMode = isTemplateHidden
-										? 'template-locked'
-										: 'post-only';
-									setRenderingMode( newRenderingMode );
-									setDefaultRenderingMode( newRenderingMode );
-									resetZoomLevel();
-								} }
-							>
+							</Menu.ItemLabel>
+						</Menu.LinkItem>
+					</>
+				) }
+				{ ! isTemplate && !! templateId && (
+					<>
+						<Menu.Separator />
+						<Menu.CheckboxItem
+							checked={ ! isTemplateHidden }
+							onClick={ () => {
+								const newRenderingMode = isTemplateHidden
+									? 'template-locked'
+									: 'post-only';
+								setRenderingMode( newRenderingMode );
+								setDefaultRenderingMode( newRenderingMode );
+								resetZoomLevel();
+							} }
+						>
+							<Menu.ItemLabel>
 								{ __( 'Show template' ) }
-							</MenuItem>
-						</MenuGroup>
+							</Menu.ItemLabel>
+						</Menu.CheckboxItem>
+					</>
+				) }
+				{ isViewable && (
+					<>
+						<Menu.Separator />
+						<PostPreviewMenuItem
+							forceIsAutosaveable={ forceIsAutosaveable }
+						/>
+					</>
+				) }
+				<ActionItem.Slot
+					name="core/plugin-preview-menu"
+					fillProps={ { as: MoreMenuItem } }
+				>
+					{ ( items ) => (
+						<>
+							<Menu.Separator />
+							<Menu.Group>{ items }</Menu.Group>
+						</>
 					) }
-					{ isViewable && (
-						<MenuGroup>
-							<PostPreviewMenuItem
-								forceIsAutosaveable={ forceIsAutosaveable }
-								onPreview={ onClose }
-							/>
-						</MenuGroup>
-					) }
-					<ActionItem.Slot
-						name="core/plugin-preview-menu"
-						fillProps={ { onClick: onClose } }
-					/>
-				</>
-			) }
-		</DropdownMenu>
+				</ActionItem.Slot>
+			</Menu.Popup>
+		</Menu.Root>
 	);
 }

--- a/packages/editor/src/components/preview-dropdown/style.scss
+++ b/packages/editor/src/components/preview-dropdown/style.scss
@@ -1,4 +1,4 @@
-.editor-preview-dropdown .editor-preview-dropdown__toggle.has-icon.has-text {
+.editor-preview-dropdown__toggle.has-icon.has-text {
 	padding-right: 4px;
 	padding-left: 6px;
 }
@@ -7,6 +7,12 @@
 // synced-pattern color for a consistent "special state" cue. Coloring the
 // button (rather than just the icon) also tints the "View" text label when the
 // "Show button text labels" preference is on; the icon follows via currentColor.
-.editor-preview-dropdown.is-responsive-editing .editor-preview-dropdown__toggle {
+.editor-preview-dropdown__toggle.is-responsive-editing {
 	color: var(--wp-block-synced-color);
+}
+
+.editor-preview-dropdown__popup {
+	// Narrower than the default of the menu, closer to the previous menu, which
+	// sized itself to its longest label.
+	--wp-ui-menu-max-width: var(--wpds-dimension-surface-width-sm);
 }


### PR DESCRIPTION
## What?

See #81226

Rebuilds the editor's View menu with the `Menu` component of `@wordpress/ui`, and offers the viewport options as radio menu items instead of a list of checkmarked items.

cc @ciampo, who [suggested radio menu items](https://github.com/WordPress/gutenberg/issues/81226#issuecomment-5370047630) and asked to be pinged on a PR trying the new component out.

## Why?

As reported in #81226, turning responsive editing on and choosing which viewport to look at both lived in this one menu as checkmarked items. The checklist implied being able to be in multiple modes at once and the presentation also implied several viewports could be selected at once, when only one can:

> With a checklist, it also feels like I should be able to select multiple viewports at one, but only one is allowed at a time.

@ramonjd [asked](https://github.com/WordPress/gutenberg/issues/81226#issuecomment-5365895236) whether a control that enforces single selection could be used, and @ciampo answered that this is what radio menu items in a menu are for. @talldan [noted](https://github.com/WordPress/gutenberg/issues/81226#issuecomment-5390584254) the menu already used `MenuItemsChoice`, which enforces single selection but renders it as check marks, and asked whether there was a plan to switch to the new component. 

## How?

`PreviewDropdown` moves from `DropdownMenu` + `MenuItemsChoice` to `Menu.Root` / `Menu.Trigger` / `Menu.Popup`, following the more menu (#81564) and the mode switcher:

- **Viewports** become `Menu.RadioGroup` + `Menu.RadioItem`, so single selection is shown by radio dots.
- **Responsive styles** and **Show template** stay checkmarks as `Menu.CheckboxItem`, which now read as a different kind of thing from the viewport group.
- Groups become `Menu.Separator`, and **View site** becomes a `Menu.LinkItem`.

The item defaults happen to match the old behaviour exactly: Base UI's radio and checkbox items keep the menu open on click, while plain and link items close it, which is what the old `onClose` wiring did by hand.

A few things worth reviewer attention:

- **`PostPreviewMenuItem` is migrated too.** A legacy `MenuItem` inside a Base UI popup renders a `menuitem` the menu's composite doesn't know about, so it isn't keyboard reachable. It keeps the named `wp-preview-{id}` window its click handler reuses (via a `render` anchor, as in `packages/ui/src/breadcrumb/link-item.tsx`), and falls back to a disabled `Menu.Item` for an unsaveable post, since `Menu.LinkItem` has no disabled state.
- **It deliberately does not use `openInNewTab`.** That appends "(opens in a new tab)" to the accessible name, which only repeats a label already reading "Preview in new tab" — and it would replace the named window with `_blank`. **View site** does use it, matching the `VisuallyHidden` text it had before.
- **The menu is now named "View" after its trigger**, not "View options". Base UI sets `aria-labelledby` on the popup pointing at the trigger, which takes precedence over an `aria-label` of its own. The more menu behaves the same way.
- **Plugin fills** route through the item the more menu already shares with them, which the `as` deprecation of `PluginPreviewMenuItem` (#82319) anticipated.
- **`Menu.Root` renders no element**, so the wrapper the toggle was styled through is gone; its rules move onto the button, including the distraction-free hide rule in `header/style.scss`.

Also removed, all dead: the `editor-preview-dropdown--{device}` class, the `icon` on each viewport choice (`MenuItemsChoice` discarded it in favour of the check mark), and the header rule keeping `MenuItemsChoice` check icons visible, whose last use in the header was this menu.

## Testing Instructions

1. Open a post or page in the editor.
2. Open the View menu in the header.
3. Confirm Desktop / Tablet / Mobile are radio buttons, with exactly one selected, and that picking one switches the canvas and leaves the menu open.
4. Confirm Responsive styles below them is still a check mark, so the two groups read differently.
5. Toggle Responsive styles on. The menu stays open, the toggle button picks up the responsive tint, and each viewport's description changes from "Preview … viewport." to "Style … only.".
6. Confirm Preview in new tab opens a preview, and that previewing again reuses the same tab.
7. On a page with a template, confirm Show template still toggles. When editing a template instead, confirm View site opens the front end in a new tab.
8. Turn on **Preferences → Appearance → Show button text labels** and confirm the toggle still shows its "View" label.
9. Turn on Distraction free and confirm the toggle is hidden.
10. With a plugin registering a `PluginPreviewMenuItem`, confirm its item still appears at the bottom of the menu and closes the menu when clicked.

### Testing Instructions for Keyboard

1. Tab to the View button in the header and press <kbd>Enter</kbd> (or <kbd>Space</kbd>, or <kbd>↓</kbd>).
2. Confirm the menu opens with the **currently selected viewport highlighted**.
3. Use <kbd>↑</kbd> / <kbd>↓</kbd> to move through every item, including **Responsive styles**, **Preview in new tab**, and any plugin items — nothing should be skipped.
4. Press <kbd>Enter</kbd> on a viewport and confirm it is selected and the menu stays open, with the radio state announced.
5. Press <kbd>Enter</kbd> on Responsive styles and confirm the checked state is announced and the menu stays open.
6. Press <kbd>Esc</kbd> and confirm the menu closes and focus returns to the View button.
7. With a screen reader, confirm the menu is announced as a menu named "View", the viewport items as radio items, and Responsive styles as a checkbox item.

## Visuals

Before:
<img width="310" height="246" alt="Screenshot 2026-09-02 at 2 00 31 PM" src="https://github.com/user-attachments/assets/d626a735-1c2e-4ab0-bbdd-aed280392b64" />

After:
<img width="398" height="330" alt="Screenshot 2026-09-02 at 1 59 09 PM" src="https://github.com/user-attachments/assets/b0d2a925-1c32-47f0-8377-7102a7ef2795" />


## Use of AI Tools

This pull request was authored with Claude Code (Claude Opus 5), which wrote the implementation, the tests, this description, and the changelog entry, working from the existing `more-menu` and `mode-switcher` migrations as precedent. I directed the work and take responsibility for it.
