### PR TITLE
Fix: Responsive horizontal orientation does not override a vertical layout.

### DIFF
--- a/backport-changelog/7.2/13370.md
+++ b/backport-changelog/7.2/13370.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13370
+
+* https://github.com/WordPress/gutenberg/pull/82364

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -794,7 +794,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * override that switches a vertical base layout to horizontal has to declare
 			 * it explicitly, otherwise the base `flex-direction: column` keeps applying.
 			 */
-			if ( $should_output_flex_orientation && null !== $viewport_overrides ) {
+			if ( null !== $viewport_overrides && $has_viewport_property_override( 'orientation' ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'flex-direction' => 'row' ),

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -790,6 +790,17 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		if ( 'horizontal' === $layout_orientation ) {
 			/*
+			 * `row` is the flex default, so the base layout never declares it. A viewport
+			 * override that switches a vertical base layout to horizontal has to declare
+			 * it explicitly, otherwise the base `flex-direction: column` keeps applying.
+			 */
+			if ( $should_output_flex_orientation && null !== $viewport_overrides ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'flex-direction' => 'row' ),
+				);
+			}
+			/*
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Flex layout: Output `flex-direction: row` when a viewport override switches a vertical layout to horizontal, so the base `flex-direction: column` no longer keeps applying on that viewport ([#82364](https://github.com/WordPress/gutenberg/pull/82364)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   Block List Appender: Show the appender button as a drop target when dragging a block over an empty container such as a Column, restoring the reveal that the `visibility`-to-`opacity` migration left behind ([#77852](https://github.com/WordPress/gutenberg/pull/77852)).
 -   Inserter: Keep the hovered block preview inside the viewport, so a tall preview in a short window is no longer clipped ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).

--- a/packages/block-editor/src/layouts/flex.jsx
+++ b/packages/block-editor/src/layouts/flex.jsx
@@ -355,7 +355,7 @@ export default {
 			// A viewport override that switches a vertical base layout to
 			// horizontal has to declare it explicitly, otherwise the base
 			// `flex-direction: column` keeps applying.
-			if ( shouldOutputFlexOrientation && hasViewportOverrides ) {
+			if ( hasViewportOverride( 'orientation' ) ) {
 				rules.push( 'flex-direction: row' );
 			}
 			if ( shouldOutputFlexAlignment && verticalAlignment ) {

--- a/packages/block-editor/src/layouts/flex.jsx
+++ b/packages/block-editor/src/layouts/flex.jsx
@@ -351,6 +351,13 @@ export default {
 		}
 
 		if ( orientation === 'horizontal' ) {
+			// `row` is the flex default, so the base layout never declares it.
+			// A viewport override that switches a vertical base layout to
+			// horizontal has to declare it explicitly, otherwise the base
+			// `flex-direction: column` keeps applying.
+			if ( shouldOutputFlexOrientation && hasViewportOverrides ) {
+				rules.push( 'flex-direction: row' );
+			}
 			if ( shouldOutputFlexAlignment && verticalAlignment ) {
 				rules.push( `align-items: ${ verticalAlignment }` );
 			}

--- a/packages/block-editor/src/layouts/test/flex.jsdom.test.jsx
+++ b/packages/block-editor/src/layouts/test/flex.jsdom.test.jsx
@@ -34,6 +34,51 @@ describe( 'getLayoutStyle', () => {
 
 		expect( result ).toBe( expected );
 	} );
+
+	it( 'should output flex-direction row when a viewport override switches a vertical layout to horizontal', () => {
+		const result = flex.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {
+				type: 'flex',
+				orientation: 'vertical',
+				flexWrap: 'nowrap',
+				justifyContent: 'center',
+			},
+			viewportOverrides: {
+				orientation: 'horizontal',
+				justifyContent: 'left',
+			},
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: false,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).toBe(
+			'.my-container {\n\t\t\t\tflex-direction: row; justify-content: flex-start;\n\t\t\t}'
+		);
+	} );
+
+	it( 'should keep flex-direction implicit when a viewport override does not change a horizontal orientation', () => {
+		const result = flex.getLayoutStyle( {
+			selector: '.my-container',
+			layout: {
+				type: 'flex',
+				orientation: 'horizontal',
+				justifyContent: 'left',
+			},
+			viewportOverrides: {
+				justifyContent: 'right',
+			},
+			style: {},
+			blockName: 'test-block',
+			hasBlockGapSupport: false,
+			layoutDefinitions: undefined,
+		} );
+
+		expect( result ).not.toContain( 'flex-direction' );
+		expect( result ).toContain( 'justify-content: flex-end' );
+	} );
 } );
 
 describe( 'FlexLayoutInspectorControls', () => {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -459,6 +459,40 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;flex-direction:column;align-items:flex-start;justify-content:flex-end;}',
 			),
+			'vertical flex layout switched to horizontal in a viewport' => array(
+				'args'            => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
+						'type'           => 'flex',
+						'orientation'    => 'vertical',
+						'flexWrap'       => 'nowrap',
+						'justifyContent' => 'center',
+					),
+					'options'  => array(
+						'viewport_overrides' => array(
+							'orientation'    => 'horizontal',
+							'justifyContent' => 'left',
+						),
+					),
+				),
+				'expected_output' => '.wp-layout{flex-direction:row;justify-content:flex-start;}',
+			),
+			'horizontal flex layout keeps flex-direction implicit in a viewport' => array(
+				'args'            => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
+						'type'           => 'flex',
+						'orientation'    => 'horizontal',
+						'justifyContent' => 'left',
+					),
+					'options'  => array(
+						'viewport_overrides' => array(
+							'justifyContent' => 'right',
+						),
+					),
+				),
+				'expected_output' => '.wp-layout{justify-content:flex-end;}',
+			),
 			'default grid layout'                          => array(
 				'args'            => array(
 					'selector' => '.wp-layout',


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/82266.

Currently, when a vertical (Stack) layout is set to horizontal on the tablet or mobile viewports, the block stays vertical. The viewport rule only outputs the justification and the base `flex-direction: column` keeps applying. This PR fixes the issue by outputting `flex-direction: row` when a viewport override switches the orientation to horizontal, on the frontend and in the editor.

## Before
<img width="420" alt="Two groups stacked vertically on a mobile viewport" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/responsive-flex-orientation-override/frontend-before.png" />

## After
<img width="420" alt="Two groups side by side on a mobile viewport" src="https://raw.githubusercontent.com/jorgefilipecosta/gutenberg/assets/responsive-flex-orientation-override/frontend-after.png" />

## Testing Instructions
Create a new page with the following markup (pasted on the code editor).
```
<!-- wp:group {"style":{"@tablet":{"layout":{"orientation":"horizontal","justifyContent":"left"}},"@mobile":{"layout":{"orientation":"horizontal","justifyContent":"left"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:group {"style":{"@tablet":{"layout":{"selfStretch":"fit","flexSize":null},"dimensions":{"minWidth":"50%"}},"@mobile":{"layout":{"selfStretch":"fit","flexSize":null},"dimensions":{"minWidth":"50%"}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"layout":{"selfStretch":"fit","flexSize":null},"dimensions":{"minWidth":"100%"}},"backgroundColor":"accent-2","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-accent-2-background-color has-background" style="min-width:100%;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"style":{"typography":{"textAlign":"center"}}} -->
<h3 class="wp-block-heading has-text-align-center">Content ONE</h3>
<!-- /wp:heading --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"@tablet":{"layout":{"selfStretch":"fit","flexSize":null},"dimensions":{"minWidth":"50%"}},"@mobile":{"layout":{"selfStretch":"fit","flexSize":null},"dimensions":{"minWidth":"50%"}},"dimensions":{"minWidth":"100%"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"accent-1","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-accent-1-background-color has-background" style="min-width:100%;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"style":{"typography":{"textAlign":"center"}}} -->
<h3 class="wp-block-heading has-text-align-center">Content TWO</h3>
<!-- /wp:heading --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
Open the page on the frontend, resize the browser to a mobile width and verify the two groups are displayed side by side.
Open the page in the editor, preview it on mobile and verify the same.

AI usage disclosure: fix and description drafted with AI assistance and reviewed by me.
