### PR TITLE
View Config: Move the table column style descriptions to the 7.2 compat layer

### DIFF
--- a/backport-changelog/7.2/13330.md
+++ b/backport-changelog/7.2/13330.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/13330
 
 * https://github.com/WordPress/gutenberg/pull/82238
+* https://github.com/WordPress/gutenberg/pull/82372

--- a/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
+++ b/lib/compat/wordpress-7.1/class-gutenberg-rest-view-config-controller-7-1.php
@@ -487,21 +487,17 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'width'    => array(
-					'description' => __( 'The width of the column.', 'gutenberg' ),
-					'type'        => array( 'string', 'number' ),
+					'type' => array( 'string', 'number' ),
 				),
 				'maxWidth' => array(
-					'description' => __( 'The maximum width of the column.', 'gutenberg' ),
-					'type'        => array( 'string', 'number' ),
+					'type' => array( 'string', 'number' ),
 				),
 				'minWidth' => array(
-					'description' => __( 'The minimum width of the column.', 'gutenberg' ),
-					'type'        => array( 'string', 'number' ),
+					'type' => array( 'string', 'number' ),
 				),
 				'align'    => array(
-					'description' => __( 'The horizontal alignment of the column content.', 'gutenberg' ),
-					'type'        => 'string',
-					'enum'        => array( 'start', 'center', 'end' ),
+					'type' => 'string',
+					'enum' => array( 'start', 'center', 'end' ),
 				),
 			),
 		);
@@ -517,7 +513,6 @@ class Gutenberg_REST_View_Config_Controller_7_1 extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'styles'       => array(
-					'description'          => __( 'Column styles keyed by field id, for the columns listed in the view fields. The primary column (title, media, and description fields) ignores these styles; in the table layout it takes the width left over by the other columns, or the last column does when there is no primary column.', 'gutenberg' ),
 					'type'                 => 'object',
 					'additionalProperties' => $this->get_column_style_schema(),
 				),

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_View_Config_Controller_7_2 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Controller which provides a REST endpoint for retrieving the default
+ * view configuration for a given entity type.
+ *
+ * Extends the 7.1 controller to describe the table column styles in the
+ * item schema.
+ *
+ * @since 7.2.0
+ *
+ * @see Gutenberg_REST_View_Config_Controller_7_1
+ */
+class Gutenberg_REST_View_Config_Controller_7_2 extends Gutenberg_REST_View_Config_Controller_7_1 {
+
+	/**
+	 * Returns the schema for the ColumnStyle type.
+	 *
+	 * @since 7.2.0 Added descriptions to the column style properties.
+	 *
+	 * @return array Schema for a column style object.
+	 */
+	protected function get_column_style_schema() {
+		$schema = parent::get_column_style_schema();
+
+		$schema['properties']['width']['description']    = __( 'The width of the column.', 'gutenberg' );
+		$schema['properties']['maxWidth']['description'] = __( 'The maximum width of the column.', 'gutenberg' );
+		$schema['properties']['minWidth']['description'] = __( 'The minimum width of the column.', 'gutenberg' );
+		$schema['properties']['align']['description']    = __( 'The horizontal alignment of the column content.', 'gutenberg' );
+
+		return $schema;
+	}
+
+	/**
+	 * Returns the layout schema for table-type views (ViewTable, ViewPickerTable).
+	 *
+	 * @since 7.2.0 Added a description to the `styles` property.
+	 *
+	 * @return array Schema for a table layout object.
+	 */
+	protected function get_table_layout_schema() {
+		$schema = parent::get_table_layout_schema();
+
+		$schema['properties']['styles']['description'] = __( 'Column styles keyed by field id, for the columns listed in the view fields. The primary column (title, media, and description fields) ignores these styles; in the table layout it takes the width left over by the other columns, or the last column does when there is no primary column.', 'gutenberg' );
+
+		return $schema;
+	}
+}

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * WordPress 7.2 compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the View Config REST API routes.
+ *
+ * Replaces the 7.1 registration so the route is served by the 7.2 controller.
+ */
+function gutenberg_register_view_config_controller_endpoints_7_2() {
+	$view_config_controller = new Gutenberg_REST_View_Config_Controller_7_2();
+	$view_config_controller->register_routes();
+}
+remove_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpoints', PHP_INT_MAX );
+add_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpoints_7_2', PHP_INT_MAX );

