### PR TITLE
Dropdown: Close popover when focus moves into an unrelated dialog

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+-   `Dropdown`: Close popover when focus moves to an unrelated dialog outside the dropdown ([#82371](https://github.com/WordPress/gutenberg/pull/82371)).
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `BorderBoxControl`: Give the group of border controls an accessible name from the `label` prop, by rendering the wrapper as a `role="group"` associated with the label through `aria-labelledby`. A consumer-supplied `aria-labelledby` or `aria-label` takes precedence over `label` and names the group instead; the wrapper is only given the `group` role when one of the three provides a name. A hidden label (`hideLabelFromVision`) now renders as a `span` rather than a `label` element, matching the visible one ([#82279](https://github.com/WordPress/gutenberg/pull/82279)).

--- a/packages/components/src/dropdown/index.tsx
+++ b/packages/components/src/dropdown/index.tsx
@@ -8,6 +8,17 @@ import { useControlledValue } from '../utils/hooks';
 import Popover from '../popover';
 import type { DropdownProps, DropdownInternalContext } from './types';
 
+const OVERLAY_SELECTOR = [
+	'dialog',
+	'[role~="dialog" i]',
+	'[role~="alertdialog" i]',
+	'[aria-modal="true" i]',
+	'[popover]',
+].join( ',' );
+
+const getActiveOverlay = ( ownerDocument: Document ) =>
+	ownerDocument.activeElement?.closest( OVERLAY_SELECTOR ) ?? null;
+
 const UnconnectedDropdown = (
 	props: DropdownProps,
 	forwardedRef: ForwardedRef< any >
@@ -51,6 +62,8 @@ const UnconnectedDropdown = (
 	const [ fallbackPopoverAnchor, setFallbackPopoverAnchor ] =
 		useState< HTMLDivElement | null >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
+	const overlayOpenedByActivationRef = useRef< Element | null >( null );
+	const activationSequenceRef = useRef( 0 );
 
 	const [ isOpen, setIsOpen ] = useControlledValue( {
 		defaultValue: defaultOpen,
@@ -58,11 +71,65 @@ const UnconnectedDropdown = (
 		onChange: onToggle,
 	} );
 
+	function recordActivationInside(
+		event: React.SyntheticEvent< HTMLDivElement >
+	) {
+		if ( ! containerRef.current ) {
+			return;
+		}
+
+		const containerDocument = containerRef.current.ownerDocument;
+		const eventDocument = ( event.target as Node | null )?.ownerDocument;
+		const ownerDocuments = [ containerDocument ];
+		if ( eventDocument && eventDocument !== containerDocument ) {
+			ownerDocuments.push( eventDocument );
+		}
+		const overlaysBefore = ownerDocuments.map( getActiveOverlay );
+
+		const sequence = ++activationSequenceRef.current;
+		const recordOpenedOverlay = () => {
+			if ( sequence !== activationSequenceRef.current ) {
+				return false;
+			}
+
+			for ( const [ index, ownerDocument ] of ownerDocuments.entries() ) {
+				const overlay = getActiveOverlay( ownerDocument );
+				if ( overlay && overlay !== overlaysBefore[ index ] ) {
+					overlayOpenedByActivationRef.current = overlay;
+					return true;
+				}
+			}
+
+			return false;
+		};
+
+		// An overlay can move focus in a timer. Check once after the activation
+		// and once more after a deferred focus handoff. An unrelated overlay
+		// focused during this bounded window is indistinguishable and treated as
+		// related.
+		containerDocument.defaultView?.setTimeout( () => {
+			if ( ! recordOpenedOverlay() ) {
+				containerDocument.defaultView?.setTimeout(
+					recordOpenedOverlay,
+					0
+				);
+			}
+		}, 0 );
+	}
+
+	function recordKeyboardActivationInside(
+		event: React.KeyboardEvent< HTMLDivElement >
+	) {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			recordActivationInside( event );
+		}
+	}
+
 	/**
 	 * Closes the popover when focus leaves it unless the toggle was pressed or
-	 * focus has moved to a separate dialog. The former is to let the toggle
-	 * handle closing the popover and the latter is to preserve presence in
-	 * case a dialog has opened, allowing focus to return when it's dismissed.
+	 * focus has moved to a dialog-like overlay opened from the dropdown. The
+	 * former lets the toggle handle closing the popover. The latter preserves
+	 * presence so focus can return when the overlay is dismissed.
 	 */
 	function closeIfFocusOutside() {
 		if ( ! containerRef.current ) {
@@ -70,11 +137,19 @@ const UnconnectedDropdown = (
 		}
 
 		const { ownerDocument } = containerRef.current;
-		const dialog =
-			ownerDocument?.activeElement?.closest( '[role="dialog"]' );
+		const activeElement = ownerDocument?.activeElement;
+		const overlay = activeElement?.closest( OVERLAY_SELECTOR );
+		const isParentOverlay = overlay?.contains( containerRef.current );
+		const overlayOpenedByActivation = overlayOpenedByActivationRef.current;
+		overlayOpenedByActivationRef.current = null;
+		activationSequenceRef.current += 1;
+		const relatedOverlayIsActive =
+			!! overlayOpenedByActivation &&
+			getActiveOverlay( overlayOpenedByActivation.ownerDocument ) ===
+				overlayOpenedByActivation;
 		if (
-			! containerRef.current.contains( ownerDocument.activeElement ) &&
-			( ! dialog || dialog.contains( containerRef.current ) )
+			! containerRef.current.contains( activeElement ) &&
+			( isParentOverlay || ! relatedOverlayIsActive )
 		) {
 			close();
 		}
@@ -101,6 +176,9 @@ const UnconnectedDropdown = (
 	return (
 		<div
 			className={ className }
+			onClickCapture={ recordActivationInside }
+			onPointerDownCapture={ recordActivationInside }
+			onKeyDownCapture={ recordKeyboardActivationInside }
 			ref={ useMergeRefs( [
 				containerRef,
 				forwardedRef,

--- a/packages/components/src/dropdown/test/index.jsdom.test.tsx
+++ b/packages/components/src/dropdown/test/index.jsdom.test.tsx
@@ -1,8 +1,187 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createPortal, useState } from '@wordpress/element';
 import Dropdown from '..';
+import Modal from '../../modal';
 import { DropdownContentWrapper } from '../dropdown-content-wrapper';
 import styles from '../style.module.scss';
+
+const DropdownWithModal = ( {
+	dialogRole = 'dialog',
+	dialogTriggerLocation,
+	onClose,
+	stopDialogTriggerPropagation = false,
+}: {
+	dialogRole?: 'dialog' | 'alertdialog';
+	dialogTriggerLocation: 'inside' | 'outside';
+	onClose?: () => void;
+	stopDialogTriggerPropagation?: boolean;
+} ) => {
+	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
+	const dialogTrigger = (
+		<button
+			onClick={ ( event ) => {
+				if ( stopDialogTriggerPropagation ) {
+					event.stopPropagation();
+				}
+				setIsDialogOpen( true );
+			} }
+		>
+			Open dialog
+		</button>
+	);
+
+	return (
+		<>
+			<Dropdown
+				onClose={ onClose }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<button aria-expanded={ isOpen } onClick={ onToggle }>
+						Toggle
+					</button>
+				) }
+				renderContent={ () => (
+					<>
+						<button>Dropdown item</button>
+						{ dialogTriggerLocation === 'inside' && dialogTrigger }
+					</>
+				) }
+			/>
+			{ dialogTriggerLocation === 'outside' && dialogTrigger }
+			{ isDialogOpen && (
+				<Modal
+					role={ dialogRole }
+					title="Dialog"
+					onRequestClose={ () => setIsDialogOpen( false ) }
+				>
+					<p>Dialog content</p>
+				</Modal>
+			) }
+		</>
+	);
+};
+
+const DropdownWithSemanticOverlay = ( {
+	overlayType,
+	onClose,
+}: {
+	overlayType: 'native-dialog' | 'native-popover' | 'aria-modal';
+	onClose: () => void;
+} ) => {
+	const [ isOverlayOpen, setIsOverlayOpen ] = useState( false );
+	const overlayContent = (
+		<button ref={ ( element ) => element?.focus() }>Overlay item</button>
+	);
+
+	return (
+		<>
+			<Dropdown
+				onClose={ onClose }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<button aria-expanded={ isOpen } onClick={ onToggle }>
+						Toggle
+					</button>
+				) }
+				renderContent={ () => (
+					<>
+						<button>Dropdown item</button>
+						<button onClick={ () => setIsOverlayOpen( true ) }>
+							Open overlay
+						</button>
+					</>
+				) }
+			/>
+			{ isOverlayOpen && overlayType === 'native-dialog' && (
+				<dialog open>{ overlayContent }</dialog>
+			) }
+			{ isOverlayOpen && overlayType === 'native-popover' && (
+				<div
+					ref={ ( element ) =>
+						element?.setAttribute( 'popover', 'manual' )
+					}
+				>
+					{ overlayContent }
+				</div>
+			) }
+			{ isOverlayOpen && overlayType === 'aria-modal' && (
+				<div aria-modal="true">{ overlayContent }</div>
+			) }
+		</>
+	);
+};
+
+const DropdownWithProgrammaticModal = ( {
+	isDialogOpen,
+	onClose,
+}: {
+	isDialogOpen: boolean;
+	onClose: () => void;
+} ) => (
+	<>
+		<Dropdown
+			onClose={ onClose }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<button aria-expanded={ isOpen } onClick={ onToggle }>
+					Toggle
+				</button>
+			) }
+			renderContent={ () => <button>Dropdown item</button> }
+		/>
+		{ isDialogOpen && (
+			<Modal
+				title="Programmatic dialog"
+				onRequestClose={ () => undefined }
+			>
+				<p>Programmatic dialog content</p>
+			</Modal>
+		) }
+	</>
+);
+
+const DropdownWithPortaledModalTrigger = ( {
+	portalContainer,
+	onClose,
+}: {
+	portalContainer: Element;
+	onClose: () => void;
+} ) => {
+	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
+
+	return (
+		<>
+			<Dropdown
+				onClose={ onClose }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<button aria-expanded={ isOpen } onClick={ onToggle }>
+						Toggle
+					</button>
+				) }
+				renderContent={ () =>
+					createPortal(
+						<button onClick={ () => setIsDialogOpen( true ) }>
+							Open portaled dialog
+						</button>,
+						portalContainer
+					)
+				}
+			/>
+			{ isDialogOpen && (
+				<Modal
+					title="Portaled dialog"
+					onRequestClose={ () => setIsDialogOpen( false ) }
+				>
+					<p>Portaled dialog content</p>
+				</Modal>
+			) }
+		</>
+	);
+};
 
 describe( 'DropdownContentWrapper', () => {
 	it( 'should apply the small padding class by default', () => {
@@ -122,5 +301,316 @@ describe( 'Dropdown', () => {
 		await user.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( screen.queryByText( 'test' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should close when a dialog opens after an outside activation', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render(
+			<DropdownWithModal
+				dialogTriggerLocation="outside"
+				onClose={ onClose }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		await screen.findByRole( 'button', { name: 'Dropdown item' } );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Open dialog' } )
+		);
+
+		await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.queryByText( 'Dropdown item' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should stay open and restore focus when its dialog closes', async () => {
+		const user = userEvent.setup();
+		render( <DropdownWithModal dialogTriggerLocation="inside" /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dialogTrigger = await screen.findByRole( 'button', {
+			name: 'Open dialog',
+		} );
+		await user.click( dialogTrigger );
+
+		await screen.findByRole( 'dialog' );
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await waitFor( () =>
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+		);
+		expect( dialogTrigger ).toHaveFocus();
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should stay open and restore focus when its alert dialog closes', async () => {
+		const user = userEvent.setup();
+		render(
+			<DropdownWithModal
+				dialogRole="alertdialog"
+				dialogTriggerLocation="inside"
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dialogTrigger = await screen.findByRole( 'button', {
+			name: 'Open dialog',
+		} );
+		await user.click( dialogTrigger );
+
+		await screen.findByRole( 'alertdialog' );
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'alertdialog' )
+			).not.toBeInTheDocument()
+		);
+		expect( dialogTrigger ).toHaveFocus();
+		expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+	} );
+
+	it.each( [
+		[ 'native dialog', 'native-dialog' ],
+		[ 'native popover', 'native-popover' ],
+		[ 'ARIA modal', 'aria-modal' ],
+	] as const )(
+		'should stay open when its %s receives focus',
+		async ( _label, overlayType ) => {
+			const user = userEvent.setup();
+			const onClose = jest.fn();
+			render(
+				<DropdownWithSemanticOverlay
+					overlayType={ overlayType }
+					onClose={ onClose }
+				/>
+			);
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle' } )
+			);
+			await user.click(
+				await screen.findByRole( 'button', {
+					name: 'Open overlay',
+				} )
+			);
+
+			await screen.findByRole( 'button', { name: 'Overlay item' } );
+			await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+			expect( screen.getByText( 'Dropdown item' ) ).toBeInTheDocument();
+		}
+	);
+
+	it( 'should stay open when a propagation-stopping trigger opens its dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render(
+			<DropdownWithModal
+				dialogTriggerLocation="inside"
+				onClose={ onClose }
+				stopDialogTriggerPropagation
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dialogTrigger = await screen.findByRole( 'button', {
+			name: 'Open dialog',
+		} );
+		await user.click( dialogTrigger );
+
+		await screen.findByRole( 'dialog', { name: 'Dialog' } );
+		await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+		expect(
+			screen.getByRole( 'button', { name: 'Toggle', hidden: true } )
+		).toHaveAttribute( 'aria-expanded', 'true' );
+	} );
+
+	it( 'should stay open when a portaled trigger opens its dialog from another document', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		let unmount: () => void = () => undefined;
+
+		try {
+			( { unmount } = render(
+				<DropdownWithPortaledModalTrigger
+					portalContainer={ iframe.contentDocument!.body }
+					onClose={ onClose }
+				/>
+			) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle' } )
+			);
+			await user.click(
+				within( iframe.contentDocument!.body ).getByRole( 'button', {
+					name: 'Open portaled dialog',
+				} )
+			);
+
+			await screen.findByRole( 'dialog', { name: 'Portaled dialog' } );
+			await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Toggle',
+					hidden: true,
+				} )
+			).toHaveAttribute( 'aria-expanded', 'true' );
+		} finally {
+			unmount();
+			iframe.remove();
+		}
+	} );
+
+	it( 'should stay open when an iframe dropdown opens a dialog in the parent document', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const mountNode = iframe.contentDocument!.createElement( 'div' );
+		iframe.contentDocument!.body.appendChild( mountNode );
+		let unmount: () => void = () => undefined;
+
+		try {
+			( { unmount } = render(
+				<DropdownWithModal
+					dialogTriggerLocation="inside"
+					onClose={ onClose }
+				/>,
+				{ container: mountNode }
+			) );
+			await user.click(
+				within( iframe.contentDocument!.body ).getByRole( 'button', {
+					name: 'Toggle',
+				} )
+			);
+			await user.click(
+				await screen.findByRole( 'button', {
+					name: 'Open dialog',
+				} )
+			);
+
+			await screen.findByRole( 'dialog', { name: 'Dialog' } );
+			await waitFor( () => expect( onClose ).not.toHaveBeenCalled() );
+			expect(
+				within( iframe.contentDocument!.body ).getByRole( 'button', {
+					name: 'Toggle',
+					hidden: true,
+				} )
+			).toHaveAttribute( 'aria-expanded', 'true' );
+		} finally {
+			unmount();
+			iframe.remove();
+		}
+	} );
+
+	it( 'should not reuse a stale internal activation for an unrelated dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const { rerender } = render(
+			<DropdownWithProgrammaticModal
+				isDialogOpen={ false }
+				onClose={ onClose }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		await user.click(
+			await screen.findByRole( 'button', { name: 'Dropdown item' } )
+		);
+		rerender(
+			<DropdownWithProgrammaticModal isDialogOpen onClose={ onClose } />
+		);
+
+		await screen.findByRole( 'dialog', { name: 'Programmatic dialog' } );
+		await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.queryByText( 'Dropdown item' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should close when an iframe activation opens an unrelated dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const { rerender } = render(
+			<DropdownWithProgrammaticModal
+				isDialogOpen={ false }
+				onClose={ onClose }
+			/>
+		);
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+
+		try {
+			await user.click(
+				screen.getByRole( 'button', { name: 'Toggle' } )
+			);
+			await user.click(
+				await screen.findByRole( 'button', { name: 'Dropdown item' } )
+			);
+
+			const iframeButton =
+				iframe.contentDocument!.createElement( 'button' );
+			iframeButton.addEventListener( 'click', () => {
+				rerender(
+					<DropdownWithProgrammaticModal
+						isDialogOpen
+						onClose={ onClose }
+					/>
+				);
+			} );
+			iframe.contentDocument!.body.appendChild( iframeButton );
+			fireEvent.click( iframeButton );
+
+			await screen.findByRole( 'dialog', {
+				name: 'Programmatic dialog',
+			} );
+			await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+			expect(
+				screen.queryByText( 'Dropdown item' )
+			).not.toBeInTheDocument();
+		} finally {
+			iframe.remove();
+		}
+	} );
+
+	it( 'should close when focus moves into an unrelated dialog', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render(
+			<>
+				<div role="dialog" aria-label="Existing dialog">
+					<button>Existing dialog item</button>
+				</div>
+				<Dropdown
+					onClose={ onClose }
+					popoverProps={ { constrainTabbing: false } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<button aria-expanded={ isOpen } onClick={ onToggle }>
+							Toggle
+						</button>
+					) }
+					renderContent={ () => <button>Dropdown item</button> }
+				/>
+			</>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Toggle' } ) );
+		const dropdownItem = await screen.findByRole( 'button', {
+			name: 'Dropdown item',
+		} );
+		dropdownItem.focus();
+		expect( dropdownItem ).toHaveFocus();
+		fireEvent.keyDown( dropdownItem, { key: 'Tab' } );
+		const existingDialogItem = screen.getByRole( 'button', {
+			name: 'Existing dialog item',
+		} );
+		existingDialogItem.focus();
+
+		expect( existingDialogItem ).toHaveFocus();
+		await waitFor( () => expect( onClose ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.queryByText( 'Dropdown item' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes #82124
Continues and replaces #82170 (previously closed for inactivity).

## Description

Closes a `Dropdown` when focus moves into an unrelated dialog or overlay outside the dropdown. Dialogs and overlays opened from inside the dropdown still preserve presence so focus can return after the dialog is dismissed.

### Changes & Review Follow-ups (from #82170)
- **Capture Event Handlers**: Tracks interaction origins via `onClickCapture`, `onPointerDownCapture`, and `onKeyDownCapture` on the Dropdown container wrapper, removing the need for `popoverRef`, `useMergeRefs`, or modifying `popoverProps`.
- **Keyboard Navigation**: Properly handles keyboard Tab navigation into an existing unrelated non-modal dialog by verifying internal activation provenance before keeping presence.
- **Overlay Selector Support**: Recognizes dialogs, alertdialogs, popovers, and elements with `aria-modal="true"`.
- **Comprehensive Unit Tests**: Updated `index.jsdom.test.tsx` with tests covering focus return on dismiss, unrelated dialog closure, propagation-stopping triggers, and iframe interactions.
- **Changelog**: Added changelog entry in `packages/components/CHANGELOG.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Dropdown focus handling when opening dialogs and other modal overlays.
  - Dropdowns now close appropriately when focus moves to an unrelated external dialog.
  - Preserved dropdown state while an associated overlay remains active.
  - Improved focus restoration across portaled content, iframes, and native or ARIA-based overlays.

- **Tests**
  - Expanded coverage for dialog interactions, focus transitions, keyboard and pointer activation, and cross-document behavior.

- **Documentation**
  - Added a changelog entry describing the Dropdown focus behavior fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->