### PR TITLE
API Fetch: Document that requests are meant for the current site's REST API.

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -70,9 +70,9 @@ Sent on `POST` or `PUT` requests only. Shorthand to be used in place of `body`, 
 
 ### Requests to other sites
 
-`apiFetch` is meant for the REST API of the WordPress site the script runs on. Whenever WordPress loads the package it registers the root URL and nonce middlewares, so every request, including one made with a full `url`, is sent with the current user's `X-WP-Nonce` header and with cookies (`credentials: 'include'`). A WordPress site on another origin cannot validate that nonce and rejects the request with a `403` `rest_cookie_invalid_nonce` error, even for public endpoints, and other origins may refuse a credentialed cross-origin request altogether.
+`apiFetch` is meant for the REST API of the WordPress site the script runs on. Whenever WordPress loads the package it registers the root URL and nonce middlewares, so with the default fetch handler every request, including one made with a full `url`, is sent with the current user's `X-WP-Nonce` header and with cookies (`credentials: 'include'`). A WordPress site on another origin cannot validate that nonce and rejects the request with a `403` `rest_cookie_invalid_nonce` error, even for public endpoints, and other origins may refuse a credentialed cross-origin request altogether.
 
-Use `window.fetch` for requests to other sites, or make them from the server.
+Use `window.fetch` for requests to other sites, or make them from the server. A browser request to another site still needs that site to allow the cross-origin request; a WordPress site does so through the CORS headers its REST API sends by default.
 
 ```js
 import apiFetch from '@wordpress/api-fetch';

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -58,7 +58,7 @@ Shorthand to be used in place of `url`, appended to the REST API root URL for th
 
 #### `url` (`string`)
 
-Absolute URL to the endpoint from which to fetch.
+Absolute URL to the endpoint from which to fetch. The request still goes through the registered middlewares, so see [Requests to other sites](#requests-to-other-sites) before pointing it at another site.
 
 #### `parse` (`boolean`, default `true`)
 
@@ -67,6 +67,29 @@ Unlike `fetch`, the `Promise` return value of `apiFetch` will resolve to the par
 #### `data` (`object`)
 
 Sent on `POST` or `PUT` requests only. Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON.
+
+### Requests to other sites
+
+`apiFetch` is meant for the REST API of the WordPress site the script runs on. Whenever WordPress loads the package it registers the root URL and nonce middlewares, so every request, including one made with a full `url`, is sent with the current user's `X-WP-Nonce` header and with cookies (`credentials: 'include'`). A WordPress site on another origin cannot validate that nonce and rejects the request with a `403` `rest_cookie_invalid_nonce` error, even for public endpoints, and other origins may refuse a credentialed cross-origin request altogether.
+
+Use `window.fetch` for requests to other sites, or make them from the server.
+
+```js
+import apiFetch from '@wordpress/api-fetch';
+
+// Same site: goes through the middlewares.
+apiFetch( { path: '/wp/v2/posts' } ).then( ( posts ) => {
+	console.log( posts );
+} );
+
+// Another site: use fetch directly.
+window
+	.fetch( 'https://example.com/wp-json/wp/v2/posts' )
+	.then( ( response ) => response.json() )
+	.then( ( posts ) => {
+		console.log( posts );
+	} );
+```
 
 ### Aborting a request
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/46787.

Currently, the api-fetch README does not say the package is meant for the REST API of the site the script runs on. WordPress registers the nonce and root URL middlewares whenever it loads the package, so a request with a full `url` to another site is sent with the `X-WP-Nonce` header and cookies and fails with a 403 "Cookie check failed" error. Two people in the issue lost a lot of time on this. This PR documents the limitation under the `url` option and in a new "Requests to other sites" section, and points to `window.fetch` for those requests.

## Testing Instructions
Read the new section in `packages/api-fetch/README.md` and verify it matches what the nonce middleware does.

AI usage disclosure: docs and description drafted with AI assistance and reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that absolute-URL requests pass through registered middleware.
  * Updated cross-site request guidance to limit automatic nonce and credential handling to the default fetch handler.
  * Added a requirement that browser requests be permitted by the target site’s CORS headers.
  * Documented expected errors and alternatives for requests to other sites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->