--- a/lib/load.php
+++ b/lib/load.php
@@ -73,6 +73,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.2 compat.
 	require __DIR__ . '/compat/wordpress-7.2/view-config-api.php';
+	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php';
+	require __DIR__ . '/compat/wordpress-7.2/rest-api.php';
 
 	// Real-time collaboration.
 	require __DIR__ . '/experimental/collaboration/class-gutenberg-rest-autosaves-controller.php';

--- a/phpunit/class-gutenberg-rest-view-config-controller-7-2-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-7-2-test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Unit tests covering Gutenberg_REST_View_Config_Controller_7_2 functionality.
+ *
+ * @package gutenberg
+ *
+ * @coversDefaultClass Gutenberg_REST_View_Config_Controller_7_2
+ */
+class Tests_REST_View_Config_Controller_7_2 extends WP_Test_REST_TestCase {
+
+	/**
+	 * The REST route the controller registers.
+	 */
+	const ROUTE = '/wp/v2/view-config';
+
+	/**
+	 * The route is served by the 7.2 controller, not the 7.1 one.
+	 */
+	public function test_route_is_served_by_the_7_2_controller() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( self::ROUTE, $routes );
+		$this->assertCount( 1, $routes[ self::ROUTE ], 'The route should be registered once.' );
+		$this->assertInstanceOf( 'Gutenberg_REST_View_Config_Controller_7_2', $routes[ self::ROUTE ][0]['callback'][0] );
+	}
+
+	/**
+	 * The table layout schema describes the column styles.
+	 *
+	 * @covers ::get_item_schema
+	 * @covers ::get_table_layout_schema
+	 * @covers ::get_column_style_schema
+	 */
+	public function test_item_schema_describes_table_column_styles() {
+		$controller = new Gutenberg_REST_View_Config_Controller_7_2();
+		$schema     = $controller->get_item_schema();
+
+		$styles = $schema['properties']['default_layouts']['properties']['table']['properties']['layout']['properties']['styles'];
+
+		$this->assertArrayHasKey( 'description', $styles );
+		foreach ( array( 'width', 'maxWidth', 'minWidth', 'align' ) as $property ) {
+			$this->assertArrayHasKey( 'description', $styles['additionalProperties']['properties'][ $property ], "The `$property` column style should be described." );
+		}
+	}
+}


### PR DESCRIPTION
## What?

Follow up to #82238. Moves the descriptions of the table column styles in the view config REST schema from the WordPress 7.1 compat folder to the 7.2 one, as requested in https://github.com/WordPress/gutenberg/pull/82238#discussion_r3916480046.

## Why?

The descriptions were committed to WordPress core for 7.2 (https://core.trac.wordpress.org/changeset/63436), so the plugin should ship them from `lib/compat/wordpress-7.2/`. The 7.1 compat code should match what WordPress 7.1 shipped.

## How?

A new `Gutenberg_REST_View_Config_Controller_7_2` extends the 7.1 controller and adds the descriptions to the column style and table layout schemas. A new `lib/compat/wordpress-7.2/rest-api.php` registers the 7.2 controller for the `/wp/v2/view-config` route in place of the 7.1 one. The 7.1 controller goes back to the schema it had before #82238. A PHP test checks that the route is served by the 7.2 controller and that the schema carries the descriptions.

## Testing Instructions

1. Run the PHP tests: `npm run test:unit:php:base -- --filter View_Config`.
2. Visit `/wp-json/wp/v2/view-config` with an `OPTIONS` request (or open `/wp-json/wp/v2/` and look at the `view-config` route) and check that `default_layouts.table.properties.styles` and its `width`, `maxWidth`, `minWidth`, and `align` properties have a `description`.

### Testing Instructions for Keyboard

Not applicable, there are no UI changes.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Prepared with Claude Code, including the PHP changes, the test, and this description. Reviewed by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added WordPress 7.2 support for the View Config REST API.
  * The `/wp/v2/view-config` endpoint now uses the WordPress 7.2 compatibility behavior.
  * REST schema documentation for table column styles is available in WordPress 7.2.

* **Documentation**
  * Added the related Gutenberg pull request reference to the 7.2 backport changelog.

* **Tests**
  * Added coverage verifying endpoint registration and schema documentation for WordPress 7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->